### PR TITLE
workspace: align seed PKB index bar with new pass-through framing

### DIFF
--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -7,7 +7,7 @@ const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear
 
 # Knowledge Base
 
-**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.
+**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.
 
 ## Always Loaded
 - essentials.md — Core facts, patterns, and biographical info


### PR DESCRIPTION
## Summary
- Replace the "remember aggressively" line in the seed INDEX.md template with the same pass-through framing used in SOUL.md and the tool description.
- Only affects newly-seeded workspaces; existing workspaces keep their existing INDEX.md.

Part of plan: remember-bar-fix.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
