### PR TITLE
fix(githooks): fix sed delimiter collision that broke bun install hook

### DIFF
--- a/.githooks/bun-install-if-deps-changed.sh
+++ b/.githooks/bun-install-if-deps-changed.sh
@@ -62,7 +62,7 @@ fi
 # the repo root, which we skip since there is no root manifest).
 pkgs="$(printf '%s\n' "$changed" \
     | grep -E '(^|/)(package\.json|bun\.lock)$' \
-    | sed -E 's|/?(package\.json|bun\.lock)$||' \
+    | sed -E 's#/?(package\.json|bun\.lock)$##' \
     | awk 'NF' \
     | sort -u)"
 


### PR DESCRIPTION
Addresses P1 feedback from Codex and Devin on #25510. The sed expression at bun-install-if-deps-changed.sh:65 used `|` both as the s/// delimiter and as regex alternation inside the capture group. On BSD sed (macOS) this errors with 'parentheses not balanced', silently emptying `pkgs` and short-circuiting the hook — `bun install` never ran. Switches the delimiter to `#` so the alternation inside the pattern parses correctly. Verified locally: `echo 'assistant/package.json' | sed -E 's#/?(package\.json|bun\.lock)$##'` now correctly outputs `assistant`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
