### PR TITLE
fix(clients): exclude queued user messages from refinement turn boundary scan

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -477,7 +477,20 @@ final class ChatActionHandler {
             // nil. Constrain the fallback to assistant messages in the current
             // turn (after the last user message) so we don't flip unrelated
             // historical or cancelled surfaces to complete.
-            let turnStart = (vm.messages.lastIndex(where: { $0.role == .user }) ?? -1) + 1
+            //
+            // When a user queues a new prompt while refinement is in-flight,
+            // MessageSendCoordinator appends the queued user message immediately.
+            // Using the raw last user message would push turnStart past the
+            // in-flight refinement surfaces, leaving dynamic-page cards stuck
+            // incomplete. Instead, find the last user message that actually has
+            // an assistant response after it — queued-but-unanswered messages
+            // won't have one yet.
+            let answeredUserIndex = vm.messages.lastIndex(where: { msg in
+                guard msg.role == .user else { return false }
+                guard let idx = vm.messages.firstIndex(where: { $0.id == msg.id }) else { return false }
+                return vm.messages[(idx + 1)...].contains(where: { $0.role == .assistant })
+            })
+            let turnStart = (answeredUserIndex ?? -1) + 1
             for msgIdx in turnStart..<vm.messages.count {
                 guard vm.messages[msgIdx].role == .assistant else { continue }
                 for surfIdx in vm.messages[msgIdx].inlineSurfaces.indices {


### PR DESCRIPTION
## Summary
- In the `wasRefinement` fallback path of `handleMessageComplete`, the turn boundary (`turnStart`) was computed using `lastIndex(where: { $0.role == .user })`, which includes queued user messages appended while refinement is in-flight.
- When a user queues a new prompt during refinement, this shifts `turnStart` past the in-flight refinement surfaces, leaving dynamic-page cards stuck with `isToolCallComplete == false` (e.g. "Open App" remains disabled).
- Fix: find the last user message that has at least one assistant message after it, so queued-but-unanswered user messages don't move the boundary.

Addresses feedback from #25561.

## Test plan
- [ ] Start a workspace refinement that creates dynamic-page surfaces
- [ ] While refinement is in-flight, type and send a new prompt (queuing it)
- [ ] Verify the "Open App" button on the refinement's dynamic-page card becomes enabled when `message_complete` arrives
- [ ] Verify normal (non-queued) refinement flows still mark surfaces complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
