### PR TITLE
docs(architecture): correct slack DELETE endpoint description

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -337,7 +337,7 @@ The Slack channel provides text-based messaging via Slack's Socket Mode API. Unl
 | --------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/v1/integrations/slack/channel/config` | GET    | Returns current config status: `hasBotToken`, `hasAppToken`, `hasUserToken`, `connected`, plus workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`)                                                                  |
 | `/v1/integrations/slack/channel/config` | POST   | Validates and stores credentials. Body: `{ botToken?: string, appToken?: string, userToken?: string }`                                                                                                                                |
-| `/v1/integrations/slack/channel/config` | DELETE | Clears Slack channel credentials. Deleting `field=user_token` is surgical — it clears only the user token via `clearSlackUserToken` and leaves the `oauth_connection` row intact. Deleting `bot_token` or `app_token` does a full teardown. |
+| `/v1/integrations/slack/channel/config` | DELETE | Clears all Slack channel credentials (bot, app, and user tokens) from secure storage and credential metadata. Surgical user-token-only deletion is exposed internally via `clearSlackUserToken` (used by the credential vault) but is not reachable through this HTTP endpoint. |
 
 All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`.
 


### PR DESCRIPTION
Round-2 review on #25585 flagged that the DELETE /v1/integrations/slack/channel/config row claimed a `field=user_token` query parameter for surgical user-token deletion. The actual handler (`assistant/src/runtime/routes/integrations/slack/channel.ts:53-56`) takes no parameters and always calls `clearSlackChannelConfig()`, which tears down all tokens.

Update the row to describe the actual unconditional teardown behavior, and note that `clearSlackUserToken` is reachable internally (credential vault) but not via HTTP.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
