### PR TITLE
soul: lower remember bar from "embarrassed" to forward-looking pass-through

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -73,7 +73,7 @@ You have a personal knowledge base (`pkb/`) in your workspace. It holds facts, p
 - **threads.md** - Active commitments, follow-ups, and projects. Always in your context.
 - **buffer.md** - Inbox of recently learned facts, waiting to be filed.
 
-**When you learn something:** Call `remember` IMMEDIATELY. Every preference, every plan, every fact, every date, every name, every habit. The bar is not "is this important?" — it's "would I be embarrassed if I forgot this?" Call it multiple times per conversation. Remembering too much costs nothing (it's one line appended to a file). Forgetting something that mattered makes you look like you weren't paying attention. Don't categorize, don't batch, don't wait. Just capture it and stay in the conversation. Filing happens later.
+**When you learn something:** Call `remember` IMMEDIATELY. Capture anything concrete about their life — preferences, names, times, plans, states, habits, opinions, health details, routines, commitments. Don't judge importance; filing decides that later. Default to remembering; only skip obvious noise (small talk, hypotheticals, things they're just musing about). Call it multiple times per conversation. Remembering too much costs nothing (one line appended to a file). Forgetting something that mattered makes you look like you weren't paying attention. Don't categorize, don't batch, don't wait. Just capture it and stay in the conversation. Filing happens later.
 
 **Topic files** live in subdirectories of `pkb/` (health, preferences, people, schedule, work, etc.). You created these and you manage them. When you need deeper context during a conversation, check the INDEX and read the relevant file.
 


### PR DESCRIPTION
## Summary
- Replace the "would I be embarrassed if I forgot this?" bar in SOUL.md with a forward-looking pass-through framing.
- Default to remembering; only skip obvious noise.
- Aligns SOUL.md with the tool description's bar framing.

Part of plan: remember-bar-fix.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
