### PR TITLE
fix(lint): sort imports to unbreak Lint on main

### DIFF
--- a/assistant/src/__tests__/gmail-archive-gate.test.ts
+++ b/assistant/src/__tests__/gmail-archive-gate.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import type { ToolContext } from "../tools/types.js";
 import {
   buildTaskRules,
   clearTaskRunRules,
   getTaskRunRules,
   setTaskRunRules,
 } from "../tasks/ephemeral-permissions.js";
+import type { ToolContext } from "../tools/types.js";
 
 const mockBatchModifyMessages =
   mock<

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -28,9 +28,9 @@ import {
 } from "../permissions/trust-store.js";
 import { isAllowDecision } from "../permissions/types.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
-import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import { coreAppProxyTools } from "../tools/apps/definitions.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";


### PR DESCRIPTION
## Summary
- Ran `eslint --fix` on the two files flagged by simple-import-sort/imports in CI run 24430715930 (Lint failing on main @ aff061b)
- Reorders one import block in `assistant/src/__tests__/gmail-archive-gate.test.ts` and one in `assistant/src/daemon/conversation-tool-setup.ts`; no behavior change

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24430715930/job/71374369635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
