### PR TITLE
fix(assistant): guard splitLongTextSegment against non-positive maxChars

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -120,6 +120,12 @@ describe("splitLongTextSegment", () => {
     expect(chunks[0]).toBe(lineA);
     expect(chunks[1]).toBe(lineB);
   });
+
+  test("returns input unchanged when maxChars is non-positive (avoids infinite loop)", () => {
+    const text = "a".repeat(100);
+    expect(splitLongTextSegment(text, 0)).toEqual([text]);
+    expect(splitLongTextSegment(text, -1)).toEqual([text]);
+  });
 });
 
 describe("textToSlackBlocks long-text splitting", () => {

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -348,7 +348,7 @@ export function splitLongTextSegment(
   text: string,
   maxChars: number = SLACK_SECTION_MAX_CHARS,
 ): string[] {
-  if (text.length <= maxChars) return [text];
+  if (maxChars <= 0 || text.length <= maxChars) return [text];
 
   const chunks: string[] = [];
   let remaining = text;


### PR DESCRIPTION
Both Codex and Devin flagged that splitLongTextSegment can infinite-loop when called with maxChars <= 0 (window slice is empty, no boundary found, splitAt falls through to maxChars, remaining never shrinks).

Adds an early return for non-positive maxChars and a regression test.

Follow-up to #25548.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
