### PR TITLE
feat(environments): route CLI lockfile R/W and allocator through environment helpers; delete getDataDir

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -474,3 +474,127 @@ describe("legacy migration via loadAllAssistants", () => {
     );
   });
 });
+
+describe("env-scoped lockfile and migration", () => {
+  test("migrateLegacyEntry uses env-scoped multi-instance dir in non-prod", () => {
+    // GIVEN VELLUM_ENVIRONMENT=dev and an XDG_DATA_HOME override
+    const prevEnv = process.env.VELLUM_ENVIRONMENT;
+    const prevXdg = process.env.XDG_DATA_HOME;
+    const xdgDataHome = mkdtempSync(join(tmpdir(), "cli-xdg-data-"));
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    process.env.XDG_DATA_HOME = xdgDataHome;
+    try {
+      // AND a legacy local entry with no resources
+      const entry: Record<string, unknown> = {
+        assistantId: "dev-bot",
+        runtimeUrl: "http://localhost:7830",
+        cloud: "local",
+      };
+
+      // WHEN we migrate it
+      const changed = migrateLegacyEntry(entry);
+
+      // THEN resources.instanceDir points at the env-scoped multi-instance dir
+      expect(changed).toBe(true);
+      const resources = entry.resources as Record<string, unknown>;
+      expect(resources.instanceDir).toBe(
+        join(xdgDataHome, "vellum-dev", "assistants", "dev-bot"),
+      );
+    } finally {
+      if (prevEnv !== undefined) {
+        process.env.VELLUM_ENVIRONMENT = prevEnv;
+      } else {
+        delete process.env.VELLUM_ENVIRONMENT;
+      }
+      if (prevXdg !== undefined) {
+        process.env.XDG_DATA_HOME = prevXdg;
+      } else {
+        delete process.env.XDG_DATA_HOME;
+      }
+      rmSync(xdgDataHome, { recursive: true, force: true });
+    }
+  });
+
+  test("readLockfile/writeLockfile use $XDG_CONFIG_HOME/vellum-<env>/lockfile.json in non-prod", () => {
+    // The env package's xdgConfigHome() reads process.env.XDG_CONFIG_HOME
+    // fresh on every call, so redirecting via that env var works without
+    // mocking `os`. We temporarily unset VELLUM_LOCKFILE_DIR so the env
+    // package falls through to getConfigDir(env).
+    const prevEnv = process.env.VELLUM_ENVIRONMENT;
+    const prevXdgConfig = process.env.XDG_CONFIG_HOME;
+    const prevLockDir = process.env.VELLUM_LOCKFILE_DIR;
+    const xdgConfigHome = mkdtempSync(join(tmpdir(), "cli-xdg-config-"));
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    try {
+      // WHEN we save an assistant entry (which triggers writeLockfile)
+      saveAssistantEntry({
+        assistantId: "dev-env-bot",
+        runtimeUrl: "http://localhost:7830",
+        cloud: "local",
+      });
+
+      // THEN the lockfile lives at the env-scoped XDG config path
+      const expectedPath = join(xdgConfigHome, "vellum-dev", "lockfile.json");
+      const raw = JSON.parse(readFileSync(expectedPath, "utf-8"));
+      expect(raw.assistants).toHaveLength(1);
+      expect(raw.assistants[0].assistantId).toBe("dev-env-bot");
+
+      // AND readLockfile reads it back via loadAllAssistants()
+      const all = loadAllAssistants();
+      expect(all).toHaveLength(1);
+      expect(all[0].assistantId).toBe("dev-env-bot");
+    } finally {
+      if (prevEnv !== undefined) {
+        process.env.VELLUM_ENVIRONMENT = prevEnv;
+      } else {
+        delete process.env.VELLUM_ENVIRONMENT;
+      }
+      if (prevXdgConfig !== undefined) {
+        process.env.XDG_CONFIG_HOME = prevXdgConfig;
+      } else {
+        delete process.env.XDG_CONFIG_HOME;
+      }
+      if (prevLockDir !== undefined) {
+        process.env.VELLUM_LOCKFILE_DIR = prevLockDir;
+      }
+      rmSync(xdgConfigHome, { recursive: true, force: true });
+    }
+  });
+
+  test("production lockfile path is unchanged — uses .vellum.lock.json", () => {
+    // With VELLUM_ENVIRONMENT unset, the env package resolves production,
+    // whose canonical lockfile filename is `.vellum.lock.json`. This test
+    // uses the existing VELLUM_LOCKFILE_DIR=testDir override to route the
+    // lockfile to a scratch directory but verifies the FILENAME matches
+    // the production convention (not the non-prod "lockfile.json").
+    const prevEnv = process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_ENVIRONMENT;
+    try {
+      // Clear any existing lockfile from earlier tests
+      try {
+        rmSync(join(testDir, ".vellum.lock.json"));
+      } catch {
+        // ignore
+      }
+
+      saveAssistantEntry({
+        assistantId: "prod-bot",
+        runtimeUrl: "http://localhost:7830",
+        cloud: "local",
+      });
+
+      // The file should land at testDir/.vellum.lock.json — the production
+      // filename — rather than testDir/lockfile.json.
+      const prodPath = join(testDir, ".vellum.lock.json");
+      const raw = JSON.parse(readFileSync(prodPath, "utf-8"));
+      expect(raw.assistants).toHaveLength(1);
+      expect(raw.assistants[0].assistantId).toBe("prod-bot");
+    } finally {
+      if (prevEnv !== undefined) {
+        process.env.VELLUM_ENVIRONMENT = prevEnv;
+      }
+    }
+  });
+});

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -94,22 +94,69 @@ describe("multi-local", () => {
   });
 
   describe("allocateLocalResources() produces non-conflicting ports", () => {
-    test("first instance gets home directory and default ports", async () => {
-      // GIVEN no local assistants exist in the lockfile
+    test("first instance (prod) gets XDG multi-instance dir with default ports", async () => {
+      // GIVEN XDG_DATA_HOME points at a scratch directory and no local
+      // assistants exist in the lockfile
+      const prevXdg = process.env.XDG_DATA_HOME;
+      const xdgDataHome = mkdtempSync(join(tmpdir(), "cli-multi-xdg-data-"));
+      process.env.XDG_DATA_HOME = xdgDataHome;
+      try {
+        // WHEN we allocate resources for the first instance
+        const res = await allocateLocalResources("instance-a");
 
-      // WHEN we allocate resources for the first instance
-      const res = await allocateLocalResources("instance-a");
+        // THEN it lands under the XDG multi-instance dir (no "first = home"
+        // special case anymore)
+        expect(res.instanceDir).toBe(
+          join(xdgDataHome, "vellum", "assistants", "instance-a"),
+        );
 
-      // THEN it gets the home directory as its instance root
-      expect(res.instanceDir).toBe(testDir);
+        // AND it gets the default ports since no other instances exist
+        expect(res.daemonPort).toBe(DEFAULT_DAEMON_PORT);
+        expect(res.gatewayPort).toBe(DEFAULT_GATEWAY_PORT);
+        expect(res.qdrantPort).toBe(DEFAULT_QDRANT_PORT);
 
-      // AND it gets the default ports since no other instances exist
-      expect(res.daemonPort).toBe(DEFAULT_DAEMON_PORT);
-      expect(res.gatewayPort).toBe(DEFAULT_GATEWAY_PORT);
-      expect(res.qdrantPort).toBe(DEFAULT_QDRANT_PORT);
+        // AND the PID file is under the instance's .vellum/
+        expect(res.pidFile).toBe(
+          join(res.instanceDir, ".vellum", "vellum.pid"),
+        );
+      } finally {
+        if (prevXdg !== undefined) {
+          process.env.XDG_DATA_HOME = prevXdg;
+        } else {
+          delete process.env.XDG_DATA_HOME;
+        }
+        rmSync(xdgDataHome, { recursive: true, force: true });
+      }
+    });
 
-      // AND the PID file is under ~/.vellum/
-      expect(res.pidFile).toBe(join(testDir, ".vellum", "vellum.pid"));
+    test("first instance (dev) uses env-scoped multi-instance dir", async () => {
+      // GIVEN VELLUM_ENVIRONMENT=dev and XDG_DATA_HOME set to scratch
+      const prevEnv = process.env.VELLUM_ENVIRONMENT;
+      const prevXdg = process.env.XDG_DATA_HOME;
+      const xdgDataHome = mkdtempSync(join(tmpdir(), "cli-multi-xdg-dev-"));
+      process.env.VELLUM_ENVIRONMENT = "dev";
+      process.env.XDG_DATA_HOME = xdgDataHome;
+      try {
+        // WHEN we allocate resources for the first instance
+        const res = await allocateLocalResources("instance-a");
+
+        // THEN it lands under the env-scoped multi-instance dir
+        expect(res.instanceDir).toBe(
+          join(xdgDataHome, "vellum-dev", "assistants", "instance-a"),
+        );
+      } finally {
+        if (prevEnv !== undefined) {
+          process.env.VELLUM_ENVIRONMENT = prevEnv;
+        } else {
+          delete process.env.VELLUM_ENVIRONMENT;
+        }
+        if (prevXdg !== undefined) {
+          process.env.XDG_DATA_HOME = prevXdg;
+        } else {
+          delete process.env.XDG_DATA_HOME;
+        }
+        rmSync(xdgDataHome, { recursive: true, force: true });
+      }
     });
 
     test("second instance gets distinct ports and dir when first instance is saved", async () => {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 
 import {
   DAEMON_INTERNAL_ASSISTANT_ID,
@@ -16,8 +16,13 @@ import {
   DEFAULT_DAEMON_PORT,
   DEFAULT_GATEWAY_PORT,
   DEFAULT_QDRANT_PORT,
-  LOCKFILE_NAMES,
 } from "./constants.js";
+import {
+  getLockfilePath,
+  getLockfilePaths,
+  getMultiInstanceDir,
+} from "./environments/paths.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
 import { probePort } from "./port-probe.js";
 
 /**
@@ -27,10 +32,11 @@ import { probePort } from "./port-probe.js";
  */
 export interface LocalInstanceResources {
   /**
-   * Instance-specific data root. The first local assistant uses `~` (home
-   * directory) with default ports. Subsequent instances are placed under
-   * `~/.local/share/vellum/assistants/<name>/`.
-   * The daemon's `.vellum/` directory lives inside it.
+   * Instance-specific data root. New local assistants are placed under
+   * `$XDG_DATA_HOME/vellum{-env}/assistants/<name>/`. Legacy entries
+   * (pre env-data-layout) may still point at `~` — the read path honors
+   * whatever `instanceDir` is stored. The daemon's `.vellum/` directory
+   * lives inside it.
    */
   instanceDir: string;
   /** HTTP port for the daemon runtime server */
@@ -113,15 +119,8 @@ export function getBaseDir(): string {
   return process.env.BASE_DATA_DIR?.trim() || homedir();
 }
 
-/** The lockfile always lives under the home directory. */
-function getLockfileDir(): string {
-  return process.env.VELLUM_LOCKFILE_DIR?.trim() || homedir();
-}
-
 function readLockfile(): LockfileData {
-  const base = getLockfileDir();
-  const candidates = LOCKFILE_NAMES.map((name) => join(base, name));
-  for (const lockfilePath of candidates) {
+  for (const lockfilePath of getLockfilePaths(getCurrentEnvironment())) {
     if (!existsSync(lockfilePath)) continue;
     try {
       const raw = readFileSync(lockfilePath, "utf-8");
@@ -137,7 +136,8 @@ function readLockfile(): LockfileData {
 }
 
 function writeLockfile(data: LockfileData): void {
-  const lockfilePath = join(getLockfileDir(), LOCKFILE_NAMES[0]);
+  const lockfilePath = getLockfilePath(getCurrentEnvironment());
+  mkdirSync(dirname(lockfilePath), { recursive: true });
   const tmpPath = `${lockfilePath}.${randomBytes(4).toString("hex")}.tmp`;
   try {
     writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n");
@@ -186,6 +186,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     return false;
   }
 
+  const env = getCurrentEnvironment();
   let mutated = false;
 
   // Migrate top-level `baseDataDir` → `resources.instanceDir`
@@ -207,11 +208,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     const gatewayPort =
       parsePortFromUrl(raw.runtimeUrl) ?? DEFAULT_GATEWAY_PORT;
     const instanceDir = join(
-      homedir(),
-      ".local",
-      "share",
-      "vellum",
-      "assistants",
+      getMultiInstanceDir(env),
       typeof raw.assistantId === "string"
         ? raw.assistantId
         : DAEMON_INTERNAL_ASSISTANT_ID,
@@ -230,11 +227,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     const res = raw.resources as Record<string, unknown>;
     if (!res.instanceDir) {
       res.instanceDir = join(
-        homedir(),
-        ".local",
-        "share",
-        "vellum",
-        "assistants",
+        getMultiInstanceDir(env),
         typeof raw.assistantId === "string"
           ? raw.assistantId
           : DAEMON_INTERNAL_ASSISTANT_ID,
@@ -416,58 +409,32 @@ async function findAvailablePort(
 
 /**
  * Allocate an isolated set of resources for a named local instance.
- * The first local assistant uses the home directory with default ports.
- * Subsequent assistants are placed under
- * `~/.local/share/vellum/assistants/<name>/` with scanned ports.
+ * Every new local assistant is allocated under
+ * `$XDG_DATA_HOME/vellum{-env}/assistants/<name>/`. The legacy `~/.vellum/`
+ * path is only reached via existing lockfile entries from before this change
+ * — the read path honors whatever `resources.instanceDir` is stored, so
+ * production users' existing first-local assistants keep their `~/.vellum/`
+ * roots unchanged.
  */
 export async function allocateLocalResources(
   instanceName: string,
 ): Promise<LocalInstanceResources> {
-  // First local assistant gets the home directory with default ports.
-  // Respect BASE_DATA_DIR when set (e.g. in e2e tests) so the daemon,
-  // gateway, and credential store all resolve paths under the same root.
-  const existingLocals = loadAllAssistants().filter((e) => e.cloud === "local");
-  if (existingLocals.length === 0) {
-    const baseDir = getBaseDir();
-    const vellumDir = join(baseDir, ".vellum");
-    return {
-      instanceDir: baseDir,
-      daemonPort: DEFAULT_DAEMON_PORT,
-      gatewayPort: DEFAULT_GATEWAY_PORT,
-      qdrantPort: DEFAULT_QDRANT_PORT,
-      cesPort: DEFAULT_CES_PORT,
-      pidFile: join(vellumDir, "vellum.pid"),
-    };
-  }
-
-  const instanceDir = join(
-    homedir(),
-    ".local",
-    "share",
-    "vellum",
-    "assistants",
-    instanceName,
-  );
+  const env = getCurrentEnvironment();
+  const instanceDir = join(getMultiInstanceDir(env), instanceName);
   mkdirSync(instanceDir, { recursive: true });
 
   // Collect ports already assigned to other local instances in the lockfile.
-  // Even if those instances are stopped, we must avoid reusing their ports
-  // to prevent binding collisions when both are woken.
   const reservedPorts: number[] = [];
   for (const entry of loadAllAssistants()) {
-    if (entry.cloud !== "local") continue;
-    if (entry.resources) {
-      reservedPorts.push(
-        entry.resources.daemonPort,
-        entry.resources.gatewayPort,
-        entry.resources.qdrantPort,
-        entry.resources.cesPort,
-      );
-    }
+    if (entry.cloud !== "local" || !entry.resources) continue;
+    reservedPorts.push(
+      entry.resources.daemonPort,
+      entry.resources.gatewayPort,
+      entry.resources.qdrantPort,
+      entry.resources.cesPort,
+    );
   }
 
-  // Allocate ports sequentially to avoid overlapping ranges assigning the
-  // same port to multiple services (e.g. daemon 7821-7920 overlaps gateway 7830-7929).
   const daemonPort = await findAvailablePort(
     DEFAULT_DAEMON_PORT,
     reservedPorts,

--- a/cli/src/lib/environments/__tests__/paths.test.ts
+++ b/cli/src/lib/environments/__tests__/paths.test.ts
@@ -22,7 +22,6 @@ mock.module("os", () => ({
 // mock.module() calls above.
 const {
   getConfigDir,
-  getDataDir,
   getDefaultPorts,
   getLockfilePath,
   getLockfilePaths,
@@ -61,54 +60,6 @@ describe("path helpers", () => {
         process.env[key] = value;
       }
     }
-  });
-
-  describe("getDataDir", () => {
-    test("production returns legacy ~/.vellum/", () => {
-      expect(getDataDir(prod)).toBe(join(TEST_HOME, ".vellum"));
-    });
-
-    test("dev returns ~/.local/share/vellum-dev/ by default", () => {
-      expect(getDataDir(dev)).toBe(
-        join(TEST_HOME, ".local", "share", "vellum-dev"),
-      );
-    });
-
-    test("staging returns ~/.local/share/vellum-staging/ by default", () => {
-      const staging: EnvironmentDefinition = {
-        name: "staging",
-        platformUrl: "https://staging-platform.vellum.ai",
-      };
-      expect(getDataDir(staging)).toBe(
-        join(TEST_HOME, ".local", "share", "vellum-staging"),
-      );
-    });
-
-    test("respects XDG_DATA_HOME for non-prod envs", () => {
-      process.env.XDG_DATA_HOME = "/custom/data";
-      expect(getDataDir(dev)).toBe("/custom/data/vellum-dev");
-    });
-
-    test("XDG_DATA_HOME does not affect production (legacy path)", () => {
-      process.env.XDG_DATA_HOME = "/custom/data";
-      expect(getDataDir(prod)).toBe(join(TEST_HOME, ".vellum"));
-    });
-
-    test("respects env.dataDirOverride for production", () => {
-      const env: EnvironmentDefinition = {
-        ...prod,
-        dataDirOverride: "/tmp/test",
-      };
-      expect(getDataDir(env)).toBe("/tmp/test");
-    });
-
-    test("respects env.dataDirOverride for non-prod", () => {
-      const env: EnvironmentDefinition = {
-        ...dev,
-        dataDirOverride: "/tmp/test",
-      };
-      expect(getDataDir(env)).toBe("/tmp/test");
-    });
   });
 
   describe("getConfigDir", () => {

--- a/cli/src/lib/environments/paths.ts
+++ b/cli/src/lib/environments/paths.ts
@@ -26,20 +26,6 @@ const DEFAULT_PORTS: Readonly<PortMap> = {
 };
 
 /**
- * Root data directory for an environment.
- * Production is grandfathered at `~/.vellum/` to preserve backward compatibility;
- * non-production environments use `$XDG_DATA_HOME/vellum-<env>/`.
- */
-export function getDataDir(env: EnvironmentDefinition): string {
-  if (env.dataDirOverride) return env.dataDirOverride;
-  // `production` is the legacy-compat alias; it keeps its pre-plan path.
-  if (env.name === PRODUCTION_ENVIRONMENT_NAME) {
-    return join(homedir(), ".vellum");
-  }
-  return join(xdgDataHome(), `vellum-${env.name}`);
-}
-
-/**
  * Config directory for an environment.
  * Production preserves the existing `~/.config/vellum/` location;
  * non-production environments use `$XDG_CONFIG_HOME/vellum-<env>/`.

--- a/cli/src/lib/environments/resolve.ts
+++ b/cli/src/lib/environments/resolve.ts
@@ -30,7 +30,7 @@ export function getSeed(name: string): EnvironmentDefinition | undefined {
  *   - `VELLUM_PLATFORM_URL` overrides `platformUrl`
  *   - `VELLUM_ASSISTANT_PLATFORM_URL` overrides `assistantPlatformUrl`
  *   - `VELLUM_LOCKFILE_DIR` overrides `lockfileDirOverride` (legacy e2e
- *     test hook used by `cli/src/lib/assistant-config.ts:getLockfileDir`)
+ *     test hook)
  *
  * This function should be the single entrypoint for environment resolution.
  * No other code should drive off `VELLUM_ENVIRONMENT` directly.

--- a/cli/src/lib/environments/types.ts
+++ b/cli/src/lib/environments/types.ts
@@ -48,17 +48,13 @@ export interface EnvironmentDefinition {
   /** Per-service port overrides merged on top of defaults. */
   portsOverride?: Partial<PortMap>;
 
-  /** Override for the data directory root (e.g. used by e2e tests). */
-  dataDirOverride?: string;
-
   /** Override for the XDG config directory. */
   configDirOverride?: string;
 
   /**
    * Override for the directory containing the lockfile. Populated by the
-   * resolver from `VELLUM_LOCKFILE_DIR` (an existing e2e test escape hatch
-   * — see `cli/src/lib/assistant-config.ts:getLockfileDir`) so path helpers
-   * don't read env vars directly.
+   * resolver from `VELLUM_LOCKFILE_DIR` (an existing e2e test escape hatch)
+   * so path helpers don't read env vars directly.
    */
   lockfileDirOverride?: string;
 }

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -312,20 +312,9 @@ export async function hatchLocal(
   }
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram, Twilio) are configured.
-  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
-  const prevBaseDataDir = process.env.BASE_DATA_DIR;
-  process.env.BASE_DATA_DIR = resources.instanceDir;
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
-  if (ngrokChild?.pid) {
-    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
-    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
-  }
-  if (prevBaseDataDir !== undefined) {
-    process.env.BASE_DATA_DIR = prevBaseDataDir;
-  } else {
-    delete process.env.BASE_DATA_DIR;
-  }
-
+  // Set BASE_DATA_DIR so ngrok reads the correct instance config. Keep the
+  // lockfile save/sync inside the same scope so syncConfigToLockfile() reads
+  // this instance's workspace/config.json rather than a stale default path.
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,
@@ -335,10 +324,27 @@ export async function hatchLocal(
     hatchedAt: new Date().toISOString(),
     resources: { ...resources, signingKey },
   };
-  emitProgress(7, 7, "Saving configuration...");
-  saveAssistantEntry(localEntry);
-  setActiveAssistant(instanceName);
-  syncConfigToLockfile();
+
+  const prevBaseDataDir = process.env.BASE_DATA_DIR;
+  process.env.BASE_DATA_DIR = resources.instanceDir;
+  try {
+    const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+    if (ngrokChild?.pid) {
+      const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+      writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+    }
+
+    emitProgress(7, 7, "Saving configuration...");
+    saveAssistantEntry(localEntry);
+    setActiveAssistant(instanceName);
+    syncConfigToLockfile();
+  } finally {
+    if (prevBaseDataDir !== undefined) {
+      process.env.BASE_DATA_DIR = prevBaseDataDir;
+    } else {
+      delete process.env.BASE_DATA_DIR;
+    }
+  }
 
   if (process.env.VELLUM_DESKTOP_APP) {
     installCLISymlink();


### PR DESCRIPTION
## Summary
- Lockfile R/W routes through getLockfilePath(env) — non-prod lockfile now lives in $XDG_CONFIG_HOME/vellum-<env>/lockfile.json
- allocateLocalResources always uses getMultiInstanceDir(env) — no 'first local = homedir' special case; new production hatches land in ~/.local/share/vellum/assistants/<name>/
- Delete getDataDir(env) from the env package (confused abstraction; no consumers after this PR)
- Move syncConfigToLockfile call in hatch-local.ts inside the BASE_DATA_DIR scope so it reads the correct workspace/config.json

Part of plan: env-data-layout.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
