### PR TITLE
feat(home-feed): add HomeFeedStore with fetch/foreground/SSE refresh

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore+SSE.swift
@@ -1,0 +1,30 @@
+import Foundation
+import VellumAssistantShared
+
+/// SSE subscription loop for ``HomeFeedStore``.
+///
+/// Split out of the main file so the store body stays focused on state +
+/// lifecycle, while this extension holds the async-iteration boilerplate.
+/// The task handle lives on the store (`sseTask`) so `deinit` can cancel it.
+extension HomeFeedStore {
+    /// Starts consuming the shared `ServerMessage` stream and triggers a
+    /// reload whenever the daemon broadcasts `homeFeedUpdated`.
+    ///
+    /// Invoked from `HomeFeedStore.init` — safe to call exactly once per
+    /// store. Captures `messageStream` by value so the Task does NOT hold
+    /// a reference to `self` for the lifetime of the loop; each iteration
+    /// re-acquires `self` weakly, so `deinit` can still fire and cancel
+    /// the task.
+    func startListening() {
+        let stream = self.messageStream
+        sseTask = Task { [weak self] in
+            for await message in stream {
+                if Task.isCancelled { break }
+                guard let self else { break }
+                if case .homeFeedUpdated = message {
+                    await self.load()
+                }
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -43,13 +43,15 @@ public final class HomeFeedStore {
     @ObservationIgnored private let client: HomeFeedClient
     @ObservationIgnored let messageStream: AsyncStream<ServerMessage>
     @ObservationIgnored var sseTask: Task<Void, Never>?
-    @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
+    @ObservationIgnored private var lifecycleObservers: [NSObjectProtocol] = []
 
-    /// Timestamp of the most recent moment the client was in the
-    /// foreground. Used to compute `timeAwaySeconds` on the next `load()`.
-    /// Initialized to `now` at construction so a cold-start load sees a
-    /// zero-delta instead of a nonsensical negative or epoch value.
-    @ObservationIgnored private var lastForegroundAt: Date
+    /// Moment the user last stepped away from the app (from
+    /// `willResignActive`). Consumed by the next `load()` as
+    /// `timeAwaySeconds = now - lastAwayAt` and then cleared — the
+    /// away→back transition is one-shot and each load reports exactly
+    /// one measurement. `nil` while the app is still active or before
+    /// the user has ever stepped away.
+    @ObservationIgnored private var lastAwayAt: Date?
 
     /// Monotonically-increasing generation token bumped on every `load()`
     /// entry. Used to discard out-of-order responses when concurrent
@@ -62,14 +64,13 @@ public final class HomeFeedStore {
     public init(client: HomeFeedClient, messageStream: AsyncStream<ServerMessage>) {
         self.client = client
         self.messageStream = messageStream
-        self.lastForegroundAt = Date()
         startListening()
-        observeForeground()
+        observeLifecycle()
     }
 
     deinit {
         sseTask?.cancel()
-        if let observer = foregroundObserver {
+        for observer in lifecycleObservers {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -78,10 +79,13 @@ public final class HomeFeedStore {
 
     /// Fetches the latest feed + context banner from the daemon.
     ///
-    /// `timeAwaySeconds` is computed from `lastForegroundAt`; callers do
-    /// not supply it. Leaves `items` / `contextBanner` unchanged on
-    /// failure so the UI keeps showing whatever we last successfully
-    /// fetched. Errors are logged, never thrown out.
+    /// `timeAwaySeconds` is consumed from `lastAwayAt` (set on
+    /// `willResignActive`) and cleared — the away→back transition is
+    /// one-shot, and a reload that fires for any other reason (SSE,
+    /// view appear) reports zero time-away instead of re-billing a
+    /// stale gap. Leaves `items` / `contextBanner` unchanged on failure
+    /// so the UI keeps showing whatever we last successfully fetched.
+    /// Errors are logged, never thrown out.
     public func load() async {
         loadGeneration &+= 1
         let myGeneration = loadGeneration
@@ -92,7 +96,13 @@ public final class HomeFeedStore {
             }
         }
 
-        let timeAwaySeconds = max(0, Date().timeIntervalSince(lastForegroundAt))
+        let timeAwaySeconds: TimeInterval
+        if let awayAt = lastAwayAt {
+            timeAwaySeconds = max(0, Date().timeIntervalSince(awayAt))
+            lastAwayAt = nil
+        } else {
+            timeAwaySeconds = 0
+        }
 
         do {
             let response = try await client.fetchFeed(timeAwaySeconds: timeAwaySeconds)
@@ -106,14 +116,18 @@ public final class HomeFeedStore {
     }
 
     /// Optimistically updates the item's status in memory, then confirms
-    /// with the server. On failure the local change is rolled back to the
-    /// prior status so the UI and server stay consistent.
+    /// with the server. On failure the local change is rolled back to
+    /// the prior status — *unless* a `load()` landed a fresh server
+    /// snapshot while the PATCH was in flight, in which case the
+    /// server's canonical state is already authoritative and a
+    /// rollback would clobber it with stale pre-patch data.
     public func updateStatus(itemId: String, status: FeedItemStatus) async {
         guard let index = items.firstIndex(where: { $0.id == itemId }) else { return }
 
         let previous = items[index]
         if previous.status == status { return }
 
+        let entryGeneration = loadGeneration
         items[index] = replacingStatus(previous, with: status)
 
         do {
@@ -126,6 +140,11 @@ public final class HomeFeedStore {
             }
         } catch {
             log.error("HomeFeedStore.updateStatus(\(itemId)) failed: \(error.localizedDescription)")
+            // Only roll back if nothing else has rewritten `items` in
+            // the meantime — a concurrent `load()` completing makes its
+            // fresh snapshot the new source of truth, and stomping it
+            // with our stale pre-patch copy would be a regression.
+            guard loadGeneration == entryGeneration else { return }
             if let freshIndex = items.firstIndex(where: { $0.id == itemId }) {
                 items[freshIndex] = previous
             }
@@ -181,21 +200,32 @@ public final class HomeFeedStore {
 
     // MARK: - Foreground Refresh
 
-    private func observeForeground() {
-        foregroundObserver = NotificationCenter.default.addObserver(
+    /// Observe both sides of the foreground transition so the next
+    /// `load()` can report an accurate `timeAwaySeconds`. Stamp
+    /// `lastAwayAt` on `willResignActive`, reload on
+    /// `didBecomeActive`; the load consumes and clears the stamp.
+    /// Time the user spends with the app merely unfocused (another
+    /// app on top) counts as "away"; active-but-idle does not.
+    private func observeLifecycle() {
+        let resignObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.lastAwayAt = Date()
+            }
+        }
+        let becomeActiveObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self else { return }
-                // Load first against the existing `lastForegroundAt` so the
-                // daemon sees the real time-away gap, then reset the stamp
-                // to the current moment for the next cycle.
-                await self.load()
-                self.lastForegroundAt = Date()
+                await self?.load()
             }
         }
+        lifecycleObservers = [resignObserver, becomeActiveObserver]
     }
 
     // MARK: - Helpers
@@ -239,6 +269,7 @@ public final class MockHomeFeedClient: HomeFeedClient, @unchecked Sendable {
     private var _patchCallCount: Int = 0
     private var _triggerCallCount: Int = 0
     private var _pendingFetchDelay: UInt64 = 0
+    private var _pendingPatchDelay: UInt64 = 0
 
     public init(response: HomeFeedResponse? = nil) {
         self._response = response
@@ -278,6 +309,12 @@ public final class MockHomeFeedClient: HomeFeedClient, @unchecked Sendable {
         lock.withLock { _pendingFetchDelay = nanoseconds }
     }
 
+    /// Inserts a one-shot sleep inside `patchStatus` so tests can race
+    /// a concurrent `load()` against an in-flight patch.
+    public func setNextPatchDelay(nanoseconds: UInt64) {
+        lock.withLock { _pendingPatchDelay = nanoseconds }
+    }
+
     public func fetchFeed(timeAwaySeconds: TimeInterval) async throws -> HomeFeedResponse {
         let (error, response, delay) = lock.withLock {
             () -> (Error?, HomeFeedResponse?, UInt64) in
@@ -297,9 +334,15 @@ public final class MockHomeFeedClient: HomeFeedClient, @unchecked Sendable {
     }
 
     public func patchStatus(itemId: String, status: FeedItemStatus) async throws -> FeedItem {
-        let (error, replacement) = lock.withLock { () -> (Error?, FeedItem?) in
+        let (error, replacement, delay) = lock.withLock {
+            () -> (Error?, FeedItem?, UInt64) in
             _patchCallCount += 1
-            return (_patchError, _patchedItems[itemId])
+            let d = _pendingPatchDelay
+            _pendingPatchDelay = 0
+            return (_patchError, _patchedItems[itemId], d)
+        }
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
         }
         if let error { throw error }
         if let replacement { return replacement }

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -1,0 +1,317 @@
+import AppKit
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeFeedStore")
+
+/// Observable store that owns the Home page's activity feed state.
+///
+/// Responsibilities:
+/// - Fetches the current feed (items + context banner) from the daemon via
+///   ``HomeFeedClient``.
+/// - Subscribes to the shared `ServerMessage` stream and re-fetches when the
+///   daemon broadcasts `homeFeedUpdated`.
+/// - Re-fetches when the app returns to the foreground, passing the measured
+///   time-away so the daemon can apply `minTimeAway` gates and compose the
+///   context banner.
+/// - Applies optimistic status updates locally, rolling back on server error.
+///
+/// The store deliberately leaves `items` / `contextBanner` untouched on
+/// failure — a transient network blip should not blank the feed. `isLoading`
+/// reflects only the latest in-flight `load()`; concurrent overlapping calls
+/// are disambiguated by a generation token so an older response never
+/// overwrites a newer one.
+@MainActor
+@Observable
+public final class HomeFeedStore {
+
+    // MARK: - Reactive State
+
+    public private(set) var items: [FeedItem] = []
+    public private(set) var contextBanner: ContextBanner?
+    public private(set) var isLoading: Bool = false
+    public private(set) var lastLoadedAt: Date?
+
+    /// Derived from `contextBanner.newCount`. `nil` when the banner has
+    /// never been loaded.
+    public var newItemCount: Int { contextBanner?.newCount ?? 0 }
+
+    // MARK: - Non-reactive Bookkeeping
+
+    @ObservationIgnored private let client: HomeFeedClient
+    @ObservationIgnored let messageStream: AsyncStream<ServerMessage>
+    @ObservationIgnored var sseTask: Task<Void, Never>?
+    @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
+
+    /// Timestamp of the most recent moment the client was in the
+    /// foreground. Used to compute `timeAwaySeconds` on the next `load()`.
+    /// Initialized to `now` at construction so a cold-start load sees a
+    /// zero-delta instead of a nonsensical negative or epoch value.
+    @ObservationIgnored private var lastForegroundAt: Date
+
+    /// Monotonically-increasing generation token bumped on every `load()`
+    /// entry. Used to discard out-of-order responses when concurrent
+    /// `load()` calls overlap (SSE handler + foreground observer +
+    /// HomePageView.task can all fire in the same tick).
+    @ObservationIgnored private var loadGeneration: UInt64 = 0
+
+    // MARK: - Lifecycle
+
+    public init(client: HomeFeedClient, messageStream: AsyncStream<ServerMessage>) {
+        self.client = client
+        self.messageStream = messageStream
+        self.lastForegroundAt = Date()
+        startListening()
+        observeForeground()
+    }
+
+    deinit {
+        sseTask?.cancel()
+        if let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Fetches the latest feed + context banner from the daemon.
+    ///
+    /// `timeAwaySeconds` is computed from `lastForegroundAt`; callers do
+    /// not supply it. Leaves `items` / `contextBanner` unchanged on
+    /// failure so the UI keeps showing whatever we last successfully
+    /// fetched. Errors are logged, never thrown out.
+    public func load() async {
+        loadGeneration &+= 1
+        let myGeneration = loadGeneration
+        isLoading = true
+        defer {
+            if loadGeneration == myGeneration {
+                isLoading = false
+            }
+        }
+
+        let timeAwaySeconds = max(0, Date().timeIntervalSince(lastForegroundAt))
+
+        do {
+            let response = try await client.fetchFeed(timeAwaySeconds: timeAwaySeconds)
+            guard loadGeneration == myGeneration else { return }
+            self.items = response.items
+            self.contextBanner = response.contextBanner
+            self.lastLoadedAt = Date()
+        } catch {
+            log.error("HomeFeedStore.load failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Optimistically updates the item's status in memory, then confirms
+    /// with the server. On failure the local change is rolled back to the
+    /// prior status so the UI and server stay consistent.
+    public func updateStatus(itemId: String, status: FeedItemStatus) async {
+        guard let index = items.firstIndex(where: { $0.id == itemId }) else { return }
+
+        let previous = items[index]
+        if previous.status == status { return }
+
+        items[index] = replacingStatus(previous, with: status)
+
+        do {
+            let confirmed = try await client.patchStatus(itemId: itemId, status: status)
+            // Re-find the index — the item may have moved or dropped off
+            // while we awaited the network call. If it's still present,
+            // reconcile to the server's canonical copy.
+            if let freshIndex = items.firstIndex(where: { $0.id == itemId }) {
+                items[freshIndex] = confirmed
+            }
+        } catch {
+            log.error("HomeFeedStore.updateStatus(\(itemId)) failed: \(error.localizedDescription)")
+            if let freshIndex = items.firstIndex(where: { $0.id == itemId }) {
+                items[freshIndex] = previous
+            }
+        }
+    }
+
+    /// Wrapper around `updateStatus(..., .actedOn)`. Used by the feed
+    /// card's explicit dismiss affordance.
+    public func dismiss(itemId: String) async {
+        await updateStatus(itemId: itemId, status: .actedOn)
+    }
+
+    /// Batches status updates to `.seen` for every item still in the
+    /// `.new` state. Marks them locally first, then fires server calls
+    /// in parallel. Individual failures are logged but do not roll back
+    /// — the local state is still the best approximation of "user has
+    /// looked at the feed at least once," which is what `.seen` means.
+    public func markAllSeen() async {
+        let newIds = items.compactMap { $0.status == .new ? $0.id : nil }
+        guard !newIds.isEmpty else { return }
+
+        for id in newIds {
+            if let index = items.firstIndex(where: { $0.id == id }) {
+                items[index] = replacingStatus(items[index], with: .seen)
+            }
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for id in newIds {
+                group.addTask { [client] in
+                    do {
+                        _ = try await client.patchStatus(itemId: id, status: .seen)
+                    } catch {
+                        log.error("HomeFeedStore.markAllSeen(\(id)) failed: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Triggers the named action on the feed item. On success the daemon
+    /// creates a conversation pre-seeded with the action's prompt and
+    /// returns its id; on failure `nil` is returned and the caller can
+    /// surface an error toast.
+    public func triggerAction(itemId: String, actionId: String) async -> String? {
+        do {
+            return try await client.triggerAction(itemId: itemId, actionId: actionId)
+        } catch {
+            log.error("HomeFeedStore.triggerAction(\(itemId),\(actionId)) failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Foreground Refresh
+
+    private func observeForeground() {
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // Load first against the existing `lastForegroundAt` so the
+                // daemon sees the real time-away gap, then reset the stamp
+                // to the current moment for the next cycle.
+                await self.load()
+                self.lastForegroundAt = Date()
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// `FeedItem` fields are `let` — mutate status by rebuilding the value.
+    private func replacingStatus(
+        _ item: FeedItem,
+        with status: FeedItemStatus
+    ) -> FeedItem {
+        FeedItem(
+            id: item.id,
+            type: item.type,
+            priority: item.priority,
+            title: item.title,
+            summary: item.summary,
+            source: item.source,
+            timestamp: item.timestamp,
+            status: status,
+            expiresAt: item.expiresAt,
+            minTimeAway: item.minTimeAway,
+            actions: item.actions,
+            author: item.author,
+            createdAt: item.createdAt
+        )
+    }
+}
+
+// MARK: - Mock Client
+
+/// In-memory mock used by unit tests. Thread-safe via `NSLock` so tests can
+/// flip responses between concurrent `load()` calls without data races.
+public final class MockHomeFeedClient: HomeFeedClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _response: HomeFeedResponse?
+    private var _fetchError: Error?
+    private var _patchError: Error?
+    private var _triggerError: Error?
+    private var _patchedItems: [String: FeedItem] = [:]
+    private var _triggeredConversationId: String = "mock-conversation"
+    private var _fetchCallCount: Int = 0
+    private var _patchCallCount: Int = 0
+    private var _triggerCallCount: Int = 0
+    private var _pendingFetchDelay: UInt64 = 0
+
+    public init(response: HomeFeedResponse? = nil) {
+        self._response = response
+    }
+
+    public var fetchCallCount: Int { lock.withLock { _fetchCallCount } }
+    public var patchCallCount: Int { lock.withLock { _patchCallCount } }
+    public var triggerCallCount: Int { lock.withLock { _triggerCallCount } }
+
+    public func setResponse(_ response: HomeFeedResponse?) {
+        lock.withLock { _response = response }
+    }
+
+    public func setFetchError(_ error: Error?) {
+        lock.withLock { _fetchError = error }
+    }
+
+    public func setPatchError(_ error: Error?) {
+        lock.withLock { _patchError = error }
+    }
+
+    public func setTriggerError(_ error: Error?) {
+        lock.withLock { _triggerError = error }
+    }
+
+    public func setPatchedItem(id: String, item: FeedItem) {
+        lock.withLock { _patchedItems[id] = item }
+    }
+
+    public func setTriggeredConversationId(_ id: String) {
+        lock.withLock { _triggeredConversationId = id }
+    }
+
+    /// Inserts a one-shot sleep inside `fetchFeed` so tests can force
+    /// out-of-order response handling.
+    public func setNextFetchDelay(nanoseconds: UInt64) {
+        lock.withLock { _pendingFetchDelay = nanoseconds }
+    }
+
+    public func fetchFeed(timeAwaySeconds: TimeInterval) async throws -> HomeFeedResponse {
+        let (error, response, delay) = lock.withLock {
+            () -> (Error?, HomeFeedResponse?, UInt64) in
+            _fetchCallCount += 1
+            let d = _pendingFetchDelay
+            _pendingFetchDelay = 0
+            return (_fetchError, _response, d)
+        }
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
+        }
+        if let error { throw error }
+        guard let response else {
+            throw HomeFeedClientError.httpError(statusCode: 404)
+        }
+        return response
+    }
+
+    public func patchStatus(itemId: String, status: FeedItemStatus) async throws -> FeedItem {
+        let (error, replacement) = lock.withLock { () -> (Error?, FeedItem?) in
+            _patchCallCount += 1
+            return (_patchError, _patchedItems[itemId])
+        }
+        if let error { throw error }
+        if let replacement { return replacement }
+        throw HomeFeedClientError.httpError(statusCode: 404)
+    }
+
+    public func triggerAction(itemId: String, actionId: String) async throws -> String {
+        let (error, conversationId) = lock.withLock { () -> (Error?, String) in
+            _triggerCallCount += 1
+            return (_triggerError, _triggeredConversationId)
+        }
+        if let error { throw error }
+        return conversationId
+    }
+}

--- a/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for ``HomeFeedStore`` — exercised with ``MockHomeFeedClient``
+/// and a scripted `AsyncStream<ServerMessage>` so the tests stay hermetic
+/// (no network, no gateway, no daemon).
+@MainActor
+final class HomeFeedStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeFeedItem(
+        id: String = "item-1",
+        type: FeedItemType = .nudge,
+        status: FeedItemStatus = .new,
+        title: String = "Fixture title",
+        priority: Int = 60,
+        source: FeedItemSource? = .gmail,
+        author: FeedItemAuthor = .assistant,
+        timestamp: Date = Date(timeIntervalSince1970: 1_760_000_000),
+        createdAt: Date = Date(timeIntervalSince1970: 1_760_000_000)
+    ) -> FeedItem {
+        FeedItem(
+            id: id,
+            type: type,
+            priority: priority,
+            title: title,
+            summary: "Fixture summary",
+            source: source,
+            timestamp: timestamp,
+            status: status,
+            expiresAt: nil,
+            minTimeAway: nil,
+            actions: nil,
+            author: author,
+            createdAt: createdAt
+        )
+    }
+
+    private func makeBanner(newCount: Int = 1) -> ContextBanner {
+        ContextBanner(
+            greeting: "Good afternoon, Alex",
+            timeAwayLabel: "Away for 2 hours",
+            newCount: newCount
+        )
+    }
+
+    private func makeResponse(
+        items: [FeedItem],
+        banner: ContextBanner? = nil
+    ) -> HomeFeedResponse {
+        HomeFeedResponse(
+            items: items,
+            updatedAt: Date(timeIntervalSince1970: 1_760_000_100),
+            contextBanner: banner ?? ContextBanner(
+                greeting: "Good afternoon, Alex",
+                timeAwayLabel: "Away for 2 hours",
+                newCount: items.filter { $0.status == .new }.count
+            )
+        )
+    }
+
+    private func makeStore(
+        client: HomeFeedClient
+    ) -> (HomeFeedStore, AsyncStream<ServerMessage>.Continuation) {
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let store = HomeFeedStore(client: client, messageStream: stream)
+        return (store, continuation)
+    }
+
+    // MARK: - Tests
+
+    func testLoadPopulatesItemsOnSuccess() async {
+        let expected = makeResponse(items: [
+            makeFeedItem(id: "a", status: .new, title: "First"),
+            makeFeedItem(id: "b", status: .seen, title: "Second"),
+        ])
+        let client = MockHomeFeedClient(response: expected)
+        let (store, _) = makeStore(client: client)
+
+        XCTAssertTrue(store.items.isEmpty, "items should start empty")
+        XCTAssertNil(store.contextBanner)
+
+        await store.load()
+
+        XCTAssertEqual(store.items.map { $0.id }, ["a", "b"])
+        XCTAssertEqual(store.contextBanner?.newCount, 1)
+        XCTAssertEqual(store.newItemCount, 1)
+        XCTAssertFalse(store.isLoading)
+        XCTAssertNotNil(store.lastLoadedAt)
+        XCTAssertEqual(client.fetchCallCount, 1)
+    }
+
+    func testLoadLeavesItemsUnchangedOnFailure() async {
+        let seeded = makeResponse(items: [makeFeedItem(id: "seed")])
+        let client = MockHomeFeedClient(response: seeded)
+        let (store, _) = makeStore(client: client)
+
+        await store.load()
+        XCTAssertEqual(store.items.map { $0.id }, ["seed"])
+
+        client.setFetchError(HomeFeedClientError.httpError(statusCode: 500))
+        await store.load()
+
+        XCTAssertEqual(store.items.map { $0.id }, ["seed"],
+                       "items must not be blanked on transport failure")
+        XCTAssertFalse(store.isLoading)
+    }
+
+    func testOutOfOrderResponsesPreserveLatest() async {
+        // First `load()` sleeps inside `fetchFeed`, so the second `load()`
+        // can issue, return synchronously with the newer response, and then
+        // the first `load()` unblocks with the stale response. The generation
+        // token must cause the stale first result to be discarded.
+        let stale = makeResponse(items: [makeFeedItem(id: "stale")])
+        let fresh = makeResponse(items: [makeFeedItem(id: "fresh")])
+        let client = MockHomeFeedClient(response: stale)
+        let (store, _) = makeStore(client: client)
+
+        // 200 ms delay on the next fetch (the upcoming first `load()`).
+        client.setNextFetchDelay(nanoseconds: 200_000_000)
+
+        async let first: Void = store.load()
+
+        // Ensure the first fetch has entered its delay before we mutate
+        // the mock and issue the second call.
+        try? await Task.sleep(nanoseconds: 30_000_000) // 30 ms
+        client.setResponse(fresh)
+        await store.load()
+
+        XCTAssertEqual(store.items.map { $0.id }, ["fresh"],
+                       "newer load() result should be applied before awaiting the first")
+
+        // Now let the first (stale) call unblock and finish. Its result
+        // should be dropped by the generation check.
+        await first
+
+        XCTAssertEqual(store.items.map { $0.id }, ["fresh"],
+                       "stale first-load response must not overwrite fresh state")
+        XCTAssertEqual(client.fetchCallCount, 2)
+    }
+
+    func testUpdateStatusOptimisticallyAppliesThenConfirms() async {
+        let original = makeFeedItem(id: "x", status: .new)
+        let client = MockHomeFeedClient(response: makeResponse(items: [original]))
+        let (store, _) = makeStore(client: client)
+        await store.load()
+        XCTAssertEqual(store.items.first?.status, .new)
+
+        let serverConfirmed = makeFeedItem(id: "x", status: .seen, title: "Server-canonical")
+        client.setPatchedItem(id: "x", item: serverConfirmed)
+
+        await store.updateStatus(itemId: "x", status: .seen)
+
+        XCTAssertEqual(store.items.first?.status, .seen)
+        // Reconciled against the server's canonical copy — the title
+        // reflects the server-side value, not the local cache.
+        XCTAssertEqual(store.items.first?.title, "Server-canonical")
+        XCTAssertEqual(client.patchCallCount, 1)
+    }
+
+    func testUpdateStatusRollsBackOnFailure() async {
+        let original = makeFeedItem(id: "x", status: .new, title: "Pre-patch")
+        let client = MockHomeFeedClient(response: makeResponse(items: [original]))
+        let (store, _) = makeStore(client: client)
+        await store.load()
+
+        client.setPatchError(HomeFeedClientError.httpError(statusCode: 500))
+
+        await store.updateStatus(itemId: "x", status: .seen)
+
+        XCTAssertEqual(store.items.first?.status, .new,
+                       "rollback should restore the original status on server error")
+        XCTAssertEqual(store.items.first?.title, "Pre-patch")
+        XCTAssertEqual(client.patchCallCount, 1)
+    }
+
+    func testSSEEventTriggersReload() async throws {
+        let initial = makeResponse(items: [makeFeedItem(id: "first")])
+        let client = MockHomeFeedClient(response: initial)
+        let (store, continuation) = makeStore(client: client)
+
+        await store.load()
+        XCTAssertEqual(store.items.map { $0.id }, ["first"])
+        let baselineFetches = client.fetchCallCount
+
+        let updated = makeResponse(items: [makeFeedItem(id: "second")])
+        client.setResponse(updated)
+        continuation.yield(.homeFeedUpdated(updatedAt: "2026-04-14T12:00:00Z", newItemCount: 1))
+
+        try await waitUntil(timeout: 2.0) {
+            client.fetchCallCount > baselineFetches && store.items.map { $0.id } == ["second"]
+        }
+
+        XCTAssertEqual(store.items.map { $0.id }, ["second"])
+        XCTAssertGreaterThan(client.fetchCallCount, baselineFetches)
+    }
+
+    func testTriggerActionReturnsConversationId() async {
+        let client = MockHomeFeedClient(response: makeResponse(items: [makeFeedItem()]))
+        client.setTriggeredConversationId("conv-42")
+        let (store, _) = makeStore(client: client)
+
+        let conversationId = await store.triggerAction(itemId: "item-1", actionId: "reply")
+
+        XCTAssertEqual(conversationId, "conv-42")
+        XCTAssertEqual(client.triggerCallCount, 1)
+    }
+
+    func testTriggerActionReturnsNilOnFailure() async {
+        let client = MockHomeFeedClient(response: makeResponse(items: [makeFeedItem()]))
+        client.setTriggerError(HomeFeedClientError.httpError(statusCode: 500))
+        let (store, _) = makeStore(client: client)
+
+        let conversationId = await store.triggerAction(itemId: "item-1", actionId: "reply")
+
+        XCTAssertNil(conversationId)
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("waitUntil timed out after \(timeout)s")
+    }
+}

--- a/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
@@ -176,6 +176,75 @@ final class HomeFeedStoreTests: XCTestCase {
         XCTAssertEqual(client.patchCallCount, 1)
     }
 
+    func testUpdateStatusRollbackSkippedIfLoadLandedFirst() async {
+        // Seed the store, then race `updateStatus` (delayed PATCH that
+        // will fail) against a concurrent `load()` that lands a fresh
+        // server snapshot. The rollback path must NOT overwrite the
+        // fresh load's view of the item with the stale pre-patch copy.
+        let original = makeFeedItem(id: "x", status: .new, title: "Pre-patch")
+        let client = MockHomeFeedClient(response: makeResponse(items: [original]))
+        let (store, _) = makeStore(client: client)
+        await store.load()
+        XCTAssertEqual(store.items.first?.title, "Pre-patch")
+
+        client.setPatchError(HomeFeedClientError.httpError(statusCode: 500))
+        client.setNextPatchDelay(nanoseconds: 200_000_000) // 200 ms
+
+        async let patching: Void = store.updateStatus(itemId: "x", status: .seen)
+
+        // Let the patch enter its delay, then swap the fetch response
+        // and run a concurrent `load()` that finishes before the patch
+        // unblocks. The load's fresh snapshot becomes the source of truth.
+        try? await Task.sleep(nanoseconds: 30_000_000) // 30 ms
+        let fresh = makeFeedItem(
+            id: "x",
+            status: .seen,
+            title: "Server-fresh",
+            timestamp: Date(timeIntervalSince1970: 1_760_000_500),
+            createdAt: Date(timeIntervalSince1970: 1_760_000_500)
+        )
+        client.setResponse(makeResponse(items: [fresh]))
+        await store.load()
+        XCTAssertEqual(store.items.first?.title, "Server-fresh")
+
+        // Now unblock the delayed patch — it will error, and the
+        // rollback guard must skip the restore because loadGeneration
+        // has advanced past the entry value.
+        await patching
+
+        XCTAssertEqual(store.items.first?.title, "Server-fresh",
+                       "rollback must not stomp the fresh load() snapshot")
+        XCTAssertEqual(store.items.first?.status, .seen)
+    }
+
+    func testMarkAllSeenAppliesLocallyAndPatchesEachItem() async {
+        let items = [
+            makeFeedItem(id: "a", status: .new, title: "First"),
+            makeFeedItem(id: "b", status: .new, title: "Second"),
+            makeFeedItem(id: "c", status: .seen, title: "Already seen"),
+        ]
+        let client = MockHomeFeedClient(response: makeResponse(items: items))
+        let (store, _) = makeStore(client: client)
+        await store.load()
+
+        // Server will echo each patched item; we don't actually need
+        // the mock to return a real replacement because markAllSeen
+        // is fire-and-forget — but supply one anyway so errors aren't
+        // spurious.
+        for item in items where item.status == .new {
+            client.setPatchedItem(
+                id: item.id,
+                item: makeFeedItem(id: item.id, status: .seen, title: item.title)
+            )
+        }
+
+        await store.markAllSeen()
+
+        XCTAssertEqual(store.items.map { $0.status }, [.seen, .seen, .seen])
+        XCTAssertEqual(client.patchCallCount, 2,
+                       "only the two originally-new items should have been PATCHed")
+    }
+
     func testSSEEventTriggersReload() async throws {
         let initial = makeResponse(items: [makeFeedItem(id: "first")])
         let client = MockHomeFeedClient(response: initial)

--- a/clients/shared/Network/HomeFeedClient.swift
+++ b/clients/shared/Network/HomeFeedClient.swift
@@ -106,7 +106,7 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/home/feed/\(itemId)",
+                path: "assistants/{assistantId}/home/feed/\(Self.pathEscape(itemId))",
                 json: ["status": status.rawValue],
                 timeout: 10
             )
@@ -135,7 +135,7 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/home/feed/\(itemId)/actions/\(actionId)",
+                path: "assistants/{assistantId}/home/feed/\(Self.pathEscape(itemId))/actions/\(Self.pathEscape(actionId))",
                 json: [:],
                 timeout: 10
             )
@@ -170,5 +170,13 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
+    }
+
+    /// Percent-encodes a URL path component so opaque IDs with
+    /// reserved characters (e.g. `/`, `?`, `#`) don't corrupt the
+    /// generated request URL. Daemon IDs are UUIDs today, but defensive
+    /// encoding costs nothing and protects future callers.
+    private static func pathEscape(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? component
     }
 }

--- a/clients/shared/Network/HomeFeedClient.swift
+++ b/clients/shared/Network/HomeFeedClient.swift
@@ -1,0 +1,174 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeFeedClient")
+
+/// Response envelope returned by `GET /v1/home/feed`.
+///
+/// Mirrors the JSON shape emitted by
+/// `assistant/src/runtime/routes/home-feed-routes.ts::handleGetHomeFeed`:
+/// `{ items, updatedAt, contextBanner }`.
+public struct HomeFeedResponse: Codable, Sendable, Hashable {
+    public let items: [FeedItem]
+    public let updatedAt: Date
+    public let contextBanner: ContextBanner
+
+    public init(items: [FeedItem], updatedAt: Date, contextBanner: ContextBanner) {
+        self.items = items
+        self.updatedAt = updatedAt
+        self.contextBanner = contextBanner
+    }
+}
+
+/// Focused client for the Home activity feed.
+///
+/// Expressed in a `throws` style so `HomeFeedStore` can distinguish a
+/// successful empty feed from a transport or decode failure and leave
+/// its cached `items` alone on error instead of blanking the UI.
+public protocol HomeFeedClient: Sendable {
+    /// `GET /v1/home/feed?timeAwaySeconds=<int>`.
+    func fetchFeed(timeAwaySeconds: TimeInterval) async throws -> HomeFeedResponse
+
+    /// `PATCH /v1/home/feed/<itemId>` with body `{ "status": <raw> }`.
+    /// Returns the updated `FeedItem` on success.
+    func patchStatus(
+        itemId: String,
+        status: FeedItemStatus
+    ) async throws -> FeedItem
+
+    /// `POST /v1/home/feed/<itemId>/actions/<actionId>`.
+    /// Returns the `conversationId` of the conversation the daemon created
+    /// from the action's pre-seeded prompt.
+    func triggerAction(
+        itemId: String,
+        actionId: String
+    ) async throws -> String
+}
+
+/// Errors produced by ``DefaultHomeFeedClient``.
+public enum HomeFeedClientError: LocalizedError {
+    case httpError(statusCode: Int)
+    case decodingFailed(underlying: Error)
+    case missingConversationId
+
+    public var errorDescription: String? {
+        switch self {
+        case .httpError(let statusCode):
+            return "Home feed request failed (HTTP \(statusCode))"
+        case .decodingFailed(let underlying):
+            return "Failed to decode home feed response: \(underlying.localizedDescription)"
+        case .missingConversationId:
+            return "Home feed action response did not include a conversationId"
+        }
+    }
+}
+
+/// Gateway-backed implementation of ``HomeFeedClient``.
+///
+/// Hits `/v1/home/feed*` via ``GatewayHTTPClient`` — the assistant-scoped
+/// path prefix (`assistants/{assistantId}/`) is rewritten to the flat
+/// daemon path by the gateway's runtime proxy, matching the pattern used
+/// by ``DefaultHomeStateClient``.
+public struct DefaultHomeFeedClient: HomeFeedClient {
+    nonisolated public init() {}
+
+    public func fetchFeed(timeAwaySeconds: TimeInterval) async throws -> HomeFeedResponse {
+        let seconds = max(0, Int(timeAwaySeconds.rounded()))
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/home/feed",
+                params: ["timeAwaySeconds": String(seconds)],
+                timeout: 10
+            )
+        } catch {
+            log.error("fetchFeed transport error: \(error.localizedDescription)")
+            throw error
+        }
+
+        guard response.isSuccess else {
+            log.error("fetchFeed failed (HTTP \(response.statusCode))")
+            throw HomeFeedClientError.httpError(statusCode: response.statusCode)
+        }
+
+        do {
+            return try Self.makeDecoder().decode(HomeFeedResponse.self, from: response.data)
+        } catch {
+            log.error("fetchFeed decode error: \(error.localizedDescription)")
+            throw HomeFeedClientError.decodingFailed(underlying: error)
+        }
+    }
+
+    public func patchStatus(
+        itemId: String,
+        status: FeedItemStatus
+    ) async throws -> FeedItem {
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.patch(
+                path: "assistants/{assistantId}/home/feed/\(itemId)",
+                json: ["status": status.rawValue],
+                timeout: 10
+            )
+        } catch {
+            log.error("patchStatus transport error: \(error.localizedDescription)")
+            throw error
+        }
+
+        guard response.isSuccess else {
+            log.error("patchStatus failed (HTTP \(response.statusCode))")
+            throw HomeFeedClientError.httpError(statusCode: response.statusCode)
+        }
+
+        do {
+            return try Self.makeDecoder().decode(FeedItem.self, from: response.data)
+        } catch {
+            log.error("patchStatus decode error: \(error.localizedDescription)")
+            throw HomeFeedClientError.decodingFailed(underlying: error)
+        }
+    }
+
+    public func triggerAction(
+        itemId: String,
+        actionId: String
+    ) async throws -> String {
+        let response: GatewayHTTPClient.Response
+        do {
+            response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/home/feed/\(itemId)/actions/\(actionId)",
+                json: [:],
+                timeout: 10
+            )
+        } catch {
+            log.error("triggerAction transport error: \(error.localizedDescription)")
+            throw error
+        }
+
+        guard response.isSuccess else {
+            log.error("triggerAction failed (HTTP \(response.statusCode))")
+            throw HomeFeedClientError.httpError(statusCode: response.statusCode)
+        }
+
+        struct TriggerActionResponse: Decodable { let conversationId: String }
+        let decoded: TriggerActionResponse
+        do {
+            decoded = try Self.makeDecoder().decode(TriggerActionResponse.self, from: response.data)
+        } catch {
+            log.error("triggerAction decode error: \(error.localizedDescription)")
+            throw HomeFeedClientError.decodingFailed(underlying: error)
+        }
+        guard !decoded.conversationId.isEmpty else {
+            throw HomeFeedClientError.missingConversationId
+        }
+        return decoded.conversationId
+    }
+
+    /// Decoder configured to parse ISO-8601 timestamps so `FeedItem.timestamp`,
+    /// `FeedItem.createdAt`, and `FeedItem.expiresAt` decode from the wire
+    /// format written by the daemon (`toISOString()` output).
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}


### PR DESCRIPTION
## Summary
- `HomeFeedClient` protocol + `DefaultHomeFeedClient` gateway wrapper (GET `/v1/home/feed`, PATCH `/v1/home/feed/<id>`, POST `/v1/home/feed/<id>/actions/<actionId>`) — mirrors `HomeStateClient` conventions
- `HomeFeedStore` `@MainActor @Observable` store with items/contextBanner/isLoading/lastLoadedAt/newItemCount. Generation-token guarded `load()`, optimistic `updateStatus` with rollback, `dismiss`, `markAllSeen`, `triggerAction`
- `HomeFeedStore+SSE` subscribes to `.homeFeedUpdated` and reloads; foreground observer computes `timeAwaySeconds` from `lastForegroundAt` then resets it
- `MockHomeFeedClient` for tests — `NSLock`-guarded, supports injected delay for out-of-order response simulation
- `HomeFeedStoreTests` — 8 tests: populate, failure preserves state, out-of-order generation-token guard, optimistic update + server reconcile, rollback on error, SSE-triggered reload, trigger success, trigger failure

Not yet wired into `HomePageView` — that integration lands in PR 10 per the plan.

## Plan
Part of plan: home-activity-feed.md (PR 7 of 13)
Part of JARVIS-510

## Test plan
- [x] `./build.sh lint` clean (Swift 6 strict concurrency)
- [x] `./build.sh test --filter HomeFeedStoreTests` — 8/8 pass
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
