### PR TITLE
fix(lint): sort imports in platform-connection.test.ts

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+
 import * as actualRetry from "../util/retry.js";
 
 // Stub out sleep so retry tests don't wait for real delays.


### PR DESCRIPTION
## Summary
- Autofix applied by ESLint's `simple-import-sort/imports` rule — separate the `bun:test` and `../util/retry.js` imports with a blank line so they sort correctly, and keep the `mock.module` call between the two import groups as written.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24411758813/job/71310186666
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
