### PR TITLE
fix: differentiate queue_disabled from queue_full in HTTP response

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -226,7 +226,12 @@ export function enqueueMessage(
   options?: { isInteractive?: boolean },
   displayContent?: string,
   transport?: ConversationTransportMetadata,
-): { queued: boolean; requestId: string; rejected?: boolean } {
+): {
+  queued: boolean;
+  requestId: string;
+  rejected?: boolean;
+  reason?: "queue_full" | "queue_disabled";
+} {
   if (!ctx.processing) {
     return { queued: false, requestId };
   }
@@ -238,7 +243,7 @@ export function enqueueMessage(
         "The assistant is busy processing another message. Please wait for it to finish before sending a new one.",
       category: "queue_disabled",
     });
-    return { queued: false, requestId, rejected: true };
+    return { queued: false, requestId, rejected: true, reason: "queue_disabled" };
   }
 
   const turnChannelContext =
@@ -271,7 +276,7 @@ export function enqueueMessage(
         "The assistant is busy and cannot accept more messages right now. Please try again shortly.",
       category: "queue_full",
     });
-    return { queued: false, requestId, rejected: true };
+    return { queued: false, requestId, rejected: true, reason: "queue_full" };
   }
   return { queued: true, requestId };
 }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,14 +8,14 @@
 import { v4 as uuid } from "uuid";
 
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import {
   attachInlineAttachmentToMessage,
   attachmentExists,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -300,7 +300,12 @@ export interface SurfaceConversationContext {
     options?: { isInteractive?: boolean },
     displayContent?: string,
     transport?: ConversationTransportMetadata,
-  ): { queued: boolean; requestId: string; rejected?: boolean };
+  ): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+    reason?: "queue_full" | "queue_disabled";
+  };
   getQueueDepth(): number;
   processMessage(
     content: string,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -747,7 +747,12 @@ export class Conversation {
     options?: { isInteractive?: boolean },
     displayContent?: string,
     transport?: ConversationTransportMetadata,
-  ): { queued: boolean; requestId: string; rejected?: boolean } {
+  ): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+    reason?: "queue_full" | "queue_disabled";
+  } {
     return enqueueMessageImpl(
       this,
       content,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1803,9 +1803,10 @@ export async function handleSendMessage(
       transport,
     );
     if (enqueueResult.rejected) {
+      const isDisabled = enqueueResult.reason === "queue_disabled";
       return Response.json(
-        { accepted: false, error: "queue_full" },
-        { status: 429 },
+        { accepted: false, error: enqueueResult.reason ?? "queue_full" },
+        { status: isDisabled ? 503 : 429 },
       );
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chat-msg-queue-flag.md.

**Gap:** HTTP endpoint returns misleading queue_full for queue_disabled rejections
**What was expected:** HTTP response should distinguish the two rejection reasons
**What was found:** Both flag-disabled and budget-exceeded rejections return error: queue_full with 429
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
