### PR TITLE
fix: update locale test to expect platform-aware UTF-8 value

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -450,8 +450,10 @@ describe("buildSanitizedEnv", () => {
     delete process.env.LC_ALL;
 
     const env = buildSanitizedEnv();
-    expect(env.LANG).toBe("C.UTF-8");
-    expect(env.LC_ALL).toBe("C.UTF-8");
+    const expectedLocale =
+      process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8";
+    expect(env.LANG).toBe(expectedLocale);
+    expect(env.LC_ALL).toBe(expectedLocale);
   });
 
   test("injects INTERNAL_GATEWAY_BASE_URL from gateway config", () => {


### PR DESCRIPTION
## Summary
- Addresses review feedback on #25394
- The test at `terminal-tools.test.ts` hardcoded `C.UTF-8` as the expected locale, but `buildSanitizedEnv()` now returns `en_US.UTF-8` on macOS (darwin) and `C.UTF-8` elsewhere
- Updated the test to compute the expected locale based on `process.platform`, matching the production logic in `safe-env.ts`

## Test plan
- [x] Test computes expected locale dynamically based on `process.platform`
- [x] Matches the production logic in `safe-env.ts` lines 85-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
