### PR TITLE
fix: subtract prior turn content from minHeight to prevent confirmation scroll jump

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -125,7 +125,7 @@ let turnMinHeight = containerHeight - composerHeight - estimatedUserHeight - lay
 - **Uses `containerHeight`** (full chat pane from GeometryReader), NOT `scrollState.viewportHeight`. The viewport height fluctuates when the composer resizes — the container height is stable.
 - **Composer is static 80pt.** We only care about the composer height when it's empty (after the user hits send). It grows when typing, but by then minHeight doesn't matter.
 - **User message estimated via `NSString.boundingRect`** for word-wrap accuracy. Cell overhead is 100pt (bubble padding 24 + timestamp 24 + spacing 12 + show more button 30 + gradient 10). Capped at 260pt (collapse threshold + overhead).
-- **MinHeight applies when `row.isLatestAssistant && row.message.id == state.rows.last?.message.id`.** No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
+- **MinHeight applies when `row.isLatestAssistant || row.isThinkingPlaceholder`.** Each row's effective minHeight is `max(0, turnMinHeight - row.priorTurnContentHeight)` so the total turn height stays consistent as new rows (e.g. confirmation bubbles) accumulate. No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -208,17 +208,18 @@ struct MessageListContentView: View, Equatable {
                 .equatable()
             }
         }
-        // Latest assistant message (or thinking placeholder): wrap in
-        // VStack with minHeight so user message sits at top. The same
-        // wrapper applies to both the placeholder and the real assistant
-        // message, eliminating layout jump on transition.
-        .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
+        // Latest assistant row (or thinking placeholder): wrap in VStack
+        // with minHeight so user message stays pinned at the top of the
+        // viewport. minHeight shrinks by priorTurnContentHeight so the
+        // total turn height stays consistent as new rows (e.g.
+        // confirmation bubbles) accumulate below the assistant message.
+        .if(row.isLatestAssistant || row.isThinkingPlaceholder) { view in
             VStack(spacing: 0) {
                 view
                 Color.clear.frame(height: 1)
                     .id("active-turn-content-bottom")
             }
-            .frame(minHeight: turnMinHeight, alignment: .top)
+            .frame(minHeight: max(0, turnMinHeight - row.priorTurnContentHeight), alignment: .top)
         }
     }
 


### PR DESCRIPTION
## Summary
- Change minHeight condition: `row.isLatestAssistant || row.isThinkingPlaceholder` instead of `state.rows.last` check
- Subtract `priorTurnContentHeight` from minHeight for each row
- Confirmation bubbles no longer steal full minHeight
- Update SCROLL_STRATEGY.md to reflect new behavior

Part of plan: dynamic-turn-minheight.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
