### PR TITLE
ci(macos): bump Build macOS app timeout to 20 min

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -269,7 +269,7 @@ jobs:
           ./build.sh binaries
 
       - name: Build macOS app
-        timeout-minutes: 15
+        timeout-minutes: 20
         working-directory: clients/macos
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary

- The \`Build macOS app\` step in \`ci-main-macos.yaml\` timed out after 15 minutes in [run 24412665496](https://github.com/vellum-ai/vellum-assistant/actions/runs/24412665496/job/71313411939) at 97% completion (file 2424/2484 compiled).
- Successful builds typically complete in ~7 minutes; 15 minutes was too tight a margin for slow-runner flakes.
- Bump the timeout to 20 minutes for headroom. Only touches the main-branch workflow, per the specific failing job.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24412665496/job/71313411939
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
