### PR TITLE
feat(home-feed): instrument scheduler + sequence with emitFeedEvent [JARVIS-512]

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,3 +1,4 @@
+import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
@@ -141,11 +142,21 @@ async function runScheduleOnce(
         });
         if (isOneShot) {
           completeOneShot(job.id);
+          emitScheduleFeedEvent({
+            title: job.name,
+            summary: "Reminder fired.",
+            dedupKey: `schedule-notify-oneshot:${job.id}`,
+          });
         } else {
           // Track recurring notify-mode success so lastStatus resets to ok
           // and retryCount clears after a transient failure.
           const runId = createScheduleRun(job.id, `notify-ok:${job.id}`);
           completeScheduleRun(runId, { status: "ok" });
+          emitScheduleFeedEvent({
+            title: job.name,
+            summary: "Scheduled notification fired.",
+            dedupKey: `schedule-run:${runId}`,
+          });
         }
       } catch (err) {
         log.warn(
@@ -223,6 +234,11 @@ async function runScheduleOnce(
           completeScheduleRun(runId, { status: "ok" });
           if (!job.quiet) {
             notifySchedule({ id: job.id, name: job.name });
+            emitScheduleFeedEvent({
+              title: job.name,
+              summary: "Scheduled task ran.",
+              dedupKey: `schedule-run:${runId}`,
+            });
           }
           if (isOneShot) completeOneShot(job.id);
         }
@@ -317,6 +333,11 @@ async function runScheduleOnce(
       completeScheduleRun(runId, { status: "ok" });
       if (!job.quiet) {
         notifySchedule({ id: job.id, name: job.name });
+        emitScheduleFeedEvent({
+          title: job.name,
+          summary: isOneShot ? "One-shot reminder ran." : "Scheduled job ran.",
+          dedupKey: `schedule-run:${runId}`,
+        });
       }
       if (isOneShot) completeOneShot(job.id);
       processed += 1;
@@ -383,4 +404,33 @@ async function runScheduleOnce(
     log.info({ processed }, "Schedule tick complete");
   }
   return processed;
+}
+
+/**
+ * Fire-and-forget home-feed emit for a successful schedule run.
+ *
+ * Wraps {@link emitFeedEvent} with local error handling so a schema
+ * failure or writer hiccup can never interrupt the scheduler tick
+ * loop. The dedupKey is always derived from the schedule run id (or
+ * the job id, for one-shot notify-mode which fires before a run
+ * record is created) so each run lands as its own entry in the
+ * activity log — the writer's per-source cap keeps total volume
+ * bounded.
+ */
+function emitScheduleFeedEvent(params: {
+  title: string;
+  summary: string;
+  dedupKey: string;
+}): void {
+  void emitFeedEvent({
+    source: "assistant",
+    title: params.title,
+    summary: params.summary,
+    dedupKey: params.dedupKey,
+  }).catch((err) => {
+    log.warn(
+      { err, dedupKey: params.dedupKey },
+      "Failed to emit schedule feed event",
+    );
+  });
 }

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -6,6 +6,7 @@
  * sends through the messaging layer.
  */
 
+import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getMessages } from "../memory/conversation-crud.js";
 import type { ScheduleMessageProcessor } from "../schedule/scheduler.js";
@@ -199,6 +200,28 @@ async function processEnrollment(
   // rate-limit counters — only actual sends are counted.
   recordSend(sequence.id);
   recordEvent(sequence.id, enrollment.id, "send", step.index);
+
+  // Fire-and-forget home-feed activity log entry. Each (enrollment,
+  // step) pair is a distinct real signal (an email actually went
+  // out), so the dedupKey embeds both — repeat emits for the same
+  // step are impossible because the enrollment advances after this
+  // line, but if they did occur they'd land on the same entry.
+  void emitFeedEvent({
+    source: "assistant",
+    title: sequence.name,
+    summary: `Sent step ${step.index + 1} of ${sequence.steps.length} to ${enrollment.contactEmail}.`,
+    dedupKey: `sequence-step:${enrollment.id}:${step.index}`,
+  }).catch((err) => {
+    log.warn(
+      {
+        err,
+        sequenceId: sequence.id,
+        enrollmentId: enrollment.id,
+        step: step.index,
+      },
+      "Failed to emit sequence step feed event",
+    );
+  });
 
   // Advance to the next step
   const nextStepIndex = enrollment.currentStep + 1;


### PR DESCRIPTION
## Summary

Third step of JARVIS-512, stacked on #25584 and #25586 (both merged). Wires `emitFeedEvent` into the first batch of background-job completion points so real assistant activity starts showing up in the home feed's activity log.

### What lands

**`scheduler.ts` — 4 emit points**

| Branch | When | dedupKey |
|---|---|---|
| notify mode, one-shot | After `notifyScheduleOneShot` + `completeOneShot` | `schedule-notify-oneshot:<jobId>` |
| notify mode, recurring | After `completeScheduleRun(ok)` | `schedule-run:<runId>` |
| execute mode, task | After `completeScheduleRun(ok)` in the `run_task:` branch (gated on `!job.quiet`) | `schedule-run:<runId>` |
| execute mode, message | After `completeScheduleRun(ok)` in the plain-message branch (gated on `!job.quiet`) | `schedule-run:<runId>` |

Execute-mode emits mirror the existing `notifySchedule` gating on `!job.quiet` — users who opted out of push notifications also opt out of activity log entries. Notify-mode emits always fire because notify-mode IS notification by design.

A small `emitScheduleFeedEvent` helper at the bottom of the file wraps `emitFeedEvent` with fire-and-forget `.catch` handling so a schema error or writer hiccup can never interrupt the 15s scheduler tick.

**`sequence/engine.ts` — 1 emit point**

After `recordSend` in `processEnrollment`, keyed on `sequence-step:<enrollmentId>:<stepIndex>`. Placed after the `step.requireApproval` gate so draft-only steps (which pause without sending) don't show up in the log — only actual sends produce a real signal.

### Loop / runaway-cost audit (per the concern raised in-thread)

- **No feedback loop**: no daemon-side subscriber to `home_feed_updated` was found in the audit (only the macOS client consumes it). Emits can't trigger more background work.
- **No unguarded high-frequency emit**: scheduler ticks every 15s but only emits when a schedule actually fires (bounded by user-defined RRULE/cron cadence). Sequences are capped at 10 enrollments/tick.
- **No LLM cost multiplier**: the reflection/gmail-digest producers were deliberately *not* instrumented — they're the activity log's *consumers*, not sources. Double-emitting there would spam SSE and inflate the per-source action cap without adding signal.
- **Bounded volume**: per-source action cap (`MAX_ACTIONS_PER_SOURCE = 20`, from #25584) keeps total `source: "assistant"` actions at ≤20 most-recent. Older emits fall off deterministically.

### Deferred to follow-ups (with specific reasons)

- **Gmail watcher event processing** (`watcher/engine.ts:222`) — loop-risk: the LLM event-processing path could itself re-trigger watcher polling if we're not careful. Needs its own audit.
- **Manual task-runner completion** (`task-runner.ts:102`) — needs a dedup story with the scheduler layer so schedule-triggered tasks don't double-emit (scheduler AND task-runner both firing).
- **Skill runner completion** — no single well-defined "skill done" hook in the codebase yet; instrumentation would be sprinkled and hard to reason about.

### Testing

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test src/home/` — 144/144 pass (regression check; no new tests in this PR — see below)
- [ ] Manual smoke test on the branch: trigger a schedule and observe a feed entry land

No new unit tests in this PR. The scheduler and sequence modules don't have existing test harnesses (no `src/schedule/__tests__`, no `src/sequence/__tests__`) — standing one up just for these pass-through emits is significant scope creep. The `emitFeedEvent` helper itself has thorough unit coverage in #25586. Manual smoke after merge will verify end-to-end wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
