### PR TITLE
fix(gmail): add deadline to fetch settlement phase in gmail_sender_digest

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -135,14 +135,32 @@ export async function run(
       );
     }
 
-    // Settle all fetch promises — collect successes and tolerate 429 failures
-    const settled = await Promise.allSettled(fetchPromises);
+    // Settle all fetch promises — collect successes and tolerate 429 failures.
+    // Race each promise against a deadline so slow retries don't exceed the
+    // executor's 120s tool timeout.
+    const elapsedMs = Date.now() - startTime;
+    const settleDeadlineMs = Math.max(TIME_BUDGET_MS - elapsedMs, 5_000);
+    const deadlineRejection = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("fetch deadline exceeded")),
+        settleDeadlineMs,
+      ),
+    );
+    const settled = await Promise.allSettled(
+      fetchPromises.map((p) => Promise.race([p, deadlineRejection])),
+    );
     const messages: GmailMessage[] = [];
     for (const result of settled) {
       if (result.status === "fulfilled") {
         messages.push(...result.value);
       } else if (isRateLimitError(result.reason)) {
         rateLimited = true;
+        truncated = true;
+      } else if (
+        result.reason instanceof Error &&
+        result.reason.message === "fetch deadline exceeded"
+      ) {
+        timeBudgetExceeded = true;
         truncated = true;
       } else {
         throw result.reason;


### PR DESCRIPTION
## Summary
- The `gmail_sender_digest` tool was consistently timing out at 120s because `Promise.allSettled()` waited indefinitely for in-flight batch fetches (which include retries with exponential backoff)
- Race each fetch promise against a deadline derived from the remaining time budget, so the tool returns partial results instead of hitting the executor timeout
- Treat deadline-exceeded fetches as `time_budget_exceeded` (same as existing flag) with `truncated: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
