### PR TITLE
fix: only treat odd-backslash pipes as escaped in Slack table parsing

### DIFF
--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -140,6 +140,27 @@ describe("textToSlackBlocks", () => {
     expect(section.text.text).toContain("Description: filters output");
   });
 
+  test("treats pipe after even backslashes as a real column separator", () => {
+    // C:\\ ends with two backslashes (even count), so the trailing | is a
+    // real column separator, not an escaped pipe.
+    const table = [
+      "| Path | Description |",
+      "| --- | --- |",
+      "| C:\\\\| a windows path |",
+    ].join("\n");
+
+    const blocks = textToSlackBlocks(table);
+    expect(blocks).toBeDefined();
+    expect(blocks!.length).toBe(1);
+    const section = blocks![0] as {
+      type: "section";
+      text: { type: string; text: string };
+    };
+    // C:\\ should be its own cell, "a windows path" in the Description column
+    expect(section.text.text).toContain("C:\\\\");
+    expect(section.text.text).toContain("Description: a windows path");
+  });
+
   test("requires header + separator + data row for table detection", () => {
     // Only header and separator, no data rows
     const input = "| A | B |\n| --- | --- |";

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -205,13 +205,20 @@ function splitIntoSegments(text: string): Segment[] {
  */
 function parseTableRow(line: string): string[] {
   const ESCAPED_PIPE_PLACEHOLDER = "\x00PIPE\x00";
+  const ESCAPED_BACKSLASH_PLACEHOLDER = "\x00BSLASH\x00";
   return line
+    // First, protect escaped backslashes (\\) so they don't interfere
+    .replace(/\\\\/g, ESCAPED_BACKSLASH_PLACEHOLDER)
+    // Now a remaining \| is a genuinely escaped pipe (odd backslash)
     .replace(/\\\|/g, ESCAPED_PIPE_PLACEHOLDER)
     .replace(/^\|/, "")
     .replace(/\|$/, "")
     .split("|")
     .map((cell) =>
-      cell.replaceAll(ESCAPED_PIPE_PLACEHOLDER, "|").trim(),
+      cell
+        .replaceAll(ESCAPED_PIPE_PLACEHOLDER, "|")
+        .replaceAll(ESCAPED_BACKSLASH_PLACEHOLDER, "\\\\")
+        .trim(),
     );
 }
 


### PR DESCRIPTION
## Summary
- Fixes escaped-pipe handling in `parseTableRow` so that pipes preceded by an even number of backslashes (e.g. `C:\\|`) are treated as real column separators, not escaped pipes
- Uses a two-phase placeholder approach: first protect `\\` pairs, then treat remaining `\|` as escaped
- Adds test case for the even-backslash scenario

Addresses feedback from PR #25522.

## Test plan
- [ ] Existing escaped-pipe test (`cmd \| grep`) still passes
- [ ] New test verifies `C:\\|` splits into two columns correctly
- [ ] No regressions in other table parsing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
