### PR TITLE
fix(cli): delete unused LOCKFILE_NAMES export

### DIFF
--- a/cli/src/lib/constants.ts
+++ b/cli/src/lib/constants.ts
@@ -16,16 +16,6 @@ export const DEFAULT_GATEWAY_PORT = 7830;
 export const DEFAULT_QDRANT_PORT = 6333;
 export const DEFAULT_CES_PORT = 8090;
 
-/**
- * Lockfile candidate filenames, checked in priority order.
- * `.vellum.lock.json` is the current name; `.vellum.lockfile.json` is the
- * legacy name kept for backwards compatibility with older installs.
- */
-export const LOCKFILE_NAMES = [
-  ".vellum.lock.json",
-  ".vellum.lockfile.json",
-] as const;
-
 export const VALID_REMOTE_HOSTS = [
   "local",
   "gcp",

--- a/cli/src/lib/environments/paths.ts
+++ b/cli/src/lib/environments/paths.ts
@@ -6,10 +6,9 @@ import type { EnvironmentDefinition, PortMap } from "./types.js";
 const PRODUCTION_ENVIRONMENT_NAME = "production";
 
 /**
- * Production lockfile filenames in priority order. Mirrors `LOCKFILE_NAMES`
- * in `cli/src/lib/constants.ts`. The current name is `.vellum.lock.json`;
- * `.vellum.lockfile.json` is the legacy name kept for backward compatibility
- * with installs that predate the rename.
+ * Production lockfile filenames in priority order. The current name is
+ * `.vellum.lock.json`; `.vellum.lockfile.json` is the legacy name kept for
+ * backward compatibility with installs that predate the rename.
  */
 const PRODUCTION_LOCKFILE_NAMES = [
   ".vellum.lock.json",

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -9,7 +9,7 @@
  * the full lockfile schema.
  *
  * The lockfile filenames and priority order are kept in sync with
- * `cli/src/lib/constants.ts` (`LOCKFILE_NAMES`).
+ * `PRODUCTION_LOCKFILE_NAMES` in `cli/src/lib/environments/paths.ts`.
  */
 
 import { readFileSync } from "node:fs";
@@ -21,7 +21,7 @@ import { join } from "node:path";
  * `.vellum.lock.json` is the current name; `.vellum.lockfile.json` is the
  * legacy name kept for backwards compatibility with older installs.
  *
- * Mirrors `LOCKFILE_NAMES` in `cli/src/lib/constants.ts`.
+ * Mirrors `PRODUCTION_LOCKFILE_NAMES` in `cli/src/lib/environments/paths.ts`.
  */
 const LOCKFILE_NAMES = [
   ".vellum.lock.json",


### PR DESCRIPTION
## Summary
PR #25458 removed the only importer of LOCKFILE_NAMES from assistant-config.ts. The export in cli/src/lib/constants.ts is now dead code. PRODUCTION_LOCKFILE_NAMES in cli/src/lib/environments/paths.ts is the canonical source for the production lockfile filenames.

Addresses Devin finding on PR #25458.

Part of plan: env-data-layout.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
