### PR TITLE
feat: scheduled tasks bypass surface-action gate for email bulk ops

### DIFF
--- a/assistant/src/__tests__/gmail-archive-gate.test.ts
+++ b/assistant/src/__tests__/gmail-archive-gate.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../tools/types.js";
+
+const mockBatchModifyMessages =
+  mock<
+    (
+      conn: unknown,
+      ids: string[],
+      opts: Record<string, unknown>,
+    ) => Promise<void>
+  >();
+const mockListMessages =
+  mock<
+    (
+      conn: unknown,
+      query: string,
+      limit: number,
+      pageToken?: string,
+    ) => Promise<{
+      messages?: { id: string }[];
+      nextPageToken?: string | null;
+    }>
+  >();
+const mockModifyMessage =
+  mock<
+    (
+      conn: unknown,
+      messageId: string,
+      opts: Record<string, unknown>,
+    ) => Promise<void>
+  >();
+const mockResolveOAuthConnection =
+  mock<(provider: string, opts?: unknown) => Promise<unknown>>();
+
+mock.module("../messaging/providers/gmail/client.js", () => ({
+  batchModifyMessages: mockBatchModifyMessages,
+  listMessages: mockListMessages,
+  modifyMessage: mockModifyMessage,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+mock.module("../config/bundled-skills/gmail/tools/scan-result-store.js", () => ({
+  getSenderMessageIds: () => ["msg-a", "msg-b"],
+}));
+
+const { run } = await import(
+  "../config/bundled-skills/gmail/tools/gmail-archive.js"
+);
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    conversationId: "conv-1",
+    ...overrides,
+  } as ToolContext;
+}
+
+describe("gmail_archive gate", () => {
+  test("rejects query path when neither surface action nor batch-authorized task", async () => {
+    const result = await run(
+      { query: "in:inbox" },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: false,
+      }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("surface action");
+  });
+
+  test("rejects batch message_ids path when neither flag set", async () => {
+    const result = await run(
+      { message_ids: ["m1", "m2"] },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: false,
+      }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("surface action");
+  });
+
+  test("rejects scan_id path when neither flag set", async () => {
+    const result = await run(
+      { scan_id: "scan-1", sender_ids: ["s1"] },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: false,
+      }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("surface action");
+  });
+
+  test("allows query path in a scheduled task run (batchAuthorizedByTask)", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages.mockResolvedValueOnce({
+      messages: [{ id: "m1" }, { id: "m2" }],
+      nextPageToken: null,
+    });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const result = await run(
+      { query: "in:inbox category:promotions" },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: true,
+      }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Archived 2 message(s)");
+  });
+
+  test("allows batch message_ids path in a scheduled task run", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const result = await run(
+      { message_ids: ["m1", "m2"] },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: true,
+      }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Archived 2 message(s)");
+  });
+
+  test("single message_id path works without either flag (no gate on that path)", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockModifyMessage.mockResolvedValueOnce(undefined);
+
+    const result = await run(
+      { message_id: "msg-1" },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: false,
+      }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Message archived");
+  });
+});

--- a/assistant/src/__tests__/outlook-unsubscribe.test.ts
+++ b/assistant/src/__tests__/outlook-unsubscribe.test.ts
@@ -91,13 +91,42 @@ function makeMessage(
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("outlook_unsubscribe", () => {
-  test("rejects when not triggered by surface action", async () => {
+  test("rejects when neither surface action nor batch-authorized task", async () => {
     const result = await run(
       { message_id: "msg-1", confidence: 0.9 },
-      makeContext({ triggeredBySurfaceAction: false }),
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: false,
+      }),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("surface action");
+  });
+
+  test("allows scheduled task run with batchAuthorizedByTask", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value: "<https://mail.example.com/unsubscribe?id=789>",
+        },
+      ]),
+    );
+    mockResolveRequestAddress.mockResolvedValueOnce({
+      addresses: ["93.184.216.34"],
+    });
+    mockPinnedHttpsRequest.mockResolvedValueOnce(200);
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext({
+        triggeredBySurfaceAction: false,
+        batchAuthorizedByTask: true,
+      }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Successfully unsubscribed via HTTPS GET");
   });
 
   test("returns error when message_id is missing", async () => {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -28,9 +28,9 @@ export async function run(
   // Resolve message IDs via priority: query → scan_id+sender_ids → message_ids → message_id
   if (query) {
     // Query path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction) {
+    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
       return err(
-        "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+        "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );
     }
 
@@ -83,9 +83,9 @@ export async function run(
     }
   } else if (scanId && senderIds?.length) {
     // Scan path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction) {
+    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
       return err(
-        "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+        "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );
     }
 
@@ -98,9 +98,9 @@ export async function run(
     messageIds = resolved;
   } else if (messageIds?.length) {
     // Batch message_ids path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction) {
+    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
       return err(
-        "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+        "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );
     }
   } else if (messageId) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -19,9 +19,9 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const account = input.account as string | undefined;
-  if (!context.triggeredBySurfaceAction) {
+  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
     return err(
-      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+      "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );
   }
 

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -8,9 +8,9 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  if (!context.triggeredBySurfaceAction) {
+  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
     return err(
-      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+      "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );
   }
 

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
@@ -23,9 +23,9 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const account = input.account as string | undefined;
-  if (!context.triggeredBySurfaceAction) {
+  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
     return err(
-      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+      "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );
   }
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -185,6 +185,7 @@ export function createToolExecutor(
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:
         ctx.surfaceActionRequestIds?.has(ctx.currentRequestId ?? "") ?? false,
+      batchAuthorizedByTask: ctx.taskRunId != null,
       requesterExternalUserId: ctx.trustContext?.requesterExternalUserId,
       requesterChatId: ctx.trustContext?.requesterChatId,
       requesterIdentifier: ctx.trustContext?.requesterIdentifier,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -163,6 +163,14 @@ export interface ToolContext {
   callSessionId?: string;
   /** True when the tool invocation was triggered by a user clicking a surface action button (not a regular message). */
   triggeredBySurfaceAction?: boolean;
+  /**
+   * True when the invocation is inside a scheduled task run whose
+   * `required_tools` array pre-authorized this tool at task-creation time.
+   * Tools that normally require a surface-action click (e.g. bulk archive,
+   * unsubscribe) may treat this as equivalent consent, since the user
+   * already reviewed the tool list when the task was saved.
+   */
+  batchAuthorizedByTask?: boolean;
   /** External user ID of the requester (non-guardian actor). Used for scoped grant consumption. */
   requesterExternalUserId?: string;
   /** Chat ID of the requester (non-guardian actor). Used for tool grant request escalation notifications. */


### PR DESCRIPTION
## Summary
- Add optional `batchAuthorizedByTask` field to `ToolContext`; `conversation-tool-setup.ts` sets it when a `taskRunId` is present so scheduled runs are recognized as pre-authorized.
- Relax the hardcoded surface-action gate in `gmail_archive` (query / batch / scan_id paths), `gmail_unsubscribe`, `outlook_unsubscribe`, and `messaging_archive_by_sender` to accept either `triggeredBySurfaceAction` or `batchAuthorizedByTask`.
- Updated error strings name both acceptable preconditions.
- Extended `outlook-unsubscribe.test.ts` and added `gmail-archive-gate.test.ts` to cover both the reject-when-neither-flag-set case and the allow-under-scheduled-task case.

## Why this is safe
- `required_tools` on a saved task is user-reviewed at task-creation time (`bundled-skills/tasks/SKILL.md:37`: "The user must approve these tools before the task can run").
- Scheduled runs already get `trustClass: "guardian"` + ephemeral allow rules for every tool in `required_tools`; the permission system was never the blocker here.
- The surface-action gate was designed to stop in-conversation bulk operations where the model could hallucinate an over-broad list. Scheduled tasks have a different, earlier consent point.
- `permission-controls-v2` is fine with this — we're narrowing an existing deterministic gate, not introducing a new one.

## Out of scope
- `outlook_send_draft` — sending email on the user's behalf is higher-stakes.
- SKILL.md updates (follow-up).

Full rationale in the local plan file `/Users/sidd/.claude/plans/fuzzy-forging-unicorn.md`.

## Original prompt
Implement Option A2 from the plan — scheduled tasks should bypass the hardcoded \`triggeredBySurfaceAction\` gate for email archive/unsubscribe tools.

## Test plan
- [x] \`bun test src/__tests__/gmail-archive-gate.test.ts src/__tests__/outlook-unsubscribe.test.ts\` — 15 pass
- [x] \`bunx tsc --noEmit\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
