### PR TITLE
feat(runtime): expose analyze deps via module singleton

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -227,6 +227,7 @@ import { watchRouteDefinitions } from "./routes/watch-routes.js";
 import { workItemRouteDefinitions } from "./routes/work-items-routes.js";
 import { workspaceCommitRouteDefinitions } from "./routes/workspace-commit-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
+import { setAnalysisDeps } from "./services/analyze-deps-singleton.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -1795,13 +1796,28 @@ export class RuntimeHttpServer {
         ? conversationManagementRouteDefinitions(conversationManagementDeps)
         : []),
 
-      ...(this.sendMessageDeps
-        ? conversationAnalysisRouteDefinitions({
-            sendMessageDeps: this.sendMessageDeps,
-            buildConversationDetailResponse: (id) =>
-              this.buildConversationDetailResponse(id),
-          })
-        : []),
+      ...((): RouteDefinition[] => {
+        const sendMessageDeps = this.sendMessageDeps;
+        if (!sendMessageDeps) return [];
+        const analysisDeps = {
+          sendMessageDeps,
+          buildConversationDetailResponse: (id: string) =>
+            this.buildConversationDetailResponse(id),
+        };
+        // Also expose via the module singleton so background callers
+        // (e.g. job handlers) can invoke analyzeConversation() without
+        // HTTP-layer wiring. Daemon startup must never block, so failures
+        // to register the singleton are logged and swallowed.
+        try {
+          setAnalysisDeps(analysisDeps);
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to register analysis deps singleton; background analysis jobs will be skipped",
+          );
+        }
+        return conversationAnalysisRouteDefinitions(analysisDeps);
+      })(),
 
       ...groupRouteDefinitions(),
 

--- a/assistant/src/runtime/services/__tests__/analyze-deps-singleton.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-deps-singleton.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the analyze-deps singleton.
+ *
+ * The singleton holds the ConversationAnalysisDeps bundle so background
+ * callers (e.g. job handlers) can invoke analyzeConversation() without
+ * HTTP-layer wiring. Tests exercise the get/set round-trip, the null
+ * default before startup, and last-write-wins semantics.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ConversationAnalysisDeps } from "../analyze-conversation.js";
+import {
+  getAnalysisDeps,
+  setAnalysisDeps,
+} from "../analyze-deps-singleton.js";
+
+// Helper: build a minimal ConversationAnalysisDeps object. The content is
+// irrelevant to the singleton — it only stores and returns the reference.
+function makeDeps(tag: string): ConversationAnalysisDeps {
+  return {
+    // The cast is safe: the singleton never dereferences these fields.
+    sendMessageDeps: { _tag: tag } as unknown as ConversationAnalysisDeps["sendMessageDeps"],
+    buildConversationDetailResponse: () => ({ tag }),
+  };
+}
+
+// The singleton is module-level state. Reset it between tests by writing a
+// fresh value (or by clearing via a sentinel pattern — but we keep it simple
+// and rely on explicit overwrites since setAnalysisDeps is last-write-wins).
+// The "before startup" behavior is validated by the first describe block,
+// which must run before any set call — bun:test executes tests in source
+// order within a file, and this describe runs first.
+describe("analyze-deps singleton (pre-startup)", () => {
+  test("getAnalysisDeps() returns null before setAnalysisDeps() is called", () => {
+    // This test relies on source order: it runs before any setAnalysisDeps()
+    // call in this file. If this test moves, it may start to observe deps
+    // set by earlier tests.
+    expect(getAnalysisDeps()).toBeNull();
+  });
+});
+
+describe("analyze-deps singleton (round-trip)", () => {
+  beforeEach(() => {
+    // Reset to a known "unset" by writing a sentinel, then overwriting in each
+    // test. We cannot truly null the singleton without exposing a reset
+    // helper; tests instead assert on identity/equality.
+  });
+
+  test("getAnalysisDeps() returns the same object after setAnalysisDeps() is called", () => {
+    const deps = makeDeps("round-trip");
+    setAnalysisDeps(deps);
+    expect(getAnalysisDeps()).toBe(deps);
+  });
+
+  test("multiple setAnalysisDeps() calls update the singleton (last write wins)", () => {
+    const first = makeDeps("first");
+    const second = makeDeps("second");
+
+    setAnalysisDeps(first);
+    expect(getAnalysisDeps()).toBe(first);
+
+    setAnalysisDeps(second);
+    expect(getAnalysisDeps()).toBe(second);
+    expect(getAnalysisDeps()).not.toBe(first);
+  });
+});

--- a/assistant/src/runtime/services/analyze-deps-singleton.ts
+++ b/assistant/src/runtime/services/analyze-deps-singleton.ts
@@ -1,0 +1,32 @@
+/**
+ * Module-level singleton holding the `ConversationAnalysisDeps` bundle.
+ *
+ * The manual analyze route constructs this dependency bundle once during
+ * daemon startup and passes it to `conversationAnalysisRouteDefinitions`.
+ * Background callers (e.g. the auto-analyze job handler) don't have access
+ * to the HTTP-layer wiring that the route has, so we stash the bundle here
+ * so they can invoke `analyzeConversation()` with the same deps.
+ *
+ * The HTTP route continues to pass deps explicitly; this singleton is purely
+ * additive for background callers. Both paths coexist.
+ */
+import type { ConversationAnalysisDeps } from "./analyze-conversation.js";
+
+let _deps: ConversationAnalysisDeps | null = null;
+
+/**
+ * Set the analysis deps bundle. Called once during daemon startup with the
+ * same deps the manual analysis route uses, so background jobs can invoke
+ * `analyzeConversation()` without HTTP-layer wiring.
+ */
+export function setAnalysisDeps(deps: ConversationAnalysisDeps): void {
+  _deps = deps;
+}
+
+/**
+ * Returns the deps bundle, or null if the daemon has not finished startup.
+ * Callers (e.g. job handlers) should treat null as "skip this job, retry".
+ */
+export function getAnalysisDeps(): ConversationAnalysisDeps | null {
+  return _deps;
+}


### PR DESCRIPTION
## Summary
- Add `setAnalysisDeps()` / `getAnalysisDeps()` module singleton in `assistant/src/runtime/services/`.
- Wired from daemon startup with the same deps the manual analysis route uses.
- Lets background jobs invoke `analyzeConversation()` without HTTP-layer wiring (consumer in PR 13).

Part of plan: auto-analyze-loop.md (PR 10 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
