### PR TITLE
feat(home-feed): add FeedItem TypeScript types and Zod schema

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+
+import { type FeedItem, feedItemSchema, parseFeedFile } from "../feed-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW_ISO = "2026-04-14T12:00:00.000Z";
+
+function minimalNudge(): Record<string, unknown> {
+  return {
+    id: "nudge-1",
+    type: "nudge",
+    priority: 50,
+    title: "Follow up on the Figma file",
+    summary: "You mentioned wanting to review the onboarding designs.",
+    timestamp: NOW_ISO,
+    author: "assistant",
+    createdAt: NOW_ISO,
+  };
+}
+
+function minimalDigest(): Record<string, unknown> {
+  return {
+    id: "digest-gmail",
+    type: "digest",
+    priority: 40,
+    title: "3 new emails",
+    summary: "Since yesterday",
+    source: "gmail",
+    timestamp: NOW_ISO,
+    author: "platform",
+    createdAt: NOW_ISO,
+  };
+}
+
+function minimalAction(): Record<string, unknown> {
+  return {
+    id: "action-1",
+    type: "action",
+    priority: 60,
+    title: "Approve expense report",
+    summary: "Pending since Tuesday",
+    timestamp: NOW_ISO,
+    author: "assistant",
+    createdAt: NOW_ISO,
+    actions: [
+      {
+        id: "approve",
+        label: "Approve",
+        prompt: "Approve the expense report.",
+      },
+    ],
+  };
+}
+
+function minimalThread(): Record<string, unknown> {
+  return {
+    id: "thread-1",
+    type: "thread",
+    priority: 30,
+    title: "Draft reply to Alice",
+    summary: "Waiting on your input",
+    timestamp: NOW_ISO,
+    author: "assistant",
+    createdAt: NOW_ISO,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Valid minimal items
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — valid minimal items", () => {
+  test("valid minimal nudge parses successfully", () => {
+    const parsed = feedItemSchema.parse(minimalNudge());
+    expect(parsed.type).toBe("nudge");
+    // `status` defaults to "new" when absent.
+    expect(parsed.status).toBe("new");
+    expect(parsed.author).toBe("assistant");
+  });
+
+  test("valid minimal digest parses successfully", () => {
+    const parsed = feedItemSchema.parse(minimalDigest());
+    expect(parsed.type).toBe("digest");
+    expect(parsed.source).toBe("gmail");
+    expect(parsed.author).toBe("platform");
+  });
+
+  test("valid minimal action parses successfully", () => {
+    const parsed = feedItemSchema.parse(minimalAction());
+    expect(parsed.type).toBe("action");
+    expect(parsed.actions).toHaveLength(1);
+    expect(parsed.actions?.[0]?.prompt).toBe("Approve the expense report.");
+  });
+
+  test("valid minimal thread parses successfully", () => {
+    const parsed = feedItemSchema.parse(minimalThread());
+    expect(parsed.type).toBe("thread");
+  });
+
+  test("status defaults to 'new' when omitted", () => {
+    const parsed = feedItemSchema.parse(minimalNudge());
+    expect(parsed.status).toBe("new");
+  });
+
+  test("explicit status value is preserved", () => {
+    const parsed = feedItemSchema.parse({ ...minimalNudge(), status: "seen" });
+    expect(parsed.status).toBe("seen");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid priority values
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — priority validation", () => {
+  test("rejects priority -1", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: -1 }),
+    ).toThrow();
+  });
+
+  test("rejects priority 101", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: 101 }),
+    ).toThrow();
+  });
+
+  test("rejects priority as string '5'", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: "5" }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer priority (e.g. 50.5)", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: 50.5 }),
+    ).toThrow();
+  });
+
+  test("accepts boundary values 0 and 100", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: 0 }),
+    ).not.toThrow();
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), priority: 100 }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid enum fields
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — enum validation", () => {
+  test("rejects unknown `type`", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), type: "banner" }),
+    ).toThrow();
+  });
+
+  test("rejects unknown `status`", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), status: "archived" }),
+    ).toThrow();
+  });
+
+  test("rejects unknown `source` (e.g. 'facebook')", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), source: "facebook" }),
+    ).toThrow();
+  });
+
+  test("rejects unknown `author`", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), author: "user" }),
+    ).toThrow();
+  });
+
+  test("allows omitted `source`", () => {
+    const raw = minimalNudge();
+    delete (raw as Record<string, unknown>).source;
+    expect(() => feedItemSchema.parse(raw)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// minTimeAway validation
+// ---------------------------------------------------------------------------
+
+describe("feedItemSchema — minTimeAway validation", () => {
+  test("accepts non-negative integer", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNudge(),
+      minTimeAway: 3600,
+    });
+    expect(parsed.minTimeAway).toBe(3600);
+  });
+
+  test("accepts 0", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: 0 }),
+    ).not.toThrow();
+  });
+
+  test("rejects negative values", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: -1 }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer values", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: 1.5 }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFeedFile
+// ---------------------------------------------------------------------------
+
+describe("parseFeedFile", () => {
+  test("accepts empty file with version 1", () => {
+    const parsed = parseFeedFile({
+      version: 1,
+      items: [],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.version).toBe(1);
+    expect(parsed.items).toEqual([]);
+    expect(parsed.updatedAt).toBe(NOW_ISO);
+  });
+
+  test("accepts file with multiple valid items", () => {
+    const parsed = parseFeedFile({
+      version: 1,
+      items: [
+        minimalNudge(),
+        minimalDigest(),
+        minimalAction(),
+        minimalThread(),
+      ],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toHaveLength(4);
+    const types = parsed.items.map((i: FeedItem) => i.type);
+    expect(types).toEqual(["nudge", "digest", "action", "thread"]);
+  });
+
+  test("throws on non-object input", () => {
+    expect(() => parseFeedFile(null)).toThrow();
+    expect(() => parseFeedFile(undefined)).toThrow();
+    expect(() => parseFeedFile("not an object")).toThrow();
+    expect(() => parseFeedFile(42)).toThrow();
+  });
+
+  test("throws on wrong version", () => {
+    expect(() =>
+      parseFeedFile({ version: 2, items: [], updatedAt: NOW_ISO }),
+    ).toThrow();
+  });
+
+  test("throws when an item in the file is invalid", () => {
+    expect(() =>
+      parseFeedFile({
+        version: 1,
+        items: [{ ...minimalNudge(), priority: 999 }],
+        updatedAt: NOW_ISO,
+      }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -1,0 +1,181 @@
+/**
+ * Home activity feed data contract.
+ *
+ * Defines the shape of `FeedItem`s shown in the macOS Home page feed
+ * section (nudges, digests, actions, threads) plus the on-disk file
+ * format written by the daemon feed writer (PR 5) and served by the
+ * daemon HTTP route (PR 6).
+ *
+ * The TDD contract field originally named `ttl` is renamed internally
+ * to `expiresAt` — it is an absolute ISO-8601 timestamp, not a
+ * duration. Absolute timestamps match the `timestamp` and `createdAt`
+ * fields and make stateless read-time expiry filtering trivial. If we
+ * ever need to expose `ttl` on a public wire format again we can add
+ * a translation layer at the route boundary; within the daemon, all
+ * internal types use `expiresAt`.
+ *
+ * A structurally compatible Swift mirror lives at
+ * `clients/shared/Network/FeedItem.swift` (PR 3). Any change here
+ * must be mirrored there.
+ */
+
+import { z } from "zod";
+
+/** High-level kind of feed item — drives which Swift view renders it. */
+export type FeedItemType = "nudge" | "digest" | "action" | "thread";
+
+/** User-facing lifecycle of a feed item. */
+export type FeedItemStatus = "new" | "seen" | "acted_on";
+
+/**
+ * Origin of the underlying event.
+ *
+ * In v1 this is constrained to a closed set so the Swift icon mapping
+ * stays exhaustive. Future sources will be added explicitly rather
+ * than letting arbitrary strings slip through.
+ */
+export type FeedItemSource = "gmail" | "slack" | "calendar" | "assistant";
+
+/**
+ * Internal field used by the hybrid authoring resolver (PR 5 writer).
+ *
+ * Not part of the TDD public interface — it distinguishes items the
+ * assistant produced on its own from items the platform baseline
+ * generators (e.g. Gmail digest in PR 12) produced, so assistant
+ * overrides can win over platform defaults for the same source.
+ */
+export type FeedItemAuthor = "assistant" | "platform";
+
+/**
+ * A single action button attached to a feed item.
+ *
+ * `prompt` is the pre-seeded user message the action sends to the
+ * assistant when triggered — the HTTP route (PR 6) creates a new
+ * conversation with this prompt as the first user turn.
+ */
+export interface FeedAction {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+/**
+ * A single item rendered in the Home feed.
+ *
+ * Mirrors the TDD contract plus two internal-only fields:
+ *   - `author`  — hybrid-authoring resolver discriminator
+ *   - `createdAt` — when the writer recorded the item (distinct from
+ *                   `timestamp`, which is the event time). Used for
+ *                   TTL sweeps and stable ordering.
+ *
+ * The TDD's `ttl` field is renamed to `expiresAt` here; see the
+ * module comment above for the rationale.
+ */
+export interface FeedItem {
+  id: string;
+  type: FeedItemType;
+  /** Integer in [0, 100]; higher values sort earlier. */
+  priority: number;
+  title: string;
+  summary: string;
+  /** Optional; when present must be one of the four v1 sources. */
+  source?: FeedItemSource;
+  /** Event time (ISO-8601). */
+  timestamp: string;
+  /** Defaults to `"new"` at parse time. */
+  status: FeedItemStatus;
+  /** Absolute ISO-8601 expiry timestamp (renamed from TDD `ttl`). */
+  expiresAt?: string;
+  /** Minimum seconds the user must be away before the item is shown. */
+  minTimeAway?: number;
+  actions?: FeedAction[];
+  /** Internal: who authored this item. */
+  author: FeedItemAuthor;
+  /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
+  createdAt: string;
+}
+
+/**
+ * On-disk file format for `~/.vellum/workspace/data/home-feed.json`.
+ *
+ * Written by the PR 5 writer, read by the PR 6 HTTP route and
+ * `parseFeedFile` below. `version` is pinned to `1`; future format
+ * changes bump this and live behind a workspace migration.
+ */
+export interface HomeFeedFile {
+  version: 1;
+  items: FeedItem[];
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const feedItemTypeSchema = z.enum(["nudge", "digest", "action", "thread"]);
+
+const feedItemStatusSchema = z.enum(["new", "seen", "acted_on"]);
+
+const feedItemSourceSchema = z.enum([
+  "gmail",
+  "slack",
+  "calendar",
+  "assistant",
+]);
+
+const feedItemAuthorSchema = z.enum(["assistant", "platform"]);
+
+const feedActionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  prompt: z.string(),
+});
+
+/**
+ * Schema for a single `FeedItem`.
+ *
+ * Notes:
+ *   - `priority` must be an integer in [0, 100]; string numerics
+ *     (e.g. `"5"`) are rejected — we want deterministic ordering and
+ *     silent coercion tends to mask writer bugs.
+ *   - `status` defaults to `"new"` so the writer does not need to
+ *     set it on every append.
+ *   - `source` is optional but, when present, must be one of the
+ *     four v1 sources — unknown values (e.g. `"facebook"`) are
+ *     rejected rather than silently passed through.
+ *   - `minTimeAway` is a non-negative integer number of seconds.
+ */
+export const feedItemSchema = z.object({
+  id: z.string(),
+  type: feedItemTypeSchema,
+  priority: z.number().int().min(0).max(100),
+  title: z.string(),
+  summary: z.string(),
+  source: feedItemSourceSchema.optional(),
+  timestamp: z.string(),
+  status: feedItemStatusSchema.default("new"),
+  expiresAt: z.string().optional(),
+  minTimeAway: z.number().int().min(0).optional(),
+  actions: z.array(feedActionSchema).optional(),
+  author: feedItemAuthorSchema,
+  createdAt: z.string(),
+});
+
+/** Schema for the on-disk `home-feed.json` file. */
+export const homeFeedFileSchema = z.object({
+  version: z.literal(1),
+  items: z.array(feedItemSchema),
+  updatedAt: z.string(),
+});
+
+/**
+ * Parse and validate a raw value read from `home-feed.json`.
+ *
+ * Used by the PR 5 writer on read-back and by the PR 6 HTTP route
+ * when serving the feed. Throws a `ZodError` on any validation
+ * failure — callers are expected to log + recover (e.g. treat the
+ * file as empty).
+ */
+export function parseFeedFile(raw: unknown): HomeFeedFile {
+  return homeFeedFileSchema.parse(raw) as HomeFeedFile;
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/home/feed-types.ts` with the FeedItem contract, hybrid-authoring `author` field, and Zod schemas
- Adds `parseFeedFile` for validated read-back (used by PR 5)
- Covered by unit tests in `assistant/src/home/__tests__/feed-types.test.ts`

Part of plan: home-activity-feed.md (PR 2 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
