### PR TITLE
feat(home-feed): add assistant-authoring helper for feed items

### DIFF
--- a/assistant/src/home/__tests__/assistant-feed-authoring.test.ts
+++ b/assistant/src/home/__tests__/assistant-feed-authoring.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { FeedAction, FeedItem } from "../feed-types.js";
+
+// ─── feed-writer mock ──────────────────────────────────────────────────
+// We mock `appendFeedItem` at the module level so the helper under
+// test delegates to the mock instead of hitting disk. The mock is
+// installed before the dynamic import below so the helper module
+// picks it up during resolution.
+const appendFeedItemMock = mock<(item: FeedItem) => Promise<void>>(
+  async () => {},
+);
+
+mock.module("../feed-writer.js", () => ({
+  appendFeedItem: appendFeedItemMock,
+}));
+
+// Dynamic import — must run after `mock.module` above so the helper
+// resolves against the mocked writer.
+const { writeAssistantFeedItem } =
+  await import("../assistant-feed-authoring.js");
+
+beforeEach(() => {
+  appendFeedItemMock.mockClear();
+});
+
+describe("writeAssistantFeedItem", () => {
+  test("builds an assistant-authored FeedItem and delegates to appendFeedItem", async () => {
+    const item = await writeAssistantFeedItem({
+      type: "nudge",
+      source: "gmail",
+      title: "Urgent email from Alice",
+      summary: "Alice is asking when the deck lands",
+    });
+
+    // Author is hard-coded to "assistant" — this is the whole point
+    // of the helper (wins over platform for the same (type,source)).
+    expect(item.author).toBe("assistant");
+    // Non-empty UUID id was generated.
+    expect(typeof item.id).toBe("string");
+    expect(item.id.length).toBeGreaterThan(0);
+    // Status defaults to "new".
+    expect(item.status).toBe("new");
+    // Semantic fields are passed through untouched.
+    expect(item.type).toBe("nudge");
+    expect(item.source).toBe("gmail");
+    expect(item.title).toBe("Urgent email from Alice");
+    expect(item.summary).toBe("Alice is asking when the deck lands");
+
+    // Delegated to the writer exactly once with the constructed item.
+    expect(appendFeedItemMock.mock.calls).toHaveLength(1);
+    const [appended] = appendFeedItemMock.mock.calls[0]!;
+    expect(appended).toBe(item);
+  });
+
+  test("defaults priority to 60 when not supplied", async () => {
+    const item = await writeAssistantFeedItem({
+      type: "digest",
+      source: "slack",
+      title: "Slack digest",
+      summary: "3 threads need a reply",
+    });
+
+    expect(item.priority).toBe(60);
+    expect(appendFeedItemMock.mock.calls).toHaveLength(1);
+    expect(appendFeedItemMock.mock.calls[0]![0]!.priority).toBe(60);
+  });
+
+  test("passes an explicit priority through untouched", async () => {
+    const item = await writeAssistantFeedItem({
+      type: "nudge",
+      source: "slack",
+      title: "High-priority nudge",
+      summary: "You should look at this",
+      priority: 80,
+    });
+
+    expect(item.priority).toBe(80);
+    expect(appendFeedItemMock.mock.calls[0]![0]!.priority).toBe(80);
+  });
+
+  test("populates createdAt and timestamp as ISO strings", async () => {
+    const before = Date.now();
+    const item = await writeAssistantFeedItem({
+      type: "nudge",
+      title: "Ping",
+      summary: "Ping summary",
+    });
+    const after = Date.now();
+
+    expect(typeof item.timestamp).toBe("string");
+    expect(typeof item.createdAt).toBe("string");
+
+    const timestampMs = Date.parse(item.timestamp);
+    const createdAtMs = Date.parse(item.createdAt);
+    expect(Number.isNaN(timestampMs)).toBe(false);
+    expect(Number.isNaN(createdAtMs)).toBe(false);
+
+    // Both are stamped at call time.
+    expect(timestampMs).toBeGreaterThanOrEqual(before);
+    expect(timestampMs).toBeLessThanOrEqual(after);
+    expect(createdAtMs).toBeGreaterThanOrEqual(before);
+    expect(createdAtMs).toBeLessThanOrEqual(after);
+  });
+
+  test("passes the actions array through untouched", async () => {
+    const actions: FeedAction[] = [
+      { id: "reply", label: "Reply", prompt: "Draft a reply to Alice" },
+      { id: "snooze", label: "Snooze", prompt: "Snooze this for 1 hour" },
+    ];
+
+    const item = await writeAssistantFeedItem({
+      type: "action",
+      source: "gmail",
+      title: "Alice needs a reply",
+      summary: "Reply or snooze",
+      actions,
+    });
+
+    expect(item.actions).toEqual(actions);
+    // Delegated value is the same object the caller passed in.
+    expect(appendFeedItemMock.mock.calls[0]![0]!.actions).toEqual(actions);
+  });
+
+  test("throws a Zod validation error when the constructed item violates the schema", async () => {
+    // Plan calls for a "missing required fields → throws Zod error"
+    // test. The underlying `feedItemSchema` uses `z.string()` (not
+    // `.min(1)`) so an empty title technically parses, but an
+    // out-of-range priority is a guaranteed schema violation and
+    // exercises the same guardrail path: `feedItemSchema.parse()`
+    // rejects the item, the helper rethrows, and `appendFeedItem` is
+    // NEVER called.
+    await expect(
+      writeAssistantFeedItem({
+        type: "nudge",
+        title: "bad",
+        summary: "also bad",
+        priority: 150,
+      }),
+    ).rejects.toThrow();
+
+    // And for the original "missing required field" intent from the
+    // plan: force-omit `title` through a type cast and confirm the
+    // schema still rejects (z.string() rejects `undefined`).
+    await expect(
+      writeAssistantFeedItem({
+        type: "nudge",
+        summary: "no title",
+        // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid
+      } as any),
+    ).rejects.toThrow();
+
+    // The invalid calls must NOT have reached the writer.
+    expect(appendFeedItemMock.mock.calls).toHaveLength(0);
+  });
+});

--- a/assistant/src/home/assistant-feed-authoring.ts
+++ b/assistant/src/home/assistant-feed-authoring.ts
@@ -1,0 +1,124 @@
+/**
+ * Assistant-authoring helper for the home activity feed.
+ *
+ * This is the in-process API the assistant daemon (or a skill / tool
+ * running inside it) calls to append a nudge, digest, action, or
+ * thread to the macOS Home page feed under `author: "assistant"`.
+ *
+ * The helper exists so callers don't have to hand-roll the ceremony
+ * around a `FeedItem`:
+ *
+ *   - generate a stable `id`
+ *   - set the `author` discriminator to `"assistant"` (so the hybrid
+ *     authoring resolver in `feed-writer.ts` lets it override
+ *     platform baseline items for the same `(type, source)` pair)
+ *   - seed `status` / `timestamp` / `createdAt`
+ *   - pick a sensible default `priority` that outranks the platform
+ *     baseline (40) so assistant-authored items surface above
+ *     background generators unless an explicit priority is passed
+ *   - validate the constructed item against `feedItemSchema` so a
+ *     malformed call throws loudly at the source instead of corrupting
+ *     the on-disk snapshot via `appendFeedItem`
+ *
+ * Persistence is delegated to `appendFeedItem` — all of the merge
+ * semantics (digest replacement, thread in-place update, author
+ * precedence, action auto-fade) continue to live in the writer and
+ * are not re-implemented here.
+ *
+ * NOTE: This helper is intentionally in-process only. There is no
+ * HTTP route wrapping it. Callers (skills, tools, daemon code) import
+ * and call `writeAssistantFeedItem` directly. Wiring the trigger side
+ * — prompt-driven calls, skill entry points, etc. — is deliberately
+ * out of scope for Phase 5 of the home-activity-feed plan and lives
+ * in follow-up work.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import {
+  type FeedAction,
+  type FeedItem,
+  feedItemSchema,
+  type FeedItemSource,
+  type FeedItemType,
+} from "./feed-types.js";
+import { appendFeedItem } from "./feed-writer.js";
+
+/**
+ * Default priority for assistant-authored feed items. Sits above the
+ * platform baseline (40) so an assistant-authored digest / nudge
+ * surfaces above a same-source platform default unless the caller
+ * passes an explicit value.
+ */
+const DEFAULT_ASSISTANT_PRIORITY = 60;
+
+/**
+ * Parameters accepted by {@link writeAssistantFeedItem}.
+ *
+ * The helper hard-codes `author: "assistant"`, `status: "new"`, and
+ * the id / timestamps, so callers only have to supply the semantic
+ * fields that describe *what* the item is about.
+ */
+export interface WriteAssistantFeedItemParams {
+  /** Kind of feed item — drives the Swift view used to render it. */
+  type: FeedItemType;
+  /** Origin of the underlying event (gmail, slack, calendar, assistant). */
+  source?: FeedItemSource;
+  /** Short headline rendered in the feed row. */
+  title: string;
+  /** Body copy rendered below the title. */
+  summary: string;
+  /**
+   * Priority in [0, 100]. Defaults to {@link DEFAULT_ASSISTANT_PRIORITY}
+   * (60) — higher than the platform baseline of 40 so assistant items
+   * beat same-source platform defaults by default.
+   */
+  priority?: number;
+  /** Action buttons surfaced on the feed row. */
+  actions?: FeedAction[];
+  /** Minimum seconds the user must be away before the item is shown. */
+  minTimeAway?: number;
+  /** Absolute ISO-8601 expiry timestamp. */
+  expiresAt?: string;
+}
+
+/**
+ * Build a fully-formed assistant-authored {@link FeedItem}, validate
+ * it against the canonical schema, persist it through
+ * {@link appendFeedItem}, and return the constructed item so the
+ * caller can log / reference it downstream.
+ *
+ * Throws a `ZodError` if the constructed item fails validation —
+ * that is a programming error in the caller (e.g. empty `title`) and
+ * must not be silently swallowed. Persistence-layer failures are
+ * absorbed by `appendFeedItem` itself per its warn-log contract.
+ */
+export async function writeAssistantFeedItem(
+  params: WriteAssistantFeedItemParams,
+): Promise<FeedItem> {
+  const now = new Date().toISOString();
+
+  const item: FeedItem = {
+    id: randomUUID(),
+    type: params.type,
+    source: params.source,
+    title: params.title,
+    summary: params.summary,
+    priority: params.priority ?? DEFAULT_ASSISTANT_PRIORITY,
+    status: "new",
+    author: "assistant",
+    timestamp: now,
+    createdAt: now,
+    actions: params.actions,
+    minTimeAway: params.minTimeAway,
+    expiresAt: params.expiresAt,
+  };
+
+  // Programming-error guardrail: invalid input throws at the source
+  // instead of corrupting the on-disk snapshot via the writer.
+  feedItemSchema.parse(item);
+
+  await appendFeedItem(item);
+
+  return item;
+}


### PR DESCRIPTION
## Summary
- New `assistant/src/home/assistant-feed-authoring.ts` exporting `writeAssistantFeedItem`
- Generates UUIDs, fills author/status/timestamps, validates via feedItemSchema, delegates to appendFeedItem
- In-process only — no HTTP endpoint
- No consumers yet; wired up in a follow-up skill/tool integration out of Phase 5 scope

Part of plan: home-activity-feed.md (PR 11 of 13)
Part of JARVIS-510
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
