### PR TITLE
feat(home-feed): add nudge card + compact list row views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedItemIcon.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedItemIcon.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Tiny helper view that maps a `FeedItemSource` to a design-system icon.
+///
+/// Used by both `HomeFeedNudgeCard` and `HomeFeedListRow` so every feed item
+/// surfaces a consistent source glyph (Gmail / Slack / Calendar / assistant /
+/// unknown) without each call site re-implementing the mapping.
+///
+/// Icons are resolved through `VIconView` so they honour the vendored Lucide
+/// PDF catalogue — never raw `Image(systemName:)` — and are tinted with the
+/// muted content token so they sit quietly next to a prominent title.
+///
+/// This view is intentionally stateless and takes only a single
+/// `source: FeedItemSource?` plus an optional size override (defaulting to a
+/// 16pt glyph that matches `HomeFactsSection.emptyState`'s sparkles icon).
+struct HomeFeedItemIcon: View {
+    let source: FeedItemSource?
+    var size: CGFloat = 16
+
+    var body: some View {
+        VIconView(Self.icon(for: source), size: size)
+            .foregroundStyle(VColor.contentTertiary)
+            .accessibilityHidden(true)
+    }
+
+    /// Source → icon mapping. Kept exhaustive so a new `FeedItemSource` case
+    /// forces this switch to be updated (matches the TDD "closed set in v1"
+    /// contract noted on the Swift enum).
+    static func icon(for source: FeedItemSource?) -> VIcon {
+        guard let source else { return .circle }
+        switch source {
+        case .gmail:     return .mail
+        case .slack:     return .messageSquare
+        case .calendar:  return .calendar
+        case .assistant: return .sparkles
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedListRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedListRow.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Compact, tappable row that renders a `FeedItem` whose `type` is one of
+/// `.digest`, `.action`, or `.thread`.
+///
+/// These are the "quiet" feed items — they live under any nudges as a
+/// vertical list with a thin divider between rows. Tapping a row fires
+/// `onTap`; the wiring PR uses that to open a new conversation pre-seeded
+/// with the item's first action prompt (or a canned "tell me more"
+/// fallback) via the daemon's feed HTTP route.
+///
+/// Layout (left → right):
+///
+///   icon · title / summary  · spacer · relative timestamp
+///   divider
+///
+/// The row is wrapped in a `.plain`-style `Button` so the whole horizontal
+/// area is a hit target without any platform button chrome.
+struct HomeFeedListRow: View {
+    let item: FeedItem
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                rowContent
+                divider
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(Text("Opens a conversation about this item"))
+    }
+
+    // MARK: - Row body
+
+    private var rowContent: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            HomeFeedItemIcon(source: item.source)
+                .padding(.top, VSpacing.xxs)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(item.title)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentEmphasized)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if !item.summary.isEmpty {
+                    Text(item.summary)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: VSpacing.sm)
+
+            Text(Self.relativeTimestamp(item.timestamp))
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+                .monospacedDigit()
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .padding(.vertical, VSpacing.sm)
+    }
+
+    // MARK: - Divider
+
+    /// Hairline divider below each row. Uses `borderBase` — the same token
+    /// `HomeIdentityPanel` uses for its metadata separator — so list rows
+    /// feel consistent with the other Home sections.
+    private var divider: some View {
+        Rectangle()
+            .fill(VColor.borderBase)
+            .frame(height: 1)
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Relative timestamp
+
+    /// Produces a short relative timestamp (e.g. "5m ago", "2h ago") for the
+    /// right-hand column. Uses `RelativeDateTimeFormatter` in its `.short`
+    /// style to keep the label narrow so it never pushes the title into
+    /// truncation on medium-width windows.
+    static func relativeTimestamp(_ date: Date, now: Date = Date()) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: now)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedListRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedListRow.swift
@@ -84,12 +84,12 @@ struct HomeFeedListRow: View {
     // MARK: - Relative timestamp
 
     /// Produces a short relative timestamp (e.g. "5m ago", "2h ago") for the
-    /// right-hand column. Uses `RelativeDateTimeFormatter` in its `.short`
+    /// right-hand column. Uses `RelativeDateTimeFormatter` in its `.abbreviated`
     /// style to keep the label narrow so it never pushes the title into
     /// truncation on medium-width windows.
     static func relativeTimestamp(_ date: Date, now: Date = Date()) -> String {
         let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .short
+        formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: now)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedNudgeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedNudgeCard.swift
@@ -90,7 +90,7 @@ struct HomeFeedNudgeCard: View {
 
     private var actionsRow: some View {
         HStack(spacing: VSpacing.sm) {
-            ForEach(Array(visibleActions.enumerated()), id: \.element.id) { index, action in
+            ForEach(Array(visibleActions.enumerated()), id: \.offset) { index, action in
                 VButton(
                     label: action.label,
                     style: index == 0 ? .primary : .outlined,

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedNudgeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedNudgeCard.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Full-bleed card that renders a `FeedItem` whose `type == .nudge`.
+///
+/// Nudges are the highest-signal feed surface: they nearly always carry 1–2
+/// action buttons the assistant wants the user to tap straight from the Home
+/// page (e.g. "Draft reply", "Snooze"). This view gives them a raised card
+/// treatment so they visually dominate the compact digest/action/thread rows
+/// rendered by `HomeFeedListRow`.
+///
+/// Layout (top → bottom):
+///
+///   icon · title · spacer · dismiss (X)
+///   summary
+///   [action button]  [action button]
+///
+/// The view is intentionally pure — it takes the `FeedItem`, an `onAction`
+/// closure invoked with the tapped `FeedAction`, and an `onDismiss` closure.
+/// No store coupling lives here; the wiring PR binds it to `HomeFeedStore`.
+struct HomeFeedNudgeCard: View {
+    let item: FeedItem
+    let onAction: (FeedAction) -> Void
+    let onDismiss: () -> Void
+
+    /// Cap the visible action buttons at two per the TDD's "1–2 max" rule so
+    /// a malformed feed item can never push a wall of buttons into the card.
+    private var visibleActions: [FeedAction] {
+        let actions = item.actions ?? []
+        return Array(actions.prefix(2))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            headerRow
+            summaryText
+            if !visibleActions.isEmpty {
+                actionsRow
+            }
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.window, style: .continuous)
+                .fill(VColor.surfaceLift)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.window, style: .continuous)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text(item.title))
+        .accessibilityHint(Text(item.summary))
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
+            HomeFeedItemIcon(source: item.source)
+            Text(item.title)
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: VSpacing.sm)
+
+            VButton(
+                label: "Dismiss",
+                iconOnly: VIcon.x.rawValue,
+                style: .ghost,
+                size: .compact,
+                tintColor: VColor.contentTertiary,
+                action: onDismiss
+            )
+            .accessibilityLabel(Text("Dismiss"))
+        }
+    }
+
+    // MARK: - Summary
+
+    private var summaryText: some View {
+        Text(item.summary)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentDefault)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Actions
+
+    private var actionsRow: some View {
+        HStack(spacing: VSpacing.sm) {
+            ForEach(Array(visibleActions.enumerated()), id: \.element.id) { index, action in
+                VButton(
+                    label: action.label,
+                    style: index == 0 ? .primary : .outlined,
+                    size: .compact
+                ) {
+                    onAction(action)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.top, VSpacing.xxs)
+    }
+}


### PR DESCRIPTION
## Summary
- `HomeFeedNudgeCard.swift` — full card for `type == .nudge` with icon, title, body, action buttons, dismiss
- `HomeFeedListRow.swift` — compact tappable row for digest/action/thread
- `HomeFeedItemIcon.swift` — source -> VIcon helper
- Design-token compliant: VColor, VSpacing, VRadius, VFont; no `#Preview`, no `.foregroundColor`
- Pure views — no store coupling. Wired into HomePageView in PR 10.

Part of plan: home-activity-feed.md (PR 8 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
