### PR TITLE
fix(gmail): preserve rate-limit signal on empty scan and add resilience to outreach-scan

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3433,6 +3433,76 @@ paths:
                   description: Upper bound epoch ms
                   type: number
               additionalProperties: false
+  /v1/filing/config:
+    get:
+      operationId: filing_config_get
+      summary: Get filing config
+      description: Return the current filing schedule configuration.
+      tags:
+        - filing
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  activeHoursStart:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  activeHoursEnd:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - enabled
+                  - intervalMs
+                  - activeHoursStart
+                  - activeHoursEnd
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+  /v1/filing/run-now:
+    post:
+      operationId: filing_runnow_post
+      summary: Run filing now
+      description: Trigger an immediate filing run.
+      tags:
+        - filing
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  ran:
+                    type: boolean
+                    description: Whether the filing actually ran
+                required:
+                  - success
+                  - ran
+                additionalProperties: false
   /v1/groups:
     get:
       operationId: groups_get

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -11,6 +11,11 @@ import type {
 import { storeScanResult } from "./scan-result-store.js";
 import { err, ok } from "./shared.js";
 
+function isRateLimitError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return /\b429\b/.test(e.message);
+}
+
 const MAX_MESSAGES_CAP = 5000;
 const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
@@ -69,6 +74,8 @@ export async function run(
     const startTime = Date.now();
     const TIME_BUDGET_MS = 90_000;
 
+    let rateLimited = false;
+
     while (allMessageIds.length < maxMessages) {
       if (Date.now() - startTime > TIME_BUDGET_MS) {
         timeBudgetExceeded = true;
@@ -76,12 +83,22 @@ export async function run(
         break;
       }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
-      const listResp = await listMessages(
-        connection,
-        query,
-        pageSize,
-        pageToken,
-      );
+      let listResp;
+      try {
+        listResp = await listMessages(
+          connection,
+          query,
+          pageSize,
+          pageToken,
+        );
+      } catch (e) {
+        if (isRateLimitError(e)) {
+          rateLimited = true;
+          truncated = true;
+          break;
+        }
+        throw e;
+      }
       const ids = (listResp.messages ?? []).map((m) => m.id);
       if (ids.length === 0) break;
       allMessageIds.push(...ids);
@@ -103,6 +120,17 @@ export async function run(
     }
 
     if (allMessageIds.length === 0) {
+      if (rateLimited) {
+        return ok(
+          JSON.stringify({
+            senders: [],
+            total_scanned: 0,
+            rate_limited: true,
+            truncated: true,
+            note: "Rate limited before any messages could be fetched. Try again later or reduce max_messages.",
+          }),
+        );
+      }
       return ok(
         JSON.stringify({
           senders: [],
@@ -112,7 +140,35 @@ export async function run(
       );
     }
 
-    const messages = (await Promise.all(fetchPromises)).flat();
+    // Settle all fetch promises — collect successes and tolerate 429 failures.
+    const elapsedMs = Date.now() - startTime;
+    const settleDeadlineMs = Math.max(TIME_BUDGET_MS - elapsedMs, 5_000);
+    const deadlineRejection = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("fetch deadline exceeded")),
+        settleDeadlineMs,
+      ),
+    );
+    const settled = await Promise.allSettled(
+      fetchPromises.map((p) => Promise.race([p, deadlineRejection])),
+    );
+    const messages: GmailMessage[] = [];
+    for (const result of settled) {
+      if (result.status === "fulfilled") {
+        messages.push(...result.value);
+      } else if (isRateLimitError(result.reason)) {
+        rateLimited = true;
+        truncated = true;
+      } else if (
+        result.reason instanceof Error &&
+        result.reason.message === "fetch deadline exceeded"
+      ) {
+        timeBudgetExceeded = true;
+        truncated = true;
+      } else {
+        throw result.reason;
+      }
+    }
 
     // Aggregate all fetched messages by sender
     const senderMap = new Map<string, OutreachSenderAggregation>();
@@ -211,6 +267,7 @@ export async function run(
         total_scanned: allMessageIds.length,
         ...(truncated ? { truncated: true } : {}),
         ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        ...(rateLimited ? { rate_limited: true } : {}),
         note: "Scanned inbox for senders without List-Unsubscribe headers (potential cold outreach). Use gmail_archive and gmail_filters for cleanup.",
       }),
     );

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -125,6 +125,18 @@ export async function run(
     }
 
     if (allMessageIds.length === 0) {
+      if (rateLimited) {
+        return ok(
+          JSON.stringify({
+            senders: [],
+            total_scanned: 0,
+            rate_limited: true,
+            truncated: true,
+            message:
+              "Rate limited before any messages could be fetched. Try again later or reduce max_messages.",
+          }),
+        );
+      }
       return ok(
         JSON.stringify({
           senders: [],


### PR DESCRIPTION
## Summary
- When `listMessages` throws a 429 on the first iteration of `gmail_sender_digest`, `allMessageIds` stays empty and the empty-result branch previously returned "No emails found" without `rate_limited` flag. Fixed by checking `rateLimited` in the empty-result branch and returning an appropriate rate-limit signal.
- Applied the same `Promise.allSettled` + `isRateLimitError` rate-limit resilience pattern to `gmail-outreach-scan.ts` for consistency with `gmail-sender-digest.ts`, including try/catch around `listMessages`, deadline-bounded settle, and `rate_limited` flag in the response.

## Test plan
- [ ] Verify `gmail_sender_digest` returns `rate_limited: true` when 429 hits on first iteration (empty allMessageIds)
- [ ] Verify `gmail_outreach_scan` gracefully handles 429 from `listMessages` during pagination
- [ ] Verify `gmail_outreach_scan` handles 429 from `batchGetMessages` via `Promise.allSettled`
- [ ] Verify both tools include `rate_limited` flag in final response when rate limited

Addresses feedback from #25625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
