### PR TITLE
fix(macos): correct Fish Audio API key URL and reorder TTS help text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -396,11 +396,11 @@ struct VoiceSettingsView: View {
                 // Unified API key field
                 ttsApiKeyField
 
-                // Credentials guide — contextual help for obtaining an API key
-                ttsCredentialsGuideView
-
                 // Voice ID / Reference ID field (provider-specific)
                 ttsVoiceIdField
+
+                // Credentials guide — contextual help for obtaining an API key
+                ttsCredentialsGuideView
 
                 // Save + Reset actions
                 ServiceCardActions(

--- a/clients/shared/Utilities/TTSProviderRegistry.swift
+++ b/clients/shared/Utilities/TTSProviderRegistry.swift
@@ -92,7 +92,7 @@ private let fallbackRegistry = TTSProviderRegistry(
             setupHint: "Run the setup commands in your terminal to configure Fish Audio.",
             credentialsGuide: TTSCredentialsGuide(
                 description: "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
-                url: "https://fish.audio/api-keys/",
+                url: "https://fish.audio/app/api-keys/",
                 linkLabel: "Open Fish Audio API Keys"
             )
         ),

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -21,7 +21,7 @@
       "setupHint": "Run the setup commands in your terminal to configure Fish Audio.",
       "credentialsGuide": {
         "description": "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
-        "url": "https://fish.audio/api-keys/",
+        "url": "https://fish.audio/app/api-keys/",
         "linkLabel": "Open Fish Audio API Keys"
       }
     }


### PR DESCRIPTION
## Summary
- Fix the Fish Audio API key URL from `https://fish.audio/api-keys/` to `https://fish.audio/app/api-keys/` in both the provider catalog and fallback registry
- Move the TTS credentials guide help text to appear below the Voice ID field instead of between the API key and Voice ID fields

## Original prompt
Make two improvements to the text-to-speech section on the Voice page:

1. Fix the Fish Audio API key URL - the correct URL for getting a Fish Audio API key is https://fish.audio/app/api-keys/ (update wherever the current incorrect URL is used)
2. Move the TTS help text so it appears below the Voice ID input field, rather than between the API key and Voice ID fields
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
