### PR TITLE
feat(home-feed): add FeedItem Swift types mirroring TS contract

### DIFF
--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Home activity feed data contract.
+///
+/// Wire-compatible Swift mirror of
+/// `assistant/src/home/feed-types.ts`. The TypeScript types are the
+/// source of truth — any change there must be mirrored here so a JSON
+/// blob produced by the daemon decodes byte-for-byte on the macOS side.
+///
+/// The TDD contract field originally named `ttl` is renamed internally
+/// to `expiresAt` on both sides — it is an absolute ISO-8601 timestamp,
+/// not a duration. See the TypeScript module comment for rationale.
+///
+/// These are pure value types — `Date` fields are decoded via
+/// `JSONDecoder.dateDecodingStrategy = .iso8601` at the call site, not
+/// inside the type definitions.
+
+// MARK: - Enums
+
+/// High-level kind of feed item — drives which Swift view renders it.
+public enum FeedItemType: String, Codable, Sendable, Hashable {
+    case nudge
+    case digest
+    case action
+    case thread
+}
+
+/// User-facing lifecycle of a feed item.
+public enum FeedItemStatus: String, Codable, Sendable, Hashable {
+    case new
+    case seen
+    case actedOn = "acted_on"
+}
+
+/// Origin of the underlying event.
+///
+/// In v1 this is constrained to a closed set so the Swift icon mapping
+/// stays exhaustive. Future sources will be added explicitly rather
+/// than letting arbitrary strings slip through.
+public enum FeedItemSource: String, Codable, Sendable, Hashable {
+    case gmail
+    case slack
+    case calendar
+    case assistant
+}
+
+/// Internal field used by the hybrid authoring resolver.
+///
+/// Distinguishes items the assistant produced on its own from items
+/// the platform baseline generators produced, so assistant overrides
+/// can win over platform defaults for the same source.
+public enum FeedItemAuthor: String, Codable, Sendable, Hashable {
+    case assistant
+    case platform
+}
+
+// MARK: - FeedAction
+
+/// A single action button attached to a feed item.
+///
+/// `prompt` is the pre-seeded user message the action sends to the
+/// assistant when triggered — the daemon's feed HTTP route creates a
+/// new conversation with this prompt as the first user turn.
+public struct FeedAction: Codable, Sendable, Identifiable, Hashable {
+    public let id: String
+    public let label: String
+    public let prompt: String
+
+    public init(id: String, label: String, prompt: String) {
+        self.id = id
+        self.label = label
+        self.prompt = prompt
+    }
+}
+
+// MARK: - FeedItem
+
+/// A single item rendered in the Home feed.
+///
+/// Mirrors the TDD contract plus two internal-only fields:
+///   - `author`    — hybrid-authoring resolver discriminator
+///   - `createdAt` — when the writer recorded the item (distinct from
+///                   `timestamp`, which is the event time). Used for
+///                   TTL sweeps and stable ordering.
+public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
+    public let id: String
+    public let type: FeedItemType
+    /// Integer in [0, 100]; higher values sort earlier.
+    public let priority: Int
+    public let title: String
+    public let summary: String
+    /// Optional; when present must be one of the four v1 sources.
+    public let source: FeedItemSource?
+    /// Event time.
+    public let timestamp: Date
+    public let status: FeedItemStatus
+    /// Absolute expiry timestamp (renamed from TDD `ttl`).
+    public let expiresAt: Date?
+    /// Minimum seconds the user must be away before the item is shown.
+    public let minTimeAway: TimeInterval?
+    public let actions: [FeedAction]?
+    /// Internal: who authored this item.
+    public let author: FeedItemAuthor
+    /// Internal: writer-record time, used for ordering + TTL.
+    public let createdAt: Date
+
+    public init(
+        id: String,
+        type: FeedItemType,
+        priority: Int,
+        title: String,
+        summary: String,
+        source: FeedItemSource? = nil,
+        timestamp: Date,
+        status: FeedItemStatus,
+        expiresAt: Date? = nil,
+        minTimeAway: TimeInterval? = nil,
+        actions: [FeedAction]? = nil,
+        author: FeedItemAuthor,
+        createdAt: Date
+    ) {
+        self.id = id
+        self.type = type
+        self.priority = priority
+        self.title = title
+        self.summary = summary
+        self.source = source
+        self.timestamp = timestamp
+        self.status = status
+        self.expiresAt = expiresAt
+        self.minTimeAway = minTimeAway
+        self.actions = actions
+        self.author = author
+        self.createdAt = createdAt
+    }
+}
+
+// MARK: - HomeFeedFile
+
+/// On-disk file format for `~/.vellum/workspace/data/home-feed.json`.
+///
+/// Written by the daemon feed writer, read by the daemon HTTP route
+/// and the macOS `HomeFeedStore` (lands in a later PR). `version` is
+/// pinned to `1`; future format changes bump this and live behind a
+/// workspace migration.
+public struct HomeFeedFile: Codable, Sendable, Hashable {
+    public let version: Int
+    public let items: [FeedItem]
+    public let updatedAt: Date
+
+    public init(version: Int, items: [FeedItem], updatedAt: Date) {
+        self.version = version
+        self.items = items
+        self.updatedAt = updatedAt
+    }
+}

--- a/clients/shared/Tests/FeedItemCodingTests.swift
+++ b/clients/shared/Tests/FeedItemCodingTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// Codable coverage for the shared `FeedItem` / `HomeFeedFile` types.
+///
+/// These types are the Swift mirror of
+/// `assistant/src/home/feed-types.ts` — the TypeScript side is the
+/// source of truth, so these tests assert wire compatibility:
+///   - All four `FeedItemType` fixtures (nudge, digest, action, thread)
+///     decode cleanly.
+///   - Round-trip encode/decode preserves equality.
+///   - `"acted_on"` decodes to `.actedOn`.
+///   - Missing optional fields (`source`, `expiresAt`, `minTimeAway`,
+///     `actions`) decode successfully.
+///
+/// `Date` fields use `JSONDecoder.dateDecodingStrategy = .iso8601` at
+/// the call site, not inside the type definitions — these tests
+/// exercise that pattern as well.
+final class FeedItemCodingTests: XCTestCase {
+
+    private var decoder: JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+
+    private var encoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        // Sorted keys so round-trip comparisons are stable.
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }
+
+    // MARK: - Nudge
+
+    func testDecodesNudgeFixture() throws {
+        let json = Data(
+            """
+            {
+              "id": "nudge-1",
+              "type": "nudge",
+              "priority": 50,
+              "title": "You have 3 unread threads",
+              "summary": "Since yesterday afternoon.",
+              "source": "gmail",
+              "timestamp": "2026-04-14T10:00:00Z",
+              "status": "new",
+              "expiresAt": "2026-04-15T10:00:00Z",
+              "minTimeAway": 120,
+              "author": "assistant",
+              "createdAt": "2026-04-14T09:30:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+
+        XCTAssertEqual(item.id, "nudge-1")
+        XCTAssertEqual(item.type, .nudge)
+        XCTAssertEqual(item.priority, 50)
+        XCTAssertEqual(item.source, .gmail)
+        XCTAssertEqual(item.status, .new)
+        XCTAssertEqual(item.author, .assistant)
+        XCTAssertEqual(item.minTimeAway, 120)
+        XCTAssertNotNil(item.expiresAt)
+    }
+
+    // MARK: - Digest
+
+    func testDecodesDigestFixture() throws {
+        let json = Data(
+            """
+            {
+              "id": "digest-1",
+              "type": "digest",
+              "priority": 75,
+              "title": "Morning digest",
+              "summary": "5 emails, 2 meetings, 1 Slack thread.",
+              "source": "assistant",
+              "timestamp": "2026-04-14T08:00:00Z",
+              "status": "seen",
+              "author": "platform",
+              "createdAt": "2026-04-14T08:00:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+
+        XCTAssertEqual(item.id, "digest-1")
+        XCTAssertEqual(item.type, .digest)
+        XCTAssertEqual(item.priority, 75)
+        XCTAssertEqual(item.status, .seen)
+        XCTAssertEqual(item.author, .platform)
+        // Missing optionals.
+        XCTAssertNil(item.expiresAt)
+        XCTAssertNil(item.minTimeAway)
+        XCTAssertNil(item.actions)
+    }
+
+    // MARK: - Action
+
+    func testDecodesActionFixture() throws {
+        let json = Data(
+            """
+            {
+              "id": "action-1",
+              "type": "action",
+              "priority": 90,
+              "title": "Reply to Alex?",
+              "summary": "They asked about the Q3 planning doc.",
+              "source": "slack",
+              "timestamp": "2026-04-14T11:15:00Z",
+              "status": "new",
+              "actions": [
+                {
+                  "id": "reply",
+                  "label": "Draft reply",
+                  "prompt": "Draft a reply to Alex about the Q3 planning doc."
+                },
+                {
+                  "id": "snooze",
+                  "label": "Snooze 1h",
+                  "prompt": "Remind me about Alex's Slack message in an hour."
+                }
+              ],
+              "author": "assistant",
+              "createdAt": "2026-04-14T11:15:30Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+
+        XCTAssertEqual(item.id, "action-1")
+        XCTAssertEqual(item.type, .action)
+        XCTAssertEqual(item.source, .slack)
+        XCTAssertEqual(item.actions?.count, 2)
+        XCTAssertEqual(item.actions?.first?.id, "reply")
+        XCTAssertEqual(item.actions?.first?.label, "Draft reply")
+        XCTAssertEqual(item.actions?[1].id, "snooze")
+    }
+
+    // MARK: - Thread
+
+    func testDecodesThreadFixture() throws {
+        let json = Data(
+            """
+            {
+              "id": "thread-1",
+              "type": "thread",
+              "priority": 30,
+              "title": "Trip planning",
+              "summary": "Picking up where you left off yesterday.",
+              "source": "assistant",
+              "timestamp": "2026-04-13T18:45:00Z",
+              "status": "acted_on",
+              "author": "assistant",
+              "createdAt": "2026-04-13T18:45:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+
+        XCTAssertEqual(item.id, "thread-1")
+        XCTAssertEqual(item.type, .thread)
+        XCTAssertEqual(item.status, .actedOn)
+    }
+
+    // MARK: - acted_on enum raw value
+
+    func testActedOnRawValueDecoding() throws {
+        let json = Data(#""acted_on""#.utf8)
+        let status = try decoder.decode(FeedItemStatus.self, from: json)
+        XCTAssertEqual(status, .actedOn)
+    }
+
+    func testActedOnRawValueEncoding() throws {
+        let data = try encoder.encode(FeedItemStatus.actedOn)
+        let raw = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(raw, #""acted_on""#)
+    }
+
+    // MARK: - Missing optional fields
+
+    func testDecodesWithAllOptionalsMissing() throws {
+        let json = Data(
+            """
+            {
+              "id": "bare-1",
+              "type": "digest",
+              "priority": 10,
+              "title": "Bare item",
+              "summary": "Only required fields present.",
+              "timestamp": "2026-04-14T10:00:00Z",
+              "status": "new",
+              "author": "platform",
+              "createdAt": "2026-04-14T10:00:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+
+        XCTAssertEqual(item.id, "bare-1")
+        XCTAssertNil(item.source)
+        XCTAssertNil(item.expiresAt)
+        XCTAssertNil(item.minTimeAway)
+        XCTAssertNil(item.actions)
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripPreservesEquality() throws {
+        let json = Data(
+            """
+            {
+              "id": "action-1",
+              "type": "action",
+              "priority": 90,
+              "title": "Reply to Alex?",
+              "summary": "They asked about the Q3 planning doc.",
+              "source": "slack",
+              "timestamp": "2026-04-14T11:15:00Z",
+              "status": "new",
+              "expiresAt": "2026-04-15T11:15:00Z",
+              "minTimeAway": 60,
+              "actions": [
+                {
+                  "id": "reply",
+                  "label": "Draft reply",
+                  "prompt": "Draft a reply to Alex about the Q3 planning doc."
+                }
+              ],
+              "author": "assistant",
+              "createdAt": "2026-04-14T11:15:30Z"
+            }
+            """.utf8
+        )
+
+        let decoded = try decoder.decode(FeedItem.self, from: json)
+        let reencoded = try encoder.encode(decoded)
+        let redecoded = try decoder.decode(FeedItem.self, from: reencoded)
+
+        XCTAssertEqual(decoded, redecoded)
+    }
+
+    // MARK: - HomeFeedFile
+
+    func testDecodesHomeFeedFile() throws {
+        let json = Data(
+            """
+            {
+              "version": 1,
+              "updatedAt": "2026-04-14T12:00:00Z",
+              "items": [
+                {
+                  "id": "item-1",
+                  "type": "nudge",
+                  "priority": 50,
+                  "title": "Item one",
+                  "summary": "Summary one.",
+                  "timestamp": "2026-04-14T10:00:00Z",
+                  "status": "new",
+                  "author": "assistant",
+                  "createdAt": "2026-04-14T10:00:00Z"
+                },
+                {
+                  "id": "item-2",
+                  "type": "thread",
+                  "priority": 20,
+                  "title": "Item two",
+                  "summary": "Summary two.",
+                  "timestamp": "2026-04-14T10:05:00Z",
+                  "status": "acted_on",
+                  "author": "platform",
+                  "createdAt": "2026-04-14T10:05:00Z"
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let file = try decoder.decode(HomeFeedFile.self, from: json)
+
+        XCTAssertEqual(file.version, 1)
+        XCTAssertEqual(file.items.count, 2)
+        XCTAssertEqual(file.items[0].id, "item-1")
+        XCTAssertEqual(file.items[1].status, .actedOn)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `clients/shared/Network/FeedItem.swift` with `FeedItem`, `FeedAction`, `HomeFeedFile`, and supporting enums
- All JSON field names and enum raw values match the TS contract from PR 2 (`acted_on` → `.actedOn`, `expiresAt` replaces TDD's `ttl`)
- Coding tests cover all 4 item types, round-trip, `acted_on` decoding, and missing-optional handling
- No consumers yet; isolated addition

Part of plan: home-activity-feed.md (PR 3 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
