### PR TITLE
feat(slack-adapter): prefer user_token for read methods

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
@@ -1,12 +1,11 @@
 /**
  * Guard test that verifies the Slack adapter routes reads and writes through
- * the correct cached auth. Today (PR 3 of the slack-user-token-triage plan)
- * both caches hold the bot token — this test locks in that behavior so the
- * follow-up PR that introduces user_token for reads cannot silently regress
- * write routing.
+ * the correct cached auth.
  *
- * PR 5 will extend this file with a two-token case (bot + user) asserting
- * reads switch to the user token while writes stay on the bot token.
+ * PR 3 introduced the read/write auth split and locked in behavior for the
+ * bot-token-only case. PR 5 extended this file to cover the dual-token case
+ * (bot + user): reads MUST use the user token while writes MUST stay on the
+ * bot token so posts come from the bot identity.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -23,13 +22,13 @@ mock.module("../../../../security/secure-keys.js", () => ({
   getSecureKeyAsync: getSecureKeyAsyncMock,
 }));
 
-// OAuth helpers aren't exercised when a bot token is present, but the adapter
-// imports them at module load — provide no-op stubs so imports resolve.
+// OAuth helpers are exercised only when no bot_token is cached. The adapter
+// imports them at module load — route them through a stub that signals any
+// OAuth fallback with a distinctive error so tests can assert on it.
+const OAUTH_FALLBACK_SENTINEL = "OAUTH_FALLBACK_NOT_STUBBED";
 mock.module("../../../../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: async (): Promise<OAuthConnection> => {
-    throw new Error(
-      "resolveOAuthConnection should not be called when bot_token is present",
-    );
+    throw new Error(OAUTH_FALLBACK_SENTINEL);
   },
 }));
 mock.module("../../../../oauth/oauth-store.js", () => ({
@@ -90,6 +89,12 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   if (url.includes("/conversations.list")) {
     return { ok: true, channels: [], response_metadata: { next_cursor: "" } };
   }
+  if (url.includes("/conversations.history")) {
+    return { ok: true, messages: [], has_more: false };
+  }
+  if (url.includes("/conversations.mark")) {
+    return { ok: true };
+  }
   if (url.includes("/chat.postMessage")) {
     return { ok: true, ts: "1700000000.000100", channel: "C123" };
   }
@@ -100,6 +105,7 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
 // ── Test setup ──────────────────────────────────────────────────────────────
 
 const BOT_TOKEN = "xoxb-BOT";
+const USER_TOKEN = "xoxp-USER";
 
 describe("Slack adapter token routing", () => {
   beforeEach(() => {
@@ -116,9 +122,10 @@ describe("Slack adapter token routing", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("bot-token only: reads and writes both authenticate with the bot token (behavior-preserving refactor)", async () => {
-    // Populate both caches via resolveConnection(). With only a bot token
-    // configured today, read auth and write auth both resolve to it.
+  test("bot-token only: reads and writes both authenticate with the bot token (regression guard for pre-user-token behavior)", async () => {
+    // With only a bot token stored, reads must fall back to the bot token
+    // so the adapter keeps working for installs that haven't re-consented
+    // the user scope. Writes stay on the bot token always.
     const resolved = await slackProvider.resolveConnection!();
     expect(resolved).toBeUndefined();
 
@@ -130,11 +137,72 @@ describe("Slack adapter token routing", () => {
     expect(readCall).toBeDefined();
     expect(readCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
 
-    // Write path: sendMessage → /chat.postMessage must also use bot token
-    // (same token until PR 5 introduces a user_token for reads).
+    // Write path: sendMessage → /chat.postMessage must also use bot token.
     await slackProvider.sendMessage(undefined, "C123", "hello");
     const writeCall = captured.find((c) => c.url.includes("/chat.postMessage"));
     expect(writeCall).toBeDefined();
     expect(writeCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+
+  test("bot + user tokens: reads authenticate with the user token, writes with the bot token", async () => {
+    // With both tokens stored, reads MUST flip to the user token so the
+    // adapter can see channels the user is in but the bot isn't. Writes
+    // MUST stay on the bot token so posts come from the bot identity.
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      if (key === credentialKey("slack_channel", "user_token"))
+        return USER_TOKEN;
+      return null;
+    });
+
+    const resolved = await slackProvider.resolveConnection!();
+    expect(resolved).toBeUndefined();
+
+    // Reads: listConversations → user token.
+    await slackProvider.listConversations(undefined);
+    const listCall = captured.find((c) =>
+      c.url.includes("/conversations.list"),
+    );
+    expect(listCall).toBeDefined();
+    expect(listCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
+
+    // Reads: getHistory → user token.
+    await slackProvider.getHistory(undefined, "C123");
+    const historyCall = captured.find((c) =>
+      c.url.includes("/conversations.history"),
+    );
+    expect(historyCall).toBeDefined();
+    expect(historyCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
+
+    // Writes: sendMessage → bot token.
+    await slackProvider.sendMessage(undefined, "C123", "hello");
+    const sendCall = captured.find((c) => c.url.includes("/chat.postMessage"));
+    expect(sendCall).toBeDefined();
+    expect(sendCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+
+    // Writes: markRead → bot token.
+    await slackProvider.markRead!(undefined, "C123", "1700000000.000100");
+    const markCall = captured.find((c) =>
+      c.url.includes("/conversations.mark"),
+    );
+    expect(markCall).toBeDefined();
+    expect(markCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+
+  test("user-token only (no bot token): falls through to the OAuth path", async () => {
+    // Edge case: if only a user token is stored with no bot token, we do NOT
+    // have Socket Mode credentials, so resolveConnection() falls through to
+    // the legacy OAuth path. The mocked resolveOAuthConnection throws, which
+    // documents current behavior — user-token-only without an OAuth
+    // connection is not a supported install configuration.
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "user_token"))
+        return USER_TOKEN;
+      return null;
+    });
+
+    await expect(slackProvider.resolveConnection!()).rejects.toThrow(
+      OAUTH_FALLBACK_SENTINEL,
+    );
   });
 });

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -37,11 +37,11 @@ const userNameCache = new Map<string, string>();
 /**
  * Cached auth resolved during resolveConnection(), split by direction.
  *
- * Read and write auth are tracked separately so a future change can point
- * reads at a user OAuth token (xoxp-) while writes continue to use the bot
- * token (xoxb-). Today both caches hold the same value (behavior-preserving
- * refactor); PR 5 of the slack-user-token-triage plan wires a user_token
- * into the read cache.
+ * Read and write auth are tracked separately so reads can use a user OAuth
+ * token (xoxp-) — giving visibility into channels the user is in but the
+ * bot isn't — while writes continue to use the bot token (xoxb-) so posts
+ * come from the bot identity. When no user_token is stored, reads fall
+ * back to the bot token (unchanged legacy behavior).
  *
  * For Socket Mode these hold a raw bot token string; for OAuth they hold the
  * OAuthConnection. The Slack client functions accept both via their own
@@ -54,7 +54,8 @@ let _cachedSlackReadAuth: OAuthConnection | string | null = null;
 /**
  * Get the Slack auth value to pass to Slack client functions.
  * Prefers the explicit connection from the caller; falls back to the cached
- * write auth (which equals the read auth until PR 5 introduces a split).
+ * write auth. Callers that care about read vs write semantics should use
+ * getReadAuth() / getWriteAuth() directly.
  */
 function getSlackAuth(connection?: OAuthConnection): OAuthConnection | string {
   if (connection) return connection;
@@ -75,6 +76,8 @@ function getReadAuth(connection?: OAuthConnection): OAuthConnection | string {
   return getSlackAuth(connection);
 }
 
+// SAFETY: writes MUST use the bot token. Using the user token for writes
+// would post as the user, not as the bot.
 /**
  * Resolve auth for write operations (postMessage, markRead, and any future
  * state-changing method like reactions, joins, leaves, updates, or deletes).
@@ -213,12 +216,20 @@ export const slackProvider: MessagingProvider = {
   ): Promise<OAuthConnection | undefined> {
     // Socket Mode: cache the raw bot token for use in adapter methods.
     // Token presence is sufficient — no connection row required.
+    //
+    // When a user_token is also stored, prefer it for reads so the adapter
+    // can see channels the user is in but the bot isn't (conversations.list,
+    // conversations.history, search.messages). Writes always stay on the
+    // bot token — see SAFETY note above getWriteAuth().
     const botToken = await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     );
+    const userToken = await getSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+    );
     if (botToken) {
       _cachedSlackWriteAuth = botToken;
-      _cachedSlackReadAuth = botToken; // PR 5 will point this at user_token when available
+      _cachedSlackReadAuth = userToken ?? botToken;
       return undefined;
     }
     // Preserve existing OAuth path for backwards compat.


### PR DESCRIPTION
## Summary
- resolveConnection() now loads the user_token alongside the bot_token, and populates _cachedSlackReadAuth with the user token when present
- Safety: writes always stay on the bot token; extended guard test covers the dual-token case

Part of plan: slack-user-token-triage.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
