### PR TITLE
feat(chrome-ext): add Verified CRX Uploads for protected package updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,22 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Install Chrome for CRX signing
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Write CRX signing key
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          if [ -n "$CRX_PRIVATE_KEY" ]; then
+            echo "$CRX_PRIVATE_KEY" > clients/chrome-extension/privatekey.pem
+            chmod 600 clients/chrome-extension/privatekey.pem
+          else
+            echo "::warning::CRX_PRIVATE_KEY secret not set — CRX signing will be skipped"
+          fi
+
       - name: Build extension
         working-directory: clients/chrome-extension
         env:
@@ -216,15 +232,23 @@ jobs:
             exit 1
           fi
 
-      - name: Package extension zip
-        working-directory: clients/chrome-extension
-        run: cd dist && zip -r ../vellum-browser-relay-${{ needs.extract-version.outputs.version }}.zip .
+      - name: Clean up signing key
+        if: always()
+        run: rm -f clients/chrome-extension/privatekey.pem
+
+      - name: Upload extension CRX
+        if: hashFiles('clients/chrome-extension/vellum-browser-relay.crx') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-crx
+          path: clients/chrome-extension/vellum-browser-relay.crx
+          retention-days: 90
 
       - name: Upload extension zip
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-zip
-          path: clients/chrome-extension/vellum-browser-relay-${{ needs.extract-version.outputs.version }}.zip
+          path: clients/chrome-extension/vellum-browser-relay.zip
           retention-days: 90
 
   publish-chrome-extension:
@@ -236,7 +260,16 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - name: Download extension zip
+      - name: Download extension CRX
+        id: download-crx
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: chrome-extension-crx
+          path: /tmp/chrome-extension
+
+      - name: Download extension zip (fallback)
+        if: steps.download-crx.outcome != 'success'
         uses: actions/download-artifact@v4
         with:
           name: chrome-extension-zip
@@ -252,9 +285,11 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
-          ZIP_FILE=$(ls /tmp/chrome-extension/*.zip)
+          # Prefer signed CRX if available, fall back to zip
+          UPLOAD_FILE=$(ls /tmp/chrome-extension/*.crx 2>/dev/null || ls /tmp/chrome-extension/*.zip)
+          echo "Uploading: $UPLOAD_FILE"
           chrome-webstore-upload upload \
-            --source "$ZIP_FILE" \
+            --source "$UPLOAD_FILE" \
             --extension-id "$EXTENSION_ID" \
             --client-id "$CLIENT_ID" \
             --client-secret "$CLIENT_SECRET" \

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ worktrees/
 .DS_Store
 .githooks/.githooks
 *.pem
+*.crx
 .qdrant-initialized
 .claude/*
 !.claude/commands/

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -80,8 +80,58 @@ fi
 
 echo ""
 echo "Done! Extension built to: $DIST_DIR"
+
+# ---------------------------------------------------------------------------
+# Packaging: produce a signed .crx for Verified CRX Uploads (CWS) and a .zip
+# for local/fallback use. The private key is expected at privatekey.pem in the
+# chrome-extension directory; CI injects it via secrets.
+# ---------------------------------------------------------------------------
+CRX_KEY_FILE="${CRX_KEY_PATH:-$SCRIPT_DIR/privatekey.pem}"
+CRX_OUT="$SCRIPT_DIR/vellum-browser-relay.crx"
+ZIP_OUT="$SCRIPT_DIR/vellum-browser-relay.zip"
+
+# Detect Chrome/Chromium binary (macOS & Linux)
+find_chrome() {
+  for candidate in \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+    "/Applications/Chromium.app/Contents/MacOS/Chromium" \
+    "$(command -v google-chrome 2>/dev/null)" \
+    "$(command -v google-chrome-stable 2>/dev/null)" \
+    "$(command -v chromium-browser 2>/dev/null)" \
+    "$(command -v chromium 2>/dev/null)"; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [ -f "$CRX_KEY_FILE" ]; then
+  CHROME_BIN="$(find_chrome || true)"
+  if [ -n "$CHROME_BIN" ]; then
+    echo "Signing CRX with $CHROME_BIN ..."
+    "$CHROME_BIN" --pack-extension="$DIST_DIR" --pack-extension-key="$CRX_KEY_FILE" 2>&1 || true
+    # Chrome outputs dist.crx next to the dist/ directory
+    if [ -f "$DIST_DIR.crx" ]; then
+      mv "$DIST_DIR.crx" "$CRX_OUT"
+      echo "  Signed CRX: $CRX_OUT"
+    else
+      echo "  Warning: Chrome did not produce a .crx file"
+    fi
+  else
+    echo "  Warning: Chrome/Chromium not found — skipping CRX signing"
+  fi
+else
+  echo "  No private key at $CRX_KEY_FILE — skipping CRX signing"
+fi
+
+# Always produce a zip as well (useful for manual uploads / fallback)
+(cd "$DIST_DIR" && zip -r "$ZIP_OUT" .)
+echo "  Zip: $ZIP_OUT"
+
 echo ""
-echo "To install:"
+echo "To install locally:"
 echo "  1. Open Chrome → chrome://extensions"
 echo "  2. Enable Developer mode (top-right toggle)"
 echo "  3. Click 'Load unpacked' and select: $DIST_DIR"

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vellum Assistant Browser Relay",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "minimum_chrome_version": "116",
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
 


### PR DESCRIPTION
## Summary
- Adds CRX signing to `build.sh` — auto-detects Chrome, signs with `privatekey.pem` when present, always produces a `.zip` fallback
- Updates the release workflow to install Chrome, inject the signing key from `CRX_PRIVATE_KEY` secret, and prefer the signed `.crx` for CWS uploads
- Resets source `manifest.json` version to `0.0.0` (build stamps the real version) and adds `*.crx` to `.gitignore`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
