### PR TITLE
fix(config-watcher): use || for GATEWAY_SECURITY_DIR fallback to match sibling convention

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -328,7 +328,7 @@ export class ConfigWatcher {
   }
 
   private startFeatureFlagsWatcher(onFeatureFlagsChanged?: () => void): void {
-    const protectedDir = process.env.GATEWAY_SECURITY_DIR ?? getProtectedDir();
+    const protectedDir = process.env.GATEWAY_SECURITY_DIR || getProtectedDir();
 
     try {
       if (!existsSync(protectedDir)) {


### PR DESCRIPTION
## Summary
Fix A (#25493) introduced a `??` fallback for GATEWAY_SECURITY_DIR in config-watcher.ts but the three sibling files (trust-store.ts, assistant-feature-flags.ts, shell.ts) use `||`. The difference matters when the env var is set to an empty string: `??` keeps it, `||` falls through to getProtectedDir().

One-char fix for consistency with the daemon-wide convention.

Addresses Codex/Devin feedback on #25493.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
