### PR TITLE
feat(assistant): add splitLongTextSegment helper for oversize Slack sections

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for `splitLongTextSegment` — the pure helper that slices a
+ * string into Slack-section-sized chunks while preferring natural
+ * boundaries (paragraph → newline → sentence → hard slice).
+ *
+ * `textToSlackBlocks` integration coverage lives in PR 4, once the helper
+ * is wired into the caller.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  SLACK_SECTION_MAX_CHARS,
+  splitLongTextSegment,
+} from "../slack-block-formatting.js";
+
+describe("splitLongTextSegment", () => {
+  test("returns single-element array for text under the limit", () => {
+    const text = "short message";
+    const chunks = splitLongTextSegment(text);
+    expect(chunks).toEqual([text]);
+  });
+
+  test("returns single-element array for text exactly at the limit", () => {
+    const text = "a".repeat(SLACK_SECTION_MAX_CHARS);
+    const chunks = splitLongTextSegment(text);
+    expect(chunks).toEqual([text]);
+  });
+
+  test("splits 5000-char paragraph-only text into ≥ 2 chunks under the limit and reconstructs input", () => {
+    // Build enough paragraphs (~50 chars each + "\n\n" separators) to
+    // comfortably exceed 5000 chars.
+    const paragraphs: string[] = [];
+    for (let i = 0; i < 120; i++) {
+      paragraphs.push(`Paragraph number ${i} with filler content here.`);
+    }
+    const text = paragraphs.join("\n\n");
+    expect(text.length).toBeGreaterThanOrEqual(5000);
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_SECTION_MAX_CHARS);
+    }
+
+    // Joining chunks with empty string should recover all non-whitespace
+    // content (the helper trims chunk boundaries, so inter-chunk "\n\n"
+    // separators may be collapsed). Compare whitespace-stripped.
+    const rejoined = chunks.join("").replace(/\s+/g, "");
+    const original = text.replace(/\s+/g, "");
+    expect(rejoined).toBe(original);
+  });
+
+  test("splits on paragraph boundary rather than mid-sentence", () => {
+    // Two paragraphs where a paragraph split is available inside the
+    // first window. Use maxChars large enough that the first paragraph
+    // fits, but both together don't.
+    const firstParagraph = "a".repeat(2000);
+    const secondParagraph = "b".repeat(2000);
+    const text = `${firstParagraph}\n\n${secondParagraph}`;
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toBe(firstParagraph);
+    expect(chunks[1]).toBe(secondParagraph);
+  });
+
+  test("splits text with no paragraph or sentence boundaries via hard slice", () => {
+    const text = "x".repeat(10_000);
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(
+      Math.ceil(10_000 / SLACK_SECTION_MAX_CHARS),
+    );
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_SECTION_MAX_CHARS);
+    }
+
+    // No content lost.
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("respects custom maxChars parameter", () => {
+    const text = "a".repeat(100);
+    const chunks = splitLongTextSegment(text, 30);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(Math.ceil(100 / 30));
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(30);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("prefers sentence boundary when no paragraph or newline is available", () => {
+    const sentenceA = "This is sentence A. ".repeat(100); // ~2000 chars
+    const sentenceB = "This is sentence B. ".repeat(100); // ~2000 chars
+    const text = sentenceA + sentenceB;
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_SECTION_MAX_CHARS);
+      // Each chunk should end with a period (sentence-aligned split).
+      expect(chunk.endsWith(".")).toBe(true);
+    }
+  });
+
+  test("prefers single newline over sentence boundary when no paragraph is present", () => {
+    const lineA = "a".repeat(1500);
+    const lineB = "b".repeat(1500);
+    const text = `${lineA}\n${lineB}`;
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toBe(lineA);
+    expect(chunks[1]).toBe(lineB);
+  });
+});

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -289,3 +289,71 @@ function markdownToMrkdwn(text: string): string {
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Long-text splitting
+// ---------------------------------------------------------------------------
+
+/**
+ * Slack's `section` block has a documented ~3000-character limit on the
+ * `text.text` value. Keep a margin under that so downstream transforms
+ * (e.g. `markdownToMrkdwn` expansions) don't push a chunk over.
+ */
+export const SLACK_SECTION_MAX_CHARS = 2800;
+
+/**
+ * Split `text` into chunks no larger than `maxChars`, preferring natural
+ * boundaries. Pure helper: no Block Kit knowledge, safe to unit test.
+ *
+ * Preference order for split points:
+ *  1. Paragraph boundary (`\n\n`)
+ *  2. Single newline (`\n`)
+ *  3. Sentence boundary (`. `, `! `, `? `)
+ *  4. Hard slice at `maxChars`
+ *
+ * Short inputs (length ≤ `maxChars`) return `[text]` unchanged. Each chunk
+ * is trimmed of leading/trailing whitespace at chunk boundaries; interior
+ * whitespace is preserved.
+ */
+export function splitLongTextSegment(
+  text: string,
+  maxChars: number = SLACK_SECTION_MAX_CHARS,
+): string[] {
+  if (text.length <= maxChars) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxChars) {
+    const window = remaining.slice(0, maxChars);
+    let splitAt = findBoundary(window, ["\n\n"]);
+    if (splitAt < 0) splitAt = findBoundary(window, ["\n"]);
+    if (splitAt < 0) splitAt = findBoundary(window, [". ", "! ", "? "]);
+    // Hard-slice fallback: no natural boundary in the first `maxChars`.
+    if (splitAt < 0) splitAt = maxChars;
+
+    const chunk = remaining.slice(0, splitAt).trim();
+    if (chunk.length > 0) chunks.push(chunk);
+    remaining = remaining.slice(splitAt);
+  }
+
+  const tail = remaining.trim();
+  if (tail.length > 0) chunks.push(tail);
+
+  return chunks;
+}
+
+/**
+ * Return the end index of the last occurrence of any delimiter in `window`
+ * (so the preceding content becomes one chunk). Returns -1 if none match.
+ */
+function findBoundary(window: string, delimiters: string[]): number {
+  let best = -1;
+  for (const delim of delimiters) {
+    const idx = window.lastIndexOf(delim);
+    if (idx < 0) continue;
+    const end = idx + delim.length;
+    if (end > best) best = end;
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- Adds splitLongTextSegment helper in slack-block-formatting.ts that splits long text on paragraph / newline / sentence boundaries to fit under Slack's section block size limit.
- Pure helper — not yet wired into textToSlackBlocks (PR 4 will do that).
- Adds unit tests covering the boundary preference, hard-slice fallback, and custom maxChars.

Part of plan: slack-delivery-fix.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
