### PR TITLE
feat: add priorTurnContentHeight to TranscriptRowModel for dynamic minHeight

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -150,6 +150,19 @@ enum TranscriptProjector {
             && !hasActiveToolCall
             && !canInlineProcessing
 
+        // --- Compute prior-turn content heights for dynamic minHeight ---
+
+        let lastUserIdx = visibleMessages.lastIndex(where: { $0.role == .user })
+        var priorTurnHeightByIndex: [Int: CGFloat] = [:]
+        var accumulatedHeight: CGFloat = 0
+        for i in visibleMessages.indices {
+            let isInCurrentTurn = lastUserIdx.map { i > $0 } ?? true
+            if isInCurrentTurn && visibleMessages[i].role == .assistant {
+                priorTurnHeightByIndex[i] = accumulatedHeight
+                accumulatedHeight += Self.estimateAssistantRowHeight(visibleMessages[i])
+            }
+        }
+
         // --- Build row models ---
 
         var rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
@@ -162,7 +175,8 @@ enum TranscriptProjector {
                 index: index,
                 decidedConfirmation: nextDecidedConfirmationByIndex[index],
                 isConfirmationRenderedInline: isConfirmationRenderedInlineByIndex.contains(index),
-                isAnchoredThinkingRow: index == anchoredThinkingIndex
+                isAnchoredThinkingRow: index == anchoredThinkingIndex,
+                priorTurnContentHeight: priorTurnHeightByIndex[index] ?? 0
             )
         }
 
@@ -186,7 +200,8 @@ enum TranscriptProjector {
                 decidedConfirmation: nil,
                 isConfirmationRenderedInline: false,
                 isAnchoredThinkingRow: false,
-                isThinkingPlaceholder: true
+                isThinkingPlaceholder: true,
+                priorTurnContentHeight: accumulatedHeight
             )
             rows.append(placeholder)
         }
@@ -227,6 +242,19 @@ enum TranscriptProjector {
             }
         }
         return result
+    }
+
+    // MARK: - Height estimation
+
+    /// Estimate the rendered height of an assistant message row.
+    private static func estimateAssistantRowHeight(_ message: ChatMessage) -> CGFloat {
+        if message.confirmation != nil {
+            return 150
+        }
+        let toolCallHeight = CGFloat(message.toolCalls.count) * 60
+        let textLines = max(1, CGFloat(message.text.count) / 60)
+        let textHeight = min(textLines * 20, 200)
+        return toolCallHeight + textHeight + 40
     }
 
     // MARK: - Thinking anchor

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -108,4 +108,9 @@ struct TranscriptRowModel: Equatable, Identifiable {
     /// inside the ForEach so it shares the same minHeight wrapper that
     /// will later hold the real assistant message.
     var isThinkingPlaceholder: Bool = false
+
+    /// Estimated total height of all rows above this one in the current
+    /// assistant turn. Used to shrink the minHeight wrapper so the total
+    /// turn content fits the viewport without pushing the user message off-screen.
+    var priorTurnContentHeight: CGFloat = 0
 }


### PR DESCRIPTION
## Summary
- Add priorTurnContentHeight to TranscriptRowModel
- Compute accumulated turn heights in TranscriptProjector
- Add estimateAssistantRowHeight helper for height estimation

Part of plan: dynamic-turn-minheight.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
