### PR TITLE
feat(config): add analysis settings schema

### DIFF
--- a/assistant/src/__tests__/config-analysis.test.ts
+++ b/assistant/src/__tests__/config-analysis.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AnalysisConfigSchema,
+  AssistantConfigSchema,
+} from "../config/schema.js";
+
+describe("AnalysisConfigSchema", () => {
+  test("empty object parses to documented defaults", () => {
+    const parsed = AnalysisConfigSchema.parse({});
+    expect(parsed.batchSize).toBe(30);
+    expect(parsed.idleTimeoutMs).toBe(600_000);
+    expect(parsed.modelIntent).toBeUndefined();
+    expect(parsed.modelOverride).toBeUndefined();
+  });
+
+  test("custom values round-trip", () => {
+    const input = {
+      batchSize: 50,
+      idleTimeoutMs: 120_000,
+      modelIntent: "quality-optimized" as const,
+      modelOverride: "anthropic/claude-opus-4-6",
+    };
+    const parsed = AnalysisConfigSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("accepts each valid modelIntent value", () => {
+    for (const intent of [
+      "latency-optimized",
+      "quality-optimized",
+      "vision-optimized",
+    ] as const) {
+      const parsed = AnalysisConfigSchema.parse({ modelIntent: intent });
+      expect(parsed.modelIntent).toBe(intent);
+    }
+  });
+
+  test("rejects batchSize: 0 (must be positive)", () => {
+    const result = AnalysisConfigSchema.safeParse({ batchSize: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative batchSize", () => {
+    const result = AnalysisConfigSchema.safeParse({ batchSize: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer batchSize", () => {
+    const result = AnalysisConfigSchema.safeParse({ batchSize: 3.5 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects idleTimeoutMs: 0 (must be positive)", () => {
+    const result = AnalysisConfigSchema.safeParse({ idleTimeoutMs: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative idleTimeoutMs", () => {
+    const result = AnalysisConfigSchema.safeParse({ idleTimeoutMs: -1000 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid modelIntent value", () => {
+    const result = AnalysisConfigSchema.safeParse({
+      modelIntent: "bogus-intent",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string modelOverride", () => {
+    const result = AnalysisConfigSchema.safeParse({ modelOverride: 42 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AssistantConfigSchema — analysis integration", () => {
+  test("analysis key is populated with defaults when config is empty", () => {
+    const parsed = AssistantConfigSchema.parse({});
+    expect(parsed.analysis).toEqual({
+      batchSize: 30,
+      idleTimeoutMs: 600_000,
+    });
+  });
+
+  test("analysis overrides are threaded through to the parent config", () => {
+    const parsed = AssistantConfigSchema.parse({
+      analysis: {
+        batchSize: 15,
+        idleTimeoutMs: 300_000,
+        modelIntent: "latency-optimized",
+      },
+    });
+    expect(parsed.analysis).toEqual({
+      batchSize: 15,
+      idleTimeoutMs: 300_000,
+      modelIntent: "latency-optimized",
+    });
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -10,6 +10,8 @@ export {
 } from "../permissions/permission-mode.js";
 export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
 export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
+export type { AnalysisConfig } from "./schemas/analysis.js";
+export { AnalysisConfigSchema } from "./schemas/analysis.js";
 export type { BackupConfig, BackupDestination } from "./schemas/backup.js";
 export { BackupConfigSchema } from "./schemas/backup.js";
 export type {
@@ -223,6 +225,7 @@ export { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
 // Imports for AssistantConfigSchema composition
 import { AcpConfigSchema } from "./acp-schema.js";
+import { AnalysisConfigSchema } from "./schemas/analysis.js";
 import { BackupConfigSchema } from "./schemas/backup.js";
 import { CallsConfigSchema } from "./schemas/calls.js";
 import {
@@ -313,6 +316,7 @@ export const AssistantConfigSchema = z
       HostBrowserConfigSchema.parse({}),
     ),
     journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
+    analysis: AnalysisConfigSchema.default(AnalysisConfigSchema.parse({})),
     backup: BackupConfigSchema.default(BackupConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
     acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),

--- a/assistant/src/config/schemas/analysis.ts
+++ b/assistant/src/config/schemas/analysis.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const AnalysisConfigSchema = z
+  .object({
+    // Number of new messages in the source conversation that trigger an
+    // analysis enqueue. Defaults to 3× the extraction batch size so analysis
+    // fires less often than extraction.
+    batchSize: z
+      .number({ error: "analysis.batchSize must be a number" })
+      .int("analysis.batchSize must be an integer")
+      .positive("analysis.batchSize must be a positive integer")
+      .default(30)
+      .describe(
+        "Number of new messages in the source conversation that trigger an analysis enqueue",
+      ),
+
+    // Idle window after the last message before the debounced analysis
+    // job fires. Defaults to 2× the extraction idle window.
+    idleTimeoutMs: z
+      .number({ error: "analysis.idleTimeoutMs must be a number" })
+      .int("analysis.idleTimeoutMs must be an integer")
+      .positive("analysis.idleTimeoutMs must be a positive integer")
+      .default(600_000)
+      .describe(
+        "Milliseconds of idle time after the last message before the debounced analysis job fires",
+      ),
+
+    // Optional model intent for the analysis agent loop. When omitted,
+    // the analysis agent uses the same model as the main agent.
+    // Accepted values match the main agent's model-intent vocabulary.
+    modelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "analysis.modelIntent must be a valid model intent",
+      })
+      .optional()
+      .describe(
+        "Model selection strategy for the analysis agent loop — falls back to the main agent's model when omitted",
+      ),
+
+    // Optional explicit model override (provider/model string). Takes
+    // precedence over modelIntent when both are set.
+    modelOverride: z
+      .string({ error: "analysis.modelOverride must be a string" })
+      .optional()
+      .describe(
+        "Explicit model override (provider/model string) for the analysis agent loop — takes precedence over modelIntent when both are set",
+      ),
+  })
+  .describe("Controls the auto-analyze agent loop triggered by conversation activity");
+
+export type AnalysisConfig = z.infer<typeof AnalysisConfigSchema>;


### PR DESCRIPTION
## Summary
- Add `analysis` config schema with `batchSize`, `idleTimeoutMs`, `modelIntent`, `modelOverride` fields.
- Defaults to 30-message batch / 600s idle (3x and 2x the extraction defaults respectively).
- No consumers yet — wired in later PRs of the auto-analyze-loop plan.

Part of plan: auto-analyze-loop.md (PR 2 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
