### PR TITLE
macos: treat notification:* channel bindings as native conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -101,7 +101,13 @@ struct ConversationModel: Identifiable, Hashable {
 
     var isChannelConversation: Bool {
         guard let originChannel else { return false }
-        return originChannel != "vellum"
+        if originChannel == "vellum" { return false }
+        // `notification:*` channels are outbound-only delivery (e.g. Slack push
+        // for a scheduled reminder). The conversation itself still lives in the
+        // app, so treat it like a native conversation for sidebar affordances
+        // (archive, mark-as-unread, drag-to-reorder, analyze).
+        if originChannel.hasPrefix("notification:") { return false }
+        return true
     }
 
     /// Derive the groupId for a conversation from server metadata when the server


### PR DESCRIPTION
## Summary
- `isChannelConversation` now returns `false` for any `originChannel` with a `notification:` prefix, in addition to the existing `"vellum"` short-circuit.
- Restores Archive, Mark as unread, Analyze, drag-to-reorder, fork, and writable chat for scheduled conversations whose reminders are delivered via Slack (or any future `notification:*` transport).
- Single-site fix in `ConversationModel.swift`; all 23+ call sites of `isChannelConversation` (sidebar menu, readonly gate, fork gate, etc.) pick up the corrected semantics automatically.

## Original prompt
Fix isChannelConversation in clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift to treat notification:* source channels as non-channel conversations, so Archive/Mark-as-unread/Analyze appear in the sidebar context menu for scheduled conversations that only push notifications out via Slack/etc. Also apply the same check to the .onDrag guard in SidebarConversationItem.swift:273. Context: channelBinding with source_channel="notification:slack" is set on outbound-only notification delivery; it should not be treated as a two-way channel conversation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
