### PR TITLE
fix: handle escaped pipes in Slack table row parsing

### DIFF
--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -121,6 +121,25 @@ describe("textToSlackBlocks", () => {
     expect(blocks![0].type).toBe("section");
   });
 
+  test("handles escaped pipes in table cells", () => {
+    const table = [
+      "| Command | Description |",
+      "| --- | --- |",
+      "| cmd \\| grep | filters output |",
+    ].join("\n");
+
+    const blocks = textToSlackBlocks(table);
+    expect(blocks).toBeDefined();
+    expect(blocks!.length).toBe(1);
+    const section = blocks![0] as {
+      type: "section";
+      text: { type: string; text: string };
+    };
+    // The escaped pipe should appear as a literal pipe in the cell value
+    expect(section.text.text).toContain("cmd | grep");
+    expect(section.text.text).toContain("Description: filters output");
+  });
+
   test("requires header + separator + data row for table detection", () => {
     // Only header and separator, no data rows
     const input = "| A | B |\n| --- | --- |";

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -191,11 +191,15 @@ function splitIntoSegments(text: string): Segment[] {
  * Parse cells from a pipe-delimited table row, trimming whitespace.
  */
 function parseTableRow(line: string): string[] {
+  const ESCAPED_PIPE_PLACEHOLDER = "\x00PIPE\x00";
   return line
+    .replace(/\\\|/g, ESCAPED_PIPE_PLACEHOLDER)
     .replace(/^\|/, "")
     .replace(/\|$/, "")
     .split("|")
-    .map((cell) => cell.trim());
+    .map((cell) =>
+      cell.replaceAll(ESCAPED_PIPE_PLACEHOLDER, "|").trim(),
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes `parseTableRow` in `slack-block-formatting.ts` to handle escaped pipes (`\|`) in table cells
- Before splitting on `|`, escaped pipes are temporarily replaced with a placeholder, then restored as literal `|` in each cell
- Adds a test case verifying cells like `cmd \| grep` are parsed correctly

Addresses review feedback on #25399.

## Test plan
- [x] Added test case for escaped pipes in table cells
- [ ] Existing table formatting tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
