### PR TITLE
feat(chrome-ext): force CWS publish on minor/major version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,15 +110,28 @@ jobs:
 
       - name: Detect chrome extension changes
         id: detect-extension-changes
+        env:
+          BASE_VERSION: ${{ steps.extract.outputs.base_version }}
         run: |
           # Compare clients/chrome-extension/ against the previous release tag.
           # If no prior tag exists (first release), always build.
           PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+
+          # Force a build on minor/major version bumps so the CWS listing
+          # stays in sync even when the extension code itself hasn't changed.
           if [ -n "$PREV_TAG" ]; then
+            PREV_MAJOR_MINOR=$(echo "${PREV_TAG#v}" | cut -d. -f1-2)
+            CURR_MAJOR_MINOR=$(echo "$BASE_VERSION" | cut -d. -f1-2)
+            if [ "$PREV_MAJOR_MINOR" != "$CURR_MAJOR_MINOR" ]; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              echo "Major/minor version changed ($PREV_MAJOR_MINOR -> $CURR_MAJOR_MINOR) — forcing extension build"
+              exit 0
+            fi
             CHANGED=$(git diff --name-only "$PREV_TAG"..HEAD -- clients/chrome-extension/ | wc -l | tr -d ' ')
           else
             CHANGED=1
           fi
+
           if [ "$CHANGED" -gt 0 ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Chrome extension has $CHANGED changed file(s) since $PREV_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           # Exclude the current version's tag so retries after tagging still
           # detect minor/major bumps correctly.
           # If no prior tag exists (first release), always build.
-          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v "^v${BASE_VERSION}$" | head -1)
+          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | { grep -v "^v${BASE_VERSION}$" || true; } | head -1)
 
           # Force a build on minor/major version bumps so the CWS listing
           # stays in sync even when the extension code itself hasn't changed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,10 @@ jobs:
           BASE_VERSION: ${{ steps.extract.outputs.base_version }}
         run: |
           # Compare clients/chrome-extension/ against the previous release tag.
+          # Exclude the current version's tag so retries after tagging still
+          # detect minor/major bumps correctly.
           # If no prior tag exists (first release), always build.
-          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v "^v${BASE_VERSION}$" | head -1)
 
           # Force a build on minor/major version bumps so the CWS listing
           # stays in sync even when the extension code itself hasn't changed.


### PR DESCRIPTION
## Summary
- Updates the `detect-extension-changes` step to compare major.minor of the previous tag against the current `base_version`
- If major or minor changed (e.g. `0.6.x` -> `0.7.x`), forces `changed=true` regardless of file diffs
- Patch-only bumps (e.g. `0.6.3` -> `0.6.4`) still skip build/publish when no extension files changed

## Original prompt
Update the chrome extension change detection in `.github/workflows/release.yml` so that a new minor or major version forces a chrome extension build and publish, even if there are no code changes under `clients/chrome-extension/`. Compare the major.minor of `PREV_TAG` against the current `base_version`. If they differ, force `changed=true` regardless of the file diff.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
