### PR TITLE
feat: feature flag chat message queue (default off)

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -484,11 +484,22 @@ function resolveRun(index: number) {
   run.resolve([...run.messages, assistantMsg]);
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   turnCommitCalls.length = 0;
   turnCommitHangForever = false;
   linkAttachmentShouldThrow = false;
   addMessageShouldThrowForContent.clear();
+  const { _setOverridesForTesting } = await import(
+    "../config/assistant-feature-flags.js"
+  );
+  _setOverridesForTesting({ "chat-message-queue": true });
+});
+
+afterEach(async () => {
+  const { _setOverridesForTesting } = await import(
+    "../config/assistant-feature-flags.js"
+  );
+  _setOverridesForTesting({});
 });
 
 afterAll(() => {

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -2802,3 +2802,118 @@ describe("MessageQueue byte budget", () => {
     ).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// chat-message-queue feature flag gating
+// ---------------------------------------------------------------------------
+
+describe("chat-message-queue feature flag gating", () => {
+  beforeEach(async () => {
+    pendingRuns = [];
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({ "chat-message-queue": true });
+  });
+
+  afterEach(async () => {
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({});
+  });
+
+  test("enqueueMessage rejects with queue_disabled error when flag is false", async () => {
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({ "chat-message-queue": false });
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+
+    // Start first message to set processing = true
+    const p1 = conversation.processMessage(
+      "msg-1",
+      [],
+      (e) => events1.push(e),
+      "req-1",
+    );
+    await waitForPendingRun(1);
+    expect(conversation.isProcessing()).toBe(true);
+
+    // Attempt to enqueue a second message — flag is disabled
+    const result = conversation.enqueueMessage(
+      "msg-2",
+      [],
+      (e) => events2.push(e),
+      "req-2",
+    );
+
+    // Should be rejected, not queued
+    expect(result.queued).toBe(false);
+    expect(result.rejected).toBe(true);
+    expect(result.requestId).toBe("req-2");
+
+    // Should have emitted an error event with queue_disabled category
+    const errorEvent = events2.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.type).toBe("error");
+    expect((errorEvent as any).category).toBe("queue_disabled");
+    expect((errorEvent as any).message).toContain("busy processing");
+
+    // Queue should remain empty
+    expect(conversation.getQueueDepth()).toBe(0);
+
+    // Clean up
+    resolveRun(0);
+    await p1;
+  });
+
+  test("enqueueMessage queues message normally when flag is true", async () => {
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({ "chat-message-queue": true });
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+
+    // Start first message to set processing = true
+    const p1 = conversation.processMessage(
+      "msg-1",
+      [],
+      (e) => events1.push(e),
+      "req-1",
+    );
+    await waitForPendingRun(1);
+    expect(conversation.isProcessing()).toBe(true);
+
+    // Enqueue a second message — flag is enabled
+    const result = conversation.enqueueMessage(
+      "msg-2",
+      [],
+      (e) => events2.push(e),
+      "req-2",
+    );
+
+    // Should be accepted into the queue
+    expect(result.queued).toBe(true);
+    expect(result.rejected).toBeUndefined();
+    expect(result.requestId).toBe("req-2");
+    expect(conversation.getQueueDepth()).toBe(1);
+
+    // Clean up: complete the first run and let the queue drain
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+});

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
   AgentEvent,
@@ -295,8 +295,19 @@ function resolveRun(index: number) {
 // ---------------------------------------------------------------------------
 
 describe("Conversation queue — slash-like messages pass through to agent loop", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     pendingRuns = [];
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({ "chat-message-queue": true });
+  });
+
+  afterEach(async () => {
+    const { _setOverridesForTesting } = await import(
+      "../config/assistant-feature-flags.js"
+    );
+    _setOverridesForTesting({});
   });
 
   test("queued slash-like input does not stall queue — batches with siblings", async () => {

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,14 +8,14 @@
 import { v4 as uuid } from "uuid";
 
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import {
   attachInlineAttachmentToMessage,
   attachmentExists,
@@ -226,7 +226,12 @@ export function enqueueMessage(
   options?: { isInteractive?: boolean },
   displayContent?: string,
   transport?: ConversationTransportMetadata,
-): { queued: boolean; requestId: string; rejected?: boolean } {
+): {
+  queued: boolean;
+  requestId: string;
+  rejected?: boolean;
+  reason?: "queue_full" | "queue_disabled";
+} {
   if (!ctx.processing) {
     return { queued: false, requestId };
   }
@@ -238,7 +243,7 @@ export function enqueueMessage(
         "The assistant is busy processing another message. Please wait for it to finish before sending a new one.",
       category: "queue_disabled",
     });
-    return { queued: false, requestId, rejected: true };
+    return { queued: false, requestId, rejected: true, reason: "queue_disabled" };
   }
 
   const turnChannelContext =
@@ -271,7 +276,7 @@ export function enqueueMessage(
         "The assistant is busy and cannot accept more messages right now. Please try again shortly.",
       category: "queue_full",
     });
-    return { queued: false, requestId, rejected: true };
+    return { queued: false, requestId, rejected: true, reason: "queue_full" };
   }
   return { queued: true, requestId };
 }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,6 +8,8 @@
 import { v4 as uuid } from "uuid";
 
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -227,6 +229,16 @@ export function enqueueMessage(
 ): { queued: boolean; requestId: string; rejected?: boolean } {
   if (!ctx.processing) {
     return { queued: false, requestId };
+  }
+
+  if (!isAssistantFeatureFlagEnabled("chat-message-queue", getConfig())) {
+    onEvent({
+      type: "error",
+      message:
+        "The assistant is busy processing another message. Please wait for it to finish before sending a new one.",
+      category: "queue_disabled",
+    });
+    return { queued: false, requestId, rejected: true };
   }
 
   const turnChannelContext =

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -300,7 +300,12 @@ export interface SurfaceConversationContext {
     options?: { isInteractive?: boolean },
     displayContent?: string,
     transport?: ConversationTransportMetadata,
-  ): { queued: boolean; requestId: string; rejected?: boolean };
+  ): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+    reason?: "queue_full" | "queue_disabled";
+  };
   getQueueDepth(): number;
   processMessage(
     content: string,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -747,7 +747,12 @@ export class Conversation {
     options?: { isInteractive?: boolean },
     displayContent?: string,
     transport?: ConversationTransportMetadata,
-  ): { queued: boolean; requestId: string; rejected?: boolean } {
+  ): {
+    queued: boolean;
+    requestId: string;
+    rejected?: boolean;
+    reason?: "queue_full" | "queue_disabled";
+  } {
     return enqueueMessageImpl(
       this,
       content,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1803,9 +1803,10 @@ export async function handleSendMessage(
       transport,
     );
     if (enqueueResult.rejected) {
+      const isDisabled = enqueueResult.reason === "queue_disabled";
       return Response.json(
-        { accepted: false, error: "queue_full" },
-        { status: 429 },
+        { accepted: false, error: enqueueResult.reason ?? "queue_full" },
+        { status: isDisabled ? 503 : 429 },
       );
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -60,6 +60,11 @@ final class ConversationManager: ConversationRestorerDelegate {
     private let conversationAnalysisClient: ConversationAnalysisClientProtocol
     private let conversationRestorer: ConversationRestorer
 
+    /// Closure that resolves assistant-scoped feature flags by key.
+    /// Injected by the app layer so ChatViewModels pick up runtime overrides
+    /// from the gateway via AssistantFeatureFlagStore.
+    private let isAssistantFeatureFlagEnabled: (String) -> Bool
+
     // MARK: - Pre-Chat Onboarding
 
     /// Pre-chat onboarding context from the onboarding flow. Set by AppDelegate
@@ -172,6 +177,9 @@ final class ConversationManager: ConversationRestorerDelegate {
         conversationDetailClient: any ConversationDetailClientProtocol = ConversationDetailClient(),
         conversationHostAccessClient: any ConversationHostAccessClientProtocol = ConversationHostAccessClient(),
         conversationAnalysisClient: ConversationAnalysisClientProtocol = ConversationAnalysisClient(),
+        isAssistantFeatureFlagEnabled: @escaping (String) -> Bool = { key in
+            loadFeatureFlagRegistry()?.flags.first(where: { $0.key == key })?.defaultEnabled ?? true
+        },
         isFirstLaunch: Bool = false,
         preChatContext: PreChatOnboardingContext? = nil
     ) {
@@ -183,6 +191,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         self.conversationDetailClient = conversationDetailClient
         self.conversationHostAccessClient = conversationHostAccessClient
         self.conversationAnalysisClient = conversationAnalysisClient
+        self.isAssistantFeatureFlagEnabled = isAssistantFeatureFlagEnabled
         self.conversationRestorer = ConversationRestorer(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
         self.selectionStore = ConversationSelectionStore(listStore: listStore)
 
@@ -360,7 +369,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     // MARK: - VM Factory
 
     func makeViewModel() -> ChatViewModel {
-        let viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
+        let viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient, isAssistantFeatureFlagEnabled: isAssistantFeatureFlagEnabled)
         viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
             guard let self, let viewModel else { return false }
             return self.isLatestToolUseRecipient(viewModel)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -326,6 +326,9 @@ public final class MainWindow {
         self.conversationManager = ConversationManager(
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
+            isAssistantFeatureFlagEnabled: { [weak assistantFeatureFlagStore] key in
+                assistantFeatureFlagStore?.isEnabled(key) ?? false
+            },
             isFirstLaunch: isFirstLaunch,
             preChatContext: preChatContext
         )

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1067,7 +1067,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         settingsClient: any SettingsClientProtocol = SettingsClient(),
         interactionClient: any InteractionClientProtocol = InteractionClient(),
         conversationQueueClient: any ConversationQueueClientProtocol = ConversationQueueClient(),
-        onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil
+        onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil,
+        isAssistantFeatureFlagEnabled: @escaping (String) -> Bool = { key in
+            loadFeatureFlagRegistry()?.flags.first(where: { $0.key == key })?.defaultEnabled ?? true
+        }
     ) {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
@@ -1096,7 +1099,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             errorManager: errorManager,
             btwState: btwState,
             settingsClient: settingsClient,
-            conversationListClient: conversationListClient
+            conversationListClient: conversationListClient,
+            isAssistantFeatureFlagEnabled: isAssistantFeatureFlagEnabled
         )
 
         // Initialize the action handler for server message dispatch.

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -86,6 +86,12 @@ final class MessageSendCoordinator {
     private let settingsClient: any SettingsClientProtocol
     private let conversationListClient: any ConversationListClientProtocol
 
+    /// Closure that resolves assistant-scoped feature flags by key.
+    /// Defaults to reading the bundled registry, which reflects compile-time defaults.
+    /// Callers (e.g. macOS app) can inject `AssistantFeatureFlagStore.isEnabled` to
+    /// pick up runtime overrides from the gateway.
+    private let isAssistantFeatureFlagEnabled: (String) -> Bool
+
     init(
         delegate: any MessageSendCoordinatorDelegate,
         messageManager: ChatMessageManager,
@@ -93,7 +99,10 @@ final class MessageSendCoordinator {
         errorManager: ChatErrorManager,
         btwState: ChatBtwState,
         settingsClient: any SettingsClientProtocol,
-        conversationListClient: any ConversationListClientProtocol
+        conversationListClient: any ConversationListClientProtocol,
+        isAssistantFeatureFlagEnabled: @escaping (String) -> Bool = { key in
+            loadFeatureFlagRegistry()?.flags.first(where: { $0.key == key })?.defaultEnabled ?? true
+        }
     ) {
         self.delegate = delegate
         self.messageManager = messageManager
@@ -102,6 +111,7 @@ final class MessageSendCoordinator {
         self.btwState = btwState
         self.settingsClient = settingsClient
         self.conversationListClient = conversationListClient
+        self.isAssistantFeatureFlagEnabled = isAssistantFeatureFlagEnabled
 
     }
 
@@ -416,21 +426,26 @@ final class MessageSendCoordinator {
             log.error("Cannot send user_message: daemon not connected")
 
             // Buffer the primary (non-queued-retry) send in the offline queue
-            // instead of surfacing an error. The message stays visible with a
-            // "pending" indicator and is flushed automatically on reconnect.
+            // instead of surfacing an error — but only when the feature flag is enabled.
             if queuedMessageId == nil {
-                log.info("Buffering message in offline queue (conversation: \(conversationId))")
-                OfflineMessageQueue.shared.enqueue(conversationId: conversationId, text: text, displayText: displayText, attachments: attachments, automated: automated)
-                // Mark the corresponding chat message as offline-pending so the UI
-                // can show a visual indicator. Find the last user message with this
-                // text — it is the one just appended by sendMessage().
-                let matchText = displayText ?? text
-                if let idx = messageManager.messages.indices.reversed().first(where: { messageManager.messages[$0].role == .user && messageManager.messages[$0].text == matchText }) {
-                    messageManager.messages[idx].status = .pendingOffline
+                if isAssistantFeatureFlagEnabled("chat-message-queue") {
+                    log.info("Buffering message in offline queue (conversation: \(conversationId))")
+                    OfflineMessageQueue.shared.enqueue(conversationId: conversationId, text: text, displayText: displayText, attachments: attachments, automated: automated)
+                    // Mark the corresponding chat message as offline-pending so the UI
+                    // can show a visual indicator. Find the last user message with this
+                    // text — it is the one just appended by sendMessage().
+                    let matchText = displayText ?? text
+                    if let idx = messageManager.messages.indices.reversed().first(where: { messageManager.messages[$0].role == .user && messageManager.messages[$0].text == matchText }) {
+                        messageManager.messages[idx].status = .pendingOffline
+                    }
+                    // Don't show the error banner — the pending indicator on the bubble
+                    // communicates the offline state without interrupting the conversation.
+                    return
+                } else {
+                    log.info("Message queue disabled — rejecting offline send")
+                    // Fall through to the error handling below so the user sees
+                    // a connection failure instead of a pending indicator.
                 }
-                // Don't show the error banner — the pending indicator on the bubble
-                // communicates the offline state without interrupting the conversation.
-                return
             }
 
             // Always track the failed message for retry support.
@@ -675,6 +690,17 @@ final class MessageSendCoordinator {
     func flushOfflineQueue() {
         guard let delegate else { return }
         let queue = OfflineMessageQueue.shared
+
+        // When the flag is disabled, clear any stale queued messages so they
+        // are not flushed if the flag is later re-enabled.
+        guard isAssistantFeatureFlagEnabled("chat-message-queue") else {
+            if !queue.isEmpty {
+                log.info("Message queue disabled — clearing \(queue.allMessages.count) stale offline message(s)")
+                queue.clear()
+            }
+            return
+        }
+
         guard !queue.isEmpty else { return }
 
         guard let currentConversationId = delegate.conversationId else {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -344,6 +344,14 @@
       "label": "Home Tab",
       "description": "Replace the knowledge graph top-level tab with a new Home page showing relationship progression, facts, and capability tiers",
       "defaultEnabled": false
+    },
+    {
+      "id": "chat-message-queue",
+      "scope": "assistant",
+      "key": "chat-message-queue",
+      "label": "Chat Message Queue",
+      "description": "Queue incoming messages while the assistant is processing instead of rejecting them, and buffer messages offline for automatic replay on reconnect",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a `chat-message-queue` feature flag (default `false`) that gates both the daemon-side message queue (queuing messages while the agent is busy) and the client-side offline message queue (buffering messages when the daemon is unreachable). When disabled, messages sent while busy are rejected immediately, and messages sent while offline fail with a connection error instead of being silently buffered.

## Self-review result
PASS — 3 gaps found and fixed across 3 fix PRs

## PRs merged into feature branch
- #25464: feat: add `chat-message-queue` feature flag to registry (default false)
- #25465: feat: gate daemon message queue behind `chat-message-queue` feature flag
- #25466: feat: gate offline message queue behind `chat-message-queue` feature flag
- #25468: test: add tests for chat-message-queue feature flag gating

### Fix PRs
- #25472: fix: enable chat-message-queue flag in existing queue tests
- #25475: fix: wire AssistantFeatureFlagStore into MessageSendCoordinator
- #25470: fix: differentiate queue_disabled from queue_full in HTTP response

Part of plan: chat-msg-queue-flag.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
