### PR TITLE
fix: reliable scroll-to-bottom on thread switch via anchor-ID targeting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -176,6 +176,8 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
+        switchRestoreTask?.cancel()
+        switchRestoreTask = nil
 
         // Briefly hide scroll indicators during switch
         hideScrollIndicatorsBriefly()
@@ -192,6 +194,8 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
+        switchRestoreTask?.cancel()
+        switchRestoreTask = nil
         isPaginationInFlight = false
         lastMessageId = nil
         scrollContentHeight = 0
@@ -208,5 +212,8 @@ final class MessageListScrollState {
     @ObservationIgnored var isPaginationInFlight: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
+    /// Multi-stage scroll-to-bottom task fired on conversation switch / first mount.
+    /// Cancelled on rapid switching and when a deep-link anchor is pending.
+    @ObservationIgnored var switchRestoreTask: Task<Void, Never>?
 
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -35,6 +35,9 @@ extension MessageListView {
         // Handle pending anchor if already set.
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
+            // Deep-link anchor found — cancel any restore so it isn't overridden.
+            scrollState.switchRestoreTask?.cancel()
+            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
@@ -42,6 +45,10 @@ extension MessageListView {
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
+            // Anchor pending but not yet found — cancel restore so deep-link
+            // anchors aren't overridden by the bottom-scroll restore.
+            scrollState.switchRestoreTask?.cancel()
+            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
             // Start the independent timeout if not already running.
@@ -58,9 +65,26 @@ extension MessageListView {
                     scrollState.anchorTimeoutTask = nil
                 }
             }
+        } else if !isConversationSwitch {
+            // First mount (no prior conversationId, no anchor) — also needs
+            // multi-stage scroll since the first conversation load must land
+            // at the bottom, same as a switch.
+            scrollState.switchRestoreTask?.cancel()
+            let scrollBinding = $scrollPosition
+            scrollState.switchRestoreTask = Task { @MainActor in
+                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                guard !Task.isCancelled else { return }
+                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                guard !Task.isCancelled else { return }
+                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+                scrollState.switchRestoreTask = nil
+            }
         }
-        // For initial load (no anchor, no conversation switch),
-        // `.defaultScrollAnchor(.top)` handles positioning declaratively.
     }
 
     // MARK: - onChange handlers
@@ -195,8 +219,28 @@ extension MessageListView {
         scrollState.lastAutoFocusedRequestId = nil
         // Seed lastMessageId so scroll-to-bottom can target it.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Don't write to scrollPosition — `.defaultScrollAnchor(.bottom)` handles
-        // positioning via the `.id(conversationId)` recreation.
+        // Multi-stage scroll-to-bottom: gives LazyVStack time to materialize
+        // bottom cells across multiple layout passes. Targets "scroll-bottom-anchor"
+        // (a real Color.clear view at the absolute content bottom) instead of a
+        // message ID, avoiding height estimation errors from unmaterialized cells.
+        scrollState.switchRestoreTask?.cancel()
+        let scrollBinding = $scrollPosition
+        scrollState.switchRestoreTask = Task { @MainActor in
+            // Stage 0: immediate — catches conversations already laid out
+            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+            // Stage 1: ~3 frames (50ms) — LazyVStack initial materialization
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+            // Stage 2: slower content (150ms) — async-loaded conversations
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
+            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
+
+            scrollState.switchRestoreTask = nil
+        }
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -140,8 +140,10 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
-            // Apply only to .initialOffset — threads open at bottom (latest messages).
-            .defaultScrollAnchor(.bottom, for: .initialOffset)
+            // Apply only to .initialOffset — .top is reliable with LazyVStack
+            // (offset 0, no estimation needed). Imperative scroll in
+            // handleConversationSwitched() handles bottom positioning.
+            .defaultScrollAnchor(.top, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)


### PR DESCRIPTION
## Summary
- Revert .defaultScrollAnchor(.bottom) to .top — .bottom overshoots with LazyVStack
- Add multi-stage scroll-to-bottom in handleConversationSwitched targeting scroll-bottom-anchor ID
- 3 stages (0ms, 50ms, 150ms) give LazyVStack time to materialize bottom cells
- Cancel restore on deep-link anchors and rapid switching

Part of plan: lazyvstack-thread-switch-bottom.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
