### PR TITLE
feat: GA the stt-service feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -146,8 +146,6 @@ struct SettingsPanel: View {
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
-    private static let sttServiceFeatureFlagKey = "stt-service"
-    @State private var isSttServiceEnabled: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -205,7 +203,6 @@ struct SettingsPanel: View {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
-            isSttServiceEnabled = assistantFeatureFlagStore.isEnabled(Self.sttServiceFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -269,8 +266,6 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .schedules {
                         selectedTab = .general
                     }
-                } else if key == Self.sttServiceFeatureFlagKey {
-                    isSttServiceEnabled = enabled
                 }
             }
         }
@@ -419,7 +414,7 @@ struct SettingsPanel: View {
                 onEnableIntegration: onEnableIntegration
             )
         case .voice:
-            VoiceSettingsView(store: store, isSttServiceEnabled: isSttServiceEnabled)
+            VoiceSettingsView(store: store)
         case .sounds:
             SettingsSoundsTab()
         case .permissionsAndPrivacy:
@@ -665,9 +660,6 @@ struct SettingsPanel: View {
                 if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
                     isSchedulesEnabled = schedulesFlag.enabled
                 }
-                if let sttServiceFlag = flags.first(where: { $0.key == Self.sttServiceFeatureFlagKey }) {
-                    isSttServiceEnabled = sttServiceFlag.enabled
-                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -693,9 +685,6 @@ struct SettingsPanel: View {
         }
         if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
             isSchedulesEnabled = schedulesEnabled
-        }
-        if let sttServiceEnabled = resolved[Self.sttServiceFeatureFlagKey] {
-            isSttServiceEnabled = sttServiceEnabled
         }
         consumeDeferredDeepLinkIfVisible()
     }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -5,7 +5,6 @@ import VellumAssistantShared
 /// conversation timeout, text-to-speech provider, and speech-to-text provider.
 struct VoiceSettingsView: View {
     @ObservedObject var store: SettingsStore
-    var isSttServiceEnabled: Bool = false
 
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("voiceConversationTimeoutSeconds") private var conversationTimeoutSeconds: Int = 30
@@ -95,9 +94,7 @@ struct VoiceSettingsView: View {
             pttCard
             conversationTimeoutCard
             ttsProviderCard
-            if isSttServiceEnabled {
-                sttProviderCard
-            }
+            sttProviderCard
         }
         .onDisappear {
             stopRecordingCustomKey()

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -322,14 +322,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "stt-service",
-      "scope": "assistant",
-      "key": "stt-service",
-      "label": "Voice STT Service",
-      "description": "Enable Voice settings STT service configuration UI for selecting and configuring speech-to-text providers",
-      "defaultEnabled": true
-    },
-    {
       "id": "onboarding-pre-chat",
       "scope": "macos",
       "key": "onboarding-pre-chat",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -327,7 +327,7 @@
       "key": "stt-service",
       "label": "Voice STT Service",
       "description": "Enable Voice settings STT service configuration UI for selecting and configuring speech-to-text providers",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "onboarding-pre-chat",


### PR DESCRIPTION
## Summary
- Set `defaultEnabled: true` for the `stt-service` feature flag in the registry so all users see the STT provider configuration UI
- Removed conditional gating from `VoiceSettingsView` — the STT provider card now always renders
- Cleaned up `isSttServiceEnabled` state and all flag-checking references from `SettingsPanel`

## Original prompt
help me GA the speech-to-text or stt feature flag