### PR TITLE
feat(home-feed): add daemon feed writer with merge + TTL + coalesced writes

### DIFF
--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -1,0 +1,482 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ─── assistantEventHub mock ────────────────────────────────────────────
+// We spy on `publish` so the SSE-publish test can assert the writer
+// fires a `home_feed_updated` event with the correct `newItemCount`.
+// Other tests don't care about the spy but the mock still needs to be
+// in place before the writer module is imported so the dynamic import
+// picks it up.
+// Typed loosely so the mock's inferred call-signature doesn't force
+// us to thread the full `AssistantEvent` type through the tests.
+const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
+
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: publishSpy,
+    // Minimal stubs — the writer only touches `.publish`, but the
+    // hub's real shape has more fields. Tests never call them.
+    subscribe: () => () => {},
+  },
+}));
+
+// Dynamic import so the module resolves after the mock above is in
+// place. Bun's `mock.module` needs to run before the real import is
+// evaluated for the mock to take effect.
+const {
+  HOME_FEED_FILENAME,
+  HOME_FEED_VERSION,
+  appendFeedItem,
+  getHomeFeedPath,
+  patchFeedItemStatus,
+  readHomeFeed,
+} = await import("../feed-writer.js");
+
+type FeedItemType = "nudge" | "digest" | "action" | "thread";
+type FeedItemAuthor = "assistant" | "platform";
+type FeedItemStatus = "new" | "seen" | "acted_on";
+type FeedItemSource = "gmail" | "slack" | "calendar" | "assistant";
+
+interface TestFeedItem {
+  id: string;
+  type: FeedItemType;
+  priority: number;
+  title: string;
+  summary: string;
+  source?: FeedItemSource;
+  timestamp: string;
+  status: FeedItemStatus;
+  expiresAt?: string;
+  author: FeedItemAuthor;
+  createdAt: string;
+}
+
+function makeItem(
+  overrides: Partial<TestFeedItem> & { id: string },
+): TestFeedItem {
+  return {
+    type: "nudge",
+    priority: 50,
+    title: "Test",
+    summary: "Test summary",
+    timestamp: "2026-04-14T12:00:00.000Z",
+    status: "new",
+    author: "platform",
+    createdAt: "2026-04-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-hfw-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  publishSpy.mockClear();
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+function readFileJson(): {
+  version: number;
+  items: TestFeedItem[];
+  updatedAt: string;
+} {
+  const raw = readFileSync(getHomeFeedPath(), "utf-8");
+  return JSON.parse(raw);
+}
+
+describe("feed-writer", () => {
+  describe("getHomeFeedPath", () => {
+    test("returns <workspace>/data/home-feed.json", () => {
+      expect(getHomeFeedPath()).toBe(
+        join(workspaceDir, "data", HOME_FEED_FILENAME),
+      );
+    });
+  });
+
+  describe("readHomeFeed", () => {
+    test("missing file returns an empty v1 HomeFeedFile", () => {
+      const feed = readHomeFeed();
+      expect(feed.version).toBe(HOME_FEED_VERSION);
+      expect(feed.items).toEqual([]);
+      expect(feed.updatedAt).toBe(new Date(0).toISOString());
+    });
+
+    test("filters out items whose expiresAt is in the past", () => {
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      const past = new Date(Date.now() - 60_000).toISOString();
+      const future = new Date(Date.now() + 60_000).toISOString();
+      const file = {
+        version: 1,
+        updatedAt: "2026-04-14T12:00:00.000Z",
+        items: [
+          makeItem({
+            id: "expired",
+            type: "action",
+            expiresAt: past,
+          }),
+          makeItem({
+            id: "live",
+            type: "action",
+            expiresAt: future,
+          }),
+        ],
+      };
+      writeFileSync(getHomeFeedPath(), JSON.stringify(file, null, 2), "utf-8");
+
+      const feed = readHomeFeed();
+      expect(feed.items).toHaveLength(1);
+      expect(feed.items[0]!.id).toBe("live");
+    });
+
+    test("corrupt JSON returns an empty feed", () => {
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      writeFileSync(getHomeFeedPath(), "{not valid", "utf-8");
+      const feed = readHomeFeed();
+      expect(feed.items).toEqual([]);
+    });
+  });
+
+  describe("appendFeedItem", () => {
+    test("appends a single nudge to disk", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "nudge-1",
+          type: "nudge",
+          source: "gmail",
+          title: "New email",
+          summary: "You have a new email",
+        }),
+      );
+      const decoded = readFileJson();
+      expect(decoded.version).toBe(1);
+      expect(decoded.items).toHaveLength(1);
+      expect(decoded.items[0]!.id).toBe("nudge-1");
+      expect(decoded.items[0]!.title).toBe("New email");
+    });
+
+    test("second digest from the same source replaces the first", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "digest-old",
+          type: "digest",
+          source: "gmail",
+          title: "Old digest",
+          createdAt: "2026-04-14T10:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "digest-new",
+          type: "digest",
+          source: "gmail",
+          title: "New digest",
+          createdAt: "2026-04-14T11:00:00.000Z",
+        }),
+      );
+
+      const decoded = readFileJson();
+      const digests = decoded.items.filter((i) => i.type === "digest");
+      expect(digests).toHaveLength(1);
+      expect(digests[0]!.id).toBe("digest-new");
+      expect(digests[0]!.title).toBe("New digest");
+    });
+
+    test("assistant nudge overwrites an existing platform nudge for the same source", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "platform-nudge",
+          type: "nudge",
+          source: "slack",
+          author: "platform",
+          title: "Platform baseline",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "assistant-nudge",
+          type: "nudge",
+          source: "slack",
+          author: "assistant",
+          title: "Assistant override",
+        }),
+      );
+
+      const decoded = readFileJson();
+      const nudges = decoded.items.filter(
+        (i) => i.type === "nudge" && i.source === "slack",
+      );
+      expect(nudges).toHaveLength(1);
+      expect(nudges[0]!.author).toBe("assistant");
+      expect(nudges[0]!.title).toBe("Assistant override");
+    });
+
+    test("platform nudge over an existing assistant nudge is a no-op", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "assistant-nudge",
+          type: "nudge",
+          source: "slack",
+          author: "assistant",
+          title: "Assistant original",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "platform-nudge",
+          type: "nudge",
+          source: "slack",
+          author: "platform",
+          title: "Stale platform baseline",
+        }),
+      );
+
+      const decoded = readFileJson();
+      const nudges = decoded.items.filter(
+        (i) => i.type === "nudge" && i.source === "slack",
+      );
+      expect(nudges).toHaveLength(1);
+      expect(nudges[0]!.author).toBe("assistant");
+      expect(nudges[0]!.title).toBe("Assistant original");
+    });
+
+    test("action without expiresAt auto-fades 24h after createdAt", async () => {
+      const createdAt = "2026-04-14T12:00:00.000Z";
+      await appendFeedItem(
+        makeItem({
+          id: "action-1",
+          type: "action",
+          createdAt,
+        }),
+      );
+      const decoded = readFileJson();
+      expect(decoded.items).toHaveLength(1);
+      const item = decoded.items[0]!;
+      expect(item.expiresAt).toBeDefined();
+      const expectedMs = Date.parse(createdAt) + 24 * 60 * 60 * 1000;
+      expect(Date.parse(item.expiresAt!)).toBe(expectedMs);
+    });
+
+    test("action with an explicit expiresAt is left untouched", async () => {
+      const explicit = "2026-04-15T00:00:00.000Z";
+      await appendFeedItem(
+        makeItem({
+          id: "action-2",
+          type: "action",
+          expiresAt: explicit,
+          createdAt: "2026-04-14T12:00:00.000Z",
+        }),
+      );
+      const decoded = readFileJson();
+      expect(decoded.items[0]!.expiresAt).toBe(explicit);
+    });
+
+    test("thread updates replace the existing thread with the same id in place", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "thread-A",
+          type: "thread",
+          title: "Thread v1",
+          priority: 80,
+          createdAt: "2026-04-14T12:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "thread-B",
+          type: "thread",
+          title: "Other thread",
+          priority: 60,
+          createdAt: "2026-04-14T11:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "thread-A",
+          type: "thread",
+          title: "Thread v2 updated",
+          priority: 80,
+          createdAt: "2026-04-14T12:00:00.000Z",
+        }),
+      );
+
+      const decoded = readFileJson();
+      expect(decoded.items).toHaveLength(2);
+      const threadA = decoded.items.find((i) => i.id === "thread-A");
+      expect(threadA?.title).toBe("Thread v2 updated");
+    });
+
+    test("items sort by priority desc then createdAt desc", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "low",
+          priority: 10,
+          createdAt: "2026-04-14T12:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "high-old",
+          priority: 90,
+          createdAt: "2026-04-14T10:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "high-new",
+          priority: 90,
+          createdAt: "2026-04-14T11:00:00.000Z",
+        }),
+      );
+
+      const decoded = readFileJson();
+      expect(decoded.items.map((i) => i.id)).toEqual([
+        "high-new",
+        "high-old",
+        "low",
+      ]);
+    });
+  });
+
+  describe("patchFeedItemStatus", () => {
+    test("updates the status field on an existing item", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "item-1",
+          type: "nudge",
+          title: "Original",
+        }),
+      );
+
+      const result = await patchFeedItemStatus("item-1", "seen");
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("item-1");
+      expect(result!.status).toBe("seen");
+      // Title / other fields are preserved.
+      expect(result!.title).toBe("Original");
+
+      const decoded = readFileJson();
+      expect(decoded.items[0]!.status).toBe("seen");
+      expect(decoded.items[0]!.title).toBe("Original");
+    });
+
+    test("returns null for an unknown id", async () => {
+      await appendFeedItem(makeItem({ id: "known", type: "nudge" }));
+      const result = await patchFeedItemStatus("unknown", "seen");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("concurrency", () => {
+    test("10 concurrent appends of items with distinct (type,source) pairs all land", async () => {
+      const items = Array.from({ length: 10 }, (_, i) =>
+        makeItem({
+          id: `distinct-${i}`,
+          type: "nudge",
+          // No source → no (type,source) dedupe at all; every item
+          // lands as-is. This is the purest concurrent-append test.
+          title: `Item ${i}`,
+          createdAt: new Date(
+            Date.parse("2026-04-14T12:00:00.000Z") + i * 1000,
+          ).toISOString(),
+        }),
+      );
+
+      await Promise.all(items.map((i) => appendFeedItem(i)));
+
+      const decoded = readFileJson();
+      expect(decoded.items).toHaveLength(10);
+      const ids = new Set(decoded.items.map((i) => i.id));
+      for (const item of items) {
+        expect(ids.has(item.id)).toBe(true);
+      }
+    });
+  });
+
+  describe("SSE publish", () => {
+    test("publishes home_feed_updated with correct newItemCount", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "new-1",
+          type: "nudge",
+          status: "new",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "new-2",
+          type: "nudge",
+          status: "new",
+          createdAt: "2026-04-14T12:00:01.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "seen-1",
+          type: "nudge",
+          status: "seen",
+          createdAt: "2026-04-14T12:00:02.000Z",
+        }),
+      );
+
+      expect(publishSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      // Inspect the LAST publish — it reflects the final on-disk state.
+      const lastCall = publishSpy.mock.calls[publishSpy.mock.calls.length - 1]!;
+      const event = lastCall[0] as {
+        assistantId: string;
+        message: {
+          type: string;
+          updatedAt: string;
+          newItemCount: number;
+        };
+      };
+      expect(event.assistantId).toBe("home");
+      expect(event.message.type).toBe("home_feed_updated");
+      expect(event.message.newItemCount).toBe(2);
+      expect(Number.isNaN(Date.parse(event.message.updatedAt))).toBe(false);
+    });
+
+    test("patching to seen decrements newItemCount in the SSE event", async () => {
+      await appendFeedItem(
+        makeItem({
+          id: "x",
+          type: "nudge",
+          status: "new",
+        }),
+      );
+      publishSpy.mockClear();
+
+      await patchFeedItemStatus("x", "seen");
+
+      expect(publishSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      const lastCall = publishSpy.mock.calls[publishSpy.mock.calls.length - 1]!;
+      const event = lastCall[0] as {
+        message: { type: string; newItemCount: number };
+      };
+      expect(event.message.type).toBe("home_feed_updated");
+      expect(event.message.newItemCount).toBe(0);
+    });
+  });
+});

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import {
   mkdirSync,
   mkdtempSync,
@@ -7,7 +8,17 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 
 // ─── assistantEventHub mock ────────────────────────────────────────────
 // We spy on `publish` so the SSE-publish test can assert the writer
@@ -387,6 +398,48 @@ describe("feed-writer", () => {
       const result = await patchFeedItemStatus("unknown", "seen");
       expect(result).toBeNull();
     });
+
+    test("returns null when the underlying writeFileSync throws", async () => {
+      // Seed the feed with an existing item on disk so the patch path
+      // finds a match and would otherwise resolve with the mutated item.
+      await appendFeedItem(
+        makeItem({
+          id: "fail-item",
+          type: "nudge",
+          title: "Pre-fail title",
+        }),
+      );
+
+      // Force the next writeFileSync against the home-feed path to
+      // throw so `runWrite()` sets `wrote = false`. Other writes (e.g.
+      // to unrelated paths) are passed through untouched.
+      const feedPath = getHomeFeedPath();
+      const originalWrite = fs.writeFileSync;
+      const spy = spyOn(fs, "writeFileSync").mockImplementation(((
+        path: fs.PathOrFileDescriptor,
+        data: string | NodeJS.ArrayBufferView,
+        options?: fs.WriteFileOptions,
+      ) => {
+        if (typeof path === "string" && path === feedPath) {
+          throw new Error("Simulated write failure");
+        }
+        return originalWrite(path, data, options);
+      }) as typeof fs.writeFileSync);
+
+      try {
+        const result = await patchFeedItemStatus("fail-item", "seen");
+        // Core assertion: the caller must NOT observe a "success" return
+        // value when the write did not actually land.
+        expect(result).toBeNull();
+
+        // And the on-disk file should still show the pre-patch state.
+        const decoded = readFileJson();
+        expect(decoded.items[0]!.status).toBe("new");
+        expect(decoded.items[0]!.title).toBe("Pre-fail title");
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe("concurrency", () => {
@@ -452,7 +505,7 @@ describe("feed-writer", () => {
           newItemCount: number;
         };
       };
-      expect(event.assistantId).toBe("home");
+      expect(event.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
       expect(event.message.type).toBe("home_feed_updated");
       expect(event.message.newItemCount).toBe(2);
       expect(Number.isNaN(Date.parse(event.message.updatedAt))).toBe(false);

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -1,0 +1,396 @@
+/**
+ * Home activity feed writer.
+ *
+ * Owns `<workspace>/data/home-feed.json`, the daemon-side source of
+ * truth for the macOS Home page activity feed. Handles the merge
+ * semantics defined by the TDD / plan:
+ *
+ *   - Digest replacement: at most one digest per `source`. A fresh
+ *     digest for a source replaces any prior digest for the same
+ *     source in place.
+ *   - Thread in-place update: if an incoming `thread` item shares its
+ *     `id` with an existing item, replace that item while preserving
+ *     its array position so the UI does not jitter on updates.
+ *   - Author resolution: for matching `(type, source)` pairs the
+ *     hybrid-authoring precedence is `assistant` beats `platform` —
+ *     an assistant item overwrites an existing platform item for the
+ *     same pair, but a platform item never overwrites an existing
+ *     assistant item (no-op).
+ *   - Action auto-fade: when an `action` item is appended without an
+ *     explicit `expiresAt`, the writer fills it in as
+ *     `createdAt + 24h` so stale actions fall off on next read.
+ *   - TTL filter on read: `readHomeFeed` drops any item whose
+ *     `expiresAt` is in the past. This is a stateless sweep — the
+ *     writer does not rewrite the file on read, so concurrent reads
+ *     never race the writer.
+ *
+ * Concurrent writers are coalesced with the exact same "latest wins"
+ * pattern as `relationship-state-writer.ts`: at most one compute+write
+ * runs at a time, and overlapping calls during an in-flight write all
+ * resolve off a single tail write that reflects the final state.
+ *
+ * Each successful write publishes a `home_feed_updated` SSE event via
+ * the in-process `assistantEventHub`, carrying the post-filter count
+ * of items with `status === "new"` so subscribers can update unread
+ * badges without a full refetch.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+import {
+  type FeedItem,
+  type FeedItemStatus,
+  type HomeFeedFile,
+  parseFeedFile,
+} from "./feed-types.js";
+
+const log = getLogger("home-feed-writer");
+
+/** Filename for the on-disk home feed. Lives under the workspace data dir. */
+export const HOME_FEED_FILENAME = "home-feed.json";
+
+/** On-disk file-format version. Bump + migrate if the shape changes. */
+export const HOME_FEED_VERSION = 1;
+
+/**
+ * Action items without an explicit `expiresAt` auto-fade this many
+ * milliseconds after their `createdAt` timestamp. 24 hours matches the
+ * TDD default.
+ */
+const ACTION_AUTO_FADE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Canonical path to the home-feed snapshot
+ * (`<workspace>/data/home-feed.json`).
+ */
+export function getHomeFeedPath(): string {
+  return join(getDataDir(), HOME_FEED_FILENAME);
+}
+
+/**
+ * Read the on-disk feed file, applying the stateless TTL filter.
+ *
+ * Returns an empty `HomeFeedFile` when the file is missing, unreadable,
+ * or fails Zod validation — callers never see a throw from this path.
+ * Items whose `expiresAt` is in the past are dropped from the returned
+ * `items` array but are NOT rewritten to disk; the next append cycle
+ * will persist the post-filter view naturally.
+ */
+export function readHomeFeed(): HomeFeedFile {
+  const path = getHomeFeedPath();
+  const empty: HomeFeedFile = {
+    version: HOME_FEED_VERSION,
+    items: [],
+    updatedAt: new Date(0).toISOString(),
+  };
+
+  if (!existsSync(path)) {
+    return empty;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    log.warn({ err, path }, "Failed to read home-feed.json; returning empty");
+    return empty;
+  }
+
+  let parsed: HomeFeedFile;
+  try {
+    parsed = parseFeedFile(raw);
+  } catch (err) {
+    log.warn(
+      { err, path },
+      "home-feed.json failed schema validation; returning empty",
+    );
+    return empty;
+  }
+
+  const now = Date.now();
+  const items = parsed.items.filter((item) => !isExpired(item, now));
+  return {
+    version: parsed.version,
+    items,
+    updatedAt: parsed.updatedAt,
+  };
+}
+
+/**
+ * Append (or merge) a single feed item and persist the result.
+ *
+ * See the module comment for the precise merge semantics. Never
+ * throws — all failures degrade to a warn-log so fire-and-forget
+ * callers in the daemon don't need a try/catch wrapper. Concurrent
+ * calls are coalesced via the in-module `writeInFlight` / `writeDirty`
+ * pattern so at most one write is in flight at a time.
+ */
+export async function appendFeedItem(item: FeedItem): Promise<void> {
+  pendingAppends.push(item);
+  return scheduleWrite();
+}
+
+/**
+ * Update the `status` field of a single feed item by id.
+ *
+ * Returns the updated `FeedItem` on success, or `null` if no item with
+ * the given id exists. This is the path the HTTP route uses when the
+ * client marks an item as `"seen"` or `"acted_on"`. Concurrent patches
+ * go through the same coalescing queue as `appendFeedItem` so two
+ * overlapping status flips can't race each other.
+ *
+ * The patch is applied inside `runWrite()` so the existence check
+ * reads from the same state snapshot the mutation will land on —
+ * callers never observe a "phantom success" where we return an
+ * updated item for an id that no longer exists on disk by the time
+ * the queued write runs.
+ */
+export async function patchFeedItemStatus(
+  id: string,
+  status: FeedItemStatus,
+): Promise<FeedItem | null> {
+  let resolveResult!: (value: FeedItem | null) => void;
+  const resultPromise = new Promise<FeedItem | null>((resolve) => {
+    resolveResult = resolve;
+  });
+  pendingPatches.push({ id, status, resolve: resolveResult });
+  void scheduleWrite();
+  return resultPromise;
+}
+
+// ─── Internal: coalescing queue ────────────────────────────────────────
+
+/**
+ * Pending operations that land in the next coalesced write cycle.
+ * Appends and patches drain together so overlapping callers share a
+ * single compute+write tail.
+ */
+const pendingAppends: FeedItem[] = [];
+const pendingPatches: Array<{
+  id: string;
+  status: FeedItemStatus;
+  resolve: (value: FeedItem | null) => void;
+}> = [];
+
+let writeInFlight: Promise<void> | null = null;
+let writeDirty = false;
+
+/**
+ * Enqueue a write cycle. Mirrors the `relationship-state-writer.ts`
+ * coalescing pattern exactly: the first caller kicks off a run; any
+ * callers that arrive during an in-flight run mark dirty and resolve
+ * off the same tail promise, so N overlapping callers produce at most
+ * two runs (the initial + one coalesced tail).
+ */
+function scheduleWrite(): Promise<void> {
+  if (writeInFlight) {
+    writeDirty = true;
+    return writeInFlight;
+  }
+  writeInFlight = (async () => {
+    try {
+      await runWrite();
+      while (writeDirty) {
+        writeDirty = false;
+        await runWrite();
+      }
+    } finally {
+      writeInFlight = null;
+    }
+  })();
+  return writeInFlight;
+}
+
+/**
+ * Drain the pending-operations queue into a fresh on-disk snapshot
+ * and publish the SSE event. Never throws — the write error is caught
+ * + logged so the coalescing loop can still move on to the next cycle.
+ */
+async function runWrite(): Promise<void> {
+  const appendsToApply = pendingAppends.splice(0, pendingAppends.length);
+  const patchesToApply = pendingPatches.splice(0, pendingPatches.length);
+
+  const current = readHomeFeed();
+  let items = current.items.slice();
+
+  for (const incoming of appendsToApply) {
+    items = mergeIncoming(items, incoming);
+  }
+
+  // Track the per-patch result so callers can distinguish an update
+  // from an unknown-id no-op. We collect resolvers first and fire them
+  // after the write lands so the resolved `FeedItem` matches on-disk
+  // state exactly.
+  const patchResults: Array<{
+    resolve: (v: FeedItem | null) => void;
+    value: FeedItem | null;
+  }> = [];
+  for (const patch of patchesToApply) {
+    const idx = items.findIndex((i) => i.id === patch.id);
+    if (idx === -1) {
+      patchResults.push({ resolve: patch.resolve, value: null });
+      continue;
+    }
+    const updated: FeedItem = { ...items[idx]!, status: patch.status };
+    items[idx] = updated;
+    patchResults.push({ resolve: patch.resolve, value: updated });
+  }
+
+  items.sort(compareFeedItems);
+
+  const updatedAt = new Date().toISOString();
+  const next: HomeFeedFile = {
+    version: HOME_FEED_VERSION,
+    items,
+    updatedAt,
+  };
+
+  let wrote = false;
+  try {
+    const path = getHomeFeedPath();
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(path, JSON.stringify(next, null, 2), "utf-8");
+    wrote = true;
+    log.info({ path, items: items.length }, "Wrote home-feed.json");
+  } catch (err) {
+    log.warn({ err }, "Failed to write home-feed.json");
+  }
+
+  if (wrote) {
+    const newItemCount = items.filter((i) => i.status === "new").length;
+    publishHomeFeedUpdated(updatedAt, newItemCount);
+  }
+
+  // Resolve pending patch promises AFTER we've emitted the SSE event
+  // so callers awaiting `patchFeedItemStatus` observe a fully
+  // consistent world: the on-disk file, the SSE event, and the
+  // returned `FeedItem` all reflect the same write.
+  for (const { resolve, value } of patchResults) {
+    resolve(value);
+  }
+}
+
+/**
+ * Apply the merge semantics for a single incoming item against the
+ * current item list and return a new list. Pure function — the input
+ * array is not mutated.
+ */
+function mergeIncoming(items: FeedItem[], incoming: FeedItem): FeedItem[] {
+  const withDefaults = applyActionAutoFade(incoming);
+
+  // Digest replacement: one digest per source wins.
+  if (withDefaults.type === "digest" && withDefaults.source) {
+    const filtered = items.filter(
+      (i) => !(i.type === "digest" && i.source === withDefaults.source),
+    );
+    filtered.push(withDefaults);
+    return filtered;
+  }
+
+  // Thread in-place update: same id wins, preserve position.
+  if (withDefaults.type === "thread") {
+    const idx = items.findIndex(
+      (i) => i.type === "thread" && i.id === withDefaults.id,
+    );
+    if (idx !== -1) {
+      const copy = items.slice();
+      copy[idx] = withDefaults;
+      return copy;
+    }
+  }
+
+  // Author resolution: for matching (type, source) pairs, assistant
+  // beats platform. A platform-authored incoming item against an
+  // existing assistant item is a no-op.
+  if (withDefaults.source) {
+    const existingIdx = items.findIndex(
+      (i) => i.type === withDefaults.type && i.source === withDefaults.source,
+    );
+    if (existingIdx !== -1) {
+      const existing = items[existingIdx]!;
+      if (
+        existing.author === "assistant" &&
+        withDefaults.author === "platform"
+      ) {
+        // Platform can't overwrite assistant — no-op.
+        return items;
+      }
+      if (
+        existing.author === "platform" &&
+        withDefaults.author === "assistant"
+      ) {
+        const copy = items.slice();
+        copy[existingIdx] = withDefaults;
+        return copy;
+      }
+    }
+  }
+
+  return [...items, withDefaults];
+}
+
+/**
+ * Fill in the `expiresAt` field on action items that were appended
+ * without one. Pure — returns the original reference untouched when no
+ * auto-fade is needed so the common path avoids a copy.
+ */
+function applyActionAutoFade(item: FeedItem): FeedItem {
+  if (item.type !== "action") return item;
+  if (item.expiresAt) return item;
+  const createdAtMs = Date.parse(item.createdAt);
+  if (Number.isNaN(createdAtMs)) return item;
+  const expiresAt = new Date(createdAtMs + ACTION_AUTO_FADE_MS).toISOString();
+  return { ...item, expiresAt };
+}
+
+/**
+ * Return `true` when the item has an `expiresAt` timestamp that is in
+ * the past relative to the supplied `nowMs`. Items without
+ * `expiresAt`, or with an unparseable value, are treated as not
+ * expired (fail-open).
+ */
+function isExpired(item: FeedItem, nowMs: number): boolean {
+  if (!item.expiresAt) return false;
+  const expiresMs = Date.parse(item.expiresAt);
+  if (Number.isNaN(expiresMs)) return false;
+  return expiresMs <= nowMs;
+}
+
+/**
+ * Sort comparator: priority DESC, then createdAt DESC. Matches the
+ * ordering contract the UI expects so higher-priority and fresher
+ * items sort to the top of the feed.
+ */
+function compareFeedItems(a: FeedItem, b: FeedItem): number {
+  if (a.priority !== b.priority) return b.priority - a.priority;
+  const aMs = Date.parse(a.createdAt);
+  const bMs = Date.parse(b.createdAt);
+  if (Number.isNaN(aMs) && Number.isNaN(bMs)) return 0;
+  if (Number.isNaN(aMs)) return 1;
+  if (Number.isNaN(bMs)) return -1;
+  return bMs - aMs;
+}
+
+/**
+ * Publish a `home_feed_updated` event to the in-process hub. Wrapped
+ * in a `.catch` so a subscriber rejection never bubbles up into the
+ * writer coalescing loop.
+ */
+function publishHomeFeedUpdated(updatedAt: string, newItemCount: number): void {
+  assistantEventHub
+    .publish(
+      buildAssistantEvent("home", {
+        type: "home_feed_updated",
+        updatedAt,
+        newItemCount,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish home_feed_updated event");
+    });
+}

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -40,6 +40,7 @@ import { join } from "node:path";
 
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { getDataDir } from "../util/platform.js";
 import {
@@ -270,8 +271,12 @@ async function runWrite(): Promise<void> {
   // so callers awaiting `patchFeedItemStatus` observe a fully
   // consistent world: the on-disk file, the SSE event, and the
   // returned `FeedItem` all reflect the same write.
+  //
+  // If the write failed, resolve all patch promises with `null` — the
+  // state was not persisted, and callers (e.g. HTTP route handlers)
+  // must not report success when the underlying write failed.
   for (const { resolve, value } of patchResults) {
-    resolve(value);
+    resolve(wrote ? value : null);
   }
 }
 
@@ -384,7 +389,7 @@ function compareFeedItems(a: FeedItem, b: FeedItem): number {
 function publishHomeFeedUpdated(updatedAt: string, newItemCount: number): void {
   assistantEventHub
     .publish(
-      buildAssistantEvent("home", {
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
         type: "home_feed_updated",
         updatedAt,
         newItemCount,


### PR DESCRIPTION
## Summary
- New `assistant/src/home/feed-writer.ts` with `appendFeedItem`, `patchFeedItemStatus`, `readHomeFeed`
- Mirrors the `relationship-state-writer.ts` pattern: coalescing, `getDataDir()`, SSE publish
- Tests cover digest replacement, author resolution, auto-fade, TTL filter, concurrent writes, SSE publish

Part of plan: home-activity-feed.md (PR 5 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
