### PR TITLE
fix(cli): sync platformBaseUrl to lockfile on vellum use / vellum wake

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -9,6 +10,11 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  setActiveAssistant,
+  syncActiveAssistantConfigToLockfile,
+  syncConfigToLockfile,
+} from "../lib/assistant-config.js";
 import {
   clearPlatformToken,
   getPlatformUrl,
@@ -194,5 +200,146 @@ describe("getPlatformUrl resolution order", () => {
   test("trims whitespace from VELLUM_PLATFORM_URL", () => {
     process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
     expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
+  });
+});
+
+describe("syncActiveAssistantConfigToLockfile on vellum use", () => {
+  let tempRoot: string;
+  let savedLockDir: string | undefined;
+  let savedEnv: string | undefined;
+  let savedPlatformUrl: string | undefined;
+  let savedBaseDataDir: string | undefined;
+
+  beforeEach(() => {
+    savedLockDir = process.env.VELLUM_LOCKFILE_DIR;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    savedPlatformUrl = process.env.VELLUM_PLATFORM_URL;
+    savedBaseDataDir = process.env.BASE_DATA_DIR;
+    tempRoot = mkdtempSync(join(tmpdir(), "cli-active-sync-test-"));
+    process.env.VELLUM_LOCKFILE_DIR = tempRoot;
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_PLATFORM_URL;
+    delete process.env.BASE_DATA_DIR;
+  });
+
+  afterEach(() => {
+    const restore = (name: string, value: string | undefined): void => {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    };
+    restore("VELLUM_LOCKFILE_DIR", savedLockDir);
+    restore("VELLUM_ENVIRONMENT", savedEnv);
+    restore("VELLUM_PLATFORM_URL", savedPlatformUrl);
+    restore("BASE_DATA_DIR", savedBaseDataDir);
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  function writeWorkspaceConfig(instanceDir: string, platformUrl: string) {
+    const workspaceDir = join(instanceDir, ".vellum", "workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({ platform: { baseUrl: platformUrl } }, null, 2),
+    );
+  }
+
+  test("vellum use <name> refreshes lockfile platformBaseUrl from the new active assistant's workspace config", () => {
+    // Set up two assistants with distinct platform URLs in their own
+    // per-instance workspace configs, mimicking the multi-tenant case
+    // where `alpha` targets prod and `beta` targets dev.
+    const alphaDir = join(tempRoot, "alpha-root");
+    const betaDir = join(tempRoot, "beta-root");
+    mkdirSync(alphaDir, { recursive: true });
+    mkdirSync(betaDir, { recursive: true });
+    writeWorkspaceConfig(alphaDir, "https://prod.vellum.ai");
+    writeWorkspaceConfig(betaDir, "https://dev.vellum.ai");
+
+    // Seed the lockfile with two local entries + alpha as active.
+    writeFileSync(
+      join(tempRoot, ".vellum.lock.json"),
+      JSON.stringify(
+        {
+          activeAssistant: "alpha",
+          assistants: [
+            {
+              assistantId: "alpha",
+              runtimeUrl: "http://127.0.0.1:7830",
+              cloud: "local",
+              resources: {
+                instanceDir: alphaDir,
+                daemonPort: 7821,
+                gatewayPort: 7830,
+                qdrantPort: 6333,
+                cesPort: 8090,
+                pidFile: join(alphaDir, ".vellum", "vellum.pid"),
+              },
+            },
+            {
+              assistantId: "beta",
+              runtimeUrl: "http://127.0.0.1:7831",
+              cloud: "local",
+              resources: {
+                instanceDir: betaDir,
+                daemonPort: 7822,
+                gatewayPort: 7831,
+                qdrantPort: 6334,
+                cesPort: 8091,
+                pidFile: join(betaDir, ".vellum", "vellum.pid"),
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Mimic the hatch-time sync for alpha so the lockfile has
+    // platformBaseUrl populated — this is what Fix G3 relies on.
+    process.env.BASE_DATA_DIR = alphaDir;
+    syncConfigToLockfile();
+    delete process.env.BASE_DATA_DIR;
+
+    expect(getPlatformUrl()).toBe("https://prod.vellum.ai");
+
+    // Simulate `vellum use beta`: switch active and run the new sync
+    // helper that use.ts now calls.
+    setActiveAssistant("beta");
+    syncActiveAssistantConfigToLockfile("beta");
+
+    // getPlatformUrl must now return beta's tenant — the bug before this
+    // fix was that it kept returning the last-hatched assistant's URL.
+    expect(getPlatformUrl()).toBe("https://dev.vellum.ai");
+
+    // Switching back recovers alpha's URL.
+    setActiveAssistant("alpha");
+    syncActiveAssistantConfigToLockfile("alpha");
+    expect(getPlatformUrl()).toBe("https://prod.vellum.ai");
+  });
+
+  test("syncActiveAssistantConfigToLockfile is a no-op for legacy entries without resources", () => {
+    // Legacy entry (no resources) — helper should skip silently without
+    // clobbering an existing platformBaseUrl in the lockfile.
+    writeFileSync(
+      join(tempRoot, ".vellum.lock.json"),
+      JSON.stringify(
+        {
+          activeAssistant: "legacy",
+          platformBaseUrl: "https://preexisting.vellum.ai",
+          assistants: [
+            {
+              assistantId: "legacy",
+              runtimeUrl: "http://127.0.0.1:7830",
+              cloud: "remote",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    syncActiveAssistantConfigToLockfile("legacy");
+    expect(getPlatformUrl()).toBe("https://preexisting.vellum.ai");
   });
 });

--- a/cli/src/commands/use.ts
+++ b/cli/src/commands/use.ts
@@ -2,6 +2,7 @@ import {
   findAssistantByName,
   getActiveAssistant,
   setActiveAssistant,
+  syncActiveAssistantConfigToLockfile,
 } from "../lib/assistant-config.js";
 
 export async function use(): Promise<void> {
@@ -40,5 +41,10 @@ export async function use(): Promise<void> {
   }
 
   setActiveAssistant(name);
+  // Refresh the lockfile's top-level platformBaseUrl from the newly-active
+  // assistant's workspace config so getPlatformUrl() — and downstream code
+  // like `vellum login`, ensureRegistration, and rollback — targets the
+  // right tenant.
+  syncActiveAssistantConfigToLockfile(name);
   console.log(`Active assistant set to '${name}'.`);
 }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import {
   resolveTargetAssistant,
   saveAssistantEntry,
+  syncConfigToLockfile,
 } from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
@@ -182,19 +183,27 @@ export async function wake(): Promise<void> {
     }
   }
 
-  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
-  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
+  // Set BASE_DATA_DIR so ngrok and the config→lockfile sync read the
+  // correct instance's workspace config. Waking a different assistant must
+  // refresh the lockfile's top-level platformBaseUrl so getPlatformUrl() —
+  // and downstream code like `vellum login` and ensureRegistration — targets
+  // the tenant the woken assistant is configured for.
   const prevBaseDataDir = process.env.BASE_DATA_DIR;
   process.env.BASE_DATA_DIR = resources.instanceDir;
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
-  if (ngrokChild?.pid) {
-    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
-    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
-  }
-  if (prevBaseDataDir !== undefined) {
-    process.env.BASE_DATA_DIR = prevBaseDataDir;
-  } else {
-    delete process.env.BASE_DATA_DIR;
+  try {
+    // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
+    const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+    if (ngrokChild?.pid) {
+      const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+      writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+    }
+    syncConfigToLockfile();
+  } finally {
+    if (prevBaseDataDir !== undefined) {
+      process.env.BASE_DATA_DIR = prevBaseDataDir;
+    } else {
+      delete process.env.BASE_DATA_DIR;
+    }
   }
 
   console.log("Wake complete.");

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -499,3 +499,31 @@ export function syncConfigToLockfile(): void {
     // Config file unreadable — skip sync
   }
 }
+
+/**
+ * Sync the named assistant's workspace `config.json` to the lockfile's
+ * top-level `platformBaseUrl` field. Used by `vellum use` and `vellum wake`
+ * so `getPlatformUrl()` returns the tenant URL of the newly-active
+ * assistant rather than whichever assistant was most recently hatched.
+ *
+ * Temporarily scopes `BASE_DATA_DIR` to the target instance so
+ * {@link syncConfigToLockfile} reads from that instance's workspace
+ * config. No-op for legacy entries without `resources` (they share the
+ * legacy `~/.vellum/` workspace and the lockfile value is already correct).
+ */
+export function syncActiveAssistantConfigToLockfile(name: string): void {
+  const entry = findAssistantByName(name);
+  if (!entry?.resources) return;
+
+  const prevBaseDataDir = process.env.BASE_DATA_DIR;
+  process.env.BASE_DATA_DIR = entry.resources.instanceDir;
+  try {
+    syncConfigToLockfile();
+  } finally {
+    if (prevBaseDataDir !== undefined) {
+      process.env.BASE_DATA_DIR = prevBaseDataDir;
+    } else {
+      delete process.env.BASE_DATA_DIR;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fix G3 (#25544) made getPlatformUrl() read platformBaseUrl from the top-level lockfile field. That field is written by syncConfigToLockfile() which was only called at hatch time. Switching the active assistant (vellum use) or waking a different assistant left the lockfile's platformBaseUrl pointing at whatever was last hatched — so `vellum login`, platform API calls, and ensureRegistration all targeted the wrong tenant for users with multiple assistants on different platform URLs.

This fix calls syncConfigToLockfile() from use.ts (after setActiveAssistant) and wake.ts (inside the existing BASE_DATA_DIR scope) so the lockfile always reflects the currently-active assistant's platform.baseUrl.

Addresses Codex P1 and Devin Analysis on #25544 / round-2 self-review finding.

Part of plan: env-data-layout.md (fix round 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
