### PR TITLE
docs(architecture): update slack channel endpoint table for user_token

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -335,9 +335,9 @@ The Slack channel provides text-based messaging via Slack's Socket Mode API. Unl
 
 | Endpoint                                | Method | Description                                                                                                                                          |
 | --------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/v1/integrations/slack/channel/config` | GET    | Returns current config status: `hasBotToken`, `hasAppToken`, `connected`, plus workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`) |
-| `/v1/integrations/slack/channel/config` | POST   | Validates and stores credentials. Body: `{ botToken?: string, appToken?: string }`                                                                   |
-| `/v1/integrations/slack/channel/config` | DELETE | Clears all Slack channel credentials from secure storage and credential metadata                                                                     |
+| `/v1/integrations/slack/channel/config` | GET    | Returns current config status: `hasBotToken`, `hasAppToken`, `hasUserToken`, `connected`, plus workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`)                                                                  |
+| `/v1/integrations/slack/channel/config` | POST   | Validates and stores credentials. Body: `{ botToken?: string, appToken?: string, userToken?: string }`                                                                                                                                |
+| `/v1/integrations/slack/channel/config` | DELETE | Clears Slack channel credentials. Deleting `field=user_token` is surgical — it clears only the user token via `clearSlackUserToken` and leaves the `oauth_connection` row intact. Deleting `bot_token` or `app_token` does a full teardown. |
 
 All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`.
 


### PR DESCRIPTION
## Summary
Round-2 review caught the ARCHITECTURE.md Slack Channel endpoint table still showing the two-token API. Add hasUserToken to the GET response, userToken? to the POST body, and note the surgical DELETE path for user_token.

Fixes gap identified during plan review round 2 for slack-user-token-triage.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
