### PR TITLE
fix(environments): route daemon protected/ callers through platform helpers

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-self-hosted.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-self-hosted.test.ts
@@ -321,7 +321,7 @@ describe("host-browser E2E — self-hosted native messaging path", () => {
   }
 
   // -------------------------------------------------------------------------
-  // Dev-only `~/.vellum/daemon-token` fallback
+  // Dev-only daemon-token fallback (per-instance protected dir)
   // -------------------------------------------------------------------------
 
   describe("dev daemon-token fallback path", () => {
@@ -338,9 +338,9 @@ describe("host-browser E2E — self-hosted native messaging path", () => {
     test("a token written to a local file round-trips through verifyHostBrowserCapability", () => {
       // Emulate the `writeDaemonTokenFallback` lifecycle: mint a fresh
       // capability token, persist it to a 0600 file (the production
-      // helper writes to `~/.vellum/daemon-token`, but we use a tempdir
-      // so the test doesn't clobber real dev state), then read it back
-      // and verify.
+      // helper writes to `<protectedDir>/daemon-token`, but we use a
+      // tempdir so the test doesn't clobber real dev state), then read
+      // it back and verify.
       //
       // This path is what the Mac app's manual "paste daemon token"
       // pairing UI ends up exercising — the file on disk is the only

--- a/assistant/src/bundler/package-resolver.ts
+++ b/assistant/src/bundler/package-resolver.ts
@@ -33,6 +33,10 @@ const inflight = new Map<string, Promise<string | null>>();
 
 /** Where all cached packages live on disk. */
 export function getCacheDir(): string {
+  // Package cache is intentionally shared across all local assistants to
+  // avoid re-downloading the same bundler deps per instance. Resolved
+  // against the real home directory so the cache is a single host-wide
+  // location regardless of BASE_DATA_DIR / per-instance containers.
   return join(homedir(), ".vellum", "package-cache");
 }
 

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -17,9 +17,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { getProtectedDir } from "../util/platform.js";
 import type { AssistantConfig } from "./schema.js";
 
 // ---------------------------------------------------------------------------
@@ -132,14 +132,15 @@ interface FeatureFlagFileData {
  * Resolve the path to the feature flag overrides file.
  *
  * Docker: `GATEWAY_SECURITY_DIR/feature-flags.json`
- * Local:  `~/.vellum/` + gateway security subdir + `feature-flags.json`
+ * Local:  `<protectedDir>/feature-flags.json` — resolved via `getProtectedDir()`
+ *         so it honors `BASE_DATA_DIR` for per-instance setups.
  */
 function getFeatureFlagOverridesPath(): string {
   const securityDir = process.env.GATEWAY_SECURITY_DIR;
   if (securityDir) {
     return join(securityDir, "feature-flags.json");
   }
-  return join(homedir(), ".vellum", "protected", "feature-flags.json");
+  return join(getProtectedDir(), "feature-flags.json");
 }
 
 /**

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -10,7 +10,6 @@ import {
   readdirSync,
   watch,
 } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { clearFeatureFlagOverridesCache } from "../config/assistant-feature-flags.js";
@@ -32,6 +31,7 @@ import { getLogger } from "../util/logger.js";
 import {
   AVATAR_IMAGE_FILENAME,
   getAvatarDir,
+  getProtectedDir,
   getSignalsDir,
   getSoundsDir,
   getWorkspaceDir,
@@ -282,7 +282,10 @@ export class ConfigWatcher {
       });
       attachWatcherErrorHandler(watcher, usersDir);
       this.watchers.push(watcher);
-      log.info({ dir: usersDir }, "Watching users directory for persona changes");
+      log.info(
+        { dir: usersDir },
+        "Watching users directory for persona changes",
+      );
     } catch (err) {
       log.warn(
         { err, dir: usersDir },
@@ -325,9 +328,7 @@ export class ConfigWatcher {
   }
 
   private startFeatureFlagsWatcher(onFeatureFlagsChanged?: () => void): void {
-    const protectedDir = process.env.GATEWAY_SECURITY_DIR
-      ? process.env.GATEWAY_SECURITY_DIR
-      : join(homedir(), ".vellum", "protected");
+    const protectedDir = process.env.GATEWAY_SECURITY_DIR ?? getProtectedDir();
 
     try {
       if (!existsSync(protectedDir)) {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -490,10 +490,10 @@ export async function runDaemon(): Promise<void> {
         );
       }
 
-      // Write a dev-only fallback capability token to `~/.vellum/daemon-token`
-      // so developers can manually pair the chrome extension without the
-      // native messaging helper. Production pairing goes through
-      // `POST /v1/browser-extension-pair` via the native helper.
+      // Write a dev-only fallback capability token to the per-instance
+      // protected directory so developers can manually pair the chrome
+      // extension without the native messaging helper. Production pairing
+      // goes through `POST /v1/browser-extension-pair` via the native helper.
       try {
         writeDaemonTokenFallback(localGuardianPrincipalId);
       } catch (err) {

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -49,6 +49,13 @@ export async function runHookScript(
         // @deprecated — usage of VELLUM_ROOT_DIR by hook scripts is deprecated.
         // Removing this requires an LLM-based migration or declarative migration
         // file to update existing user-authored hooks to use VELLUM_WORKSPACE_DIR.
+        //
+        // VELLUM_ROOT_DIR is kept at the legacy `~/.vellum` value even when
+        // vellumRoot() resolves per-instance via BASE_DATA_DIR. User hook
+        // scripts written against this env var expected the legacy path;
+        // changing it would be a silent contract break. Hooks that need the
+        // per-instance root should read BASE_DATA_DIR themselves or use the
+        // new env vars the environment-layout plan adds.
         VELLUM_ROOT_DIR: join(homedir(), ".vellum"),
         VELLUM_WORKSPACE_DIR: getWorkspaceDir(),
         VELLUM_HOOK_SETTINGS: JSON.stringify(

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -20,7 +20,11 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
-import { getDeprecatedDir, getWorkspaceHooksDir } from "../util/platform.js";
+import {
+  getDeprecatedDir,
+  getProtectedDir,
+  getWorkspaceHooksDir,
+} from "../util/platform.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -963,7 +967,7 @@ function isActorTokenSigningKeyPath(
   const cwd = workingDir ?? process.cwd();
   const resolvedPath = resolve(cwd, filePath);
   const signingKeyPaths = [
-    join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
+    join(getProtectedDir(), "actor-token-signing-key"),
     join(getDeprecatedDir(), "actor-token-signing-key"),
     resolve(cwd, "deprecated", "actor-token-signing-key"),
   ];

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -6,7 +6,6 @@ import {
   renameSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { Minimatch } from "minimatch";
@@ -14,6 +13,7 @@ import { v4 as uuid } from "uuid";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
+import { getProtectedDir } from "../util/platform.js";
 import { getDefaultRuleTemplates } from "./defaults.js";
 import * as trustClient from "./trust-client.js";
 import type {
@@ -135,12 +135,12 @@ function getTrustPath(): string {
  * Resolve the gateway security directory.
  *
  * Docker: `GATEWAY_SECURITY_DIR` env var.
- * Local:  falls back to `~/.vellum/` + `protected/`.
+ * Local:  the per-instance protected directory resolved by `getProtectedDir()`.
  */
 function getGatewaySecurityDir(): string {
   const securityDir = process.env.GATEWAY_SECURITY_DIR;
   if (securityDir) return securityDir;
-  return join(homedir(), ".vellum", "protected");
+  return getProtectedDir();
 }
 
 /**

--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -27,7 +27,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
@@ -375,18 +374,19 @@ export function verifyHostBrowserCapability(
  * (PRs 7/12/13).
  */
 export function getDaemonTokenFilePath(): string {
-  // Always under `~/.vellum/` (not the configurable workspace dir) so the
-  // native messaging helper can find it at a fixed path regardless of
-  // workspace overrides. This is a dev-only convenience path — production
-  // pairing goes through the native messaging flow.
-  return join(homedir(), ".vellum", "daemon-token");
+  // Stored under the per-instance protected directory. Both writer and
+  // reader run in the same daemon process, so they resolve the same
+  // per-instance path (honoring BASE_DATA_DIR for multi-instance setups).
+  // This is a dev-only convenience path — production pairing goes through
+  // the native messaging flow.
+  return join(getProtectedDir(), "daemon-token");
 }
 
 /**
- * Write a freshly-minted capability token to `~/.vellum/daemon-token` with
- * 0600 permissions. Swallows errors so a failure here never blocks daemon
- * startup — this is a dev-convenience path, not a production auth
- * requirement.
+ * Write a freshly-minted capability token to the per-instance dev token
+ * file (see `getDaemonTokenFilePath`) with 0600 permissions. Swallows
+ * errors so a failure here never blocks daemon startup — this is a
+ * dev-convenience path, not a production auth requirement.
  */
 export function writeDaemonTokenFallback(guardianId: string): void {
   try {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -9,7 +9,11 @@ import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
-import { getDataDir, getWorkspaceDir } from "../../util/platform.js";
+import {
+  getDataDir,
+  getProtectedDir,
+  getWorkspaceDir,
+} from "../../util/platform.js";
 import { resolveCredentialRef } from "../credentials/resolve.js";
 import {
   getOrStartSession,
@@ -46,9 +50,16 @@ function buildCredentialRefTrace(
  * - CES managed-mode data root (CES_DATA_DIR, or /ces-data when CES_MANAGED_MODE is set)
  */
 function buildCesProtectedPaths(): string[] {
-  const securityDir =
-    process.env.GATEWAY_SECURITY_DIR || join(homedir(), ".vellum", "protected");
-  const paths = [securityDir, join(getWorkspaceDir(), "data", "db")];
+  // Block both the legacy global protected dir and the current per-instance
+  // protected dir so the sandbox read-block works in both single-instance
+  // and multi-instance setups. In the default case (no BASE_DATA_DIR) the
+  // two entries collapse via the Set dedupe.
+  const protectedDirs = process.env.GATEWAY_SECURITY_DIR
+    ? [process.env.GATEWAY_SECURITY_DIR]
+    : Array.from(
+        new Set([join(homedir(), ".vellum", "protected"), getProtectedDir()]),
+      );
+  const paths = [...protectedDirs, join(getWorkspaceDir(), "data", "db")];
 
   // CES bootstrap socket directory - block access to the Unix socket that
   // accepts RPC commands from the assistant process.


### PR DESCRIPTION
## Summary
Fixes split-brain introduced by PR #25455 (vellumRoot() honoring BASE_DATA_DIR).

Migrated to platform helpers:
- trust-store.ts: trust.json now read via getProtectedDir() — matches backup-worker writer
- assistant-feature-flags.ts: feature-flags.json now read via getProtectedDir()
- config-watcher.ts: protected dir watcher uses getProtectedDir()
- capability-tokens.ts: daemon-token moved under getProtectedDir() (per-instance, previously at root ~/.vellum/daemon-token)
- permissions/checker.ts: actor-token-signing-key check uses getProtectedDir()

Intentionally kept global:
- hooks/runner.ts: VELLUM_ROOT_DIR env var kept at legacy ~/.vellum value (user-facing contract — changing would silently break existing hook scripts). @deprecated comment expanded to document this.
- bundler/package-resolver.ts: package download cache. Kept global per judgment: the header comment already declares this a shared cache ("installed once and reused across all app compilations"), the cache contains allowlisted third-party packages (date-fns, chart.js, lodash-es, zod, clsx, lucide) with no per-instance state, and de-duping across instances is the stated intent. Added explicit comment noting the rationale so future readers don't assume it's a bug.
- tools/terminal/shell.ts: blocks BOTH legacy ~/.vellum/protected AND getProtectedDir() in the sandbox read-block list. In default single-instance setups the two entries dedupe to one via Set; in multi-instance setups both paths are blocked so the CES shell lockdown read-block works regardless of the resolver mode.

## Other findings during the grep sweep

- assistant/src/bundler/compiler-tools.ts:47 — getToolsDir() hardcodes `join(homedir(), ".vellum", "workspace", "compiler-tools")` and bypasses getWorkspaceDir(). Not a split-brain bug (reader and writer use the same function, so they always agree), but it ignores VELLUM_WORKSPACE_DIR (Docker mode) and BASE_DATA_DIR (per-instance). Flagged for a follow-up PR.
- assistant/src/daemon/main.ts:28 — user-facing error string mentions `${join(homedir(), ".vellum")}` directly. In a multi-instance setup this could point users at the wrong directory. Cosmetic / diagnostic only, not functional. Flagged for a follow-up pass alongside the "assistant" vs "daemon" terminology sweep.

## Daemon-token path change (intentional, worth a second look)

capability-tokens.ts previously wrote the dev fallback token at `~/.vellum/daemon-token` (root level). Per the fix instructions I moved it to `<protectedDir>/daemon-token`. Both writer (writeDaemonTokenFallback) and reader (getDaemonTokenFilePath) run in the same daemon process, so the move is safe inside this repo. The file has no in-repo cross-process consumer — the only test that exercises it uses its own tempdir. The comments in capability-tokens.ts and lifecycle.ts that referenced the old path have been updated to describe the current per-instance location.

Part of plan: env-data-layout.md (fix round 1, addresses Devin findings on #25455)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
