### PR TITLE
memory: rebalance scoring for procedural memories at context-load

### DIFF
--- a/assistant/src/memory/graph/extraction.test.ts
+++ b/assistant/src/memory/graph/extraction.test.ts
@@ -111,6 +111,29 @@ describe("parseExtractionResponse — node creation", () => {
     expect(diff.createNodes[0].stability).toBe(14);
   });
 
+  test("procedural nodes get stability=60", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "ffmpeg needs -ac 2 to force stereo output.",
+          type: "procedural",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.9,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes[0].stability).toBe(60);
+  });
+
   test("clamps significance to [0, 1]", () => {
     const { diff } = parse({
       create_nodes: [

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -596,6 +596,14 @@ export function parseExtractionResponse(
       node.stability = 5;
     }
 
+    // Procedural nodes (learned skills, how-to knowledge — "ffmpeg needs -ac 2
+    // for stereo") encode facts that stay useful long after the moment they
+    // were learned. Higher initial stability slows Ebbinghaus decay so they
+    // remain retrievable months later without needing explicit reinforcement.
+    if (node.type === "procedural") {
+      node.stability = 60;
+    }
+
     diff.createNodes.push(node);
     const nodeIndex = diff.createNodes.length - 1;
 

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -25,6 +25,7 @@ import {
   computeTemporalBoost,
   PER_TURN_WEIGHTS,
   scoreCandidate,
+  weightsForContextLoad,
 } from "./scoring.js";
 import { sampleSerendipity } from "./serendipity.js";
 import { getEdgesForNode, getNodesByIds, queryNodes } from "./store.js";
@@ -530,15 +531,19 @@ export async function loadContextMemory(
     const recency = computeRecencyBoost(node, nowMs);
 
     scored.push(
-      scoreCandidate(node, {
-        semanticSimilarity: semanticSim,
-        effectiveSignificance: effectiveSig,
-        emotionalIntensity: node.emotionalCharge.intensity,
-        temporalBoost: normalizedTemporal,
-        recencyBoost: recency,
-        triggerBoost,
-        activationBoost: activation,
-      }),
+      scoreCandidate(
+        node,
+        {
+          semanticSimilarity: semanticSim,
+          effectiveSignificance: effectiveSig,
+          emotionalIntensity: node.emotionalCharge.intensity,
+          temporalBoost: normalizedTemporal,
+          recencyBoost: recency,
+          triggerBoost,
+          activationBoost: activation,
+        },
+        weightsForContextLoad(node),
+      ),
     );
   }
 
@@ -592,15 +597,19 @@ export async function loadContextMemory(
     (node) => {
       const existing = scored.find((s) => s.node.id === node.id);
       if (existing) return existing;
-      return scoreCandidate(node, {
-        semanticSimilarity: semanticCandidateIds.get(node.id) ?? 0,
-        effectiveSignificance: computeEffectiveSignificance(node, nowMs),
-        emotionalIntensity: node.emotionalCharge.intensity,
-        temporalBoost: (computeTemporalBoost(node, now) + 1) / 2,
-        recencyBoost: 0,
-        triggerBoost: 0,
-        activationBoost: 0,
-      });
+      return scoreCandidate(
+        node,
+        {
+          semanticSimilarity: semanticCandidateIds.get(node.id) ?? 0,
+          effectiveSignificance: computeEffectiveSignificance(node, nowMs),
+          emotionalIntensity: node.emotionalCharge.intensity,
+          temporalBoost: (computeTemporalBoost(node, now) + 1) / 2,
+          recencyBoost: 0,
+          triggerBoost: 0,
+          activationBoost: 0,
+        },
+        weightsForContextLoad(node),
+      );
     },
   );
 

--- a/assistant/src/memory/graph/scoring.test.ts
+++ b/assistant/src/memory/graph/scoring.test.ts
@@ -5,8 +5,11 @@ import {
   computeEffectiveSignificance,
   computeRecencyBoost,
   computeTemporalBoost,
+  DEFAULT_WEIGHTS,
   PER_TURN_WEIGHTS,
+  PROCEDURAL_WEIGHTS,
   scoreCandidate,
+  weightsForContextLoad,
   type ScoringWeights,
 } from "./scoring.js";
 import type { MemoryNode } from "./types.js";
@@ -544,5 +547,188 @@ describe("scoreCandidate", () => {
     const result = scoreCandidate(node, components);
     expect(result.scoreBreakdown.semanticSimilarity).toBe(0.9);
     expect(result.scoreBreakdown.effectiveSignificance).toBe(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// weightsForContextLoad + PROCEDURAL_WEIGHTS
+// ---------------------------------------------------------------------------
+
+describe("weightsForContextLoad", () => {
+  test("returns PROCEDURAL_WEIGHTS for procedural nodes", () => {
+    const node = makeNode({ type: "procedural" });
+    expect(weightsForContextLoad(node)).toBe(PROCEDURAL_WEIGHTS);
+  });
+
+  test("returns DEFAULT_WEIGHTS for episodic nodes", () => {
+    const node = makeNode({ type: "episodic" });
+    expect(weightsForContextLoad(node)).toBe(DEFAULT_WEIGHTS);
+  });
+
+  test("returns DEFAULT_WEIGHTS for semantic/emotional/prospective/behavioral/narrative/shared nodes", () => {
+    for (const type of [
+      "semantic",
+      "emotional",
+      "prospective",
+      "behavioral",
+      "narrative",
+      "shared",
+    ] as const) {
+      const node = makeNode({ type });
+      expect(weightsForContextLoad(node)).toBe(DEFAULT_WEIGHTS);
+    }
+  });
+});
+
+describe("PROCEDURAL_WEIGHTS", () => {
+  test("weights sum to 1.0", () => {
+    const sum =
+      PROCEDURAL_WEIGHTS.semanticSimilarity +
+      PROCEDURAL_WEIGHTS.effectiveSignificance +
+      PROCEDURAL_WEIGHTS.emotionalIntensity +
+      PROCEDURAL_WEIGHTS.temporalBoost +
+      PROCEDURAL_WEIGHTS.recencyBoost +
+      PROCEDURAL_WEIGHTS.triggerBoost +
+      PROCEDURAL_WEIGHTS.activationBoost;
+    expect(sum).toBeCloseTo(1.0, 5);
+  });
+
+  test("zeroes out emotionalIntensity and temporalBoost", () => {
+    // Procedural memories have no emotional charge and no time-of-day pattern
+    // by nature — grading on these signals is just dead weight.
+    expect(PROCEDURAL_WEIGHTS.emotionalIntensity).toBe(0);
+    expect(PROCEDURAL_WEIGHTS.temporalBoost).toBe(0);
+  });
+
+  test("weights semanticSimilarity and effectiveSignificance more heavily than DEFAULT_WEIGHTS", () => {
+    expect(PROCEDURAL_WEIGHTS.semanticSimilarity).toBeGreaterThan(
+      DEFAULT_WEIGHTS.semanticSimilarity,
+    );
+    expect(PROCEDURAL_WEIGHTS.effectiveSignificance).toBeGreaterThan(
+      DEFAULT_WEIGHTS.effectiveSignificance,
+    );
+  });
+
+  test("procedural node outscores otherwise-identical episodic node under type-aware weights", () => {
+    // A procedural memory with zero emotional charge, zero recency, zero
+    // trigger — all dead signals — should still surface under PROCEDURAL_WEIGHTS
+    // thanks to semantic relevance and significance. Under DEFAULT_WEIGHTS the
+    // same signals would leave ~45% of the budget dead.
+    const proceduralNode = makeNode({ type: "procedural" });
+    const episodicNode = makeNode({ id: "node-2", type: "episodic" });
+
+    // Components a procedural memory typically carries: semantic hit + stable
+    // significance, but no emotional charge, no recency, no trigger.
+    const proceduralComponents = {
+      semanticSimilarity: 0.8,
+      effectiveSignificance: 0.7,
+      emotionalIntensity: 0,
+      temporalBoost: 0.5, // neutral
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+
+    const proceduralScore = scoreCandidate(
+      proceduralNode,
+      proceduralComponents,
+      weightsForContextLoad(proceduralNode),
+    ).score;
+    const episodicScore = scoreCandidate(
+      episodicNode,
+      proceduralComponents,
+      weightsForContextLoad(episodicNode),
+    ).score;
+
+    expect(proceduralScore).toBeGreaterThan(episodicScore);
+  });
+
+  test("episodic node with full signal still outscores procedural with only semantic signal", () => {
+    // The change must NOT break episodic retrieval: an episodic memory with
+    // emotional charge + recency + moderate significance should still outrank
+    // a procedural memory that only has semantic relevance.
+    const episodicNode = makeNode({ type: "episodic" });
+    const proceduralNode = makeNode({ id: "node-2", type: "procedural" });
+
+    const episodicComponents = {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0.6,
+      emotionalIntensity: 0.7,
+      temporalBoost: 0.6,
+      recencyBoost: 0.9,
+      triggerBoost: 0.4,
+      activationBoost: 0.3,
+    };
+
+    const proceduralComponents = {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0.3,
+      emotionalIntensity: 0,
+      temporalBoost: 0.5,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+
+    const episodicScore = scoreCandidate(
+      episodicNode,
+      episodicComponents,
+      weightsForContextLoad(episodicNode),
+    ).score;
+    const proceduralScore = scoreCandidate(
+      proceduralNode,
+      proceduralComponents,
+      weightsForContextLoad(proceduralNode),
+    ).score;
+
+    expect(episodicScore).toBeGreaterThan(proceduralScore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: DEFAULT_WEIGHTS behavior unchanged
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_WEIGHTS (regression)", () => {
+  test("weights sum to 1.0", () => {
+    const sum =
+      DEFAULT_WEIGHTS.semanticSimilarity +
+      DEFAULT_WEIGHTS.effectiveSignificance +
+      DEFAULT_WEIGHTS.emotionalIntensity +
+      DEFAULT_WEIGHTS.temporalBoost +
+      DEFAULT_WEIGHTS.recencyBoost +
+      DEFAULT_WEIGHTS.triggerBoost +
+      DEFAULT_WEIGHTS.activationBoost;
+    expect(sum).toBeCloseTo(1.0, 5);
+  });
+
+  test("preserves exact weight values", () => {
+    expect(DEFAULT_WEIGHTS).toEqual({
+      semanticSimilarity: 0.25,
+      effectiveSignificance: 0.15,
+      emotionalIntensity: 0.15,
+      temporalBoost: 0.05,
+      recencyBoost: 0.15,
+      triggerBoost: 0.15,
+      activationBoost: 0.1,
+    });
+  });
+
+  test("scoreCandidate without weights argument uses DEFAULT_WEIGHTS", () => {
+    // Backwards-compat: existing callers that pass no weights argument should
+    // continue to get DEFAULT_WEIGHTS scoring.
+    const node = makeNode({ type: "episodic" });
+    const components = {
+      semanticSimilarity: 1.0,
+      effectiveSignificance: 1.0,
+      emotionalIntensity: 1.0,
+      temporalBoost: 1.0,
+      recencyBoost: 1.0,
+      triggerBoost: 1.0,
+      activationBoost: 1.0,
+    };
+    const implicit = scoreCandidate(node, components).score;
+    const explicit = scoreCandidate(node, components, DEFAULT_WEIGHTS).score;
+    expect(implicit).toBe(explicit);
   });
 });

--- a/assistant/src/memory/graph/scoring.ts
+++ b/assistant/src/memory/graph/scoring.ts
@@ -166,7 +166,7 @@ export interface ScoringWeights {
 }
 
 /** Weights for context-load (conversation start): balanced across all signals. */
-const DEFAULT_WEIGHTS: ScoringWeights = {
+export const DEFAULT_WEIGHTS: ScoringWeights = {
   semanticSimilarity: 0.25,
   effectiveSignificance: 0.15,
   emotionalIntensity: 0.15,
@@ -174,6 +174,28 @@ const DEFAULT_WEIGHTS: ScoringWeights = {
   recencyBoost: 0.15,
   triggerBoost: 0.15,
   activationBoost: 0.1,
+};
+
+/**
+ * Weights for context-load of procedural memories (learned skills, how-to).
+ * Procedural memories have no emotional charge, no time-of-day pattern, and
+ * are often old-but-stable (a workaround learned months ago stays useful).
+ * Grading them on DEFAULT_WEIGHTS wastes ~45% of the budget on signals that
+ * are structurally ~0 for procedurals, causing them to lose out to episodic
+ * and emotional memories that simply have more signals lit up.
+ *
+ * This redistributes the dead weight onto semantic similarity and
+ * significance — the signals that actually differentiate useful procedurals
+ * from stale ones.
+ */
+export const PROCEDURAL_WEIGHTS: ScoringWeights = {
+  semanticSimilarity: 0.45,
+  effectiveSignificance: 0.25,
+  emotionalIntensity: 0.0,
+  temporalBoost: 0.0,
+  recencyBoost: 0.05,
+  triggerBoost: 0.1,
+  activationBoost: 0.15,
 };
 
 /**
@@ -190,6 +212,14 @@ export const PER_TURN_WEIGHTS: ScoringWeights = {
   triggerBoost: 0.20,
   activationBoost: 0.05,
 };
+
+/**
+ * Pick the appropriate context-load weights for a node based on its type.
+ * Procedural nodes use PROCEDURAL_WEIGHTS; everything else uses DEFAULT_WEIGHTS.
+ */
+export function weightsForContextLoad(node: MemoryNode): ScoringWeights {
+  return node.type === "procedural" ? PROCEDURAL_WEIGHTS : DEFAULT_WEIGHTS;
+}
 
 /**
  * Compute the final retrieval score for a candidate node.


### PR DESCRIPTION
## Summary

- Procedural memories (learned how-to knowledge) were structurally disadvantaged at context-load because ~45% of the default weight budget (`emotionalIntensity` + `recencyBoost` + `triggerBoost`) maps to signals they never carry.
- Adds type-aware weights: `PROCEDURAL_WEIGHTS` redistributes onto `semanticSimilarity` (0.45), `effectiveSignificance` (0.25), and `activationBoost` (0.15). Selected via `weightsForContextLoad(node)` in the retriever.
- Bumps initial stability for procedural nodes from 14 → 60 days in extraction so Ebbinghaus decay is slow enough to keep old-but-useful how-to memories surfaceable without explicit reinforcement.

Per-turn injection (`PER_TURN_WEIGHTS`) and the `isCapabilityNode` reserve path are unchanged.

## Original prompt

> Fix procedural memories struggling to surface at context-load.
>
> **Problem** (from conversation analysis):
> Context-load scoring weights in `assistant/src/memory/graph/scoring.ts:169` (DEFAULT_WEIGHTS) are structurally biased against organic procedural memories. ~30% of the weight budget is dead for procedurals:
> - `emotionalIntensity: 0.15` — procedural memories have ~0 emotional charge
> - `recencyBoost: 0.15` — procedurals are often old/stable; recency kills them after ~14 days
> - `triggerBoost: 0.15` — usually 0 unless someone wrote a semantic trigger
>
> Capability nodes (skills/CLI) have a reserve system in `retriever.ts:551-605` and are filtered out of the main pool at `retriever.ts:612`. But **organic** procedural memories (e.g. "ffmpeg needs -ac 2 for stereo") are NOT capability nodes — they compete head-to-head against episodic/emotional memories in the main pool with weights tuned for those signals.
>
> **Fix**:
> 1. Add a type-aware weights system: `scoreCandidate` picks a weights profile based on `node.type`. Introduce `PROCEDURAL_WEIGHTS` that rebalances away from emotional/recency/trigger toward semantic similarity, significance, and activation. Rough target:
>    - semanticSimilarity: 0.45
>    - effectiveSignificance: 0.25
>    - activationBoost: 0.15
>    - triggerBoost: 0.10
>    - recencyBoost: 0.05
>    - emotionalIntensity: 0.0
>    - temporalBoost: 0.0
> 2. Higher initial stability for organic procedural memories at extraction time so Ebbinghaus decay is slower. Look at `assistant/src/memory/graph/extraction.ts` (or wherever nodes are minted) — default stability is 14 days; bump procedurals to something like 60.
>
> **Out of scope**:
> - Don't extend the reserve/filter system to organic procedurals — they should compete semantically, they just shouldn't be graded on emotional intensity.
> - Capability nodes (isCapabilityNode === true) should continue using the reserve path; the new procedural weights apply to organic procedural nodes only (or to all procedurals — either is fine, since capabilities are scored but then short-circuited by the reserve).
>
> **Tests to add**:
> - Unit test in `assistant/src/memory/graph/scoring.test.ts` (create if missing) verifying a procedural node with low emotionalIntensity/recency/trigger scores higher than an otherwise-identical episodic node under the new type-aware path.
> - Regression test ensuring episodic/emotional scoring behavior is unchanged.
>
> **No Linear ticket** — treat as a standalone PR.

## Test plan

- [x] `bun test assistant/src/memory/graph/scoring.test.ts` passes
- [x] `bun test assistant/src/memory/graph/extraction.test.ts` passes
- [ ] Manually observe procedural memories surfacing at conversation start after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
