### PR TITLE
feat(home-feed): wire real producers into the feed writer [JARVIS-511]

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -36,6 +36,10 @@ import {
 } from "../credential-execution/startup-timeout.js";
 import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import {
+  type FeedSchedulerHandle,
+  startFeedScheduler,
+} from "../home/feed-scheduler.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";
@@ -933,6 +937,19 @@ export async function runDaemon(): Promise<void> {
       },
     );
 
+    // Home activity feed scheduler — drives the assistant reflection
+    // loop + the platform Gmail digest. Fire-and-forget; a startup
+    // failure must never block the rest of daemon boot (CLAUDE.md).
+    let feedScheduler: FeedSchedulerHandle | null = null;
+    try {
+      feedScheduler = startFeedScheduler();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to start home feed scheduler — continuing startup",
+      );
+    }
+
     // Start the runtime HTTP server. Required for iOS pairing (gateway proxies
     // to it) and optional REST API access. Defaults to port 7821.
     let runtimeHttp: RuntimeHttpServer | null = null;
@@ -1411,6 +1428,7 @@ export async function runDaemon(): Promise<void> {
       hookManager,
       runtimeHttp,
       scheduler,
+      feedScheduler,
       getMemoryWorker: () => bgRefs.memoryWorker,
       getBackupWorker: () => bgRefs.backupWorker,
       getQdrantManager: () => bgRefs.qdrantManager,

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -25,6 +25,7 @@ export interface ShutdownDeps {
   hookManager: HookManager;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
+  feedScheduler: { stop(): void } | null;
   getMemoryWorker: () => { stop(): void } | null;
   getBackupWorker: () => BackupWorkerHandle | null;
   getQdrantManager: () => QdrantManager | null;
@@ -113,6 +114,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
     deps.scheduler.stop();
+    deps.feedScheduler?.stop();
     deps.getMemoryWorker()?.stop();
     deps.getBackupWorker()?.stop();
 

--- a/assistant/src/home/__tests__/feed-scheduler.test.ts
+++ b/assistant/src/home/__tests__/feed-scheduler.test.ts
@@ -86,6 +86,48 @@ describe("startFeedScheduler", () => {
     expect(summary2.reflectionRan).toBe(true);
   });
 
+  test("reflection cooldown is NOT advanced on no_provider so the next tick retries", async () => {
+    // Mimic the daemon startup ordering: the scheduler boots before
+    // the provider registry is ready. The first tick gets no_provider;
+    // the next tick (even one second later) must still run the
+    // reflection instead of waiting 30 minutes.
+    reflectionRunner.mockImplementationOnce(async () => ({
+      wroteCount: 0,
+      skippedReason: "no_provider",
+    }));
+
+    handle = startFeedScheduler(defaultOptions());
+    const t0 = new Date("2026-04-14T12:00:00.000Z");
+    await handle.runOnce(t0);
+    expect(reflectionRunner).toHaveBeenCalledTimes(1);
+
+    // One second later — providers have initialized.
+    const t1 = new Date("2026-04-14T12:00:01.000Z");
+    const summary = await handle.runOnce(t1);
+
+    expect(summary.reflectionRan).toBe(true);
+    expect(reflectionRunner).toHaveBeenCalledTimes(2);
+  });
+
+  test("reflection cooldown IS advanced on other skip reasons to preserve backoff", async () => {
+    // empty_items / malformed_output / provider_error are real attempts
+    // — the next tick should be gated by the full 30-minute window so
+    // a broken producer doesn't get hammered every tick.
+    reflectionRunner.mockImplementationOnce(async () => ({
+      wroteCount: 0,
+      skippedReason: "malformed_output",
+    }));
+
+    handle = startFeedScheduler(defaultOptions());
+    await handle.runOnce(new Date("2026-04-14T12:00:00.000Z"));
+    expect(reflectionRunner).toHaveBeenCalledTimes(1);
+
+    // Ten minutes later — below the 30-min gate, should NOT re-run.
+    const summary = await handle.runOnce(new Date("2026-04-14T12:10:00.000Z"));
+    expect(summary.reflectionRan).toBe(false);
+    expect(reflectionRunner).toHaveBeenCalledTimes(1);
+  });
+
   test("producer exceptions do not break the tick loop", async () => {
     gmailDigestRunner.mockImplementationOnce(async () => {
       throw new Error("boom");

--- a/assistant/src/home/__tests__/feed-scheduler.test.ts
+++ b/assistant/src/home/__tests__/feed-scheduler.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the home-feed scheduler's tick lifecycle.
+ *
+ * Producer implementations are injected via `FeedSchedulerOptions`
+ * spies so the tests never touch `mock.module` (which leaks across
+ * files in Bun's test runner). The dedicated producer tests
+ * (`reflection-producer.test.ts`, `platform-gmail-digest.test.ts`)
+ * cover each producer's internal behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { startFeedScheduler } from "../feed-scheduler.js";
+import type { FeedItem } from "../feed-types.js";
+import type { ReflectionResult } from "../reflection-producer.js";
+
+const gmailDigestRunner = mock<
+  (now: Date, countSource: () => Promise<number>) => Promise<FeedItem | null>
+>(async () => null);
+
+const reflectionRunner = mock<(now: Date) => Promise<ReflectionResult>>(
+  async () => ({ wroteCount: 0, skippedReason: "empty_items" }),
+);
+
+const defaultOptions = () => ({
+  gmailCountSource: async () => 0,
+  gmailDigestRunner,
+  reflectionRunner,
+  runOnStart: false,
+});
+
+beforeEach(() => {
+  gmailDigestRunner.mockClear();
+  reflectionRunner.mockClear();
+});
+
+describe("startFeedScheduler", () => {
+  let handle: ReturnType<typeof startFeedScheduler> | null = null;
+
+  afterEach(() => {
+    handle?.stop();
+    handle = null;
+  });
+
+  test("runOnce invokes both producers on the first tick", async () => {
+    handle = startFeedScheduler(defaultOptions());
+    const summary = await handle.runOnce(new Date("2026-04-14T12:00:00.000Z"));
+
+    expect(summary.gmailDigestRan).toBe(true);
+    expect(summary.reflectionRan).toBe(true);
+    expect(gmailDigestRunner).toHaveBeenCalledTimes(1);
+    expect(reflectionRunner).toHaveBeenCalledTimes(1);
+  });
+
+  test("gmail digest re-runs every tick once its interval has elapsed", async () => {
+    handle = startFeedScheduler(defaultOptions());
+
+    const t0 = new Date("2026-04-14T12:00:00.000Z");
+    await handle.runOnce(t0);
+
+    // 1 minute later — below the 5-minute gmail gate, should NOT re-run.
+    const t1 = new Date("2026-04-14T12:01:00.000Z");
+    const summary1 = await handle.runOnce(t1);
+    expect(summary1.gmailDigestRan).toBe(false);
+
+    // 6 minutes later — past the 5-minute gate, should re-run.
+    const t2 = new Date("2026-04-14T12:06:00.000Z");
+    const summary2 = await handle.runOnce(t2);
+    expect(summary2.gmailDigestRan).toBe(true);
+  });
+
+  test("reflection only re-runs every 30 minutes", async () => {
+    handle = startFeedScheduler(defaultOptions());
+
+    const t0 = new Date("2026-04-14T12:00:00.000Z");
+    await handle.runOnce(t0);
+
+    // 5 min later — below the 30-min reflection gate.
+    const t1 = new Date("2026-04-14T12:05:00.000Z");
+    const summary1 = await handle.runOnce(t1);
+    expect(summary1.reflectionRan).toBe(false);
+
+    // 31 min later — past the 30-min gate, should re-run.
+    const t2 = new Date("2026-04-14T12:31:00.000Z");
+    const summary2 = await handle.runOnce(t2);
+    expect(summary2.reflectionRan).toBe(true);
+  });
+
+  test("producer exceptions do not break the tick loop", async () => {
+    gmailDigestRunner.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    reflectionRunner.mockImplementationOnce(async () => {
+      throw new Error("also boom");
+    });
+
+    handle = startFeedScheduler(defaultOptions());
+    const summary = await handle.runOnce(new Date("2026-04-14T12:00:00.000Z"));
+
+    // Both producers were invoked and both counted as "ran" (the
+    // gating bookkeeping advanced) even though they threw. This is
+    // the intended behavior — a broken producer shouldn't cause the
+    // scheduler to hammer it every tick via a backoff bypass.
+    expect(summary.gmailDigestRan).toBe(true);
+    expect(summary.reflectionRan).toBe(true);
+  });
+
+  test("stop() makes subsequent runOnce calls no-op", async () => {
+    handle = startFeedScheduler(defaultOptions());
+    await handle.runOnce(new Date("2026-04-14T12:00:00.000Z"));
+
+    handle.stop();
+
+    const beforeCount = gmailDigestRunner.mock.calls.length;
+    // A tick well past the cadence gate should not fire after stop.
+    await handle.runOnce(new Date("2026-04-14T13:00:00.000Z"));
+    expect(gmailDigestRunner.mock.calls.length).toBe(beforeCount);
+  });
+
+  test("gmailCountSource option is threaded through to the digest runner", async () => {
+    const countSource = mock<() => Promise<number>>(async () => 7);
+    handle = startFeedScheduler({
+      ...defaultOptions(),
+      gmailCountSource: countSource,
+    });
+    await handle.runOnce(new Date("2026-04-14T12:00:00.000Z"));
+
+    expect(gmailDigestRunner).toHaveBeenCalledTimes(1);
+    const [, passedCountSource] = gmailDigestRunner.mock.calls[0]!;
+    expect(passedCountSource).toBe(countSource);
+  });
+});

--- a/assistant/src/home/__tests__/reflection-producer.test.ts
+++ b/assistant/src/home/__tests__/reflection-producer.test.ts
@@ -164,6 +164,28 @@ describe("runReflectionProducer", () => {
     expect(writeItem).toHaveBeenCalledTimes(3);
   });
 
+  test("reports malformed_output when every item in a non-empty batch fails coercion", async () => {
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          { type: "nudge", title: "", summary: "empty title, rejected" },
+          { type: "bogus", title: "bad type", summary: "also rejected" },
+          { type: "nudge", title: "valid title" }, // missing summary
+        ],
+      }),
+    ]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.skippedReason).toBe("malformed_output");
+    expect(result.wroteCount).toBe(0);
+    expect(writeItem).not.toHaveBeenCalled();
+  });
+
   test("rejects malformed items but keeps valid ones in the same batch", async () => {
     const provider = scriptedProvider([
       toolUseContent({

--- a/assistant/src/home/__tests__/reflection-producer.test.ts
+++ b/assistant/src/home/__tests__/reflection-producer.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the home-feed reflection producer.
+ *
+ * All dependencies are injected via `ReflectionProducerDeps` spies so
+ * the tests never touch `mock.module`, which leaks across files in
+ * Bun's test runner. The production caller passes `undefined` and the
+ * producer falls through to the real config loader, relationship-state
+ * reader, and provider registry.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  Provider,
+  ProviderResponse,
+} from "../../providers/types.js";
+import type { WriteAssistantFeedItemParams } from "../assistant-feed-authoring.js";
+import { runReflectionProducer } from "../reflection-producer.js";
+
+const writeItem = mock<
+  (params: WriteAssistantFeedItemParams) => Promise<unknown>
+>(async () => ({}));
+
+const stubRelationshipState = async () =>
+  ({
+    version: 1,
+    assistantId: "self",
+    tier: 2,
+    progressPercent: 42,
+    facts: [
+      { category: "voice", text: "Ships fast, explains the why." },
+      { category: "priorities", text: "JARVIS is the current focus." },
+    ],
+    capabilities: [],
+    conversationCount: 17,
+    hatchedDate: "2026-03-01T00:00:00.000Z",
+    assistantName: "Vellum",
+    userName: "Alex",
+    updatedAt: "2026-04-14T12:00:00.000Z",
+    // biome-ignore lint/suspicious/noExplicitAny: the real shape is
+    // internal-only and we only need the subset the producer reads.
+  }) as any;
+
+function makeProvider(
+  handler: (
+    messages: Parameters<Provider["sendMessage"]>[0],
+    tools: Parameters<Provider["sendMessage"]>[1],
+    systemPrompt: Parameters<Provider["sendMessage"]>[2],
+    options: Parameters<Provider["sendMessage"]>[3],
+  ) => Promise<ProviderResponse>,
+): Provider {
+  return {
+    name: "mock",
+    sendMessage: handler,
+  };
+}
+
+function scriptedProvider(content: ContentBlock[]): Provider {
+  return makeProvider(async () => ({
+    content,
+    model: "mock-model",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    stopReason: "tool_use",
+  }));
+}
+
+function throwingProvider(error: Error): Provider {
+  return makeProvider(async () => {
+    throw error;
+  });
+}
+
+function toolUseContent(input: unknown): ContentBlock {
+  return {
+    type: "tool_use",
+    id: "tu_1",
+    name: "write_feed_items",
+    input: input as Record<string, unknown>,
+  };
+}
+
+beforeEach(() => {
+  writeItem.mockClear();
+});
+
+describe("runReflectionProducer", () => {
+  test("writes each item returned in the write_feed_items tool call", async () => {
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          {
+            type: "nudge",
+            source: "assistant",
+            title: "Follow up on Figma",
+            summary: "Noa shared a file Thursday. No reply yet.",
+            priority: 70,
+            minTimeAway: 3600,
+          },
+          {
+            type: "thread",
+            source: "assistant",
+            title: "Hiring loop",
+            summary: "2 of 6 interviewed; pipeline is stalling.",
+            priority: 55,
+          },
+        ],
+      }),
+    ]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.skippedReason).toBeNull();
+    expect(result.wroteCount).toBe(2);
+    expect(writeItem).toHaveBeenCalledTimes(2);
+    const firstCall = writeItem.mock.calls[0]![0];
+    expect(firstCall.type).toBe("nudge");
+    expect(firstCall.title).toBe("Follow up on Figma");
+    expect(firstCall.priority).toBe(70);
+    expect(firstCall.minTimeAway).toBe(3600);
+  });
+
+  test("returns empty_items when the model emits an empty array", async () => {
+    const provider = scriptedProvider([toolUseContent({ items: [] })]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.skippedReason).toBe("empty_items");
+    expect(result.wroteCount).toBe(0);
+    expect(writeItem).not.toHaveBeenCalled();
+  });
+
+  test("caps the batch at MAX_ITEMS_PER_REFLECTION (3)", async () => {
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          { type: "nudge", title: "One", summary: "One summary" },
+          { type: "nudge", title: "Two", summary: "Two summary" },
+          { type: "nudge", title: "Three", summary: "Three summary" },
+          {
+            type: "nudge",
+            title: "Four",
+            summary: "Four summary — should be dropped.",
+          },
+        ],
+      }),
+    ]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.wroteCount).toBe(3);
+    expect(writeItem).toHaveBeenCalledTimes(3);
+  });
+
+  test("rejects malformed items but keeps valid ones in the same batch", async () => {
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          {
+            type: "nudge",
+            title: "", // empty title — rejected
+            summary: "Valid summary",
+          },
+          {
+            type: "bogus-type", // invalid type — rejected
+            title: "Valid title",
+            summary: "Valid summary",
+          },
+          {
+            type: "thread",
+            title: "Good item",
+            summary: "This one should land.",
+          },
+        ],
+      }),
+    ]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.wroteCount).toBe(1);
+    expect(writeItem).toHaveBeenCalledTimes(1);
+    expect(writeItem.mock.calls[0]![0].title).toBe("Good item");
+  });
+
+  test("returns no_provider when the resolver returns null", async () => {
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => null,
+    });
+
+    expect(result.skippedReason).toBe("no_provider");
+    expect(result.wroteCount).toBe(0);
+    expect(writeItem).not.toHaveBeenCalled();
+  });
+
+  test("returns provider_error when sendMessage throws", async () => {
+    const provider = throwingProvider(new Error("network down"));
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.skippedReason).toBe("provider_error");
+    expect(result.wroteCount).toBe(0);
+  });
+
+  test("returns malformed_output when the response has no matching tool_use block", async () => {
+    const provider = scriptedProvider([{ type: "text", text: "just prose" }]);
+
+    const result = await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(result.skippedReason).toBe("malformed_output");
+    expect(result.wroteCount).toBe(0);
+  });
+
+  test("clamps priority to the valid [0, 100] window", async () => {
+    const provider = scriptedProvider([
+      toolUseContent({
+        items: [
+          {
+            type: "nudge",
+            title: "High priority",
+            summary: "Model returned 150",
+            priority: 150,
+          },
+          {
+            type: "nudge",
+            title: "Low priority",
+            summary: "Model returned -5",
+            priority: -5,
+          },
+        ],
+      }),
+    ]);
+
+    await runReflectionProducer(new Date(), {
+      writeItem,
+      loadRelationshipState: stubRelationshipState,
+      resolveProvider: () => provider,
+    });
+
+    expect(writeItem).toHaveBeenCalledTimes(2);
+    expect(writeItem.mock.calls[0]![0].priority).toBe(100);
+    expect(writeItem.mock.calls[1]![0].priority).toBe(0);
+  });
+});

--- a/assistant/src/home/feed-scheduler.ts
+++ b/assistant/src/home/feed-scheduler.ts
@@ -136,7 +136,6 @@ export function startFeedScheduler(
       }
 
       if (nowMs - lastReflectionAt >= REFLECTION_INTERVAL_MS) {
-        lastReflectionAt = nowMs;
         summary.reflectionRan = true;
         const startedAt = Date.now();
         try {
@@ -149,7 +148,21 @@ export function startFeedScheduler(
             },
             "Reflection producer ran",
           );
+          // Only advance the cooldown gate when the producer actually
+          // had a chance to run. A `no_provider` skip means the provider
+          // registry wasn't ready yet (this happens on the startup tick
+          // because the feed scheduler boots before the provider init
+          // pass in `daemon/lifecycle.ts`); advancing the gate in that
+          // case would burn the 30-minute window and delay the first
+          // real reflection. Every other outcome — success, empty
+          // items, malformed output, provider error — is a real
+          // attempt and does advance the gate so a broken producer
+          // doesn't hammer us every tick.
+          if (result.skippedReason !== "no_provider") {
+            lastReflectionAt = nowMs;
+          }
         } catch (err) {
+          lastReflectionAt = nowMs;
           log.warn(
             { err, durationMs: Date.now() - startedAt },
             "Reflection producer threw",
@@ -200,23 +213,21 @@ export function startFeedScheduler(
  * the `resultSizeEstimate` field. Returns 0 when no Gmail connection
  * exists or the call fails so the digest generator no-ops without
  * throwing.
+ *
+ * Deliberately does NOT pre-check `isProviderConnected("google")` —
+ * that helper only reports local oauth-store rows, which are absent
+ * in managed-OAuth mode even when `resolveOAuthConnection("google")`
+ * would still resolve via the platform path. Letting the resolver
+ * make the decision is the only way to cover both modes.
  */
 async function defaultGmailCountSource(): Promise<number> {
   // Lazy import — the oauth resolver + gmail client drag in a fair
   // bit of transitive state, and we only want to pay that cost when a
   // tick actually runs (not at module load time).
-  const [
-    { isProviderConnected },
-    { resolveOAuthConnection },
-    { listMessages },
-  ] = await Promise.all([
-    import("../oauth/oauth-store.js"),
+  const [{ resolveOAuthConnection }, { listMessages }] = await Promise.all([
     import("../oauth/connection-resolver.js"),
     import("../messaging/providers/gmail/client.js"),
   ]);
-
-  const connected = await isProviderConnected("google");
-  if (!connected) return 0;
 
   try {
     const connection = await resolveOAuthConnection("google");
@@ -224,8 +235,9 @@ async function defaultGmailCountSource(): Promise<number> {
     const estimate = response.resultSizeEstimate;
     return typeof estimate === "number" && estimate >= 0 ? estimate : 0;
   } catch (err) {
-    // Gmail API failures are common and transient — log once and
-    // degrade to zero so the digest generator doesn't write a stale item.
+    // Either no Gmail connection exists (managed or direct) or the
+    // API call itself failed. Both paths degrade to zero so the
+    // digest generator no-ops without writing a stale item.
     log.warn({ err }, "Gmail count source failed; treating as zero");
     return 0;
   }

--- a/assistant/src/home/feed-scheduler.ts
+++ b/assistant/src/home/feed-scheduler.ts
@@ -1,0 +1,232 @@
+/**
+ * Home activity feed scheduler.
+ *
+ * Periodic tick loop that drives the feed producers — the assistant
+ * reflection loop and the platform-baseline Gmail digest generator. This
+ * is the layer that turns the Phase-5 scaffolding into a live feed: the
+ * producers exist as standalone functions, the writer knows how to
+ * persist their output, and the HTTP route + SSE pipeline surface it
+ * to the macOS client; this scheduler is what actually calls them.
+ *
+ * Design notes:
+ *
+ *   - Mirrors `schedule/scheduler.ts`: `setInterval` + coalescing flag
+ *     so two ticks never run in parallel, `timer.unref()` so the timer
+ *     never blocks daemon exit, stop() clears the interval on shutdown.
+ *
+ *   - Each producer tracks its own "last ran at" timestamp and decides
+ *     whether to run on each tick. This keeps the tick cadence short
+ *     (so cheap producers refresh often) while expensive producers
+ *     (LLM reflection) self-throttle independently.
+ *
+ *   - Fire-and-forget: every producer failure is logged and swallowed.
+ *     A broken producer must never break the tick loop or the daemon.
+ *
+ *   - `writeAssistantFeedItem` / `generateGmailDigest` both invoke the
+ *     feed writer directly, which publishes `home_feed_updated` on every
+ *     successful write, so the macOS store auto-refreshes without this
+ *     scheduler needing to touch the event hub.
+ */
+
+import { getLogger } from "../util/logger.js";
+import type { FeedItem } from "./feed-types.js";
+import {
+  generateGmailDigest,
+  type GmailCountSource,
+} from "./platform-gmail-digest.js";
+import {
+  type ReflectionResult,
+  runReflectionProducer,
+} from "./reflection-producer.js";
+
+const log = getLogger("home-feed-scheduler");
+
+/** Tick cadence — fast enough for a Gmail digest to feel fresh. */
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Per-producer minimum gap between runs. */
+const GMAIL_DIGEST_INTERVAL_MS = 5 * 60 * 1000;
+const REFLECTION_INTERVAL_MS = 30 * 60 * 1000;
+
+export interface FeedSchedulerHandle {
+  /** Stops the interval. Safe to call multiple times. */
+  stop(): void;
+  /**
+   * Run a single tick synchronously for tests. Returns a summary of
+   * which producers ran during this tick.
+   */
+  runOnce(now?: Date): Promise<FeedTickSummary>;
+}
+
+export interface FeedTickSummary {
+  gmailDigestRan: boolean;
+  reflectionRan: boolean;
+}
+
+export interface FeedSchedulerOptions {
+  /**
+   * Optional count source for the Gmail digest. Defaults to
+   * {@link defaultGmailCountSource}, which reads the active OAuth
+   * connection and issues one `messages.list?q=is:unread&maxResults=1`
+   * call to read the `resultSizeEstimate` field (no body fetches).
+   */
+  gmailCountSource?: GmailCountSource;
+  /**
+   * When true (the default), the scheduler fires one tick synchronously
+   * after startup so the feed is populated on the first app open after
+   * daemon boot. Set to false in tests so the only ticks that run are
+   * the ones the test drives via `runOnce()`.
+   */
+  runOnStart?: boolean;
+  /**
+   * Dependency seams for tests. Production callers pass `undefined` so
+   * the scheduler uses the real producer implementations. Tests pass
+   * spies to avoid `mock.module`, which leaks across files in Bun's
+   * test runner.
+   */
+  gmailDigestRunner?: (
+    now: Date,
+    countSource: GmailCountSource,
+  ) => Promise<FeedItem | null>;
+  reflectionRunner?: (now: Date) => Promise<ReflectionResult>;
+}
+
+/**
+ * Start the home feed scheduler. Returns a handle whose `stop()` is
+ * wired into the daemon shutdown sequence via `ShutdownDeps`.
+ */
+export function startFeedScheduler(
+  options: FeedSchedulerOptions = {},
+): FeedSchedulerHandle {
+  let stopped = false;
+  let tickRunning = false;
+  let lastGmailDigestAt = 0;
+  let lastReflectionAt = 0;
+
+  const gmailCountSource = options.gmailCountSource ?? defaultGmailCountSource;
+  const gmailDigestRunner = options.gmailDigestRunner ?? generateGmailDigest;
+  const reflectionRunner =
+    options.reflectionRunner ?? ((now: Date) => runReflectionProducer(now));
+
+  const tick = async (now: Date = new Date()): Promise<FeedTickSummary> => {
+    const summary: FeedTickSummary = {
+      gmailDigestRan: false,
+      reflectionRan: false,
+    };
+    if (stopped || tickRunning) return summary;
+    tickRunning = true;
+    const nowMs = now.getTime();
+    try {
+      if (nowMs - lastGmailDigestAt >= GMAIL_DIGEST_INTERVAL_MS) {
+        lastGmailDigestAt = nowMs;
+        summary.gmailDigestRan = true;
+        const startedAt = Date.now();
+        try {
+          const item = await gmailDigestRunner(now, gmailCountSource);
+          log.info(
+            { wroteItem: item !== null, durationMs: Date.now() - startedAt },
+            "Gmail digest producer ran",
+          );
+        } catch (err) {
+          log.warn(
+            { err, durationMs: Date.now() - startedAt },
+            "Gmail digest producer threw",
+          );
+        }
+      }
+
+      if (nowMs - lastReflectionAt >= REFLECTION_INTERVAL_MS) {
+        lastReflectionAt = nowMs;
+        summary.reflectionRan = true;
+        const startedAt = Date.now();
+        try {
+          const result = await reflectionRunner(now);
+          log.info(
+            {
+              wroteCount: result.wroteCount,
+              skippedReason: result.skippedReason,
+              durationMs: Date.now() - startedAt,
+            },
+            "Reflection producer ran",
+          );
+        } catch (err) {
+          log.warn(
+            { err, durationMs: Date.now() - startedAt },
+            "Reflection producer threw",
+          );
+        }
+      }
+    } finally {
+      tickRunning = false;
+    }
+    return summary;
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, TICK_INTERVAL_MS);
+  timer.unref();
+  if (options.runOnStart !== false) {
+    // Fire once on startup so the feed is populated on the first app
+    // open after daemon boot. Runs in the background — startup does
+    // not await it.
+    void tick();
+  }
+
+  log.info(
+    {
+      tickIntervalMs: TICK_INTERVAL_MS,
+      gmailDigestIntervalMs: GMAIL_DIGEST_INTERVAL_MS,
+      reflectionIntervalMs: REFLECTION_INTERVAL_MS,
+    },
+    "Home feed scheduler started",
+  );
+
+  return {
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+      log.info("Home feed scheduler stopped");
+    },
+    runOnce: tick,
+  };
+}
+
+/**
+ * Default Gmail count source — resolves the active `google` OAuth
+ * connection via {@link resolveOAuthConnection}, issues one cheap
+ * `messages.list` call with `q=is:unread&maxResults=1`, and returns
+ * the `resultSizeEstimate` field. Returns 0 when no Gmail connection
+ * exists or the call fails so the digest generator no-ops without
+ * throwing.
+ */
+async function defaultGmailCountSource(): Promise<number> {
+  // Lazy import — the oauth resolver + gmail client drag in a fair
+  // bit of transitive state, and we only want to pay that cost when a
+  // tick actually runs (not at module load time).
+  const [
+    { isProviderConnected },
+    { resolveOAuthConnection },
+    { listMessages },
+  ] = await Promise.all([
+    import("../oauth/oauth-store.js"),
+    import("../oauth/connection-resolver.js"),
+    import("../messaging/providers/gmail/client.js"),
+  ]);
+
+  const connected = await isProviderConnected("google");
+  if (!connected) return 0;
+
+  try {
+    const connection = await resolveOAuthConnection("google");
+    const response = await listMessages(connection, "is:unread", 1);
+    const estimate = response.resultSizeEstimate;
+    return typeof estimate === "number" && estimate >= 0 ? estimate : 0;
+  } catch (err) {
+    // Gmail API failures are common and transient — log once and
+    // degrade to zero so the digest generator doesn't write a stale item.
+    log.warn({ err }, "Gmail count source failed; treating as zero");
+    return 0;
+  }
+}

--- a/assistant/src/home/reflection-producer.ts
+++ b/assistant/src/home/reflection-producer.ts
@@ -200,10 +200,19 @@ export async function runReflectionProducer(
     return { wroteCount: 0, skippedReason: "empty_items" };
   }
 
+  const capped = rawItems.slice(0, MAX_ITEMS_PER_REFLECTION);
   const accepted: WriteAssistantFeedItemParams[] = [];
-  for (const raw of rawItems.slice(0, MAX_ITEMS_PER_REFLECTION)) {
+  for (const raw of capped) {
     const params = coerceReflectionItem(raw);
     if (params) accepted.push(params);
+  }
+
+  // If the model returned items but every single one failed coercion,
+  // that's a schema-drift signal we want loud in production logs — a
+  // silent "wroteCount: 0, skippedReason: null" would look like a
+  // normal quiet tick and bury the bug. Report it as malformed_output.
+  if (accepted.length === 0) {
+    return { wroteCount: 0, skippedReason: "malformed_output" };
   }
 
   let wroteCount = 0;

--- a/assistant/src/home/reflection-producer.ts
+++ b/assistant/src/home/reflection-producer.ts
@@ -1,0 +1,318 @@
+/**
+ * Assistant reflection producer for the home activity feed.
+ *
+ * On a tick, asks the configured inference provider "given this
+ * relationship state, is there anything worth nudging the user about
+ * right now?" and emits 0–N assistant-authored feed items. Mirrors the
+ * background-inference pattern established in `approval-generators.ts`:
+ * resolve the provider from config, call `provider.sendMessage` with a
+ * `tool_use`-shaped structured output schema, validate each returned
+ * block, and hand the validated shapes to `writeAssistantFeedItem`.
+ *
+ * Budget notes:
+ *
+ *   - Hard cap: {@link MAX_ITEMS_PER_REFLECTION} items per tick so a
+ *     single run can never flood the feed.
+ *   - Timeout: {@link REFLECTION_TIMEOUT_MS} so a stalled provider
+ *     can't stall the tick loop.
+ *   - Token budget: {@link REFLECTION_MAX_TOKENS} — tight, because
+ *     the output is a list of short feed items, not a long essay.
+ *
+ * Failure modes degrade gracefully: an unavailable provider, a
+ * malformed tool_use block, a schema-rejected item, or an exception
+ * in the inner loop all return a {@link ReflectionResult} with the
+ * appropriate `skippedReason`. The scheduler logs these but never
+ * surfaces them to the user.
+ */
+
+import { loadConfig } from "../config/loader.js";
+import { getProvider, listProviders } from "../providers/registry.js";
+import type { Provider } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+import {
+  writeAssistantFeedItem,
+  type WriteAssistantFeedItemParams,
+} from "./assistant-feed-authoring.js";
+import { computeRelationshipState } from "./relationship-state-writer.js";
+
+const log = getLogger("home-feed-reflection");
+
+const REFLECTION_TIMEOUT_MS = 30_000;
+const REFLECTION_MAX_TOKENS = 800;
+const MAX_ITEMS_PER_REFLECTION = 3;
+
+const REFLECTION_TOOL_NAME = "write_feed_items";
+
+const REFLECTION_SYSTEM_PROMPT = [
+  "You are a background reflection loop for a personal assistant.",
+  "Your job is to decide whether there is anything worth surfacing to the user on their Home page right now.",
+  "",
+  "Rules:",
+  "- Emit nudges only when there is a CLEAR, SPECIFIC, ACTIONABLE reason.",
+  "- Never emit generic filler like 'stay productive' or 'here's a suggestion'.",
+  "- Never repeat the same nudge on consecutive runs — trust the writer's one-per-source replacement to dedupe.",
+  "- Prefer 0 items over low-quality items.",
+  "- You may emit up to 3 items total.",
+  "",
+  "Use the `write_feed_items` tool to emit items. If nothing is worth surfacing, call the tool with an empty `items` array.",
+].join("\n");
+
+const REFLECTION_TOOL_SCHEMA = {
+  name: REFLECTION_TOOL_NAME,
+  description:
+    "Record the set of feed items to surface on the user's Home page for this reflection tick. " +
+    "Pass an empty `items` array if nothing is worth surfacing right now.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      items: {
+        type: "array",
+        maxItems: MAX_ITEMS_PER_REFLECTION,
+        items: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["nudge", "digest", "action", "thread"],
+              description:
+                "The visual shape: nudge (card with action buttons), digest (summary row), action (already-done announcement), thread (ongoing situation).",
+            },
+            source: {
+              type: "string",
+              enum: ["gmail", "slack", "calendar", "assistant"],
+              description:
+                "Origin hint used for the icon. Use 'assistant' when the nudge is self-initiated.",
+            },
+            title: {
+              type: "string",
+              description:
+                "Short headline, 4–10 words. Lowercase-sentence-case, no period.",
+            },
+            summary: {
+              type: "string",
+              description:
+                "One-sentence body copy explaining the nudge. 1–25 words.",
+            },
+            priority: {
+              type: "integer",
+              minimum: 0,
+              maximum: 100,
+              description:
+                "Relative importance (higher = more prominent). Use 70 for normal nudges, 85 for time-sensitive, 55 for background threads.",
+            },
+            minTimeAway: {
+              type: "integer",
+              minimum: 0,
+              description:
+                "Seconds the user must be away before this item appears. Use 3600 (1h) for nudges, 0 for threads the user should see immediately.",
+            },
+          },
+          required: ["type", "title", "summary"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["items"],
+    additionalProperties: false,
+  },
+};
+
+export interface ReflectionResult {
+  /** Number of items actually written to the feed. */
+  wroteCount: number;
+  /**
+   * When non-null, indicates the producer short-circuited and no LLM
+   * call was made (or the call's result was unusable). The scheduler
+   * logs this but does not treat it as an error.
+   */
+  skippedReason:
+    | "no_provider"
+    | "empty_items"
+    | "provider_error"
+    | "malformed_output"
+    | null;
+}
+
+/**
+ * Dependency seams exposed for tests. Production callers pass
+ * `undefined` so the producer uses the real helpers. Tests pass
+ * stubs to avoid `mock.module`, which leaks across files in Bun's
+ * test runner and causes cross-file isolation bugs.
+ */
+export interface ReflectionProducerDeps {
+  writeItem?: (params: WriteAssistantFeedItemParams) => Promise<unknown>;
+  loadRelationshipState?: () => Promise<
+    Awaited<ReturnType<typeof computeRelationshipState>>
+  >;
+  resolveProvider?: () => Provider | null;
+}
+
+/**
+ * Run one reflection pass. Loads the current relationship state,
+ * builds a user prompt around it, asks the provider for a
+ * `write_feed_items` tool call, and invokes
+ * {@link writeAssistantFeedItem} for each item in the returned array.
+ */
+export async function runReflectionProducer(
+  now: Date = new Date(),
+  deps: ReflectionProducerDeps = {},
+): Promise<ReflectionResult> {
+  const writeItem = deps.writeItem ?? writeAssistantFeedItem;
+  const loadRelationshipState =
+    deps.loadRelationshipState ?? computeRelationshipState;
+
+  const provider = deps.resolveProvider
+    ? deps.resolveProvider()
+    : resolveDefaultProvider();
+  if (!provider) {
+    return { wroteCount: 0, skippedReason: "no_provider" };
+  }
+
+  const state = await loadRelationshipState();
+  const userPrompt = buildUserPrompt(state, now);
+
+  let response;
+  try {
+    response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: userPrompt }] }],
+      [REFLECTION_TOOL_SCHEMA],
+      REFLECTION_SYSTEM_PROMPT,
+      {
+        config: { max_tokens: REFLECTION_MAX_TOKENS },
+        signal: AbortSignal.timeout(REFLECTION_TIMEOUT_MS),
+      },
+    );
+  } catch (err) {
+    log.warn({ err }, "Reflection provider.sendMessage failed");
+    return { wroteCount: 0, skippedReason: "provider_error" };
+  }
+
+  const toolUse = response.content.find(
+    (block) => block.type === "tool_use" && block.name === REFLECTION_TOOL_NAME,
+  );
+  if (!toolUse || toolUse.type !== "tool_use") {
+    return { wroteCount: 0, skippedReason: "malformed_output" };
+  }
+
+  const input = toolUse.input as Record<string, unknown>;
+  const rawItems = Array.isArray(input.items) ? input.items : null;
+  if (!rawItems || rawItems.length === 0) {
+    return { wroteCount: 0, skippedReason: "empty_items" };
+  }
+
+  const accepted: WriteAssistantFeedItemParams[] = [];
+  for (const raw of rawItems.slice(0, MAX_ITEMS_PER_REFLECTION)) {
+    const params = coerceReflectionItem(raw);
+    if (params) accepted.push(params);
+  }
+
+  let wroteCount = 0;
+  for (const params of accepted) {
+    try {
+      await writeItem(params);
+      wroteCount += 1;
+    } catch (err) {
+      // Schema rejection is a model-output bug, not a regression in the
+      // writer — log and keep going so a single malformed item doesn't
+      // block the rest of the batch.
+      log.warn({ err, params }, "Failed to write reflection item");
+    }
+  }
+
+  return { wroteCount, skippedReason: null };
+}
+
+function resolveDefaultProvider(): ReturnType<typeof getProvider> | null {
+  const config = loadConfig();
+  if (!listProviders().includes(config.services.inference.provider)) {
+    return null;
+  }
+  return getProvider(config.services.inference.provider);
+}
+
+/**
+ * Build the user-prompt context for one reflection pass. Kept small:
+ * the system prompt already enumerates the rules, and extra context
+ * mostly encourages hallucination. Only include fields that meaningfully
+ * change what's worth surfacing.
+ */
+function buildUserPrompt(
+  state: Awaited<ReturnType<typeof computeRelationshipState>>,
+  now: Date,
+): string {
+  const factLines = state.facts
+    .slice(0, 20)
+    .map((f) => `  - ${f.category}: ${f.text}`)
+    .join("\n");
+
+  return [
+    `Current time: ${now.toISOString()}`,
+    `Assistant name: ${state.assistantName}`,
+    state.userName ? `User name: ${state.userName}` : "User name: (unknown)",
+    `Relationship tier: ${state.tier} / 4`,
+    `Progress toward next tier: ${state.progressPercent}%`,
+    `Conversation count: ${state.conversationCount}`,
+    "",
+    "Known facts about the user:",
+    factLines.length > 0 ? factLines : "  (none yet)",
+    "",
+    "Based on this, is there anything worth nudging the user about right now? Remember: prefer 0 items over filler. Use the `write_feed_items` tool.",
+  ].join("\n");
+}
+
+/**
+ * Coerce a raw tool_use item into
+ * {@link WriteAssistantFeedItemParams}, returning null if the shape is
+ * unrecoverable. The schema on the provider side enforces most of
+ * this, but the runtime check guards against model drift.
+ */
+function coerceReflectionItem(
+  raw: unknown,
+): WriteAssistantFeedItemParams | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+
+  const type = obj.type;
+  if (
+    type !== "nudge" &&
+    type !== "digest" &&
+    type !== "action" &&
+    type !== "thread"
+  ) {
+    return null;
+  }
+
+  const title = typeof obj.title === "string" ? obj.title.trim() : "";
+  const summary = typeof obj.summary === "string" ? obj.summary.trim() : "";
+  if (!title || !summary) return null;
+
+  const source = obj.source;
+  let coercedSource: WriteAssistantFeedItemParams["source"];
+  if (
+    source === "gmail" ||
+    source === "slack" ||
+    source === "calendar" ||
+    source === "assistant"
+  ) {
+    coercedSource = source;
+  }
+
+  const priority =
+    typeof obj.priority === "number" && Number.isInteger(obj.priority)
+      ? Math.max(0, Math.min(100, obj.priority))
+      : undefined;
+
+  const minTimeAway =
+    typeof obj.minTimeAway === "number" && Number.isInteger(obj.minTimeAway)
+      ? Math.max(0, obj.minTimeAway)
+      : undefined;
+
+  return {
+    type,
+    source: coercedSource,
+    title,
+    summary,
+    priority,
+    minTimeAway,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 5 ([JARVIS-510](https://linear.app/vellum/issue/JARVIS-510)) shipped the home-feed scaffolding but every producer was a stub — the Gmail digest returned 0 and nothing ever called \`writeAssistantFeedItem\`. This PR turns on the lights with a periodic tick loop driving two producers.

### Scheduler
- **New \`assistant/src/home/feed-scheduler.ts\`** — 5-minute tick cadence, mirrors the existing \`schedule/scheduler.ts\` pattern (setInterval + coalescing flag + \`timer.unref()\` + \`stop()\`)
- Each producer gates itself with its own interval so cheap producers refresh often while expensive ones self-throttle
- Fires once on startup so the feed is populated on first app open after daemon boot (\`runOnStart: false\` for tests)
- Wired into daemon lifecycle alongside the existing scheduler; added to \`ShutdownDeps\` so \`.stop()\` runs on shutdown

### Gmail digest producer
- \`defaultGmailCountSource\` resolves the active \`google\` OAuth connection via \`resolveOAuthConnection\`, issues one \`messages.list?q=is:unread&maxResults=1\` call, and returns \`resultSizeEstimate\` — no message bodies fetched
- Returns 0 on any failure so the digest generator no-ops gracefully
- Cadence: 5 min, matching the tick loop

### Reflection producer
- **New \`assistant/src/home/reflection-producer.ts\`** — mirrors the background-inference pattern from \`approval-generators.ts\`
- Loads config → resolves provider → calls \`provider.sendMessage\` with a tight system prompt and a \`write_feed_items\` tool_use schema → coerces each returned item through a strict runtime validator → hands off to \`writeAssistantFeedItem\`
- Hard caps: 3 items per tick, 30s timeout, 800 max tokens
- Cadence: 30 min (expensive, self-throttled)
- Failure modes degrade gracefully: \`no_provider\` / \`provider_error\` / \`malformed_output\` / \`empty_items\` all return a structured result the scheduler logs but never escalates

### Dependency injection
Both the scheduler and the reflection producer accept optional deps (runner spies, write callbacks, provider resolvers) so tests stub the seams directly instead of using \`mock.module\`, which leaks across files in Bun's test runner and caused the cross-file isolation bug noted at the end of Phase 5.

## Plan
Part of [JARVIS-510](https://linear.app/vellum/issue/JARVIS-510)
Closes [JARVIS-511](https://linear.app/vellum/issue/JARVIS-511)

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run lint:unused\` (knip) clean
- [x] \`bun test src/home/\` — 131/131 pass (6 new feed-scheduler + 8 new reflection-producer)
- [ ] CI green
- [ ] **Manual smoke test**: start the daemon, open the Home panel, wait ~30 min for the reflection tick to fire; verify items appear. Gmail digest: connect a Gmail account with unread mail, wait 5 min, verify a \`"N new emails"\` digest appears.

## Out of scope
- macOS client changes (@alex is iterating on \`HomePageView\` / \`HomeFeedSection\` separately using the existing data models)
- Per-workspace budgets
- A real integration event bus — this ships with a direct API-call + LLM-reflection stopgap
- Non-Gmail platform-baseline digest sources (Slack, calendar, GitHub)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
