### PR TITLE
M2: Client — send multipart for managed connections

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1021,7 +1021,7 @@ final class ChatActionHandler {
                 // attachments survive the secret-ingress redirect.
                 if let blockedUserMessage = capturedBlockedMessage, !blockedUserMessage.attachments.isEmpty {
                     vm.secretBlockedAttachments = blockedUserMessage.attachments.compactMap { att in
-                        guard !att.data.isEmpty || att.filePath != nil else { return nil }
+                        guard !att.data.isEmpty || att.filePath != nil || att.rawData != nil else { return nil }
                         return UserMessageAttachment(
                             filename: att.filename,
                             mimeType: att.mimeType,
@@ -1029,7 +1029,8 @@ final class ChatActionHandler {
                             extractedText: nil,
                             sizeBytes: att.sizeBytes,
                             thumbnailData: att.thumbnailData?.base64EncodedString(),
-                            filePath: att.filePath
+                            filePath: att.filePath,
+                            rawData: att.rawData
                         )
                     }
                 }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -224,6 +224,9 @@ public final class ChatAttachmentManager {
         /// Original file size in bytes. Set for file-backed attachments where
         /// base64 encoding is skipped.
         let originalFileSize: Int?
+        /// Raw binary data for multipart upload in managed mode.
+        /// Nil for file-backed (local) attachments.
+        let rawData: Data?
     }
 
     /// Reads, compresses, and thumbnails an attachment from a file URL.
@@ -303,7 +306,8 @@ public final class ChatAttachmentManager {
                     thumbnailData: nil,
                     dataLength: 0,
                     filePath: uploadPath,
-                    originalFileSize: fileSize
+                    originalFileSize: fileSize,
+                    rawData: nil
                 ))
             }
 
@@ -346,6 +350,11 @@ public final class ChatAttachmentManager {
 
             let base64 = finalData.base64EncodedString()
 
+            // In managed mode, store the raw bytes for multipart upload.
+            // The base64 string is still populated for the JSON+base64 fallback
+            // path and the offline queue.
+            let rawBytes: Data? = useFileBackedUpload ? nil : finalData
+
             return .success(ProcessedAttachmentData(
                 id: attachmentId,
                 filename: filename,
@@ -354,7 +363,8 @@ public final class ChatAttachmentManager {
                 thumbnailData: thumbnail,
                 dataLength: base64.count,
                 filePath: url.path,
-                originalFileSize: nil
+                originalFileSize: nil,
+                rawData: rawBytes
             ))
         }.value
         Task { await loadSemaphore.signal() }
@@ -379,7 +389,8 @@ public final class ChatAttachmentManager {
                 dataLength: processed.dataLength,
                 sizeBytes: processed.originalFileSize,
                 thumbnailImage: thumbnailImage,
-                filePath: processed.filePath
+                filePath: processed.filePath,
+                rawData: processed.rawData
             ))
         }
     }
@@ -392,6 +403,9 @@ public final class ChatAttachmentManager {
         log.debug("[Attachment] readStart id=\(attachmentId) source=imageData filename=\(filename) rawBytes=\(imageData.count)")
         let acquired = await loadSemaphore.wait()
         guard acquired else { return .failure(.message("Attachment load cancelled.")) }
+        // Resolve connection mode so managed connections store raw bytes
+        // for multipart upload alongside the base64 fallback data.
+        let isManagedConnection = (try? GatewayHTTPClient.isConnectionManaged()) == true
         let taskResult: Result<ProcessedAttachmentData, AttachmentError> = await Task.detached(priority: .userInitiated) {
             // Validate that ImageIO can decode the data.
             guard Self.loadCGImage(from: imageData) != nil else {
@@ -449,7 +463,8 @@ public final class ChatAttachmentManager {
                 thumbnailData: thumbnail,
                 dataLength: base64.count,
                 filePath: nil,
-                originalFileSize: nil
+                originalFileSize: nil,
+                rawData: isManagedConnection ? finalData : nil
             ))
         }.value
         Task { await loadSemaphore.signal() }
@@ -472,7 +487,8 @@ public final class ChatAttachmentManager {
                 data: processed.base64,
                 thumbnailData: processed.thumbnailData,
                 dataLength: processed.dataLength,
-                thumbnailImage: thumbnailImage
+                thumbnailImage: thumbnailImage,
+                rawData: processed.rawData
             ))
         }
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1491,7 +1491,7 @@ public struct ChatAttachment: Identifiable {
     /// Raw binary data for multipart upload in managed mode. Nil for file-backed
     /// (local) attachments. When set, ``data`` also contains the base64 encoding
     /// of the same bytes as a fallback for JSON+base64 upload and the offline queue.
-    public let rawData: Data?
+    public var rawData: Data?
 
     /// Whether this attachment's binary data was omitted to keep the payload small.
     /// The client should fetch it lazily via the HTTP endpoint when the user interacts.
@@ -1871,6 +1871,7 @@ public struct ChatMessage: Identifiable, Equatable {
         for i in attachments.indices {
             attachments[i].data = ""
             attachments[i].dataLength = 0
+            attachments[i].rawData = nil
         }
         for i in inlineSurfaces.indices {
             if inlineSurfaces[i].completionState != nil {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1488,12 +1488,17 @@ public struct ChatAttachment: Identifiable {
     /// (e.g. recordings) where the file lives on the same Mac as the client.
     public let filePath: String?
 
+    /// Raw binary data for multipart upload in managed mode. Nil for file-backed
+    /// (local) attachments. When set, ``data`` also contains the base64 encoding
+    /// of the same bytes as a fallback for JSON+base64 upload and the offline queue.
+    public let rawData: Data?
+
     /// Whether this attachment's binary data was omitted to keep the payload small.
     /// The client should fetch it lazily via the HTTP endpoint when the user interacts.
     public var isLazyLoad: Bool { data.isEmpty && sizeBytes != nil }
 
     #if os(macOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?, filePath: String? = nil, sourceType: String? = nil) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?, filePath: String? = nil, sourceType: String? = nil, rawData: Data? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -1504,9 +1509,10 @@ public struct ChatAttachment: Identifiable {
         self.sizeBytes = sizeBytes
         self.thumbnailImage = thumbnailImage
         self.filePath = filePath
+        self.rawData = rawData
     }
     #elseif os(iOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?, filePath: String? = nil, sourceType: String? = nil) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?, filePath: String? = nil, sourceType: String? = nil, rawData: Data? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -1517,6 +1523,7 @@ public struct ChatAttachment: Identifiable {
         self.sizeBytes = sizeBytes
         self.thumbnailImage = thumbnailImage
         self.filePath = filePath
+        self.rawData = rawData
     }
     #else
     #error("Unsupported platform")

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1747,7 +1747,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             lastFailedMessageBypassSecretCheck = false
             // Preserve attachments so they are resent with the retry.
             lastFailedMessageAttachments = lastMsg.attachments.compactMap { att in
-                guard !att.data.isEmpty || att.filePath != nil else { return nil }
+                guard !att.data.isEmpty || att.filePath != nil || att.rawData != nil else { return nil }
                 return UserMessageAttachment(
                     id: att.id,
                     filename: att.filename,
@@ -1756,7 +1756,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     extractedText: nil,
                     sizeBytes: att.sizeBytes,
                     thumbnailData: att.thumbnailData?.base64EncodedString(),
-                    filePath: att.filePath
+                    filePath: att.filePath,
+                    rawData: att.rawData
                 )
             }
             retryLastMessage()
@@ -1835,7 +1836,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // Keep file-path-based attachments even when data is empty,
         // since the daemon can read the file from disk.
         let userAttachments: [UserMessageAttachment]? = message.attachments.isEmpty ? nil : message.attachments.compactMap { att in
-            guard !att.data.isEmpty || att.filePath != nil else { return nil }
+            guard !att.data.isEmpty || att.filePath != nil || att.rawData != nil else { return nil }
             return UserMessageAttachment(
                 id: att.id,
                 filename: att.filename,
@@ -1844,7 +1845,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 extractedText: nil,
                 sizeBytes: att.sizeBytes,
                 thumbnailData: att.thumbnailData?.base64EncodedString(),
-                filePath: att.filePath
+                filePath: att.filePath,
+                rawData: att.rawData
             )
         }
 

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -214,7 +214,7 @@ final class MessageSendCoordinator {
                 delegate.pendingUserMessageDisplayText = rawText
                 delegate.pendingUserMessageAutomated = hidden
                 delegate.pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
-                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
+                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath, rawData: $0.rawData)
                 }
                 messageManager.isThinking = true
                 var userMsg = ChatMessage(role: .user, text: rawText, status: .sent, skillInvocation: messageManager.pendingSkillInvocation, attachments: attachments)
@@ -300,7 +300,7 @@ final class MessageSendCoordinator {
         delegate.flushCoalescedPublish()
 
         let messageAttachments: [UserMessageAttachment]? = attachments.isEmpty ? nil : attachments.map {
-            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
+            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath, rawData: $0.rawData)
         }
 
         // Track the user text for this turn so assistantTextDelta can tag the

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -163,14 +163,37 @@ public final class EventStreamClient {
 
             // Upload attachments
             var attachmentIds: [String] = []
+            let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) == true
             if let attachments, !attachments.isEmpty {
                 for attachment in attachments {
-                    let result = await messageClient.uploadAttachment(
-                        filename: attachment.filename,
-                        mimeType: attachment.mimeType,
-                        data: attachment.data,
-                        filePath: attachment.filePath
-                    )
+                    var result: AttachmentUploadResult
+                    if isManaged, let rawData = attachment.rawData {
+                        // Try multipart first for managed connections
+                        log.info("[send-pipeline] multipart upload — filename=\(attachment.filename, privacy: .public)")
+                        result = await messageClient.uploadAttachmentMultipart(
+                            filename: attachment.filename,
+                            mimeType: attachment.mimeType,
+                            data: rawData
+                        )
+                        // If server doesn't support multipart yet, retry with JSON+base64
+                        if case .transientFailure = result {
+                            log.info("[send-pipeline] multipart failed, retrying with JSON+base64 — filename=\(attachment.filename, privacy: .public)")
+                            result = await messageClient.uploadAttachment(
+                                filename: attachment.filename,
+                                mimeType: attachment.mimeType,
+                                data: attachment.data,
+                                filePath: attachment.filePath
+                            )
+                        }
+                    } else {
+                        // Local: file-backed or JSON+base64
+                        result = await messageClient.uploadAttachment(
+                            filename: attachment.filename,
+                            mimeType: attachment.mimeType,
+                            data: attachment.data,
+                            filePath: attachment.filePath
+                        )
+                    }
                     switch result {
                     case .success(let id):
                         attachmentIds.append(id)

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -3,6 +3,12 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "GatewayHTTPClient")
 
+/// Represents a single part in a multipart/form-data request.
+public enum MultipartPart {
+    case text(name: String, value: String)
+    case file(name: String, filename: String, mimeType: String, data: Data)
+}
+
 /// Authenticated HTTP client for gateway and platform proxy requests.
 ///
 /// Consolidates URL construction, auth headers, org-id injection, and
@@ -120,6 +126,50 @@ public enum GatewayHTTPClient {
                     request.setValue(value, forHTTPHeaderField: key)
                 }
             }
+        }
+    }
+
+    /// Performs an authenticated POST request with a `multipart/form-data` body.
+    ///
+    /// Constructs the multipart body from an array of ``MultipartPart`` values
+    /// (text fields and binary file parts), generates a UUID-based boundary,
+    /// and uses the standard `buildRequest()` pipeline for auth headers and URL
+    /// resolution.
+    ///
+    /// - Parameters:
+    ///   - path: Path segment after `/v1/`.
+    ///   - parts: The multipart form-data parts to include in the request body.
+    ///   - timeout: Request timeout in seconds. Defaults to 60.
+    /// - Returns: A `Response` with the raw data and HTTP status code.
+    /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
+    public static func postMultipart(path: String, parts: [MultipartPart], timeout: TimeInterval = 60) async throws -> Response {
+        let boundary = UUID().uuidString
+        var body = Data()
+
+        for part in parts {
+            switch part {
+            case .text(let name, let value):
+                body.append("--\(boundary)\r\n".data(using: .utf8)!)
+                body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+                body.append("\(value)\r\n".data(using: .utf8)!)
+            case .file(let name, let filename, let mimeType, let data):
+                let sanitizedFilename = filename
+                    .replacingOccurrences(of: "\"", with: "_")
+                    .replacingOccurrences(of: "\r", with: "_")
+                    .replacingOccurrences(of: "\n", with: "_")
+                body.append("--\(boundary)\r\n".data(using: .utf8)!)
+                body.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(sanitizedFilename)\"\r\n".data(using: .utf8)!)
+                body.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+                body.append(data)
+                body.append("\r\n".data(using: .utf8)!)
+            }
+        }
+
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        return try await executeWithRetry(path: path, method: "POST", timeout: timeout) { request in
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
         }
     }
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -5163,8 +5163,16 @@ public struct UserMessageAttachment: Codable, Sendable {
     public let filePath: String?
     /// True when the attachment is file-backed and clients should hydrate via the /content endpoint.
     public let fileBacked: Bool?
+    /// Raw binary data for multipart upload in managed mode. Excluded from
+    /// Codable encoding/decoding — only used for in-process transport.
+    public let rawData: Data?
 
-    public init(id: String? = nil, filename: String, mimeType: String, data: String, sourceType: String? = nil, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil, fileBacked: Bool? = nil) {
+    // Exclude rawData from Codable so it doesn't interfere with JSON serialization.
+    private enum CodingKeys: String, CodingKey {
+        case id, filename, mimeType, data, sourceType, extractedText, sizeBytes, thumbnailData, filePath, fileBacked
+    }
+
+    public init(id: String? = nil, filename: String, mimeType: String, data: String, sourceType: String? = nil, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil, fileBacked: Bool? = nil, rawData: Data? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -5175,6 +5183,22 @@ public struct UserMessageAttachment: Codable, Sendable {
         self.thumbnailData = thumbnailData
         self.filePath = filePath
         self.fileBacked = fileBacked
+        self.rawData = rawData
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        filename = try container.decode(String.self, forKey: .filename)
+        mimeType = try container.decode(String.self, forKey: .mimeType)
+        data = try container.decode(String.self, forKey: .data)
+        sourceType = try container.decodeIfPresent(String.self, forKey: .sourceType)
+        extractedText = try container.decodeIfPresent(String.self, forKey: .extractedText)
+        sizeBytes = try container.decodeIfPresent(Int.self, forKey: .sizeBytes)
+        thumbnailData = try container.decodeIfPresent(String.self, forKey: .thumbnailData)
+        filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
+        fileBacked = try container.decodeIfPresent(Bool.self, forKey: .fileBacked)
+        rawData = nil
     }
 }
 

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -27,6 +27,7 @@ public enum MessageSendResult: Sendable {
 /// Focused client for uploading attachments and sending user messages.
 public protocol MessageClientProtocol {
     func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String?) async -> AttachmentUploadResult
+    func uploadAttachmentMultipart(filename: String, mimeType: String, data: Data) async -> AttachmentUploadResult
     func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?, onboarding: PreChatOnboardingContext?) async -> MessageSendResult
 }
 
@@ -98,6 +99,53 @@ public struct MessageClient: MessageClientProtocol {
             }
         } catch {
             log.error("[send-pipeline] attachment upload error: \(error.localizedDescription)")
+            return .transientFailure
+        }
+    }
+
+    /// Uploads an attachment using `multipart/form-data` instead of JSON+base64.
+    ///
+    /// Sends the raw binary data directly, avoiding the 33% base64 overhead.
+    /// Used for managed (cloud/container) connections where file-backed uploads
+    /// are not available.
+    ///
+    /// - Parameters:
+    ///   - filename: The original filename of the attachment.
+    ///   - mimeType: The MIME type of the attachment.
+    ///   - data: The raw binary data of the attachment.
+    /// - Returns: An ``AttachmentUploadResult`` indicating success, transient failure, or auth failure.
+    public func uploadAttachmentMultipart(filename: String, mimeType: String, data: Data) async -> AttachmentUploadResult {
+        log.info("[send-pipeline] multipart upload — filename=\(filename, privacy: .public), mimeType=\(mimeType, privacy: .public), bytes=\(data.count, privacy: .public)")
+
+        let parts: [MultipartPart] = [
+            .text(name: "filename", value: filename),
+            .text(name: "mimeType", value: mimeType),
+            .file(name: "file", filename: filename, mimeType: mimeType, data: data),
+        ]
+
+        do {
+            let response = try await GatewayHTTPClient.postMultipart(
+                path: "assistants/{assistantId}/attachments",
+                parts: parts,
+                timeout: 60
+            )
+
+            if response.isSuccess {
+                let json = try JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+                if let id = json?["id"] as? String {
+                    log.info("[send-pipeline] multipart upload success — id=\(id, privacy: .public)")
+                    return .success(id: id)
+                }
+                log.error("[send-pipeline] multipart upload response missing id")
+                return .transientFailure
+            } else if response.statusCode == 401 {
+                return .terminalAuthFailure
+            } else {
+                log.error("[send-pipeline] multipart upload failed (HTTP \(response.statusCode))")
+                return .transientFailure
+            }
+        } catch {
+            log.error("[send-pipeline] multipart upload error: \(error.localizedDescription)")
             return .transientFailure
         }
     }


### PR DESCRIPTION
## Summary
- Add `MultipartPart` enum and `postMultipart()` helper to `GatewayHTTPClient` for multipart/form-data POST requests
- Add `uploadAttachmentMultipart()` to `MessageClient` that sends raw binary data instead of JSON+base64
- Add `rawData: Data?` field to `ProcessedAttachmentData`, `ChatAttachment`, and `UserMessageAttachment` to carry raw bytes for managed connections
- Branch on connection mode in `EventStreamClient.sendUserMessage()`: managed connections try multipart first, fall back to JSON+base64 on transient failure
- Wire `rawData` through all `ChatAttachment` -> `UserMessageAttachment` mapping sites

Part of #25605. Managed connections now send multipart/form-data instead of JSON+base64 for attachment uploads. Includes retry-on-failure fallback to JSON+base64 for backward compatibility. Closes #25607.

## Test plan
- [ ] Verify managed connection attachment uploads use multipart/form-data (check logs for `[send-pipeline] multipart upload`)
- [ ] Verify local connection attachments still use file-backed upload path (unchanged)
- [ ] Verify multipart fallback: if server returns transient failure for multipart, retries with JSON+base64
- [ ] Verify image attachments in managed mode carry both `rawData` and `data` (base64)
- [ ] Verify non-image file attachments in managed mode carry both `rawData` and `data` (base64)
- [ ] Verify file-backed (local) attachments have `rawData: nil` (unchanged path)
- [ ] Verify offline queue still works (rawData excluded from Codable encoding)
- [ ] Verify retry/resend flows preserve rawData through ChatAttachment -> UserMessageAttachment mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
