### PR TITLE
fix(environments): CLI falls back to production on unknown VELLUM_ENVIRONMENT (parity with daemon and Swift)

### DIFF
--- a/cli/src/lib/environments/__tests__/resolve.test.ts
+++ b/cli/src/lib/environments/__tests__/resolve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { getCurrentEnvironment, getSeed } from "../resolve.js";
 
@@ -74,18 +74,54 @@ describe("getCurrentEnvironment", () => {
     expect(env.name).toBe("dev");
   });
 
-  test("throws actionable error for unknown env name via override", () => {
-    expect(() => getCurrentEnvironment("no-such-env")).toThrow(
-      /unknown environment "no-such-env"/,
+  test("falls back to production seed for unknown env name via override, warns on stderr", () => {
+    const stderr = spyOn(process.stderr, "write").mockImplementation(
+      () => true,
     );
-    expect(() => getCurrentEnvironment("no-such-env")).toThrow(
-      /cli\/src\/lib\/environments\/seeds\.ts/,
-    );
+    try {
+      const env = getCurrentEnvironment("no-such-env");
+      expect(env.name).toBe("production");
+      expect(env.platformUrl).toBe("https://platform.vellum.ai");
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('unknown environment "no-such-env"'),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('falling back to "production"'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
   });
 
-  test("throws for unknown env name via env var", () => {
+  test("falls back to production seed for unknown env name via env var, warns on stderr", () => {
     process.env.VELLUM_ENVIRONMENT = "nope";
-    expect(() => getCurrentEnvironment()).toThrow(/unknown environment "nope"/);
+    const stderr = spyOn(process.stderr, "write").mockImplementation(
+      () => true,
+    );
+    try {
+      const env = getCurrentEnvironment();
+      expect(env.name).toBe("production");
+      expect(env.platformUrl).toBe("https://platform.vellum.ai");
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('unknown environment "nope"'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  test("VELLUM_ENVIRONMENT=production does not emit a warning", () => {
+    process.env.VELLUM_ENVIRONMENT = "production";
+    const stderr = spyOn(process.stderr, "write").mockImplementation(
+      () => true,
+    );
+    try {
+      const env = getCurrentEnvironment();
+      expect(env.name).toBe("production");
+      expect(stderr).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
+    }
   });
 
   test("VELLUM_PLATFORM_URL overrides platformUrl on the resolved definition", () => {
@@ -118,11 +154,25 @@ describe("getCurrentEnvironment", () => {
   });
 
   test("does not auto-materialize a new environment from VELLUM_PLATFORM_URL alone", () => {
+    // Unknown env names fall back to production (parity with daemon + Swift).
+    // The per-field VELLUM_PLATFORM_URL override is intentionally dropped on
+    // the fallback path — fallback returns a pristine production seed so a
+    // typo'd env var can't accidentally stitch together a new environment.
     process.env.VELLUM_ENVIRONMENT = "my-custom";
     process.env.VELLUM_PLATFORM_URL = "https://my-custom.example.com";
-    expect(() => getCurrentEnvironment()).toThrow(
-      /unknown environment "my-custom"/,
+    const stderr = spyOn(process.stderr, "write").mockImplementation(
+      () => true,
     );
+    try {
+      const env = getCurrentEnvironment();
+      expect(env.name).toBe("production");
+      expect(env.platformUrl).toBe("https://platform.vellum.ai");
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('unknown environment "my-custom"'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
   });
 
   test("VELLUM_LOCKFILE_DIR populates lockfileDirOverride on the resolved definition", () => {

--- a/cli/src/lib/environments/resolve.ts
+++ b/cli/src/lib/environments/resolve.ts
@@ -41,9 +41,24 @@ export function getCurrentEnvironment(
   const name = resolveEnvironmentName(override);
   const seed = SEEDS[name];
   if (!seed) {
-    throw new Error(
-      `unknown environment "${name}"; add it to cli/src/lib/environments/seeds.ts and rebuild, or wait for the future file-based context layer`,
-    );
+    if (name !== DEFAULT_ENVIRONMENT_NAME) {
+      // Warn on stderr instead of throwing, to match the silent-fallback
+      // behavior in assistant/src/util/platform.ts:getXdgVellumConfigDirName
+      // and clients/shared/App/VellumEnvironment.swift:current. Those two
+      // silently fall back to production; the CLI should agree so all three
+      // writers don't end up in disjoint states on a typo.
+      process.stderr.write(
+        `warning: unknown environment "${name}"; falling back to "${DEFAULT_ENVIRONMENT_NAME}". ` +
+          `Add it to cli/src/lib/environments/seeds.ts and rebuild if this was intentional.\n`,
+      );
+    }
+    const fallback = SEEDS[DEFAULT_ENVIRONMENT_NAME];
+    if (!fallback) {
+      throw new Error(
+        `fatal: default environment "${DEFAULT_ENVIRONMENT_NAME}" missing from seed table — this is a build error`,
+      );
+    }
+    return { ...fallback };
   }
 
   const resolved: EnvironmentDefinition = { ...seed };


### PR DESCRIPTION
## Summary
CLI getCurrentEnvironment() used to throw on any unknown VELLUM_ENVIRONMENT value, while daemon (assistant/src/util/platform.ts:getXdgVellumConfigDirName) and Swift (clients/shared/App/VellumEnvironment.swift:current) silently fell back to production. A user setting VELLUM_ENVIRONMENT=foo would see their daemon and macOS app read/write production paths while every CLI command crashed.

Now all three systems fall back to production on unknown values. CLI additionally warns on stderr so typos aren't silent.

Addresses Pass 3 Issue 2 in self-review of env-data-layout plan.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
