### PR TITLE
feat(environments): Phase 1 — Swift-side env-aware path helpers

### DIFF
--- a/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
@@ -10,14 +10,14 @@ private let log = Logger(
 
 /// File-based CredentialStorage implementation.
 ///
-/// Stores each credential as an individual file under
-/// `~/.vellum/protected/credentials/` with 0600 permissions.
+/// Stores each credential as an individual file under the env-aware
+/// credentials directory with 0600 permissions. For production, this is
+/// the legacy `~/.vellum/protected/credentials/`; for non-production it's
+/// `$XDG_CONFIG_HOME/vellum-<env>/credentials/`. See
+/// `VellumPaths.credentialsDir`.
 struct FileCredentialStorage: CredentialStorage {
 
-    private static let credentialsDir: URL = {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".vellum/protected/credentials")
-    }()
+    private static let credentialsDir: URL = VellumPaths.current.credentialsDir
 
     /// Returns the file URL for a given credential account name.
     /// The account name is sanitized to a safe filename by replacing

--- a/clients/macos/vellum-assistantTests/VellumPathsTests.swift
+++ b/clients/macos/vellum-assistantTests/VellumPathsTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Golden-value parity tests for `VellumPaths`. Asserts that each getter
+/// returns the expected path string for each canonical environment. The
+/// production expectations double as regression tests guaranteeing that
+/// existing installs see byte-identical paths to the legacy inline code
+/// they replace.
+final class VellumPathsTests: XCTestCase {
+    private let testHome = URL(fileURLWithPath: "/test/home")
+    private let testXdgConfig = URL(fileURLWithPath: "/test/home/.config")
+
+    private func paths(for env: VellumEnvironment) -> VellumPaths {
+        VellumPaths(
+            environment: env,
+            homeDirectory: testHome,
+            xdgConfigHome: testXdgConfig
+        )
+    }
+
+    // MARK: - Production (legacy paths)
+
+    func testProductionDeviceIdFile() {
+        XCTAssertEqual(
+            paths(for: .production).deviceIdFile.path,
+            "/test/home/.vellum/device.json"
+        )
+    }
+
+    func testProductionSigningKeyFile() {
+        XCTAssertEqual(
+            paths(for: .production).signingKeyFile.path,
+            "/test/home/.vellum/protected/app-signing-key"
+        )
+    }
+
+    func testProductionCredentialsDir() {
+        XCTAssertEqual(
+            paths(for: .production).credentialsDir.path,
+            "/test/home/.vellum/protected/credentials"
+        )
+    }
+
+    func testProductionPlatformTokenFile() {
+        XCTAssertEqual(
+            paths(for: .production).platformTokenFile.path,
+            "/test/home/.config/vellum/platform-token"
+        )
+    }
+
+    func testProductionLockfileCandidates() {
+        XCTAssertEqual(
+            paths(for: .production).lockfileCandidates.map(\.path),
+            [
+                "/test/home/.vellum.lock.json",
+                "/test/home/.vellum.lockfile.json",
+            ]
+        )
+    }
+
+    // MARK: - Dev (non-prod, XDG-scoped)
+
+    func testDevDeviceIdFile() {
+        XCTAssertEqual(
+            paths(for: .dev).deviceIdFile.path,
+            "/test/home/.config/vellum-dev/device.json"
+        )
+    }
+
+    func testDevSigningKeyFile() {
+        XCTAssertEqual(
+            paths(for: .dev).signingKeyFile.path,
+            "/test/home/.config/vellum-dev/app-signing-key"
+        )
+    }
+
+    func testDevCredentialsDir() {
+        XCTAssertEqual(
+            paths(for: .dev).credentialsDir.path,
+            "/test/home/.config/vellum-dev/credentials"
+        )
+    }
+
+    func testDevPlatformTokenFile() {
+        XCTAssertEqual(
+            paths(for: .dev).platformTokenFile.path,
+            "/test/home/.config/vellum-dev/platform-token"
+        )
+    }
+
+    func testDevLockfileCandidates() {
+        XCTAssertEqual(
+            paths(for: .dev).lockfileCandidates.map(\.path),
+            ["/test/home/.config/vellum-dev/lockfile.json"]
+        )
+    }
+
+    // MARK: - Staging (non-prod, XDG-scoped)
+
+    func testStagingDeviceIdFile() {
+        XCTAssertEqual(
+            paths(for: .staging).deviceIdFile.path,
+            "/test/home/.config/vellum-staging/device.json"
+        )
+    }
+
+    func testStagingLockfileCandidates() {
+        XCTAssertEqual(
+            paths(for: .staging).lockfileCandidates.map(\.path),
+            ["/test/home/.config/vellum-staging/lockfile.json"]
+        )
+    }
+
+    // MARK: - Test (non-prod, XDG-scoped)
+
+    func testTestEnvDeviceIdFile() {
+        XCTAssertEqual(
+            paths(for: .test).deviceIdFile.path,
+            "/test/home/.config/vellum-test/device.json"
+        )
+    }
+
+    func testTestEnvPlatformTokenFile() {
+        XCTAssertEqual(
+            paths(for: .test).platformTokenFile.path,
+            "/test/home/.config/vellum-test/platform-token"
+        )
+    }
+
+    // MARK: - Local (non-prod, XDG-scoped)
+
+    func testLocalDeviceIdFile() {
+        XCTAssertEqual(
+            paths(for: .local).deviceIdFile.path,
+            "/test/home/.config/vellum-local/device.json"
+        )
+    }
+
+    func testLocalCredentialsDir() {
+        XCTAssertEqual(
+            paths(for: .local).credentialsDir.path,
+            "/test/home/.config/vellum-local/credentials"
+        )
+    }
+
+    func testLocalLockfileCandidates() {
+        XCTAssertEqual(
+            paths(for: .local).lockfileCandidates.map(\.path),
+            ["/test/home/.config/vellum-local/lockfile.json"]
+        )
+    }
+
+    // MARK: - Custom XDG_CONFIG_HOME
+
+    func testCustomXdgConfigHomeDoesNotAffectProductionLegacyPaths() {
+        let paths = VellumPaths(
+            environment: .production,
+            homeDirectory: testHome,
+            xdgConfigHome: URL(fileURLWithPath: "/custom/xdg")
+        )
+        // Production's dotfile paths are home-rooted, not XDG-rooted, so a
+        // custom XDG_CONFIG_HOME should not move them.
+        XCTAssertEqual(paths.deviceIdFile.path, "/test/home/.vellum/device.json")
+        XCTAssertEqual(
+            paths.signingKeyFile.path,
+            "/test/home/.vellum/protected/app-signing-key"
+        )
+        // ...but production's platform-token lives under XDG, so it *does*
+        // follow the override.
+        XCTAssertEqual(
+            paths.platformTokenFile.path,
+            "/custom/xdg/vellum/platform-token"
+        )
+    }
+
+    func testCustomXdgConfigHomeAppliesToNonProduction() {
+        let paths = VellumPaths(
+            environment: .dev,
+            homeDirectory: testHome,
+            xdgConfigHome: URL(fileURLWithPath: "/custom/xdg")
+        )
+        XCTAssertEqual(
+            paths.deviceIdFile.path,
+            "/custom/xdg/vellum-dev/device.json"
+        )
+        XCTAssertEqual(
+            paths.platformTokenFile.path,
+            "/custom/xdg/vellum-dev/platform-token"
+        )
+    }
+
+    // MARK: - Production parity with legacy inline code
+
+    /// Documents that the production paths VellumPaths returns match exactly
+    /// the paths the pre-Phase-1 inline code constructed. These strings are
+    /// the load-bearing contract with the daemon, CLI, CES, and chrome
+    /// extension native host — any change here would break cross-process
+    /// coordination for existing installs.
+    func testProductionPathsMatchLegacyInlineConventions() {
+        let p = paths(for: .production)
+        // LockfilePaths.swift legacy: `~/.vellum.lock.json` + legacy fallback
+        XCTAssertEqual(p.lockfileCandidates[0].path, "/test/home/.vellum.lock.json")
+        XCTAssertEqual(p.lockfileCandidates[1].path, "/test/home/.vellum.lockfile.json")
+        // DeviceIdStore.swift legacy: `~/.vellum/device.json`
+        XCTAssertEqual(p.deviceIdFile.path, "/test/home/.vellum/device.json")
+        // SigningIdentityManager.swift legacy: `~/.vellum/protected/app-signing-key`
+        XCTAssertEqual(p.signingKeyFile.path, "/test/home/.vellum/protected/app-signing-key")
+        // FileCredentialStorage.swift legacy: `~/.vellum/protected/credentials`
+        XCTAssertEqual(p.credentialsDir.path, "/test/home/.vellum/protected/credentials")
+    }
+}

--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -1,11 +1,16 @@
 import Foundation
 
-/// Reads or creates a per-device UUID stored at ~/.vellum/device.json.
-/// This file is shared with the daemon (TypeScript), so both runtimes
-/// use the same device identifier for telemetry and platform registration.
+/// Reads or creates a per-device UUID. Shared with the daemon (TypeScript),
+/// so both runtimes use the same device identifier for telemetry and
+/// platform registration.
 ///
-/// The file is a JSON object: { "deviceId": "<uuid>", ... }
-/// Additional per-device metadata can be added alongside deviceId in the future.
+/// Path resolution: for production, the file lives at the legacy
+/// `~/.vellum/device.json` location. For non-production environments it
+/// lives at the env-scoped `$XDG_CONFIG_HOME/vellum-<env>/device.json`.
+/// See `VellumPaths.deviceIdFile`.
+///
+/// The file is a JSON object: { "deviceId": "<uuid>", ... }. Additional
+/// per-device metadata can be added alongside deviceId in the future.
 ///
 /// On first access, migrates any existing UUID from UserDefaults
 /// (legacy LocalInstallationIdStore key) into the file to preserve
@@ -15,8 +20,9 @@ public enum DeviceIdStore {
     private static var cached: String?
     private static let legacyUserDefaultsKey = "vellum_local_installation_id"
 
-    /// Returns the device ID, reading from ~/.vellum/device.json or creating it
-    /// if it doesn't exist. Thread-safe and cached after first access.
+    /// Returns the device ID, reading from the resolved device.json path
+    /// or creating it if it doesn't exist. Thread-safe and cached after
+    /// first access.
     ///
     /// Migration: if the file has no deviceId, checks UserDefaults for the
     /// legacy key and seeds the file with that value before cleaning up
@@ -27,9 +33,8 @@ public enum DeviceIdStore {
 
         if let cached { return cached }
 
-        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
-        let vellumDir = home.appendingPathComponent(".vellum", isDirectory: true)
-        let deviceFile = vellumDir.appendingPathComponent("device.json")
+        let deviceFile = VellumPaths.current.deviceIdFile
+        let vellumDir = deviceFile.deletingLastPathComponent()
 
         // 1. Try to read existing file (daemon or a previous run may have created it).
         if let data = try? Data(contentsOf: deviceFile),
@@ -94,14 +99,8 @@ public enum DeviceIdStore {
     /// mirroring the daemon's `003-seed-device-id` migration so the same
     /// legacy ID is preserved regardless of whether macOS or daemon starts first.
     private static func installationIdFromLockfile() -> String? {
-        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
-        let candidates = [
-            home.appendingPathComponent(".vellum.lock.json"),
-            home.appendingPathComponent(".vellum.lockfile.json"),
-        ]
-
         var lockJSON: [String: Any]?
-        for candidate in candidates {
+        for candidate in VellumPaths.current.lockfileCandidates {
             guard let data = try? Data(contentsOf: candidate),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 continue

--- a/clients/shared/App/SigningIdentityManager.swift
+++ b/clients/shared/App/SigningIdentityManager.swift
@@ -8,19 +8,21 @@ private let log = Logger(
     category: "SigningIdentityManager"
 )
 
-/// Manages the Ed25519 signing identity stored on disk in ~/.vellum/protected/.
-/// Previously used the macOS Keychain, which triggers repeated authorization
-/// prompts with ad-hoc code-signed builds.
+/// Manages the Ed25519 signing identity stored on disk. For production
+/// installs the key lives at `~/.vellum/protected/app-signing-key`; for
+/// non-production environments it lives at the env-scoped XDG config dir
+/// (see `VellumPaths.signingKeyFile`). Previously used the macOS Keychain,
+/// which triggers repeated authorization prompts with ad-hoc code-signed
+/// builds.
 ///
 /// Uses `actor` isolation instead of `@MainActor` so that file I/O
 /// (loading/saving the key) does not block the main thread.
 public actor SigningIdentityManager {
     public static let shared = SigningIdentityManager()
 
-    /// File path for the signing key: ~/.vellum/protected/app-signing-key
+    /// File path for the signing key. Env-aware via `VellumPaths`.
     private var keyFilePath: URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".vellum/protected/app-signing-key")
+        VellumPaths.current.signingKeyFile
     }
 
     /// Cached private key to avoid repeated file reads.

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -133,19 +133,6 @@ public struct LockfileAssistant {
         cloud.lowercased() == "apple-container"
     }
 
-    /// The resolved workspace directory for this assistant, accounting for both
-    /// the canonical `instanceDir` (post-migration) and legacy `baseDataDir`.
-    public var workspaceDir: String? {
-        if let instanceDir {
-            return instanceDir + "/.vellum/workspace"
-        }
-        if let baseDataDir {
-            // Legacy: baseDataDir already includes the .vellum segment
-            return baseDataDir + "/workspace"
-        }
-        return nil
-    }
-
     public static func loadLatest() -> LockfileAssistant? {
         loadAll().first
     }

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -1,25 +1,23 @@
 import Foundation
 
 public enum LockfilePaths {
-    private static var homeDir: URL {
-        URL(fileURLWithPath: NSHomeDirectory())
-    }
-
+    /// Canonical lockfile path used for writes. Resolved via
+    /// `VellumPaths.current.lockfileCandidates.first` so the path is
+    /// environment-aware: production returns the legacy
+    /// `~/.vellum.lock.json`, non-production returns the env-scoped
+    /// `$XDG_CONFIG_HOME/vellum-<env>/lockfile.json`.
     public static var primary: URL {
-        homeDir.appendingPathComponent(".vellum.lock.json")
-    }
-
-    public static var legacy: URL {
-        homeDir.appendingPathComponent(".vellum.lockfile.json")
+        VellumPaths.current.lockfileCandidates[0]
     }
 
     public static var primaryPath: String { primary.path }
 
-    /// Read and parse the lockfile, trying the primary path first,
-    /// then falling back to the legacy path.
-    /// Returns nil if neither file exists or both are malformed.
+    /// Read and parse the lockfile, trying each candidate path in priority
+    /// order. For production, this means the current `.vellum.lock.json`
+    /// followed by the legacy `.vellum.lockfile.json` fallback. Returns
+    /// `nil` if no candidate exists or all are malformed.
     public static func read() -> [String: Any]? {
-        for url in [primary, legacy] {
+        for url in VellumPaths.current.lockfileCandidates {
             guard let data = try? Data(contentsOf: url),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 continue

--- a/clients/shared/Utilities/VellumPaths.swift
+++ b/clients/shared/Utilities/VellumPaths.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Env-aware filesystem path helpers for client-owned state. Mirrors
+/// `cli/src/lib/environments/paths.ts` from the Phase 0 module so the Swift
+/// client and the TypeScript daemon/CLI produce byte-identical paths for
+/// production users while sharing the same convention for non-production
+/// environments.
+///
+/// **Production is grandfathered**: every getter returns the legacy
+/// `~/.vellum/...` path (or the existing `~/.config/vellum/...` path for
+/// things that were already XDG-compliant). No migration is needed for
+/// existing installs.
+///
+/// **Non-production environments** use env-scoped XDG paths
+/// (`$XDG_CONFIG_HOME/vellum-<env>/...`). These are dormant today — no build
+/// currently bakes a non-production `VELLUM_ENVIRONMENT` into `Info.plist`
+/// for end users — and become live as the daemon-side phases land.
+///
+/// Production code reads `VellumPaths.current` (cached singleton). Tests
+/// construct their own `VellumPaths` with explicit roots so they don't
+/// depend on the surrounding process state.
+public struct VellumPaths {
+    public let environment: VellumEnvironment
+    public let homeDirectory: URL
+    public let xdgConfigHome: URL
+
+    /// Resolved path bundle for the current process environment.
+    ///
+    /// `NSHomeDirectory()` is used intentionally here and in
+    /// `resolveXdgConfigHome()` to match the existing convention across the
+    /// codebase (`LockfilePaths.swift`, `SessionTokenManager.swift`). For
+    /// **unsandboxed** macOS apps — the Vellum desktop app today — this is
+    /// equivalent to `FileManager.default.homeDirectoryForCurrentUser`. If
+    /// macOS app sandboxing is ever enabled, `NSHomeDirectory()` will
+    /// return the sandbox container path instead of the real user home,
+    /// which would move every path this struct produces. That migration
+    /// would need to be coordinated with daemon-side reads (same files are
+    /// shared: device.json, app-signing-key, credentials, platform-token,
+    /// lockfile) and is out of scope until sandboxing becomes a target.
+    public static let current: VellumPaths = {
+        VellumPaths(
+            environment: .current,
+            homeDirectory: URL(fileURLWithPath: NSHomeDirectory()),
+            xdgConfigHome: Self.resolveXdgConfigHome()
+        )
+    }()
+
+    public init(
+        environment: VellumEnvironment,
+        homeDirectory: URL,
+        xdgConfigHome: URL
+    ) {
+        self.environment = environment
+        self.homeDirectory = homeDirectory
+        self.xdgConfigHome = xdgConfigHome
+    }
+
+    // MARK: - Path getters
+
+    /// Shared with the TypeScript daemon.
+    public var deviceIdFile: URL {
+        if environment == .production {
+            return homeDirectory.appendingPathComponent(".vellum/device.json")
+        }
+        return envScopedXdgDir.appendingPathComponent("device.json")
+    }
+
+    /// macOS-client-owned; not read by the daemon.
+    public var signingKeyFile: URL {
+        if environment == .production {
+            return homeDirectory.appendingPathComponent(
+                ".vellum/protected/app-signing-key"
+            )
+        }
+        return envScopedXdgDir.appendingPathComponent("app-signing-key")
+    }
+
+    /// macOS-client-owned; not read by the daemon.
+    public var credentialsDir: URL {
+        if environment == .production {
+            return homeDirectory.appendingPathComponent(
+                ".vellum/protected/credentials"
+            )
+        }
+        return envScopedXdgDir.appendingPathComponent("credentials")
+    }
+
+    /// Shared with the daemon. Always XDG-rooted (no legacy branch).
+    public var platformTokenFile: URL {
+        envScopedXdgDir.appendingPathComponent("platform-token")
+    }
+
+    /// Priority order: current name first, legacy fallback second.
+    /// Production returns both; non-prod returns only the current.
+    public var lockfileCandidates: [URL] {
+        if environment == .production {
+            return [
+                homeDirectory.appendingPathComponent(".vellum.lock.json"),
+                homeDirectory.appendingPathComponent(".vellum.lockfile.json"),
+            ]
+        }
+        return [envScopedXdgDir.appendingPathComponent("lockfile.json")]
+    }
+
+    // MARK: - Internals
+
+    /// `~/.config/vellum/` for production, `~/.config/vellum-<env>/` otherwise.
+    private var envScopedXdgDir: URL {
+        let dirName: String
+        if environment == .production {
+            dirName = "vellum"
+        } else {
+            dirName = "vellum-\(environment.rawValue)"
+        }
+        return xdgConfigHome.appendingPathComponent(dirName)
+    }
+
+    private static func resolveXdgConfigHome() -> URL {
+        if let raw = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        {
+            return URL(fileURLWithPath: raw)
+        }
+        return URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".config")
+    }
+}


### PR DESCRIPTION
Introduce environment-aware `VellumPaths.swift` and cut over hardcoded call sites.

We're deferring call sites that depend on behavior of bundled CLI. Unfortunately there are a lot of moving parts, and this isn't safe to merge incrementally into main.

Production environments should be grandfathered into legacy paths. Non-production environments should generally respect new namespaces.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
