### PR TITLE
feat(filing): add Run Now to Schedules settings page

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1088,6 +1088,7 @@ export async function runDaemon(): Promise<void> {
       onProviderCredentialsChanged: () =>
         server.refreshConversationsForProviderChange(),
       getHeartbeatService: () => server.getHeartbeatService(),
+      getFilingService: () => server.getFilingService(),
     });
 
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.
@@ -1405,6 +1406,7 @@ export async function runDaemon(): Promise<void> {
         }),
     });
     filing.start();
+    server.setFilingService(filing);
     log.info(
       {
         enabled: filingConfig.enabled,

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -54,6 +54,15 @@ export interface HeartbeatChecklistWrite {
   content: string;
 }
 
+export interface FilingConfig {
+  type: "filing_config";
+  action: "get";
+}
+
+export interface FilingRunNow {
+  type: "filing_run_now";
+}
+
 // === Server → Client ===
 
 export interface SchedulesListResponse {
@@ -133,6 +142,25 @@ export interface HeartbeatChecklistWriteResponse {
   error?: string;
 }
 
+export interface FilingConfigResponse {
+  type: "filing_config_response";
+  enabled: boolean;
+  intervalMs: number;
+  activeHoursStart: number | null;
+  activeHoursEnd: number | null;
+  nextRunAt: number | null;
+  lastRunAt: number | null;
+  success: boolean;
+  error?: string;
+}
+
+export interface FilingRunNowResponse {
+  type: "filing_run_now_response";
+  success: boolean;
+  ran: boolean;
+  error?: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _SchedulesClientMessages =
@@ -145,7 +173,9 @@ export type _SchedulesClientMessages =
   | HeartbeatRunsList
   | HeartbeatRunNow
   | HeartbeatChecklistRead
-  | HeartbeatChecklistWrite;
+  | HeartbeatChecklistWrite
+  | FilingConfig
+  | FilingRunNow;
 
 export type _SchedulesServerMessages =
   | SchedulesListResponse
@@ -155,4 +185,6 @@ export type _SchedulesServerMessages =
   | HeartbeatRunsListResponse
   | HeartbeatRunNowResponse
   | HeartbeatChecklistResponse
-  | HeartbeatChecklistWriteResponse;
+  | HeartbeatChecklistWriteResponse
+  | FilingConfigResponse
+  | FilingRunNowResponse;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -23,6 +23,7 @@ import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { CesProcessManager } from "../credential-execution/process-manager.js";
+import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
@@ -365,6 +366,17 @@ export class DaemonServer {
 
   getHeartbeatService(): HeartbeatService | undefined {
     return this._heartbeatService;
+  }
+
+  /** Optional filing service reference for "Run Now" from the UI. */
+  private _filingService?: FilingService;
+
+  setFilingService(service: FilingService): void {
+    this._filingService = service;
+  }
+
+  getFilingService(): FilingService | undefined {
+    return this._filingService;
   }
 
   private deriveMemoryPolicy(conversationId: string): ConversationMemoryPolicy {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -164,6 +164,7 @@ import { debugRouteDefinitions } from "./routes/debug-routes.js";
 import { diagnosticsRouteDefinitions } from "./routes/diagnostics-routes.js";
 import { documentRouteDefinitions } from "./routes/documents-routes.js";
 import { eventsRouteDefinitions } from "./routes/events-routes.js";
+import { filingRouteDefinitions } from "./routes/filing-routes.js";
 import { globalSearchRouteDefinitions } from "./routes/global-search-routes.js";
 import { groupRouteDefinitions } from "./routes/group-routes.js";
 import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.js";
@@ -358,6 +359,7 @@ export class RuntimeHttpServer {
   private getCesClient?: RuntimeHttpServerOptions["getCesClient"];
   private onProviderCredentialsChanged?: RuntimeHttpServerOptions["onProviderCredentialsChanged"];
   private getHeartbeatService?: RuntimeHttpServerOptions["getHeartbeatService"];
+  private getFilingService?: RuntimeHttpServerOptions["getFilingService"];
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -382,6 +384,7 @@ export class RuntimeHttpServer {
     this.getCesClient = options.getCesClient;
     this.onProviderCredentialsChanged = options.onProviderCredentialsChanged;
     this.getHeartbeatService = options.getHeartbeatService;
+    this.getFilingService = options.getFilingService;
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -1686,6 +1689,9 @@ export class RuntimeHttpServer {
       }),
       ...heartbeatRouteDefinitions({
         getHeartbeatService: this.getHeartbeatService,
+      }),
+      ...filingRouteDefinitions({
+        getFilingService: this.getFilingService,
       }),
       ...homeStateRouteDefinitions(),
       ...homeFeedRouteDefinitions(),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -241,6 +241,10 @@ export interface RuntimeHttpServerOptions {
   getHeartbeatService?: () =>
     | import("../heartbeat/heartbeat-service.js").HeartbeatService
     | undefined;
+  /** Accessor for the filing service (for run-now and config routes). */
+  getFilingService?: () =>
+    | import("../filing/filing-service.js").FilingService
+    | undefined;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/filing-routes.ts
+++ b/assistant/src/runtime/routes/filing-routes.ts
@@ -1,0 +1,93 @@
+/**
+ * HTTP route handlers for filing management.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../config/loader.js";
+import type { FilingService } from "../../filing/filing-service.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("filing-routes");
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleGetConfig(filingService?: FilingService): Response {
+  const config = getConfig().filing;
+  return Response.json({
+    enabled: config.enabled,
+    intervalMs: config.intervalMs,
+    activeHoursStart: config.activeHoursStart ?? null,
+    activeHoursEnd: config.activeHoursEnd ?? null,
+    nextRunAt: filingService?.nextRunAt ?? null,
+    lastRunAt: filingService?.lastRunAt ?? null,
+    success: true,
+  });
+}
+
+async function handleRunNow(
+  filingService?: FilingService,
+): Promise<Response> {
+  if (!filingService) {
+    return httpError(
+      "SERVICE_UNAVAILABLE",
+      "Filing service not available",
+      503,
+    );
+  }
+
+  try {
+    const ran = await filingService.runOnce({ force: true });
+    return Response.json({ success: true, ran });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Filing run-now failed");
+    return Response.json({ success: false, ran: false, error: message });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function filingRouteDefinitions(deps: {
+  getFilingService?: () => FilingService | undefined;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "filing/config",
+      method: "GET",
+      policyKey: "filing",
+      summary: "Get filing config",
+      description: "Return the current filing schedule configuration.",
+      tags: ["filing"],
+      responseBody: z.object({
+        enabled: z.boolean(),
+        intervalMs: z.number(),
+        activeHoursStart: z.number().nullable(),
+        activeHoursEnd: z.number().nullable(),
+        nextRunAt: z.number().nullable(),
+        lastRunAt: z.number().nullable(),
+        success: z.boolean(),
+      }),
+      handler: () => handleGetConfig(deps.getFilingService?.()),
+    },
+    {
+      endpoint: "filing/run-now",
+      method: "POST",
+      policyKey: "filing",
+      summary: "Run filing now",
+      description: "Trigger an immediate filing run.",
+      tags: ["filing"],
+      responseBody: z.object({
+        success: z.boolean(),
+        ran: z.boolean().describe("Whether the filing actually ran"),
+      }),
+      handler: () => handleRunNow(deps.getFilingService?.()),
+    },
+  ];
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
@@ -20,8 +20,13 @@ struct SettingsSchedulesTab: View {
     @State private var heartbeatConfig: HeartbeatConfigResponse?
     @State private var isHeartbeatRunning = false
 
+    // Filing state
+    @State private var filingConfig: FilingConfigResponse?
+    @State private var isFilingRunning = false
+
     private let scheduleClient: ScheduleClientProtocol = ScheduleClient()
     private let heartbeatClient: HeartbeatClientProtocol = HeartbeatClient()
+    private let filingClient: FilingClientProtocol = FilingClient()
 
     // MARK: - Computed Filters
 
@@ -41,12 +46,16 @@ struct SettingsSchedulesTab: View {
                 heartbeatCard(config)
             }
 
+            if let config = filingConfig {
+                filingCard(config)
+            }
+
             if isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = loadError {
                 errorView(error)
-            } else if schedules.isEmpty && heartbeatConfig == nil {
+            } else if schedules.isEmpty && heartbeatConfig == nil && filingConfig == nil {
                 VEmptyState(
                     title: "No schedules",
                     subtitle: "Schedules you create through conversation will appear here.",
@@ -60,6 +69,7 @@ struct SettingsSchedulesTab: View {
         .task {
             await loadSchedules()
             heartbeatConfig = await heartbeatClient.fetchConfig()
+            filingConfig = await filingClient.fetchConfig()
         }
         .alert("Delete Schedule", isPresented: deleteConfirmBinding) {
             Button("Cancel", role: .cancel) {
@@ -517,6 +527,77 @@ struct SettingsSchedulesTab: View {
             _ = await heartbeatClient.runNow()
             heartbeatConfig = await heartbeatClient.fetchConfig()
             isHeartbeatRunning = false
+        }
+    }
+
+    // MARK: - Filing
+
+    @ViewBuilder
+    private func filingCard(_ config: FilingConfigResponse) -> some View {
+        SettingsCard(
+            title: "Filing",
+            subtitle: filingSubtitle(config)
+        ) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.sm) {
+                        Circle()
+                            .fill(config.enabled ? VColor.systemPositiveStrong : VColor.contentDisabled)
+                            .frame(width: 8, height: 8)
+                        Text(config.enabled ? "Enabled" : "Disabled")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                    if let lastRun = config.lastRunAt, let formatted = formatEpochMs(lastRun) {
+                        Text("Last ran \(formatted)")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    if let nextRun = config.nextRunAt, let formatted = formatEpochMs(nextRun) {
+                        Text("Next run \(formatted)")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                }
+                Spacer()
+                if isFilingRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 20, height: 20)
+                } else {
+                    VButton(
+                        label: "Run Now",
+                        iconOnly: VIcon.play.rawValue,
+                        style: .ghost,
+                        tooltip: "Run filing now"
+                    ) {
+                        runFilingNow()
+                    }
+                }
+            }
+        }
+    }
+
+    private func filingSubtitle(_ config: FilingConfigResponse) -> String {
+        let minutes = Int(config.intervalMs / 60_000)
+        var subtitle: String
+        if minutes >= 60 && minutes % 60 == 0 {
+            subtitle = "Every \(minutes / 60) hr"
+        } else {
+            subtitle = "Every \(minutes) min"
+        }
+        if let start = config.activeHoursStart, let end = config.activeHoursEnd {
+            subtitle += " (\(Int(start)):00\u{2013}\(Int(end)):00)"
+        }
+        return subtitle
+    }
+
+    private func runFilingNow() {
+        isFilingRunning = true
+        Task {
+            _ = await filingClient.runNow()
+            filingConfig = await filingClient.fetchConfig()
+            isFilingRunning = false
         }
     }
 

--- a/clients/shared/Network/FilingClient.swift
+++ b/clients/shared/Network/FilingClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "FilingClient")
+
+/// Focused client for filing-related operations routed through the gateway.
+///
+/// Covers filing configuration reads and on-demand runs.
+public protocol FilingClientProtocol {
+    func fetchConfig() async -> FilingConfigResponse?
+    func runNow() async -> FilingRunNowResponse?
+}
+
+/// Gateway-backed implementation of ``FilingClientProtocol``.
+public struct FilingClient: FilingClientProtocol {
+    nonisolated public init() {}
+
+    public func fetchConfig() async -> FilingConfigResponse? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/filing/config", timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("fetchConfig failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            let patched = injectType("filing_config_response", into: response.data)
+            return try JSONDecoder().decode(FilingConfigResponse.self, from: patched)
+        } catch {
+            log.error("fetchConfig error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func runNow() async -> FilingRunNowResponse? {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/filing/run-now", timeout: 120
+            )
+            guard response.isSuccess else {
+                log.error("runNow failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            let patched = injectType("filing_run_now_response", into: response.data)
+            return try JSONDecoder().decode(FilingRunNowResponse.self, from: patched)
+        } catch {
+            log.error("runNow error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Injects the `"type"` discriminant required by `Codable` decoding of
+    /// server message types whose JSON payloads omit it over HTTP.
+    private func injectType(_ type: String, into data: Data) -> Data {
+        guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return data
+        }
+        json["type"] = type
+        return (try? JSONSerialization.data(withJSONObject: json)) ?? data
+    }
+}

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1894,6 +1894,44 @@ public struct HeartbeatConfigResponse: Codable, Sendable {
     }
 }
 
+public struct FilingConfigResponse: Codable, Sendable {
+    public let type: String
+    public let enabled: Bool
+    public let intervalMs: Double
+    public let activeHoursStart: Double?
+    public let activeHoursEnd: Double?
+    public let nextRunAt: Int?
+    public let lastRunAt: Int?
+    public let success: Bool
+    public let error: String?
+
+    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
+        self.type = type
+        self.enabled = enabled
+        self.intervalMs = intervalMs
+        self.activeHoursStart = activeHoursStart
+        self.activeHoursEnd = activeHoursEnd
+        self.nextRunAt = nextRunAt
+        self.lastRunAt = lastRunAt
+        self.success = success
+        self.error = error
+    }
+}
+
+public struct FilingRunNowResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let ran: Bool
+    public let error: String?
+
+    public init(type: String, success: Bool, ran: Bool, error: String? = nil) {
+        self.type = type
+        self.success = success
+        self.ran = ran
+        self.error = error
+    }
+}
+
 public struct HeartbeatRunNow: Codable, Sendable {
     public let type: String
 


### PR DESCRIPTION
## Summary

- Expose filing over HTTP: `GET /v1/filing/config` + `POST /v1/filing/run-now`, wired through the daemon server + lifecycle the same way heartbeat already is.
- Add a `FilingClient` + `FilingConfigResponse` / `FilingRunNowResponse` DTOs on the Swift side, mirroring `HeartbeatClient`.
- Add a **Filing** card to `Settings → Schedules` directly below the Heartbeat card, with status (enabled, last/next run) and a Run Now play button.

No changes to `FilingService` — `runOnce({ force: true })` already existed; this PR just exposes it.

## Original prompt

> it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
