### PR TITLE
fix(environments): forward VELLUM_ENVIRONMENT across desktop→CLI→daemon handoffs

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -855,11 +855,15 @@ export async function startLocalDaemon(
         HOME: process.env.HOME || home,
         PATH: [...extraDirs, basePath].filter(Boolean).join(":"),
       };
-      // Forward optional config env vars the daemon may need
+      // Forward optional config env vars the daemon may need.
+      // `VELLUM_ENVIRONMENT` must be forwarded so the daemon resolves
+      // env-scoped paths (device ID, platform/guardian tokens, XDG
+      // config dir) to the same location as the CLI that spawned it.
       for (const key of [
         "ANTHROPIC_API_KEY",
         "APP_VERSION",
         "BASE_DATA_DIR",
+        "VELLUM_ENVIRONMENT",
         "VELLUM_PLATFORM_URL",
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -109,7 +109,12 @@ final class VellumCli: AssistantManagementClient {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
+    /// `VELLUM_ENVIRONMENT` must be forwarded so the bundled CLI resolves
+    /// env-scoped paths (lockfile, device ID, platform/guardian tokens,
+    /// workspace config) to the same location the desktop app uses. The
+    /// app's Info.plist sets this at build time (see `build.sh:1054`).
     nonisolated private static let forwardedEnvKeys: [String] = [
+        "VELLUM_ENVIRONMENT",
         "VELLUM_PLATFORM_URL",
         "VELLUM_WORKSPACE_DIR",
         "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",


### PR DESCRIPTION
## Summary
Forward \`VELLUM_ENVIRONMENT\` through two spawn-env whitelists that were silently stripping it, which caused the main desktop launch path to run as production regardless of how the app was built.

1. **\`VellumCli.makeBaseEnvironment()\`** (\`clients/macos/vellum-assistant/App/VellumCli.swift:112\`) — add \`VELLUM_ENVIRONMENT\` to \`forwardedEnvKeys\`. The app's Info.plist sets it at build time (\`build.sh:1054\`), so forwarding the variable is sufficient for every bundled-CLI command (\`hatch\`, \`wake\`, \`sleep\`, \`retire\`, …).
2. **\`startLocalDaemon()\` compiled-daemon spawn** (\`cli/src/lib/local.ts:858\`) — add \`VELLUM_ENVIRONMENT\` to the \`daemonEnv\` whitelist. Without this, even a correctly-scoped CLI would spawn a production-bound daemon on packaged desktop builds, so assistant-side env-scoped state (device ID, platform/guardian tokens, XDG-backed config reads) bled into prod.

## Scope notes
- The watch/source daemon spawn path at \`local.ts:281\` is unaffected — it uses \`{...process.env}\` and inherits the variable naturally.
- No tests added: both whitelists live inside runtime spawn functions and aren't currently unit-testable without refactoring. The fix is a 1-line addition at each site with no behavioral coupling.

## Why this is P1
Without these forwards, the environment-isolation goal of the env-data-layout plan is only partially realized: the CLI knows which environment it's in, but the two main process-spawn boundaries (app→CLI, CLI→daemon) quietly reset the variable, so every child process resolves env-scoped paths as production. This would have shipped silently on the desktop app's main path.

Part of plan: env-data-layout.md (fix L1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
