### PR TITLE
fix(macos): filter aux message_complete from streaming guard, not just sound gate

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -396,12 +396,15 @@ final class ChatActionHandler {
     private func handleMessageComplete(_ complete: MessageCompleteMessage, vm: ChatViewModel) {
         guard belongsToConversation(complete.conversationId) else { return }
         // Auxiliary message_complete events (watch notifiers, call notifications)
-        // that lack a messageId should not reset the main agent turn state.
+        // tagged with source == "aux" — plus legacy events lacking a messageId —
+        // must not reset the main agent turn state. Some aux notifiers (watch
+        // commentary, watch completion, call question) emit both a messageId and
+        // source: "aux", so filtering on messageId alone is insufficient.
         // Filter when a main agent turn is actively streaming (currentAssistantMessageId
         // is set) OR still in the thinking phase (isThinking is true but
         // currentAssistantMessageId hasn't been set yet by the first streaming flush).
         // This allows slash commands and other non-auxiliary completions to process normally.
-        if complete.messageId == nil && (vm.currentAssistantMessageId != nil || vm.isThinking) {
+        if (complete.messageId == nil || complete.source == "aux") && (vm.currentAssistantMessageId != nil || vm.isThinking) {
             return
         }
         // Capture before dispatchPendingSendDirect clears the flag so we can


### PR DESCRIPTION
Addresses Devin feedback on #25512. The sound gate at line 601 correctly uses `complete.source != "aux"`, but the earlier streaming-active guard at line 404 still used the legacy `complete.messageId == nil` check. Three of the five aux notifiers (watch commentary, watch completion, call question) emit both `messageId` and `source: "aux"`, so they bypassed line 404 and ran through the destructive handleMessageComplete path while a main turn was streaming — clearing `currentAssistantMessageId`, resetting `isSending`, and corrupting turn state. Extends the guard to also treat `source == "aux"` as aux, and refreshes the stale comment that claimed aux events lack a messageId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
