### PR TITLE
fix(filing): register auth policy for filing routes

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -462,6 +462,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "schedules/run", scopes: ["settings.write"] },
   { endpoint: "schedules/cancel", scopes: ["settings.write"] },
 
+  // Filing
+  { endpoint: "filing", scopes: ["settings.read"] },
+  { endpoint: "filing:POST", scopes: ["settings.write"] },
+
   // Diagnostics
   { endpoint: "export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/env-vars", scopes: ["settings.read"] },


### PR DESCRIPTION
PR #25610 added /v1/filing/config and /v1/filing/run-now with policyKey 'filing', but the policy was never registered in route-policy.ts. enforcePolicy returns null for unregistered keys, so any authenticated principal could call these endpoints. Registers filing (settings.read) and filing:POST (settings.write), mirroring schedules. The existing guard test in guard-tests.test.ts already catches unregistered policyKeys — it was failing for 'filing' before this fix.

Addresses Codex P1 review on #25610.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
