### PR TITLE
feat: make welcome-screen avatar clickable with bounce + sound

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -35,6 +35,7 @@ struct ChatEmptyStateView: View {
 
     @State private var visible = false
     @State private var fallbackPlaceholder: String = placeholderTexts.randomElement()!
+    @State private var avatarBounceScale: CGFloat = 1.0
 
     // Stable random pick from SOUL.md (loaded asynchronously, computed once per view lifecycle)
     @State private var soulGreeting: String?
@@ -101,15 +102,29 @@ struct ChatEmptyStateView: View {
             Group {
                 if appearance.customAvatarImage != nil {
                     VAvatarImage(image: appearance.chatAvatarImage, size: 40)
+                        .scaleEffect(avatarBounceScale)
+                        .onTapGesture {
+                            SoundManager.shared.play(.characterPoke)
+                            triggerBounce()
+                        }
                 } else if let body = appearance.characterBodyShape,
                    let eyes = appearance.characterEyeStyle,
                    let color = appearance.characterColor {
+                    // Sound is played by AnimatedAvatarView.mouseDown; don't double up here.
                     AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 40)
                         .frame(width: 40, height: 40)
+                        .scaleEffect(avatarBounceScale)
+                        .onTapGesture { triggerBounce() }
                 } else {
                     VAvatarImage(image: appearance.chatAvatarImage, size: 40)
+                        .scaleEffect(avatarBounceScale)
+                        .onTapGesture {
+                            SoundManager.shared.play(.characterPoke)
+                            triggerBounce()
+                        }
                 }
             }
+            .animation(.spring(response: 0.3, dampingFraction: 0.5), value: avatarBounceScale)
 
             Group {
                 if let greeting = effectiveGreeting {
@@ -183,6 +198,17 @@ struct ChatEmptyStateView: View {
         onFetchConversationStarters?()
         withAnimation(.easeOut(duration: 0.5)) {
             visible = true
+        }
+    }
+
+    private func triggerBounce() {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+            avatarBounceScale = 1.15
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                avatarBounceScale = 1.0
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Wires tap gesture + spring bounce + \`characterPoke\` sound onto the welcome/empty-state avatar in \`ChatEmptyStateView\`, reusing the exact pattern from \`ChatBubble.inlineAvatar\` (state var, 1.15→1.0 spring, sound call).
- All three avatar branches (custom image, \`AnimatedAvatarView\`, fallback) get parity with chat. The \`AnimatedAvatarView\` branch intentionally skips the explicit \`SoundManager.play\` call because \`AnimatedAvatarView.mouseDown\` already plays \`characterPoke\` internally — avoids double-play.
- macOS only; iOS empty state shows a sparkles icon (no avatar), and the temporary-chat empty state shows a leaf emoji, so both are out of scope.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
