### PR TITLE
M1: Server — accept binary uploads in attachment endpoint

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -493,6 +493,42 @@ export function validateAttachmentUpload(
 }
 
 // ---------------------------------------------------------------------------
+// Binary upload helper (multipart / octet-stream)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write raw bytes to the staging directory and register as a file-backed
+ * attachment. Used by the multipart/form-data and application/octet-stream
+ * upload paths.
+ *
+ * @param filename  Original filename from the client
+ * @param mimeType  MIME type of the file
+ * @param bytes     Raw file content
+ * @returns The stored attachment record
+ */
+export function uploadAttachmentFromBytes(
+  filename: string,
+  mimeType: string,
+  bytes: Uint8Array,
+): StoredAttachment {
+  const dir = join(getWorkspaceDir(), "data", "attachments");
+  mkdirSync(dir, { recursive: true });
+
+  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const stagingFilename = `${Date.now()}-${sanitized}`;
+  const stagedPath = join(dir, stagingFilename);
+
+  writeFileSync(stagedPath, bytes);
+
+  return uploadFileBackedAttachment(
+    filename,
+    mimeType,
+    stagedPath,
+    bytes.length,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // File-backed attachment storage (avoids reading large files into memory)
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -124,6 +124,17 @@ function attachmentResponse(
  * Expects: "file" (Blob), "filename" (string), "mimeType" (string).
  */
 async function handleMultipartUpload(req: Request): Promise<Response> {
+  // Pre-check Content-Length before parsing to reject oversized requests
+  // without buffering the full multipart body into memory.
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_UPLOAD_BODY_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      413,
+    );
+  }
+
   let formData: FormData;
   try {
     formData = await req.formData();
@@ -150,9 +161,8 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
     return httpError("BAD_REQUEST", "mimeType field is required", 400);
   }
 
-  // Enforce body-level size limit (the overall request may contain form
-  // overhead beyond the file part, but checking the file size is the
-  // meaningful limit here).
+  // Secondary check on the file part itself (Content-Length may be absent
+  // or inaccurate; this catches the actual parsed file size).
   if (file.size > MAX_UPLOAD_BODY_BYTES) {
     return httpError(
       "BAD_REQUEST",

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -97,7 +97,153 @@ export function resolveAllowedFileBackedAttachmentPath(
   return null;
 }
 
-export async function handleUploadAttachment(req: Request): Promise<Response> {
+/** 100 MB — maximum file size for binary uploads (multipart / octet-stream). */
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Build the standard JSON success response for an uploaded attachment.
+ */
+function attachmentResponse(
+  attachment: attachmentsStore.StoredAttachment,
+): Response {
+  return Response.json({
+    id: attachment.id,
+    original_filename: attachment.originalFilename,
+    mime_type: attachment.mimeType,
+    size_bytes: attachment.sizeBytes,
+    kind: attachment.kind,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Content-Type dispatched upload handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle multipart/form-data upload.
+ * Expects: "file" (Blob), "filename" (string), "mimeType" (string).
+ */
+async function handleMultipartUpload(req: Request): Promise<Response> {
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return httpError("BAD_REQUEST", "Invalid multipart form data", 400);
+  }
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof Blob)) {
+    return httpError(
+      "BAD_REQUEST",
+      'Multipart upload requires a "file" field',
+      400,
+    );
+  }
+
+  const filename = formData.get("filename");
+  if (!filename || typeof filename !== "string") {
+    return httpError("BAD_REQUEST", "filename field is required", 400);
+  }
+
+  const mimeType = formData.get("mimeType");
+  if (!mimeType || typeof mimeType !== "string") {
+    return httpError("BAD_REQUEST", "mimeType field is required", 400);
+  }
+
+  // Enforce body-level size limit (the overall request may contain form
+  // overhead beyond the file part, but checking the file size is the
+  // meaningful limit here).
+  if (file.size > MAX_UPLOAD_BODY_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      413,
+    );
+  }
+
+  const validation = validateAttachmentUpload(filename, mimeType);
+  if (!validation.ok) {
+    return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+
+  if (bytes.length > MAX_UPLOAD_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `File is ${Math.round(bytes.length / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
+      413,
+    );
+  }
+
+  const attachment = attachmentsStore.uploadAttachmentFromBytes(
+    filename,
+    mimeType,
+    bytes,
+  );
+  return attachmentResponse(attachment);
+}
+
+/**
+ * Handle application/octet-stream upload.
+ * filename and mimeType come from URL query params.
+ */
+async function handleOctetStreamUpload(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const filename = url.searchParams.get("filename");
+  if (!filename || typeof filename !== "string") {
+    return httpError(
+      "BAD_REQUEST",
+      "filename query parameter is required",
+      400,
+    );
+  }
+
+  const mimeType = url.searchParams.get("mimeType");
+  if (!mimeType || typeof mimeType !== "string") {
+    return httpError(
+      "BAD_REQUEST",
+      "mimeType query parameter is required",
+      400,
+    );
+  }
+
+  const rawBody = await req.arrayBuffer();
+  if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      413,
+    );
+  }
+
+  const validation = validateAttachmentUpload(filename, mimeType);
+  if (!validation.ok) {
+    return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
+  }
+
+  const bytes = new Uint8Array(rawBody);
+
+  if (bytes.length > MAX_UPLOAD_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `File is ${Math.round(bytes.length / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
+      413,
+    );
+  }
+
+  const attachment = attachmentsStore.uploadAttachmentFromBytes(
+    filename,
+    mimeType,
+    bytes,
+  );
+  return attachmentResponse(attachment);
+}
+
+/**
+ * Handle application/json upload (existing behaviour — base64 or file-path).
+ */
+async function handleJsonUpload(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();
   if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
     return httpError(
@@ -205,13 +351,22 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
     }
   }
 
-  return Response.json({
-    id: attachment.id,
-    original_filename: attachment.originalFilename,
-    mime_type: attachment.mimeType,
-    size_bytes: attachment.sizeBytes,
-    kind: attachment.kind,
-  });
+  return attachmentResponse(attachment);
+}
+
+export async function handleUploadAttachment(req: Request): Promise<Response> {
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("multipart/form-data")) {
+    return handleMultipartUpload(req);
+  }
+
+  if (contentType.includes("application/octet-stream")) {
+    return handleOctetStreamUpload(req);
+  }
+
+  // Default: JSON+base64 (existing behaviour)
+  return handleJsonUpload(req);
 }
 
 export async function handleDeleteAttachment(req: Request): Promise<Response> {
@@ -392,7 +547,7 @@ export function attachmentRouteDefinitions(): RouteDefinition[] {
       method: "POST",
       summary: "Upload attachment",
       description:
-        "Upload an attachment as base64 data or file path reference.",
+        "Upload an attachment. Supports application/json (base64 data or file path reference), multipart/form-data (file + filename + mimeType fields), and application/octet-stream (raw bytes with filename and mimeType query params).",
       tags: ["attachments"],
       requestBody: z.object({
         filename: z.string(),

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -125,12 +125,13 @@ function attachmentResponse(
  */
 async function handleMultipartUpload(req: Request): Promise<Response> {
   // Pre-check Content-Length before parsing to reject oversized requests
-  // without buffering the full multipart body into memory.
+  // without buffering the full multipart body into memory. Binary uploads
+  // have no base64 overhead, so use the raw file size limit directly.
   const contentLength = req.headers.get("content-length");
-  if (contentLength && Number(contentLength) > MAX_UPLOAD_BODY_BYTES) {
+  if (contentLength && Number(contentLength) > MAX_UPLOAD_BYTES) {
     return httpError(
       "BAD_REQUEST",
-      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      `File too large (limit: ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB)`,
       413,
     );
   }
@@ -161,12 +162,12 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
     return httpError("BAD_REQUEST", "mimeType field is required", 400);
   }
 
-  // Secondary check on the file part itself (Content-Length may be absent
-  // or inaccurate; this catches the actual parsed file size).
-  if (file.size > MAX_UPLOAD_BODY_BYTES) {
+  // Check file part size against the raw file limit (Content-Length may be
+  // absent or inaccurate, so this is the authoritative check).
+  if (file.size > MAX_UPLOAD_BYTES) {
     return httpError(
       "BAD_REQUEST",
-      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      `File is ${Math.round(file.size / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
       413,
     );
   }
@@ -177,14 +178,6 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
   }
 
   const bytes = new Uint8Array(await file.arrayBuffer());
-
-  if (bytes.length > MAX_UPLOAD_BYTES) {
-    return httpError(
-      "BAD_REQUEST",
-      `File is ${Math.round(bytes.length / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
-      413,
-    );
-  }
 
   const attachment = attachmentsStore.uploadAttachmentFromBytes(
     filename,
@@ -199,6 +192,17 @@ async function handleMultipartUpload(req: Request): Promise<Response> {
  * filename and mimeType come from URL query params.
  */
 async function handleOctetStreamUpload(req: Request): Promise<Response> {
+  // Pre-check Content-Length before buffering to reject oversized requests
+  // without reading the full body into memory.
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_UPLOAD_BYTES) {
+    return httpError(
+      "BAD_REQUEST",
+      `File too large (limit: ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB)`,
+      413,
+    );
+  }
+
   const url = new URL(req.url);
   const filename = url.searchParams.get("filename");
   if (!filename || typeof filename !== "string") {
@@ -219,10 +223,11 @@ async function handleOctetStreamUpload(req: Request): Promise<Response> {
   }
 
   const rawBody = await req.arrayBuffer();
-  if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
+  // Post-read check (Content-Length may be absent or inaccurate).
+  if (rawBody.byteLength > MAX_UPLOAD_BYTES) {
     return httpError(
       "BAD_REQUEST",
-      `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`,
+      `File is ${Math.round(rawBody.byteLength / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
       413,
     );
   }
@@ -233,14 +238,6 @@ async function handleOctetStreamUpload(req: Request): Promise<Response> {
   }
 
   const bytes = new Uint8Array(rawBody);
-
-  if (bytes.length > MAX_UPLOAD_BYTES) {
-    return httpError(
-      "BAD_REQUEST",
-      `File is ${Math.round(bytes.length / (1024 * 1024))} MB which exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB upload limit`,
-      413,
-    );
-  }
 
   const attachment = attachmentsStore.uploadAttachmentFromBytes(
     filename,


### PR DESCRIPTION
## Summary
- Adds `multipart/form-data` and `application/octet-stream` Content-Type support to `handleUploadAttachment()`, keeping JSON+base64 as a permanent fallback
- New `uploadAttachmentFromBytes()` helper in `attachments-store.ts` writes raw bytes to the staging directory and registers as file-backed
- Both binary paths validate via `validateAttachmentUpload()` and enforce `MAX_UPLOAD_BODY_BYTES` (150 MB) and `MAX_UPLOAD_BYTES` (100 MB) limits

## Test plan
- [ ] Verify existing JSON+base64 uploads still work unchanged
- [ ] Test multipart/form-data upload with file, filename, and mimeType fields
- [ ] Test application/octet-stream upload with filename and mimeType query params
- [ ] Verify validation rejects dangerous file extensions and unsupported MIME types for all three paths
- [ ] Verify size limits are enforced for both new paths

Part of #25605. Closes #25606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
