### PR TITLE
feat: point macOS staging builds at staging-platform.vellum.ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1511,7 +1511,6 @@ jobs:
         run: |
           IS_STAGING="${{ needs.extract-version.outputs.is_staging }}"
           if [ "$IS_STAGING" = "true" ]; then
-            export VELLUM_PLATFORM_URL="https://dev-platform.vellum.ai"
             export BUNDLE_DISPLAY_NAME="Vellum Staging"
           fi
           BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"
@@ -1935,7 +1934,6 @@ jobs:
         run: |
           IS_STAGING="${{ needs.extract-version.outputs.is_staging }}"
           if [ "$IS_STAGING" = "true" ]; then
-            export VELLUM_PLATFORM_URL="https://dev-platform.vellum.ai"
             export BUNDLE_DISPLAY_NAME="Vellum Staging"
           fi
           BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"


### PR DESCRIPTION
## Summary
- Remove VELLUM_PLATFORM_URL override from staging macOS builds (both arm64 and x64)
- Staging builds now rely on VellumEnvironment.staging.platformURL which resolves to staging-platform.vellum.ai
- Production builds are unaffected

Part of plan: staging-environment.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
