### PR TITLE
fix(cli): read platformBaseUrl from lockfile instead of legacy workspace config path

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   clearPlatformToken,
+  getPlatformUrl,
   readPlatformToken,
   savePlatformToken,
 } from "../lib/platform-client.js";
@@ -106,5 +113,86 @@ describe("platform-client token path is env-scoped", () => {
 
     // Prod still there
     expect(existsSync(join(tempHome, "vellum", "platform-token"))).toBe(true);
+  });
+});
+
+describe("getPlatformUrl resolution order", () => {
+  let tempLockDir: string;
+  let savedLockDir: string | undefined;
+  let savedEnv: string | undefined;
+  let savedPlatformUrl: string | undefined;
+
+  beforeEach(() => {
+    savedLockDir = process.env.VELLUM_LOCKFILE_DIR;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    savedPlatformUrl = process.env.VELLUM_PLATFORM_URL;
+    tempLockDir = mkdtempSync(join(tmpdir(), "cli-platform-url-test-"));
+    process.env.VELLUM_LOCKFILE_DIR = tempLockDir;
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_PLATFORM_URL;
+  });
+
+  afterEach(() => {
+    if (savedLockDir === undefined) {
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = savedLockDir;
+    }
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+    if (savedPlatformUrl === undefined) {
+      delete process.env.VELLUM_PLATFORM_URL;
+    } else {
+      process.env.VELLUM_PLATFORM_URL = savedPlatformUrl;
+    }
+    rmSync(tempLockDir, { recursive: true, force: true });
+  });
+
+  function writeLockfile(data: Record<string, unknown>): void {
+    // VELLUM_ENVIRONMENT is unset → production env → `.vellum.lock.json`.
+    writeFileSync(
+      join(tempLockDir, ".vellum.lock.json"),
+      JSON.stringify(data, null, 2),
+    );
+  }
+
+  test("returns lockfile platformBaseUrl when set", () => {
+    writeLockfile({ platformBaseUrl: "https://staging.vellum.ai" });
+    expect(getPlatformUrl()).toBe("https://staging.vellum.ai");
+  });
+
+  test("lockfile platformBaseUrl takes priority over VELLUM_PLATFORM_URL", () => {
+    writeLockfile({ platformBaseUrl: "https://lockfile.vellum.ai" });
+    process.env.VELLUM_PLATFORM_URL = "https://env.vellum.ai";
+    expect(getPlatformUrl()).toBe("https://lockfile.vellum.ai");
+  });
+
+  test("falls back to VELLUM_PLATFORM_URL when lockfile is missing", () => {
+    process.env.VELLUM_PLATFORM_URL = "https://env-only.vellum.ai";
+    expect(getPlatformUrl()).toBe("https://env-only.vellum.ai");
+  });
+
+  test("falls back to VELLUM_PLATFORM_URL when lockfile has no platformBaseUrl", () => {
+    writeLockfile({ assistants: [] });
+    process.env.VELLUM_PLATFORM_URL = "https://env-fallback.vellum.ai";
+    expect(getPlatformUrl()).toBe("https://env-fallback.vellum.ai");
+  });
+
+  test("falls back to VELLUM_PLATFORM_URL when lockfile platformBaseUrl is blank", () => {
+    writeLockfile({ platformBaseUrl: "   " });
+    process.env.VELLUM_PLATFORM_URL = "https://env-after-blank.vellum.ai";
+    expect(getPlatformUrl()).toBe("https://env-after-blank.vellum.ai");
+  });
+
+  test("falls back to production default when lockfile and env are unset", () => {
+    expect(getPlatformUrl()).toBe("https://platform.vellum.ai");
+  });
+
+  test("trims whitespace from VELLUM_PLATFORM_URL", () => {
+    process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
+    expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
   });
 });

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -466,6 +466,18 @@ export async function allocateLocalResources(
 }
 
 /**
+ * Return `platformBaseUrl` from the lockfile, if set. This is the value
+ * persisted by {@link syncConfigToLockfile} the last time the active
+ * assistant was hatched/waked, and is the source of truth for "which
+ * platform does the currently-active assistant target".
+ */
+export function getLockfilePlatformBaseUrl(): string | undefined {
+  const url = readLockfile().platformBaseUrl;
+  if (typeof url === "string" && url.trim()) return url.trim();
+  return undefined;
+}
+
+/**
  * Read the assistant config file and sync client-relevant values to the
  * lockfile. This lets external tools (e.g. vel) discover the platform URL
  * without importing the assistant config schema.

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -6,9 +6,9 @@ import {
   existsSync,
   mkdirSync,
 } from "fs";
-import { homedir } from "os";
 import { join, dirname } from "path";
 
+import { getLockfilePlatformBaseUrl } from "./assistant-config.js";
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
 
@@ -16,25 +16,25 @@ function getPlatformTokenPath(): string {
   return join(getConfigDir(getCurrentEnvironment()), "platform-token");
 }
 
+/**
+ * Resolve the platform API base URL. Resolution order:
+ *   1. `platformBaseUrl` persisted on the lockfile by
+ *      {@link syncConfigToLockfile} when the active assistant was last
+ *      hatched/waked. This is the source of truth for "what URL does the
+ *      currently-active assistant target" — reading the workspace
+ *      `config.json` directly is incorrect for multi-instance and
+ *      non-production XDG layouts because the CLI process has no way to
+ *      know which instance to read from without first consulting the
+ *      lockfile anyway.
+ *   2. `VELLUM_PLATFORM_URL` env var (explicit override, e.g. in CI).
+ *   3. Production default: `https://platform.vellum.ai`.
+ */
 export function getPlatformUrl(): string {
-  let configUrl: string | undefined;
-  try {
-    const base = process.env.BASE_DATA_DIR?.trim() || homedir();
-    const configPath = join(base, ".vellum", "workspace", "config.json");
-    if (existsSync(configPath)) {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-        string,
-        unknown
-      >;
-      const val = (raw.platform as Record<string, unknown> | undefined)
-        ?.baseUrl;
-      if (typeof val === "string" && val.trim()) configUrl = val.trim();
-    }
-  } catch {
-    // Config not available — fall through
-  }
+  const lockfileUrl = getLockfilePlatformBaseUrl();
   return (
-    configUrl || process.env.VELLUM_PLATFORM_URL || "https://platform.vellum.ai"
+    lockfileUrl ||
+    process.env.VELLUM_PLATFORM_URL?.trim() ||
+    "https://platform.vellum.ai"
   );
 }
 


### PR DESCRIPTION
## Summary
getPlatformUrl() used to read <BASE_DATA_DIR || homedir()>/.vellum/workspace/config.json to pick up the active assistant's platform.baseUrl. For new hatches on the env-data-layout feature branch, workspaces live at $XDG_DATA_HOME/vellum/assistants/<name>/.vellum/workspace/ and the hardcoded path is empty, so getPlatformUrl silently fell back to production.

Now getPlatformUrl reads platformBaseUrl directly from the lockfile (already persisted there by syncConfigToLockfile). Resolution order: lockfile > VELLUM_PLATFORM_URL env > production default.

Addresses Pass 3 Issue 4 in self-review of env-data-layout plan.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
