### PR TITLE
refactor(recover): drop unreachable legacy fallback in collision check

### DIFF
--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -51,14 +51,8 @@ export async function recover(): Promise<void> {
     );
   }
 
-  // 3. Check that the recovering entry's own target directory is free. Only
-  //    this one path matters — iterating all lockfile entries would block
-  //    recovery whenever any unrelated local assistant is still installed.
-  //    Fall back to the legacy `~/.vellum` path for entries without
-  //    resources (pre env-data-layout installs).
-  const target = entry.resources?.instanceDir
-    ? join(entry.resources.instanceDir, ".vellum")
-    : join(homedir(), ".vellum");
+  // 3. Check that the recovering entry's own target directory is free.
+  const target = join(entry.resources.instanceDir, ".vellum");
   if (existsSync(target)) {
     console.error(
       `Error: ${target} already exists (owned by ${entry.assistantId}). ` +


### PR DESCRIPTION
## Summary
After an earlier refactor added `if (!entry.resources) throw` at the top of `recover()`, the collision-check ternary `entry.resources?.instanceDir ? ... : join(homedir(), '.vellum')` became unreachable on the fallback branch — `entry.resources` is guaranteed defined by the time that line runs. Drop the ternary and the wrong comment.

No runtime behavior change. Cosmetic dead-code cleanup flagged in round-2 self-review.

Part of plan: env-data-layout.md (fix round 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
