### PR TITLE
feat(environments): route CLI platform token, guardian token, and device-id paths through getConfigDir(env)

### DIFF
--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getOrCreatePersistedDeviceId,
+  loadGuardianToken,
+  saveGuardianToken,
+  type GuardianTokenData,
+} from "../lib/guardian-token.js";
+
+function makeTokenData(suffix: string): GuardianTokenData {
+  const now = new Date().toISOString();
+  return {
+    guardianPrincipalId: `principal-${suffix}`,
+    accessToken: `access-${suffix}`,
+    accessTokenExpiresAt: now,
+    refreshToken: `refresh-${suffix}`,
+    refreshTokenExpiresAt: now,
+    refreshAfter: now,
+    isNew: true,
+    deviceId: `device-${suffix}`,
+    leasedAt: now,
+  };
+}
+
+describe("guardian-token paths are env-scoped", () => {
+  let tempHome: string;
+  let savedXdg: string | undefined;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_CONFIG_HOME;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    tempHome = mkdtempSync(join(tmpdir(), "cli-guardian-token-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    if (savedXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = savedXdg;
+    }
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("prod: guardian token lands at $XDG_CONFIG_HOME/vellum/assistants/<id>/guardian-token.json", () => {
+    const data = makeTokenData("prod");
+    saveGuardianToken("alpha", data);
+
+    const prodPath = join(
+      tempHome,
+      "vellum",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    expect(existsSync(prodPath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(prodPath, "utf-8"));
+    expect(parsed.guardianPrincipalId).toBe("principal-prod");
+
+    const loaded = loadGuardianToken("alpha");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.guardianPrincipalId).toBe("principal-prod");
+  });
+
+  test("dev: guardian token lands at $XDG_CONFIG_HOME/vellum-dev/assistants/<id>/guardian-token.json", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    const data = makeTokenData("dev");
+    saveGuardianToken("alpha", data);
+
+    const devPath = join(
+      tempHome,
+      "vellum-dev",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    expect(existsSync(devPath)).toBe(true);
+
+    // Prod directory must NOT have this token
+    const prodPath = join(
+      tempHome,
+      "vellum",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    expect(existsSync(prodPath)).toBe(false);
+
+    const loaded = loadGuardianToken("alpha");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.guardianPrincipalId).toBe("principal-dev");
+  });
+
+  test("same assistant id in prod and dev is isolated on disk", () => {
+    // Write prod token for assistant 'alpha'
+    delete process.env.VELLUM_ENVIRONMENT;
+    saveGuardianToken("alpha", makeTokenData("prod"));
+
+    // Write dev token for assistant 'alpha'
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    saveGuardianToken("alpha", makeTokenData("dev"));
+
+    // Dev load returns dev
+    expect(loadGuardianToken("alpha")!.guardianPrincipalId).toBe(
+      "principal-dev",
+    );
+
+    // Back to prod — prod token is unchanged
+    delete process.env.VELLUM_ENVIRONMENT;
+    expect(loadGuardianToken("alpha")!.guardianPrincipalId).toBe(
+      "principal-prod",
+    );
+
+    // Both files exist at distinct paths
+    const prodPath = join(
+      tempHome,
+      "vellum",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    const devPath = join(
+      tempHome,
+      "vellum-dev",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    expect(existsSync(prodPath)).toBe(true);
+    expect(existsSync(devPath)).toBe(true);
+    expect(prodPath).not.toBe(devPath);
+  });
+
+  test("prod: persisted device id lands at $XDG_CONFIG_HOME/vellum/device-id", () => {
+    const id = getOrCreatePersistedDeviceId();
+    expect(id.length).toBeGreaterThan(0);
+
+    const prodPath = join(tempHome, "vellum", "device-id");
+    expect(existsSync(prodPath)).toBe(true);
+    expect(readFileSync(prodPath, "utf-8").trim()).toBe(id);
+  });
+
+  test("dev: persisted device id lands at $XDG_CONFIG_HOME/vellum-dev/device-id", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    const id = getOrCreatePersistedDeviceId();
+    expect(id.length).toBeGreaterThan(0);
+
+    const devPath = join(tempHome, "vellum-dev", "device-id");
+    expect(existsSync(devPath)).toBe(true);
+    expect(readFileSync(devPath, "utf-8").trim()).toBe(id);
+
+    const prodPath = join(tempHome, "vellum", "device-id");
+    expect(existsSync(prodPath)).toBe(false);
+  });
+
+  test("device id is stable across repeated calls in the same env", () => {
+    delete process.env.VELLUM_ENVIRONMENT;
+    const first = getOrCreatePersistedDeviceId();
+    const second = getOrCreatePersistedDeviceId();
+    expect(first).toBe(second);
+  });
+});

--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  clearPlatformToken,
+  readPlatformToken,
+  savePlatformToken,
+} from "../lib/platform-client.js";
+
+describe("platform-client token path is env-scoped", () => {
+  let tempHome: string;
+  let savedXdg: string | undefined;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_CONFIG_HOME;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    tempHome = mkdtempSync(join(tmpdir(), "cli-platform-client-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    if (savedXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = savedXdg;
+    }
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test("prod (VELLUM_ENVIRONMENT unset) writes to $XDG_CONFIG_HOME/vellum/platform-token", () => {
+    const token = "vak_prod_token_123";
+    savePlatformToken(token);
+
+    const prodPath = join(tempHome, "vellum", "platform-token");
+    expect(existsSync(prodPath)).toBe(true);
+    expect(readFileSync(prodPath, "utf-8").trim()).toBe(token);
+    expect(readPlatformToken()).toBe(token);
+  });
+
+  test("dev (VELLUM_ENVIRONMENT=dev) writes to $XDG_CONFIG_HOME/vellum-dev/platform-token", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    const token = "vak_dev_token_456";
+    savePlatformToken(token);
+
+    const devPath = join(tempHome, "vellum-dev", "platform-token");
+    expect(existsSync(devPath)).toBe(true);
+    expect(readFileSync(devPath, "utf-8").trim()).toBe(token);
+
+    const prodPath = join(tempHome, "vellum", "platform-token");
+    expect(existsSync(prodPath)).toBe(false);
+
+    expect(readPlatformToken()).toBe(token);
+  });
+
+  test("prod and dev tokens are isolated on disk", () => {
+    // Save prod token
+    delete process.env.VELLUM_ENVIRONMENT;
+    savePlatformToken("prod-token");
+
+    // Switch to dev and save a different token
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    savePlatformToken("dev-token");
+
+    // Dev read returns dev
+    expect(readPlatformToken()).toBe("dev-token");
+
+    // Switch back to prod — prod value is unchanged
+    delete process.env.VELLUM_ENVIRONMENT;
+    expect(readPlatformToken()).toBe("prod-token");
+
+    // Files live at distinct paths
+    expect(
+      readFileSync(join(tempHome, "vellum", "platform-token"), "utf-8").trim(),
+    ).toBe("prod-token");
+    expect(
+      readFileSync(
+        join(tempHome, "vellum-dev", "platform-token"),
+        "utf-8",
+      ).trim(),
+    ).toBe("dev-token");
+  });
+
+  test("clearPlatformToken removes only the env-scoped token", () => {
+    // Prod token
+    delete process.env.VELLUM_ENVIRONMENT;
+    savePlatformToken("prod-token");
+
+    // Dev token
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    savePlatformToken("dev-token");
+
+    // Clear dev
+    clearPlatformToken();
+    expect(existsSync(join(tempHome, "vellum-dev", "platform-token"))).toBe(
+      false,
+    );
+
+    // Prod still there
+    expect(existsSync(join(tempHome, "vellum", "platform-token"))).toBe(true);
+  });
+});

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -23,11 +23,16 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-// Import the real assistant-config module — do NOT mock it with mock.module()
-// because Bun's mock.module() replaces the module globally and leaks into
-// other test files (e.g. multi-local.test.ts) running in the same process.
-// Instead, we use spyOn to mock findAssistantByName on the imported module object.
+// Import the real modules — do NOT mock them with mock.module() because
+// Bun's mock.module() replaces modules globally and the replacement leaks
+// into other test files (e.g. platform-client.test.ts, guardian-token.test.ts,
+// multi-local.test.ts) running in the same process with no way to unmock.
+// Instead, we use spyOn() on the imported module namespace objects — these
+// mutate only the current process's live binding and are restored via
+// mockRestore() in afterAll.
 import * as assistantConfig from "../lib/assistant-config.js";
+import * as guardianToken from "../lib/guardian-token.js";
+import * as platformClient from "../lib/platform-client.js";
 
 const findAssistantByNameMock = spyOn(
   assistantConfig,
@@ -49,43 +54,72 @@ const removeAssistantEntryMock = spyOn(
   "removeAssistantEntry",
 ).mockImplementation(() => {});
 
-const loadGuardianTokenMock = mock((_id: string) => ({
+const loadGuardianTokenMock = spyOn(
+  guardianToken,
+  "loadGuardianToken",
+).mockReturnValue({
   accessToken: "local-token",
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
-}));
-const leaseGuardianTokenMock = mock(async () => ({
+} as unknown as ReturnType<typeof guardianToken.loadGuardianToken>);
+
+const leaseGuardianTokenMock = spyOn(
+  guardianToken,
+  "leaseGuardianToken",
+).mockResolvedValue({
   accessToken: "leased-token",
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
-}));
+} as unknown as Awaited<ReturnType<typeof guardianToken.leaseGuardianToken>>);
 
-mock.module("../lib/guardian-token.js", () => ({
-  loadGuardianToken: loadGuardianTokenMock,
-  leaseGuardianToken: leaseGuardianTokenMock,
-}));
+const readPlatformTokenMock = spyOn(
+  platformClient,
+  "readPlatformToken",
+).mockReturnValue("platform-token");
 
-const readPlatformTokenMock = mock((): string | null => "platform-token");
-const getPlatformUrlMock = mock(() => "https://platform.vellum.ai");
-const hatchAssistantMock = mock(async () => ({
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.vellum.ai");
+
+const hatchAssistantMock = spyOn(
+  platformClient,
+  "hatchAssistant",
+).mockResolvedValue({
   assistant: {
     id: "platform-new-id",
     name: "platform-new",
     status: "active",
   },
   reusedExisting: false,
-}));
-const platformInitiateExportMock = mock(async () => ({
+});
+
+const platformInitiateExportMock = spyOn(
+  platformClient,
+  "platformInitiateExport",
+).mockResolvedValue({
   jobId: "job-1",
   status: "pending",
-}));
-const platformPollExportStatusMock = mock(async () => ({
+});
+
+const platformPollExportStatusMock = spyOn(
+  platformClient,
+  "platformPollExportStatus",
+).mockResolvedValue({
   status: "complete" as string,
   downloadUrl: "https://cdn.example.com/bundle.tar.gz",
-}));
-const platformDownloadExportMock = mock(async () => {
+});
+
+const platformDownloadExportMock = spyOn(
+  platformClient,
+  "platformDownloadExport",
+).mockImplementation(async () => {
   const data = new Uint8Array([10, 20, 30]);
   return new Response(data, { status: 200 });
 });
-const platformImportPreflightMock = mock(async () => ({
+
+const platformImportPreflightMock = spyOn(
+  platformClient,
+  "platformImportPreflight",
+).mockResolvedValue({
   statusCode: 200,
   body: {
     can_import: true,
@@ -96,8 +130,12 @@ const platformImportPreflightMock = mock(async () => ({
       total_files: 3,
     },
   } as Record<string, unknown>,
-}));
-const platformImportBundleMock = mock(async () => ({
+});
+
+const platformImportBundleMock = spyOn(
+  platformClient,
+  "platformImportBundle",
+).mockResolvedValue({
   statusCode: 200,
   body: {
     success: true,
@@ -109,14 +147,26 @@ const platformImportBundleMock = mock(async () => ({
       backups_created: 1,
     },
   } as Record<string, unknown>,
-}));
-const platformRequestUploadUrlMock = mock(async () => ({
+});
+
+const platformRequestUploadUrlMock = spyOn(
+  platformClient,
+  "platformRequestUploadUrl",
+).mockResolvedValue({
   uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
   bundleKey: "bundle-key-123",
   expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-}));
-const platformUploadToSignedUrlMock = mock(async () => {});
-const platformImportPreflightFromGcsMock = mock(async () => ({
+});
+
+const platformUploadToSignedUrlMock = spyOn(
+  platformClient,
+  "platformUploadToSignedUrl",
+).mockResolvedValue(undefined);
+
+const platformImportPreflightFromGcsMock = spyOn(
+  platformClient,
+  "platformImportPreflightFromGcs",
+).mockResolvedValue({
   statusCode: 200,
   body: {
     can_import: true,
@@ -127,8 +177,12 @@ const platformImportPreflightFromGcsMock = mock(async () => ({
       total_files: 3,
     },
   } as Record<string, unknown>,
-}));
-const platformImportBundleFromGcsMock = mock(async () => ({
+});
+
+const platformImportBundleFromGcsMock = spyOn(
+  platformClient,
+  "platformImportBundleFromGcs",
+).mockResolvedValue({
   statusCode: 200,
   body: {
     success: true,
@@ -140,27 +194,12 @@ const platformImportBundleFromGcsMock = mock(async () => ({
       backups_created: 1,
     },
   } as Record<string, unknown>,
-}));
-const checkExistingPlatformAssistantMock = mock(
-  async (): Promise<{ id: string; name: string; status: string } | null> =>
-    null,
-);
+});
 
-mock.module("../lib/platform-client.js", () => ({
-  readPlatformToken: readPlatformTokenMock,
-  getPlatformUrl: getPlatformUrlMock,
-  hatchAssistant: hatchAssistantMock,
-  checkExistingPlatformAssistant: checkExistingPlatformAssistantMock,
-  platformInitiateExport: platformInitiateExportMock,
-  platformPollExportStatus: platformPollExportStatusMock,
-  platformDownloadExport: platformDownloadExportMock,
-  platformImportPreflight: platformImportPreflightMock,
-  platformImportBundle: platformImportBundleMock,
-  platformRequestUploadUrl: platformRequestUploadUrlMock,
-  platformUploadToSignedUrl: platformUploadToSignedUrlMock,
-  platformImportPreflightFromGcs: platformImportPreflightFromGcsMock,
-  platformImportBundleFromGcs: platformImportBundleFromGcsMock,
-}));
+const checkExistingPlatformAssistantMock = spyOn(
+  platformClient,
+  "checkExistingPlatformAssistant",
+).mockResolvedValue(null);
 
 const hatchLocalMock = mock(async () => {});
 
@@ -222,6 +261,21 @@ afterAll(() => {
   saveAssistantEntryMock.mockRestore();
   loadAllAssistantsMock.mockRestore();
   removeAssistantEntryMock.mockRestore();
+  loadGuardianTokenMock.mockRestore();
+  leaseGuardianTokenMock.mockRestore();
+  readPlatformTokenMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  hatchAssistantMock.mockRestore();
+  checkExistingPlatformAssistantMock.mockRestore();
+  platformInitiateExportMock.mockRestore();
+  platformPollExportStatusMock.mockRestore();
+  platformDownloadExportMock.mockRestore();
+  platformImportPreflightMock.mockRestore();
+  platformImportBundleMock.mockRestore();
+  platformRequestUploadUrlMock.mockRestore();
+  platformUploadToSignedUrlMock.mockRestore();
+  platformImportPreflightFromGcsMock.mockRestore();
+  platformImportBundleFromGcsMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });
@@ -249,7 +303,7 @@ beforeEach(() => {
   loadGuardianTokenMock.mockReturnValue({
     accessToken: "local-token",
     accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
-  });
+  } as unknown as ReturnType<typeof guardianToken.loadGuardianToken>);
   leaseGuardianTokenMock.mockReset();
 
   readPlatformTokenMock.mockReset();

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -7,8 +7,11 @@ import {
   readFileSync,
   writeFileSync,
 } from "fs";
-import { homedir, platform } from "os";
+import { platform } from "os";
 import { dirname, join } from "path";
+
+import { getConfigDir } from "./environments/paths.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
 
 const DEVICE_ID_SALT = "vellum-assistant-host-id";
 
@@ -24,14 +27,9 @@ export interface GuardianTokenData {
   leasedAt: string;
 }
 
-function getXdgConfigHome(): string {
-  return process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
-}
-
 function getGuardianTokenPath(assistantId: string): string {
   return join(
-    getXdgConfigHome(),
-    "vellum",
+    getConfigDir(getCurrentEnvironment()),
     "assistants",
     assistantId,
     "guardian-token.json",
@@ -39,7 +37,7 @@ function getGuardianTokenPath(assistantId: string): string {
 }
 
 function getPersistedDeviceIdPath(): string {
-  return join(getXdgConfigHome(), "vellum", "device-id");
+  return join(getConfigDir(getCurrentEnvironment()), "device-id");
 }
 
 function hashWithSalt(input: string): string {
@@ -82,7 +80,7 @@ function getWindowsMachineGuid(): string | null {
   }
 }
 
-function getOrCreatePersistedDeviceId(): string {
+export function getOrCreatePersistedDeviceId(): string {
   const path = getPersistedDeviceIdPath();
   try {
     const existing = readFileSync(path, "utf-8").trim();
@@ -161,7 +159,7 @@ export function saveGuardianToken(
 /**
  * Call POST /v1/guardian/init on the remote gateway to bootstrap a JWT
  * credential pair. The returned tokens are persisted locally under
- * `$XDG_CONFIG_HOME/vellum/assistants/<assistantId>/guardian-token.json`.
+ * `$XDG_CONFIG_HOME/vellum{-env}/assistants/<assistantId>/guardian-token.json`.
  */
 export async function leaseGuardianToken(
   gatewayUrl: string,

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -9,12 +9,11 @@ import {
 import { homedir } from "os";
 import { join, dirname } from "path";
 
-function getXdgConfigHome(): string {
-  return process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
-}
+import { getConfigDir } from "./environments/paths.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
 
 function getPlatformTokenPath(): string {
-  return join(getXdgConfigHome(), "vellum", "platform-token");
+  return join(getConfigDir(getCurrentEnvironment()), "platform-token");
 }
 
 export function getPlatformUrl(): string {


### PR DESCRIPTION
## Summary
- platform-client.ts and guardian-token.ts route through getConfigDir(env) instead of hardcoded 'vellum'
- Non-prod config lives at $XDG_CONFIG_HOME/vellum-<env>/... (platform-token, assistants/<id>/guardian-token.json, device-id)
- Production paths unchanged; 'vellum login' remains byte-identical for existing users

Part of plan: env-data-layout.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
