### PR TITLE
fix(slack-adapter): markRead uses read auth; fall back to bot token on 401

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
@@ -2,10 +2,11 @@
  * Guard test that verifies the Slack adapter routes reads and writes through
  * the correct cached auth.
  *
- * PR 3 introduced the read/write auth split and locked in behavior for the
- * bot-token-only case. PR 5 extended this file to cover the dual-token case
- * (bot + user): reads MUST use the user token while writes MUST stay on the
- * bot token so posts come from the bot identity.
+ * Covers the bot-token-only case (reads and writes both use the bot token),
+ * the dual-token case (bot + user): reads MUST use the user token while
+ * content-creating writes (postMessage) MUST stay on the bot token so posts
+ * come from the bot identity, and the runtime fallback when a stored user
+ * token is rejected with an auth error.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -180,13 +181,86 @@ describe("Slack adapter token routing", () => {
     expect(sendCall).toBeDefined();
     expect(sendCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
 
-    // Writes: markRead → bot token.
+    // markRead → user token. conversations.mark sets the read cursor for
+    // the authenticated identity, so it must use the same token whose unread
+    // counts the adapter exposes.
     await slackProvider.markRead!(undefined, "C123", "1700000000.000100");
     const markCall = captured.find((c) =>
       c.url.includes("/conversations.mark"),
     );
     expect(markCall).toBeDefined();
-    expect(markCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+    expect(markCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
+  });
+
+  test("user token rejected: read calls fall back to bot token and stay on it", async () => {
+    // If the cached user token is revoked/expired, the next read returns
+    // invalid_auth (HTTP 200 with ok:false). The adapter must retry the call
+    // with the bot token and reset the read cache so subsequent reads in the
+    // same session don't re-hit the failure path.
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      if (key === credentialKey("slack_channel", "user_token"))
+        return USER_TOKEN;
+      return null;
+    });
+
+    // Replace the default fetch stub: first user-token call to history fails
+    // with invalid_auth; everything else succeeds.
+    let userTokenHistoryCalls = 0;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const headers = new Headers(init?.headers ?? {});
+      const auth = headers.get("authorization");
+      captured.push({
+        url,
+        method: (init?.method ?? "GET").toUpperCase(),
+        authorization: auth,
+      });
+      if (
+        url.includes("/conversations.history") &&
+        auth === `Bearer ${USER_TOKEN}`
+      ) {
+        userTokenHistoryCalls += 1;
+        return new Response(
+          JSON.stringify({ ok: false, error: "invalid_auth" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify(fakeSlackResponse(url)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const resolved = await slackProvider.resolveConnection!();
+    expect(resolved).toBeUndefined();
+
+    // First read: tries user token, fails, retries with bot token.
+    await slackProvider.getHistory(undefined, "C123");
+    expect(userTokenHistoryCalls).toBe(1);
+    const historyCalls = captured.filter((c) =>
+      c.url.includes("/conversations.history"),
+    );
+    expect(historyCalls).toHaveLength(2);
+    expect(historyCalls[0].authorization).toBe(`Bearer ${USER_TOKEN}`);
+    expect(historyCalls[1].authorization).toBe(`Bearer ${BOT_TOKEN}`);
+
+    // Subsequent read: cache reset, only bot token is used (no retry needed).
+    captured.length = 0;
+    await slackProvider.getHistory(undefined, "C456");
+    const next = captured.filter((c) =>
+      c.url.includes("/conversations.history"),
+    );
+    expect(next).toHaveLength(1);
+    expect(next[0].authorization).toBe(`Bearer ${BOT_TOKEN}`);
   });
 
   test("user-token only (no bot token): falls through to the OAuth path", async () => {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -25,6 +25,7 @@ import type {
   SendResult,
 } from "../../provider-types.js";
 import * as slack from "./client.js";
+import { SlackApiError } from "./client.js";
 import type {
   SlackConversation,
   SlackMessage,
@@ -41,7 +42,9 @@ const userNameCache = new Map<string, string>();
  * token (xoxp-) — giving visibility into channels the user is in but the
  * bot isn't — while writes continue to use the bot token (xoxb-) so posts
  * come from the bot identity. When no user_token is stored, reads fall
- * back to the bot token (unchanged legacy behavior).
+ * back to the bot token. If a stored user_token is rejected at runtime
+ * (revoked/expired), the read cache is reset to the bot token for the rest
+ * of the session — see runReadWithFallback().
  *
  * For Socket Mode these hold a raw bot token string; for OAuth they hold the
  * OAuthConnection. The Slack client functions accept both via their own
@@ -76,16 +79,50 @@ function getReadAuth(connection?: OAuthConnection): OAuthConnection | string {
   return getSlackAuth(connection);
 }
 
-// SAFETY: writes MUST use the bot token. Using the user token for writes
-// would post as the user, not as the bot.
+// SAFETY: content-creating writes (postMessage, updateMessage, deleteMessage,
+// reactions) MUST use the bot token. Using the user token would post as the
+// user, not as the bot. State-changing methods that target the authenticated
+// identity's own state (e.g. conversations.mark) should use the read auth so
+// the cursor matches the perspective the adapter exposes.
 /**
- * Resolve auth for write operations (postMessage, markRead, and any future
- * state-changing method like reactions, joins, leaves, updates, or deletes).
+ * Resolve auth for content-creating write operations (postMessage and any
+ * future reactions, joins, leaves, updates, or deletes).
  */
 function getWriteAuth(connection?: OAuthConnection): OAuthConnection | string {
   if (connection) return connection;
   if (_cachedSlackWriteAuth) return _cachedSlackWriteAuth;
   return getSlackAuth(connection);
+}
+
+/**
+ * Run a read-path Slack call, falling back to the bot token if the cached
+ * user token is rejected with an auth error. On fallback, the read cache is
+ * reset to the bot token so subsequent reads in this session don't re-pay
+ * the round trip. Caller-supplied connections are passed through unchanged
+ * (no fallback) since the caller owns that auth.
+ */
+async function runReadWithFallback<T>(
+  connection: OAuthConnection | undefined,
+  call: (auth: OAuthConnection | string) => Promise<T>,
+): Promise<T> {
+  if (connection) return call(connection);
+  const auth = getReadAuth(undefined);
+  const usingUserToken =
+    _cachedSlackWriteAuth !== null && _cachedSlackReadAuth !== _cachedSlackWriteAuth;
+  try {
+    return await call(auth);
+  } catch (err) {
+    if (
+      usingUserToken &&
+      err instanceof SlackApiError &&
+      err.status === 401 &&
+      _cachedSlackWriteAuth
+    ) {
+      _cachedSlackReadAuth = _cachedSlackWriteAuth;
+      return call(_cachedSlackWriteAuth);
+    }
+    throw err;
+  }
 }
 
 async function resolveUserName(
@@ -254,7 +291,6 @@ export const slackProvider: MessagingProvider = {
     connection: OAuthConnection | undefined,
     options?: ListOptions,
   ): Promise<Conversation[]> {
-    const auth = getReadAuth(connection);
     const typeMap: Record<string, string> = {
       channel: "public_channel,private_channel",
       dm: "im",
@@ -270,16 +306,32 @@ export const slackProvider: MessagingProvider = {
 
     const conversations: Conversation[] = [];
     let cursor: string | undefined = options?.cursor;
+    let auth = getReadAuth(connection);
 
-    // Paginate through all results
+    // Paginate through all results. The first page is wrapped in
+    // runReadWithFallback so that a 401 on the user token retries with the
+    // bot token before we commit to the rest of the pagination.
+    let firstPage = true;
     do {
-      const resp = await slack.listConversations(
-        auth,
-        types,
-        options?.excludeArchived ?? true,
-        options?.limit ?? 200,
-        cursor,
-      );
+      const resp = firstPage
+        ? await runReadWithFallback(connection, async (a) => {
+            auth = a;
+            return slack.listConversations(
+              a,
+              types,
+              options?.excludeArchived ?? true,
+              options?.limit ?? 200,
+              cursor,
+            );
+          })
+        : await slack.listConversations(
+            auth,
+            types,
+            options?.excludeArchived ?? true,
+            options?.limit ?? 200,
+            cursor,
+          );
+      firstPage = false;
       conversations.push(...resp.channels.map(mapConversation));
       cursor = resp.response_metadata?.next_cursor || undefined;
     } while (
@@ -322,14 +374,17 @@ export const slackProvider: MessagingProvider = {
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const auth = getReadAuth(connection);
-    const resp = await slack.conversationHistory(
-      auth,
-      conversationId,
-      options?.limit ?? 50,
-      options?.before,
-      options?.after,
-    );
+    let auth: OAuthConnection | string = getReadAuth(connection);
+    const resp = await runReadWithFallback(connection, async (a) => {
+      auth = a;
+      return slack.conversationHistory(
+        a,
+        conversationId,
+        options?.limit ?? 50,
+        options?.before,
+        options?.after,
+      );
+    });
 
     const messages: Message[] = [];
     for (const msg of resp.messages) {
@@ -345,8 +400,9 @@ export const slackProvider: MessagingProvider = {
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const auth = getReadAuth(connection);
-    const resp = await slack.searchMessages(auth, query, options?.count ?? 20);
+    const resp = await runReadWithFallback(connection, (auth) =>
+      slack.searchMessages(auth, query, options?.count ?? 20),
+    );
     return {
       total: resp.messages.total,
       messages: resp.messages.matches.map(mapSearchMatch),
@@ -380,13 +436,16 @@ export const slackProvider: MessagingProvider = {
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const auth = getReadAuth(connection);
-    const resp = await slack.conversationReplies(
-      auth,
-      conversationId,
-      threadId,
-      options?.limit ?? 50,
-    );
+    let auth: OAuthConnection | string = getReadAuth(connection);
+    const resp = await runReadWithFallback(connection, async (a) => {
+      auth = a;
+      return slack.conversationReplies(
+        a,
+        conversationId,
+        threadId,
+        options?.limit ?? 50,
+      );
+    });
     const messages: Message[] = [];
     for (const msg of resp.messages) {
       const name = await resolveUserName(auth, msg.user ?? "");
@@ -400,9 +459,13 @@ export const slackProvider: MessagingProvider = {
     conversationId: string,
     messageId?: string,
   ): Promise<void> {
-    const auth = getWriteAuth(connection);
+    // conversations.mark sets the read cursor for the authenticated identity.
+    // It must use the same token as the read path so the cursor matches the
+    // perspective the adapter exposes (unread counts in listConversations).
     // Slack's conversations.mark requires a timestamp — use the provided one or "now"
     const ts = messageId ?? String(Date.now() / 1000);
-    await slack.conversationMark(auth, conversationId, ts);
+    await runReadWithFallback(connection, (auth) =>
+      slack.conversationMark(auth, conversationId, ts),
+    );
   },
 };


### PR DESCRIPTION
## Summary
- markRead now uses the read auth so the cursor it sets matches the perspective the adapter exposes via listConversations unread counts.
- Reads fall back to the bot token (and reset the read cache) when a stored user token is rejected with a 401 — protects installs whose user token was revoked.
- Drop history-narrating phrasing in adapter and test comments per AGENTS.md.

## Test plan
- [x] bun test src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts (4/4 pass; new fallback test included)
- [x] bunx tsc --noEmit clean for the slack/* tree

Addresses review feedback on #25564.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
