### PR TITLE
fix(slack): drop stale user_token when bot_token workspace changes

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -442,6 +442,170 @@ describe("Slack channel config handler", () => {
     ).toBeUndefined();
   });
 
+  test("POST drops stale user_token when bot_token workspace differs", async () => {
+    // Scenario: user provisionally stores a user_token for workspace A before
+    // any bot token exists. Later they store a bot_token for workspace B.
+    // The handler must clear the stale user_token so reads (user_token) and
+    // writes (bot_token) never span workspaces.
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+      "xoxp-workspace-a",
+    );
+    upsertCredentialMetadata("slack_channel", "user_token", {});
+    // No bot token yet — config has no teamId.
+
+    // fetch is called twice: once to validate the new bot_token (workspace B),
+    // once to auth.test the persisted user_token (workspace A).
+    const calls: string[] = [];
+    globalThis.fetch = (async (
+      _url: string,
+      init?: { headers?: Record<string, string> },
+    ) => {
+      const auth = init?.headers?.["Authorization"] ?? "";
+      calls.push(auth);
+      if (auth === "Bearer xoxb-workspace-b") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_B",
+            team: "TeamB",
+            user_id: "U_BOT_B",
+            user: "botb",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (auth === "Bearer xoxp-workspace-a") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_A",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected auth header: ${auth}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await setSlackChannelConfig("xoxb-workspace-b");
+
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasUserToken).toBe(false);
+    expect(result.teamId).toBe("T_B");
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain("different workspace");
+
+    // user_token secure key + metadata are gone.
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
+    ).toBeUndefined();
+    expect(
+      getCredentialMetadata("slack_channel", "user_token"),
+    ).toBeUndefined();
+
+    // Both fetches happened: bot validation and user_token cross-check.
+    expect(calls).toContain("Bearer xoxb-workspace-b");
+    expect(calls).toContain("Bearer xoxp-workspace-a");
+  });
+
+  test("POST keeps user_token when bot_token workspace matches", async () => {
+    // Same workspace as persisted user_token — keep it.
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+      "xoxp-workspace-a",
+    );
+    upsertCredentialMetadata("slack_channel", "user_token", {});
+
+    globalThis.fetch = (async (
+      _url: string,
+      init?: { headers?: Record<string, string> },
+    ) => {
+      const auth = init?.headers?.["Authorization"] ?? "";
+      if (auth === "Bearer xoxb-workspace-a") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_A",
+            team: "TeamA",
+            user_id: "U_BOT_A",
+            user: "bota",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (auth === "Bearer xoxp-workspace-a") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_A",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected auth header: ${auth}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await setSlackChannelConfig("xoxb-workspace-a");
+
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasUserToken).toBe(true);
+    expect(result.teamId).toBe("T_A");
+    // No cross-workspace warning — both tokens match.
+    expect(result.warning ?? "").not.toContain("different workspace");
+
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
+    ).toBe("xoxp-workspace-a");
+  });
+
+  test("POST drops user_token whose auth.test now fails when bot_token is stored", async () => {
+    await setSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+      "xoxp-revoked",
+    );
+    upsertCredentialMetadata("slack_channel", "user_token", {});
+
+    globalThis.fetch = (async (
+      _url: string,
+      init?: { headers?: Record<string, string> },
+    ) => {
+      const auth = init?.headers?.["Authorization"] ?? "";
+      if (auth === "Bearer xoxb-workspace-a") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            team_id: "T_A",
+            team: "TeamA",
+            user_id: "U_BOT_A",
+            user: "bota",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (auth === "Bearer xoxp-revoked") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "token_revoked" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected auth header: ${auth}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await setSlackChannelConfig("xoxb-workspace-a");
+
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasUserToken).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain("User token");
+
+    expect(
+      await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
+    ).toBeUndefined();
+  });
+
   test("POST rejects user token from a different workspace than the bot token", async () => {
     // Pre-seed config with bot-token-derived team id (T_TEAM) to simulate that
     // a bot token has already been configured.

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -221,6 +221,51 @@ export async function setSlackChannelConfig(
     setNestedValue(raw, "slack.botUsername", metadata.botUsername ?? "");
     saveRawConfig(raw);
     invalidateConfigCache();
+
+    // Cross-check existing user_token against the newly-stored bot_token's
+    // workspace. A user_token persisted under a previous workspace (or whose
+    // auth.test now fails) must be cleared so reads and writes never fan out
+    // across workspaces. Best-effort: any failure fetching auth.test is treated
+    // as a reason to drop the token defensively.
+    const existingUserToken = await getSecureKeyAsync(
+      credentialKey("slack_channel", "user_token"),
+    );
+    if (existingUserToken) {
+      let shouldClear = false;
+      let clearReason: string | undefined;
+      try {
+        const res = await fetch("https://slack.com/api/auth.test", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${existingUserToken}` },
+        });
+        const data = (await res.json()) as {
+          ok: boolean;
+          error?: string;
+          team_id?: string;
+        };
+        if (!data.ok) {
+          shouldClear = true;
+          clearReason = "User token validation failed; it has been removed.";
+        } else if (
+          metadata.teamId &&
+          data.team_id &&
+          data.team_id !== metadata.teamId
+        ) {
+          shouldClear = true;
+          clearReason =
+            "User token from a different workspace was removed.";
+        }
+      } catch {
+        shouldClear = true;
+        clearReason = "User token validation failed; it has been removed.";
+      }
+      if (shouldClear) {
+        await clearSlackUserToken();
+        if (clearReason) {
+          warning = warning ? `${warning} ${clearReason}` : clearReason;
+        }
+      }
+    }
   } else {
     // Use existing metadata from config if no new bot token provided
     const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
@@ -316,11 +361,13 @@ export async function setSlackChannelConfig(
   ));
 
   if (hasBotToken && !hasAppToken) {
-    warning =
+    const msg =
       "Bot token stored but app token is missing — connection incomplete.";
+    warning = warning ? `${warning} ${msg}` : msg;
   } else if (!hasBotToken && hasAppToken) {
-    warning =
+    const msg =
       "App token stored but bot token is missing — connection incomplete.";
+    warning = warning ? `${warning} ${msg}` : msg;
   }
 
   // Sync oauth_connection record so getConnectionByProvider("slack_channel")


### PR DESCRIPTION
## Summary
Prevent silent token/workspace drift: when a bot_token is stored and the workspace team_id differs from an existing user_token's, drop the stale user_token and surface a warning.

Fixes gap identified during plan review for slack-user-token-triage.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
