### PR TITLE
feat: add `chat-message-queue` feature flag to registry (default false)

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -344,6 +344,14 @@
       "label": "Home Tab",
       "description": "Replace the knowledge graph top-level tab with a new Home page showing relationship progression, facts, and capability tiers",
       "defaultEnabled": false
+    },
+    {
+      "id": "chat-message-queue",
+      "scope": "assistant",
+      "key": "chat-message-queue",
+      "label": "Chat Message Queue",
+      "description": "Queue incoming messages while the assistant is processing instead of rejecting them, and buffer messages offline for automatic replay on reconnect",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new `chat-message-queue` assistant-scope feature flag to the unified registry
- Defaults to `false` — message queuing is disabled unless explicitly enabled
- Readable by both the daemon (isAssistantFeatureFlagEnabled) and macOS client (AssistantFeatureFlagStore)

Part of plan: chat-msg-queue-flag.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
