### PR TITLE
fix(sounds): reload after suppression window when broadcast was dropped

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -63,6 +63,12 @@ final class SoundManager {
     /// without significantly delaying legitimate cross-client updates.
     private static let postSaveGraceWindow: TimeInterval = 0.5
 
+    /// Set when a broadcast is dropped because a save was in flight or the
+    /// post-save grace window had not elapsed. The save task flushes this
+    /// after the grace window so a cross-client update that arrived during
+    /// the suppression window isn't permanently missed.
+    @ObservationIgnored private var pendingReloadAfterSuppression = false
+
     /// Whether a valid config has ever been decoded from disk. While `false`,
     /// fetch failures fall back to `.defaultConfig` so first-run (no file
     /// yet) still renders sensible state. Once `true`, fetch failures
@@ -186,10 +192,12 @@ final class SoundManager {
     /// another client) and triggers a reload.
     func handleSoundsConfigBroadcast() {
         if inFlightSaveCount > 0 {
+            pendingReloadAfterSuppression = true
             return
         }
         if let completed = lastSaveCompletedAt,
            Date().timeIntervalSince(completed) < Self.postSaveGraceWindow {
+            pendingReloadAfterSuppression = true
             return
         }
         reloadConfig()
@@ -206,6 +214,7 @@ final class SoundManager {
             defer {
                 inFlightSaveCount -= 1
                 lastSaveCompletedAt = Date()
+                scheduleSuppressionFlush()
             }
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -219,6 +228,28 @@ final class SoundManager {
             if !success {
                 log.error("Failed to save sounds config via gateway")
             }
+        }
+    }
+
+    /// After a save settles, wait out the post-save grace window and then
+    /// flush a suppressed broadcast (if any) by reloading. Without this,
+    /// a cross-client update that arrived while `inFlightSaveCount > 0` or
+    /// inside the grace window would be permanently dropped — the client
+    /// would stay stale until some unrelated later reload (reconnect, etc).
+    /// Bails out if another save is in flight or a newer save has reset the
+    /// grace window; that save's own flush will handle the pending flag.
+    private func scheduleSuppressionFlush() {
+        Task { @MainActor in
+            let nanos = UInt64(Self.postSaveGraceWindow * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanos)
+            guard pendingReloadAfterSuppression else { return }
+            guard inFlightSaveCount == 0 else { return }
+            if let completed = lastSaveCompletedAt,
+               Date().timeIntervalSince(completed) < Self.postSaveGraceWindow {
+                return
+            }
+            pendingReloadAfterSuppression = false
+            reloadConfig()
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #25430. When `handleSoundsConfigBroadcast()` suppresses a broadcast (because a save is in flight or we're inside the 500ms post-save grace window), the update is now remembered and flushed after the grace window instead of being permanently dropped.

- Added `pendingReloadAfterSuppression` flag, set whenever a broadcast is suppressed.
- After each save settles, a deferred task waits out the grace window then reloads if the flag is set and no newer save has re-entered suppression. Any overlapping saves schedule their own flush, so the latest one always wins.

Without this, a cross-client update arriving during a save burst could leave the client stale until an unrelated reload (reconnect, app restart).

## Test plan

- [ ] Manual: edit sounds config from one client while another is saving; verify the second client refreshes after the grace window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
