### PR TITLE
fix(permissions): restore legacy signing-key path in risk classification

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -231,6 +231,25 @@ describe("Permission Checker", () => {
         });
         expect(risk).toBe(RiskLevel.High);
       });
+
+      test("file_read of legacy signing key is high risk even when BASE_DATA_DIR relocates getProtectedDir()", async () => {
+        const savedBaseDataDir = process.env.BASE_DATA_DIR;
+        process.env.BASE_DATA_DIR = "/tmp/fake-instance-signing-key-test";
+        try {
+          const risk = await classifyRisk("file_read", {
+            path: join(
+              homedir(),
+              ".vellum",
+              "protected",
+              "actor-token-signing-key",
+            ),
+          });
+          expect(risk).toBe(RiskLevel.High);
+        } finally {
+          if (savedBaseDataDir === undefined) delete process.env.BASE_DATA_DIR;
+          else process.env.BASE_DATA_DIR = savedBaseDataDir;
+        }
+      });
     });
 
     // file_write is always low (sandboxed)

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -966,11 +966,17 @@ function isActorTokenSigningKeyPath(
   if (!filePath) return false;
   const cwd = workingDir ?? process.cwd();
   const resolvedPath = resolve(cwd, filePath);
-  const signingKeyPaths = [
-    join(getProtectedDir(), "actor-token-signing-key"),
-    join(getDeprecatedDir(), "actor-token-signing-key"),
-    resolve(cwd, "deprecated", "actor-token-signing-key"),
-  ];
+  // Include both the per-instance protected dir AND the legacy global
+  // ~/.vellum/protected path so upgraded machines with a host-wide signing
+  // key still classify reads as High risk.
+  const signingKeyPaths = Array.from(
+    new Set([
+      join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
+      join(getProtectedDir(), "actor-token-signing-key"),
+      join(getDeprecatedDir(), "actor-token-signing-key"),
+      resolve(cwd, "deprecated", "actor-token-signing-key"),
+    ]),
+  );
   return signingKeyPaths.includes(resolvedPath);
 }
 


### PR DESCRIPTION
## Summary
Fix A (#25493) migrated isActorTokenSigningKeyPath to getProtectedDir() but dropped the legacy ~/.vellum/protected/actor-token-signing-key from the risk classification list. In multi-instance mode, reads of the legacy host-wide key no longer classify as High risk and can be auto-approved.

Mirrors the dedup-Set pattern in shell.ts:buildCesProtectedPaths(), which already handles the legacy + per-instance dual-path correctly.

Addresses Codex P2 on #25493 and #25504.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
