### PR TITLE
fix(filing): default to running 24/7

### DIFF
--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -24,21 +24,42 @@ export const FilingConfigSchema = z
       .int("filing.activeHoursStart must be an integer")
       .min(0, "filing.activeHoursStart must be >= 0")
       .max(23, "filing.activeHoursStart must be <= 23")
-      .default(8)
-      .describe("Hour of the day (0-23) when filing runs begin"),
+      .nullable()
+      .default(null)
+      .describe(
+        "Hour of the day (0-23) when filing runs begin, or null to disable active hours restriction",
+      ),
     activeHoursEnd: z
       .number({ error: "filing.activeHoursEnd must be a number" })
       .int("filing.activeHoursEnd must be an integer")
       .min(0, "filing.activeHoursEnd must be >= 0")
       .max(23, "filing.activeHoursEnd must be <= 23")
-      .default(22)
-      .describe("Hour of the day (0-23) when filing runs stop"),
+      .nullable()
+      .default(null)
+      .describe(
+        "Hour of the day (0-23) when filing runs stop, or null to disable active hours restriction",
+      ),
   })
   .describe(
     "Periodic PKB (personal knowledge base) filing — processes the buffer into topic files and maintains knowledge organization",
   )
   .superRefine((config, ctx) => {
-    if (config.activeHoursStart === config.activeHoursEnd) {
+    const startNull = config.activeHoursStart == null;
+    const endNull = config.activeHoursEnd == null;
+    if (startNull !== endNull) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
+        message:
+          "filing.activeHoursStart and filing.activeHoursEnd must both be set or both be null",
+      });
+      return;
+    }
+    if (
+      config.activeHoursStart != null &&
+      config.activeHoursEnd != null &&
+      config.activeHoursStart === config.activeHoursEnd
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["activeHoursEnd"],


### PR DESCRIPTION
## Summary
- Filing's `activeHoursStart`/`activeHoursEnd` now default to `null` (24/7) instead of `8`/`22`, matching the runtime's already-nullable behavior in `filing-service.ts`.
- Schema fields are made `nullable()` and the `superRefine` is updated (mirroring `heartbeat.ts`) to require both fields to be null together or both to be set, while still rejecting equal start/end.
- No migration needed: explicit values in existing `config.json` files win over defaults; only fresh/unset configs change behavior.

## Original prompt
The filing job config shouldn't default to having active hours enabled, it should run 24/7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
