### PR TITLE
M2: Add interaction polish — hover states, cursors, and step indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -129,6 +129,8 @@ struct NameExchangeView: View {
                 hoveredSuggestion = hovering ? name : nil
             }
         })
+        .accessibilityLabel(name)
+        .accessibilityValue(isActive ? "Selected" : "Not selected")
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -19,6 +19,7 @@ struct NameExchangeView: View {
 
     @State private var showHeader = false
     @State private var showContent = false
+    @State private var hoveredSuggestion: String?
 
     /// Quick-tap suggestion pills for the assistant name.
     private static let assistantNameSuggestions = ["Pax", "Atlas", "Sage", "Nova", "Kit"]
@@ -104,24 +105,30 @@ struct NameExchangeView: View {
     // MARK: - Subviews
 
     private func suggestionPill(_ name: String) -> some View {
-        Button {
+        let isActive = assistantName == name
+        return Button {
             assistantName = name
         } label: {
             Text(name)
                 .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
+                .foregroundStyle(isActive ? VColor.contentInset : VColor.contentSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xs)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.pill)
-                        .fill(VColor.surfaceLift)
+                        .fill(isActive ? VColor.primaryBase : (hoveredSuggestion == name ? VColor.surfaceHover : VColor.surfaceLift))
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.pill)
-                                .stroke(VColor.borderElement, lineWidth: 1)
+                                .stroke(isActive ? VColor.primaryBase : (hoveredSuggestion == name ? VColor.borderHover : VColor.borderElement), lineWidth: 1)
                         )
                 )
         }
         .buttonStyle(.plain)
+        .pointerCursor(onHover: { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredSuggestion = hovering ? name : nil
+            }
+        })
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -24,14 +24,18 @@ struct PreChatOnboardingFlow: View {
         Group {
             switch state.currentScreen {
             case 0:
-                ToolSelectionView(
-                    selectedTools: $state.selectedTools,
-                    onContinue: { advanceTo(1) },
-                    onSkip: { skipAll() }
-                )
+                VStack(spacing: 0) {
+                    stepIndicator(currentStep: 0)
+                    ToolSelectionView(
+                        selectedTools: $state.selectedTools,
+                        onContinue: { advanceTo(1) },
+                        onSkip: { skipAll() }
+                    )
+                }
             case 1:
                 VStack(spacing: 0) {
                     backButton { advanceTo(0) }
+                    stepIndicator(currentStep: 1)
                     TaskToneSelectionView(
                         selectedTasks: $state.selectedTasks,
                         toneValue: $state.toneValue,
@@ -42,6 +46,7 @@ struct PreChatOnboardingFlow: View {
             default:
                 VStack(spacing: 0) {
                     backButton { advanceTo(1) }
+                    stepIndicator(currentStep: 2)
                     NameExchangeView(
                         contextSummary: state.contextSummary,
                         userName: $state.userName,
@@ -76,6 +81,23 @@ struct PreChatOnboardingFlow: View {
             Spacer()
         }
         .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: 0, trailing: VSpacing.lg))
+    }
+
+    // MARK: - Step Indicator
+
+    @ViewBuilder
+    private func stepIndicator(currentStep: Int, totalSteps: Int = 3) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            ForEach(0..<totalSteps, id: \.self) { step in
+                Circle()
+                    .fill(step == currentStep ? VColor.primaryBase : VColor.borderElement)
+                    .frame(width: 6, height: 6)
+                    .animation(VAnimation.fast, value: currentStep)
+            }
+        }
+        .padding(.top, VSpacing.md)
+        .padding(.bottom, VSpacing.sm)
+        .accessibilityHidden(true)
     }
 
     // MARK: - Navigation

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/TaskToneSelectionView.swift
@@ -18,6 +18,7 @@ struct TaskToneSelectionView: View {
     @State private var showTitle = false
     @State private var showContent = false
     @State private var showCharacters = false
+    @State private var hoveredTask: String?
 
     private static let welcomeCharacters: NSImage? = {
         guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
@@ -189,15 +190,20 @@ struct TaskToneSelectionView: View {
             .padding(VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? VColor.primaryBase.opacity(0.08) : VColor.surfaceLift)
+                    .fill(isSelected ? VColor.primaryBase.opacity(0.08) : (hoveredTask == category.id ? VColor.surfaceHover : VColor.surfaceLift))
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(isSelected ? VColor.primaryBase.opacity(0.3) : VColor.surfaceBase, lineWidth: 1)
+                            .stroke(isSelected ? VColor.primaryBase.opacity(0.3) : (hoveredTask == category.id ? VColor.borderHover : VColor.surfaceBase), lineWidth: 1)
                     )
             )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor(onHover: { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredTask = hovering ? category.id : nil
+            }
+        })
         .accessibilityLabel(category.label)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(.isToggle)

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
@@ -10,6 +10,7 @@ struct ToolSelectionView: View {
     @State private var showTitle = false
     @State private var showGrid = false
     @State private var showFooter = false
+    @State private var hoveredTool: String?
 
     private static let allItems: [ToolItem] = {
         var items = ToolItem.allTools
@@ -128,17 +129,22 @@ struct ToolSelectionView: View {
             .padding(.horizontal, VSpacing.xs)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isSelected ? VColor.primaryBase.opacity(0.08) : VColor.surfaceLift)
+                    .fill(isSelected ? VColor.primaryBase.opacity(0.08) : (hoveredTool == item.id ? VColor.surfaceHover : VColor.surfaceLift))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .stroke(
-                        isSelected ? VColor.primaryBase : VColor.borderElement.opacity(0.5),
+                        isSelected ? VColor.primaryBase : (hoveredTool == item.id ? VColor.borderHover : VColor.borderElement.opacity(0.5)),
                         lineWidth: isSelected ? 1.5 : 1
                     )
             )
         }
         .buttonStyle(.plain)
+        .pointerCursor(onHover: { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredTool = hovering ? item.id : nil
+            }
+        })
         .accessibilityLabel(item.label)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(.isToggle)


### PR DESCRIPTION
## Summary
- Add hover states (background + border color changes) and pointer cursors to tool tiles, task rows, and suggestion pills across all three PreChat onboarding screens
- Highlight the active suggestion pill with primary fill and inset text color when it matches the current assistant name
- Add animated step indicator dots (3 dots) to show progress through the onboarding flow

## Test plan
- [ ] Hover over tool tiles in ToolSelectionView — background should change to `surfaceHover` and border to `borderHover`
- [ ] Hover over task rows in TaskToneSelectionView — same hover feedback
- [ ] Hover over suggestion pills in NameExchangeView — hover feedback on non-active pills
- [ ] Click a suggestion pill — it should fill with `primaryBase` and text turns white
- [ ] Verify pointer cursor (hand) appears on all interactive elements
- [ ] Step indicator dots appear at the top of each screen, with the current step highlighted
- [ ] Navigate between screens and verify dots animate correctly

Part of #25589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
