### PR TITLE
perf(gmail): reduce default scan volume and increase batch concurrency

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -494,7 +494,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 5000, cap 10000)"
+            "description": "Maximum messages to scan (default 2000, cap 10000)"
           },
           "max_senders": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -52,7 +52,7 @@ export async function run(
   const query =
     (input.query as string) ?? "in:inbox category:promotions newer_than:90d";
   const maxMessages = Math.min(
-    (input.max_messages as number) ?? 5000,
+    (input.max_messages as number) ?? 2000,
     MAX_MESSAGES_CAP,
   );
   const maxSenders = (input.max_senders as number) ?? 50;

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -24,7 +24,7 @@ const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 /** Max sub-requests per batch HTTP call (Gmail API limit) */
 const BATCH_SUB_LIMIT = 100;
 /** Max concurrent batch calls */
-const BATCH_CONCURRENCY = 5;
+const BATCH_CONCURRENCY = 8;
 
 export class GmailApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary
- Lower `gmail_sender_digest` default `max_messages` from 5000 → 2000 (fewer pages to list sequentially)
- Increase `BATCH_CONCURRENCY` from 5 → 8 for faster parallel metadata fetching
- Update TOOLS.json description to reflect the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
