### PR TITLE
fix(slack): split oversize fenced code segments across section blocks

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   SLACK_SECTION_MAX_CHARS,
+  splitCodeSegmentContent,
   splitLongTextSegment,
   textToSlackBlocks,
 } from "../slack-block-formatting.js";
@@ -125,6 +126,46 @@ describe("splitLongTextSegment", () => {
     const text = "a".repeat(100);
     expect(splitLongTextSegment(text, 0)).toEqual([text]);
     expect(splitLongTextSegment(text, -1)).toEqual([text]);
+  });
+});
+
+describe("splitCodeSegmentContent", () => {
+  test("returns single-element array when content fits in one fenced section", () => {
+    const content = "short\ncode\nblock";
+    expect(splitCodeSegmentContent(content, "js")).toEqual([content]);
+  });
+
+  test("splits on line boundaries so each chunk + fence fits the section limit", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 300; i++) {
+      lines.push(`line ${i} with some filler`);
+    }
+    const content = lines.join("\n");
+    const lang = "javascript";
+    const chunks = splitCodeSegmentContent(content, lang);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    const overhead = 3 + lang.length + 1 + 1 + 3;
+    for (const chunk of chunks) {
+      expect(chunk.length + overhead).toBeLessThanOrEqual(
+        SLACK_SECTION_MAX_CHARS,
+      );
+    }
+    // All lines preserved in order.
+    expect(chunks.join("\n")).toBe(content);
+  });
+
+  test("hard-slices a single line longer than the budget", () => {
+    const content = "x".repeat(10_000);
+    const chunks = splitCodeSegmentContent(content, "");
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    const overhead = 3 + 0 + 1 + 1 + 3;
+    for (const chunk of chunks) {
+      expect(chunk.length + overhead).toBeLessThanOrEqual(
+        SLACK_SECTION_MAX_CHARS,
+      );
+    }
+    expect(chunks.join("")).toBe(content);
   });
 });
 
@@ -246,6 +287,34 @@ describe("textToSlackBlocks long-text splitting", () => {
     // bold across all blocks.
     const combined = sectionBlocks.map((s) => s.text.text).join("\n");
     expect(combined).toContain("*First sentence. Second sentence*");
+  });
+
+  test("oversize code block is split into multiple fenced section blocks, each ≤ 3000 chars", () => {
+    // Build a code block whose content exceeds a single Slack section's limit.
+    // Include newlines so the splitter has line boundaries to use.
+    const codeLines: string[] = [];
+    for (let i = 0; i < 300; i++) {
+      codeLines.push(`const value${i} = "filler content on line ${i}";`);
+    }
+    const codeBody = codeLines.join("\n");
+    expect(codeBody.length).toBeGreaterThan(SLACK_SECTION_MAX_CHARS);
+    const text = "```javascript\n" + codeBody + "\n```";
+
+    const blocks = textToSlackBlocks(text);
+    expect(blocks).toBeDefined();
+
+    const sectionBlocks = blocks!.filter((b) => b.type === "section") as Array<{
+      type: "section";
+      text: { type: string; text: string };
+    }>;
+    expect(sectionBlocks.length).toBeGreaterThanOrEqual(2);
+
+    for (const section of sectionBlocks) {
+      // Each chunk must start and end with a fence and fit inside Slack's limit.
+      expect(section.text.text.startsWith("```javascript\n")).toBe(true);
+      expect(section.text.text.endsWith("\n```")).toBe(true);
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
   });
 
   test("4000-char paragraph followed by header and second paragraph preserves ordering", () => {

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -57,11 +57,19 @@ export function textToSlackBlocks(text: string): Block[] | undefined {
 
     if (segment.type === "code") {
       const lang = segment.lang ?? "";
-      const codeText = "```" + lang + "\n" + segment.content + "\n```";
-      blocks.push({
-        type: "section",
-        text: { type: "mrkdwn", text: codeText },
-      });
+      const codeChunks = splitCodeSegmentContent(segment.content, lang);
+      for (let c = 0; c < codeChunks.length; c++) {
+        if (c > 0) {
+          blocks.push({ type: "divider" });
+        }
+        blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "```" + lang + "\n" + codeChunks[c] + "\n```",
+          },
+        });
+      }
     } else if (segment.type === "header") {
       blocks.push({
         type: "header",
@@ -369,6 +377,68 @@ export function splitLongTextSegment(
   const tail = remaining.trim();
   if (tail.length > 0) chunks.push(tail);
 
+  return chunks;
+}
+
+/**
+ * Split a code segment's inner content into chunks that, once wrapped in
+ * ```lang … ``` fences, each fit inside Slack's section-text limit.
+ *
+ * Prefers line boundaries so code stays readable across chunks; falls back
+ * to a hard character slice for pathological single-line content.
+ */
+export function splitCodeSegmentContent(
+  content: string,
+  lang: string = "",
+  maxChars: number = SLACK_SECTION_MAX_CHARS,
+): string[] {
+  // Fence overhead: "```" + lang + "\n" + content + "\n```"
+  const overhead = 3 + lang.length + 1 + 1 + 3;
+  const budget = maxChars - overhead;
+  if (budget <= 0 || content.length <= budget) return [content];
+
+  const chunks: string[] = [];
+  const lines = content.split("\n");
+  let current: string[] = [];
+  let currentLen = 0;
+
+  const flush = (): void => {
+    if (current.length > 0) {
+      chunks.push(current.join("\n"));
+      current = [];
+      currentLen = 0;
+    }
+  };
+
+  for (const line of lines) {
+    // +1 for the joining "\n" (only if current is non-empty)
+    const added = current.length === 0 ? line.length : line.length + 1;
+    if (currentLen + added <= budget) {
+      current.push(line);
+      currentLen += added;
+      continue;
+    }
+
+    flush();
+
+    // A single line longer than the budget — hard-slice it across chunks.
+    if (line.length > budget) {
+      let remaining = line;
+      while (remaining.length > budget) {
+        chunks.push(remaining.slice(0, budget));
+        remaining = remaining.slice(budget);
+      }
+      if (remaining.length > 0) {
+        current.push(remaining);
+        currentLen = remaining.length;
+      }
+    } else {
+      current.push(line);
+      currentLen = line.length;
+    }
+  }
+
+  flush();
   return chunks;
 }
 


### PR DESCRIPTION
Addresses Devin review feedback on #25560.

Long code blocks that render as a single Slack `section` could exceed Slack's ~3000-char `text.text` limit and produce `invalid_blocks` — the original PR split text/table segments but left fenced code untouched.

`textToSlackBlocks` now routes code segments through a new `splitCodeSegmentContent` helper that:
- splits on line boundaries so code stays readable across chunks
- accounts for fence overhead (````lang\n ... \n````)
- hard-slices only for a pathological single line longer than the budget
- wraps each chunk in its own fence (divider between chunks, matching the text/table paths)

## Test plan
- [x] Unit tests cover single-chunk pass-through, multi-line split under the fenced budget, and hard-slice fallback
- [x] Integration test verifies a 300-line JS code block produces ≥ 2 fenced sections, each ≤ 3000 chars
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
