### PR TITLE
fix: add missing VellumAssistantShared import in StackDefinition.swift

### DIFF
--- a/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
+++ b/clients/macos/vellum-assistant/AppleContainer/StackDefinition.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 // MARK: - Service Names
 


### PR DESCRIPTION
## Summary
- Add `import VellumAssistantShared` to `StackDefinition.swift` so `VellumEnvironment.current.rawValue` compiles
- Fixes macOS CI build failure introduced by #25616 which added `VELLUM_ENVIRONMENT` forwarding to container env dicts without the required import
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
