### PR TITLE
fix: dynamic turn minHeight — prevent confirmation scroll jump

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -125,7 +125,7 @@ let turnMinHeight = containerHeight - composerHeight - estimatedUserHeight - lay
 - **Uses `containerHeight`** (full chat pane from GeometryReader), NOT `scrollState.viewportHeight`. The viewport height fluctuates when the composer resizes — the container height is stable.
 - **Composer is static 80pt.** We only care about the composer height when it's empty (after the user hits send). It grows when typing, but by then minHeight doesn't matter.
 - **User message estimated via `NSString.boundingRect`** for word-wrap accuracy. Cell overhead is 100pt (bubble padding 24 + timestamp 24 + spacing 12 + show more button 30 + gradient 10). Capped at 260pt (collapse threshold + overhead).
-- **MinHeight applies when `row.isLatestAssistant && row.message.id == state.rows.last?.message.id`.** No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
+- **MinHeight applies when `row.isLatestAssistant || row.isThinkingPlaceholder`.** Each row's effective minHeight is `max(0, turnMinHeight - row.priorTurnContentHeight)` so the total turn height stays consistent as new rows (e.g. confirmation bubbles) accumulate. No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -208,17 +208,18 @@ struct MessageListContentView: View, Equatable {
                 .equatable()
             }
         }
-        // Latest assistant message (or thinking placeholder): wrap in
-        // VStack with minHeight so user message sits at top. The same
-        // wrapper applies to both the placeholder and the real assistant
-        // message, eliminating layout jump on transition.
-        .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
+        // Latest assistant row (or thinking placeholder): wrap in VStack
+        // with minHeight so user message stays pinned at the top of the
+        // viewport. minHeight shrinks by priorTurnContentHeight so the
+        // total turn height stays consistent as new rows (e.g.
+        // confirmation bubbles) accumulate below the assistant message.
+        .if(row.isLatestAssistant || row.isThinkingPlaceholder) { view in
             VStack(spacing: 0) {
                 view
                 Color.clear.frame(height: 1)
                     .id("active-turn-content-bottom")
             }
-            .frame(minHeight: turnMinHeight, alignment: .top)
+            .frame(minHeight: max(0, turnMinHeight - row.priorTurnContentHeight), alignment: .top)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -150,6 +150,19 @@ enum TranscriptProjector {
             && !hasActiveToolCall
             && !canInlineProcessing
 
+        // --- Compute prior-turn content heights for dynamic minHeight ---
+
+        let lastUserIdx = visibleMessages.lastIndex(where: { $0.role == .user })
+        var priorTurnHeightByIndex: [Int: CGFloat] = [:]
+        var accumulatedHeight: CGFloat = 0
+        for i in visibleMessages.indices {
+            let isInCurrentTurn = lastUserIdx.map { i > $0 } ?? true
+            if isInCurrentTurn && visibleMessages[i].role == .assistant {
+                priorTurnHeightByIndex[i] = accumulatedHeight
+                accumulatedHeight += Self.estimateAssistantRowHeight(visibleMessages[i])
+            }
+        }
+
         // --- Build row models ---
 
         var rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
@@ -162,7 +175,8 @@ enum TranscriptProjector {
                 index: index,
                 decidedConfirmation: nextDecidedConfirmationByIndex[index],
                 isConfirmationRenderedInline: isConfirmationRenderedInlineByIndex.contains(index),
-                isAnchoredThinkingRow: index == anchoredThinkingIndex
+                isAnchoredThinkingRow: index == anchoredThinkingIndex,
+                priorTurnContentHeight: priorTurnHeightByIndex[index] ?? 0
             )
         }
 
@@ -186,7 +200,8 @@ enum TranscriptProjector {
                 decidedConfirmation: nil,
                 isConfirmationRenderedInline: false,
                 isAnchoredThinkingRow: false,
-                isThinkingPlaceholder: true
+                isThinkingPlaceholder: true,
+                priorTurnContentHeight: accumulatedHeight
             )
             rows.append(placeholder)
         }
@@ -227,6 +242,19 @@ enum TranscriptProjector {
             }
         }
         return result
+    }
+
+    // MARK: - Height estimation
+
+    /// Estimate the rendered height of an assistant message row.
+    private static func estimateAssistantRowHeight(_ message: ChatMessage) -> CGFloat {
+        if message.confirmation != nil {
+            return 150
+        }
+        let toolCallHeight = CGFloat(message.toolCalls.count) * 60
+        let textLines = max(1, CGFloat(message.text.count) / 60)
+        let textHeight = min(textLines * 20, 200)
+        return toolCallHeight + textHeight + 40
     }
 
     // MARK: - Thinking anchor

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -180,6 +180,21 @@ enum TranscriptProjector {
             )
         }
 
+        // --- Prior turn content height ---
+
+        // Walk the rows and accumulate estimated heights within each
+        // assistant turn (reset on user messages).
+        var turnAccumulator: CGFloat = 0
+        for i in rows.indices {
+            let msg = rows[i].message
+            if msg.role == .user {
+                turnAccumulator = 0
+            } else if msg.role == .assistant {
+                rows[i].priorTurnContentHeight = turnAccumulator
+                turnAccumulator += Self.estimateAssistantRowHeight(for: msg)
+            }
+        }
+
         // When thinking indicator should show but no assistant message exists yet,
         // append a synthetic placeholder row so the thinking indicator renders
         // inside the ForEach's minHeight wrapper — same container that will later
@@ -297,5 +312,30 @@ enum TranscriptProjector {
         }
 
         return nil
+    }
+
+    // MARK: - Height estimation
+
+    /// Rough per-row height estimate for assistant messages. Used to
+    /// compute `priorTurnContentHeight` so the dynamic min-height can
+    /// anticipate how much space the turn occupies. Exact pixel accuracy
+    /// is not required — the value just needs to be in the right ballpark.
+    static func estimateAssistantRowHeight(for message: ChatMessage) -> CGFloat {
+        // Confirmation-only rows (no text content) get a compact height.
+        if message.confirmation != nil {
+            return 44
+        }
+
+        // Tool-call rows are taller due to the expanded card chrome.
+        if !message.toolCalls.isEmpty {
+            return 80
+        }
+
+        // Plain text: rough estimate based on character count.
+        let charCount = message.text.count
+        if charCount == 0 { return 32 }
+        if charCount < 100 { return 48 }
+        if charCount < 500 { return 120 }
+        return 200
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -108,4 +108,9 @@ struct TranscriptRowModel: Equatable, Identifiable {
     /// inside the ForEach so it shares the same minHeight wrapper that
     /// will later hold the real assistant message.
     var isThinkingPlaceholder: Bool = false
+
+    /// Estimated total height of all rows above this one in the current
+    /// assistant turn. Used to shrink the minHeight wrapper so the total
+    /// turn content fits the viewport without pushing the user message off-screen.
+    var priorTurnContentHeight: CGFloat = 0
 }

--- a/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
@@ -479,6 +479,130 @@ final class TranscriptProjectorTests: XCTestCase {
             XCTAssertEqual(row.index, i, "Row index should match position in rows array")
         }
     }
+
+    // MARK: - Prior Turn Content Height
+
+    func testPriorTurnContentHeight_SingleAssistantAfterUser() {
+        let user = makeMessage(role: .user, text: "Hi")
+        let assistant = makeMessage(role: .assistant, text: "Hello there")
+
+        let model = project(messages: [user, assistant])
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First assistant message after user should have priorTurnContentHeight = 0")
+    }
+
+    func testPriorTurnContentHeight_AssistantPlusConfirmation() {
+        let user = makeMessage(role: .user, text: "Run something")
+        let assistant = makeMessage(role: .assistant, text: "Running command")
+        let confirmation = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .pending
+            )
+        )
+
+        let model = project(messages: [user, assistant, confirmation])
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First assistant row in turn has 0 prior height")
+        let expectedHeight = TranscriptProjector.estimateAssistantRowHeight(for: assistant)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, expectedHeight,
+                       "Confirmation row should accumulate height of preceding assistant message")
+        XCTAssertGreaterThan(model.rows[2].priorTurnContentHeight, 0)
+    }
+
+    func testPriorTurnContentHeight_ThinkingPlaceholder() {
+        let user = makeMessage(role: .user, text: "Question")
+
+        let model = project(
+            messages: [user],
+            isSending: true,
+            isThinking: true
+        )
+
+        // Thinking placeholder is appended as a synthetic row
+        XCTAssertTrue(model.shouldShowThinkingIndicator)
+        let placeholder = model.rows.last!
+        XCTAssertTrue(placeholder.isThinkingPlaceholder)
+        XCTAssertEqual(placeholder.priorTurnContentHeight, 0,
+                       "Thinking placeholder with no preceding assistant rows should have 0 prior height")
+    }
+
+    func testPriorTurnContentHeight_MultipleToolCallsPlusConfirmation() {
+        let user = makeMessage(role: .user, text: "Do multiple things")
+        let tool1 = makeMessage(
+            role: .assistant,
+            text: "Running first",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "cmd1", isComplete: true)]
+        )
+        let tool2 = makeMessage(
+            role: .assistant,
+            text: "Running second",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "cmd2", isComplete: true)]
+        )
+        let confirmation = makeMessage(
+            role: .assistant,
+            text: "",
+            confirmation: ToolConfirmationData(
+                requestId: "req-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                state: .pending
+            )
+        )
+
+        let model = project(messages: [user, tool1, tool2, confirmation])
+
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0,
+                       "First tool call row has 0 prior height")
+        let height1 = TranscriptProjector.estimateAssistantRowHeight(for: tool1)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, height1,
+                       "Second tool call accumulates first tool call height")
+        let height2 = TranscriptProjector.estimateAssistantRowHeight(for: tool2)
+        XCTAssertEqual(model.rows[3].priorTurnContentHeight, height1 + height2,
+                       "Confirmation accumulates all preceding tool call heights")
+    }
+
+    func testPriorTurnContentHeight_NewTurnResetsAccumulator() {
+        // First turn
+        let user1 = makeMessage(role: .user, text: "First question")
+        let assistant1 = makeMessage(role: .assistant, text: "First answer with a lot of text to make it tall enough")
+        let tool1 = makeMessage(
+            role: .assistant,
+            text: "Tool output",
+            toolCalls: [ToolCallData(toolName: "bash", inputSummary: "ls", isComplete: true)]
+        )
+
+        // Second turn
+        let user2 = makeMessage(role: .user, text: "Second question")
+        let assistant2 = makeMessage(role: .assistant, text: "Second answer")
+
+        let model = project(messages: [user1, assistant1, tool1, user2, assistant2])
+
+        // Verify first turn accumulated
+        let height1 = TranscriptProjector.estimateAssistantRowHeight(for: assistant1)
+        XCTAssertEqual(model.rows[1].priorTurnContentHeight, 0)
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, height1)
+
+        // After user2, accumulator resets
+        XCTAssertEqual(model.rows[4].priorTurnContentHeight, 0,
+                       "First assistant row after a new user message should reset to 0")
+    }
+
+    func testPriorTurnContentHeight_UserMessageRowIsZero() {
+        let user = makeMessage(role: .user, text: "Hi")
+        let assistant = makeMessage(role: .assistant, text: "Hello")
+        let user2 = makeMessage(role: .user, text: "Thanks")
+
+        let model = project(messages: [user, assistant, user2])
+        XCTAssertEqual(model.rows[0].priorTurnContentHeight, 0,
+                       "User messages should always have 0 priorTurnContentHeight")
+        XCTAssertEqual(model.rows[2].priorTurnContentHeight, 0,
+                       "User messages should always have 0 priorTurnContentHeight")
+    }
 }
 
 // MARK: - ToolCallData convenience init for tests


### PR DESCRIPTION
## Summary
When a confirmation bubble appears during an active turn, the minHeight wrapper used to jump to it (because it became the latest assistant row with `state.rows.last` check). This pushed the user message off-screen. Fix: each assistant row carries `priorTurnContentHeight` — the sum of estimated heights of all rows above it in the current turn. The view subtracts this from minHeight, so the total turn height stays consistent.

## PRs merged into feature branch
- #25460: Add priorTurnContentHeight to TranscriptRowModel + projector computation
- #25461: Tests for priorTurnContentHeight computation (6 test cases)
- #25462: View layer fix — subtract priorTurnContentHeight from minHeight

## Test plan
- [ ] Send a message that triggers a tool confirmation — user message should stay visible
- [ ] Multiple confirmations in sequence — minHeight shrinks proportionally
- [ ] Normal messages without confirmations — no behavior change
- [ ] Thinking indicator → assistant transition — no layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
