### PR TITLE
fix(sounds): distinguish main-turn completions from aux message_complete events

### DIFF
--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -100,6 +100,7 @@ export function registerConversationNotifiers(
           type: "message_complete",
           conversationId: conversationId,
           messageId: msg.id,
+          source: "aux",
         });
       }
     },
@@ -135,6 +136,7 @@ export function registerConversationNotifiers(
           type: "message_complete",
           conversationId: conversationId,
           messageId: msg.id,
+          source: "aux",
         });
       }
     },
@@ -171,6 +173,7 @@ export function registerConversationNotifiers(
         type: "message_complete",
         conversationId: conversationId,
         messageId: msg.id,
+        source: "aux",
       });
     },
   );
@@ -189,6 +192,7 @@ export function registerConversationNotifiers(
       ctx.sendToClient({
         type: "message_complete",
         conversationId: conversationId,
+        source: "aux",
       });
     },
   );
@@ -204,6 +208,7 @@ export function registerConversationNotifiers(
     ctx.sendToClient({
       type: "message_complete",
       conversationId: conversationId,
+      source: "aux",
     });
   });
 }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -201,6 +201,13 @@ export interface MessageComplete {
   attachmentWarnings?: string[];
   /** Database ID of the persisted assistant message, if any. */
   messageId?: string;
+  /**
+   * Distinguishes a real main-turn completion from auxiliary events such as
+   * call transcripts, call summaries, and watch notifier outputs. Clients
+   * gate turn-completion side effects (e.g. the task_complete sound) on
+   * `source !== "aux"`. Absent is treated as main for backwards compatibility.
+   */
+  source?: "main" | "aux";
 }
 
 export interface ErrorMessage {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -595,9 +595,10 @@ final class ChatActionHandler {
         // Signal turn completion to observers (e.g. the `task_complete` sound).
         // Cancel-acknowledgements are user-initiated aborts, not real turn ends,
         // so they stay silent. Auxiliary `message_complete` events (call
-        // transcript updates, summaries, watch notifiers) lack a `messageId`
-        // and must not be counted as turn ends.
-        if !wasCancelAck && complete.messageId != nil {
+        // transcript updates, summaries, watch notifiers) are tagged with
+        // `source == "aux"` and must not be counted as turn ends. Absent
+        // source is treated as main for backwards compatibility.
+        if !wasCancelAck && complete.source != "aux" {
             vm.messageManager.turnCompletionTick &+= 1
         }
     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2530,13 +2530,15 @@ public struct MessageComplete: Codable, Sendable {
     public let attachments: [UserMessageAttachment]?
     public let attachmentWarnings: [String]?
     public let messageId: String?
+    public let source: String?
 
-    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
+    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, source: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.attachments = attachments
         self.attachmentWarnings = attachmentWarnings
         self.messageId = messageId
+        self.source = source
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -708,8 +708,8 @@ extension AssistantThinkingDelta {
 public typealias MessageCompleteMessage = MessageComplete
 
 extension MessageComplete {
-    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
-        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId)
+    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, source: String? = nil) {
+        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId, source: source)
     }
 }
 


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #25429. The `complete.messageId != nil` gate added to `ChatActionHandler.swift` to suppress the `task_complete` sound for auxiliary events also silently dropped legitimate slash-command completions — `/compact` and unknown slash commands emit `message_complete` without a `messageId`, so `turnCompletionTick` was no longer advancing for those user-initiated turns.

Replaces the implicit `messageId`-based filter with an explicit `source: "main" | "aux"` field on `MessageComplete`:
- Server: the five auxiliary emitters in `conversation-notifiers.ts` (watch commentary, watch completion, call question, call transcript, call completion summary) now tag their events with `source: "aux"`. All other emission sites remain unchanged and are implicitly treated as main.
- Client: `ChatActionHandler` now gates `turnCompletionTick` on `complete.source != "aux"` (absent is treated as main for backwards compatibility).

End state:
- `/compact`, unknown slash commands, regular LLM turns → `turnCompletionTick` advances (sound fires).
- Call/transcript/watch notifiers → `turnCompletionTick` does not advance.

## Test plan
- [ ] Verify `/compact` plays the `task_complete` sound on completion.
- [ ] Verify unknown slash command (e.g. `/bogus`) plays the `task_complete` sound on completion.
- [ ] Verify a normal LLM turn still plays the sound.
- [ ] Verify live call transcripts / call summaries / watch notifier outputs do NOT play the sound.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
