### PR TITLE
feat(macos): promote Home to standalone sidebar panel [LUM-805]

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -2,15 +2,13 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Assembles the Home page: identity column on the left, and the facts +
-/// capabilities columns on the right. This view is rendered inside
-/// ``IntelligencePanel``'s existing `VPageContainer`, so it does NOT wrap
-/// itself in another page container.
+/// capabilities columns on the right. This view is rendered inside the
+/// Home panel's `VPageContainer` in ``PanelCoordinator``, so it does NOT
+/// wrap itself in another page container.
 ///
 /// The parent owns all navigation decisions — the "Start a conversation"
 /// and capability CTAs are plain closures plumbed through from the
-/// ``PanelCoordinator``. PR 14 wires only `onStartConversation`; the
-/// capability CTAs ship as no-op stubs that PR 15 replaces with seeded
-/// new-chat handlers. Loading is driven by `store.load()` on appear; on
+/// ``PanelCoordinator``. Loading is driven by `store.load()` on appear; on
 /// transport failure the store keeps the last-good state so we never
 /// blank the UI between refreshes.
 struct HomePageView: View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Equatable, Sendable {
-    case chat, conversationList, settings, logsAndUsage, generated, avatarCustomization, apps, intelligence
+    case chat, conversationList, settings, logsAndUsage, generated, avatarCustomization, apps, intelligence, home
 }
 
 extension NativePanelId: Codable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -57,31 +57,21 @@ extension MainWindowView {
 
     var sidebarOuterMargin: CGFloat { 16 }
 
-    /// Small notification-red dot overlaid on the Intelligence sidebar row
-    /// whenever `HomeStore` has observed a background `relationshipStateUpdated`
-    /// event while the user was on some other surface. Hidden when:
+    /// Small notification-red dot overlaid on the Home sidebar row whenever
+    /// `HomeStore` has observed a background `relationshipStateUpdated` event
+    /// while the user was on some other surface. Hidden when:
     ///
     /// - The `home-tab` feature flag is off (Home page not live).
     /// - `HomeStore.hasUnseenChanges` is false (nothing new, or user has seen it).
-    /// - The user is already sitting on the Intelligence panel (no point in
-    ///   nagging them — navigating to the Home sub-tab will clear the flag).
+    /// - The user is already sitting on the Home panel.
     ///
-    /// Shared between the expanded and collapsed sidebar variants so both
-    /// states stay in lockstep.
+    /// `home-tab` is a macos-scope flag, resolved via
+    /// `MacOSClientFeatureFlagManager`, not the assistant-scope store.
     @ViewBuilder
-    var intelligenceUnseenChangesDot: some View {
-        // Hide the dot only when the user is actively looking at the Home
-        // sub-tab (`isHomeTabVisible == true`). Being on a different
-        // Intelligence sub-tab (Identity, Skills, Workspace, etc.) does NOT
-        // count as "seen" — the user can be in the panel without ever opening
-        // Home. `IntelligencePanel` flips `isHomeTabVisible` via .onAppear /
-        // .onDisappear on the Home tab content, so this stays in sync.
-        //
-        // `home-tab` is a macos-scope flag, resolved via
-        // `MacOSClientFeatureFlagManager`, not the assistant-scope store.
+    var homeUnseenChangesDot: some View {
         if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab")
             && homeStore.hasUnseenChanges
-            && !homeStore.isHomeTabVisible {
+            && windowState.selection != .panel(.home) {
             Circle()
                 .fill(VColor.systemNegativeStrong)
                 .frame(width: 8, height: 8)
@@ -403,11 +393,16 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
+            if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab") {
+                SidebarNavRow(icon: VIcon.house.rawValue, label: "Home", isActive: windowState.selection == .panel(.home)) {
+                    windowState.showPanel(.home)
+                }
+                .overlay(alignment: .topTrailing) {
+                    homeUnseenChangesDot
+                }
+            }
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
-            }
-            .overlay(alignment: .topTrailing) {
-                intelligenceUnseenChangesDot
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
                 windowState.showPanel(.apps)
@@ -539,11 +534,16 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
+            if MacOSClientFeatureFlagManager.shared.isEnabled("home-tab") {
+                SidebarNavRow(icon: VIcon.house.rawValue, label: "Home", isActive: windowState.selection == .panel(.home), isExpanded: false) {
+                    windowState.showPanel(.home)
+                }
+                .overlay(alignment: .topTrailing) {
+                    homeUnseenChangesDot
+                }
+            }
             SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
-            }
-            .overlay(alignment: .topTrailing) {
-                intelligenceUnseenChangesDot
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
                 windowState.showPanel(.apps)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -81,13 +81,12 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
-    /// Long-lived store for the Home page. Constructed eagerly so the
-    /// Intelligence panel's Home sub-tab always has a backing store the
-    /// instant the user toggles the `home-tab` flag on, even if the panel
-    /// is opened without a relaunch. The cost (one SSE subscriber + one
-    /// foreground observer + one cached HTTP client) is small enough that
-    /// gating construction on the flag isn't worth the runtime-toggle
-    /// surface bug it created.
+    /// Long-lived store for the Home page. Constructed eagerly so the Home
+    /// sidebar panel always has a backing store the instant the user toggles
+    /// the `home-tab` flag on, even if the panel is opened without a
+    /// relaunch. The cost (one SSE subscriber + one foreground observer +
+    /// one cached HTTP client) is small enough that gating construction on
+    /// the flag isn't worth the runtime-toggle surface bug it created.
     @State var homeStore: HomeStore
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -131,37 +131,60 @@ extension MainWindowView {
                         windowState.selection = nil
                     }
                 },
-                onStartConversation: { startNewConversation() },
-                onCapabilityCTA: { capability in
-                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
-                    conversationManager.openConversation(message: seed, forceNew: true)
-                    if let id = conversationManager.activeConversationId {
-                        windowState.selection = .conversation(id)
-                    } else {
-                        windowState.selection = nil
-                    }
-                },
-                onCapabilityShortcutCTA: { capability in
-                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .shortcut)
-                    conversationManager.openConversation(message: seed, forceNew: true)
-                    if let id = conversationManager.activeConversationId {
-                        windowState.selection = .conversation(id)
-                    } else {
-                        windowState.selection = nil
-                    }
-                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
-                homeStore: homeStore,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId,
                 pendingSkillId: $windowState.pendingSkillId
             )
+        case .home:
+            homePanelView(onDismiss: { windowState.selection = nil })
+        }
+    }
+
+    @ViewBuilder
+    func homePanelView(onDismiss: @escaping () -> Void) -> some View {
+        VPageContainer(title: "Home") {
+            HomePageView(
+                store: homeStore,
+                onStartConversation: {
+                    startNewConversation()
+                    onDismiss()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
+                },
+                onPrimaryCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    onDismiss()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
+                },
+                onShortcutCTA: { capability in
+                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .shortcut)
+                    conversationManager.openConversation(message: seed, forceNew: true)
+                    onDismiss()
+                    if let id = conversationManager.activeConversationId {
+                        windowState.selection = .conversation(id)
+                    }
+                }
+            )
+            .onAppear {
+                homeStore.isHomeTabVisible = true
+                homeStore.markSeen()
+            }
+            .onDisappear {
+                homeStore.isHomeTabVisible = false
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .clipped()
         }
     }
 
@@ -612,41 +635,19 @@ extension MainWindowView {
                         windowState.selection = .conversation(id)
                     }
                 },
-                onStartConversation: {
-                    startNewConversation()
-                    windowState.dismissOverlay()
-                    if let id = conversationManager.activeConversationId {
-                        windowState.selection = .conversation(id)
-                    }
-                },
-                onCapabilityCTA: { capability in
-                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
-                    conversationManager.openConversation(message: seed, forceNew: true)
-                    windowState.dismissOverlay()
-                    if let id = conversationManager.activeConversationId {
-                        windowState.selection = .conversation(id)
-                    }
-                },
-                onCapabilityShortcutCTA: { capability in
-                    let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .shortcut)
-                    conversationManager.openConversation(message: seed, forceNew: true)
-                    windowState.dismissOverlay()
-                    if let id = conversationManager.activeConversationId {
-                        windowState.selection = .conversation(id)
-                    }
-                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
-                homeStore: homeStore,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId,
                 pendingSkillId: $windowState.pendingSkillId
             )
+        case .home:
+            homePanelView(onDismiss: { windowState.dismissOverlay() })
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -8,15 +8,11 @@ struct IntelligencePanel: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     var onCreateSkill: (() -> Void)?
     var onImportMemory: ((String) -> Void)?
-    var onStartConversation: () -> Void
-    var onCapabilityCTA: ((Capability) -> Void)?
-    var onCapabilityShortcutCTA: ((Capability) -> Void)?
     let connectionManager: GatewayConnectionManager
     let eventStreamClient: EventStreamClient?
     var store: SettingsStore?
     var conversationManager: ConversationManager?
     var authManager: AuthManager?
-    var homeStore: HomeStore?
     var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var showToast: ((String, ToastInfo.Style) -> Void)?
     var initialTab: String? = nil
@@ -27,39 +23,25 @@ struct IntelligencePanel: View {
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, onStartConversation: @escaping () -> Void = {}, onCapabilityCTA: ((Capability) -> Void)? = nil, onCapabilityShortcutCTA: ((Capability) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, homeStore: HomeStore? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.onCreateSkill = onCreateSkill
         self.onImportMemory = onImportMemory
-        self.onStartConversation = onStartConversation
-        self.onCapabilityCTA = onCapabilityCTA
-        self.onCapabilityShortcutCTA = onCapabilityShortcutCTA
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.store = store
         self.conversationManager = conversationManager
         self.authManager = authManager
-        self.homeStore = homeStore
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.showToast = showToast
         self.initialTab = initialTab
         _pendingMemoryId = pendingMemoryId
         _pendingSkillId = pendingSkillId
-        // `home-tab` is a macos-scope flag, so it lives in
-        // `MacOSClientFeatureFlagManager`, NOT the assistant-scope
-        // `AssistantFeatureFlagStore`. The assistant store filters out
-        // macos-scope flags from its registry defaults, so calling
-        // `.isEnabled("home-tab")` on it falls through to its `?? true`
-        // fallback and silently shows the tab even when the registry says
-        // `defaultEnabled: false`. Same fix in `visibleTabs` below.
-        let homeTabFlagOn = MacOSClientFeatureFlagManager.shared.isEnabled("home-tab")
-        let defaultTab: IntelligenceTab = homeTabFlagOn ? .home : .identity
-        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? defaultTab)
+        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
     }
 
     private enum IntelligenceTab: String, CaseIterable {
-        case home = "Home"
         case identity = "Identity"
         case installedSkills = "Skills"
         case workspace = "Workspace"
@@ -73,7 +55,7 @@ struct IntelligencePanel: View {
         VPageContainer(title: "About \(cachedAssistantName)") {
             // Tab bar
             VTabs(
-                items: visibleTabs.map { (label: $0.rawValue, tag: $0) },
+                items: IntelligenceTab.allCases.map { (label: $0.rawValue, tag: $0) },
                 selection: $selectedTab
             )
             .padding(.bottom, VSpacing.md)
@@ -86,36 +68,9 @@ struct IntelligencePanel: View {
                 withAnimation(VAnimation.fast) { selectedTab = .memories }
             }
         }
-        .onChange(of: selectedTab) { _, newValue in
-            // Clear the sidebar unseen-changes dot as soon as the user
-            // navigates onto the Home sub-tab. `.onAppear` on the Home
-            // branch covers the first render; this onChange covers every
-            // subsequent tab switch back to Home.
-            if newValue == .home {
-                homeStore?.markSeen()
-            }
-        }
-        .onDisappear {
-            // Belt-and-suspenders cleanup: when the entire Intelligence
-            // panel goes away (user navigates to a conversation or another
-            // panel), make sure the Home tab is no longer counted as
-            // visible. Without this, `homeStore.isHomeTabVisible` could
-            // remain `true` if the parent removes the panel without
-            // SwiftUI firing the inner `.onDisappear` on the .home branch
-            // first, and the sidebar dot would never light up again.
-            homeStore?.isHomeTabVisible = false
-        }
         .task {
             let info = await IdentityInfo.loadAsync()
             cachedAssistantName = AssistantDisplayName.resolve(info?.name, fallback: "Your Assistant")
-        }
-    }
-
-    private var visibleTabs: [IntelligenceTab] {
-        let flagOn = MacOSClientFeatureFlagManager.shared.isEnabled("home-tab")
-        return IntelligenceTab.allCases.filter { tab in
-            if tab == .home { return flagOn }
-            return true
         }
     }
 
@@ -124,28 +79,6 @@ struct IntelligencePanel: View {
     @ViewBuilder
     private var tabContent: some View {
         switch selectedTab {
-        case .home:
-            if let homeStore {
-                HomePageView(
-                    store: homeStore,
-                    onStartConversation: onStartConversation,
-                    onPrimaryCTA: { capability in onCapabilityCTA?(capability) },
-                    onShortcutCTA: { capability in onCapabilityShortcutCTA?(capability) }
-                )
-                .onAppear {
-                    homeStore.isHomeTabVisible = true
-                    homeStore.markSeen()
-                }
-                .onDisappear {
-                    homeStore.isHomeTabVisible = false
-                }
-                .padding(.top, VSpacing.sm)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                .clipped()
-            } else {
-                EmptyView()
-            }
-
         case .identity:
             IdentityPanel(
                 onClose: onClose,

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -6,6 +6,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case avatarCustomization
     case apps
     case intelligence
+    case home
 
     init?(rawValue: String) {
         switch rawValue {
@@ -16,6 +17,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "avatarCustomization": self = .avatarCustomization
         case "apps": self = .apps
         case "intelligence": self = .intelligence
+        case "home": self = .home
         // Legacy values — map to the unified Logs & Usage panel
         case "debug", "usageDashboard": self = .logsAndUsage
         // Legacy values from older builds — map to the unified Intelligence panel


### PR DESCRIPTION
## Summary
- Move the Home page out of the Intelligence tab bar and into its own top-level sidebar nav item, rendered **above** Intelligence (gated by the `home-tab` feature flag, matching previous behavior).
- New `.home` case in `NativePanelId` / `SidePanelType`, routed through `PanelCoordinator.homePanelView` which wraps `HomePageView` in its own `VPageContainer(title: "Home")`.
- Unseen-changes dot moves from the Intelligence row to the new Home row. Visibility rule simplifies to "not currently on the Home panel"; `HomeStore.isHomeTabVisible` is still flipped from `HomePageView`'s appear/disappear so the SSE handler keeps raising the dot for background events (existing `HomeStoreUnseenChangesTests` still pass untouched).
- `IntelligencePanel` loses its `.home` sub-tab plus the now-dead `onStartConversation` / `onCapabilityCTA` / `onCapabilityShortcutCTA` / `homeStore` plumbing on both call sites; default selected tab drops back to `.identity`.

## Test plan
- [x] `./build.sh` — macOS build succeeds.
- [x] `./build.sh test` — full suite (271 tests / 41 suites) green.
- [ ] Launch app with `home-tab` flag on: Home row appears above Intelligence, opens the standalone Home page with its own title, unseen-changes dot lights up on the Home row when a background `relationshipStateUpdated` event arrives while the user is elsewhere and clears when Home is opened.
- [ ] Launch app with `home-tab` flag off: Home row is hidden, Intelligence defaults to the Identity tab, no dot ever shows.
- [ ] Collapsed sidebar mirrors the expanded layout (Home row above Intelligence, same dot behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
