### PR TITLE
M3: Offline queue — store raw bytes for managed mode

### DIFF
--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -707,7 +707,12 @@ final class MessageSendCoordinator {
         // via the normal error retry path, rather than duplicating on the next flush.
         for queued in mine {
             queue.remove(id: queued.id)
-            sendUserMessage(queued.text, displayText: queued.displayText, attachments: queued.messageAttachments, automated: queued.automated)
+            let attachments = queued.messageAttachments
+            let multipartCount = attachments?.filter({ $0.rawData != nil }).count ?? 0
+            if multipartCount > 0 {
+                log.info("Offline flush: \(multipartCount) attachment(s) have rawData for multipart upload")
+            }
+            sendUserMessage(queued.text, displayText: queued.displayText, attachments: attachments, automated: queued.automated)
         }
     }
 

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -55,10 +55,15 @@ struct OfflineQueuedMessage: Codable, Identifiable {
     }
 
     /// Reconstruct the attachment list for dispatch.
+    ///
+    /// When the base64 `data` field is non-empty, decodes it back into `rawData`
+    /// so that the managed-mode multipart upload path in ``EventStreamClient`` can
+    /// use the raw bytes directly instead of re-encoding.
     var messageAttachments: [UserMessageAttachment]? {
         guard !attachments.isEmpty else { return nil }
         return attachments.map {
-            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText, filePath: $0.filePath)
+            let rawData: Data? = $0.data.isEmpty ? nil : Data(base64Encoded: $0.data)
+            return UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText, filePath: $0.filePath, rawData: rawData)
         }
     }
 }

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -56,13 +56,15 @@ struct OfflineQueuedMessage: Codable, Identifiable {
 
     /// Reconstruct the attachment list for dispatch.
     ///
-    /// When the base64 `data` field is non-empty, decodes it back into `rawData`
-    /// so that the managed-mode multipart upload path in ``EventStreamClient`` can
-    /// use the raw bytes directly instead of re-encoding.
+    /// When the connection is managed and the base64 `data` field is non-empty,
+    /// decodes it back into `rawData` so that the multipart upload path in
+    /// ``EventStreamClient`` can use the raw bytes directly. For local connections,
+    /// `rawData` is left nil to avoid unnecessary base64 decoding on the main actor.
     var messageAttachments: [UserMessageAttachment]? {
         guard !attachments.isEmpty else { return nil }
+        let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) == true
         return attachments.map {
-            let rawData: Data? = $0.data.isEmpty ? nil : Data(base64Encoded: $0.data)
+            let rawData: Data? = (isManaged && !$0.data.isEmpty) ? Data(base64Encoded: $0.data) : nil
             return UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText, filePath: $0.filePath, rawData: rawData)
         }
     }


### PR DESCRIPTION
## Summary
- When flushing the offline queue on reconnect, reconstruct `rawData` from the persisted base64 `data` field so `EventStreamClient` can attempt multipart upload for managed connections
- Falls back to JSON+base64 if multipart upload fails, matching the same pattern used in the live send path
- Backward compatible: existing queued messages without `rawData` continue to work via the JSON upload path

Part of #25605. Closes #25608.

## Test plan
- [ ] Queue a message with an attachment while in managed mode and offline
- [ ] Reconnect and verify the flush log shows "attachment(s) have rawData for multipart upload"
- [ ] Verify the multipart upload path is attempted first, with JSON+base64 fallback
- [ ] Queue a message with an attachment in local mode (file-backed) and verify flush works normally without rawData
- [ ] Verify old queued messages (without the rawData reconstruction) still flush correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
