### PR TITLE
feat(feature-flags): register auto-analyze flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -2,6 +2,14 @@
   "version": 1,
   "flags": [
     {
+      "id": "auto-analyze",
+      "scope": "assistant",
+      "key": "auto-analyze",
+      "label": "Auto-analyze conversations",
+      "description": "Automatically trigger conversation analysis on the same cadence as memory extraction (batch threshold, idle debounce, end-of-conversation). The analysis agent has full tool access and writes back to memory and skills without user approval.",
+      "defaultEnabled": false
+    },
+    {
       "id": "browser",
       "scope": "assistant",
       "key": "browser",


### PR DESCRIPTION
## Summary
- Register `auto-analyze` assistant-scoped feature flag (default off).
- Companion to upcoming auto-analysis loop PRs that automatically trigger conversation analysis on the same cadence as memory extraction.

Part of plan: auto-analyze-loop.md (PR 1 of 15)