### PR TITLE
daemon: soften per-turn PKB reminder to reduce fatigue

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -609,9 +609,8 @@ const MAX_BUFFER_LINES = 50;
 
 const PKB_SYSTEM_REMINDER =
   "<system_reminder>" +
-  "\n**CRITICAL:** you MUST read any PKB files that might be relevant to this conversation — " +
-  "INDEX.md is your table of contents. Don't wait to be asked. " +
-  "Use `remember` OFTEN for EVERY new fact you learn IMMEDIATELY, don't wait for the next turn." +
+  "\nRead any PKB files that might be relevant — INDEX.md is your table of contents. " +
+  "Don't wait to be asked." +
   "\n</system_reminder>";
 
 /**


### PR DESCRIPTION
## Summary
- Remove the duplicated "call remember IMMEDIATELY" instruction from the per-turn PKB system reminder.
- The remember instruction is now carried solely by the tool description and SOUL.md; duplicating it contributes to reminder fatigue.
- Keep the "read PKB files / INDEX.md is your table of contents" nudge.

Part of plan: remember-bar-fix.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
