### PR TITLE
fix(gateway): strip blocks on chat.update invalid_blocks fallback

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -1091,6 +1091,109 @@ describe("slack-deliver endpoint", () => {
     );
     expect(postCalls.length).toBe(1);
   });
+
+  test("chat.update invalid_blocks falls back to chat.postMessage without blocks on first attempt", async () => {
+    let postMessageCalls = 0;
+    let updateCalls = 0;
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        let body: unknown;
+        let rawBody: string | undefined;
+        try {
+          if (init?.body && typeof init.body === "string") {
+            rawBody = init.body;
+            body = JSON.parse(init.body);
+          }
+        } catch {
+          /* not JSON */
+        }
+        fetchCalls.push({ url, body, rawBody });
+
+        if (url.includes("chat.update")) {
+          updateCalls++;
+          return new Response(
+            JSON.stringify({ ok: false, error: "invalid_blocks" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("chat.postMessage")) {
+          postMessageCalls++;
+          return new Response(
+            JSON.stringify({ ok: true, ts: "123.456" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    const handler = createSlackDeliverHandler(
+      makeConfig(),
+      undefined,
+      makeCaches(),
+    );
+    const customBlocks = [
+      { type: "section", text: { type: "mrkdwn", text: "Rich content" } },
+    ];
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Plain text fallback",
+      blocks: customBlocks,
+      messageTs: "1700000000.000050",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // chat.update must have been called exactly once (invalid_blocks).
+    expect(updateCalls).toBe(1);
+
+    // chat.postMessage must have been called exactly once — the fallback
+    // must strip blocks on the first attempt rather than re-trying with
+    // blocks and relying on the outer retry.
+    expect(postMessageCalls).toBe(1);
+    const postCalls = fetchCalls.filter((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(postCalls.length).toBe(1);
+
+    // The single postMessage call must NOT have blocks in its body.
+    expect((postCalls[0]!.body as any).blocks).toBeUndefined();
+    expect((postCalls[0]!.body as any).text).toBe("Plain text fallback");
+    expect((postCalls[0]!.body as any).channel).toBe("C123");
+    // ts is only valid for chat.update — must not leak into postMessage.
+    expect((postCalls[0]!.body as any).ts).toBeUndefined();
+
+    // A warn-level log must describe the pre-stripped fallback.
+    const fallbackLog = logCalls.find((c) => {
+      const [firstArg, secondArg] = c.args;
+      const message =
+        typeof firstArg === "string"
+          ? firstArg
+          : typeof secondArg === "string"
+            ? secondArg
+            : undefined;
+      return (
+        c.method === "warn" &&
+        typeof message === "string" &&
+        message.includes(
+          "chat.update returned invalid_blocks; falling back to chat.postMessage without blocks",
+        )
+      );
+    });
+    expect(fallbackLog).toBeDefined();
+  });
 });
 
 describe("slack attachment delivery", () => {

--- a/gateway/src/__tests__/slack-errors.test.ts
+++ b/gateway/src/__tests__/slack-errors.test.ts
@@ -40,6 +40,10 @@ describe("classifySlackError", () => {
     expect(classifySlackError("thread_not_found")).toBe("not_found");
   });
 
+  test("classifies invalid_blocks as client_error", () => {
+    expect(classifySlackError("invalid_blocks")).toBe("client_error");
+  });
+
   test("returns unknown for unrecognized error codes", () => {
     expect(classifySlackError("some_new_error")).toBe("unknown");
     expect(classifySlackError("internal_error")).toBe("unknown");
@@ -77,6 +81,10 @@ describe("isRetryable", () => {
 
   test("channel_not_found is not retryable", () => {
     expect(isRetryable("channel_not_found")).toBe(false);
+  });
+
+  test("client_error is not retryable", () => {
+    expect(isRetryable("client_error")).toBe(false);
   });
 });
 
@@ -156,6 +164,12 @@ describe("getUserMessage", () => {
   test("returns message for rate_limit errors", () => {
     expect(getUserMessage("rate_limited")).toBe(
       "Slack rate limit reached. Please try again in a moment.",
+    );
+  });
+
+  test("returns message for invalid_blocks client_error", () => {
+    expect(getUserMessage("invalid_blocks")).toBe(
+      "I couldn't format that message for Slack. Please try again.",
     );
   });
 });

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -139,6 +139,13 @@ async function callSlackApiWithRetries(
           { error: "Permission denied", ...(userMessage && { userMessage }) },
           { status: 403 },
         );
+      } else if (category === "client_error") {
+        // Client-side payload problems (e.g. invalid_blocks) — the daemon
+        // must NOT retry the exact same payload. 400 signals this clearly.
+        errorResponse = Response.json(
+          { error: "Invalid payload", ...(userMessage && { userMessage }) },
+          { status: 400 },
+        );
       } else {
         // Auth errors use 502 so downstream retry logic treats them as
         // transient (token rotation, brief credential desync). Permanent
@@ -868,17 +875,40 @@ export function createSlackDeliverHandler(
           );
 
           // Fall back to posting a new message if update fails (either a
-          // transport error or a Slack-level error). The caller of chat.update
-          // may still retry without blocks below if the fallback
-          // chat.postMessage also reports invalid_blocks.
+          // transport error or a Slack-level error).
           if (
             result instanceof Response ||
             ("kind" in result && result.kind === "slack_error")
           ) {
-            tlog.warn(
-              { chatId, messageTs },
-              "Slack chat.update failed, falling back to chat.postMessage",
-            );
+            // If chat.update rejected the payload because the blocks are
+            // invalid, strip blocks before the postMessage fallback — the
+            // blocks will fail identically there. This collapses what would
+            // otherwise be three round-trips (update+blocks, post+blocks,
+            // post without blocks via the outer retry) into two.
+            const updateRejectedBlocks =
+              !(result instanceof Response) &&
+              "kind" in result &&
+              result.kind === "slack_error" &&
+              result.slackError === "invalid_blocks" &&
+              !body.approval &&
+              !isEphemeral &&
+              Array.isArray(slackBody.blocks) &&
+              slackBody.blocks.length > 0;
+
+            if (updateRejectedBlocks) {
+              tlog.warn(
+                { chatId, messageTs },
+                "chat.update returned invalid_blocks; falling back to chat.postMessage without blocks",
+              );
+              delete slackBody.blocks;
+              blockFallback = true;
+            } else {
+              tlog.warn(
+                { chatId, messageTs },
+                "Slack chat.update failed, falling back to chat.postMessage",
+              );
+            }
+
             result = await callSlackApiWithRetries(
               "https://slack.com/api/chat.postMessage",
               slackBody,
@@ -886,6 +916,18 @@ export function createSlackDeliverHandler(
               chatId,
               tlog,
             );
+
+            // If we pre-stripped blocks above but the postMessage call still
+            // failed, clear the fallback flag so the success log isn't
+            // misleading. The outer error handling below will return the
+            // appropriate response.
+            if (
+              updateRejectedBlocks &&
+              (result instanceof Response ||
+                ("kind" in result && result.kind === "slack_error"))
+            ) {
+              blockFallback = false;
+            }
           }
         } else {
           const slackMethod = isEphemeral

--- a/gateway/src/slack/errors.ts
+++ b/gateway/src/slack/errors.ts
@@ -11,6 +11,7 @@ export type SlackErrorCategory =
   | "not_found"
   | "permission"
   | "channel_not_found"
+  | "client_error"
   | "transient"
   | "unknown";
 
@@ -43,6 +44,11 @@ const ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
   user_not_found: "not_found",
   message_not_found: "not_found",
   thread_not_found: "not_found",
+
+  // Client-side errors — the payload itself is invalid, retrying the same
+  // request will fail identically. Callers that inspect the category should
+  // treat these as permanent failures and not re-send the same payload.
+  invalid_blocks: "client_error",
 };
 
 /**
@@ -57,6 +63,8 @@ export function classifySlackError(
 
 /**
  * Whether the error category indicates the request could succeed on retry.
+ * `client_error` is explicitly non-retryable: the payload itself is the
+ * problem, so re-sending it would fail identically.
  */
 export function isRetryable(category: SlackErrorCategory): boolean {
   return (
@@ -78,6 +86,8 @@ const CATEGORY_USER_MESSAGES: Record<SlackErrorCategory, string | undefined> = {
     "I don't have the required permissions for this channel. Please check my access.",
   not_found: "The requested resource could not be found in Slack.",
   rate_limit: "Slack rate limit reached. Please try again in a moment.",
+  client_error:
+    "I couldn't format that message for Slack. Please try again.",
   transient: undefined,
   unknown: undefined,
 };


### PR DESCRIPTION
## Summary
- When chat.update returns invalid_blocks, the chat.postMessage fallback now strips blocks on the first attempt instead of waiting for the outer retry to strip them. Collapses three round-trips into two.
- Adds invalid_blocks to the Slack error classifier with a new 'client_error' category; isRetryable returns false so the daemon does not retry permanent client-side errors.

Addresses two gaps found during slack-delivery-fix plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
