### PR TITLE
fix(slack-app-setup): make Step 0 decision tree exhaustive for user_token states

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -39,12 +39,13 @@ Scan the array for entries matching `service: "slack_channel"` and determine whi
 - `bot_token`
 - `user_token`
 
-Then branch:
+Then branch on the state of `app_token` and `bot_token` first (those are the required pair), and treat `user_token` as a secondary dimension:
 
-- If all three are present — Slack is fully configured with full triage visibility. Offer to show status or reconfigure.
-- If `app_token` and `bot_token` are present but `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
-- If only one of `app_token` or `bot_token` is present — offer to resume setup from the missing step.
-- If none are present — continue to Step 1.
+- If `app_token` and `bot_token` are **both** present:
+  - If `user_token` is also present — Slack is fully configured with full triage visibility. Offer to show status or reconfigure.
+  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 3.5) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
+- If exactly **one** of `app_token` or `bot_token` is present — offer to resume setup from the missing step. (If a `user_token` is also present, leave it in place; it will be re-validated against the bot's workspace once setup completes.)
+- If **neither** `app_token` nor `bot_token` is present — continue to Step 1. (If a `user_token` is present without a paired bot/app, it is orphaned from a prior incomplete setup. Tell the user it will be replaced during this run, and proceed.)
 
 Note: `user_token` is optional. Missing `user_token` is **not** blocking — setup is considered complete with just the app and bot tokens (bot-only visibility).
 


### PR DESCRIPTION
## Summary
Addresses Codex P2 review feedback on #25567.

The Step 0 decision tree was non-exhaustive: states where `user_token` is present without both `app_token` and `bot_token` (a valid backend state per `setSlackChannelConfig`) matched none of the listed branches, leaving the skill with no instructed next action.

## Changes
- Restructured Step 0 to branch first on the required `app_token` + `bot_token` pair, then treat `user_token` as a secondary dimension.
- Added explicit handling for the orphaned-`user_token` state (no bot/app): tell the user it will be replaced and proceed with full setup.
- Added guidance for partial state with a `user_token` already stored: leave it in place; it will be re-validated against the bot's workspace once setup completes.

## Files
- `skills/slack-app-setup/SKILL.md`

## Notes
The other inline review comment from Devin (about `action: "inspect"`) was already addressed in #25574, which migrated Step 0 to use `action: "list"`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
