### PR TITLE
refactor(runtime): extract analyzeConversation service

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -3,35 +3,22 @@
  *
  * POST /v1/conversations/:id/analyze — analyze a conversation via a new
  * agent loop that produces a structured self-assessment.
+ *
+ * The heavy lifting lives in `services/analyze-conversation.ts`. This module
+ * is thin glue: map the route params to the service, translate service
+ * errors into HTTP errors, and build the success response.
  */
 
-import type { ServerMessage } from "../../daemon/message-protocol.js";
-import {
-  addMessage,
-  createConversation,
-  getConversation,
-  getMessages,
-} from "../../memory/conversation-crud.js";
-import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
-import { httpError } from "../http-errors.js";
+import { httpError, type HttpErrorCode } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
-import type { SendMessageDeps } from "../http-types.js";
+import {
+  analyzeConversation,
+  type ConversationAnalysisDeps,
+} from "../services/analyze-conversation.js";
 
-const log = getLogger("conversation-analysis-routes");
-
-// ---------------------------------------------------------------------------
-// Dependency types — injected by the daemon at wiring time
-// ---------------------------------------------------------------------------
-
-export interface ConversationAnalysisDeps {
-  sendMessageDeps: SendMessageDeps;
-  buildConversationDetailResponse: (
-    id: string,
-  ) => Record<string, unknown> | null;
-}
+// Re-export the dependency type so existing callers can continue importing it
+// from this module.
+export type { ConversationAnalysisDeps };
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -50,132 +37,25 @@ export function conversationAnalysisRouteDefinitions(
         "Create a new conversation with a structured self-assessment of an existing conversation.",
       tags: ["conversations"],
       handler: async ({ params }) => {
-        // a. Resolve conversation ID
-        const resolvedId = resolveConversationId(params.id);
-        if (!resolvedId) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${params.id} not found`,
-            404,
-          );
-        }
-
-        // b. Load the conversation
-        const conversation = getConversation(resolvedId);
-        if (!conversation) {
-          return httpError(
-            "NOT_FOUND",
-            `Conversation ${resolvedId} not found`,
-            404,
-          );
-        }
-
-        // c. Reject private conversations
-        if (conversation.conversationType === "private") {
-          return httpError(
-            "FORBIDDEN",
-            "Private conversations cannot be analyzed",
-            403,
-          );
-        }
-
-        // d. Check for messages
-        const existingMessages = getMessages(resolvedId);
-        if (existingMessages.length === 0) {
-          return httpError(
-            "BAD_REQUEST",
-            "Conversation has no messages to analyze",
-            400,
-          );
-        }
-
-        // e. Build the analysis transcript
-        const { buildAnalysisTranscript } =
-          await import("../../export/transcript-formatter.js");
-        const transcript = buildAnalysisTranscript(resolvedId);
-
-        // f. Create a new conversation for the analysis
-        const newConv = createConversation({
-          title: `Analysis: ${conversation.title ?? "Untitled"}`,
+        const result = await analyzeConversation(params.id, deps, {
+          trigger: "manual",
         });
 
-        // g. Build the analysis prompt
-        const prompt = `<transcript>
-${transcript}
-</transcript>
+        if ("error" in result) {
+          return httpError(
+            result.error.kind as HttpErrorCode,
+            result.error.message,
+            result.error.status,
+          );
+        }
 
-Analyze the conversation above. Provide a structured self-assessment:
-
-1. **Summary**: What was the user trying to accomplish? What was the outcome?
-2. **What went well**: Effective tool usage, good reasoning, helpful responses, problem-solving patterns.
-3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
-4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
-5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
-6. **Code & tooling changes**: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet — just provide your analysis.
-
-Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
-
-Do not use tools during analysis. If you identify insights worth remembering for future conversations, include them in the response as explicit memory candidates instead of saving them directly.`;
-
-        // h. Persist the user message
-        const message = await addMessage(
-          newConv.id,
-          "user",
-          JSON.stringify([{ type: "text", text: prompt }]),
-          { provenanceTrustClass: "unknown" as const },
+        const detail = deps.buildConversationDetailResponse(
+          result.analysisConversationId,
         );
-        const messageId = message.id;
-
-        // i. Load the conversation into memory with untrusted analysis context
-        const analysisConversation =
-          await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
-        analysisConversation.setTrustContext({
-          trustClass: "unknown",
-          sourceChannel: "vellum",
-        });
-        await analysisConversation.ensureActorScopedHistory();
-        // Analysis runs over attacker-influenced transcript content, so do not
-        // expose any tools, even when a live client is available.
-        analysisConversation.setSubagentAllowedTools(new Set<string>());
-
-        const hasLiveSubscriber =
-          deps.sendMessageDeps.assistantEventHub.hasSubscribersForEvent({
-            assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-            conversationId: newConv.id,
-          });
-
-        // j. Build onEvent using inline hub publisher
-        const onEvent = (msg: ServerMessage) => {
-          deps.sendMessageDeps.assistantEventHub.publish(
-            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, newConv.id),
-          );
-        };
-        analysisConversation.updateClient(onEvent, !hasLiveSubscriber);
-
-        // k. Set up processing state (required by runAgentLoop guard)
-        analysisConversation.processing = true;
-        analysisConversation.abortController = new AbortController();
-        analysisConversation.currentRequestId = crypto.randomUUID();
-
-        // l. Fire-and-forget the agent loop
-        analysisConversation
-          .runAgentLoop(prompt, messageId, onEvent, {
-            isInteractive: false,
-            isUserMessage: true,
-          })
-          .catch((err) => {
-            log.error(
-              { err, conversationId: newConv.id },
-              "Analysis agent loop failed",
-            );
-          });
-
-        // m. Return the new conversation detail
-        const detail = deps.buildConversationDetailResponse(newConv.id);
         if (!detail) {
           return httpError(
             "INTERNAL_ERROR",
-            `Analysis conversation ${newConv.id} could not be loaded`,
+            `Analysis conversation ${result.analysisConversationId} could not be loaded`,
             500,
           );
         }

--- a/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the analyzeConversation service.
+ *
+ * The service is driven directly (no HTTP routing) so tests exercise the
+ * validation + setup logic against mocked memory/CRUD + transcript helpers.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const mockResolveConversationId = mock((id: string) => id as string | null);
+const mockGetConversation = mock(
+  () =>
+    ({
+      id: "conv-1",
+      title: "Source",
+      conversationType: "normal",
+    }) as Record<string, unknown> | null,
+);
+const mockGetMessages = mock(() => [{ id: "m-source" }] as Array<{ id: string }>);
+const mockCreateConversation = mock(() => ({ id: "analysis-1" }));
+const mockAddMessage = mock(async () => ({ id: "msg-1" }));
+
+mock.module("../../../memory/conversation-key-store.js", () => ({
+  resolveConversationId: mockResolveConversationId,
+}));
+
+mock.module("../../../memory/conversation-crud.js", () => ({
+  getConversation: mockGetConversation,
+  getMessages: mockGetMessages,
+  createConversation: mockCreateConversation,
+  addMessage: mockAddMessage,
+}));
+
+mock.module("../../../export/transcript-formatter.js", () => ({
+  buildAnalysisTranscript: () => "user: hi",
+}));
+
+import { AssistantEventHub } from "../../assistant-event-hub.js";
+import type { SendMessageDeps } from "../../http-types.js";
+import { analyzeConversation } from "../analyze-conversation.js";
+
+beforeEach(() => {
+  mockResolveConversationId.mockReset();
+  mockResolveConversationId.mockImplementation((id: string) => id);
+  mockGetConversation.mockReset();
+  mockGetConversation.mockImplementation(() => ({
+    id: "conv-1",
+    title: "Source",
+    conversationType: "normal",
+  }));
+  mockGetMessages.mockReset();
+  mockGetMessages.mockImplementation(() => [{ id: "m-source" }]);
+  mockCreateConversation.mockReset();
+  mockCreateConversation.mockImplementation(() => ({ id: "analysis-1" }));
+  mockAddMessage.mockReset();
+  mockAddMessage.mockImplementation(async () => ({ id: "msg-1" }));
+});
+
+function makeConversation() {
+  return {
+    setTrustContext: mock(() => {}),
+    ensureActorScopedHistory: mock(() => Promise.resolve()),
+    setSubagentAllowedTools: mock(() => {}),
+    updateClient: mock(() => {}),
+    processing: false,
+    abortController: null as AbortController | null,
+    currentRequestId: null as string | null,
+    runAgentLoop: mock(() => Promise.resolve()),
+  };
+}
+
+function makeDeps(conversation: ReturnType<typeof makeConversation>) {
+  const assistantEventHub = new AssistantEventHub();
+  const sendMessageDeps = {
+    getOrCreateConversation: mock(async () => conversation),
+    assistantEventHub,
+    resolveAttachments: () => [],
+  } as unknown as SendMessageDeps;
+  return {
+    sendMessageDeps,
+    buildConversationDetailResponse: (id: string) => ({ id }),
+  };
+}
+
+describe("analyzeConversation", () => {
+  test("returns NOT_FOUND when the source ID does not resolve", async () => {
+    mockResolveConversationId.mockImplementation(() => null);
+    const deps = makeDeps(makeConversation());
+
+    const result = await analyzeConversation("missing", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.kind).toBe("NOT_FOUND");
+    expect(result.error.status).toBe(404);
+    expect(mockGetConversation).not.toHaveBeenCalled();
+  });
+
+  test("returns NOT_FOUND when the conversation record is missing", async () => {
+    mockGetConversation.mockImplementation(() => null);
+    const deps = makeDeps(makeConversation());
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.kind).toBe("NOT_FOUND");
+    expect(result.error.status).toBe(404);
+  });
+
+  test("returns FORBIDDEN when the source conversation is private", async () => {
+    mockGetConversation.mockImplementation(() => ({
+      id: "conv-1",
+      title: "Private",
+      conversationType: "private",
+    }));
+    const deps = makeDeps(makeConversation());
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.kind).toBe("FORBIDDEN");
+    expect(result.error.status).toBe(403);
+  });
+
+  test("returns BAD_REQUEST when the source conversation has no messages", async () => {
+    mockGetMessages.mockImplementation(() => []);
+    const deps = makeDeps(makeConversation());
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.kind).toBe("BAD_REQUEST");
+    expect(result.error.status).toBe(400);
+  });
+
+  test("creates an analysis conversation with unknown trust, no tools, and returns the new ID", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.analysisConversationId).toBe("analysis-1");
+
+    // Persists the prompt as a user message with unknown trust.
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      "analysis-1",
+      "user",
+      expect.any(String),
+      { provenanceTrustClass: "unknown" },
+    );
+
+    // Sets trust context to unknown.
+    expect(conversation.setTrustContext).toHaveBeenCalledWith({
+      trustClass: "unknown",
+      sourceChannel: "vellum",
+    });
+
+    // Strips all tools.
+    expect(conversation.setSubagentAllowedTools).toHaveBeenCalledTimes(1);
+    const allowedTools = (
+      conversation.setSubagentAllowedTools.mock.calls as unknown as Array<
+        [Set<string> | undefined]
+      >
+    )[0]?.[0];
+    expect(allowedTools).toBeInstanceOf(Set);
+    expect(allowedTools?.size).toBe(0);
+
+    // Fires the agent loop.
+    expect(conversation.runAgentLoop).toHaveBeenCalledWith(
+      expect.any(String),
+      "msg-1",
+      expect.any(Function),
+      expect.objectContaining({ isInteractive: false, isUserMessage: true }),
+    );
+  });
+});

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -1,0 +1,206 @@
+/**
+ * Service: analyzeConversation
+ *
+ * Factored out of the manual analyze route handler so the same core logic can
+ * be invoked from multiple call sites (manual HTTP trigger today; additional
+ * triggers planned). Behavior for the manual path is preserved exactly —
+ * this is a pure refactor.
+ *
+ * The service:
+ *   1. Resolves the source conversation and validates it can be analyzed.
+ *   2. Builds the analysis transcript + prompt.
+ *   3. Creates a new analysis conversation with unknown trust and no tools.
+ *   4. Fires the agent loop in the background.
+ *   5. Returns the new conversation ID on success, or a structured error.
+ */
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import {
+  addMessage,
+  createConversation,
+  getConversation,
+  getMessages,
+} from "../../memory/conversation-crud.js";
+import { resolveConversationId } from "../../memory/conversation-key-store.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import type { SendMessageDeps } from "../http-types.js";
+
+const log = getLogger("analyze-conversation-service");
+
+// ---------------------------------------------------------------------------
+// Dependency types — injected by the caller (route handler / future triggers)
+// ---------------------------------------------------------------------------
+
+export interface ConversationAnalysisDeps {
+  sendMessageDeps: SendMessageDeps;
+  buildConversationDetailResponse: (
+    id: string,
+  ) => Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Request/response shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of analyze triggers. Today only `manual` is supported;
+ * additional triggers (e.g. `auto`) will be added in follow-up PRs without
+ * changing the manual path.
+ */
+export interface AnalyzeOptions {
+  trigger: "manual";
+}
+
+export interface AnalyzeResult {
+  analysisConversationId: string;
+}
+
+export interface AnalyzeError {
+  error: {
+    kind: string;
+    status: number;
+    message: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export async function analyzeConversation(
+  sourceConversationId: string,
+  deps: ConversationAnalysisDeps,
+  _opts: AnalyzeOptions,
+): Promise<AnalyzeResult | AnalyzeError> {
+  // a. Resolve conversation ID
+  const resolvedId = resolveConversationId(sourceConversationId);
+  if (!resolvedId) {
+    return {
+      error: {
+        kind: "NOT_FOUND",
+        status: 404,
+        message: `Conversation ${sourceConversationId} not found`,
+      },
+    };
+  }
+
+  // b. Load the conversation
+  const conversation = getConversation(resolvedId);
+  if (!conversation) {
+    return {
+      error: {
+        kind: "NOT_FOUND",
+        status: 404,
+        message: `Conversation ${resolvedId} not found`,
+      },
+    };
+  }
+
+  // c. Reject private conversations
+  if (conversation.conversationType === "private") {
+    return {
+      error: {
+        kind: "FORBIDDEN",
+        status: 403,
+        message: "Private conversations cannot be analyzed",
+      },
+    };
+  }
+
+  // d. Check for messages
+  const existingMessages = getMessages(resolvedId);
+  if (existingMessages.length === 0) {
+    return {
+      error: {
+        kind: "BAD_REQUEST",
+        status: 400,
+        message: "Conversation has no messages to analyze",
+      },
+    };
+  }
+
+  // e. Build the analysis transcript
+  const { buildAnalysisTranscript } = await import(
+    "../../export/transcript-formatter.js"
+  );
+  const transcript = buildAnalysisTranscript(resolvedId);
+
+  // f. Create a new conversation for the analysis
+  const newConv = createConversation({
+    title: `Analysis: ${conversation.title ?? "Untitled"}`,
+  });
+
+  // g. Build the analysis prompt
+  const prompt = `<transcript>
+${transcript}
+</transcript>
+
+Analyze the conversation above. Provide a structured self-assessment:
+
+1. **Summary**: What was the user trying to accomplish? What was the outcome?
+2. **What went well**: Effective tool usage, good reasoning, helpful responses, problem-solving patterns.
+3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
+4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
+5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
+6. **Code & tooling changes**: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet — just provide your analysis.
+
+Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
+
+Do not use tools during analysis. If you identify insights worth remembering for future conversations, include them in the response as explicit memory candidates instead of saving them directly.`;
+
+  // h. Persist the user message
+  const message = await addMessage(
+    newConv.id,
+    "user",
+    JSON.stringify([{ type: "text", text: prompt }]),
+    { provenanceTrustClass: "unknown" as const },
+  );
+  const messageId = message.id;
+
+  // i. Load the conversation into memory with untrusted analysis context
+  const analysisConversation =
+    await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
+  analysisConversation.setTrustContext({
+    trustClass: "unknown",
+    sourceChannel: "vellum",
+  });
+  await analysisConversation.ensureActorScopedHistory();
+  // Analysis runs over attacker-influenced transcript content, so do not
+  // expose any tools, even when a live client is available.
+  analysisConversation.setSubagentAllowedTools(new Set<string>());
+
+  const hasLiveSubscriber =
+    deps.sendMessageDeps.assistantEventHub.hasSubscribersForEvent({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      conversationId: newConv.id,
+    });
+
+  // j. Build onEvent using inline hub publisher
+  const onEvent = (msg: ServerMessage) => {
+    deps.sendMessageDeps.assistantEventHub.publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, newConv.id),
+    );
+  };
+  analysisConversation.updateClient(onEvent, !hasLiveSubscriber);
+
+  // k. Set up processing state (required by runAgentLoop guard)
+  analysisConversation.processing = true;
+  analysisConversation.abortController = new AbortController();
+  analysisConversation.currentRequestId = crypto.randomUUID();
+
+  // l. Fire-and-forget the agent loop
+  analysisConversation
+    .runAgentLoop(prompt, messageId, onEvent, {
+      isInteractive: false,
+      isUserMessage: true,
+    })
+    .catch((err) => {
+      log.error(
+        { err, conversationId: newConv.id },
+        "Analysis agent loop failed",
+      );
+    });
+
+  return { analysisConversationId: newConv.id };
+}


### PR DESCRIPTION
## Summary
- Extract `analyzeConversation()` service from the manual analyze route handler.
- Behavior unchanged: manual mode preserved exactly.
- Sets up the service shape so PR 9 can add an `auto` trigger branch.

Part of plan: auto-analyze-loop.md (PR 3 of 15)