### PR TITLE
Add .isSelected trait to suggestion pills

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -131,6 +131,7 @@ struct NameExchangeView: View {
         })
         .accessibilityLabel(name)
         .accessibilityValue(isActive ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Adds .accessibilityAddTraits(isActive ? .isSelected : []) to suggestion pills in NameExchangeView per Codex review feedback on #25596. Part of #25589.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
