### PR TITLE
fix(slack): only treat link-shaped <...> as protected spans

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -127,6 +127,33 @@ describe("splitLongTextSegment", () => {
     expect(splitLongTextSegment(text, 0)).toEqual([text]);
     expect(splitLongTextSegment(text, -1)).toEqual([text]);
   });
+
+  test("plain `<` in technical prose does not protect trailing sentence boundaries from being used as split points", () => {
+    // Regression: `computeMrkdwnSpans` used to treat every `<` as a link
+    // span start. For prose like `a < b. Another sentence. ...`, an
+    // unmatched `<` near the front of the window extended a "protected"
+    // span to the window edge, rejecting every `. ` boundary after it and
+    // forcing a mid-word hard slice.
+    const sentence = "a < b. ";
+    // Repeat enough to comfortably exceed maxChars so the splitter must
+    // pick a boundary inside the window.
+    const text = sentence.repeat(500);
+    expect(text.length).toBeGreaterThan(SLACK_SECTION_MAX_CHARS);
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_SECTION_MAX_CHARS);
+      // Sentence-aligned split: chunks should end on a sentence terminator
+      // (trailing space is trimmed), not mid-token.
+      expect(chunk.endsWith(".")).toBe(true);
+    }
+    // No content lost (ignoring inter-chunk whitespace trimming).
+    expect(chunks.join(" ").replace(/\s+/g, " ").trim()).toBe(
+      text.replace(/\s+/g, " ").trim(),
+    );
+  });
 });
 
 describe("splitCodeSegmentContent", () => {

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -390,11 +390,54 @@ export function splitLongTextSegment(
 }
 
 /**
+ * Slack link/mention tokens always start with one of these prefixes after
+ * the opening `<`. A plain `<` in technical prose (e.g. `a < b`) does not
+ * match any of these and must not be treated as a span start, or the
+ * splitter would reject every boundary past the `<` and fall back to a
+ * hard slice that can land mid-word.
+ */
+const SLACK_LINK_PREFIXES = [
+  "http://",
+  "https://",
+  "mailto:",
+  "#C", // channel ref: <#C0123ABCD|name>
+  "@U", // user mention: <@U0123ABCD>
+  "@W", // workspace user: <@W0123ABCD>
+  "!channel",
+  "!here",
+  "!everyone",
+  "!subteam",
+  "!date",
+];
+
+function looksLikeLinkStart(window: string, openIdx: number): boolean {
+  const rest = window.slice(openIdx + 1);
+  if (rest.length === 0) return false;
+  const first = rest.charCodeAt(0);
+  // Fast reject: whitespace or another `<` immediately after `<` is never a link.
+  if (first === 0x20 || first === 0x09 || first === 0x0a || first === 0x3c) {
+    return false;
+  }
+  for (const prefix of SLACK_LINK_PREFIXES) {
+    if (rest.startsWith(prefix)) return true;
+    // Near the window edge the prefix may be truncated — e.g. `<https`
+    // when `://` is past the cutoff. If `rest` is a strict prefix of a
+    // known link prefix, treat it as link-shaped so the continuation
+    // past the window is still protected from mid-token hard slicing.
+    if (rest.length < prefix.length && prefix.startsWith(rest)) return true;
+  }
+  return false;
+}
+
+/**
  * Find half-open intervals `[start, end)` covering Slack mrkdwn spans in
- * `window` that the splitter must not bisect: `<...>` tokens (links, user
- * mentions, channel refs) and `*...*` single-asterisk bold runs. An
- * unclosed `<` is treated as a span extending to the end of the window so
- * the splitter avoids landing inside a span that straddles the cutoff.
+ * `window` that the splitter must not bisect: `<...>` link/mention tokens
+ * and `*...*` single-asterisk bold runs. A `<` is only treated as a span
+ * start when it is followed by a recognized Slack link/mention prefix
+ * (see `SLACK_LINK_PREFIXES`); plain `<` in technical text is skipped.
+ * An unclosed link-shaped `<...` is treated as a span extending to the
+ * end of the window so the splitter avoids landing inside a span that
+ * straddles the cutoff.
  */
 function computeMrkdwnSpans(window: string): Array<[number, number]> {
   const intervals: Array<[number, number]> = [];
@@ -403,6 +446,10 @@ function computeMrkdwnSpans(window: string): Array<[number, number]> {
   while (i < window.length) {
     const open = window.indexOf("<", i);
     if (open < 0) break;
+    if (!looksLikeLinkStart(window, open)) {
+      i = open + 1;
+      continue;
+    }
     const close = window.indexOf(">", open + 1);
     // For unclosed `<...` (span continues past the window), use a sentinel
     // larger than any in-window position so split-point checks treat the


### PR DESCRIPTION
computeMrkdwnSpans treated every unmatched `<` as the start of a protected span extending to the window edge, causing plain technical text like `a < b. Another sentence...` to fall back to hard slicing and break mid-word. Now requires the `<` to be followed by URL/mention syntax before marking it as a span start. Plain `<` in technical content splits at sentence boundaries again. Adds a regression test.

Addresses Codex P2 review on #25629.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
