### PR TITLE
fix: scroll to bottom on thread switch

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -13,7 +13,7 @@
 1. **No auto-follow.** The viewport does NOT track streaming content. The user message stays pinned at the top while the assistant response grows below it.
 2. **Scroll to bottom on send.** When the user sends a message, we smoothly scroll to the bottom. The assistant's minHeight container fills the viewport, naturally pinning the user message to the top.
 3. **Simple distance-based CTA.** "Scroll to latest" appears when >400pt from bottom. No modes, no hysteresis, no state machine.
-4. **Threads open at top.** `.defaultScrollAnchor(.top, for: .initialOffset)` — conversations start at the first message, not the last.
+4. **Threads open at bottom.** `.defaultScrollAnchor(.bottom, for: .initialOffset)` — conversations start at the latest messages.
 5. **One container for thinking + assistant.** A synthetic placeholder row in the ForEach holds the thinking indicator. When the real assistant message arrives, it replaces the placeholder in the same container — no layout jump.
 
 ---
@@ -228,7 +228,6 @@ These were removed for a reason. Do not re-introduce:
 | Recovery windows / deadlines | Complex timer-based scroll correction; the flat model doesn't need it |
 | Stabilization / circuit breaker | Protected against layout storms from mode transitions; no modes = no storms |
 | `isAtBottom` hysteresis | Asymmetric thresholds to prevent oscillation; distance CTA is simpler |
-| `.defaultScrollAnchor(.bottom)` | Conversations should open at top, not bottom |
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -195,7 +195,7 @@ extension MessageListView {
         scrollState.lastAutoFocusedRequestId = nil
         // Seed lastMessageId so scroll-to-bottom can target it.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Don't write to scrollPosition — `.defaultScrollAnchor(.top)` handles
+        // Don't write to scrollPosition — `.defaultScrollAnchor(.bottom)` handles
         // positioning via the `.id(conversationId)` recreation.
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -140,8 +140,8 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
-            // Apply only to .initialOffset — threads open at top.
-            .defaultScrollAnchor(.top, for: .initialOffset)
+            // Apply only to .initialOffset — threads open at bottom (latest messages).
+            .defaultScrollAnchor(.bottom, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)


### PR DESCRIPTION
## Summary
- Change `.defaultScrollAnchor(.top)` to `.defaultScrollAnchor(.bottom)` — threads open at latest messages
- Update comments and SCROLL_STRATEGY.md to reflect the change
- Purely declarative — SwiftUI handles positioning via `.id(conversationId)` recreation

## Test plan
- [ ] Switch between threads — should scroll to bottom (latest messages)
- [ ] Send a message — scroll-to-bottom on send still works
- [ ] Scroll-to-latest CTA still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
