### PR TITLE
fix(macos): treat sounds config 404 as authoritative defaults

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -142,13 +142,15 @@ final class SoundManager {
             initialConfigLoaded = true
             flushPendingAppOpen()
         } catch WorkspaceFileError.notFound {
-            // First-run state: config.json doesn't exist yet. Treat as a
-            // successful empty-data load so the initial fetch settles and any
-            // pending `app_open` fires now instead of queuing indefinitely
-            // until an unrelated later reload.
-            if !hasLoadedConfig {
-                config = .defaultConfig
-            }
+            // Authoritative "file absent" from the gateway: config.json
+            // doesn't exist in this assistant's workspace. Reset to defaults
+            // unconditionally (including clearing `hasLoadedConfig`) so
+            // switching to an assistant with no config doesn't retain the
+            // previous assistant's settings. This is distinct from the
+            // generic `catch` below, which preserves known-good state on
+            // transient errors.
+            config = .defaultConfig
+            hasLoadedConfig = false
             initialConfigLoaded = true
             flushPendingAppOpen()
         } catch {


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on #25404. `SoundManager` is a singleton, so switching to an assistant with no `data/sounds/config.json` would retain the previous assistant's sound settings because `hasLoadedConfig` was still true.

The fix: \`WorkspaceFileError.notFound\` is authoritative (the gateway said "no such file"), not transient. On \`notFound\` we now unconditionally reset \`config\` to \`.defaultConfig\` and clear \`hasLoadedConfig\`. The \`hasLoadedConfig\` guard still protects the generic \`catch\` branch so transient network/decode errors preserve known-good state, preserving the original PR's goal.

## Test plan
- [ ] Switch from an assistant with sound config to one without — defaults load instead of the previous assistant's settings.
- [ ] Transient fetch failure (network blip) on an assistant with loaded config still preserves in-memory state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
