### PR TITLE
fix(slack): treat user_token not-found as delete failure

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -873,6 +873,35 @@ describe("Slack channel config handler", () => {
     expect(after.hasUserToken).toBe(false);
   });
 
+  test("clearSlackUserToken reports failure when user_token is already absent", async () => {
+    // Seed bot+app tokens but no user_token.
+    await Promise.all([
+      setSecureKeyAsync(
+        credentialKey("slack_channel", "bot_token"),
+        "xoxb-test",
+      ),
+      setSecureKeyAsync(
+        credentialKey("slack_channel", "app_token"),
+        "xapp-test",
+      ),
+    ]);
+    oauthConnectionStore["slack_channel"] = {
+      id: "conn-slack",
+      status: "active",
+    };
+
+    const result = await clearSlackUserToken();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasAppToken).toBe(true);
+    expect(result.hasUserToken).toBe(false);
+    // bot+app tokens and oauth_connection remain intact.
+    expect(oauthConnectionStore["slack_channel"]).toBeDefined();
+    expect(oauthConnectionStore["slack_channel"].status).toBe("active");
+  });
+
   test("GET reports hasUserToken: false when only bot+app tokens present", async () => {
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -421,14 +421,17 @@ export async function setSlackChannelConfig(
  * Deletes only the user_token secure key and its credential metadata. Leaves
  * the bot_token, app_token, oauth_connection row, and Slack config metadata
  * untouched so the Socket Mode connection stays up. Returns a
- * `SlackChannelConfigResult` reflecting the remaining state.
+ * `SlackChannelConfigResult` reflecting the remaining state. A `not-found`
+ * delete outcome is reported as a failure to match the credential_store
+ * delete semantics (callers and automation rely on missing-credential
+ * detection).
  */
 export async function clearSlackUserToken(): Promise<SlackChannelConfigResult> {
   const result = await deleteSecureKeyAsync(
     credentialKey("slack_channel", "user_token"),
   );
 
-  if (result === "error") {
+  if (result === "error" || result === "not-found") {
     const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     ));
@@ -446,7 +449,10 @@ export async function clearSlackUserToken(): Promise<SlackChannelConfigResult> {
       hasUserToken,
       connected:
         !!(conn && conn.status === "active") && hasBotToken && hasAppToken,
-      error: "Failed to delete Slack user token from secure storage",
+      error:
+        result === "not-found"
+          ? "Slack user token not found in secure storage"
+          : "Failed to delete Slack user token from secure storage",
     };
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #25581. `clearSlackUserToken()` was treating a `not-found` outcome from `deleteSecureKeyAsync()` as success, which silently diverges from the credential_store delete flow (`vault.ts`) where missing credentials are reported as errors. Callers and automation that rely on missing-credential detection would be misled.

Now `not-found` returns `success: false` with a distinct error message; the `error` outcome behavior is unchanged.

Also adds a regression test for the not-found path.

## Files
- assistant/src/daemon/handlers/config-slack-channel.ts
- assistant/src/__tests__/slack-channel-config.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
