### PR TITLE
Fix gmail_sender_digest 429 rate limit errors with graceful degradation

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -494,7 +494,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 10000)"
+            "description": "Maximum messages to scan (default 2000, cap 5000)"
           },
           "max_senders": {
             "type": "number",
@@ -502,7 +502,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 10,000 messages in a single call)"
+            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -11,7 +11,12 @@ import type {
 import { storeScanResult } from "./scan-result-store.js";
 import { err, ok } from "./shared.js";
 
-const MAX_MESSAGES_CAP = 10000;
+function isRateLimitError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return /\b429\b/.test(e.message);
+}
+
+const MAX_MESSAGES_CAP = 5000;
 const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
@@ -73,6 +78,8 @@ export async function run(
     const startTime = Date.now();
     const TIME_BUDGET_MS = 90_000;
 
+    let rateLimited = false;
+
     while (allMessageIds.length < maxMessages) {
       if (Date.now() - startTime > TIME_BUDGET_MS) {
         timeBudgetExceeded = true;
@@ -80,12 +87,22 @@ export async function run(
         break;
       }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
-      const listResp = await listMessages(
-        connection,
-        query,
-        pageSize,
-        pageToken,
-      );
+      let listResp;
+      try {
+        listResp = await listMessages(
+          connection,
+          query,
+          pageSize,
+          pageToken,
+        );
+      } catch (e) {
+        if (isRateLimitError(e)) {
+          rateLimited = true;
+          truncated = true;
+          break;
+        }
+        throw e;
+      }
       const ids = (listResp.messages ?? []).map((m) => m.id);
       if (ids.length === 0) break;
       allMessageIds.push(...ids);
@@ -118,7 +135,19 @@ export async function run(
       );
     }
 
-    const messages = (await Promise.all(fetchPromises)).flat();
+    // Settle all fetch promises — collect successes and tolerate 429 failures
+    const settled = await Promise.allSettled(fetchPromises);
+    const messages: GmailMessage[] = [];
+    for (const result of settled) {
+      if (result.status === "fulfilled") {
+        messages.push(...result.value);
+      } else if (isRateLimitError(result.reason)) {
+        rateLimited = true;
+        truncated = true;
+      } else {
+        throw result.reason;
+      }
+    }
 
     // Group by sender email
     const senderMap = new Map<string, SenderAggregation>();
@@ -242,6 +271,7 @@ export async function run(
         query_used: query,
         ...(truncated ? { truncated: true } : {}),
         ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        ...(rateLimited ? { rate_limited: true } : {}),
         note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
       }),
     );

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -24,7 +24,7 @@ const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 /** Max sub-requests per batch HTTP call (Gmail API limit) */
 const BATCH_SUB_LIMIT = 100;
 /** Max concurrent batch calls */
-const BATCH_CONCURRENCY = 8;
+const BATCH_CONCURRENCY = 5;
 
 export class GmailApiError extends Error {
   constructor(
@@ -135,7 +135,18 @@ async function request<T>(
         body: extractBody(options),
       });
     } catch (err) {
-      // Network-level errors from connection.request() are not retryable
+      // Retry thrown errors that indicate a retryable status (e.g. platform
+      // proxy throws BackendError on 429 after exhausting its own retries)
+      if (
+        canRetry &&
+        attempt < MAX_RETRIES &&
+        err instanceof Error &&
+        /\b(429|5\d{2})\b/.test(err.message)
+      ) {
+        const delayMs = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
       throw err;
     }
 


### PR DESCRIPTION
## Summary
- Lower `MAX_MESSAGES_CAP` from 10000 to 5000 and revert `BATCH_CONCURRENCY` from 8 to 5 to reduce request volume
- Add retry logic in Gmail client for thrown 429/5xx errors from platform proxy (previously only retried response-level errors)
- Gracefully degrade on rate limits: catch 429s mid-scan and return partial results with `rate_limited: true` flag instead of failing entirely

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Test gmail_sender_digest with a large inbox scan via platform connection
- [ ] Confirm partial results are returned when rate limited instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
