### PR TITLE
feat(home-feed): add HomeContextBanner view + ContextBanner shared type

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeContextBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeContextBanner.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 ///
 /// Renders three server-composed segments — greeting, time-away label, and
 /// optional "N new" count — separated by middot dividers. The greeting and
-/// time-away strings are prepared by the daemon, so this view is pure
+/// time-away strings are prepared by the assistant, so this view is pure
 /// layout: no date math, no localization, no store coupling.
 ///
 /// When `banner.newCount == 0` the "N new" segment *and* its leading
@@ -31,8 +31,7 @@ struct HomeContextBannerView: View {
         }
         .font(VFont.bodySmallDefault)
         .foregroundStyle(VColor.contentSecondary)
-        .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
+        .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
         .accessibilityElement(children: .combine)
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeContextBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeContextBanner.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Single-line context strip that sits flush above the Home activity feed.
+///
+/// Renders three server-composed segments — greeting, time-away label, and
+/// optional "N new" count — separated by middot dividers. The greeting and
+/// time-away strings are prepared by the daemon, so this view is pure
+/// layout: no date math, no localization, no store coupling.
+///
+/// When `banner.newCount == 0` the "N new" segment *and* its leading
+/// middot separator are hidden entirely so the banner never reads
+/// "… · 0 new". When it's positive, the segment is appended with its
+/// own middot so the dividers look consistent.
+///
+/// The view deliberately has no background fill — it's meant to sit
+/// flush above the feed section as a secondary-text annotation, not as
+/// its own card.
+struct HomeContextBannerView: View {
+    let banner: ContextBanner
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(banner.greeting)
+            separator
+            Text(banner.timeAwayLabel)
+            if banner.newCount > 0 {
+                separator
+                Text("\(banner.newCount) new")
+            }
+        }
+        .font(VFont.bodySmallDefault)
+        .foregroundStyle(VColor.contentSecondary)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var separator: some View {
+        Text("·")
+            .accessibilityHidden(true)
+    }
+}

--- a/clients/shared/Network/HomeContextBanner.swift
+++ b/clients/shared/Network/HomeContextBanner.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Shared network contract for the Home page context banner.
 ///
-/// The daemon returns this as part of the `GET /v1/home/feed` response
+/// The assistant returns this as part of the `GET /v1/home/feed` response
 /// alongside the list of `FeedItem`s. It carries the small, one-line
 /// "greeting · time-away · N new" strip that sits above the activity
 /// feed so the user immediately knows what's changed since they last

--- a/clients/shared/Network/HomeContextBanner.swift
+++ b/clients/shared/Network/HomeContextBanner.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Shared network contract for the Home page context banner.
+///
+/// The daemon returns this as part of the `GET /v1/home/feed` response
+/// alongside the list of `FeedItem`s. It carries the small, one-line
+/// "greeting · time-away · N new" strip that sits above the activity
+/// feed so the user immediately knows what's changed since they last
+/// checked in.
+///
+/// The greeting and time-away labels are fully composed server-side —
+/// the macOS client does not do any date math or localization on these
+/// fields, it just renders them verbatim. `newCount` is the integer
+/// count of unseen feed items; the view hides the "N new" segment
+/// entirely when it is zero so the banner never reads "0 new".
+public struct ContextBanner: Codable, Sendable, Hashable {
+    /// Pre-composed greeting line, e.g. "Good afternoon, Alex".
+    public let greeting: String
+    /// Pre-composed time-away label, e.g. "Away for 3 hours".
+    public let timeAwayLabel: String
+    /// Count of unseen feed items. Zero hides the "N new" segment.
+    public let newCount: Int
+
+    public init(greeting: String, timeAwayLabel: String, newCount: Int) {
+        self.greeting = greeting
+        self.timeAwayLabel = timeAwayLabel
+        self.newCount = newCount
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `clients/shared/Network/HomeContextBanner.swift` with the shared `ContextBanner` struct
- Adds `clients/macos/vellum-assistant/Features/Home/HomeContextBanner.swift` SwiftUI view
- Hides the "N new" segment when `newCount == 0`
- Design-token compliant: VColor/VSpacing/VFont; no `#Preview`, no `.foregroundColor`
- Pure view — no store coupling yet

Part of plan: home-activity-feed.md (PR 9 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
