### PR TITLE
feat: register dev images with dev platform after CI pushes

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -265,7 +265,6 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -177,6 +177,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     environment: dev
     steps:
       - name: Generate GitHub App token
@@ -209,37 +215,137 @@ jobs:
           DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
         run: bun scripts/docker-login-with-retry.ts
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute dev version and image name
-        id: meta
+      - name: Compute image name
+        id: image
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}"
-          echo "image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "tag=dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "gcp=${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
       - name: Sync feature flag registry for Docker context
         run: cp meta/feature-flags/feature-flag-registry.json assistant/src/config/feature-flag-registry.json
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: assistant/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
-            ${{ steps.meta.outputs.image }}:dev
-          cache-from: type=gha,scope=assistant-dev-linux/amd64
-          cache-to: type=gha,mode=max,scope=assistant-dev-linux/amd64
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ steps.image.outputs.gcp }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=assistant-dev-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=assistant-dev-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Prepare platform suffix
+        id: platform
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "suffix=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: assistant-digests-dev-${{ steps.platform.outputs.suffix }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  push-dev-manifest:
+    name: Push Dev Manifest (Assistant)
+    needs: [push-dev-image]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    environment: dev
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+
+      - name: Fail if image build failed
+        if: needs.push-dev-image.result != 'success'
+        run: |
+          echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
+          exit 1
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: bun scripts/docker-login-with-retry.ts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: assistant-digests-dev-*
+          merge-multiple: true
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
+          GCP_TAGS="${GCP_IMAGE}:${GITHUB_SHA}"
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:${IMMUTABLE_TAG}")
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:dev")
+          echo "gcp_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$GCP_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "gcp_image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          TAG_ARGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAG_ARGS="$TAG_ARGS -t $tag"
+          done <<< "${{ steps.tags.outputs.gcp_tags }}"
+          SOURCES=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create $TAG_ARGS $SOURCES
 
       - name: Write image ref artifact
         run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
           mkdir -p /tmp/dev-image-ref
-          echo "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}" > /tmp/dev-image-ref/image-ref.txt
+          echo "${IMAGE}:${IMMUTABLE_TAG}" > /tmp/dev-image-ref/image-ref.txt
           echo "Image ref: $(cat /tmp/dev-image-ref/image-ref.txt)"
 
       - name: Upload image ref

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -284,6 +284,11 @@ jobs:
           echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
           exit 1
 
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -140,7 +140,6 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -159,6 +159,11 @@ jobs:
           echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
           exit 1
 
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -55,6 +55,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     environment: dev
     steps:
       - name: Generate GitHub App token
@@ -87,34 +93,134 @@ jobs:
           DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
         run: bun scripts/docker-login-with-retry.ts
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute dev version and image name
-        id: meta
+      - name: Compute image name
+        id: image
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
-          echo "image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "tag=dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "gcp=${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: credential-executor/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
-            ${{ steps.meta.outputs.image }}:dev
-          cache-from: type=gha,scope=credential-executor-dev-linux/amd64
-          cache-to: type=gha,mode=max,scope=credential-executor-dev-linux/amd64
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ steps.image.outputs.gcp }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=credential-executor-dev-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=credential-executor-dev-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Prepare platform suffix
+        id: platform
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "suffix=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: credential-executor-digests-dev-${{ steps.platform.outputs.suffix }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  push-dev-manifest:
+    name: Push Dev Manifest (Credential Executor)
+    needs: [push-dev-image]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    environment: dev
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+
+      - name: Fail if image build failed
+        if: needs.push-dev-image.result != 'success'
+        run: |
+          echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
+          exit 1
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: bun scripts/docker-login-with-retry.ts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: credential-executor-digests-dev-*
+          merge-multiple: true
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
+          GCP_TAGS="${GCP_IMAGE}:${GITHUB_SHA}"
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:${IMMUTABLE_TAG}")
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:dev")
+          echo "gcp_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$GCP_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "gcp_image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          TAG_ARGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAG_ARGS="$TAG_ARGS -t $tag"
+          done <<< "${{ steps.tags.outputs.gcp_tags }}"
+          SOURCES=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create $TAG_ARGS $SOURCES
 
       - name: Write image ref artifact
         run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
           mkdir -p /tmp/dev-image-ref
-          echo "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}" > /tmp/dev-image-ref/image-ref.txt
+          echo "${IMAGE}:${IMMUTABLE_TAG}" > /tmp/dev-image-ref/image-ref.txt
           echo "Image ref: $(cat /tmp/dev-image-ref/image-ref.txt)"
 
       - name: Upload image ref

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -138,7 +138,6 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -157,6 +157,11 @@ jobs:
           echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
           exit 1
 
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -51,6 +51,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     environment: dev
     steps:
       - name: Generate GitHub App token
@@ -83,36 +89,136 @@ jobs:
           DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
         run: bun scripts/docker-login-with-retry.ts
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute dev version and image name
-        id: meta
+      - name: Compute image name
+        id: image
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
-          echo "image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "tag=dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "gcp=${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
       - name: Sync feature flag registry for Docker context
         run: cp meta/feature-flags/feature-flag-registry.json gateway/src/feature-flag-registry.json
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: gateway
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
-            ${{ steps.meta.outputs.image }}:dev
-          cache-from: type=gha,scope=gateway-dev-linux/amd64
-          cache-to: type=gha,mode=max,scope=gateway-dev-linux/amd64
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ steps.image.outputs.gcp }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=gateway-dev-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=gateway-dev-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Prepare platform suffix
+        id: platform
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "suffix=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-digests-dev-${{ steps.platform.outputs.suffix }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  push-dev-manifest:
+    name: Push Dev Manifest (Gateway)
+    needs: [push-dev-image]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    environment: dev
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+
+      - name: Fail if image build failed
+        if: needs.push-dev-image.result != 'success'
+        run: |
+          echo "::error::push-dev-image failed with result: ${{ needs.push-dev-image.result }}"
+          exit 1
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: bun scripts/docker-login-with-retry.ts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: gateway-digests-dev-*
+          merge-multiple: true
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          GCP_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
+          GCP_TAGS="${GCP_IMAGE}:${GITHUB_SHA}"
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:${IMMUTABLE_TAG}")
+          GCP_TAGS=$(printf "%s\n%s" "$GCP_TAGS" "${GCP_IMAGE}:dev")
+          echo "gcp_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$GCP_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "gcp_image=${GCP_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          TAG_ARGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAG_ARGS="$TAG_ARGS -t $tag"
+          done <<< "${{ steps.tags.outputs.gcp_tags }}"
+          SOURCES=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create $TAG_ARGS $SOURCES
 
       - name: Write image ref artifact
         run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          IMAGE="${{ steps.tags.outputs.gcp_image }}"
+          IMMUTABLE_TAG="dev.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
           mkdir -p /tmp/dev-image-ref
-          echo "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}" > /tmp/dev-image-ref/image-ref.txt
+          echo "${IMAGE}:${IMMUTABLE_TAG}" > /tmp/dev-image-ref/image-ref.txt
           echo "Image ref: $(cat /tmp/dev-image-ref/image-ref.txt)"
 
       - name: Upload image ref

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: register-dev-images
+  cancel-in-progress: true
+
 jobs:
   register-dev-images:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -25,24 +25,24 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Check all CI workflows passed for this commit
+      - name: Verify push-dev-image succeeded for triggered workflow
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           REPO="${{ github.repository }}"
-          WORKFLOWS=("CI Main Assistant Checks" "CI Main Gateway Checks" "CI Main Credential Executor Checks")
-          for WF_NAME in "${WORKFLOWS[@]}"; do
-            STATUS=$(gh api "repos/${REPO}/actions/workflows" --jq ".workflows[] | select(.name == \"${WF_NAME}\") | .id" | while read WF_ID; do
-              gh api "repos/${REPO}/actions/workflows/${WF_ID}/runs?head_sha=${HEAD_SHA}&status=success&per_page=1" --jq '.total_count'
-            done)
-            if [ "${STATUS:-0}" -lt 1 ]; then
-              echo "Workflow '${WF_NAME}' has not completed successfully for commit ${HEAD_SHA}. Skipping registration."
-              exit 1
-            fi
-            echo "✓ ${WF_NAME} passed for ${HEAD_SHA}"
-          done
-          echo "All CI workflows passed — proceeding with registration."
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          # Check that the push-dev-image job in the triggering workflow
+          # actually succeeded (not just the workflow overall, which can
+          # report success even when push-dev-image has continue-on-error).
+          PUSH_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "push-dev-image") | .conclusion')
+
+          if [ "$PUSH_CONCLUSION" != "success" ]; then
+            echo "::warning::push-dev-image job did not succeed (conclusion: ${PUSH_CONCLUSION:-not found}). Skipping registration."
+            exit 1
+          fi
+          echo "✓ push-dev-image succeeded for ${{ github.event.workflow_run.name }}"
 
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -162,10 +162,37 @@ jobs:
           echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
 
+      - name: Compute dev version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the latest release tag to use as the base version
+          git fetch --tags
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | sed -n '1p')
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          LATEST_VERSION=${LATEST_TAG#v}
+
+          # Count successful runs of this workflow to get a monotonically
+          # increasing dev version number
+          REPO="${{ github.repository }}"
+          WORKFLOW_FILE="ci-register-dev-images.yaml"
+          DEV_COUNT=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=1" --jq '.total_count' || true)
+          if [ -z "$DEV_COUNT" ] || ! [ "$DEV_COUNT" -ge 0 ] 2>/dev/null; then
+            DEV_COUNT=0
+          fi
+          DEV_COUNT=$((DEV_COUNT + 1))
+
+          VERSION="${LATEST_VERSION}.dev.${DEV_COUNT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Dev version: $VERSION (base: $LATEST_TAG, count: $DEV_COUNT)"
+
       - name: Register with platform
         run: |
           SHA="${{ github.event.workflow_run.head_sha }}"
-          VERSION="dev.${SHA:0:7}"
+          VERSION="${{ steps.version.outputs.version }}"
           ASSISTANT_REPO="${{ steps.images.outputs.assistant_image }}"
           GATEWAY_REPO="${{ steps.images.outputs.gateway_image }}"
           CREDENTIAL_EXECUTOR_REPO="${{ steps.images.outputs.ce_image }}"
@@ -252,8 +279,7 @@ jobs:
 
       - name: Summary
         run: |
-          SHA="${{ github.event.workflow_run.head_sha }}"
-          VERSION="dev.${SHA:0:7}"
+          VERSION="${{ steps.version.outputs.version }}"
           echo "## Dev Images Registered" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -25,6 +25,25 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Check all CI workflows passed for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          REPO="${{ github.repository }}"
+          WORKFLOWS=("CI Main Assistant Checks" "CI Main Gateway Checks" "CI Main Credential Executor Checks")
+          for WF_NAME in "${WORKFLOWS[@]}"; do
+            STATUS=$(gh api "repos/${REPO}/actions/workflows" --jq ".workflows[] | select(.name == \"${WF_NAME}\") | .id" | while read WF_ID; do
+              gh api "repos/${REPO}/actions/workflows/${WF_ID}/runs?head_sha=${HEAD_SHA}&status=success&per_page=1" --jq '.total_count'
+            done)
+            if [ "${STATUS:-0}" -lt 1 ]; then
+              echo "Workflow '${WF_NAME}' has not completed successfully for commit ${HEAD_SHA}. Skipping registration."
+              exit 1
+            fi
+            echo "✓ ${WF_NAME} passed for ${HEAD_SHA}"
+          done
+          echo "All CI workflows passed — proceeding with registration."
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v2

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -51,18 +51,19 @@ jobs:
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.event.workflow_run.id }}"
 
-          # Check that the push-dev-image job in the triggering workflow
-          # actually succeeded (not just the workflow overall, which can
-          # report success even when push-dev-image has continue-on-error).
-          # Job display names include a service suffix, e.g. "Push Dev Image (Assistant)".
-          PUSH_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-            --jq '[.jobs[] | select(.name | startswith("Push Dev Image")) | .conclusion] | first')
+          # Check that the push-dev-manifest job in the triggering workflow
+          # succeeded. This confirms both platform builds and the manifest
+          # merge completed (not just the workflow overall, which can report
+          # success even when push jobs have continue-on-error).
+          # Job display names include a service suffix, e.g. "Push Dev Manifest (Assistant)".
+          MANIFEST_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
 
-          if [ "$PUSH_CONCLUSION" != "success" ]; then
-            echo "::warning::push-dev-image job did not succeed (conclusion: ${PUSH_CONCLUSION:-not found}). Skipping registration."
+          if [ "$MANIFEST_CONCLUSION" != "success" ]; then
+            echo "::warning::push-dev-manifest job did not succeed (conclusion: ${MANIFEST_CONCLUSION:-not found}). Skipping registration."
             exit 1
           fi
-          echo "✓ push-dev-image succeeded for ${{ github.event.workflow_run.name }}"
+          echo "✓ push-dev-manifest succeeded for ${{ github.event.workflow_run.name }}"
 
       - name: Generate GitHub App token
         id: app-token
@@ -97,7 +98,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get the latest release tag to use as the base version
-          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | sed -n '1p')
+          # Filter to clean semver tags only (exclude pre-release like v0.6.4-staging.3)
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed -n '1p')
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="v0.0.0"
           fi

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -26,46 +26,43 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Skip if newer run is pending
+      - name: Check if this run should proceed
+        id: gate
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           REPO="${{ github.repository }}"
           THIS_RUN_ID="${{ github.run_id }}"
-          # Check for newer pending or in_progress runs of this workflow
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          SHOULD_SKIP="false"
+
+          # Skip if a newer run is queued or in progress
           NEWER_COUNT=$(gh api "repos/${REPO}/actions/workflows/ci-register-dev-images.yaml/runs?status=queued&per_page=100" \
             --jq "[.workflow_runs[] | select(.id > ${THIS_RUN_ID})] | length")
           NEWER_IN_PROGRESS=$(gh api "repos/${REPO}/actions/workflows/ci-register-dev-images.yaml/runs?status=in_progress&per_page=100" \
             --jq "[.workflow_runs[] | select(.id > ${THIS_RUN_ID})] | length")
           TOTAL_NEWER=$(( ${NEWER_COUNT:-0} + ${NEWER_IN_PROGRESS:-0} ))
           if [ "$TOTAL_NEWER" -gt 0 ]; then
-            echo "Newer registration run(s) pending — skipping this run to avoid redundant work."
-            exit 1
+            echo "Newer registration run(s) pending — skipping this run."
+            SHOULD_SKIP="true"
           fi
-          echo "✓ No newer runs pending — proceeding."
 
-      - name: Verify push-dev-image succeeded for triggered workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          REPO="${{ github.repository }}"
-          RUN_ID="${{ github.event.workflow_run.id }}"
-
-          # Check that the push-dev-manifest job in the triggering workflow
-          # succeeded. This confirms both platform builds and the manifest
-          # merge completed (not just the workflow overall, which can report
-          # success even when push jobs have continue-on-error).
-          # Job display names include a service suffix, e.g. "Push Dev Manifest (Assistant)".
-          MANIFEST_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-            --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
-
-          if [ "$MANIFEST_CONCLUSION" != "success" ]; then
-            echo "::warning::push-dev-manifest job did not succeed (conclusion: ${MANIFEST_CONCLUSION:-not found}). Skipping registration."
-            exit 1
+          # Verify push-dev-manifest succeeded in the triggering workflow
+          if [ "$SHOULD_SKIP" = "false" ]; then
+            MANIFEST_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+              --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
+            if [ "$MANIFEST_CONCLUSION" != "success" ]; then
+              echo "::warning::push-dev-manifest did not succeed (conclusion: ${MANIFEST_CONCLUSION:-not found}). Skipping."
+              SHOULD_SKIP="true"
+            else
+              echo "✓ push-dev-manifest succeeded for ${{ github.event.workflow_run.name }}"
+            fi
           fi
-          echo "✓ push-dev-manifest succeeded for ${{ github.event.workflow_run.name }}"
+
+          echo "skip=$SHOULD_SKIP" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
+        if: steps.gate.outputs.skip != 'true'
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -73,6 +70,7 @@ jobs:
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -81,18 +79,22 @@ jobs:
           fetch-tags: true
 
       - name: Authenticate to GCP
+        if: steps.gate.outputs.skip != 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Configure Docker for GCR
+        if: steps.gate.outputs.skip != 'true'
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Docker Buildx
+        if: steps.gate.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Compute dev version
+        if: steps.gate.outputs.skip != 'true'
         id: version
         env:
           GH_TOKEN: ${{ github.token }}
@@ -120,6 +122,7 @@ jobs:
           echo "Dev version: $VERSION (base: $LATEST_TAG, count: $DEV_COUNT)"
 
       - name: Resolve image digests and tag bundle
+        if: steps.gate.outputs.skip != 'true'
         id: images
         env:
           GH_TOKEN: ${{ github.token }}
@@ -194,6 +197,7 @@ jobs:
           echo "ce_digest=$CE_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Compute migration ceilings
+        if: steps.gate.outputs.skip != 'true'
         id: migration-ceilings
         run: |
           # Extract max DB migration version from the registry
@@ -227,6 +231,7 @@ jobs:
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
 
       - name: Register with platform
+        if: steps.gate.outputs.skip != 'true'
         run: |
           SHA="${{ github.event.workflow_run.head_sha }}"
           VERSION="${{ steps.version.outputs.version }}"
@@ -316,6 +321,7 @@ jobs:
           done
 
       - name: Summary
+        if: steps.gate.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "## Dev Images Registered" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: register-dev-images
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   register-dev-images:
@@ -26,6 +26,24 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Skip if newer run is pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPO="${{ github.repository }}"
+          THIS_RUN_ID="${{ github.run_id }}"
+          # Check for newer pending or in_progress runs of this workflow
+          NEWER_COUNT=$(gh api "repos/${REPO}/actions/workflows/ci-register-dev-images.yaml/runs?status=queued&per_page=100" \
+            --jq "[.workflow_runs[] | select(.id > ${THIS_RUN_ID})] | length")
+          NEWER_IN_PROGRESS=$(gh api "repos/${REPO}/actions/workflows/ci-register-dev-images.yaml/runs?status=in_progress&per_page=100" \
+            --jq "[.workflow_runs[] | select(.id > ${THIS_RUN_ID})] | length")
+          TOTAL_NEWER=$(( ${NEWER_COUNT:-0} + ${NEWER_IN_PROGRESS:-0} ))
+          if [ "$TOTAL_NEWER" -gt 0 ]; then
+            echo "Newer registration run(s) pending — skipping this run to avoid redundant work."
+            exit 1
+          fi
+          echo "✓ No newer runs pending — proceeding."
+
       - name: Verify push-dev-image succeeded for triggered workflow
         env:
           GH_TOKEN: ${{ github.token }}
@@ -58,6 +76,8 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -71,7 +91,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute image references and get digest for triggering service
+      - name: Compute dev version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the latest release tag to use as the base version
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | sed -n '1p')
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          LATEST_VERSION=${LATEST_TAG#v}
+
+          # Count total runs of this workflow for a monotonically increasing
+          # dev version number (mirrors staging's RUN_COUNT approach).
+          REPO="${{ github.repository }}"
+          WORKFLOW_FILE="ci-register-dev-images.yaml"
+          DEV_COUNT=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1" --jq '.total_count' || true)
+          if [ -z "$DEV_COUNT" ] || ! [ "$DEV_COUNT" -ge 0 ] 2>/dev/null; then
+            DEV_COUNT=0
+          fi
+          DEV_COUNT=$((DEV_COUNT + 1))
+
+          VERSION="${LATEST_VERSION}-dev.${DEV_COUNT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Dev version: $VERSION (base: $LATEST_TAG, count: $DEV_COUNT)"
+
+      - name: Resolve image digests and tag bundle
         id: images
         env:
           GH_TOKEN: ${{ github.token }}
@@ -80,22 +126,23 @@ jobs:
           GATEWAY_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
           CE_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
 
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION_TAG="v${VERSION}"
+
           # The triggering CI workflow tags images as dev.{run_number}.{short_sha}.
-          # Use the immutable tag from the triggering run to get the exact digest,
-          # avoiding races with the mutable :dev tag.
+          # Use the immutable tag for the triggered service to get the exact digest.
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.event.workflow_run.id }}"
           RUN_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.run_number')
-          SHORT_SHA="${{ github.event.workflow_run.head_sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
+          SHORT_SHA="${SHA:0:7}"
           IMMUTABLE_TAG="dev.${RUN_NUMBER}.${SHORT_SHA}"
-          echo "Using immutable tag: ${IMMUTABLE_TAG}"
 
-          # Determine which service was just built based on the triggering workflow name.
+          # Determine which service was just built.
           WF_NAME="${{ github.event.workflow_run.name }}"
           case "$WF_NAME" in
-            *Assistant*) TRIGGERED_IMAGE="$ASSISTANT_IMAGE" ;;
-            *Gateway*)   TRIGGERED_IMAGE="$GATEWAY_IMAGE" ;;
+            *Assistant*)  TRIGGERED_IMAGE="$ASSISTANT_IMAGE" ;;
+            *Gateway*)    TRIGGERED_IMAGE="$GATEWAY_IMAGE" ;;
             *Credential*) TRIGGERED_IMAGE="$CE_IMAGE" ;;
           esac
 
@@ -103,7 +150,7 @@ jobs:
           TRIGGERED_DIGEST=$(docker buildx imagetools inspect "${TRIGGERED_IMAGE}:${IMMUTABLE_TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Triggered service digest (${WF_NAME}): ${TRIGGERED_DIGEST}"
 
-          # For the other two services, use the current :dev tag (latest available).
+          # For the other two services, capture the current :dev digest.
           case "$WF_NAME" in
             *Assistant*)
               ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
@@ -121,6 +168,21 @@ jobs:
               CE_DIGEST="$TRIGGERED_DIGEST"
               ;;
           esac
+
+          # Tag all three images with the version tag and SHA tag.
+          # Uses digest-pinned retags so even if :dev moves, we tag the
+          # exact digests we captured above.
+          for IMAGE_REF in \
+            "${ASSISTANT_IMAGE}@${ASSISTANT_DIGEST}" \
+            "${GATEWAY_IMAGE}@${GATEWAY_DIGEST}" \
+            "${CE_IMAGE}@${CE_DIGEST}"; do
+            BASE="${IMAGE_REF%%@*}"
+            echo "Tagging ${BASE} with ${VERSION_TAG} and ${SHA}"
+            docker buildx imagetools create \
+              -t "${BASE}:${VERSION_TAG}" \
+              -t "${BASE}:${SHA}" \
+              "${IMAGE_REF}"
+          done
 
           echo "assistant_image=$ASSISTANT_IMAGE" >> "$GITHUB_OUTPUT"
           echo "gateway_image=$GATEWAY_IMAGE" >> "$GITHUB_OUTPUT"
@@ -162,37 +224,11 @@ jobs:
           echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
 
-      - name: Compute dev version
-        id: version
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Get the latest release tag to use as the base version
-          git fetch --tags
-          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | sed -n '1p')
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0"
-          fi
-          LATEST_VERSION=${LATEST_TAG#v}
-
-          # Count successful runs of this workflow to get a monotonically
-          # increasing dev version number
-          REPO="${{ github.repository }}"
-          WORKFLOW_FILE="ci-register-dev-images.yaml"
-          DEV_COUNT=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=1" --jq '.total_count' || true)
-          if [ -z "$DEV_COUNT" ] || ! [ "$DEV_COUNT" -ge 0 ] 2>/dev/null; then
-            DEV_COUNT=0
-          fi
-          DEV_COUNT=$((DEV_COUNT + 1))
-
-          VERSION="${LATEST_VERSION}.dev.${DEV_COUNT}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Dev version: $VERSION (base: $LATEST_TAG, count: $DEV_COUNT)"
-
       - name: Register with platform
         run: |
           SHA="${{ github.event.workflow_run.head_sha }}"
           VERSION="${{ steps.version.outputs.version }}"
+          VERSION_TAG="v${VERSION}"
           ASSISTANT_REPO="${{ steps.images.outputs.assistant_image }}"
           GATEWAY_REPO="${{ steps.images.outputs.gateway_image }}"
           CREDENTIAL_EXECUTOR_REPO="${{ steps.images.outputs.ce_image }}"
@@ -205,15 +241,15 @@ jobs:
             --argjson db_migration_version "${{ steps.migration-ceilings.outputs.db_version }}" \
             --arg last_workspace_migration_id "${{ steps.migration-ceilings.outputs.ws_id }}" \
             --arg assistant_repo "$ASSISTANT_REPO" \
-            --arg assistant_tag "dev" \
+            --arg assistant_tag "$VERSION_TAG" \
             --arg assistant_sha "$SHA" \
             --arg assistant_digest "${{ steps.images.outputs.assistant_digest }}" \
             --arg gateway_repo "$GATEWAY_REPO" \
-            --arg gateway_tag "dev" \
+            --arg gateway_tag "$VERSION_TAG" \
             --arg gateway_sha "$SHA" \
             --arg gateway_digest "${{ steps.images.outputs.gateway_digest }}" \
             --arg credential_executor_repo "$CREDENTIAL_EXECUTOR_REPO" \
-            --arg credential_executor_tag "dev" \
+            --arg credential_executor_tag "$VERSION_TAG" \
             --arg credential_executor_sha "$SHA" \
             --arg credential_executor_digest "${{ steps.images.outputs.ce_digest }}" \
             '{
@@ -283,5 +319,6 @@ jobs:
           echo "## Dev Images Registered" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** \`v${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Trigger:** ${{ github.event.workflow_run.name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** Registered successfully" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -232,7 +232,7 @@ jobs:
           ASSISTANT_REPO="${{ steps.images.outputs.assistant_image }}"
           GATEWAY_REPO="${{ steps.images.outputs.gateway_image }}"
           CREDENTIAL_EXECUTOR_REPO="${{ steps.images.outputs.ce_image }}"
-          IS_STABLE="false"
+          IS_STABLE="true"
 
           PAYLOAD=$(jq -n \
             --arg version "$VERSION" \

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       id-token: write
       contents: read
     steps:
@@ -35,8 +36,9 @@ jobs:
           # Check that the push-dev-image job in the triggering workflow
           # actually succeeded (not just the workflow overall, which can
           # report success even when push-dev-image has continue-on-error).
+          # Job display names include a service suffix, e.g. "Push Dev Image (Assistant)".
           PUSH_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-            --jq '.jobs[] | select(.name == "push-dev-image") | .conclusion')
+            --jq '[.jobs[] | select(.name | startswith("Push Dev Image")) | .conclusion] | first')
 
           if [ "$PUSH_CONCLUSION" != "success" ]; then
             echo "::warning::push-dev-image job did not succeed (conclusion: ${PUSH_CONCLUSION:-not found}). Skipping registration."
@@ -69,16 +71,56 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute image references and get digests
+      - name: Compute image references and get digest for triggering service
         id: images
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           ASSISTANT_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}"
           GATEWAY_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
           CE_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
 
-          ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-          GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-          CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          # The triggering CI workflow tags images as dev.{run_number}.{short_sha}.
+          # Use the immutable tag from the triggering run to get the exact digest,
+          # avoiding races with the mutable :dev tag.
+          REPO="${{ github.repository }}"
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          RUN_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.run_number')
+          SHORT_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          IMMUTABLE_TAG="dev.${RUN_NUMBER}.${SHORT_SHA}"
+          echo "Using immutable tag: ${IMMUTABLE_TAG}"
+
+          # Determine which service was just built based on the triggering workflow name.
+          WF_NAME="${{ github.event.workflow_run.name }}"
+          case "$WF_NAME" in
+            *Assistant*) TRIGGERED_IMAGE="$ASSISTANT_IMAGE" ;;
+            *Gateway*)   TRIGGERED_IMAGE="$GATEWAY_IMAGE" ;;
+            *Credential*) TRIGGERED_IMAGE="$CE_IMAGE" ;;
+          esac
+
+          # Get digest for the triggered service using its immutable tag.
+          TRIGGERED_DIGEST=$(docker buildx imagetools inspect "${TRIGGERED_IMAGE}:${IMMUTABLE_TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "Triggered service digest (${WF_NAME}): ${TRIGGERED_DIGEST}"
+
+          # For the other two services, use the current :dev tag (latest available).
+          case "$WF_NAME" in
+            *Assistant*)
+              ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
+              GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              ;;
+            *Gateway*)
+              ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              GATEWAY_DIGEST="$TRIGGERED_DIGEST"
+              CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              ;;
+            *Credential*)
+              ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              CE_DIGEST="$TRIGGERED_DIGEST"
+              ;;
+          esac
 
           echo "assistant_image=$ASSISTANT_IMAGE" >> "$GITHUB_OUTPUT"
           echo "gateway_image=$GATEWAY_IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -1,0 +1,196 @@
+name: CI Register Dev Images
+
+on:
+  workflow_run:
+    workflows:
+      - CI Main Assistant Checks
+      - CI Main Gateway Checks
+      - CI Main Credential Executor Checks
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  register-dev-images:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment: dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image references and get digests
+        id: images
+        run: |
+          ASSISTANT_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}"
+          GATEWAY_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
+          CE_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
+
+          ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+
+          echo "assistant_image=$ASSISTANT_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "gateway_image=$GATEWAY_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "ce_image=$CE_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "assistant_digest=$ASSISTANT_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "gateway_digest=$GATEWAY_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "ce_digest=$CE_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Compute migration ceilings
+        id: migration-ceilings
+        run: |
+          # Extract max DB migration version from the registry
+          DB_VERSION=$(node -e "
+            const fs = require('fs');
+            const content = fs.readFileSync('assistant/src/memory/migrations/registry.ts', 'utf-8');
+            const versions = [...content.matchAll(/version:\s*(\d+)/g)].map(m => parseInt(m[1]));
+            console.log(Math.max(...versions));
+          ")
+          echo "db_version=$DB_VERSION" >> "$GITHUB_OUTPUT"
+
+          # Extract last workspace migration ID from the registry
+          WS_ID=$(node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const registry = fs.readFileSync('assistant/src/workspace/migrations/registry.ts', 'utf-8');
+            const importMap = {};
+            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]\.\/([^'\x22]+)['\x22];/g)) {
+              importMap[m[1]] = m[2];
+            }
+            const arrayMatch = registry.match(/WORKSPACE_MIGRATIONS[^=]*=\s*\[([\s\S]*?)\]/);
+            const entries = arrayMatch[1].match(/\w+/g);
+            const lastVar = entries[entries.length - 1];
+            const relPath = importMap[lastVar];
+            const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
+            const src = fs.readFileSync(filePath, 'utf-8');
+            const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            console.log(idMatch[1]);
+          ")
+          echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
+          echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
+
+      - name: Register with platform
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          VERSION="dev.${SHA:0:7}"
+          ASSISTANT_REPO="${{ steps.images.outputs.assistant_image }}"
+          GATEWAY_REPO="${{ steps.images.outputs.gateway_image }}"
+          CREDENTIAL_EXECUTOR_REPO="${{ steps.images.outputs.ce_image }}"
+          IS_STABLE="false"
+
+          PAYLOAD=$(jq -n \
+            --arg version "$VERSION" \
+            --arg released_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson is_stable "$IS_STABLE" \
+            --argjson db_migration_version "${{ steps.migration-ceilings.outputs.db_version }}" \
+            --arg last_workspace_migration_id "${{ steps.migration-ceilings.outputs.ws_id }}" \
+            --arg assistant_repo "$ASSISTANT_REPO" \
+            --arg assistant_tag "dev" \
+            --arg assistant_sha "$SHA" \
+            --arg assistant_digest "${{ steps.images.outputs.assistant_digest }}" \
+            --arg gateway_repo "$GATEWAY_REPO" \
+            --arg gateway_tag "dev" \
+            --arg gateway_sha "$SHA" \
+            --arg gateway_digest "${{ steps.images.outputs.gateway_digest }}" \
+            --arg credential_executor_repo "$CREDENTIAL_EXECUTOR_REPO" \
+            --arg credential_executor_tag "dev" \
+            --arg credential_executor_sha "$SHA" \
+            --arg credential_executor_digest "${{ steps.images.outputs.ce_digest }}" \
+            '{
+              version: $version,
+              released_at: $released_at,
+              is_stable: $is_stable,
+              db_migration_version: $db_migration_version,
+              last_workspace_migration_id: $last_workspace_migration_id,
+              assistant_image: {
+                repository: $assistant_repo,
+                tag: $assistant_tag,
+                sha: $assistant_sha,
+                digest: $assistant_digest
+              },
+              gateway_image: {
+                repository: $gateway_repo,
+                tag: $gateway_tag,
+                sha: $gateway_sha,
+                digest: $gateway_digest
+              },
+              credential_executor_image: {
+                repository: $credential_executor_repo,
+                tag: $credential_executor_tag,
+                sha: $credential_executor_sha,
+                digest: $credential_executor_digest
+              }
+            }')
+
+          DELAYS=(5 15 30)
+          MAX_ATTEMPTS=3
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            CURL_EXIT=0
+            echo "Registering dev images ${VERSION} with platform [attempt ${attempt}/${MAX_ATTEMPTS}]..."
+            HTTP_STATUS=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+              -X POST "${{ secrets.PLATFORM_API_URL }}/v1/internal/assistant-image-releases/" \
+              -H "Content-Type: application/json" \
+              -H "X-Internal-Service-Api-Key: ${{ secrets.PLATFORM_INTERNAL_SERVICE_API_KEY }}" \
+              -d "$PAYLOAD") || CURL_EXIT=$?
+
+            if [ "${CURL_EXIT:-0}" -ne 0 ]; then
+              echo "::warning::curl transport error (exit code $CURL_EXIT) on attempt ${attempt}"
+              HTTP_STATUS="000"
+            else
+              echo "HTTP Status: $HTTP_STATUS"
+              cat /tmp/response.json
+            fi
+
+            if [ "$HTTP_STATUS" -ge 200 ] 2>/dev/null && [ "$HTTP_STATUS" -lt 300 ] 2>/dev/null; then
+              echo "Registration succeeded on attempt ${attempt}"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              DELAY=${DELAYS[$((attempt - 1))]}
+              echo "::warning::Attempt ${attempt} failed (HTTP $HTTP_STATUS). Retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            else
+              echo "::error::Dev image registration failed after ${MAX_ATTEMPTS} attempts (last HTTP $HTTP_STATUS)"
+              exit 1
+            fi
+          done
+
+      - name: Summary
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          VERSION="dev.${SHA:0:7}"
+          echo "## Dev Images Registered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event.workflow_run.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** Registered successfully" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -26,15 +26,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Check if this run should proceed
-        id: gate
+      - name: Verify this run should proceed
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           REPO="${{ github.repository }}"
           THIS_RUN_ID="${{ github.run_id }}"
           RUN_ID="${{ github.event.workflow_run.id }}"
-          SHOULD_SKIP="false"
 
           # Skip if a newer run is queued or in progress
           NEWER_COUNT=$(gh api "repos/${REPO}/actions/workflows/ci-register-dev-images.yaml/runs?status=queued&per_page=100" \
@@ -44,25 +42,19 @@ jobs:
           TOTAL_NEWER=$(( ${NEWER_COUNT:-0} + ${NEWER_IN_PROGRESS:-0} ))
           if [ "$TOTAL_NEWER" -gt 0 ]; then
             echo "Newer registration run(s) pending — skipping this run."
-            SHOULD_SKIP="true"
+            exit 1
           fi
 
           # Verify push-dev-manifest succeeded in the triggering workflow
-          if [ "$SHOULD_SKIP" = "false" ]; then
-            MANIFEST_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-              --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
-            if [ "$MANIFEST_CONCLUSION" != "success" ]; then
-              echo "::warning::push-dev-manifest did not succeed (conclusion: ${MANIFEST_CONCLUSION:-not found}). Skipping."
-              SHOULD_SKIP="true"
-            else
-              echo "✓ push-dev-manifest succeeded for ${{ github.event.workflow_run.name }}"
-            fi
+          MANIFEST_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
+          if [ "$MANIFEST_CONCLUSION" != "success" ]; then
+            echo "::warning::push-dev-manifest did not succeed (conclusion: ${MANIFEST_CONCLUSION:-not found}). Skipping."
+            exit 1
           fi
-
-          echo "skip=$SHOULD_SKIP" >> "$GITHUB_OUTPUT"
+          echo "✓ push-dev-manifest succeeded for ${{ github.event.workflow_run.name }}"
 
       - name: Generate GitHub App token
-        if: steps.gate.outputs.skip != 'true'
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -70,7 +62,7 @@ jobs:
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
-        if: steps.gate.outputs.skip != 'true'
+
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -79,22 +71,22 @@ jobs:
           fetch-tags: true
 
       - name: Authenticate to GCP
-        if: steps.gate.outputs.skip != 'true'
+
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Configure Docker for GCR
-        if: steps.gate.outputs.skip != 'true'
+
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Docker Buildx
-        if: steps.gate.outputs.skip != 'true'
+
         uses: docker/setup-buildx-action@v3
 
       - name: Compute dev version
-        if: steps.gate.outputs.skip != 'true'
+
         id: version
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,7 +114,7 @@ jobs:
           echo "Dev version: $VERSION (base: $LATEST_TAG, count: $DEV_COUNT)"
 
       - name: Resolve image digests and tag bundle
-        if: steps.gate.outputs.skip != 'true'
+
         id: images
         env:
           GH_TOKEN: ${{ github.token }}
@@ -197,7 +189,7 @@ jobs:
           echo "ce_digest=$CE_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Compute migration ceilings
-        if: steps.gate.outputs.skip != 'true'
+
         id: migration-ceilings
         run: |
           # Extract max DB migration version from the registry
@@ -231,7 +223,7 @@ jobs:
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
 
       - name: Register with platform
-        if: steps.gate.outputs.skip != 'true'
+
         run: |
           SHA="${{ github.event.workflow_run.head_sha }}"
           VERSION="${{ steps.version.outputs.version }}"
@@ -321,7 +313,7 @@ jobs:
           done
 
       - name: Summary
-        if: steps.gate.outputs.skip != 'true'
+
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "## Dev Images Registered" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Add a new GitHub Actions workflow (`ci-register-dev-images.yaml`) that registers dev images with the dev platform after any CI main workflow pushes a new image to GCR.

- Triggers on `workflow_run` completion of CI Main Assistant/Gateway/Credential Executor workflows
- Inspects `:dev` tagged images in GCR for all three services, gets manifest digests
- Computes migration ceilings from the triggering commit's source code
- Registers with the dev platform via `/v1/internal/assistant-image-releases/` with `is_stable=false`
- Includes retry logic (3 attempts with 5/15/30s backoff)

## Self-review result
PASS — checkout ref fixed to use triggering workflow's commit SHA per reviewer feedback

## PRs merged into feature branch
- #25638: feat: register dev images with dev platform after CI pushes

Part of plan: ci-dev-image-registration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
