### PR TITLE
daemon: restore strong PKB reminder and add corrections-priority cue

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -609,8 +609,10 @@ const MAX_BUFFER_LINES = 50;
 
 const PKB_SYSTEM_REMINDER =
   "<system_reminder>" +
-  "\nRead any PKB files that might be relevant — INDEX.md is your table of contents. " +
-  "Don't wait to be asked." +
+  "\n**CRITICAL:** you MUST read any PKB files that might be relevant to this conversation — " +
+  "INDEX.md is your table of contents. Don't wait to be asked. " +
+  "Use `remember` OFTEN for EVERY new fact you learn IMMEDIATELY, don't wait for the next turn. " +
+  "Corrections to things you had wrong are the highest-priority remembers — never skip them." +
   "\n</system_reminder>";
 
 /**


### PR DESCRIPTION
## Summary

Reverts the softening from #25533 and adds a corrections-specific cue.

The original strong reminder ("CRITICAL / MUST / OFTEN / IMMEDIATELY") was put in place deliberately to fix observed under-use of PKB reading and \`remember\`. Softening it was hypothesis-driven (reminder fatigue) without evidence it was actually costing calls — and Velissa's own self-report said the reminder "helps" even when it gets drowned out. Evidence-based prompting should beat hypothesis.

Also adds a new final sentence: **"Corrections to things you had wrong are the highest-priority remembers — never skip them."** This triples the corrections signal (already added in #25534 to SOUL.md and #25535 to the \`remember\` tool description) in the exact position where in-turn timing matters most — corrections invalidate facts already propagated across prior turns and the memory graph.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
