### PR TITLE
fix(macos): only clear isCompacting on main-turn completions

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -443,7 +443,14 @@ final class ChatActionHandler {
         vm.cancelTimeoutTask = nil
         vm.isCancelling = false
         vm.isThinking = false
-        vm.isCompacting = false
+        // Only clear the compaction indicator on main-turn completions. Aux
+        // `message_complete` events (call notifiers, watch updates) can arrive
+        // while `/compact` is still running — activity phase may be `tool_running`
+        // (so `isThinking == false`) with no assistant message yet, so the
+        // nil-messageId filter above does not catch them.
+        if complete.source != "aux" {
+            vm.isCompacting = false
+        }
         // When a send-direct is pending, this messageComplete is the
         // cancel acknowledgment. Reset all queue state so the follow-up
         // sendMessage() starts a fresh send instead of re-queuing.


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #25445: auxiliary `message_complete` events (call transcript notifiers, watch notifications) were clearing \`isCompacting\` early, hiding the \"Compacting context…\" UI before compaction actually finishes.

During \`/compact\`, activity phase can be \`tool_running\` (so \`isThinking == false\`) with no assistant message yet, so the nil-messageId guard added in #25445 does not catch aux completions in that window.

Gate the \`vm.isCompacting = false\` line on the same \`complete.source != \"aux\"\` discriminator that #25512 introduced for \`turnCompletionTick\`. The existing per-turn resets (\`isThinking\`, \`isCancelling\`, \`isSending\`) stay unconditional so cancel-acks continue to clear stuck UI.

## Test plan
- [ ] Trigger \`/compact\` while call notifiers are emitting aux \`message_complete\` events; \"Compacting context…\" should persist until the real \`/compact\` completion fires.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
