### PR TITLE
Revert scroll-to-bottom fix from v0.6.4

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -405,7 +405,6 @@ struct ChatView: View {
                 containerWidth: containerWidth,
                 containerHeight: containerHeight
             )
-            .id(conversationId)
             .animation(nil, value: queuedMessages.isEmpty)
 
             if let error = viewModel.errorManager.conversationError, error.isCreditsExhausted {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -176,8 +176,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
 
         // Briefly hide scroll indicators during switch
         hideScrollIndicatorsBriefly()
@@ -194,8 +192,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
         isPaginationInFlight = false
         lastMessageId = nil
         scrollContentHeight = 0
@@ -212,8 +208,5 @@ final class MessageListScrollState {
     @ObservationIgnored var isPaginationInFlight: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
-    /// Multi-stage scroll-to-bottom task fired on conversation switch / first mount.
-    /// Cancelled on rapid switching and when a deep-link anchor is pending.
-    @ObservationIgnored var switchRestoreTask: Task<Void, Never>?
 
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -35,9 +35,6 @@ extension MessageListView {
         // Handle pending anchor if already set.
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
-            // Deep-link anchor found — cancel any restore so it isn't overridden.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
@@ -45,10 +42,6 @@ extension MessageListView {
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
-            // Anchor pending but not yet found — cancel restore so deep-link
-            // anchors aren't overridden by the bottom-scroll restore.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
             // Start the independent timeout if not already running.
@@ -65,29 +58,9 @@ extension MessageListView {
                     scrollState.anchorTimeoutTask = nil
                 }
             }
-        } else if !isConversationSwitch {
-            // First mount (no prior conversationId, no anchor) — also needs
-            // multi-stage scroll since the first conversation load must land
-            // at the bottom, same as a switch.
-            scrollState.switchRestoreTask?.cancel()
-            let scrollBinding = $scrollPosition
-            scrollState.switchRestoreTask = Task { @MainActor in
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                try? await Task.sleep(nanoseconds: 50_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-                withAnimation(VAnimation.fast) {
-                    isScrollRestored = true
-                }
-
-                try? await Task.sleep(nanoseconds: 150_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                scrollState.switchRestoreTask = nil
-            }
         }
+        // For initial load (no anchor, no conversation switch),
+        // `.defaultScrollAnchor(.top)` handles positioning declaratively.
     }
 
     // MARK: - onChange handlers
@@ -222,32 +195,8 @@ extension MessageListView {
         scrollState.lastAutoFocusedRequestId = nil
         // Seed lastMessageId so scroll-to-bottom can target it.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Multi-stage scroll-to-bottom: gives LazyVStack time to materialize
-        // bottom cells across multiple layout passes. Targets "scroll-bottom-anchor"
-        // (a real Color.clear view at the absolute content bottom) instead of a
-        // message ID, avoiding height estimation errors from unmaterialized cells.
-        scrollState.switchRestoreTask?.cancel()
-        let scrollBinding = $scrollPosition
-        scrollState.switchRestoreTask = Task { @MainActor in
-            // Stage 0: immediate — catches conversations already laid out
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            // Stage 1: ~3 frames (50ms) — LazyVStack initial materialization
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-            // Fade in after scroll is positioned
-            withAnimation(VAnimation.fast) {
-                isScrollRestored = true
-            }
-
-            // Stage 2: slower content (150ms) — final correction
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            scrollState.switchRestoreTask = nil
-        }
+        // Don't write to scrollPosition — `.defaultScrollAnchor(.top)` handles
+        // positioning via the `.id(conversationId)` recreation.
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -111,9 +111,6 @@ struct MessageListView: View {
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
     /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
     @State var scrollPosition = ScrollPosition()
-    /// Starts false on fresh mount; set to true after scroll restore settles.
-    /// Hides the scroll view during the restore window to prevent jitter.
-    @State var isScrollRestored = false
 
     // MARK: - Body
 
@@ -143,13 +140,14 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
+            // Apply only to .initialOffset — threads open at top.
             .defaultScrollAnchor(.top, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
+            .id(conversationId)
             .frame(width: widths.scrollSurfaceWidth)
-            .opacity(isScrollRestored ? 1 : 0)
             .overlay(alignment: .bottom) {
                 ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .bottom) })
             }


### PR DESCRIPTION
## Summary
- Reverts the "fix: jitter-free scroll-to-bottom on thread switch (#25540)" changes that were incorrectly included in the cherry-pick PR #25546
- Surgically removes only the 4 files touched by that commit, leaving all other cherry-picked fixes intact

## Test plan
- [ ] Verify scroll behavior is back to pre-cherry-pick state
- [ ] Confirm no other cherry-picked fixes were affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
