### PR TITLE
fix: enable chat-message-queue flag in existing queue tests

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -484,11 +484,22 @@ function resolveRun(index: number) {
   run.resolve([...run.messages, assistantMsg]);
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
   addMessageShouldThrowForContent.clear();
+  const { _setOverridesForTesting } = await import(
+    "../config/assistant-feature-flags.js"
+  );
+  _setOverridesForTesting({ "chat-message-queue": true });
+});
+
+afterEach(async () => {
+  const { _setOverridesForTesting } = await import(
+    "../config/assistant-feature-flags.js"
+  );
+  _setOverridesForTesting({});
 });
 
 afterAll(() => {

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   AgentEvent,
@@ -295,8 +295,19 @@ function resolveRun(index: number) {
 // ---------------------------------------------------------------------------
 
 describe("Conversation queue — slash-like messages pass through to agent loop", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     pendingRuns = [];
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({ "chat-message-queue": true });
+  });
+
+  afterEach(async () => {
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({});
   });
 
   test("queued slash-like input does not stall queue — batches with siblings", async () => {

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,14 +8,14 @@
 import { v4 as uuid } from "uuid";
 
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import {
   attachInlineAttachmentToMessage,
   attachmentExists,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chat-msg-queue-flag.md.

**Gap:** Existing queue tests break because they don't enable the chat-message-queue flag
**What was expected:** Existing tests should continue passing
**What was found:** Tests expect enqueueMessage to return queued: true but the new flag defaults to false
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
