### PR TITLE
test(environments): drift-guard for KNOWN_ENVIRONMENTS across TS sites

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -154,9 +154,12 @@ export function getTCPHost(): string {
   return "127.0.0.1";
 }
 
-// Kept in sync with `cli/src/lib/environments/seeds.ts`. The daemon does not
-// import from the CLI package, so the list is duplicated here. If a new
-// environment is added to the seed table, add it here too.
+// Kept in sync with `cli/src/lib/environments/seeds.ts` and
+// `clients/chrome-extension/native-host/src/lockfile.ts`. Drift between
+// these three sites is caught at test time by
+// `cli/src/__tests__/env-drift.test.ts`. Fast follow: hoist the shared
+// list into a `packages/environments` package so all three sites import
+// from one place.
 const KNOWN_ENVIRONMENTS: ReadonlySet<string> = new Set([
   "production",
   "staging",

--- a/cli/src/__tests__/env-drift.test.ts
+++ b/cli/src/__tests__/env-drift.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { SEEDS } from "../lib/environments/seeds.js";
+
+// Drift guard for the three TypeScript sites that each hardcode the set of
+// known environment names:
+//
+//   1. cli/src/lib/environments/seeds.ts          — SEEDS record (source of truth)
+//   2. assistant/src/util/platform.ts             — KNOWN_ENVIRONMENTS set
+//   3. clients/chrome-extension/native-host/
+//         src/lockfile.ts                         — NON_PRODUCTION_ENVIRONMENTS set
+//
+// Cross-package relative imports don't work here: assistant's tsconfig
+// restricts `include` to its own src tree, and the native host is a
+// standalone TS project with `rootDir: ./src`. So this test parses the
+// literal sets out of the two external files and asserts they agree with
+// CLI's SEEDS.
+//
+// FOLLOW-UP: split the env name list into a shared `packages/environments`
+// package (mirroring `packages/ces-contracts`, `credential-storage`) so
+// all three sites can `import { KNOWN_ENVIRONMENTS }` from one place and
+// this drift guard becomes a compile-time check. Planned alongside CLI-
+// driven context support — see the "Environments" design doc.
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
+const ASSISTANT_PLATFORM = join(
+  REPO_ROOT,
+  "assistant",
+  "src",
+  "util",
+  "platform.ts",
+);
+const NATIVE_HOST_LOCKFILE = join(
+  REPO_ROOT,
+  "clients",
+  "chrome-extension",
+  "native-host",
+  "src",
+  "lockfile.ts",
+);
+
+/**
+ * Extract the string literals from a Set constructor body in a TS source
+ * file. Looks for `<setName>: ReadonlySet<string> = new Set([ ... ])` and
+ * pulls out every `"..."` entry within the array. The match is anchored to
+ * the `setName` to avoid picking up unrelated sets that happen to live in
+ * the same file.
+ */
+function extractSetLiterals(source: string, setName: string): string[] {
+  const pattern = new RegExp(
+    `${setName}\\s*:\\s*ReadonlySet<string>\\s*=\\s*new Set\\(\\[([^\\]]*)\\]`,
+    "m",
+  );
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(
+      `Could not find Set literal for ${setName}. Update the drift-guard regex in env-drift.test.ts.`,
+    );
+  }
+  const body = match[1];
+  const literals = body.match(/"([^"]+)"/g) ?? [];
+  return literals.map((lit) => lit.slice(1, -1));
+}
+
+describe("KNOWN_ENVIRONMENTS drift guard (TS-side)", () => {
+  const seedNames = new Set(Object.keys(SEEDS));
+
+  test("assistant/src/util/platform.ts KNOWN_ENVIRONMENTS matches CLI SEEDS", () => {
+    const source = readFileSync(ASSISTANT_PLATFORM, "utf8");
+    const assistantNames = new Set(
+      extractSetLiterals(source, "KNOWN_ENVIRONMENTS"),
+    );
+    expect([...assistantNames].sort()).toEqual([...seedNames].sort());
+  });
+
+  test("native-host/src/lockfile.ts NON_PRODUCTION_ENVIRONMENTS matches CLI SEEDS minus production", () => {
+    const source = readFileSync(NATIVE_HOST_LOCKFILE, "utf8");
+    const nativeNames = new Set(
+      extractSetLiterals(source, "NON_PRODUCTION_ENVIRONMENTS"),
+    );
+    const expected = new Set(seedNames);
+    expected.delete("production");
+    expect([...nativeNames].sort()).toEqual([...expected].sort());
+  });
+});

--- a/cli/src/lib/environments/seeds.ts
+++ b/cli/src/lib/environments/seeds.ts
@@ -2,8 +2,16 @@ import type { EnvironmentDefinition } from "./types.js";
 
 /**
  * Built-in environment definitions. Mirrors Swift's
- * `clients/macos/vellum-assistant/App/VellumEnvironment.swift` enum. Five
- * entries that ship with the binary and are always available.
+ * `clients/macos/vellum-assistant/App/VellumEnvironment.swift` enum and is
+ * the TS-side source of truth for the set of known environment names.
+ * Two other TS sites duplicate the name list:
+ *   - `assistant/src/util/platform.ts` (`KNOWN_ENVIRONMENTS`)
+ *   - `clients/chrome-extension/native-host/src/lockfile.ts`
+ *     (`NON_PRODUCTION_ENVIRONMENTS`, excludes `production`)
+ * Drift between these three sites is caught at test time by
+ * `cli/src/__tests__/env-drift.test.ts`. Fast follow: hoist the shared
+ * list into a `packages/environments` package so all three sites import
+ * from one place.
  *
  * Custom environments via a user config file are a future phase — see the
  * "Coexisting environments" design doc. Until then, a call site that needs a

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -34,8 +34,12 @@ const PRODUCTION_LOCKFILE_NAMES = [
 /**
  * Non-production environment names that map to `$XDG_CONFIG_HOME/vellum-<env>/`.
  * Anything not in this set (including typos like `foo`) falls back to the
- * production path. Mirrors `KNOWN_ENVIRONMENTS` in
- * `assistant/src/util/platform.ts` — keep in sync when new envs are added.
+ * production path. Mirrors `SEEDS` in `cli/src/lib/environments/seeds.ts`
+ * and `KNOWN_ENVIRONMENTS` in `assistant/src/util/platform.ts`. Drift
+ * between these three sites is caught at test time by
+ * `cli/src/__tests__/env-drift.test.ts`. Fast follow: hoist the shared
+ * list into a `packages/environments` package so all three sites import
+ * from one place.
  */
 const NON_PRODUCTION_ENVIRONMENTS: ReadonlySet<string> = new Set([
   "dev",


### PR DESCRIPTION
## Summary
- Add a test in \`cli/src/__tests__/env-drift.test.ts\` that parses the \`KNOWN_ENVIRONMENTS\` / \`NON_PRODUCTION_ENVIRONMENTS\` sets out of \`assistant/src/util/platform.ts\` and \`clients/chrome-extension/native-host/src/lockfile.ts\` and asserts they agree with \`SEEDS\` in \`cli/src/lib/environments/seeds.ts\`.
- Refresh the comments on all three declarations to point at the new drift-guard test and the fast-follow plan.

## Why
Devin flagged that the set of known environment names is duplicated in three TS locations (plus Swift). Cross-package relative imports don't work today — \`assistant\`'s tsconfig restricts \`include\` to its own src tree, and the native host is a standalone TS project with \`rootDir: ./src\`. A runtime drift-guard is the cheapest stop-gap that catches any future addition to the seed table that fails to propagate.

**Verified it actually catches drift:** temporarily mutated \`assistant/src/util/platform.ts\` to swap \`\"staging\"\` → \`\"bogus\"\` and the test failed with a clean set diff.

## Fast follow
Hoist the shared name list into a \`packages/environments\` package (mirroring \`packages/ces-contracts\`, \`credential-storage\`, \`egress-proxy\`) so all three sites can \`import { KNOWN_ENVIRONMENTS }\` from one place and this check becomes a compile-time import. Planned alongside CLI-driven context support.

## Scope notes
- Swift's \`VellumEnvironment.swift\` is intentionally out of scope — happy to let it drift from TS for now; it'll get driven off the CLI once contexts land.
- Only TS sites are checked.

Part of plan: env-data-layout.md (fix K1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
