### PR TITLE
fix(macos): scope channel echo dedup to surface-action echoes only

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -132,13 +132,18 @@ final class ChatActionHandler {
                 break
             }
 
-            // History-loaded dedup: for channel conversations, a Slack/Telegram
-            // user message may already be in `vm.messages` from history
-            // reconstruction with a different daemonMessageId than the echo
-            // carries. If an existing .user row has matching text and a tagged
-            // daemonMessageId, treat the echo as a redundant notification for an
-            // already-visible message and do not append.
-            if vm.isChannelConversation,
+            // History-loaded dedup: surface-action echoes (from
+            // conversation-surfaces.ts) can arrive with a nil messageId. For
+            // channel conversations, if an existing user row already has
+            // matching text and a daemonMessageId (loaded from history), treat
+            // the echo as a redundant notification and do not append.
+            // Channel-inbound echoes always carry a messageId, so check 1 above
+            // handles them correctly by exact-id match — scoping this branch to
+            // nil messageId avoids suppressing legitimate repeat sends (e.g. a
+            // user sending "hello" twice on Slack would otherwise collapse into
+            // a single visible bubble).
+            if echo.messageId == nil,
+               vm.isChannelConversation,
                vm.messages.contains(where: {
                    $0.role == .user
                        && $0.text == echo.text

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -667,6 +667,12 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// underlying `ConversationModel.isChannelConversation` is true. Used by
     /// `ChatActionHandler` to suppress echo duplication when a channel user
     /// message is already visible from history reconstruction.
+    ///
+    /// NOTE: Only the macOS client currently populates this flag. iOS does not
+    /// yet plumb `isChannelConversation` from the platform layer into
+    /// `ChatViewModel`, so channel-specific echo dedup is effectively a no-op on
+    /// iOS. If iOS gains support for channel-mirrored conversations, the iOS
+    /// conversation-loading path must set this flag alongside `conversationId`.
     public var isChannelConversation: Bool = false
     /// Skill IDs to pre-activate in the conversation. Included in the
     /// `conversation_create` request for deterministic skill activation.

--- a/clients/shared/Tests/ChatActionHandlerEchoDedupTests.swift
+++ b/clients/shared/Tests/ChatActionHandlerEchoDedupTests.swift
@@ -22,9 +22,14 @@ final class ChatActionHandlerEchoDedupTests: XCTestCase {
     }
 
     /// A channel user message already loaded from history should not be duplicated
-    /// when a `user_message_echo` arrives carrying a different `messageId` shape.
-    /// The dedup must also suppress the `isThinking` side effect so the orphan
-    /// "thinking" indicator does not flash on an already-visible message.
+    /// when a surface-action `user_message_echo` (nil messageId) arrives referring
+    /// to an already-visible message. The dedup must also suppress the `isThinking`
+    /// side effect so the orphan "thinking" indicator does not flash on an
+    /// already-visible message.
+    ///
+    /// Channel-inbound echoes always carry a `messageId` — those are deduped by
+    /// the exact-id match earlier in the handler, so this branch is scoped to
+    /// nil-messageId surface-action echoes.
     func testChannelConversationDedupsHistoryLoadedUserMessage() {
         viewModel.isChannelConversation = true
 
@@ -36,17 +41,49 @@ final class ChatActionHandlerEchoDedupTests: XCTestCase {
             type: "user_message_echo",
             text: "hello from slack",
             conversationId: "sess-1",
-            messageId: "echo-id",
+            messageId: nil,
             requestId: nil
         )))
 
-        XCTAssertEqual(viewModel.messages.count, 1, "Echo should not append a duplicate user row for a history-loaded channel message")
+        XCTAssertEqual(viewModel.messages.count, 1, "Surface-action echo should not append a duplicate user row for a history-loaded channel message")
         XCTAssertFalse(viewModel.isThinking, "isThinking side effect should be suppressed for the dedup-suppressed echo")
     }
 
+    /// Regression test for the duplicate-send case: when a Slack user sends the
+    /// same text twice ("hello" then "hello"), both messages arrive as
+    /// channel-inbound echoes with different `messageId`s. BOTH must render —
+    /// the text-based dedup must not suppress the second arrival just because
+    /// the first is now in `vm.messages` with a tagged daemonMessageId.
+    ///
+    /// Before the fix, the second echo (id-2) would match the first row (id-1,
+    /// text="hello", daemonMessageId != nil) on the channel-history-dedup branch
+    /// and be suppressed — producing an orphan assistant reply with no visible
+    /// user turn.
+    func testChannelConversationRendersBothIdenticalTextMessages() {
+        viewModel.isChannelConversation = true
+
+        var firstMessage = ChatMessage(role: .user, text: "hello", status: .sent)
+        firstMessage.daemonMessageId = "id-1"
+        viewModel.messages = [firstMessage]
+
+        viewModel.handleServerMessage(.userMessageEcho(UserMessageEcho(
+            type: "user_message_echo",
+            text: "hello",
+            conversationId: "sess-1",
+            messageId: "id-2",
+            requestId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 2, "Second identical-text Slack message must render as its own row")
+        XCTAssertEqual(viewModel.messages[0].daemonMessageId, "id-1", "Existing row should retain its original daemonMessageId")
+        XCTAssertEqual(viewModel.messages[1].daemonMessageId, "id-2", "New row should be tagged with the echo's messageId")
+        XCTAssertTrue(viewModel.isThinking, "Channel-inbound echo should flip isThinking to signal an incoming reply")
+    }
+
     /// Non-channel conversations must keep the pre-existing passive-client
-    /// behavior: the echo appends a new row and flips the conversation into
-    /// "reply incoming" state. Guards against over-broad dedup.
+    /// behavior: a nil-messageId surface-action echo appends a new row and flips
+    /// the conversation into "reply incoming" state. Guards against over-broad
+    /// dedup for the non-channel code path.
     func testNonChannelConversationAppendsEchoNormally() {
         viewModel.isChannelConversation = false
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #25552. The text-based channel dedup was too aggressive — two Slack messages with identical text (e.g., user sends 'hello' twice) had the second echo suppressed.
- Narrows the dedup to echoes with nil messageId (surface-action echoes from conversation-surfaces.ts). Channel-inbound echoes always carry a messageId and are handled correctly by the existing exact-id check.
- Adds a regression test for identical-text Slack messages with different messageIds both rendering.
- Adds a doc comment noting iOS does not populate isChannelConversation.

Addresses gap found during slack-delivery-fix plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
