### PR TITLE
feat(home-feed): register home-feed feature flag (phase 5)

### DIFF
--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -395,3 +395,23 @@ export function isAssistantFeatureFlagEnabled(
 export function getAssistantFeatureFlagDefaults(): FeatureFlagDefaultsRegistry {
   return loadDefaultsRegistry();
 }
+
+// ---------------------------------------------------------------------------
+// Named flag helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical key for the `home-feed` flag — gates the activity feed section on
+ * the macOS Home page (nudges, digests, actions, threads). Requires the
+ * `home-tab` flag to also be enabled. Declared in
+ * `meta/feature-flags/feature-flag-registry.json` with scope `macos`.
+ */
+export const HOME_FEED_FLAG = "home-feed";
+
+/**
+ * Resolve whether the `home-feed` flag is enabled for the current assistant
+ * config. Wraps `isAssistantFeatureFlagEnabled` with the canonical key.
+ */
+export function isHomeFeedEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(HOME_FEED_FLAG, config);
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -344,6 +344,14 @@
       "label": "Home Tab",
       "description": "Replace the knowledge graph top-level tab with a new Home page showing relationship progression, facts, and capability tiers",
       "defaultEnabled": false
+    },
+    {
+      "id": "home-feed",
+      "scope": "macos",
+      "key": "home-feed",
+      "label": "Home Feed",
+      "description": "Render the activity feed section on the macOS Home page (nudges, digests, actions, threads). Requires home-tab to also be enabled.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `home-feed` entry to `meta/feature-flags/feature-flag-registry.json` with scope `macos`, `defaultEnabled: false`
- Exposes `isHomeFeedEnabled(config)` in `assistant/src/config/assistant-feature-flags.ts`
- **Companion Terraform PR required** in `../vellum-assistant-platform` to provision the flag in LaunchDarkly — NOT opened in this PR

Part of plan: home-activity-feed.md (PR 1 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
