### PR TITLE
fix(macos): dedupe user_message_echo against history-loaded channel messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -328,8 +328,11 @@ final class ConversationManager: ConversationRestorerDelegate {
         // loadHistoryIfNeeded fetches fresh data from the daemon.
         if let conversation = listStore.conversations.first(where: { $0.id == id }),
            conversation.isChannelConversation,
-           let vm = selectionStore.chatViewModels[id], vm.isHistoryLoaded {
-            vm.prepareForChannelRefresh()
+           let vm = selectionStore.chatViewModels[id] {
+            vm.isChannelConversation = true
+            if vm.isHistoryLoaded {
+                vm.prepareForChannelRefresh()
+            }
         }
 
         selectionStore.performActivation(for: id)
@@ -812,6 +815,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         if selectionStore.chatViewModels[id] == nil {
             let viewModel = makeViewModel()
             viewModel.conversationId = conversation.conversationId
+            viewModel.isChannelConversation = conversation.isChannelConversation
             selectionStore.chatViewModels[id] = viewModel
             activityStore.observeBusyState(for: id, messageManager: viewModel.messageManager)
             activityStore.observeAssistantActivity(for: id, messageManager: viewModel.messageManager)
@@ -821,8 +825,11 @@ final class ConversationManager: ConversationRestorerDelegate {
 
         selectionStore.touchVMAccessOrder(id)
 
-        if conversation.isChannelConversation, let vm = selectionStore.chatViewModels[id], vm.isHistoryLoaded {
-            vm.prepareForChannelRefresh()
+        if conversation.isChannelConversation, let vm = selectionStore.chatViewModels[id] {
+            vm.isChannelConversation = true
+            if vm.isHistoryLoaded {
+                vm.prepareForChannelRefresh()
+            }
         }
 
         selectionStore.performActivation(for: id)
@@ -1286,15 +1293,17 @@ final class ConversationManager: ConversationRestorerDelegate {
 
         if let existingIdx = listStore.conversations.firstIndex(where: { $0.conversationId == item.id }) {
             let existingConversation = listStore.conversations[existingIdx]
-            listStore.conversations[existingIdx] = listStore.conversationModel(
+            let updatedConversation = listStore.conversationModel(
                 from: item,
                 localId: existingConversation.id,
                 createdAt: existingConversation.createdAt,
                 isArchived: isArchived
             )
+            listStore.conversations[existingIdx] = updatedConversation
             listStore.mergeAssistantAttention(from: item, intoConversationAt: existingIdx)
             if let viewModel = selectionStore.chatViewModels[existingConversation.id] {
                 viewModel.conversationId = item.id
+                viewModel.isChannelConversation = updatedConversation.isChannelConversation
                 viewModel.ensureMessageLoopStarted()
             }
             return existingConversation.id
@@ -1303,6 +1312,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         let conversationModel = listStore.conversationModel(from: item, isArchived: isArchived)
         let viewModel = makeViewModel()
         viewModel.conversationId = item.id
+        viewModel.isChannelConversation = conversationModel.isChannelConversation
         viewModel.startMessageLoop()
 
         listStore.conversations.insert(conversationModel, at: 0)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -236,6 +236,7 @@ final class ConversationSelectionStore {
         guard let conversation = listStore.conversations.first(where: { $0.id == conversationId }) else { return nil }
         guard let viewModel = viewModelFactory?() else { return nil }
         viewModel.conversationId = conversation.conversationId
+        viewModel.isChannelConversation = conversation.isChannelConversation
         if conversation.conversationId == nil {
             viewModel.isHistoryLoaded = true
         }

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -132,6 +132,21 @@ final class ChatActionHandler {
                 break
             }
 
+            // History-loaded dedup: for channel conversations, a Slack/Telegram
+            // user message may already be in `vm.messages` from history
+            // reconstruction with a different daemonMessageId than the echo
+            // carries. If an existing .user row has matching text and a tagged
+            // daemonMessageId, treat the echo as a redundant notification for an
+            // already-visible message and do not append.
+            if vm.isChannelConversation,
+               vm.messages.contains(where: {
+                   $0.role == .user
+                       && $0.text == echo.text
+                       && $0.daemonMessageId != nil
+               }) {
+                break
+            }
+
             // Passive client (or nil messageId for back-compat surface-action
             // echoes): append a new user row and enter "reply incoming" state.
             var userMsg = ChatMessage(role: .user, text: echo.text, status: .sent)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -662,6 +662,12 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Set by `createConversationIfNeeded(conversationType:)` and included in the
     /// message so the daemon can persist the correct conversation kind.
     public var conversationType: String?
+    /// Whether this conversation belongs to a non-Vellum channel (e.g. Slack,
+    /// Telegram). Set by the platform layer alongside `conversationId` when the
+    /// underlying `ConversationModel.isChannelConversation` is true. Used by
+    /// `ChatActionHandler` to suppress echo duplication when a channel user
+    /// message is already visible from history reconstruction.
+    public var isChannelConversation: Bool = false
     /// Skill IDs to pre-activate in the conversation. Included in the
     /// `conversation_create` request for deterministic skill activation.
     public var preactivatedSkillIds: [String]?

--- a/clients/shared/Tests/ChatActionHandlerEchoDedupTests.swift
+++ b/clients/shared/Tests/ChatActionHandlerEchoDedupTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatActionHandlerEchoDedupTests: XCTestCase {
+
+    private var connectionManager: GatewayConnectionManager!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: connectionManager.eventStreamClient)
+        viewModel.conversationId = "sess-1"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    /// A channel user message already loaded from history should not be duplicated
+    /// when a `user_message_echo` arrives carrying a different `messageId` shape.
+    /// The dedup must also suppress the `isThinking` side effect so the orphan
+    /// "thinking" indicator does not flash on an already-visible message.
+    func testChannelConversationDedupsHistoryLoadedUserMessage() {
+        viewModel.isChannelConversation = true
+
+        var historyMessage = ChatMessage(role: .user, text: "hello from slack", status: .sent)
+        historyMessage.daemonMessageId = "history-id"
+        viewModel.messages = [historyMessage]
+
+        viewModel.handleServerMessage(.userMessageEcho(UserMessageEcho(
+            type: "user_message_echo",
+            text: "hello from slack",
+            conversationId: "sess-1",
+            messageId: "echo-id",
+            requestId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 1, "Echo should not append a duplicate user row for a history-loaded channel message")
+        XCTAssertFalse(viewModel.isThinking, "isThinking side effect should be suppressed for the dedup-suppressed echo")
+    }
+
+    /// Non-channel conversations must keep the pre-existing passive-client
+    /// behavior: the echo appends a new row and flips the conversation into
+    /// "reply incoming" state. Guards against over-broad dedup.
+    func testNonChannelConversationAppendsEchoNormally() {
+        viewModel.isChannelConversation = false
+
+        var historyMessage = ChatMessage(role: .user, text: "hello from slack", status: .sent)
+        historyMessage.daemonMessageId = "history-id"
+        viewModel.messages = [historyMessage]
+
+        viewModel.handleServerMessage(.userMessageEcho(UserMessageEcho(
+            type: "user_message_echo",
+            text: "hello from slack",
+            conversationId: "sess-1",
+            messageId: "echo-id",
+            requestId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 2, "Non-channel conversations should still append the echo as a new row")
+        XCTAssertTrue(viewModel.isThinking, "Non-channel echo should flip isThinking to signal an incoming reply")
+    }
+
+    /// Channel conversations with no matching history row must still accept
+    /// a legitimate first-arrival echo. Guards against blocking first arrivals
+    /// when the user opens the desktop app after Slack activity and the echo
+    /// outpaces the history fetch.
+    func testChannelConversationAppendsFirstArrivalEcho() {
+        viewModel.isChannelConversation = true
+        viewModel.messages = []
+
+        viewModel.handleServerMessage(.userMessageEcho(UserMessageEcho(
+            type: "user_message_echo",
+            text: "hello from slack",
+            conversationId: "sess-1",
+            messageId: "echo-id",
+            requestId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 1, "First-arrival echo should append a new user row when no history row matches")
+        XCTAssertEqual(viewModel.messages[0].daemonMessageId, "echo-id", "Appended row should carry the echo's messageId")
+    }
+}


### PR DESCRIPTION
## Summary
- For channel conversations, the ChatActionHandler echo handler now skips the append-new-bubble fallback when a user row with matching text and a tagged daemonMessageId already exists (loaded from history). Prevents the duplicate user bubble seen in Slack-mirrored threads when the echo messageId differs from the history row's daemonMessageId.
- Does not change dedup behavior for in-app optimistic sends or for echoes in non-channel conversations.
- Adds three regression tests covering the channel-dedup path, non-channel pass-through, and first-arrival (no history) path.

Part of plan: slack-delivery-fix.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
