### PR TITLE
feat: gate daemon message queue behind `chat-message-queue` feature flag

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,6 +8,8 @@
 import { v4 as uuid } from "uuid";
 
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -227,6 +229,16 @@ export function enqueueMessage(
 ): { queued: boolean; requestId: string; rejected?: boolean } {
   if (!ctx.processing) {
     return { queued: false, requestId };
+  }
+
+  if (!isAssistantFeatureFlagEnabled("chat-message-queue", getConfig())) {
+    onEvent({
+      type: "error",
+      message:
+        "The assistant is busy processing another message. Please wait for it to finish before sending a new one.",
+      category: "queue_disabled",
+    });
+    return { queued: false, requestId, rejected: true };
   }
 
   const turnChannelContext =


### PR DESCRIPTION
## Summary
- Gates the daemon-side MessageQueue enqueuing behind the `chat-message-queue` feature flag
- When disabled (default), messages sent while the agent is busy are rejected with a `queue_disabled` error
- When enabled, existing queuing behavior is preserved unchanged

Part of plan: chat-msg-queue-flag.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
