### PR TITLE
fix(slack-share): prefer user_token for channel enumeration in Share UI

### DIFF
--- a/assistant/src/runtime/routes/integrations/slack/__tests__/share.test.ts
+++ b/assistant/src/runtime/routes/integrations/slack/__tests__/share.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the Share UI Slack route handlers.
+ *
+ * Verifies the read/write auth split mirrors `messaging/providers/slack/adapter.ts`:
+ * - Channel enumeration (GET /v1/slack/channels) is a read path and must
+ *   prefer the user_token when present so the picker surfaces channels the
+ *   user is in but the bot isn't.
+ * - Channel sharing (POST /v1/slack/share) is a write path and must always
+ *   use the bot_token so posts come from the bot identity.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../../../../../security/credential-key.js";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+const getSecureKeyAsyncMock = mock(
+  async (_key: string): Promise<string | null> => null,
+);
+mock.module("../../../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+// share.ts imports getConnectionByProvider from oauth-store at module load.
+// Stub it to return undefined so Socket Mode tokens are the only source.
+mock.module("../../../../../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: () => undefined,
+}));
+
+// Stub the app store so handleShareToSlackChannel finds the app.
+const FAKE_APP = { id: "app-1", name: "Test App", description: "desc" };
+mock.module("../../../../../memory/app-store.js", () => ({
+  getApp: (id: string) => (id === FAKE_APP.id ? FAKE_APP : undefined),
+}));
+
+const { handleListSlackChannels, handleShareToSlackChannel } = await import(
+  "../share.js"
+);
+
+// ── fetch capture ───────────────────────────────────────────────────────────
+
+type CapturedRequest = {
+  url: string;
+  method: string;
+  authorization: string | null;
+};
+
+const captured: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+
+function installFetchStub() {
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = new Headers(init?.headers ?? {});
+    captured.push({
+      url,
+      method,
+      authorization: headers.get("authorization"),
+    });
+
+    // Minimal OK Slack envelopes so handlers don't throw on shape mismatches.
+    const body = fakeSlackResponse(url);
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function fakeSlackResponse(url: string): Record<string, unknown> {
+  if (url.includes("/conversations.list")) {
+    return { ok: true, channels: [], response_metadata: { next_cursor: "" } };
+  }
+  if (url.includes("/chat.postMessage")) {
+    return { ok: true, ts: "1700000000.000100", channel: "C123" };
+  }
+  return { ok: true };
+}
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+const BOT_TOKEN = "xoxb-BOT";
+const USER_TOKEN = "xoxp-USER";
+
+describe("Slack share route token routing", () => {
+  beforeEach(() => {
+    captured.length = 0;
+    getSecureKeyAsyncMock.mockReset();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("GET /v1/slack/channels: bot-only install reads with bot token", async () => {
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      return null;
+    });
+
+    const res = await handleListSlackChannels();
+    expect(res.status).toBe(200);
+
+    const listCall = captured.find((c) =>
+      c.url.includes("/conversations.list"),
+    );
+    expect(listCall).toBeDefined();
+    expect(listCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+
+  test("GET /v1/slack/channels: bot + user tokens prefer user_token for reads", async () => {
+    // Core fix: with both tokens stored, the Share UI picker must see every
+    // channel the USER can see — not just ones the bot is a member of.
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      if (key === credentialKey("slack_channel", "user_token"))
+        return USER_TOKEN;
+      return null;
+    });
+
+    const res = await handleListSlackChannels();
+    expect(res.status).toBe(200);
+
+    const listCall = captured.find((c) =>
+      c.url.includes("/conversations.list"),
+    );
+    expect(listCall).toBeDefined();
+    expect(listCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
+  });
+
+  test("POST /v1/slack/share: bot + user tokens still write with bot token", async () => {
+    // SAFETY invariant: posts MUST come from the bot identity. If the handler
+    // ever routed the write through user_token, the posted message would
+    // appear as the user — unambiguously wrong.
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      if (key === credentialKey("slack_channel", "user_token"))
+        return USER_TOKEN;
+      return null;
+    });
+
+    const req = new Request("http://localhost/v1/slack/share", {
+      method: "POST",
+      body: JSON.stringify({ appId: FAKE_APP.id, channelId: "C123" }),
+    });
+
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(200);
+
+    const postCall = captured.find((c) => c.url.includes("/chat.postMessage"));
+    expect(postCall).toBeDefined();
+    expect(postCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+
+  test("no tokens configured: both handlers return 503", async () => {
+    getSecureKeyAsyncMock.mockImplementation(async () => null);
+
+    const listRes = await handleListSlackChannels();
+    expect(listRes.status).toBe(503);
+
+    const shareReq = new Request("http://localhost/v1/slack/share", {
+      method: "POST",
+      body: JSON.stringify({ appId: FAKE_APP.id, channelId: "C123" }),
+    });
+    const shareRes = await handleShareToSlackChannel(shareReq);
+    expect(shareRes.status).toBe(503);
+  });
+});

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
 import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
+import { credentialKey } from "../../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import { httpError } from "../../../http-errors.js";
@@ -25,13 +26,46 @@ const log = getLogger("slack-share");
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the Slack bot token from the OAuth connection store.
+ * Resolve a Slack token for the Share UI, mirroring the read/write auth split
+ * in `messaging/providers/slack/adapter.ts`.
+ *
+ * For Socket Mode installs (tokens stored under `credential/slack_channel/*`),
+ * prefer the user OAuth token (xoxp-) for reads when present — this lets the
+ * channel picker surface channels the user belongs to but the bot doesn't.
+ * Fall back to the bot token (xoxb-) otherwise.
+ *
+ * Writes MUST always use the bot token so posted messages come from the bot
+ * identity, never the user. Passing `user_token` to chat.postMessage would
+ * post as the user — unambiguously wrong for Share UI behavior.
+ *
+ * For legacy OAuth installs (no Socket Mode tokens), fall back to the OAuth
+ * connection's access_token, which is the bot token in Slack's OAuth v2 flow.
  */
-async function resolveSlackToken(): Promise<string | undefined> {
+async function resolveSlackToken(
+  mode: "read" | "write",
+): Promise<string | undefined> {
+  // Socket Mode path — tokens stored directly in the credential vault.
+  const botToken = await getSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  if (botToken) {
+    if (mode === "read") {
+      const userToken = await getSecureKeyAsync(
+        credentialKey("slack_channel", "user_token"),
+      );
+      return userToken ?? botToken;
+    }
+    // SAFETY: writes must use the bot token. Using the user token here would
+    // post as the user rather than the bot.
+    return botToken;
+  }
+
+  // Legacy OAuth path. Slack's OAuth v2 access_token is the bot token; there
+  // is no separate user token stored for this install, so reads and writes
+  // both use access_token.
   const conn = getConnectionByProvider("slack");
-  return conn
-    ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
-    : undefined;
+  if (!conn) return undefined;
+  return await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
 }
 
 // ---------------------------------------------------------------------------
@@ -61,7 +95,9 @@ const TYPE_SORT_ORDER: Record<string, number> = {
 };
 
 export async function handleListSlackChannels(): Promise<Response> {
-  const token = await resolveSlackToken();
+  // Channel enumeration is a read path — prefer user_token when present so
+  // the picker surfaces channels the user is in but the bot isn't.
+  const token = await resolveSlackToken("read");
   if (!token) {
     return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
   }
@@ -137,7 +173,9 @@ export async function handleListSlackChannels(): Promise<Response> {
 export async function handleShareToSlackChannel(
   req: Request,
 ): Promise<Response> {
-  const token = await resolveSlackToken();
+  // Posting a message is a write path — must use the bot token so the message
+  // comes from the bot identity, never the user.
+  const token = await resolveSlackToken("write");
   if (!token) {
     return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
   }


### PR DESCRIPTION
## Summary
The Share UI's channel picker listed only channels the bot was a member of. Use the same read/write auth split as the messaging adapter: reads (listConversations) prefer user_token when present; writes stay on bot_token.

Fixes gap identified during plan review for slack-user-token-triage.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
