### PR TITLE
fix(chrome-ext): native host reads env-aware lockfile path

### DIFF
--- a/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
@@ -3,6 +3,7 @@
  *
  * These tests exercise:
  *   - Fallback from `.vellum.lock.json` to `.vellum.lockfile.json`
+ *   - Env-aware path resolution (`VELLUM_ENVIRONMENT` production vs non-prod)
  *   - Parsing of assistant entries with and without `resources.daemonPort`
  *   - Active-assistant resolution
  *   - Graceful handling of missing, empty, and malformed lockfiles
@@ -13,7 +14,7 @@
  * This avoids touching the user's real `~/.vellum.lock.json`.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -30,14 +31,40 @@ import {
 // ---------------------------------------------------------------------------
 
 let tempDir: string;
+let savedVellumEnvironment: string | undefined;
+let savedXdgConfigHome: string | undefined;
+let savedVellumLockfileDir: string | undefined;
 
 beforeEach(() => {
+  // Save env vars we may mutate so each test starts from a clean slate.
+  savedVellumEnvironment = process.env.VELLUM_ENVIRONMENT;
+  savedXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  savedVellumLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+  delete process.env.VELLUM_ENVIRONMENT;
+  delete process.env.XDG_CONFIG_HOME;
+
   tempDir = mkdtempSync(join(tmpdir(), "lockfile-test-"));
   process.env.VELLUM_LOCKFILE_DIR = tempDir;
 });
 
 afterEach(() => {
-  delete process.env.VELLUM_LOCKFILE_DIR;
+  // Restore each variable to its original value (including "was unset").
+  if (savedVellumEnvironment === undefined) {
+    delete process.env.VELLUM_ENVIRONMENT;
+  } else {
+    process.env.VELLUM_ENVIRONMENT = savedVellumEnvironment;
+  }
+  if (savedXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = savedXdgConfigHome;
+  }
+  if (savedVellumLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = savedVellumLockfileDir;
+  }
+
   try {
     rmSync(tempDir, { recursive: true, force: true });
   } catch {
@@ -341,6 +368,170 @@ describe("lockfile — readAssistantInventory", () => {
     expect(cloudOne.cloud).toBe("vellum");
     expect(cloudOne.daemonPort).toBeUndefined();
     expect(cloudOne.isActive).toBe(false);
+  });
+});
+
+describe("lockfile — env-aware path resolution", () => {
+  test("non-prod env reads lockfile.json from VELLUM_LOCKFILE_DIR", () => {
+    // With VELLUM_LOCKFILE_DIR set (by beforeEach) to `tempDir` and
+    // VELLUM_ENVIRONMENT=dev, the reader should look for
+    // `${tempDir}/lockfile.json` (NOT `.vellum.lock.json`).
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    writeLockfile("lockfile.json", {
+      assistants: [
+        {
+          assistantId: "dev-one",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+      activeAssistant: "dev-one",
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("dev-one");
+    expect(result.assistants[0]!.daemonPort).toBe(7821);
+    expect(result.activeAssistantId).toBe("dev-one");
+  });
+
+  test("non-prod env ignores .vellum.lock.json (wrong filename for non-prod)", () => {
+    process.env.VELLUM_ENVIRONMENT = "staging";
+    // A prod-shaped file at the override dir should NOT be picked up when
+    // running in a non-prod env; only `lockfile.json` is the canonical
+    // non-prod name.
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "should-not-be-found",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+    expect(result.activeAssistantId).toBeNull();
+  });
+
+  test("non-prod env without VELLUM_LOCKFILE_DIR reads from $XDG_CONFIG_HOME/vellum-<env>", () => {
+    // Remove the override so the reader falls back to the XDG path.
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    const envDir = join(tempDir, "vellum-dev");
+    mkdirSync(envDir, { recursive: true });
+    writeFileSync(
+      join(envDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "xdg-dev",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: 7821 },
+          },
+        ],
+        activeAssistant: "xdg-dev",
+      }),
+    );
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("xdg-dev");
+    expect(result.assistants[0]!.daemonPort).toBe(7821);
+  });
+
+  test("non-prod env iterates exactly one candidate (no legacy fallback)", () => {
+    // `.vellum.lockfile.json` is the prod-legacy name and should NOT be
+    // read in non-prod mode.
+    process.env.VELLUM_ENVIRONMENT = "local";
+    writeLockfile(".vellum.lockfile.json", {
+      assistants: [
+        {
+          assistantId: "legacy-should-not-load",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toEqual([]);
+  });
+
+  test("unknown env name falls back to production path (reads .vellum.lock.json)", () => {
+    // `foo` is not in NON_PRODUCTION_ENVIRONMENTS; should behave like prod.
+    process.env.VELLUM_ENVIRONMENT = "foo";
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "fallback-prod",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("fallback-prod");
+    expect(result.assistants[0]!.daemonPort).toBe(7821);
+  });
+
+  test("empty VELLUM_ENVIRONMENT is treated as production", () => {
+    process.env.VELLUM_ENVIRONMENT = "";
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "empty-env",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("empty-env");
+  });
+
+  test("whitespace-only VELLUM_ENVIRONMENT is treated as production", () => {
+    process.env.VELLUM_ENVIRONMENT = "   ";
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "whitespace-env",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("whitespace-env");
+  });
+
+  test("explicit VELLUM_ENVIRONMENT=production uses production path", () => {
+    process.env.VELLUM_ENVIRONMENT = "production";
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "explicit-prod",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory();
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("explicit-prod");
   });
 });
 

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -179,6 +179,12 @@ function loadAllowedExtensionIds(): ReadonlySet<string> {
 const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = loadAllowedExtensionIds();
 
 const DEFAULT_ASSISTANT_PORT = 7821;
+// NOTE: `~/.vellum/runtime-port` is the legacy single-instance fallback and
+// is not env-aware. This is a known limitation for new production
+// multi-local users — tracked separately from the env-data-layout fix.
+// The authoritative source for per-assistant routing is the lockfile's
+// `resources.daemonPort`, resolved via `resolveDaemonPort()` in
+// `./lockfile.ts` using an env-aware path.
 const RUNTIME_PORT_FILE = join(homedir(), ".vellum", "runtime-port");
 
 /**

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -1,15 +1,20 @@
 /**
  * Lockfile reader for the Chrome native messaging helper.
  *
- * Reads `~/.vellum.lock.json` (preferred) with fallback to
- * `~/.vellum.lockfile.json` (legacy), parses the `assistants[]` array and
- * `activeAssistant` field, and returns a normalized assistant summary shape
- * that downstream consumers (e.g. the `list_assistants` frame handler and
- * the assistant-scoped `request_token` path) can use without coupling to
- * the full lockfile schema.
+ * Resolves the environment-aware lockfile path(s), parses the
+ * `assistants[]` array and `activeAssistant` field, and returns a
+ * normalized assistant summary shape that downstream consumers (e.g. the
+ * `list_assistants` frame handler and the assistant-scoped `request_token`
+ * path) can use without coupling to the full lockfile schema.
  *
- * The lockfile filenames and priority order are kept in sync with
- * `PRODUCTION_LOCKFILE_NAMES` in `cli/src/lib/environments/paths.ts`.
+ * Production path: `~/.vellum.lock.json` (preferred) with fallback to
+ * `~/.vellum.lockfile.json` (legacy). Non-production environments store
+ * the lockfile at `$XDG_CONFIG_HOME/vellum-<env>/lockfile.json`.
+ *
+ * The path resolution mirrors `getLockfilePaths()` in
+ * `cli/src/lib/environments/paths.ts`. Native host is a standalone binary
+ * with its own build, so the logic is replicated inline rather than
+ * imported.
  */
 
 import { readFileSync } from "node:fs";
@@ -17,16 +22,27 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Lockfile candidate filenames, checked in priority order.
+ * Production lockfile filenames, checked in priority order.
  * `.vellum.lock.json` is the current name; `.vellum.lockfile.json` is the
  * legacy name kept for backwards compatibility with older installs.
- *
- * Mirrors `PRODUCTION_LOCKFILE_NAMES` in `cli/src/lib/environments/paths.ts`.
  */
-const LOCKFILE_NAMES = [
+const PRODUCTION_LOCKFILE_NAMES = [
   ".vellum.lock.json",
   ".vellum.lockfile.json",
 ] as const;
+
+/**
+ * Non-production environment names that map to `$XDG_CONFIG_HOME/vellum-<env>/`.
+ * Anything not in this set (including typos like `foo`) falls back to the
+ * production path. Mirrors `KNOWN_ENVIRONMENTS` in
+ * `assistant/src/util/platform.ts` — keep in sync when new envs are added.
+ */
+const NON_PRODUCTION_ENVIRONMENTS: ReadonlySet<string> = new Set([
+  "dev",
+  "staging",
+  "test",
+  "local",
+]);
 
 /** Normalized summary of a single assistant from the lockfile. */
 export interface AssistantSummary {
@@ -68,12 +84,35 @@ interface RawAssistantEntry {
 }
 
 /**
- * Resolve the directory containing the lockfile. Respects
- * `VELLUM_LOCKFILE_DIR` for testing, falling back to the user's home
- * directory.
+ * Resolve the candidate lockfile paths, in priority order, based on the
+ * current `VELLUM_ENVIRONMENT`.
+ *
+ * - Production (unset/empty/unknown env name): returns
+ *   `[<dir>/.vellum.lock.json, <dir>/.vellum.lockfile.json]` where `<dir>`
+ *   is `VELLUM_LOCKFILE_DIR` if set, else the user's home directory.
+ * - Non-production (`dev`/`staging`/`test`/`local`): returns a single
+ *   `[<dir>/lockfile.json]` where `<dir>` is `VELLUM_LOCKFILE_DIR` if set,
+ *   else `$XDG_CONFIG_HOME/vellum-<env>` (falling back to
+ *   `~/.config/vellum-<env>` when `XDG_CONFIG_HOME` is unset).
+ *
+ * Mirrors `getLockfilePaths()` in `cli/src/lib/environments/paths.ts`.
+ * Unknown env names fall back to production silently — browser users
+ * don't see warnings.
  */
-function getLockfileDir(): string {
-  return process.env.VELLUM_LOCKFILE_DIR?.trim() || homedir();
+function getLockfileCandidates(): string[] {
+  const lockfileDirOverride = process.env.VELLUM_LOCKFILE_DIR?.trim();
+  const rawEnv = process.env.VELLUM_ENVIRONMENT?.trim() || "production";
+  const isNonProd = NON_PRODUCTION_ENVIRONMENTS.has(rawEnv);
+
+  if (!isNonProd) {
+    const dir = lockfileDirOverride || homedir();
+    return PRODUCTION_LOCKFILE_NAMES.map((name) => join(dir, name));
+  }
+
+  const xdgConfigHome =
+    process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
+  const dir = lockfileDirOverride || join(xdgConfigHome, `vellum-${rawEnv}`);
+  return [join(dir, "lockfile.json")];
 }
 
 /**
@@ -81,9 +120,7 @@ function getLockfileDir(): string {
  * and contains valid JSON. Returns `null` if no valid lockfile is found.
  */
 function readRawLockfile(): RawLockfile | null {
-  const base = getLockfileDir();
-  for (const name of LOCKFILE_NAMES) {
-    const filePath = join(base, name);
+  for (const filePath of getLockfileCandidates()) {
     try {
       const raw = readFileSync(filePath, "utf8");
       const parsed: unknown = JSON.parse(raw);


### PR DESCRIPTION
## Summary
The Chrome extension native host hardcoded `LOCKFILE_NAMES` and read them from homedir, so in non-production environments (dev/staging/test/local) it couldn't see any assistants after the env-data-layout plan moved the non-prod lockfile to $XDG_CONFIG_HOME/vellum-<env>/lockfile.json.

Native host is a standalone binary with its own build, so this replicates the getLockfilePaths logic from cli/src/lib/environments/paths.ts inline. Unknown env names fall back to production, matching the daemon's KNOWN_ENVIRONMENTS check.

Production path is byte-identical.

Addresses Codex P2 on #25504.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
