### PR TITLE
feat(home-feed): wire feed store + components into HomePageView behind home-feed flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedSection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedSection.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Composition view that binds `HomeFeedStore` to the feed item views.
+///
+/// Responsibilities:
+/// - Renders the context banner above the sorted list of feed items.
+/// - Dispatches to `HomeFeedNudgeCard` for `.nudge` items and to
+///   `HomeFeedListRow` for `.digest` / `.action` / `.thread` items.
+/// - Translates user gestures (tap, action, dismiss) into async calls on
+///   the store and forwards the resulting `conversationId` to the parent
+///   so it can navigate into the newly-created conversation.
+///
+/// Empty state: when `store.items.isEmpty`, this view renders nothing —
+/// not even the context banner — so the capabilities section below it
+/// stays the dominant content. This matches the TDD's "empty feed state"
+/// requirement: capabilities-only view with no feed chrome.
+///
+/// Sort order: items are displayed by `priority` descending, ties broken
+/// by `createdAt` descending (newer within the same priority wins). The
+/// store's `items` array is the raw feed as returned by the daemon; any
+/// ordering not specified here is out of scope.
+struct HomeFeedSection: View {
+    @Bindable var store: HomeFeedStore
+
+    /// Forwarded up to the parent when a feed action resolves to a
+    /// conversation — the store returns the daemon-created conversation
+    /// id, and the parent (PanelCoordinator) navigates into it.
+    let onConversationOpened: (String) -> Void
+
+    var body: some View {
+        if !store.items.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                if let banner = store.contextBanner {
+                    HomeContextBannerView(banner: banner)
+                }
+                LazyVStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(sortedItems, id: \.id) { item in
+                        itemView(for: item)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func itemView(for item: FeedItem) -> some View {
+        switch item.type {
+        case .nudge:
+            HomeFeedNudgeCard(
+                item: item,
+                onAction: { action in
+                    Task { await triggerAction(itemId: item.id, actionId: action.id) }
+                },
+                onDismiss: {
+                    Task { await store.dismiss(itemId: item.id) }
+                }
+            )
+        case .digest, .action, .thread:
+            HomeFeedListRow(
+                item: item,
+                onTap: {
+                    // Synthetic "open" action — the daemon interprets any
+                    // unknown action id as an open intent and seeds the
+                    // new conversation with the first available action's
+                    // prompt (or the item summary if no actions exist).
+                    Task { await triggerAction(itemId: item.id, actionId: "open") }
+                }
+            )
+        }
+    }
+
+    private func triggerAction(itemId: String, actionId: String) async {
+        if let conversationId = await store.triggerAction(itemId: itemId, actionId: actionId) {
+            onConversationOpened(conversationId)
+        }
+    }
+
+    /// `priority` desc → `createdAt` desc. Newer items float up within
+    /// the same priority bucket so the feed never buries a just-arrived
+    /// platform digest under yesterday's leftover.
+    private var sortedItems: [FeedItem] {
+        store.items.sorted { a, b in
+            if a.priority != b.priority {
+                return a.priority > b.priority
+            }
+            return a.createdAt > b.createdAt
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedSection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedSection.swift
@@ -78,7 +78,10 @@ struct HomeFeedSection: View {
 
     /// `priority` desc → `createdAt` desc. Newer items float up within
     /// the same priority bucket so the feed never buries a just-arrived
-    /// platform digest under yesterday's leftover.
+    /// platform digest under yesterday's leftover. Items with identical
+    /// priority AND createdAt keep their original insertion order
+    /// (Swift's `sorted(by:)` is stable), so two platform digests
+    /// written in the same tick stay in writer order.
     private var sortedItems: [FeedItem] {
         store.items.sorted { a, b in
             if a.priority != b.priority {

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -29,9 +29,13 @@ struct HomePageView: View {
     private let maxContentWidth: CGFloat = 920
 
     /// `home-feed` is a macos-scope flag — same registry as `home-tab`.
-    /// Resolved once at view creation; a runtime toggle requires a rebuild
-    /// of the panel, which is acceptable for a v1 feature flag.
-    private let isHomeFeedEnabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("home-feed")
+    /// Computed on every render so a live debug toggle takes effect on
+    /// the next redraw instead of requiring a full panel rebuild. The
+    /// flag read itself is an in-memory lookup; re-evaluating it per
+    /// render is free.
+    private var isHomeFeedEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("home-feed")
+    }
 
     var body: some View {
         Group {

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -15,14 +15,23 @@ import VellumAssistantShared
 /// blank the UI between refreshes.
 struct HomePageView: View {
     @Bindable var store: HomeStore
+    @Bindable var feedStore: HomeFeedStore
     let onStartConversation: () -> Void
     let onPrimaryCTA: (Capability) -> Void
     let onShortcutCTA: (Capability) -> Void
+    /// Fired when a feed action resolves to a daemon-created conversation
+    /// — the receiver (usually `PanelCoordinator`) navigates into it.
+    let onFeedConversationOpened: (String) -> Void
 
     /// Cap the two-column layout so the right column doesn't sprawl on a
     /// 32-inch display. Beyond ~960pt the line lengths stop being readable
     /// and the page starts to feel empty in the middle.
     private let maxContentWidth: CGFloat = 920
+
+    /// `home-feed` is a macos-scope flag — same registry as `home-tab`.
+    /// Resolved once at view creation; a runtime toggle requires a rebuild
+    /// of the panel, which is acceptable for a v1 feature flag.
+    private let isHomeFeedEnabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("home-feed")
 
     var body: some View {
         Group {
@@ -36,6 +45,9 @@ struct HomePageView: View {
         .background(VColor.surfaceBase)
         .task {
             await store.load()
+            if isHomeFeedEnabled {
+                await feedStore.load()
+            }
         }
     }
 
@@ -50,6 +62,12 @@ struct HomePageView: View {
 
                 VStack(alignment: .leading, spacing: VSpacing.xxl) {
                     HomeFactsSection(facts: state.facts)
+                    if isHomeFeedEnabled {
+                        HomeFeedSection(
+                            store: feedStore,
+                            onConversationOpened: onFeedConversationOpened
+                        )
+                    }
                     HomeCapabilitiesSection(
                         capabilities: state.capabilities,
                         onPrimaryCTA: onPrimaryCTA,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -89,6 +89,7 @@ struct MainWindowView: View {
     /// gating construction on the flag isn't worth the runtime-toggle
     /// surface bug it created.
     @State var homeStore: HomeStore
+    @State var feedStore: HomeFeedStore
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.appListManager = appListManager
@@ -117,6 +118,12 @@ struct MainWindowView: View {
         // without an app relaunch.
         self._homeStore = State(initialValue: HomeStore(
             client: DefaultHomeStateClient(),
+            messageStream: eventStreamClient.subscribe()
+        ))
+        // Same eager-construction rationale for the activity feed store
+        // — ready the instant the `home-feed` flag flips on.
+        self._feedStore = State(initialValue: HomeFeedStore(
+            client: DefaultHomeFeedClient(),
             messageStream: eventStreamClient.subscribe()
         ))
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
+import os
+
+private let panelCoordinatorLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "PanelCoordinator"
+)
 
 // MARK: - Panel Coordination Extension
 
@@ -153,7 +159,16 @@ extension MainWindowView {
                 onFeedConversationOpened: { conversationId in
                     // Daemon already created the conversation in response to
                     // `store.triggerAction`; the client just needs to navigate.
-                    guard let uuid = UUID(uuidString: conversationId) else { return }
+                    // A non-UUID id here means the daemon returned something
+                    // the client contract does not allow — log loudly so the
+                    // regression is visible instead of silently dropping.
+                    guard let uuid = UUID(uuidString: conversationId) else {
+                        panelCoordinatorLog.error(
+                            "HomeFeed: daemon returned non-UUID conversationId \(conversationId, privacy: .public); cannot navigate"
+                        )
+                        windowState.showToast(message: "Couldn't open the conversation.", style: .error)
+                        return
+                    }
                     windowState.selection = .conversation(uuid)
                 },
                 connectionManager: connectionManager,
@@ -644,7 +659,13 @@ extension MainWindowView {
                 },
                 onFeedConversationOpened: { conversationId in
                     windowState.dismissOverlay()
-                    guard let uuid = UUID(uuidString: conversationId) else { return }
+                    guard let uuid = UUID(uuidString: conversationId) else {
+                        panelCoordinatorLog.error(
+                            "HomeFeed: daemon returned non-UUID conversationId \(conversationId, privacy: .public); cannot navigate"
+                        )
+                        windowState.showToast(message: "Couldn't open the conversation.", style: .error)
+                        return
+                    }
                     windowState.selection = .conversation(uuid)
                 },
                 connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -150,12 +150,19 @@ extension MainWindowView {
                         windowState.selection = nil
                     }
                 },
+                onFeedConversationOpened: { conversationId in
+                    // Daemon already created the conversation in response to
+                    // `store.triggerAction`; the client just needs to navigate.
+                    guard let uuid = UUID(uuidString: conversationId) else { return }
+                    windowState.selection = .conversation(uuid)
+                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
                 homeStore: homeStore,
+                feedStore: feedStore,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
@@ -635,12 +642,18 @@ extension MainWindowView {
                         windowState.selection = .conversation(id)
                     }
                 },
+                onFeedConversationOpened: { conversationId in
+                    windowState.dismissOverlay()
+                    guard let uuid = UUID(uuidString: conversationId) else { return }
+                    windowState.selection = .conversation(uuid)
+                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
                 conversationManager: conversationManager,
                 authManager: authManager,
                 homeStore: homeStore,
+                feedStore: feedStore,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -11,12 +11,14 @@ struct IntelligencePanel: View {
     var onStartConversation: () -> Void
     var onCapabilityCTA: ((Capability) -> Void)?
     var onCapabilityShortcutCTA: ((Capability) -> Void)?
+    var onFeedConversationOpened: ((String) -> Void)?
     let connectionManager: GatewayConnectionManager
     let eventStreamClient: EventStreamClient?
     var store: SettingsStore?
     var conversationManager: ConversationManager?
     var authManager: AuthManager?
     var homeStore: HomeStore?
+    var feedStore: HomeFeedStore?
     var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var showToast: ((String, ToastInfo.Style) -> Void)?
     var initialTab: String? = nil
@@ -27,7 +29,7 @@ struct IntelligencePanel: View {
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, onStartConversation: @escaping () -> Void = {}, onCapabilityCTA: ((Capability) -> Void)? = nil, onCapabilityShortcutCTA: ((Capability) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, homeStore: HomeStore? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, onStartConversation: @escaping () -> Void = {}, onCapabilityCTA: ((Capability) -> Void)? = nil, onCapabilityShortcutCTA: ((Capability) -> Void)? = nil, onFeedConversationOpened: ((String) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, homeStore: HomeStore? = nil, feedStore: HomeFeedStore? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.onCreateSkill = onCreateSkill
@@ -35,12 +37,14 @@ struct IntelligencePanel: View {
         self.onStartConversation = onStartConversation
         self.onCapabilityCTA = onCapabilityCTA
         self.onCapabilityShortcutCTA = onCapabilityShortcutCTA
+        self.onFeedConversationOpened = onFeedConversationOpened
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.store = store
         self.conversationManager = conversationManager
         self.authManager = authManager
         self.homeStore = homeStore
+        self.feedStore = feedStore
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.showToast = showToast
         self.initialTab = initialTab
@@ -125,12 +129,16 @@ struct IntelligencePanel: View {
     private var tabContent: some View {
         switch selectedTab {
         case .home:
-            if let homeStore {
+            if let homeStore, let feedStore {
                 HomePageView(
                     store: homeStore,
+                    feedStore: feedStore,
                     onStartConversation: onStartConversation,
                     onPrimaryCTA: { capability in onCapabilityCTA?(capability) },
-                    onShortcutCTA: { capability in onCapabilityShortcutCTA?(capability) }
+                    onShortcutCTA: { capability in onCapabilityShortcutCTA?(capability) },
+                    onFeedConversationOpened: { conversationId in
+                        onFeedConversationOpened?(conversationId)
+                    }
                 )
                 .onAppear {
                     homeStore.isHomeTabVisible = true


### PR DESCRIPTION
## Summary
- New `HomeFeedSection.swift` composition view — renders `HomeContextBannerView` above a priority-sorted `LazyVStack` of `HomeFeedNudgeCard` (`type=nudge`) or `HomeFeedListRow` (digest/action/thread). Empty state is genuinely empty — no banner, no chrome — so `HomeCapabilitiesSection` stays dominant
- `HomePageView` now accepts `feedStore: HomeFeedStore` + `onFeedConversationOpened: (String) -> Void`; renders `HomeFeedSection` above `HomeCapabilitiesSection` when `MacOSClientFeatureFlagManager.shared.isEnabled(\"home-feed\")` is on
- `MainWindowView` eagerly constructs `HomeFeedStore` alongside `HomeStore` (same rationale: ready the instant the user flips the flag without an app relaunch)
- `IntelligencePanel` + both `PanelCoordinator` call sites plumb the feed store through and wire the conversation-open callback — `windowState.selection = .conversation(UUID)` on action success
- Sort order: `priority` desc → `createdAt` desc

## Plan
Part of plan: home-activity-feed.md (PR 10 of 13)
Part of JARVIS-510

## Test plan
Automated:
- [x] \`./build.sh lint\` — clean (Swift 6 strict concurrency)
- [x] \`./build.sh test --filter HomeFeedStore --filter HomeStore --filter IntelligencePanel\` — 18/18 pass
- [ ] CI green

Manual (NOT YET RUN — pre-merge gate):
- [ ] Build \`./build.sh\` and launch
- [ ] Toggle \`home-feed\` flag on via config override (requires \`home-tab\` also on)
- [ ] Seed \`~/.vellum/workspace/data/home-feed.json\` with 1 nudge + 1 digest
- [ ] Verify banner renders, items render, nudge action opens a pre-seeded conversation, dismiss removes the nudge
- [ ] Toggle flag off → feed disappears, capabilities take full space
- [ ] Delete feed file → empty state, capabilities dominant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
