### PR TITLE
fix(calls): defer play URL until first audio chunk and fall back to text tokens on TTS failure

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -224,6 +224,7 @@ import {
 } from "../calls/call-store.js";
 import type { CallTransport } from "../calls/call-transport.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
+import { loadConfig } from "../config/loader.js";
 import {
   getCanonicalGuardianRequest,
   getPendingCanonicalRequestByCallSessionId,
@@ -432,6 +433,10 @@ describe("call-controller", () => {
     // Reset consultation timeout to the default (long) value
     mockConsultationTimeoutMs = 90_000;
     mockSilenceTimeoutMs = 30_000;
+    // Reset TTS config to defaults so per-test mutations don't leak.
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "elevenlabs";
+    cfg.services.tts.providers["fish-audio"].referenceId = "";
     // Reset TTS provider registry to ensure clean state
     registerTestTtsProviders();
   });
@@ -2446,6 +2451,56 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: if synthesis fails before first chunk, falls back to text-token speech without sending play URL", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderRegistry();
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize() {
+        return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+      },
+    };
+    registerTtsProvider(elevenlabs);
+
+    const fishAudioFailing: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        throw new Error("fish-audio synth failure");
+      },
+      async synthesizeStream() {
+        throw new Error("fish-audio stream failure");
+      },
+    };
+    registerTtsProvider(fishAudioFailing);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from synthesized path"]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // No play URL should be emitted when synthesis fails before first chunk.
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    // Fallback token speech should still reach the caller.
+    const fallbackText = relay.sentTokens.map((t) => t.token).join("");
+    expect(fallbackText).toContain("Hello from synthesized path");
+
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken.last).toBe(true);
+
+    controller.destroy();
+  });
+
   // ── TTS provider abstraction: interruption behavior ─────────────────
 
   test("handleInterrupt: cancels synthesis abort controller for native provider path", async () => {
@@ -2508,6 +2563,17 @@ describe("call-controller", () => {
 
     test("returns fallback when provider registry is empty", () => {
       _resetTtsProviderRegistry();
+      const result = resolveCallTtsProvider();
+      expect(result.provider).toBeNull();
+      expect(result.useSynthesizedPath).toBe(false);
+      expect(result.audioFormat).toBe("mp3");
+    });
+
+    test("degrades fish-audio synthesized path when referenceId is missing", () => {
+      const cfg = loadConfig();
+      cfg.services.tts.provider = "fish-audio";
+      cfg.services.tts.providers["fish-audio"].referenceId = "";
+
       const result = resolveCallTtsProvider();
       expect(result.provider).toBeNull();
       expect(result.useSynthesizedPath).toBe(false);

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -109,7 +109,11 @@ let mockTtsSynthesizeStream: Mock<any> | null = null;
 mock.module("../tts/tts-config-resolver.js", () => ({
   resolveTtsConfig: () => ({
     provider: mockTtsProviderId,
-    providerConfig: { voiceId: "test-voice", format: "mp3" },
+    providerConfig: {
+      voiceId: "test-voice",
+      format: "mp3",
+      referenceId: "test-ref-id",
+    },
   }),
 }));
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -758,6 +758,7 @@ export class CallController {
     format: "mp3" | "wav" | "opus" = "mp3",
   ): Promise<void> {
     let handle: ReturnType<typeof createStreamingEntry> | null = null;
+    let playUrlSent = false;
     try {
       // When format is WAV (media-stream transport), request raw PCM from
       // the provider so the audio bytes match the store's content-type.
@@ -775,12 +776,17 @@ export class CallController {
       const config = loadConfig();
       const baseUrl = getPublicBaseUrl(config);
       const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-      this.transport.sendPlayUrl(url);
+      const sendPlayUrlOnce = (): void => {
+        if (playUrlSent) return;
+        this.transport.sendPlayUrl(url);
+        playUrlSent = true;
+      };
 
       const abortController = new AbortController();
       this.activeSynthesisAbort = abortController;
 
       if (provider.synthesizeStream) {
+        let streamedChunk = false;
         await provider.synthesizeStream(
           {
             text,
@@ -788,8 +794,22 @@ export class CallController {
             outputFormat,
             signal: abortController.signal,
           },
-          (chunk) => handle!.push(chunk),
+          (chunk) => {
+            if (chunk.byteLength === 0) return;
+            if (!streamedChunk) {
+              sendPlayUrlOnce();
+              streamedChunk = true;
+            }
+            handle!.push(chunk);
+          },
         );
+
+        // Some provider adapters may return a buffer without invoking
+        // onChunk. If that happens, do not leave a dangling unspeakable
+        // turn; degrade to native token TTS below by treating it as no-audio.
+        if (!streamedChunk) {
+          throw new Error("Streaming TTS returned no audio chunks");
+        }
       } else {
         // Fallback: buffer-oriented synthesis for providers that don't
         // implement streaming (shouldn't normally reach here since
@@ -800,6 +820,10 @@ export class CallController {
           outputFormat,
           signal: abortController.signal,
         });
+        if (result.audio.byteLength === 0) {
+          throw new Error("Buffer TTS returned an empty audio payload");
+        }
+        sendPlayUrlOnce();
         handle.push(result.audio);
       }
     } catch (err) {
@@ -813,6 +837,12 @@ export class CallController {
           { err, provider: provider.id },
           "TTS synthesis failed — skipping",
         );
+        // If synthesis fails before any audio has started, degrade to
+        // token-based speech on ConversationRelay so the caller still
+        // hears a response instead of silence.
+        if (!playUrlSent && !this.transport.requiresWavAudio) {
+          this.transport.sendTextToken(text, false);
+        }
       }
     } finally {
       this.activeSynthesisAbort = null;

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -79,6 +79,7 @@ async function synthesizeAndPlay(
   format: "mp3" | "wav" | "opus",
 ): Promise<void> {
   let handle: ReturnType<typeof createStreamingEntry> | null = null;
+  let playUrlSent = false;
   try {
     // When format is WAV (media-stream transport), request raw PCM from
     // the provider so the audio bytes match the store's content-type.
@@ -96,23 +97,38 @@ async function synthesizeAndPlay(
     const config = loadConfig();
     const baseUrl = getPublicBaseUrl(config);
     const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-
-    // Send the play URL FIRST so Twilio can start playing audio as soon as
-    // chunks arrive in the streaming store. This avoids the caller hearing
-    // silence during the full synthesis latency window.
-    relay.sendPlayUrl(url);
+    const sendPlayUrlOnce = (): void => {
+      if (playUrlSent) return;
+      relay.sendPlayUrl(url);
+      playUrlSent = true;
+    };
 
     if (provider.synthesizeStream) {
+      let streamedChunk = false;
       await provider.synthesizeStream(
         { text, useCase: "phone-call", outputFormat },
-        (chunk) => handle!.push(chunk),
+        (chunk) => {
+          if (chunk.byteLength === 0) return;
+          if (!streamedChunk) {
+            sendPlayUrlOnce();
+            streamedChunk = true;
+          }
+          handle!.push(chunk);
+        },
       );
+      if (!streamedChunk) {
+        throw new Error("Streaming TTS returned no audio chunks");
+      }
     } else {
       const result = await provider.synthesize({
         text,
         useCase: "phone-call",
         outputFormat,
       });
+      if (result.audio.byteLength === 0) {
+        throw new Error("Buffer TTS returned an empty audio payload");
+      }
+      sendPlayUrlOnce();
       handle.push(result.audio);
     }
 

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -11,7 +11,10 @@ import { loadConfig } from "../config/loader.js";
 import { getTtsProvider } from "../tts/provider-registry.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider } from "../tts/types.js";
+import { getLogger } from "../util/logger.js";
 import { resolveCallStrategy } from "./tts-call-strategy.js";
+
+const log = getLogger("resolve-call-tts-provider");
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -79,6 +82,29 @@ export function resolveCallTtsProvider(
     // decision path used by voice-quality.ts via resolveCallStrategy().
     const strategy = resolveCallStrategy(config);
     const useSynthesizedPath = strategy.callMode === "synthesized-play";
+
+    // For synthesized providers, preflight provider-specific config
+    // invariants that would otherwise fail only at first synthesis call.
+    // If required config is missing, degrade to the native token path
+    // (Twilio TTS) rather than letting the call stay silent.
+    //
+    // Fish Audio requires a reference ID when no per-request voiceId is
+    // supplied (which is the telephony default).
+    if (useSynthesizedPath && resolved.provider === "fish-audio") {
+      const referenceId = (resolved.providerConfig as { referenceId?: string })
+        .referenceId;
+      if (!referenceId?.trim()) {
+        log.warn(
+          { provider: resolved.provider },
+          "Synthesized call TTS disabled: fish-audio.referenceId is not configured; falling back to native token path",
+        );
+        return {
+          provider: null,
+          useSynthesizedPath: false,
+          audioFormat: "mp3",
+        };
+      }
+    }
 
     // Read the user-configured audio format from the resolved provider
     // config so the streaming store entry's content-type matches the


### PR DESCRIPTION
## Summary
- Defers `sendPlayUrl` until the first non-empty audio chunk arrives from the TTS provider, preventing Twilio from fetching an empty audio stream that produces caller silence
- When synthesis fails before any audio is sent, degrades to text-token speech on ConversationRelay so the caller still hears a response instead of silence
- Adds preflight validation for fish-audio `referenceId` in `resolveCallTtsProvider` — if missing, degrades to native token path at call setup rather than failing silently at first synthesis
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
