### PR TITLE
fix: wire AssistantFeatureFlagStore into MessageSendCoordinator

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -60,6 +60,11 @@ final class ConversationManager: ConversationRestorerDelegate {
     private let conversationAnalysisClient: ConversationAnalysisClientProtocol
     private let conversationRestorer: ConversationRestorer
 
+    /// Closure that resolves assistant-scoped feature flags by key.
+    /// Injected by the app layer so ChatViewModels pick up runtime overrides
+    /// from the gateway via AssistantFeatureFlagStore.
+    private let isAssistantFeatureFlagEnabled: (String) -> Bool
+
     // MARK: - Pre-Chat Onboarding
 
     /// Pre-chat onboarding context from the onboarding flow. Set by AppDelegate
@@ -172,6 +177,9 @@ final class ConversationManager: ConversationRestorerDelegate {
         conversationDetailClient: any ConversationDetailClientProtocol = ConversationDetailClient(),
         conversationHostAccessClient: any ConversationHostAccessClientProtocol = ConversationHostAccessClient(),
         conversationAnalysisClient: ConversationAnalysisClientProtocol = ConversationAnalysisClient(),
+        isAssistantFeatureFlagEnabled: @escaping (String) -> Bool = { key in
+            loadFeatureFlagRegistry()?.flags.first(where: { $0.key == key })?.defaultEnabled ?? true
+        },
         isFirstLaunch: Bool = false,
         preChatContext: PreChatOnboardingContext? = nil
     ) {
@@ -183,6 +191,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         self.conversationDetailClient = conversationDetailClient
         self.conversationHostAccessClient = conversationHostAccessClient
         self.conversationAnalysisClient = conversationAnalysisClient
+        self.isAssistantFeatureFlagEnabled = isAssistantFeatureFlagEnabled
         self.conversationRestorer = ConversationRestorer(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
         self.selectionStore = ConversationSelectionStore(listStore: listStore)
 
@@ -360,7 +369,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     // MARK: - VM Factory
 
     func makeViewModel() -> ChatViewModel {
-        let viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
+        let viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient, isAssistantFeatureFlagEnabled: isAssistantFeatureFlagEnabled)
         viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
             guard let self, let viewModel else { return false }
             return self.isLatestToolUseRecipient(viewModel)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -326,6 +326,9 @@ public final class MainWindow {
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
+            isAssistantFeatureFlagEnabled: { [weak assistantFeatureFlagStore] key in
+                assistantFeatureFlagStore?.isEnabled(key) ?? false
+            },
             isFirstLaunch: isFirstLaunch,
             preChatContext: preChatContext
         )

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1067,7 +1067,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         settingsClient: any SettingsClientProtocol = SettingsClient(),
         interactionClient: any InteractionClientProtocol = InteractionClient(),
         conversationQueueClient: any ConversationQueueClientProtocol = ConversationQueueClient(),
-        onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil
+        onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil,
+        isAssistantFeatureFlagEnabled: @escaping (String) -> Bool = { key in
+            loadFeatureFlagRegistry()?.flags.first(where: { $0.key == key })?.defaultEnabled ?? true
+        }
     ) {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
@@ -1096,7 +1099,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             errorManager: errorManager,
             btwState: btwState,
             settingsClient: settingsClient,
-            conversationListClient: conversationListClient
+            conversationListClient: conversationListClient,
+            isAssistantFeatureFlagEnabled: isAssistantFeatureFlagEnabled
         )
 
         // Initialize the action handler for server message dispatch.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chat-msg-queue-flag.md.

**Gap:** Client-side flag resolver never receives runtime overrides
**What was expected:** The chat-message-queue flag should be controllable at runtime
**What was found:** ChatViewModel doesn't pass AssistantFeatureFlagStore.isEnabled to MessageSendCoordinator
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
