### PR TITLE
fix(environments): VellumPaths accepts relative XDG_CONFIG_HOME to match TS/daemon

### DIFF
--- a/clients/macos/vellum-assistantTests/VellumPathsTests.swift
+++ b/clients/macos/vellum-assistantTests/VellumPathsTests.swift
@@ -158,4 +158,82 @@ final class VellumPathsTests: XCTestCase {
             "/tmp/test-home/.config/vellum/platform-token"
         )
     }
+
+    // MARK: - resolveXdgConfigHome
+
+    // These tests mutate the process environment and must restore it in
+    // `defer` blocks so they don't leak into neighbouring tests.
+
+    func testResolveXdgConfigHomeAbsolute() {
+        let previous = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+        setenv("XDG_CONFIG_HOME", "/custom/xdg", 1)
+        defer {
+            if let previous {
+                setenv("XDG_CONFIG_HOME", previous, 1)
+            } else {
+                unsetenv("XDG_CONFIG_HOME")
+            }
+        }
+
+        XCTAssertEqual(VellumPaths.resolveXdgConfigHome().path, "/custom/xdg")
+    }
+
+    func testResolveXdgConfigHomeRelativeIsAccepted() {
+        // Parity with cli/src/lib/environments/paths.ts:xdgConfigHome() and
+        // assistant/src/util/platform.ts:getXdgPlatformTokenPath, both of
+        // which accept the raw env var without an absolute-path guard.
+        let previous = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+        setenv("XDG_CONFIG_HOME", "relative/xdg", 1)
+        defer {
+            if let previous {
+                setenv("XDG_CONFIG_HOME", previous, 1)
+            } else {
+                unsetenv("XDG_CONFIG_HOME")
+            }
+        }
+
+        // `URL(fileURLWithPath:)` resolves a relative path against the
+        // current working directory — the key assertion is that we did NOT
+        // silently fall back to NSHomeDirectory()/.config.
+        let resolved = VellumPaths.resolveXdgConfigHome()
+        let fallback = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".config").path
+        XCTAssertNotEqual(resolved.path, fallback)
+        XCTAssertTrue(
+            resolved.path.hasSuffix("/relative/xdg"),
+            "expected relative path to be preserved, got \(resolved.path)"
+        )
+    }
+
+    func testResolveXdgConfigHomeUnsetFallsBackToHomeConfig() {
+        // Production path: env var unset → NSHomeDirectory()/.config. This
+        // is the byte-identical production case that must stay intact.
+        let previous = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+        unsetenv("XDG_CONFIG_HOME")
+        defer {
+            if let previous {
+                setenv("XDG_CONFIG_HOME", previous, 1)
+            }
+        }
+
+        let expected = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".config").path
+        XCTAssertEqual(VellumPaths.resolveXdgConfigHome().path, expected)
+    }
+
+    func testResolveXdgConfigHomeWhitespaceFallsBackToHomeConfig() {
+        let previous = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+        setenv("XDG_CONFIG_HOME", "   ", 1)
+        defer {
+            if let previous {
+                setenv("XDG_CONFIG_HOME", previous, 1)
+            } else {
+                unsetenv("XDG_CONFIG_HOME")
+            }
+        }
+
+        let expected = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".config").path
+        XCTAssertEqual(VellumPaths.resolveXdgConfigHome().path, expected)
+    }
 }

--- a/clients/shared/Utilities/VellumPaths.swift
+++ b/clients/shared/Utilities/VellumPaths.swift
@@ -106,14 +106,15 @@ public struct VellumPaths {
 
     // MARK: - Internals
 
-    private static func resolveXdgConfigHome() -> URL {
+    // Accept the raw XDG_CONFIG_HOME value even if relative, matching
+    // cli/src/lib/environments/paths.ts:xdgConfigHome() and
+    // assistant/src/util/platform.ts:getXdgPlatformTokenPath which both
+    // honor whatever the env var says. In practice real-world XDG paths
+    // are always absolute; this exists only for edge-case parity.
+    internal static func resolveXdgConfigHome() -> URL {
         if let raw = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-            !raw.isEmpty,
-            // XDG Base Directory spec requires absolute paths; relative values
-            // are ignored for parity with the TypeScript env package which
-            // also doesn't resolve them.
-            raw.hasPrefix("/")
+            !raw.isEmpty
         {
             return URL(fileURLWithPath: raw)
         }


### PR DESCRIPTION
## Summary
resolveXdgConfigHome() had a hasPrefix('/') guard that silently dropped relative XDG_CONFIG_HOME values. The comment claimed "parity with the TypeScript env package" but the TS env package (cli/src/lib/environments/paths.ts) and the daemon (assistant/src/util/platform.ts) both accept the raw env var value without an absolute-path check. Three sides disagreed for the edge case.

Removed the guard. All three sides now honor whatever the env var says. Production (env var unset) is byte-identical — falls back to NSHomeDirectory()+/.config.

Addresses Pass 3 Issue 5 in self-review of env-data-layout plan.

Part of plan: env-data-layout.md (fix round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
