### PR TITLE
fix(macos): remove deprecated WKProcessPool from OffscreenPreviewCapture

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
@@ -11,10 +11,8 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Offsc
 /// The entire lifecycle (create → load → render → capture → teardown) is automatic.
 ///
 /// Captures are serialized: only one offscreen WKWebView exists at a time.
-/// A shared `WKProcessPool` is reused across sequential captures so WebKit
-/// can keep a single WebContent process alive instead of spawning a new one
-/// per capture. Image encoding (resize + PNG + base64) runs off the main
-/// thread via `CGContext` to avoid blocking the UI.
+/// Image encoding (resize + PNG + base64) runs off the main thread via
+/// `CGContext` to avoid blocking the UI.
 enum OffscreenPreviewCapture {
 
     // MARK: - Serial Queue
@@ -45,12 +43,6 @@ enum OffscreenPreviewCapture {
             isSlotOccupied = false
         }
     }
-
-    // MARK: - Shared Process Pool
-
-    /// Reused across sequential captures so WebKit keeps a single WebContent
-    /// process alive instead of spawning one per WKWebViewConfiguration.
-    private static let sharedProcessPool = WKProcessPool()
 
     // MARK: - Public API
 
@@ -86,7 +78,6 @@ enum OffscreenPreviewCapture {
 
         let config = WKWebViewConfiguration()
         config.suppressesIncrementalRendering = true
-        config.processPool = sharedProcessPool
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: width, height: height), configuration: config)
         window.contentView = webView
 


### PR DESCRIPTION
## Summary

- Drop \`sharedProcessPool\` and the \`config.processPool\` assignment in \`OffscreenPreviewCapture\`. \`WKProcessPool\` was deprecated in macOS 12.0 and no longer has any effect — WebKit handles WebContent process sharing internally.
- Update the type-level doc comment to remove the now-stale claim about a shared process pool.

## Original prompt

\`\`\`
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=local
BUNDLE_ID=com.vellum.vellum-assistant-local
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift:53:44: warning: 'WKProcessPool' was deprecated in macOS 12.0: Creating and using multiple instances of WKProcessPool no longer has any effect. [#DeprecatedDeclaration]
 51 |     /// Reused across sequential captures so WebKit keeps a single WebContent
 52 |     /// process alive instead of spawning one per WKWebViewConfiguration.
 53 |     private static let sharedProcessPool = WKProcessPool()
    |                                            \`- warning: 'WKProcessPool' was deprecated in macOS 12.0: Creating and using multiple instances of WKProcessPool no longer has any effect. [#DeprecatedDeclaration]
 54 |
 55 |     // MARK: - Public API
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
