### PR TITLE
feat(runtime): add auto-trigger mode to analyzeConversation service

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -61,7 +61,8 @@ import {
 } from "../permissions/v2-consent-policy.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
-import type { Message } from "../providers/types.js";
+import { resolveModelIntent } from "../providers/model-intents.js";
+import type { Message, ModelIntent } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import type { AuthContext } from "../runtime/auth/types.js";
@@ -336,6 +337,8 @@ export class Conversation {
     sharedCesClient?: CesClient,
     speedOverride?: Speed,
     cacheTtl?: "5m" | "1h",
+    modelIntent?: ModelIntent,
+    modelOverride?: string,
   ) {
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
@@ -437,10 +440,18 @@ export class Conversation {
     const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
     this.hasSystemPromptOverride = hasSystemPromptOverride;
 
+    // If an explicit modelOverride is supplied, use it verbatim. Otherwise,
+    // if modelIntent is set, resolve it against the active provider's
+    // intent → model mapping. The AgentLoop passes the resulting string
+    // through to `providerConfig.model` on every turn.
+    const resolvedModel: string | undefined =
+      modelOverride ??
+      (modelIntent ? resolveModelIntent(provider.name, modelIntent) : undefined);
+
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],
     ): ResolvedSystemPrompt => {
-      const resolved = {
+      const resolved: ResolvedSystemPrompt = {
         systemPrompt: this.hasSystemPromptOverride
           ? systemPrompt
           : (() => {
@@ -458,6 +469,9 @@ export class Conversation {
             })(),
         maxTokens: configuredMaxTokens,
       };
+      if (resolvedModel !== undefined) {
+        resolved.model = resolvedModel;
+      }
       return resolved;
     };
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -4,6 +4,7 @@ import { getConfig } from "../../config/loader.js";
 import type { Speed } from "../../config/schemas/inference.js";
 import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import type { SecretPromptResult } from "../../permissions/secret-prompter.js";
+import type { ModelIntent } from "../../providers/types.js";
 import type { AuthContext } from "../../runtime/auth/types.js";
 import type { DebouncerMap } from "../../util/debounce.js";
 import { getLogger } from "../../util/logger.js";
@@ -127,6 +128,19 @@ export interface ConversationCreateOptions {
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
   onEvent?: (msg: ServerMessage) => void;
+  /**
+   * Optional model selection strategy for this conversation's agent loop.
+   * When set, overrides the provider's default model per-turn. Used by the
+   * auto-analyze loop to route the analysis agent to a dedicated model.
+   */
+  modelIntent?: ModelIntent;
+  /**
+   * Optional explicit model override (provider/model string) for this
+   * conversation's agent loop. Takes precedence over `modelIntent` when
+   * both are set. Used by the auto-analyze loop to pin the analysis agent
+   * to a specific model.
+   */
+  modelOverride?: string;
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1011,6 +1011,9 @@ export class DaemonServer {
           memoryPolicy,
           sharedCesClient,
           storedOptions?.speed,
+          undefined,
+          storedOptions?.modelIntent,
+          storedOptions?.modelOverride,
         );
         newConversation.updateClient(sendToClient, true);
         await newConversation.loadFromDb();

--- a/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
+++ b/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
@@ -129,6 +129,20 @@ describe("findAnalysisConversationFor", () => {
 
     expect(findAnalysisConversationFor(parent.id)).toEqual({ id: analysis.id });
   });
+
+  test("createConversation persists forkParentConversationId when supplied", () => {
+    const parent = createConversation("parent");
+
+    // Auto-analyze path creates the rolling analysis conversation with
+    // source + forkParentConversationId in the same call.
+    const analysis = createConversation({
+      title: "rolling analysis",
+      source: "auto-analysis",
+      forkParentConversationId: parent.id,
+    });
+
+    expect(findAnalysisConversationFor(parent.id)).toEqual({ id: analysis.id });
+  });
 });
 
 describe("getConversationSource", () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -248,6 +248,7 @@ export function createConversation(
         scheduleJobId?: string;
         groupId?: string;
         hostAccess?: boolean;
+        forkParentConversationId?: string;
       },
 ) {
   const db = getDb();
@@ -284,6 +285,7 @@ export function createConversation(
     source,
     memoryScopeId,
     scheduleJobId: opts.scheduleJobId ?? null,
+    forkParentConversationId: opts.forkParentConversationId ?? null,
   };
 
   // Retry on SQLITE_BUSY and SQLITE_IOERR — transient disk I/O errors or WAL

--- a/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
@@ -24,8 +24,14 @@ const mockGetConversation = mock(
     }) as Record<string, unknown> | null,
 );
 const mockGetMessages = mock(() => [{ id: "m-source" }] as Array<{ id: string }>);
-const mockCreateConversation = mock(() => ({ id: "analysis-1" }));
+const mockCreateConversation = mock(
+  (_opts?: Record<string, unknown>) => ({ id: "analysis-new" }),
+);
 const mockAddMessage = mock(async () => ({ id: "msg-1" }));
+const mockFindAnalysisConversationFor = mock(
+  (_parent: string) => null as { id: string } | null,
+);
+const mockGetConversationSource = mock((_id: string) => null as string | null);
 
 mock.module("../../../memory/conversation-key-store.js", () => ({
   resolveConversationId: mockResolveConversationId,
@@ -36,10 +42,29 @@ mock.module("../../../memory/conversation-crud.js", () => ({
   getMessages: mockGetMessages,
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
+  findAnalysisConversationFor: mockFindAnalysisConversationFor,
+  getConversationSource: mockGetConversationSource,
 }));
 
 mock.module("../../../export/transcript-formatter.js", () => ({
   buildAnalysisTranscript: () => "user: hi",
+}));
+
+// Default config stub — individual tests can override via mockGetConfig.
+interface AnalysisConfigStub {
+  analysis: {
+    modelIntent?: string;
+    modelOverride?: string;
+  };
+}
+const mockGetConfig = mock(
+  (): AnalysisConfigStub => ({
+    analysis: {},
+  }),
+);
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: mockGetConfig,
 }));
 
 import { AssistantEventHub } from "../../assistant-event-hub.js";
@@ -58,9 +83,15 @@ beforeEach(() => {
   mockGetMessages.mockReset();
   mockGetMessages.mockImplementation(() => [{ id: "m-source" }]);
   mockCreateConversation.mockReset();
-  mockCreateConversation.mockImplementation(() => ({ id: "analysis-1" }));
+  mockCreateConversation.mockImplementation(() => ({ id: "analysis-new" }));
   mockAddMessage.mockReset();
   mockAddMessage.mockImplementation(async () => ({ id: "msg-1" }));
+  mockFindAnalysisConversationFor.mockReset();
+  mockFindAnalysisConversationFor.mockImplementation(() => null);
+  mockGetConversationSource.mockReset();
+  mockGetConversationSource.mockImplementation(() => null);
+  mockGetConfig.mockReset();
+  mockGetConfig.mockImplementation(() => ({ analysis: {} }));
 });
 
 function makeConversation() {
@@ -78,14 +109,16 @@ function makeConversation() {
 
 function makeDeps(conversation: ReturnType<typeof makeConversation>) {
   const assistantEventHub = new AssistantEventHub();
+  const getOrCreateConversation = mock(async () => conversation);
   const sendMessageDeps = {
-    getOrCreateConversation: mock(async () => conversation),
+    getOrCreateConversation,
     assistantEventHub,
     resolveAttachments: () => [],
   } as unknown as SendMessageDeps;
   return {
     sendMessageDeps,
     buildConversationDetailResponse: (id: string) => ({ id }),
+    getOrCreateConversation,
   };
 }
 
@@ -161,11 +194,11 @@ describe("analyzeConversation", () => {
 
     expect("error" in result).toBe(false);
     if ("error" in result) throw new Error("expected success");
-    expect(result.analysisConversationId).toBe("analysis-1");
+    expect(result.analysisConversationId).toBe("analysis-new");
 
     // Persists the prompt as a user message with unknown trust.
     expect(mockAddMessage).toHaveBeenCalledWith(
-      "analysis-1",
+      "analysis-new",
       "user",
       expect.any(String),
       { provenanceTrustClass: "unknown" },
@@ -194,5 +227,147 @@ describe("analyzeConversation", () => {
       expect.any(Function),
       expect.objectContaining({ isInteractive: false, isUserMessage: true }),
     );
+  });
+
+  // ── Auto trigger ──────────────────────────────────────────────────
+
+  test("auto: creates a new analysis conversation when none exists, with source=auto-analysis and forkParentConversationId", async () => {
+    mockFindAnalysisConversationFor.mockImplementation(() => null);
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.analysisConversationId).toBe("analysis-new");
+
+    // Verifies the rolling-analysis lookup was consulted against the source ID.
+    expect(mockFindAnalysisConversationFor).toHaveBeenCalledWith("conv-1");
+
+    // Created exactly one new conversation row, with the expected shape.
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockCreateConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Analysis: Source",
+        source: "auto-analysis",
+        forkParentConversationId: "conv-1",
+      }),
+    );
+  });
+
+  test("auto: reuses an existing rolling analysis conversation (no new row)", async () => {
+    mockFindAnalysisConversationFor.mockImplementation(() => ({
+      id: "analysis-existing",
+    }));
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.analysisConversationId).toBe("analysis-existing");
+
+    // No new conversation row is created on reuse.
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+
+    // The new user message is appended to the existing analysis conversation.
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      "analysis-existing",
+      "user",
+      expect.any(String),
+      { provenanceTrustClass: "guardian" },
+    );
+  });
+
+  test("auto: sets trustClass to guardian", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+    expect("error" in result).toBe(false);
+
+    expect(conversation.setTrustContext).toHaveBeenCalledWith({
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+    });
+  });
+
+  test("auto: does NOT strip the tool surface", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+    expect("error" in result).toBe(false);
+
+    // Manual mode calls this with an empty Set; auto mode must leave the
+    // conversation's default tool surface intact.
+    expect(conversation.setSubagentAllowedTools).not.toHaveBeenCalled();
+  });
+
+  test("auto: rejects when the source conversation is itself an auto-analysis conversation", async () => {
+    mockGetConversationSource.mockImplementation(() => "auto-analysis");
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error.kind).toBe("BAD_REQUEST");
+    expect(result.error.status).toBe(400);
+
+    // Nothing downstream of the guard should have fired.
+    expect(mockFindAnalysisConversationFor).not.toHaveBeenCalled();
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
+
+  test("auto: passes modelOverride through to getOrCreateConversation when set in config", async () => {
+    mockGetConfig.mockImplementation(() => ({
+      analysis: {
+        modelIntent: "quality-optimized",
+        modelOverride: "claude-opus-4-6",
+      },
+    }));
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    await analyzeConversation("conv-1", deps, { trigger: "auto" });
+
+    expect(deps.getOrCreateConversation).toHaveBeenCalledWith(
+      "analysis-new",
+      expect.objectContaining({
+        modelIntent: "quality-optimized",
+        modelOverride: "claude-opus-4-6",
+      }),
+    );
+  });
+
+  test("auto: does not pass modelOverride/modelIntent keys when config leaves them unset", async () => {
+    const conversation = makeConversation();
+    const deps = makeDeps(conversation);
+
+    await analyzeConversation("conv-1", deps, { trigger: "auto" });
+
+    const [, passedOpts] = (
+      deps.getOrCreateConversation.mock.calls as unknown as Array<
+        [string, Record<string, unknown>]
+      >
+    )[0] ?? ["", {}];
+    expect(passedOpts).toBeDefined();
+    expect("modelIntent" in (passedOpts ?? {})).toBe(false);
+    expect("modelOverride" in (passedOpts ?? {})).toBe(false);
   });
 });

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -2,31 +2,42 @@
  * Service: analyzeConversation
  *
  * Factored out of the manual analyze route handler so the same core logic can
- * be invoked from multiple call sites (manual HTTP trigger today; additional
- * triggers planned). Behavior for the manual path is preserved exactly —
- * this is a pure refactor.
+ * be invoked from multiple call sites (manual HTTP trigger and auto-analyze
+ * job worker).
  *
- * The service:
- *   1. Resolves the source conversation and validates it can be analyzed.
- *   2. Builds the analysis transcript + prompt.
- *   3. Creates a new analysis conversation with unknown trust and no tools.
- *   4. Fires the agent loop in the background.
- *   5. Returns the new conversation ID on success, or a structured error.
+ * Two triggers are supported:
+ *   - **manual**: user-initiated analysis. Creates a fresh conversation each
+ *     invocation, runs with `trustClass: "unknown"`, and strips the tool
+ *     surface. Byte-for-byte unchanged from the original route logic.
+ *   - **auto**: called by the auto-analyze job when a source conversation
+ *     reaches a natural pause. Reuses a rolling analysis conversation per
+ *     parent (creating one if none exists), runs with `trustClass:
+ *     "guardian"`, and keeps the full tool surface so the analysis agent can
+ *     write memory and skills directly. Reads optional model overrides from
+ *     `analysis.modelIntent` / `analysis.modelOverride` config.
  */
+import { getConfig } from "../../config/loader.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
   addMessage,
   createConversation,
+  findAnalysisConversationFor,
   getConversation,
+  getConversationSource,
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
+import type { ModelIntent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import type { SendMessageDeps } from "../http-types.js";
+import { buildAutoAnalysisPrompt } from "./auto-analysis-prompt.js";
 
 const log = getLogger("analyze-conversation-service");
+
+/** Source column marker used to tag auto-analysis rolling conversations. */
+const AUTO_ANALYSIS_SOURCE = "auto-analysis";
 
 // ---------------------------------------------------------------------------
 // Dependency types — injected by the caller (route handler / future triggers)
@@ -44,13 +55,12 @@ export interface ConversationAnalysisDeps {
 // ---------------------------------------------------------------------------
 
 /**
- * Discriminated union of analyze triggers. Today only `manual` is supported;
- * additional triggers (e.g. `auto`) will be added in follow-up PRs without
- * changing the manual path.
+ * Discriminated union of analyze triggers. `manual` is user-initiated from
+ * the HTTP route; `auto` is fired by the auto-analyze job worker.
  */
-export interface AnalyzeOptions {
-  trigger: "manual";
-}
+export type AnalyzeOptions =
+  | { trigger: "manual" }
+  | { trigger: "auto" };
 
 export interface AnalyzeResult {
   analysisConversationId: string;
@@ -71,7 +81,7 @@ export interface AnalyzeError {
 export async function analyzeConversation(
   sourceConversationId: string,
   deps: ConversationAnalysisDeps,
-  _opts: AnalyzeOptions,
+  opts: AnalyzeOptions,
 ): Promise<AnalyzeResult | AnalyzeError> {
   // a. Resolve conversation ID
   const resolvedId = resolveConversationId(sourceConversationId);
@@ -120,66 +130,118 @@ export async function analyzeConversation(
     };
   }
 
-  // e. Build the analysis transcript
+  // e. Defense-in-depth recursion guard for auto mode: refuse to
+  // auto-analyze a conversation that is itself an auto-analysis
+  // conversation. Prevents job-handler bugs from triggering runaway
+  // self-analysis loops.
+  if (
+    opts.trigger === "auto" &&
+    getConversationSource(resolvedId) === AUTO_ANALYSIS_SOURCE
+  ) {
+    return {
+      error: {
+        kind: "BAD_REQUEST",
+        status: 400,
+        message: "Cannot auto-analyze an auto-analysis conversation",
+      },
+    };
+  }
+
+  // f. Build the analysis transcript
   const { buildAnalysisTranscript } = await import(
     "../../export/transcript-formatter.js"
   );
   const transcript = buildAnalysisTranscript(resolvedId);
 
-  // f. Create a new conversation for the analysis
-  const newConv = createConversation({
-    title: `Analysis: ${conversation.title ?? "Untitled"}`,
-  });
+  // g. Resolve the analysis conversation + prompt + trust context based on
+  // trigger. Manual trigger always creates a fresh conversation with
+  // unknown trust and no tools. Auto trigger reuses a rolling analysis
+  // conversation (creating one if missing) and runs as guardian with the
+  // default tool surface.
+  let analysisConversationId: string;
+  let prompt: string;
+  let trustClass: "unknown" | "guardian";
+  let stripTools: boolean;
+  let modelIntent: ModelIntent | undefined;
+  let modelOverride: string | undefined;
 
-  // g. Build the analysis prompt
-  const prompt = `<transcript>
-${transcript}
-</transcript>
+  if (opts.trigger === "manual") {
+    const newConv = createConversation({
+      title: `Analysis: ${conversation.title ?? "Untitled"}`,
+    });
+    analysisConversationId = newConv.id;
+    prompt = buildManualAnalysisPrompt(transcript);
+    trustClass = "unknown";
+    stripTools = true;
+  } else {
+    // Auto trigger.
+    const existing = findAnalysisConversationFor(resolvedId);
+    if (existing) {
+      analysisConversationId = existing.id;
+    } else {
+      const newConv = createConversation({
+        title: `Analysis: ${conversation.title ?? "Untitled"}`,
+        source: AUTO_ANALYSIS_SOURCE,
+        forkParentConversationId: resolvedId,
+      });
+      analysisConversationId = newConv.id;
+    }
+    prompt = buildAutoAnalysisPrompt(transcript);
+    trustClass = "guardian";
+    stripTools = false;
 
-Analyze the conversation above. Provide a structured self-assessment:
+    const analysisConfig = getConfig().analysis;
+    modelIntent = analysisConfig.modelIntent;
+    modelOverride = analysisConfig.modelOverride;
+  }
 
-1. **Summary**: What was the user trying to accomplish? What was the outcome?
-2. **What went well**: Effective tool usage, good reasoning, helpful responses, problem-solving patterns.
-3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
-4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
-5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
-6. **Code & tooling changes**: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet — just provide your analysis.
-
-Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
-
-Do not use tools during analysis. If you identify insights worth remembering for future conversations, include them in the response as explicit memory candidates instead of saving them directly.`;
-
-  // h. Persist the user message
+  // h. Persist the user message (with provenance snapshot matching the
+  // trust context we will run under).
   const message = await addMessage(
-    newConv.id,
+    analysisConversationId,
     "user",
     JSON.stringify([{ type: "text", text: prompt }]),
-    { provenanceTrustClass: "unknown" as const },
+    { provenanceTrustClass: trustClass },
   );
   const messageId = message.id;
 
-  // i. Load the conversation into memory with untrusted analysis context
+  // i. Load the conversation into memory with the appropriate trust
+  // context. Manual analysis runs untrusted over attacker-influenced
+  // transcript content; auto analysis runs as guardian so it can act on
+  // what it learns.
   const analysisConversation =
-    await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
+    await deps.sendMessageDeps.getOrCreateConversation(
+      analysisConversationId,
+      {
+        ...(modelIntent !== undefined ? { modelIntent } : {}),
+        ...(modelOverride !== undefined ? { modelOverride } : {}),
+      },
+    );
   analysisConversation.setTrustContext({
-    trustClass: "unknown",
+    trustClass,
     sourceChannel: "vellum",
   });
   await analysisConversation.ensureActorScopedHistory();
-  // Analysis runs over attacker-influenced transcript content, so do not
-  // expose any tools, even when a live client is available.
-  analysisConversation.setSubagentAllowedTools(new Set<string>());
+  if (stripTools) {
+    // Manual analysis runs over attacker-influenced transcript content, so
+    // do not expose any tools, even when a live client is available.
+    analysisConversation.setSubagentAllowedTools(new Set<string>());
+  }
 
   const hasLiveSubscriber =
     deps.sendMessageDeps.assistantEventHub.hasSubscribersForEvent({
       assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      conversationId: newConv.id,
+      conversationId: analysisConversationId,
     });
 
   // j. Build onEvent using inline hub publisher
   const onEvent = (msg: ServerMessage) => {
     deps.sendMessageDeps.assistantEventHub.publish(
-      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, newConv.id),
+      buildAssistantEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        msg,
+        analysisConversationId,
+      ),
     );
   };
   analysisConversation.updateClient(onEvent, !hasLiveSubscriber);
@@ -197,10 +259,38 @@ Do not use tools during analysis. If you identify insights worth remembering for
     })
     .catch((err) => {
       log.error(
-        { err, conversationId: newConv.id },
+        { err, conversationId: analysisConversationId },
         "Analysis agent loop failed",
       );
     });
 
-  return { analysisConversationId: newConv.id };
+  return { analysisConversationId };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Manual-mode prompt: conservative self-assessment with no side effects. The
+ * transcript is attacker-controlled so the prompt explicitly disables tool
+ * usage and asks for memory candidates rather than in-band writes.
+ */
+function buildManualAnalysisPrompt(transcript: string): string {
+  return `<transcript>
+${transcript}
+</transcript>
+
+Analyze the conversation above. Provide a structured self-assessment:
+
+1. **Summary**: What was the user trying to accomplish? What was the outcome?
+2. **What went well**: Effective tool usage, good reasoning, helpful responses, problem-solving patterns.
+3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
+4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
+5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
+6. **Code & tooling changes**: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet — just provide your analysis.
+
+Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
+
+Do not use tools during analysis. If you identify insights worth remembering for future conversations, include them in the response as explicit memory candidates instead of saving them directly.`;
 }


### PR DESCRIPTION
## Summary
- Add `{ trigger: "auto" }` branch to `analyzeConversation()`.
- Auto mode looks up an existing rolling analysis conversation per parent and appends to it; creates one if none exists with `source: "auto-analysis"` and `forkParentConversationId` set.
- Auto mode runs with `trustClass: "guardian"` and full tool surface (no allowlist override) so the analysis agent can write memory and skills directly.
- Defense-in-depth recursion guard rejects auto-analysis on auto-analysis conversations.
- Reads optional `analysis.modelIntent` / `analysis.modelOverride` from config.

Part of plan: auto-analyze-loop.md (PR 9 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
