### PR TITLE
feat(memory): add auto-analysis recursion guard helper

### DIFF
--- a/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  AUTO_ANALYSIS_SOURCE,
+  isAutoAnalysisConversation,
+} from "../auto-analysis-guard.js";
+import { createConversation } from "../conversation-crud.js";
+import { getDb, initializeDb } from "../db.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+}
+
+describe("isAutoAnalysisConversation", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("returns true for a conversation with source = 'auto-analysis'", () => {
+    const conv = createConversation({
+      title: "analysis",
+      source: AUTO_ANALYSIS_SOURCE,
+    });
+    expect(isAutoAnalysisConversation(conv.id)).toBe(true);
+  });
+
+  test("returns false for a conversation with source = 'user'", () => {
+    const conv = createConversation("regular user conversation");
+    expect(isAutoAnalysisConversation(conv.id)).toBe(false);
+  });
+
+  test("returns false for a non-existent conversation", () => {
+    expect(isAutoAnalysisConversation("does-not-exist")).toBe(false);
+  });
+});

--- a/assistant/src/memory/auto-analysis-guard.ts
+++ b/assistant/src/memory/auto-analysis-guard.ts
@@ -1,0 +1,20 @@
+import { getConversationSource } from "./conversation-crud.js";
+
+/**
+ * The `source` value used for conversations created by the auto-analysis
+ * loop. Single source of truth — downstream code (enqueue helper,
+ * service auto-branch) imports this constant rather than hardcoding the
+ * string.
+ */
+export const AUTO_ANALYSIS_SOURCE = "auto-analysis";
+
+/**
+ * Returns true if the conversation's `source` column is `"auto-analysis"`,
+ * meaning it was produced by the auto-analysis loop. Callers use this to
+ * skip both `graph_extract` and `conversation_analyze` enqueues so we
+ * never (a) analyze our own analysis output or (b) extract memory from
+ * reflective musings (the analysis agent writes memory directly via tools).
+ */
+export function isAutoAnalysisConversation(conversationId: string): boolean {
+  return getConversationSource(conversationId) === AUTO_ANALYSIS_SOURCE;
+}


### PR DESCRIPTION
## Summary
- Add `isAutoAnalysisConversation(id)` and `AUTO_ANALYSIS_SOURCE` constant.
- Used by upcoming enqueue helper (PR 12) and service auto-branch (PR 9) to prevent (a) analysis-of-analysis recursion and (b) memory extraction over reflective musings.

Part of plan: auto-analyze-loop.md (PR 6 of 15)