### PR TITLE
feat(environments): daemon vellumRoot() honors BASE_DATA_DIR per-instance override

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -7,10 +7,13 @@ import {
   ensureDataDir,
   getDataDir,
   getDbPath,
+  getDotEnvPath,
   getHistoryPath,
   getInterfacesDir,
   getLogPath,
   getPidPath,
+  getProtectedDir,
+  getRuntimePortFilePath,
   getSandboxRootDir,
   getSandboxWorkingDir,
   getWorkspaceConfigPath,
@@ -21,12 +24,18 @@ import {
 } from "../util/platform.js";
 
 const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+const originalBaseDataDir = process.env.BASE_DATA_DIR;
 
 afterEach(() => {
   if (originalWorkspaceDir == null) {
     delete process.env.VELLUM_WORKSPACE_DIR;
   } else {
     process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+  if (originalBaseDataDir == null) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = originalBaseDataDir;
   }
 });
 
@@ -69,6 +78,25 @@ describe("path characterization", () => {
     expect(getDataDir()).toBe("/tmp/custom-workspace/data");
     // Root-level paths are NOT affected by VELLUM_WORKSPACE_DIR
     expect(getPidPath()).toBe(join(homedir(), ".vellum", "vellum.pid"));
+  });
+
+  test("BASE_DATA_DIR relocates vellumRoot()-derived paths", () => {
+    const saved = process.env.BASE_DATA_DIR;
+    process.env.BASE_DATA_DIR = "/tmp/fake-instance";
+    try {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+      expect(getPidPath()).toBe("/tmp/fake-instance/.vellum/vellum.pid");
+      expect(getProtectedDir()).toBe("/tmp/fake-instance/.vellum/protected");
+      expect(getRuntimePortFilePath()).toBe(
+        "/tmp/fake-instance/.vellum/runtime-port",
+      );
+      expect(getDotEnvPath()).toBe("/tmp/fake-instance/.vellum/.env");
+      // Workspace transitively relocates via vellumRoot()
+      expect(getWorkspaceDir()).toBe("/tmp/fake-instance/.vellum/workspace");
+    } finally {
+      if (saved === undefined) delete process.env.BASE_DATA_DIR;
+      else process.env.BASE_DATA_DIR = saved;
+    }
   });
 
   test("hooks directory is inside the workspace boundary", () => {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -45,13 +45,24 @@ export function normalizeAssistantId(assistantId: string): string {
 }
 
 /**
- * Compute the root ~/.vellum directory path.
+ * The daemon's per-instance root data directory. Resolution order:
  *
- * This is a simple inline computation — not a shared function — so each
- * helper is self-contained and the module has no hidden coupling to
- * env-var indirection.
+ *   1. `BASE_DATA_DIR` env var — set by the CLI when spawning the daemon
+ *      for a specific assistant (see `cli/src/lib/local.ts`). Points at the
+ *      per-assistant instanceDir; we append `.vellum` to get the daemon's
+ *      root so root-level state (PID, credentials, runtime-port, workspace)
+ *      is isolated per instance.
+ *   2. Fallback: `join(homedir(), ".vellum")`. Used when the daemon runs
+ *      outside the CLI-spawn lifecycle (containerized deployments, manual
+ *      test invocations).
+ *
+ * Docker mode relocates the workspace via `VELLUM_WORKSPACE_DIR` rather
+ * than `BASE_DATA_DIR`, so honoring `BASE_DATA_DIR` here does not affect
+ * containerized deployments.
  */
 function vellumRoot(): string {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+  if (baseDataDir) return join(baseDataDir, ".vellum");
   return join(homedir(), ".vellum");
 }
 


### PR DESCRIPTION
## Summary
- Re-enable per-instance daemon root resolution via BASE_DATA_DIR (partial revert of #22085) (*)
- Fixes credential/runtime-port/workspace collision across multi-instance local assistants
- Docker mode unaffected: cli/src/lib/docker.ts doesn't set BASE_DATA_DIR

## Note
(*) I know we want to move away from this, but
1. multi-local assistant flow is broken because of this, and partial revert is fast way to fix it
2. I'd prefer to fully deprecate this in a separate refactor

Part of plan: env-data-layout.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
