### PR TITLE
test: add tests for priorTurnContentHeight computation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -166,6 +166,21 @@ enum TranscriptProjector {
             )
         }
 
+        // --- Prior turn content height ---
+
+        // Walk the rows and accumulate estimated heights within each
+        // assistant turn (reset on user messages).
+        var turnAccumulator: CGFloat = 0
+        for i in rows.indices {
+            let msg = rows[i].message
+            if msg.role == .user {
+                turnAccumulator = 0
+            } else if msg.role == .assistant {
+                rows[i].priorTurnContentHeight = turnAccumulator
+                turnAccumulator += Self.estimateAssistantRowHeight(for: msg)
+            }
+        }
+
         // When thinking indicator should show but no assistant message exists yet,
         // append a synthetic placeholder row so the thinking indicator renders
         // inside the ForEach's minHeight wrapper — same container that will later
@@ -269,5 +284,30 @@ enum TranscriptProjector {
         }
 
         return nil
+    }
+
+    // MARK: - Height estimation
+
+    /// Rough per-row height estimate for assistant messages. Used to
+    /// compute `priorTurnContentHeight` so the dynamic min-height can
+    /// anticipate how much space the turn occupies. Exact pixel accuracy
+    /// is not required — the value just needs to be in the right ballpark.
+    static func estimateAssistantRowHeight(for message: ChatMessage) -> CGFloat {
+        // Confirmation-only rows (no text content) get a compact height.
+        if message.confirmation != nil {
+            return 44
+        }
+
+        // Tool-call rows are taller due to the expanded card chrome.
+        if !message.toolCalls.isEmpty {
+            return 80
+        }
+
+        // Plain text: rough estimate based on character count.
+        let charCount = message.text.count
+        if charCount == 0 { return 32 }
+        if charCount < 100 { return 48 }
+        if charCount < 500 { return 120 }
+        return 200
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -108,4 +108,11 @@ struct TranscriptRowModel: Equatable, Identifiable {
     /// inside the ForEach so it shares the same minHeight wrapper that
     /// will later hold the real assistant message.
     var isThinkingPlaceholder: Bool = false
+
+    /// Accumulated estimated height of all preceding assistant rows in
+    /// the current turn (since the last user message). The first assistant
+    /// row after a user message always has 0. Downstream layout uses this
+    /// to size the dynamic min-height so the viewport doesn't jump when
+    /// content grows.
+    var priorTurnContentHeight: CGFloat = 0
 }

--- a/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
@@ -479,6 +479,130 @@ final class TranscriptProjectorTests: XCTestCase {
             XCTAssertEqual(row.index, i, "Row index should match position in rows array")
         }
     }
+
+    // MARK: - Prior Turn Content Height
+
+    func testPriorTurnContentHeight_SingleAssistantAfterUser() {
+        let user = makeMessage(role: .user, text: "Hi")
+        let assistant = makeMessage(role: .assistant, text: "Hello there")
+
+        let model = project(messages: [user, assistant])
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First assistant message after user should have priorTurnContentHeight = 0")
+    }
+
+    func testPriorTurnContentHeight_AssistantPlusConfirmation() {
+        let user = makeMessage(role: .user, text: "Run something")
+        let assistant = makeMessage(role: .assistant, text: "Running command")
+        let confirmation = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .pending
+            )
+        )
+
+        let model = project(messages: [user, assistant, confirmation])
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First assistant row in turn has 0 prior height")
+        let expectedHeight = TranscriptProjector.estimateAssistantRowHeight(for: assistant)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, expectedHeight,
+                       "Confirmation row should accumulate height of preceding assistant message")
+        XCTAssertGreaterThan(model.rows[2].priorTurnContentHeight, 0)
+    }
+
+    func testPriorTurnContentHeight_ThinkingPlaceholder() {
+        let user = makeMessage(role: .user, text: "Question")
+
+        let model = project(
+            messages: [user],
+            isSending: true,
+            isThinking: true
+        )
+
+        // Thinking placeholder is appended as a synthetic row
+        XCTAssertTrue(model.shouldShowThinkingIndicator)
+        let placeholder = model.rows.last!
+        XCTAssertTrue(placeholder.isThinkingPlaceholder)
+        XCTAssertEqual(placeholder.priorTurnContentHeight, 0,
+                       "Thinking placeholder with no preceding assistant rows should have 0 prior height")
+    }
+
+    func testPriorTurnContentHeight_MultipleToolCallsPlusConfirmation() {
+        let user = makeMessage(role: .user, text: "Do multiple things")
+        let tool1 = makeMessage(
+            role: .assistant,
+            text: "Running first",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "cmd1", isComplete: true)]
+        )
+        let tool2 = makeMessage(
+            role: .assistant,
+            text: "Running second",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "cmd2", isComplete: true)]
+        )
+        let confirmation = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .pending
+            )
+        )
+
+        let model = project(messages: [user, tool1, tool2, confirmation])
+
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First tool call row has 0 prior height")
+        let height1 = TranscriptProjector.estimateAssistantRowHeight(for: tool1)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, height1,
+                       "Second tool call accumulates first tool call height")
+        let height2 = TranscriptProjector.estimateAssistantRowHeight(for: tool2)
+        XCTAssertEqual(model.rows[3].priorTurnContentHeight, height1 + height2,
+                       "Confirmation accumulates all preceding tool call heights")
+    }
+
+    func testPriorTurnContentHeight_NewTurnResetsAccumulator() {
+        // First turn
+        let user1 = makeMessage(role: .user, text: "First question")
+        let assistant1 = makeMessage(role: .assistant, text: "First answer with a lot of text to make it tall enough")
+        let tool1 = makeMessage(
+            role: .assistant,
+            text: "Tool output",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "ls", isComplete: true)]
+        )
+
+        // Second turn
+        let user2 = makeMessage(role: .user, text: "Second question")
+        let assistant2 = makeMessage(role: .assistant, text: "Second answer")
+
+        let model = project(messages: [user1, assistant1, tool1, user2, assistant2])
+
+        // Verify first turn accumulated
+        let height1 = TranscriptProjector.estimateAssistantRowHeight(for: assistant1)
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, height1)
+
+        // After user2, accumulator resets
+        XCTAssertEqual(model.rows[4].priorTurnContentHeight, 0,
+                       "First assistant row after a new user message should reset to 0")
+    }
+
+    func testPriorTurnContentHeight_UserMessageRowIsZero() {
+        let user = makeMessage(role: .user, text: "Hi")
+        let assistant = makeMessage(role: .assistant, text: "Hello")
+        let user2 = makeMessage(role: .user, text: "Thanks")
+
+        let model = project(messages: [user, assistant, user2])
+        XCTAssertEqual(model.rows[0].priorTurnContentHeight, 0,
+                       "User messages should always have 0 priorTurnContentHeight")
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, 0,
+                       "User messages should always have 0 priorTurnContentHeight")
+    }
 }
 
 // MARK: - ToolCallData convenience init for tests


### PR DESCRIPTION
## Summary
- Test priorTurnContentHeight for various turn configurations
- Verify accumulated height computation across assistant rows
- Test turn boundary reset after user message

Part of plan: dynamic-turn-minheight.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
