### PR TITLE
fix(lint): sort imports in scoring.test.ts

### DIFF
--- a/assistant/src/memory/graph/scoring.test.ts
+++ b/assistant/src/memory/graph/scoring.test.ts
@@ -9,8 +9,8 @@ import {
   PER_TURN_WEIGHTS,
   PROCEDURAL_WEIGHTS,
   scoreCandidate,
-  weightsForContextLoad,
   type ScoringWeights,
+  weightsForContextLoad,
 } from "./scoring.js";
 import type { MemoryNode } from "./types.js";
 


### PR DESCRIPTION
## Summary
- Reorder `type ScoringWeights` import to satisfy `simple-import-sort/imports`. Fixes the Lint CI failure on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24410640597/job/71306154186
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
