### PR TITLE
feat: make getPlatformBaseUrl() resolve staging platform URL from VELLUM_ENVIRONMENT

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -152,10 +152,20 @@ export function getPlatformBaseUrl(): string {
   } catch {
     // Config not yet available (early bootstrap) — fall through
   }
-  const defaultUrl =
-    str("VELLUM_DEV") === "1"
-      ? "https://dev-platform.vellum.ai"
-      : "https://platform.vellum.ai";
+  // Resolve the default platform URL from VELLUM_ENVIRONMENT, with
+  // VELLUM_DEV=1 as a backwards-compatible fallback for the dev URL.
+  const env = str("VELLUM_ENVIRONMENT")?.trim();
+  let defaultUrl: string;
+  if (env === "local" || env === "dev") {
+    defaultUrl = "https://dev-platform.vellum.ai";
+  } else if (env === "staging") {
+    defaultUrl = "https://staging-platform.vellum.ai";
+  } else if (str("VELLUM_DEV") === "1") {
+    defaultUrl = "https://dev-platform.vellum.ai";
+  } else {
+    // production (or unset)
+    defaultUrl = "https://platform.vellum.ai";
+  }
   return (
     configUrl ||
     str("VELLUM_PLATFORM_URL") ||
@@ -167,9 +177,9 @@ export function getPlatformBaseUrl(): string {
 /**
  * Derive the assistant service domain from the platform base URL.
  *
- * Known platform URLs map directly:
+ * Known platform URLs map directly (via regex stripping of `platform.vellum.ai`):
  * - `dev-platform.vellum.ai`     → `dev.vellum.me`
- * - `staging-platform.vellum.ai` → `staging.vellum.me`
+ * - `staging-platform.vellum.ai` → `staging.vellum.me` (derived automatically from the staging URL)
  * - `platform.vellum.ai`         → `vellum.me`
  *
  * Non-vellum.ai hosts (localhost, host.docker.internal, etc.) use


### PR DESCRIPTION
## Summary
- Update getPlatformBaseUrl() to read VELLUM_ENVIRONMENT and map to the correct platform URL (local/dev → dev-platform, staging → staging-platform, production → platform)
- Preserve VELLUM_DEV=1 backwards compatibility as fallback
- Add staging derivation comment to getAssistantDomain()

Part of plan: staging-environment.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
