### PR TITLE
workspace: rewrite PKB index bar via new migration

### DIFF
--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -7,7 +7,7 @@ const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear
 
 # Knowledge Base
 
-**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.
+**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.
 
 ## Always Loaded
 - essentials.md — Core facts, patterns, and biographical info

--- a/assistant/src/workspace/migrations/036-update-pkb-index-bar.ts
+++ b/assistant/src/workspace/migrations/036-update-pkb-index-bar.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const OLD_BAR = `**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
+
+const NEW_BAR = `**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
+
+export const updatePkbIndexBarMigration: WorkspaceMigration = {
+  id: "036-update-pkb-index-bar",
+  description:
+    "Update pkb/INDEX.md 'Remember aggressively' bar to pass-through framing for users seeded by migration 029",
+
+  down(_workspaceDir: string): void {
+    // No-op: don't revert user-editable file content on rollback.
+  },
+
+  run(workspaceDir: string): void {
+    const indexPath = join(workspaceDir, "pkb", "INDEX.md");
+    if (!existsSync(indexPath)) return;
+
+    const current = readFileSync(indexPath, "utf-8");
+    if (!current.includes(OLD_BAR)) {
+      // Either already updated or user-modified — leave alone.
+      return;
+    }
+
+    writeFileSync(indexPath, current.replace(OLD_BAR, NEW_BAR), "utf-8");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -33,6 +33,7 @@ import { ttsProviderUnificationMigration } from "./032-tts-provider-unification.
 import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-config.js";
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
+import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -77,4 +78,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   sttServiceExplicitConfigMigration,
   removeCallsVoiceTranscriptionProviderMigration,
   seedSlackChannelPersonaMigration,
+  updatePkbIndexBarMigration,
 ];


### PR DESCRIPTION
## Summary

PR #25532 edited released migration `029-seed-pkb.ts` in place, which:
- Violates the write-once rule in `assistant/src/workspace/migrations/AGENTS.md`.
- Only affects brand-new installs — every existing user keeps the old bar because migration 029 is checkpointed as completed.
- Repeats a mistake already reverted once in 7b620677d.

This PR:
- Reverts `029-seed-pkb.ts`'s `INDEX_TEMPLATE` back to its original 'Remember aggressively' bar.
- Adds `036-update-pkb-index-bar.ts` that reads `pkb/INDEX.md` and replaces the original bar with the pass-through framing introduced in #25532. If the file is missing or the user has edited the bar, the migration leaves it alone.
- Registers the new migration at the end of `WORKSPACE_MIGRATIONS`.

For brand-new installs, 029 writes the original bar and 036 rewrites it on the same startup. Existing users get the rewrite applied to their long-lived `pkb/INDEX.md`.

Addresses Devin review feedback on #25532.

## Test plan
- [ ] `bunx tsc --noEmit` in `assistant/`
- [ ] Existing workspace with original bar gets rewritten on next startup
- [ ] User-edited `INDEX.md` is left untouched
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
