### PR TITLE
fix(slack): make user_token deletion surgical (don't disconnect integration)

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -48,8 +48,13 @@ mock.module("../tools/registry.js", () => ({
 // Mock oauth-store to avoid SQLite dependency in unit tests
 // ---------------------------------------------------------------------------
 
+let disconnectOAuthProviderCalls: string[] = [];
+
 mock.module("../oauth/oauth-store.js", () => ({
-  disconnectOAuthProvider: mock(async () => "not-found" as const),
+  disconnectOAuthProvider: mock(async (provider: string) => {
+    disconnectOAuthProviderCalls.push(provider);
+    return "not-found" as const;
+  }),
   getActiveConnection: mock(() => undefined),
 }));
 
@@ -59,6 +64,7 @@ let slackChannelConfigCalls: Array<{
   appToken?: string;
   userToken?: string;
 }> = [];
+let clearSlackUserTokenCalls = 0;
 
 mock.module("../oauth/manual-token-connection.js", () => ({
   syncManualTokenConnection: async (provider: string) => {
@@ -194,6 +200,38 @@ mock.module("../daemon/handlers/config-slack-channel.js", () => ({
       warning,
     };
   },
+  clearSlackUserToken: async () => {
+    clearSlackUserTokenCalls++;
+
+    const { credentialKey } = await import("../security/credential-key.js");
+    const { deleteSecureKeyAsync, getSecureKeyAsync } = await import(
+      "../security/secure-keys.js"
+    );
+    const { deleteCredentialMetadata } = await import(
+      "../tools/credentials/metadata-store.js"
+    );
+
+    await deleteSecureKeyAsync(credentialKey("slack_channel", "user_token"));
+    deleteCredentialMetadata("slack_channel", "user_token");
+
+    const hasBotToken = !!(await getSecureKeyAsync(
+      credentialKey("slack_channel", "bot_token"),
+    ));
+    const hasAppToken = !!(await getSecureKeyAsync(
+      credentialKey("slack_channel", "app_token"),
+    ));
+
+    return {
+      success: true,
+      hasBotToken,
+      hasAppToken,
+      hasUserToken: false,
+      connected:
+        manualConnectionStore["slack_channel"] === "active" &&
+        hasBotToken &&
+        hasAppToken,
+    };
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -222,6 +260,8 @@ const _ctx: ToolContext = {
 beforeEach(() => {
   manualConnectionStore = {};
   slackChannelConfigCalls = [];
+  clearSlackUserTokenCalls = 0;
+  disconnectOAuthProviderCalls = [];
 });
 
 afterAll(() => {
@@ -1058,6 +1098,150 @@ describe("credential_store tool — store validation edge cases", () => {
       await getSecureKeyAsync(credentialKey("del-test", "key")),
     ).toBeUndefined();
     expect(getCredentialMetadata("del-test", "key")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. Vault — slack_channel delete routing
+// ---------------------------------------------------------------------------
+
+describe("credential_store tool — slack_channel delete routing", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+    _setMetadataPath(join(TEST_DIR, "metadata.json"));
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    _setStorePath(null);
+    _resetBackend();
+  });
+
+  test("delete with user_token leaves bot+app tokens and oauth_connection intact", async () => {
+    // Seed all three Slack tokens + metadata, with the manual connection active.
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "bot_token"),
+      "xoxb-bot",
+    );
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "app_token"),
+      "xapp-app",
+    );
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+      "xoxp-user",
+    );
+    upsertCredentialMetadata("slack_channel", "bot_token", {});
+    upsertCredentialMetadata("slack_channel", "app_token", {});
+    upsertCredentialMetadata("slack_channel", "user_token", {});
+    manualConnectionStore["slack_channel"] = "active";
+
+    const result = await credentialStoreTool.execute(
+      {
+        action: "delete",
+        service: "slack_channel",
+        field: "user_token",
+      },
+      _ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    // Routed through the surgical helper.
+    expect(clearSlackUserTokenCalls).toBe(1);
+    // oauth_connection row was never disconnected.
+    expect(disconnectOAuthProviderCalls).toEqual([]);
+    // user_token key + metadata removed.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
+    ).toBeUndefined();
+    const { getCredentialMetadata } = await import(
+      "../tools/credentials/metadata-store.js"
+    );
+    expect(
+      getCredentialMetadata("slack_channel", "user_token"),
+    ).toBeUndefined();
+    // bot + app tokens + their metadata + manual connection still present.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
+    ).toBe("xoxb-bot");
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "app_token")),
+    ).toBe("xapp-app");
+    expect(getCredentialMetadata("slack_channel", "bot_token")).toBeDefined();
+    expect(getCredentialMetadata("slack_channel", "app_token")).toBeDefined();
+    expect(manualConnectionStore["slack_channel"]).toBe("active");
+  });
+
+  test("delete with bot_token still tears down the oauth connection (regression guard)", async () => {
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "bot_token"),
+      "xoxb-bot",
+    );
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "app_token"),
+      "xapp-app",
+    );
+    upsertCredentialMetadata("slack_channel", "bot_token", {});
+    upsertCredentialMetadata("slack_channel", "app_token", {});
+    manualConnectionStore["slack_channel"] = "active";
+
+    const result = await credentialStoreTool.execute(
+      {
+        action: "delete",
+        service: "slack_channel",
+        field: "bot_token",
+      },
+      _ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    // Surgical helper was not used.
+    expect(clearSlackUserTokenCalls).toBe(0);
+    // Full teardown path called disconnectOAuthProvider for the slack_channel.
+    expect(disconnectOAuthProviderCalls).toContain("slack_channel");
+    // bot_token key + metadata removed.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
+    ).toBeUndefined();
+    const { getCredentialMetadata } = await import(
+      "../tools/credentials/metadata-store.js"
+    );
+    expect(
+      getCredentialMetadata("slack_channel", "bot_token"),
+    ).toBeUndefined();
+  });
+
+  test("delete with app_token still tears down the oauth connection (regression guard)", async () => {
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "bot_token"),
+      "xoxb-bot",
+    );
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "app_token"),
+      "xapp-app",
+    );
+    upsertCredentialMetadata("slack_channel", "bot_token", {});
+    upsertCredentialMetadata("slack_channel", "app_token", {});
+    manualConnectionStore["slack_channel"] = "active";
+
+    const result = await credentialStoreTool.execute(
+      {
+        action: "delete",
+        service: "slack_channel",
+        field: "app_token",
+      },
+      _ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(clearSlackUserTokenCalls).toBe(0);
+    expect(disconnectOAuthProviderCalls).toContain("slack_channel");
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "app_token")),
+    ).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -139,6 +139,7 @@ const originalFetch = globalThis.fetch;
 
 import {
   clearSlackChannelConfig,
+  clearSlackUserToken,
   getSlackChannelConfig,
   setSlackChannelConfig,
 } from "../daemon/handlers/config-slack-channel.js";
@@ -507,6 +508,68 @@ describe("Slack channel config handler", () => {
       await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
     ).toBeUndefined();
     expect(getCredentialMetadata("slack_channel", "user_token")).toBeUndefined();
+  });
+
+  test("clearSlackUserToken leaves bot+app tokens and oauth_connection intact", async () => {
+    // Seed all three tokens + metadata + an active oauth_connection row.
+    await Promise.all([
+      setSecureKeyAsync(
+        credentialKey("slack_channel", "bot_token"),
+        "xoxb-test",
+      ),
+      setSecureKeyAsync(
+        credentialKey("slack_channel", "app_token"),
+        "xapp-test",
+      ),
+      setSecureKeyAsync(
+        credentialKey("slack_channel", "user_token"),
+        "xoxp-test",
+      ),
+    ]);
+    upsertCredentialMetadata("slack_channel", "bot_token", {});
+    upsertCredentialMetadata("slack_channel", "app_token", {});
+    upsertCredentialMetadata("slack_channel", "user_token", {});
+    oauthConnectionStore["slack_channel"] = {
+      id: "conn-slack",
+      status: "active",
+    };
+
+    const result = await clearSlackUserToken();
+
+    expect(result.success).toBe(true);
+    expect(result.hasUserToken).toBe(false);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasAppToken).toBe(true);
+    expect(result.connected).toBe(true);
+
+    // user_token key + metadata gone.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
+    ).toBeUndefined();
+    expect(
+      getCredentialMetadata("slack_channel", "user_token"),
+    ).toBeUndefined();
+
+    // bot + app tokens + their metadata still present.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
+    ).toBe("xoxb-test");
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "app_token")),
+    ).toBe("xapp-test");
+    expect(getCredentialMetadata("slack_channel", "bot_token")).toBeDefined();
+    expect(getCredentialMetadata("slack_channel", "app_token")).toBeDefined();
+
+    // oauth_connection row was not touched.
+    expect(oauthConnectionStore["slack_channel"]).toBeDefined();
+    expect(oauthConnectionStore["slack_channel"].status).toBe("active");
+
+    // GET reports the right state after the surgical delete.
+    const after = await getSlackChannelConfig();
+    expect(after.connected).toBe(true);
+    expect(after.hasBotToken).toBe(true);
+    expect(after.hasAppToken).toBe(true);
+    expect(after.hasUserToken).toBe(false);
   });
 
   test("GET reports hasUserToken: false when only bot+app tokens present", async () => {

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -346,6 +346,66 @@ export async function setSlackChannelConfig(
   };
 }
 
+/**
+ * Surgically remove the Slack user_token credential.
+ *
+ * Deletes only the user_token secure key and its credential metadata. Leaves
+ * the bot_token, app_token, oauth_connection row, and Slack config metadata
+ * untouched so the Socket Mode connection stays up. Returns a
+ * `SlackChannelConfigResult` reflecting the remaining state.
+ */
+export async function clearSlackUserToken(): Promise<SlackChannelConfigResult> {
+  const result = await deleteSecureKeyAsync(
+    credentialKey("slack_channel", "user_token"),
+  );
+
+  if (result === "error") {
+    const hasBotToken = !!(await getSecureKeyAsync(
+      credentialKey("slack_channel", "bot_token"),
+    ));
+    const hasAppToken = !!(await getSecureKeyAsync(
+      credentialKey("slack_channel", "app_token"),
+    ));
+    const hasUserToken = !!(await getSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+    ));
+    const conn = getConnectionByProvider("slack_channel");
+    return {
+      success: false,
+      hasBotToken,
+      hasAppToken,
+      hasUserToken,
+      connected:
+        !!(conn && conn.status === "active") && hasBotToken && hasAppToken,
+      error: "Failed to delete Slack user token from secure storage",
+    };
+  }
+
+  deleteCredentialMetadata("slack_channel", "user_token");
+
+  const hasBotToken = !!(await getSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  ));
+  const hasAppToken = !!(await getSecureKeyAsync(
+    credentialKey("slack_channel", "app_token"),
+  ));
+  const conn = getConnectionByProvider("slack_channel");
+  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+
+  return {
+    success: true,
+    hasBotToken,
+    hasAppToken,
+    hasUserToken: false,
+    connected:
+      !!(conn && conn.status === "active") && hasBotToken && hasAppToken,
+    ...(teamId ? { teamId } : {}),
+    ...(teamName ? { teamName } : {}),
+    ...(botUserId ? { botUserId } : {}),
+    ...(botUsername ? { botUsername } : {}),
+  };
+}
+
 export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
   const r1 = await deleteSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,5 +1,6 @@
 import { getConfig } from "../../config/loader.js";
 import {
+  clearSlackUserToken,
   setSlackChannelConfig,
   type SlackChannelConfigResult,
 } from "../../daemon/handlers/config-slack-channel.js";
@@ -460,6 +461,28 @@ class CredentialStoreTool implements Tool {
             content:
               "Error: credential metadata file has an unrecognized version; cannot delete credentials",
             isError: true,
+          };
+        }
+
+        // Surgical delete for the Slack user_token: it grants read-only access
+        // to channels the bot isn't a member of, but the Socket Mode connection
+        // is powered by the bot + app tokens. Tearing down the oauth_connection
+        // row when only user_token is removed would flap the integration's
+        // connected state until the next sync. Keep bot+app teardown behavior
+        // unchanged — those tokens are what the connection depends on.
+        if (service === "slack_channel" && field === "user_token") {
+          const slackResult = await clearSlackUserToken();
+          if (!slackResult.success) {
+            return {
+              content: `Error: ${
+                slackResult.error ?? "failed to delete Slack user token"
+              }`,
+              isError: true,
+            };
+          }
+          return {
+            content: `Deleted credential for ${service}/${field}.`,
+            isError: false,
           };
         }
 


### PR DESCRIPTION
## Summary
Deleting just the user_token was tearing down the whole slack_channel oauth_connection row, causing the integration to flap. Delete only the user_token's secure key + metadata when field=user_token; keep bot_token and app_token teardown behavior unchanged.

Fixes gap identified during plan review for slack-user-token-triage.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
