### PR TITLE
fix: keep mock.module factory synchronous in platform-connection test

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
+import * as actualRetry from "../util/retry.js";
 
 // Stub out sleep so retry tests don't wait for real delays.
-mock.module("../util/retry.js", async () => {
-  const actual = await import("../util/retry.js");
-  return {
-    ...actual,
-    sleep: () => Promise.resolve(),
-  };
-});
+mock.module("../util/retry.js", () => ({
+  ...actualRetry,
+  sleep: () => Promise.resolve(),
+}));
 
 import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError, VellumError } from "../util/errors.js";


### PR DESCRIPTION
Addresses review feedback on #25402. The async mock.module factory returned a Promise instead of module exports, preventing deterministic patching of retry.js. Replaced async factory + await import() with a synchronous factory that spreads from a static import of the real module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
