### PR TITLE
refactor(slack-adapter): split read vs write auth resolution

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Guard test that verifies the Slack adapter routes reads and writes through
+ * the correct cached auth. Today (PR 3 of the slack-user-token-triage plan)
+ * both caches hold the bot token — this test locks in that behavior so the
+ * follow-up PR that introduces user_token for reads cannot silently regress
+ * write routing.
+ *
+ * PR 5 will extend this file with a two-token case (bot + user) asserting
+ * reads switch to the user token while writes stay on the bot token.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { credentialKey } from "../../../../security/credential-key.js";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+const getSecureKeyAsyncMock = mock(
+  async (_key: string): Promise<string | null> => null,
+);
+mock.module("../../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+// OAuth helpers aren't exercised when a bot token is present, but the adapter
+// imports them at module load — provide no-op stubs so imports resolve.
+mock.module("../../../../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: async (): Promise<OAuthConnection> => {
+    throw new Error(
+      "resolveOAuthConnection should not be called when bot_token is present",
+    );
+  },
+}));
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  isProviderConnected: async () => false,
+}));
+
+// Stub contact DB access so the adapter doesn't touch SQLite during the test.
+mock.module("../../../../contacts/contact-store.js", () => ({
+  findContactChannel: () => undefined,
+}));
+mock.module("../../../../contacts/contacts-write.js", () => ({
+  upsertContactChannel: () => {},
+}));
+
+import { slackProvider } from "../adapter.js";
+
+// ── fetch capture ───────────────────────────────────────────────────────────
+
+type CapturedRequest = {
+  url: string;
+  method: string;
+  authorization: string | null;
+};
+
+const captured: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+
+function installFetchStub() {
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = new Headers(init?.headers ?? {});
+    captured.push({
+      url,
+      method,
+      authorization: headers.get("authorization"),
+    });
+
+    // Craft a minimal OK Slack API envelope per endpoint so the adapter's
+    // post-call mapping doesn't throw.
+    const body = fakeSlackResponse(url);
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function fakeSlackResponse(url: string): Record<string, unknown> {
+  if (url.includes("/conversations.list")) {
+    return { ok: true, channels: [], response_metadata: { next_cursor: "" } };
+  }
+  if (url.includes("/chat.postMessage")) {
+    return { ok: true, ts: "1700000000.000100", channel: "C123" };
+  }
+  // Default envelope for any other method the adapter might call.
+  return { ok: true };
+}
+
+// ── Test setup ──────────────────────────────────────────────────────────────
+
+const BOT_TOKEN = "xoxb-BOT";
+
+describe("Slack adapter token routing", () => {
+  beforeEach(() => {
+    captured.length = 0;
+    getSecureKeyAsyncMock.mockReset();
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      return null;
+    });
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("bot-token only: reads and writes both authenticate with the bot token (behavior-preserving refactor)", async () => {
+    // Populate both caches via resolveConnection(). With only a bot token
+    // configured today, read auth and write auth both resolve to it.
+    const resolved = await slackProvider.resolveConnection!();
+    expect(resolved).toBeUndefined();
+
+    // Read path: listConversations → /conversations.list must use bot token.
+    await slackProvider.listConversations(undefined);
+    const readCall = captured.find((c) =>
+      c.url.includes("/conversations.list"),
+    );
+    expect(readCall).toBeDefined();
+    expect(readCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+
+    // Write path: sendMessage → /chat.postMessage must also use bot token
+    // (same token until PR 5 introduces a user_token for reads).
+    await slackProvider.sendMessage(undefined, "C123", "hello");
+    const writeCall = captured.find((c) => c.url.includes("/chat.postMessage"));
+    expect(writeCall).toBeDefined();
+    expect(writeCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+});

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -35,25 +35,54 @@ import type {
 const userNameCache = new Map<string, string>();
 
 /**
- * Cached auth resolved during resolveConnection().
+ * Cached auth resolved during resolveConnection(), split by direction.
  *
- * For Socket Mode this holds a raw bot token string; for OAuth it holds the
+ * Read and write auth are tracked separately so a future change can point
+ * reads at a user OAuth token (xoxp-) while writes continue to use the bot
+ * token (xoxb-). Today both caches hold the same value (behavior-preserving
+ * refactor); PR 5 of the slack-user-token-triage plan wires a user_token
+ * into the read cache.
+ *
+ * For Socket Mode these hold a raw bot token string; for OAuth they hold the
  * OAuthConnection. The Slack client functions accept both via their own
- * OAuthConnection | string union, so we can pass this value through directly.
+ * OAuthConnection | string union, so we can pass the cached value through
+ * directly.
  */
-let _cachedSlackAuth: OAuthConnection | string | null = null;
+let _cachedSlackWriteAuth: OAuthConnection | string | null = null;
+let _cachedSlackReadAuth: OAuthConnection | string | null = null;
 
 /**
  * Get the Slack auth value to pass to Slack client functions.
  * Prefers the explicit connection from the caller; falls back to the cached
- * value set during resolveConnection().
+ * write auth (which equals the read auth until PR 5 introduces a split).
  */
 function getSlackAuth(connection?: OAuthConnection): OAuthConnection | string {
   if (connection) return connection;
-  if (_cachedSlackAuth) return _cachedSlackAuth;
+  if (_cachedSlackWriteAuth) return _cachedSlackWriteAuth;
+  if (_cachedSlackReadAuth) return _cachedSlackReadAuth;
   throw new Error(
     "Slack: no connection or cached token available. Was resolveConnection() called?",
   );
+}
+
+/**
+ * Resolve auth for read operations (listConversations, getHistory,
+ * conversation replies, search, users.info lookups).
+ */
+function getReadAuth(connection?: OAuthConnection): OAuthConnection | string {
+  if (connection) return connection;
+  if (_cachedSlackReadAuth) return _cachedSlackReadAuth;
+  return getSlackAuth(connection);
+}
+
+/**
+ * Resolve auth for write operations (postMessage, markRead, and any future
+ * state-changing method like reactions, joins, leaves, updates, or deletes).
+ */
+function getWriteAuth(connection?: OAuthConnection): OAuthConnection | string {
+  if (connection) return connection;
+  if (_cachedSlackWriteAuth) return _cachedSlackWriteAuth;
+  return getSlackAuth(connection);
 }
 
 async function resolveUserName(
@@ -188,12 +217,14 @@ export const slackProvider: MessagingProvider = {
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) {
-      _cachedSlackAuth = botToken;
+      _cachedSlackWriteAuth = botToken;
+      _cachedSlackReadAuth = botToken; // PR 5 will point this at user_token when available
       return undefined;
     }
     // Preserve existing OAuth path for backwards compat.
     const conn = await resolveOAuthConnection("slack", { account });
-    _cachedSlackAuth = conn;
+    _cachedSlackWriteAuth = conn;
+    _cachedSlackReadAuth = conn;
     return conn;
   },
 
@@ -212,7 +243,7 @@ export const slackProvider: MessagingProvider = {
     connection: OAuthConnection | undefined,
     options?: ListOptions,
   ): Promise<Conversation[]> {
-    const auth = getSlackAuth(connection);
+    const auth = getReadAuth(connection);
     const typeMap: Record<string, string> = {
       channel: "public_channel,private_channel",
       dm: "im",
@@ -280,7 +311,7 @@ export const slackProvider: MessagingProvider = {
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const auth = getSlackAuth(connection);
+    const auth = getReadAuth(connection);
     const resp = await slack.conversationHistory(
       auth,
       conversationId,
@@ -303,7 +334,7 @@ export const slackProvider: MessagingProvider = {
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const auth = getSlackAuth(connection);
+    const auth = getReadAuth(connection);
     const resp = await slack.searchMessages(auth, query, options?.count ?? 20);
     return {
       total: resp.messages.total,
@@ -318,7 +349,7 @@ export const slackProvider: MessagingProvider = {
     text: string,
     options?: SendOptions,
   ): Promise<SendResult> {
-    const auth = getSlackAuth(connection);
+    const auth = getWriteAuth(connection);
     const resp = await slack.postMessage(
       auth,
       conversationId,
@@ -338,7 +369,7 @@ export const slackProvider: MessagingProvider = {
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const auth = getSlackAuth(connection);
+    const auth = getReadAuth(connection);
     const resp = await slack.conversationReplies(
       auth,
       conversationId,
@@ -358,7 +389,7 @@ export const slackProvider: MessagingProvider = {
     conversationId: string,
     messageId?: string,
   ): Promise<void> {
-    const auth = getSlackAuth(connection);
+    const auth = getWriteAuth(connection);
     // Slack's conversations.mark requires a timestamp — use the provided one or "now"
     const ts = messageId ?? String(Date.now() / 1000);
     await slack.conversationMark(auth, conversationId, ts);


### PR DESCRIPTION
## Summary
- Introduce getReadAuth() / getWriteAuth() helpers with separate cached tokens; route each method to the appropriate helper
- Add guard test verifying bot token is used for both reads and writes (behavior-preserving)

Part of plan: slack-user-token-triage.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
