### PR TITLE
feat: enable staging cloud environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1192,13 +1192,8 @@ jobs:
       - name: Resolve platform credentials
         id: platform-creds
         run: |
-          if [ "${{ matrix.environment }}" = "dev" ]; then
-            echo "api_url=${{ secrets.NONPROD_PLATFORM_API_URL }}" >> "$GITHUB_OUTPUT"
-            echo "api_key=${{ secrets.NONPROD_PLATFORM_INTERNAL_SERVICE_API_KEY }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "api_url=${{ secrets.PLATFORM_API_URL }}" >> "$GITHUB_OUTPUT"
-            echo "api_key=${{ secrets.PLATFORM_INTERNAL_SERVICE_API_KEY }}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "api_url=${{ secrets.PLATFORM_API_URL }}" >> "$GITHUB_OUTPUT"
+          echo "api_key=${{ secrets.PLATFORM_INTERNAL_SERVICE_API_KEY }}" >> "$GITHUB_OUTPUT"
 
       - name: Register release with platform
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             fi
             VERSION="${BASE_VERSION}-staging.${RUN_COUNT}"
             echo "Staging prerelease version: $VERSION"
-            echo 'docker_environments=["dev"]' >> "$GITHUB_OUTPUT"
+            echo 'docker_environments=["staging"]' >> "$GITHUB_OUTPUT"
           else
             VERSION="$BASE_VERSION"
             echo 'docker_environments=["dev","production"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1511,7 +1511,6 @@ jobs:
         run: |
           IS_STAGING="${{ needs.extract-version.outputs.is_staging }}"
           if [ "$IS_STAGING" = "true" ]; then
-            export VELLUM_PLATFORM_URL="https://dev-platform.vellum.ai"
             export BUNDLE_DISPLAY_NAME="Vellum Staging"
           fi
           BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"
@@ -1935,7 +1934,6 @@ jobs:
         run: |
           IS_STAGING="${{ needs.extract-version.outputs.is_staging }}"
           if [ "$IS_STAGING" = "true" ]; then
-            export VELLUM_PLATFORM_URL="https://dev-platform.vellum.ai"
             export BUNDLE_DISPLAY_NAME="Vellum Staging"
           fi
           BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -160,6 +160,8 @@ export function getPlatformBaseUrl(): string {
     defaultUrl = "https://dev-platform.vellum.ai";
   } else if (env === "staging") {
     defaultUrl = "https://staging-platform.vellum.ai";
+  } else if (env === "test") {
+    defaultUrl = "https://test-platform.vellum.ai";
   } else if (str("VELLUM_DEV") === "1") {
     defaultUrl = "https://dev-platform.vellum.ai";
   } else {

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -153,15 +153,16 @@ export function getPlatformBaseUrl(): string {
     // Config not yet available (early bootstrap) — fall through
   }
   // Resolve the default platform URL from VELLUM_ENVIRONMENT.
+  // Default to dev-platform for safety; only production and staging
+  // opt into their respective platforms explicitly.
   const env = str("VELLUM_ENVIRONMENT")?.trim();
   let defaultUrl: string;
-  if (env === "local" || env === "dev" || env === "test") {
-    defaultUrl = "https://dev-platform.vellum.ai";
+  if (env === "production") {
+    defaultUrl = "https://platform.vellum.ai";
   } else if (env === "staging") {
     defaultUrl = "https://staging-platform.vellum.ai";
   } else {
-    // production (or unset)
-    defaultUrl = "https://platform.vellum.ai";
+    defaultUrl = "https://dev-platform.vellum.ai";
   }
   return (
     configUrl ||

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -152,10 +152,20 @@ export function getPlatformBaseUrl(): string {
   } catch {
     // Config not yet available (early bootstrap) — fall through
   }
-  const defaultUrl =
-    str("VELLUM_DEV") === "1"
-      ? "https://dev-platform.vellum.ai"
-      : "https://platform.vellum.ai";
+  // Resolve the default platform URL from VELLUM_ENVIRONMENT, with
+  // VELLUM_DEV=1 as a backwards-compatible fallback for the dev URL.
+  const env = str("VELLUM_ENVIRONMENT")?.trim();
+  let defaultUrl: string;
+  if (env === "local" || env === "dev") {
+    defaultUrl = "https://dev-platform.vellum.ai";
+  } else if (env === "staging") {
+    defaultUrl = "https://staging-platform.vellum.ai";
+  } else if (str("VELLUM_DEV") === "1") {
+    defaultUrl = "https://dev-platform.vellum.ai";
+  } else {
+    // production (or unset)
+    defaultUrl = "https://platform.vellum.ai";
+  }
   return (
     configUrl ||
     str("VELLUM_PLATFORM_URL") ||
@@ -167,9 +177,9 @@ export function getPlatformBaseUrl(): string {
 /**
  * Derive the assistant service domain from the platform base URL.
  *
- * Known platform URLs map directly:
+ * Known platform URLs map directly (via regex stripping of `platform.vellum.ai`):
  * - `dev-platform.vellum.ai`     → `dev.vellum.me`
- * - `staging-platform.vellum.ai` → `staging.vellum.me`
+ * - `staging-platform.vellum.ai` → `staging.vellum.me` (derived automatically from the staging URL)
  * - `platform.vellum.ai`         → `vellum.me`
  *
  * Non-vellum.ai hosts (localhost, host.docker.internal, etc.) use

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -152,18 +152,13 @@ export function getPlatformBaseUrl(): string {
   } catch {
     // Config not yet available (early bootstrap) — fall through
   }
-  // Resolve the default platform URL from VELLUM_ENVIRONMENT, with
-  // VELLUM_DEV=1 as a backwards-compatible fallback for the dev URL.
+  // Resolve the default platform URL from VELLUM_ENVIRONMENT.
   const env = str("VELLUM_ENVIRONMENT")?.trim();
   let defaultUrl: string;
-  if (env === "local" || env === "dev") {
+  if (env === "local" || env === "dev" || env === "test") {
     defaultUrl = "https://dev-platform.vellum.ai";
   } else if (env === "staging") {
     defaultUrl = "https://staging-platform.vellum.ai";
-  } else if (env === "test") {
-    defaultUrl = "https://test-platform.vellum.ai";
-  } else if (str("VELLUM_DEV") === "1") {
-    defaultUrl = "https://dev-platform.vellum.ai";
   } else {
     // production (or unset)
     defaultUrl = "https://platform.vellum.ai";

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -612,6 +612,7 @@ export function serviceDockerRunArgs(opts: {
       }
       for (const envVar of [
         ...Object.values(PROVIDER_ENV_VAR_NAMES),
+        "VELLUM_ENVIRONMENT",
         "VELLUM_PLATFORM_URL",
       ]) {
         if (process.env[envVar]) {
@@ -659,6 +660,9 @@ export function serviceDockerRunArgs(opts: {
         : []),
       ...(opts.bootstrapSecret
         ? ["-e", `GUARDIAN_BOOTSTRAP_SECRET=${opts.bootstrapSecret}`]
+        : []),
+      ...(process.env.VELLUM_ENVIRONMENT
+        ? ["-e", `VELLUM_ENVIRONMENT=${process.env.VELLUM_ENVIRONMENT}`]
         : []),
       ...(process.env.VELLUM_PLATFORM_URL
         ? ["-e", `VELLUM_PLATFORM_URL=${process.env.VELLUM_PLATFORM_URL}`]

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -871,6 +871,7 @@ export async function startLocalDaemon(
         "APP_VERSION",
         "BASE_DATA_DIR",
         "GATEWAY_SECURITY_DIR",
+        "VELLUM_ENVIRONMENT",
         "VELLUM_PLATFORM_URL",
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -283,6 +283,7 @@ async function startDaemonFromSource(
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
     VELLUM_CLOUD: "local",
     VELLUM_DEV: "1",
+    VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
     ...(options?.signingKey
       ? { ACTOR_TOKEN_SIGNING_KEY: options.signingKey }
       : {}),
@@ -409,6 +410,7 @@ async function startDaemonWatchFromSource(
     ...process.env,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
     VELLUM_DEV: "1",
+    VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
     ...(options?.signingKey
       ? { ACTOR_TOKEN_SIGNING_KEY: options.signingKey }
       : {}),
@@ -1060,7 +1062,12 @@ export async function startGateway(
     ...(options?.signingKey
       ? { ACTOR_TOKEN_SIGNING_KEY: options.signingKey }
       : {}),
-    ...(watch ? { VELLUM_DEV: "1" } : {}),
+    ...(watch
+      ? {
+          VELLUM_DEV: "1",
+          VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
+        }
+      : {}),
     // Set BASE_DATA_DIR and GATEWAY_SECURITY_DIR so the gateway loads the
     // correct credentials and workspace config for this instance (mirrors
     // the daemon env setup).

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -110,6 +110,7 @@ final class VellumCli: AssistantManagementClient {
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
     nonisolated private static let forwardedEnvKeys: [String] = [
+        "VELLUM_ENVIRONMENT",
         "VELLUM_PLATFORM_URL",
         "VELLUM_WORKSPACE_DIR",
         "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",

--- a/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
@@ -82,6 +82,7 @@ enum VellumContainerEnv {
             "IS_CONTAINERIZED": "true",
             "VELLUM_ASSISTANT_NAME": instanceName,
             "VELLUM_CLOUD": "apple-container",
+            "VELLUM_ENVIRONMENT": VellumEnvironment.current.rawValue,
             "RUNTIME_HTTP_HOST": "0.0.0.0",
             "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
             "CES_CREDENTIAL_URL": "http://localhost:\(VellumContainerPorts.cesHTTP)",
@@ -107,6 +108,7 @@ enum VellumContainerEnv {
     ) -> [String: String] {
         var env: [String: String] = [
             "IS_CONTAINERIZED": "true",
+            "VELLUM_ENVIRONMENT": VellumEnvironment.current.rawValue,
             "VELLUM_WORKSPACE_DIR": VellumMountPaths.workspace,
             "GATEWAY_SECURITY_DIR": VellumMountPaths.gatewaySecurityDir,
             "GATEWAY_PORT": String(VellumContainerPorts.gatewayHTTP),


### PR DESCRIPTION
## Summary
Enable the staging cloud environment end-to-end: update the backend platform URL resolution to be environment-aware (not just `VELLUM_DEV`-based), update the GitHub Actions release workflow to push Docker images to the staging GCP environment and point macOS staging builds at `staging-platform.vellum.ai` instead of `dev-platform.vellum.ai`, and consolidate the platform registration secrets to use environment-scoped values.

## Self-review result
PASS — all 4 PRs implemented faithfully, 1 integration note (infrastructure prerequisite for env-scoped secrets, already handled)

## PRs merged into feature branch
- #25613: feat: make getPlatformBaseUrl() resolve staging platform URL from VELLUM_ENVIRONMENT
- #25611: feat: push staging Docker images to staging GCP environment instead of dev
- #25612: feat: point macOS staging builds at staging-platform.vellum.ai
- #25615: refactor: remove platform API credential branching in register-release job

Part of plan: staging-environment.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
