### PR TITLE
fix(migrations): stop modifying released migration 029

### DIFF
--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -7,7 +7,7 @@ const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear
 
 # Knowledge Base
 
-**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.
+**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.
 
 ## Always Loaded
 - essentials.md — Core facts, patterns, and biographical info

--- a/assistant/src/workspace/migrations/036-update-pkb-index-bar.ts
+++ b/assistant/src/workspace/migrations/036-update-pkb-index-bar.ts
@@ -3,14 +3,20 @@ import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";
 
-const OLD_BAR = `**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
+// Original bar seeded by migration 029 at its initial release.
+const ORIGINAL_BAR = `**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
+
+// Bar introduced in PR #25532 (an in-place edit of migration 029). Users who
+// installed while that edit was live had this version seeded. Recognized here
+// so this migration can normalize both populations to NEW_BAR.
+const POST_25532_BAR = `**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
 
 const NEW_BAR = `**Remember aggressively.** Capture anything concrete about your user — preferences, names, dates, habits, plans, opinions, health details, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals). Don't judge importance — filing decides that later. Call \`remember\` immediately, multiple times per conversation. Remembering too much costs nothing. Forgetting something that mattered costs trust.`;
 
 export const updatePkbIndexBarMigration: WorkspaceMigration = {
   id: "036-update-pkb-index-bar",
   description:
-    "Update pkb/INDEX.md 'Remember aggressively' bar to pass-through framing for users seeded by migration 029",
+    "Normalize pkb/INDEX.md 'Remember aggressively' bar across both variants previously seeded by migration 029",
 
   down(_workspaceDir: string): void {
     // No-op: don't revert user-editable file content on rollback.
@@ -21,11 +27,16 @@ export const updatePkbIndexBarMigration: WorkspaceMigration = {
     if (!existsSync(indexPath)) return;
 
     const current = readFileSync(indexPath, "utf-8");
-    if (!current.includes(OLD_BAR)) {
-      // Either already updated or user-modified — leave alone.
-      return;
-    }
 
-    writeFileSync(indexPath, current.replace(OLD_BAR, NEW_BAR), "utf-8");
+    for (const bar of [ORIGINAL_BAR, POST_25532_BAR]) {
+      if (current.includes(bar)) {
+        const updated = current.replace(bar, NEW_BAR);
+        if (updated !== current) {
+          writeFileSync(indexPath, updated, "utf-8");
+        }
+        return;
+      }
+    }
+    // User-edited or unknown variant — leave alone.
   },
 };


### PR DESCRIPTION
PR #25623 tried to fix a write-once violation in 029-seed-pkb by reverting it, but the revert is itself a write-once violation — migration ID 029's output became version-dependent. Restores 029 to its post-#25532 state and makes 036 idempotent against both bar variants. End-state convergence is unchanged.

Addresses Codex P1 review on #25623.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
