### PR TITLE
M1: Standardize PreChat views to use design system tokens and components

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -83,24 +83,19 @@ struct NameExchangeView: View {
                     onComplete()
                 }
 
-                Button {
+                VButton(label: "Skip", style: .ghost) {
                     onSkip()
-                } label: {
-                    Text("Skip")
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundStyle(VColor.contentTertiary)
                 }
-                .buttonStyle(.plain)
             }
             .padding(.horizontal, VSpacing.xxl)
             .padding(.bottom, VSpacing.xxl)
             .opacity(showContent ? 1 : 0)
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+            withAnimation(VAnimation.slow.delay(0.1)) {
                 showHeader = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            withAnimation(VAnimation.slow.delay(0.3)) {
                 showContent = true
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -83,7 +83,7 @@ struct NameExchangeView: View {
                     onComplete()
                 }
 
-                VButton(label: "Skip", style: .ghost) {
+                VButton(label: "Skip", style: .ghost, tintColor: VColor.contentTertiary) {
                     onSkip()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -52,7 +52,7 @@ struct PreChatOnboardingFlow: View {
                 }
             }
         }
-        .animation(.spring(duration: 0.5, bounce: 0.1), value: state.currentScreen)
+        .animation(VAnimation.panel, value: state.currentScreen)
         .transition(.asymmetric(
             insertion: .move(edge: .trailing).combined(with: .opacity),
             removal: .move(edge: .leading).combined(with: .opacity)
@@ -64,17 +64,15 @@ struct PreChatOnboardingFlow: View {
     @ViewBuilder
     private func backButton(action: @escaping () -> Void) -> some View {
         HStack {
-            Button {
+            VButton(
+                label: "Back",
+                leftIcon: VIcon.chevronLeft.rawValue,
+                style: .ghost,
+                size: .compact,
+                tintColor: VColor.contentSecondary
+            ) {
                 action()
-            } label: {
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.chevronLeft, size: 12)
-                    Text("Back")
-                        .font(VFont.bodyMediumDefault)
-                }
-                .foregroundStyle(VColor.contentSecondary)
             }
-            .buttonStyle(.plain)
             Spacer()
         }
         .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: 0, trailing: VSpacing.lg))
@@ -83,7 +81,7 @@ struct PreChatOnboardingFlow: View {
     // MARK: - Navigation
 
     private func advanceTo(_ screen: Int) {
-        withAnimation(.spring(duration: 0.5, bounce: 0.1)) {
+        withAnimation(VAnimation.panel) {
             state.currentScreen = screen
         }
         state.persist()

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -107,7 +107,7 @@ struct TaskToneSelectionView: View {
                     onContinue()
                 }
 
-                VButton(label: "I'll set this up later", style: .ghost) {
+                VButton(label: "I'll set this up later", style: .ghost, tintColor: VColor.contentTertiary) {
                     onSkip()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -81,7 +81,8 @@ struct TaskToneSelectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(spacing: VSpacing.xs) {
-                    VSlider(value: $toneValue, range: 0...1, step: 0.5, showTickMarks: true)
+                    Slider(value: $toneValue, in: 0...1, step: 0.5)
+                        .tint(VColor.primaryBase)
 
                     HStack {
                         Text("Casual")

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -81,8 +81,7 @@ struct TaskToneSelectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(spacing: VSpacing.xs) {
-                    Slider(value: $toneValue, in: 0...1, step: 0.5)
-                        .tint(VColor.primaryBase)
+                    VSlider(value: $toneValue, range: 0...1, step: 0.5, showTickMarks: true)
 
                     HStack {
                         Text("Casual")
@@ -116,10 +115,10 @@ struct TaskToneSelectionView: View {
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {
-            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+            withAnimation(VAnimation.slow.delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            withAnimation(VAnimation.slow.delay(0.3)) {
                 showContent = true
             }
         }
@@ -140,7 +139,7 @@ struct TaskToneSelectionView: View {
                 ))
                 .opacity(showCharacters ? 1 : 0)
                 .offset(y: showCharacters ? 0 : 30)
-                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .animation(VAnimation.slow.delay(0.5), value: showCharacters)
                 .onAppear { showCharacters = true }
                 .accessibilityHidden(true)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
@@ -62,7 +62,7 @@ struct ToolSelectionView: View {
                     onContinue()
                 }
 
-                VButton(label: "I'll set this up later", style: .ghost) {
+                VButton(label: "I'll set this up later", style: .ghost, tintColor: VColor.contentTertiary) {
                     onSkip()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
@@ -62,14 +62,9 @@ struct ToolSelectionView: View {
                     onContinue()
                 }
 
-                Button {
+                VButton(label: "I'll set this up later", style: .ghost) {
                     onSkip()
-                } label: {
-                    Text("I'll set this up later")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentTertiary)
                 }
-                .buttonStyle(.plain)
             }
             .padding(.horizontal, VSpacing.xxl)
             .padding(.bottom, VSpacing.xxl)
@@ -77,13 +72,13 @@ struct ToolSelectionView: View {
             .offset(y: showFooter ? 0 : 12)
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+            withAnimation(VAnimation.slow.delay(0.1)) {
                 showTitle = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            withAnimation(VAnimation.slow.delay(0.3)) {
                 showGrid = true
             }
-            withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            withAnimation(VAnimation.slow.delay(0.5)) {
                 showFooter = true
             }
         }


### PR DESCRIPTION
Replace raw animation values with VAnimation tokens, native Slider with VSlider, and manual Button+.plain patterns with VButton(.ghost) across all PreChat onboarding views. Part of #25589.

## Changes

### 1. Replace raw animations with VAnimation tokens
- **ToolSelectionView.swift**: Replaced 3x `.easeOut(duration: 0.5)` with `VAnimation.slow` (staggered delays preserved)
- **TaskToneSelectionView.swift**: Replaced 2x `.easeOut(duration: 0.5)` and 1x `.easeOut(duration: 0.6)` with `VAnimation.slow`
- **NameExchangeView.swift**: Replaced 2x `.easeOut(duration: 0.5)` with `VAnimation.slow`
- **PreChatOnboardingFlow.swift**: Replaced 2x `.spring(duration: 0.5, bounce: 0.1)` with `VAnimation.panel`

### 2. Replace native Slider with VSlider
- **TaskToneSelectionView.swift**: Replaced `Slider(value:in:step:).tint()` with `VSlider(value:range:step:showTickMarks:)`

### 3. Replace manual buttons with VButton
- **PreChatOnboardingFlow.swift**: Replaced manual back button (Button + HStack + VIconView + Text + .plain) with `VButton(label:leftIcon:style:size:tintColor:)`
- **ToolSelectionView.swift**: Replaced manual "I'll set this up later" button with `VButton(label:style:.ghost)`
- **NameExchangeView.swift**: Replaced manual "Skip" button with `VButton(label:style:.ghost)`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
