### PR TITLE
docs: open repo to external contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- PR title format: type(scope): description -->
+<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->
+
+## Rationale
+<!-- Why are we making this change? What problem does it solve or what goal does it advance? -->
+
+## Summary
+<!-- What changed? Describe the implementation at a level useful for reviewers. -->
+
+## Test plan
+<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->
+
+## Prompt / plan
+<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # daily at 9am UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-issues: true
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been inactive for 90 days. It will be closed in 14
+            days unless there is new activity.
+          close-issue-message: >
+            Closed due to inactivity. Feel free to reopen if this is still relevant.
+
+  stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-pr: true
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has been inactive for 30 days. It will be closed in 7 days
+            unless there is new activity.
+          close-pr-message: >
+            Closed due to inactivity. Feel free to reopen if you'd like to continue working on this.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our Standards
+
+We are committed to providing a welcoming and respectful environment for everyone. All participants in this project are expected to:
+
+- Be respectful and considerate in communication
+- Welcome differing viewpoints and experiences
+- Accept constructive feedback gracefully
+- Focus on what is best for the community and the project
+
+The following behaviors are unacceptable:
+
+- Harassment, intimidation, or discrimination of any kind
+- Personal attacks, insults, or derogatory comments
+- Publishing others' private information without permission
+- Any conduct that would be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including issues, pull requests, discussions, and any other communication channels associated with this project. It also applies when representing the project in public spaces.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to **conduct@vellum.ai**. All reports will be reviewed and investigated promptly and confidentially. The project maintainers reserve the right to remove, edit, or reject contributions and to ban any contributor for behavior they deem inappropriate, threatening, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,119 @@
 # Contributing
 
-Thank you for your interest in Vellum Assistant!
+Thank you for your interest in Vellum Assistant! We welcome contributions of all kinds — bug fixes, new features, documentation improvements, and more.
 
-We are not currently accepting external contributions. This may change in the future, but for now:
+## Before you start
 
-- **Bug reports**: Feel free to [open an issue](https://github.com/vellum-ai/vellum-assistant/issues) if you find a bug.
-- **Feature requests**: We welcome ideas — please [open an issue](https://github.com/vellum-ai/vellum-assistant/issues) describing your use case.
-- **Pull requests**: Please do not submit PRs — they will be closed. If you have a fix you'd like to suggest, describe it in an issue instead.
-- **Security vulnerabilities**: Please report these privately. See [SECURITY.md](SECURITY.md) for details.
+- **Bug reports and feature requests**: [Open an issue](https://github.com/vellum-ai/vellum-assistant/issues). Use the provided templates.
+- **Security vulnerabilities**: Report these privately. See [SECURITY.md](SECURITY.md).
+- **Questions and discussion**: Join us on [Discord](https://vellum.ai/community).
+
+## Development setup
+
+### Prerequisites
+
+- [Bun](https://bun.sh) (v1.x)
+- [Docker](https://docs.docker.com/get-docker/) — required for the sandbox runtime
+- macOS with [Homebrew](https://brew.sh) — needed for native client development (xcodegen is installed automatically)
+
+### Getting started
+
+```bash
+git clone https://github.com/vellum-ai/vellum-assistant.git
+cd vellum-assistant
+./setup.sh    # installs deps, links packages, registers the global vellum CLI
+```
+
+Copy the environment template:
+
+```bash
+cp .env.example .env
+```
+
+Verify your setup:
+
+```bash
+vellum --version
+```
+
+### Running the assistant locally
+
+**macOS app (recommended):**
+
+```bash
+./clients/macos/build.sh run   # build + launch + watch for changes (auto-rebuild)
+```
+
+**CLI only:**
+
+```bash
+vellum hatch   # first-time setup (only needed once)
+vellum wake    # start the assistant + gateway
+vellum client  # interact through the terminal
+vellum sleep   # stop services
+```
+
+### Running tests
+
+```bash
+# Assistant
+cd assistant && bun run test
+
+# CLI
+cd cli && bun run test
+
+# Gateway
+cd gateway && bun run test
+```
+
+### Linting and type checking
+
+```bash
+# From any package directory (assistant/, cli/, gateway/)
+bun run lint
+bun run typecheck
+```
+
+## Project structure
+
+| Directory | What it is |
+|---|---|
+| `assistant/` | Core assistant runtime — memory, tools, skills, scheduling, integrations |
+| `gateway/` | Public ingress — webhooks, API routes, OAuth callbacks |
+| `cli/` | The `vellum` CLI |
+| `clients/` | Native clients (macOS, iOS) |
+| `credential-executor/` | Isolated credential execution service |
+| `packages/` | Shared internal packages |
+| `skills/` | Skill definitions |
+
+For deeper architectural context, see [ARCHITECTURE.md](ARCHITECTURE.md) and the domain-specific docs linked from it.
+
+## Submitting a pull request
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes. Write tests where applicable.
+3. Make sure CI passes locally: `bun run lint && bun run typecheck && bun run test` in the relevant package(s).
+4. Open a PR against `main`. Fill out the PR template — especially the **Rationale**, **Test plan**, and **Prompt/plan** sections.
+5. A maintainer will review your PR. We aim to respond within a few business days.
+
+### PR guidelines
+
+- **Keep PRs focused.** One logical change per PR. Smaller PRs get reviewed faster.
+- **PR titles** follow conventional commits format: `type(scope): description` (e.g., `feat(slack): add user token support`, `fix(cli): handle missing config`).
+- **We assume AI was used.** That's fine — just include the prompt or plan you used in the PR description.
+- **Don't submit PRs against `release/*` branches.** These are for release management only.
+
+### What makes a good contribution
+
+- Fixes a bug you encountered while using the assistant
+- Improves documentation or developer experience
+- Adds test coverage for untested paths
+- Implements a feature you've discussed in an issue or on Discord
+
+## Code of Conduct
+
+All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ All commands target the default assistant. If you have multiple assistants, pass
 
 ## Contributing
 
-We're not accepting external contributions yet. See the [Contributing](https://github.com/vellum-ai/vellum-assistant?tab=contributing-ov-file) tab for updates.
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get set up, run the project locally, and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add PR template, Code of Conduct, and stale bot workflow as new files
- Rewrite CONTRIBUTING.md from "not accepting contributions" to a full contributor guide with dev setup, project structure, and PR guidelines
- Update README.md to welcome contributions and link to the new docs

Note: This PR covers the file/workflow changes only. Branch protection rulesets (required status checks on main, release branch protection) were applied directly via the GitHub API during this session.

## Original prompt
Open up the repo to external contributors. Audit what's needed, set up branch protection, and write the community health files (PR template, Code of Conduct, CONTRIBUTING.md, README update, stale bot).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
