### PR TITLE
fix(gateway): fall back to plain text when Slack rejects Block Kit blocks

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -12,6 +12,8 @@ let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
   async () => new Response(),
 );
 
+const logCalls: { args: unknown[]; method: string }[] = [];
+
 mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
@@ -21,6 +23,29 @@ mock.module("../auth/token-exchange.js", () => ({
   mintServiceToken: () => "mock-service-token",
   mintExchangeToken: () => "mock-exchange-token",
   validateEdgeToken: () => ({ ok: true }),
+}));
+
+function createMockLogger(): Record<string, unknown> {
+  const target = {} as Record<string, unknown>;
+  const proxy = new Proxy(target, {
+    get: (_innerTarget, prop) => {
+      if (prop === "child") {
+        return () => proxy;
+      }
+
+      if (typeof prop !== "string") return undefined;
+
+      return (...args: unknown[]) => {
+        logCalls.push({ method: prop, args });
+      };
+    },
+  });
+
+  return proxy;
+}
+
+mock.module("../logger.js", () => ({
+  getLogger: () => createMockLogger(),
 }));
 
 const { createSlackDeliverHandler } =
@@ -113,6 +138,7 @@ let fetchCalls: {
 
 beforeEach(() => {
   fetchCalls = [];
+  logCalls.length = 0;
   process.env.APP_VERSION = "0.0.0-dev";
   fetchMock = mock(
     async (input: string | URL | Request, init?: RequestInit) => {
@@ -906,6 +932,164 @@ describe("slack-deliver endpoint", () => {
     expect(postCall).toBeDefined();
     const updateCall = fetchCalls.find((c) => c.url.includes("chat.update"));
     expect(updateCall).toBeUndefined();
+  });
+
+  test("retries chat.postMessage without blocks when Slack returns invalid_blocks", async () => {
+    let postMessageCalls = 0;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        let body: unknown;
+        let rawBody: string | undefined;
+        try {
+          if (init?.body && typeof init.body === "string") {
+            rawBody = init.body;
+            body = JSON.parse(init.body);
+          }
+        } catch {
+          /* not JSON */
+        }
+        fetchCalls.push({ url, body, rawBody });
+
+        if (url.includes("chat.postMessage")) {
+          postMessageCalls++;
+          // First call (with blocks) fails with invalid_blocks;
+          // second call (without blocks) succeeds.
+          if (postMessageCalls === 1) {
+            return new Response(
+              JSON.stringify({ ok: false, error: "invalid_blocks" }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            );
+          }
+          return new Response(
+            JSON.stringify({ ok: true, ts: "123.456" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    const handler = createSlackDeliverHandler(
+      makeConfig(),
+      undefined,
+      makeCaches(),
+    );
+    const customBlocks = [
+      { type: "section", text: { type: "mrkdwn", text: "Rich content" } },
+    ];
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Plain text fallback",
+      blocks: customBlocks,
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Should have called chat.postMessage exactly twice.
+    const postCalls = fetchCalls.filter((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(postCalls.length).toBe(2);
+
+    // First call includes blocks.
+    expect((postCalls[0]!.body as any).blocks).toBeDefined();
+    expect((postCalls[0]!.body as any).blocks).toEqual(customBlocks);
+
+    // Second call (retry) has no blocks field but preserves text.
+    expect((postCalls[1]!.body as any).blocks).toBeUndefined();
+    expect((postCalls[1]!.body as any).text).toBe("Plain text fallback");
+    expect((postCalls[1]!.body as any).channel).toBe("C123");
+
+    // A warn-level log was emitted describing the fallback.
+    const retryLog = logCalls.find((c) => {
+      const [firstArg, secondArg] = c.args;
+      const message =
+        typeof firstArg === "string"
+          ? firstArg
+          : typeof secondArg === "string"
+            ? secondArg
+            : undefined;
+      return (
+        c.method === "warn" &&
+        typeof message === "string" &&
+        message.includes("Retrying Slack delivery without blocks")
+      );
+    });
+    expect(retryLog).toBeDefined();
+  });
+
+  test("does not retry when Slack returns a non-invalid_blocks error", async () => {
+    let postMessageCalls = 0;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        let body: unknown;
+        let rawBody: string | undefined;
+        try {
+          if (init?.body && typeof init.body === "string") {
+            rawBody = init.body;
+            body = JSON.parse(init.body);
+          }
+        } catch {
+          /* not JSON */
+        }
+        fetchCalls.push({ url, body, rawBody });
+
+        if (url.includes("chat.postMessage")) {
+          postMessageCalls++;
+          return new Response(
+            JSON.stringify({ ok: false, error: "channel_not_found" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    const handler = createSlackDeliverHandler(
+      makeConfig(),
+      undefined,
+      makeCaches(),
+    );
+    const customBlocks = [
+      { type: "section", text: { type: "mrkdwn", text: "Rich content" } },
+    ];
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Plain text fallback",
+      blocks: customBlocks,
+    });
+    const res = await handler(req);
+    // channel_not_found maps to a 404 from the helper; either way the
+    // handler must NOT retry with blocks removed.
+    expect(res.status).toBe(404);
+
+    // chat.postMessage should have been called exactly once.
+    expect(postMessageCalls).toBe(1);
+    const postCalls = fetchCalls.filter((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(postCalls.length).toBe(1);
   });
 });
 

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -24,8 +24,21 @@ type SlackApiResult = {
 };
 
 /**
+ * Surfaced when Slack returns `ok: false` with a non-retryable error. Callers
+ * can branch on `slackError` (e.g. retry without blocks for `invalid_blocks`)
+ * before falling through to the transport-error path.
+ */
+type SlackApiError = {
+  kind: "slack_error";
+  slackError: string | undefined;
+  response: Response;
+};
+
+/**
  * Call a Slack API method with rate-limit retries. Returns the parsed
- * JSON body on success, or a ready-made error Response on failure.
+ * JSON body on success, a `SlackApiError` for non-retryable Slack errors
+ * (so callers can inspect `slackError`), or a ready-made error `Response`
+ * for transport-level failures (429/5xx exhausted, etc.).
  */
 async function callSlackApiWithRetries(
   url: string,
@@ -33,7 +46,7 @@ async function callSlackApiWithRetries(
   botToken: string,
   chatId: string,
   tlog: Pick<ReturnType<typeof getLogger>, "error" | "warn" | "info">,
-): Promise<SlackApiResult | Response> {
+): Promise<SlackApiResult | SlackApiError | Response> {
   let lastError: string | undefined;
 
   for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
@@ -107,31 +120,40 @@ async function callSlackApiWithRetries(
 
       const userMessage = getUserMessage(data.error);
 
+      let errorResponse: Response;
       if (category === "rate_limit") {
-        return Response.json(
+        errorResponse = Response.json(
           { error: "Rate limited", ...(userMessage && { userMessage }) },
           { status: 429 },
         );
-      }
-      if (category === "channel_not_found" || category === "not_found") {
-        return Response.json(
+      } else if (
+        category === "channel_not_found" ||
+        category === "not_found"
+      ) {
+        errorResponse = Response.json(
           { error: "Channel not found", ...(userMessage && { userMessage }) },
           { status: 404 },
         );
-      }
-      if (category === "permission") {
-        return Response.json(
+      } else if (category === "permission") {
+        errorResponse = Response.json(
           { error: "Permission denied", ...(userMessage && { userMessage }) },
           { status: 403 },
         );
+      } else {
+        // Auth errors use 502 so downstream retry logic treats them as
+        // transient (token rotation, brief credential desync). Permanent
+        // auth failures will exhaust retries and be dead-lettered normally.
+        errorResponse = Response.json(
+          { error: "Delivery failed", ...(userMessage && { userMessage }) },
+          { status: 502 },
+        );
       }
-      // Auth errors use 502 so downstream retry logic treats them as
-      // transient (token rotation, brief credential desync). Permanent
-      // auth failures will exhaust retries and be dead-lettered normally.
-      return Response.json(
-        { error: "Delivery failed", ...(userMessage && { userMessage }) },
-        { status: 502 },
-      );
+
+      return {
+        kind: "slack_error",
+        slackError: data.error,
+        response: errorResponse,
+      };
     }
 
     return { ok: true, ts: data.ts };
@@ -799,6 +821,8 @@ export function createSlackDeliverHandler(
         onThreadReply(threadTs);
       }
 
+      let usedBlockFallback = false;
+
       if (text && typeof text === "string") {
         const slackBody: Record<string, unknown> = {
           channel: chatId,
@@ -821,7 +845,8 @@ export function createSlackDeliverHandler(
           slackBody.user = body.user!;
         }
 
-        let result: SlackApiResult | Response;
+        let result: SlackApiResult | SlackApiError | Response;
+        let blockFallback = false;
 
         if (isUpdate) {
           // chat.update only accepts channel, ts, text, and blocks — thread_ts
@@ -842,8 +867,14 @@ export function createSlackDeliverHandler(
             tlog,
           );
 
-          // Fall back to posting a new message if update fails
-          if (result instanceof Response) {
+          // Fall back to posting a new message if update fails (either a
+          // transport error or a Slack-level error). The caller of chat.update
+          // may still retry without blocks below if the fallback
+          // chat.postMessage also reports invalid_blocks.
+          if (
+            result instanceof Response ||
+            ("kind" in result && result.kind === "slack_error")
+          ) {
             tlog.warn(
               { chatId, messageTs },
               "Slack chat.update failed, falling back to chat.postMessage",
@@ -870,10 +901,59 @@ export function createSlackDeliverHandler(
           );
         }
 
-        // If result is a Response, it's an error response — return it directly
+        // If Slack rejected the Block Kit payload, retry chat.postMessage
+        // once with plain text only. Approval prompts have a required Block
+        // Kit structure — skip the fallback for those since plain text is
+        // not a valid substitute. Ephemeral messages are also skipped so
+        // the retry doesn't broadcast a private message to the whole
+        // channel (postEphemeral is the only way to preserve ephemerality,
+        // but if Slack rejected its blocks it will reject them here too).
+        if (
+          !(result instanceof Response) &&
+          "kind" in result &&
+          result.kind === "slack_error" &&
+          result.slackError === "invalid_blocks" &&
+          !body.approval &&
+          !isEphemeral &&
+          Array.isArray(slackBody.blocks) &&
+          slackBody.blocks.length > 0
+        ) {
+          const originalBlockCount = slackBody.blocks.length;
+          tlog.warn(
+            {
+              chatId,
+              originalBlockCount,
+              textLength: text.length,
+            },
+            "Retrying Slack delivery without blocks after invalid_blocks",
+          );
+          const { blocks: _omitBlocks, ...plainSlackBody } = slackBody;
+          result = await callSlackApiWithRetries(
+            "https://slack.com/api/chat.postMessage",
+            plainSlackBody,
+            botToken,
+            chatId,
+            tlog,
+          );
+          if (
+            !(result instanceof Response) &&
+            !("kind" in result && result.kind === "slack_error")
+          ) {
+            blockFallback = true;
+          }
+        }
+
+        // If result is a Response, it's a transport-level error — return it directly
         if (result instanceof Response) {
           return result;
         }
+        // If it's a Slack-level error, return the stashed error response.
+        if ("kind" in result && result.kind === "slack_error") {
+          return result.response;
+        }
+
+        // Surface the block-fallback flag to the normal success log below.
+        usedBlockFallback = blockFallback;
       }
 
       if (attachments && attachments.length > 0) {
@@ -894,6 +974,7 @@ export function createSlackDeliverHandler(
           ephemeral: isEphemeral,
           hasText: !!text,
           attachmentCount: attachments?.length ?? 0,
+          ...(usedBlockFallback && { blockFallback: true }),
         },
         isUpdate ? "Slack message updated" : "Slack message sent",
       );


### PR DESCRIPTION
## Summary
- Gateway now retries chat.postMessage without blocks when Slack returns invalid_blocks, preventing silent drop of responses that produce a block Slack cannot render.
- callSlackApiWithRetries surfaces the Slack error string so callers can branch on it; transport-error path is unchanged.
- Adds regression tests for the invalid_blocks fallback and the no-retry path for other errors.

Part of plan: slack-delivery-fix.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
