### PR TITLE
feat(macos): show streaming continuation indicator after initial text output

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -38,6 +38,7 @@ struct ChatBubble: View, Equatable {
             && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isProcessingAfterTools == rhs.isProcessingAfterTools
             && lhs.processingStatusText == rhs.processingStatusText
+            && lhs.isStreamingContinuation == rhs.isStreamingContinuation
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.hideInlineAvatar == rhs.hideInlineAvatar
             && lhs.activeSurfaceId == rhs.activeSurfaceId
@@ -84,6 +85,9 @@ struct ChatBubble: View, Equatable {
     var isProcessingAfterTools: Bool = false
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
+    /// When true, the assistant is streaming and has already produced text.
+    /// Shows a subtle inline indicator so the user knows more content is coming.
+    var isStreamingContinuation: Bool = false
     /// Whether the message-tts feature flag is enabled. Passed from the parent.
     var isTTSEnabled: Bool = false
     /// When true, suppress the inline avatar on this bubble because
@@ -142,6 +146,7 @@ struct ChatBubble: View, Equatable {
         typographyGeneration: Int = 0,
         isProcessingAfterTools: Bool = false,
         processingStatusText: String? = nil,
+        isStreamingContinuation: Bool = false,
         activeSurfaceId: String? = nil,
         hideInlineAvatar: Bool = false
     ) {
@@ -168,6 +173,7 @@ struct ChatBubble: View, Equatable {
         self.typographyGeneration = typographyGeneration
         self.isProcessingAfterTools = isProcessingAfterTools
         self.processingStatusText = processingStatusText
+        self.isStreamingContinuation = isStreamingContinuation
         self.activeSurfaceId = activeSurfaceId
         self.hideInlineAvatar = hideInlineAvatar
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -69,6 +69,15 @@ extension ChatBubble {
                 Spacer(minLength: 0)
             }
             .padding(.top, VSpacing.xxs)
+        } else if isStreamingContinuation {
+            // Assistant is still generating after producing initial text.
+            // Show a subtle typing indicator so the user knows more content is coming.
+            HStack(spacing: 0) {
+                TypingIndicatorView()
+                Spacer(minLength: 0)
+            }
+            .padding(.top, VSpacing.xxs)
+            .transition(.opacity)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -19,6 +19,7 @@ struct MessageCellView: View, Equatable {
             && lhs.typographyGeneration == rhs.typographyGeneration
             && lhs.isProcessingAfterTools == rhs.isProcessingAfterTools
             && lhs.processingStatusText == rhs.processingStatusText
+            && lhs.isStreamingContinuation == rhs.isStreamingContinuation
             && lhs.hideInlineAvatar == rhs.hideInlineAvatar
             && lhs.showAnchoredThinkingIndicator == rhs.showAnchoredThinkingIndicator
             && lhs.anchoredThinkingLabel == rhs.anchoredThinkingLabel
@@ -45,6 +46,7 @@ struct MessageCellView: View, Equatable {
     let typographyGeneration: Int
     let isProcessingAfterTools: Bool
     let processingStatusText: String?
+    let isStreamingContinuation: Bool
     let hideInlineAvatar: Bool
     let showAnchoredThinkingIndicator: Bool
     let anchoredThinkingLabel: String
@@ -129,6 +131,7 @@ struct MessageCellView: View, Equatable {
                 typographyGeneration: typographyGeneration,
                 isProcessingAfterTools: isProcessingAfterTools,
                 processingStatusText: processingStatusText,
+                isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
                 hideInlineAvatar: hideInlineAvatar
             )
@@ -220,6 +223,7 @@ struct MessageCellView: View, Equatable {
                 typographyGeneration: typographyGeneration,
                 isProcessingAfterTools: isProcessingAfterTools,
                 processingStatusText: processingStatusText,
+                isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
                 hideInlineAvatar: hideInlineAvatar
             )

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -175,6 +175,7 @@ struct MessageListContentView: View, Equatable {
                     typographyGeneration: typographyGeneration,
                     isProcessingAfterTools: state.canInlineProcessing && row.isLatestAssistant,
                     processingStatusText: state.canInlineProcessing && row.isLatestAssistant ? state.effectiveStatusText : nil,
+                    isStreamingContinuation: state.isStreamingWithText && row.isLatestAssistant,
                     hideInlineAvatar: row.isLatestAssistant && isUnanchoredThinking,
                     showAnchoredThinkingIndicator: row.isAnchoredThinkingRow,
                     anchoredThinkingLabel: row.isAnchoredThinkingRow ? thinkingLabel : "",

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -150,6 +150,11 @@ enum TranscriptProjector {
             && !hasActiveToolCall
             && !canInlineProcessing
 
+        let isStreamingWithText = isSending
+            && (lastVisible?.isStreaming == true)
+            && !(lastVisible?.text.isEmpty ?? true)
+            && !hasActiveToolCall
+
         // --- Build row models ---
 
         var rows: [TranscriptRowModel] = visibleMessages.enumerated().map { index, message in
@@ -199,6 +204,7 @@ enum TranscriptProjector {
             canInlineProcessing: canInlineProcessing,
             shouldShowThinkingIndicator: shouldShowThinkingIndicator,
             isStreamingWithoutText: isStreamingWithoutText,
+            isStreamingWithText: isStreamingWithText,
             hasMessages: !visibleMessages.isEmpty,
             hasUserMessage: hasUserMessage,
             hasActiveToolCall: hasActiveToolCall,

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptRenderModel.swift
@@ -38,6 +38,11 @@ struct TranscriptRenderModel: Equatable {
     /// Whether the assistant is streaming but has not yet produced any text.
     let isStreamingWithoutText: Bool
 
+    /// Whether the assistant is streaming and has already produced text.
+    /// Used to show a subtle inline continuation indicator so the user
+    /// knows more content is still being generated.
+    let isStreamingWithText: Bool
+
     /// Whether the transcript has any messages at all.
     let hasMessages: Bool
 

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -67,6 +67,7 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             typographyGeneration: typographyGeneration,
             isProcessingAfterTools: false,
             processingStatusText: nil,
+            isStreamingContinuation: false,
             hideInlineAvatar: false,
             showAnchoredThinkingIndicator: false,
             anchoredThinkingLabel: "",

--- a/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
+++ b/clients/macos/vellum-assistantTests/TranscriptProjectorTests.swift
@@ -479,6 +479,39 @@ final class TranscriptProjectorTests: XCTestCase {
             XCTAssertEqual(row.index, i, "Row index should match position in rows array")
         }
     }
+
+    // MARK: - Streaming With Text (continuation indicator)
+
+    func testStreamingWithText_SetWhenStreamingAndTextExists() {
+        let msg = makeMessage(role: .assistant, text: "got 3,300 messages scanned", isStreaming: true)
+        let model = project(messages: [msg], isSending: true)
+        XCTAssertTrue(model.isStreamingWithText)
+    }
+
+    func testStreamingWithText_FalseWhenTextEmpty() {
+        let msg = makeMessage(role: .assistant, text: "", isStreaming: true)
+        let model = project(messages: [msg], isSending: true)
+        XCTAssertFalse(model.isStreamingWithText)
+    }
+
+    func testStreamingWithText_FalseWhenNotSending() {
+        let msg = makeMessage(role: .assistant, text: "some text", isStreaming: true)
+        let model = project(messages: [msg], isSending: false)
+        XCTAssertFalse(model.isStreamingWithText)
+    }
+
+    func testStreamingWithText_FalseWhenNotStreaming() {
+        let msg = makeMessage(role: .assistant, text: "some text", isStreaming: false)
+        let model = project(messages: [msg], isSending: true)
+        XCTAssertFalse(model.isStreamingWithText)
+    }
+
+    func testStreamingWithText_FalseWhenToolCallActive() {
+        let tool = ToolCallData(toolName: "gmail_search", inputSummary: "scanning", isComplete: false)
+        let msg = makeMessage(role: .assistant, text: "scanning inbox...", isStreaming: true, toolCalls: [tool])
+        let model = project(messages: [msg], isSending: true)
+        XCTAssertFalse(model.isStreamingWithText)
+    }
 }
 
 // MARK: - ToolCallData convenience init for tests


### PR DESCRIPTION
## Summary
- Add `isStreamingWithText` flag to `TranscriptRenderModel` that fires when the assistant is streaming, has already output text, and no tool calls are active
- Render a `TypingIndicatorView` inline at the bottom of the last assistant bubble during this gap, so users know more content is coming
- Add 5 test cases covering all flag conditions (streaming+text, no text, not sending, not streaming, active tool call)

## Original prompt
Show a loading state when the assistant has output text and is about to generate more content (e.g., a table), where previously no visual feedback was shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
