### PR TITLE
fix(githooks): install per-package and use bun PATH fallback

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -69,17 +69,21 @@ git push --no-verify
 
 ### post-merge & post-checkout
 
-Re-runs `bun install` at the repo root when any `package.json` or `bun.lock`
+Re-runs `bun install` in each sub-package whose `package.json` or `bun.lock`
 changed in the commits pulled in by `git pull` / `git checkout` / `git switch`.
 Prevents stale `node_modules` after a branch switch or pull that adds a new
 dependency — the failure mode looks like a silent `Cannot find package 'X'`
 at runtime.
 
+This repo has no root manifest: packages live in sub-dirs (`assistant/`,
+`cli/`, `gateway/`, `credential-executor/`, `packages/*`, etc.) each with
+their own `package.json` and `bun.lock`.
+
 **Behavior:**
 
 - Diffs the pre- and post-HEAD using git (no filesystem scan); silent no-op when no manifest file changed.
-- Runs `bun install` from the repo root when any match is found.
-- Warns and exits 0 if `bun` is not on PATH — never fails `git pull` / `git checkout`.
+- Runs `bun install` in each sub-package whose manifest changed (serialized to avoid `~/.bun` cache contention).
+- Warns and exits 0 if `bun` is not available (checks `$PATH` and `~/.bun/bin/bun`) — never fails `git pull` / `git checkout`.
 - Shared helper: `.githooks/bun-install-if-deps-changed.sh`.
 
 **Bypass:** these hooks are best-effort and cannot fail the pull/checkout. If you need to suppress the install, unset `core.hooksPath` or delete the hook file locally.

--- a/.githooks/bun-install-if-deps-changed.sh
+++ b/.githooks/bun-install-if-deps-changed.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 #
-# Re-run `bun install` at the repo root when any `package.json` or `bun.lock`
+# Re-run `bun install` in each sub-package whose `package.json` or `bun.lock`
 # changed between two git revisions. Meant to be invoked by `post-merge` and
 # `post-checkout` hooks so a `git pull` / branch switch that adds a new
 # dependency does not leave `node_modules` stale.
 #
+# This repo has no root manifest — every package lives in its own sub-dir
+# (assistant/, cli/, gateway/, credential-executor/, packages/*, etc.) with
+# its own package.json and bun.lock.
+#
 # Usage: bun-install-if-deps-changed.sh <OLD_SHA> <NEW_SHA>
 #
 # Silent no-op when OLD == NEW or when no dep-tracking file changed.
-# Emits a warning (and exits 0) when `bun` is not on PATH so `git pull`
+# Emits a warning (and exits 0) when `bun` is not executable so `git pull`
 # never fails because of this hook.
 
 set -u
@@ -43,15 +47,42 @@ if ! printf '%s\n' "$changed" | grep -Eq '(^|/)(package\.json|bun\.lock)$'; then
     exit 0
 fi
 
-if ! command -v bun >/dev/null 2>&1; then
-    echo "[git-hook] package.json/bun.lock changed but 'bun' is not on PATH — skipping bun install." >&2
+# Git hooks run in non-interactive shells where ~/.zshrc PATH tweaks aren't
+# sourced, so fall back to the default bun install location.
+BUN="${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
+
+if [ ! -x "$BUN" ]; then
+    echo "[git-hook] package.json/bun.lock changed but 'bun' is not available at $BUN — skipping bun install." >&2
     echo "[git-hook] Run 'bun install' manually once bun is available." >&2
     exit 0
 fi
 
-echo "[git-hook] Dependency manifest changed — running 'bun install' at $REPO_ROOT..." >&2
-( cd "$REPO_ROOT" && bun install ) || {
-    status=$?
-    echo "[git-hook] 'bun install' exited with status $status. Run it manually to investigate." >&2
+# Derive unique sub-package dirs that had a manifest change. Strip the trailing
+# `package.json` / `bun.lock` segment to get the package dir (empty string means
+# the repo root, which we skip since there is no root manifest).
+pkgs="$(printf '%s\n' "$changed" \
+    | grep -E '(^|/)(package\.json|bun\.lock)$' \
+    | sed -E 's|/?(package\.json|bun\.lock)$||' \
+    | awk 'NF' \
+    | sort -u)"
+
+if [ -z "$pkgs" ]; then
     exit 0
-}
+fi
+
+# Serialize installs — parallel bun runs can contend on the shared ~/.bun cache.
+while IFS= read -r pkg; do
+    [ -n "$pkg" ] || continue
+    target="$REPO_ROOT/$pkg"
+    [ -d "$target" ] || continue
+    [ -f "$target/package.json" ] || continue
+    echo "[git-hook] Dependency manifest changed — running 'bun install' in $pkg..." >&2
+    ( cd "$target" && "$BUN" install ) || {
+        status=$?
+        echo "[git-hook] 'bun install' in $pkg exited with status $status. Run it manually to investigate." >&2
+    }
+done <<EOF
+$pkgs
+EOF
+
+exit 0


### PR DESCRIPTION
Addresses feedback on #25427.

## Summary
- **Per-package installs**: This repo has no root `package.json` / `bun.lock` — manifests live in `assistant/`, `cli/`, `gateway/`, `credential-executor/`, `packages/*`, etc. The post-merge/post-checkout helper was running `bun install` at the repo root, which would be a no-op (or fail) rather than refresh the package whose lockfile actually changed. The helper now derives the set of sub-package dirs whose `package.json` or `bun.lock` changed and runs `bun install` in each, serially (parallel runs can contend on the shared `~/.bun` cache).
- **Bun PATH fallback**: Git hooks run in non-interactive shells where `~/.zshrc` PATH edits aren't sourced, so `command -v bun` often missed bun at `~/.bun/bin/bun`. Adopted the same `BUN=${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}` pattern already used by `.githooks/pre-commit` and `.githooks/pre-push`, and invoke `"$BUN" install` with an `[ ! -x "$BUN" ]` guard.
- Updated `.githooks/README.md` to reflect the per-package behavior and the PATH fallback.

Failure mode unchanged: any problem logs and exits 0 so `git pull` / `git checkout` never fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
