### PR TITLE
fix(hooks): quote CLAUDE_PROJECT_DIR for space-safe paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/linear-ticket-reminder.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-ticket-reminder.sh\""
           }
         ]
       }


### PR DESCRIPTION
Addresses Codex P2 feedback on #25423. The unquoted `$CLAUDE_PROJECT_DIR` expansion in the UserPromptSubmit hook command word-splits on paths containing spaces, causing the hook to fail with "No such file or directory". Wrapping the variable in double quotes makes it space-safe.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
