### PR TITLE
fix(assistant): split Slack section blocks on mrkdwn, not raw markdown

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -155,6 +155,93 @@ describe("textToSlackBlocks long-text splitting", () => {
     expect(blocks![0].type).toBe("section");
   });
 
+  test("does not split a markdown link across section blocks when the link text contains a sentence boundary near maxChars", () => {
+    // Craft prose so the last `. ` (sentence boundary) inside the first
+    // `SLACK_SECTION_MAX_CHARS` window falls INSIDE a markdown link's text.
+    // If `splitLongTextSegment` ran on raw markdown, it would cut the link
+    // in half — chunk 1 would end with `[First sentence. ` and chunk 2 would
+    // start with `Second sentence](https://example.com)`, leaving orphan
+    // `](` tokens that never get converted to Slack mrkdwn and leak raw
+    // markdown to Slack.
+    //
+    // By transforming to mrkdwn FIRST (so the link becomes
+    // `<url|First sentence. Second sentence>`), the splitter can no longer
+    // land on the `. ` inside the `|...>` span in a way that produces orphan
+    // markdown tokens — and `](` never appears in any chunk.
+    const linkMarkdown =
+      "[First sentence. Second sentence](https://example.com)";
+    // Fill the first window with sentence-delimited filler so there is a
+    // valid `. ` split point available and the link straddles the boundary.
+    const prefix = "Filler sentence. ".repeat(170); // ≈ 2890 chars
+    // Pad the remainder so the total length comfortably exceeds the limit.
+    const suffix = " Trailing sentence. ".repeat(100);
+    const text = prefix + linkMarkdown + suffix;
+    expect(text.length).toBeGreaterThan(SLACK_SECTION_MAX_CHARS);
+
+    const blocks = textToSlackBlocks(text);
+    expect(blocks).toBeDefined();
+
+    const sectionBlocks = blocks!.filter((b) => b.type === "section") as Array<{
+      type: "section";
+      text: { type: string; text: string };
+    }>;
+    expect(sectionBlocks.length).toBeGreaterThanOrEqual(2);
+
+    for (const section of sectionBlocks) {
+      // Every section block must be well-formed Slack mrkdwn: no raw
+      // markdown-link tokens should leak through.
+      expect(section.text.text).not.toContain("](");
+      expect(section.text.text).not.toContain("[First sentence");
+      // No orphan `**` bold markers.
+      expect(section.text.text).not.toContain("**");
+      // Section must respect Slack's 3000-char ceiling.
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
+
+    // The link should be rendered exactly once as Slack mrkdwn across all
+    // blocks — not duplicated, not broken apart.
+    const combined = sectionBlocks.map((s) => s.text.text).join("\n");
+    expect(combined).toContain(
+      "<https://example.com|First sentence. Second sentence>",
+    );
+  });
+
+  test("does not split a **bold** span across section blocks when the bold text contains a sentence boundary near maxChars", () => {
+    // Same shape as the link-straddle test, but for `**bold**`. If splitting
+    // ran on raw markdown, the splitter would land on a `. ` inside the bold
+    // span, leaving chunk 1 with `**First sentence. ` (orphan `**` opener)
+    // and chunk 2 with `Second sentence**` (orphan `**` closer). Both
+    // chunks' mrkdwn regexes would fail to match, leaking raw `**` tokens.
+    const boldMarkdown = "**First sentence. Second sentence**";
+    const prefix = "Filler sentence. ".repeat(170); // ≈ 2890 chars
+    const suffix = " Trailing sentence. ".repeat(100);
+    const text = prefix + boldMarkdown + suffix;
+    expect(text.length).toBeGreaterThan(SLACK_SECTION_MAX_CHARS);
+
+    const blocks = textToSlackBlocks(text);
+    expect(blocks).toBeDefined();
+
+    const sectionBlocks = blocks!.filter((b) => b.type === "section") as Array<{
+      type: "section";
+      text: { type: string; text: string };
+    }>;
+    expect(sectionBlocks.length).toBeGreaterThanOrEqual(2);
+
+    for (const section of sectionBlocks) {
+      // No orphan `**` bold markers should survive.
+      expect(section.text.text).not.toContain("**");
+      // No orphan link tokens either (defense in depth — this test focuses
+      // on bold, but the shared fix should protect both).
+      expect(section.text.text).not.toContain("](");
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
+
+    // The bold span should be rendered exactly once as Slack single-asterisk
+    // bold across all blocks.
+    const combined = sectionBlocks.map((s) => s.text.text).join("\n");
+    expect(combined).toContain("*First sentence. Second sentence*");
+  });
+
   test("4000-char paragraph followed by header and second paragraph preserves ordering", () => {
     const firstParagraph = "a".repeat(4000);
     const secondParagraph = "short second paragraph.";

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -84,14 +84,23 @@ export function textToSlackBlocks(text: string): Block[] | undefined {
         });
       }
     } else {
-      const chunks = splitLongTextSegment(segment.content);
+      // Transform to Slack mrkdwn FIRST, then split. Splitting raw markdown
+      // can bisect `[link text](url)` spans or `**bold**` markers at sentence
+      // boundaries inside link text, leaving orphan tokens that the regex in
+      // `markdownToMrkdwn` won't match — raw markdown would then leak through
+      // to Slack. Splitting already-converted mrkdwn is safe because
+      // well-formed `<url|text>` / `*bold*` spans don't contain the `. `,
+      // `! `, `? `, or newline delimiters the splitter looks for (and the
+      // preceding table branch follows this same ordering).
+      const mrkdwn = markdownToMrkdwn(segment.content);
+      const chunks = splitLongTextSegment(mrkdwn);
       for (let c = 0; c < chunks.length; c++) {
         if (c > 0) {
           blocks.push({ type: "divider" });
         }
         blocks.push({
           type: "section",
-          text: { type: "mrkdwn", text: markdownToMrkdwn(chunks[c]) },
+          text: { type: "mrkdwn", text: chunks[c] },
         });
       }
     }


### PR DESCRIPTION
## Summary
- textToSlackBlocks's text branch now runs markdownToMrkdwn BEFORE splitLongTextSegment, so splits cannot bisect a [link](url) or **bold** span and leave orphan markdown tokens in subsequent chunks.
- Matches the ordering already used by the table branch.
- Adds regression tests for both markdown-link and bold-span straddle-the-boundary cases.

Addresses gap found during slack-delivery-fix plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
