### PR TITLE
feat: push staging Docker images to staging GCP environment instead of dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             fi
             VERSION="${BASE_VERSION}-staging.${RUN_COUNT}"
             echo "Staging prerelease version: $VERSION"
-            echo 'docker_environments=["dev"]' >> "$GITHUB_OUTPUT"
+            echo 'docker_environments=["staging"]' >> "$GITHUB_OUTPUT"
           else
             VERSION="$BASE_VERSION"
             echo 'docker_environments=["dev","production"]' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Change staging docker_environments from ["dev"] to ["staging"] so staging releases push images to the staging GCP environment
- Production releases continue pushing to both dev and production

Part of plan: staging-environment.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
