### PR TITLE
fix(macos): add a11y traits + Task.sleep on welcome avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -125,6 +125,13 @@ struct ChatEmptyStateView: View {
                 }
             }
             .animation(.spring(response: 0.3, dampingFraction: 0.5), value: avatarBounceScale)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Poke assistant")
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction {
+                SoundManager.shared.play(.characterPoke)
+                triggerBounce()
+            }
 
             Group {
                 if let greeting = effectiveGreeting {
@@ -205,7 +212,9 @@ struct ChatEmptyStateView: View {
         withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
             avatarBounceScale = 1.15
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                 avatarBounceScale = 1.0
             }


### PR DESCRIPTION
PR #25644 added .onTapGesture to three avatar branches without accessibility traits/labels/actions, leaving the new poke interaction invisible to VoiceOver and keyboard users. Adds .accessibilityAddTraits(.isButton), .accessibilityLabel, and .accessibilityAction on the parent Group so all three branches are reachable. Also swaps DispatchQueue.main.asyncAfter in triggerBounce for Task.sleep with a cancellation guard, per clients/AGENTS.md.

Addresses Codex P1 + Devin reviews on #25644.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
