### PR TITLE
feat(memory): add enqueueAutoAnalysisIfEnabled helper

### DIFF
--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock state — reset between tests.
+// ---------------------------------------------------------------------------
+
+let flagEnabled = true;
+let isAuto = false;
+let configValue: { analysis?: { idleTimeoutMs?: number } } = {
+  analysis: { idleTimeoutMs: 600_000 },
+};
+let getConfigThrows = false;
+
+const enqueueCalls: Array<{
+  type: string;
+  payload: Record<string, unknown>;
+  runAfter?: number;
+}> = [];
+const debouncedCalls: Array<{
+  type: string;
+  payload: { conversationId: string };
+  runAfter: number;
+}> = [];
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => {
+    if (getConfigThrows) throw new Error("boom");
+    return configValue;
+  },
+}));
+
+mock.module("../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (_key: string, _config: unknown) =>
+    flagEnabled,
+}));
+
+mock.module("../auto-analysis-guard.js", () => ({
+  AUTO_ANALYSIS_SOURCE: "auto-analysis",
+  isAutoAnalysisConversation: (_conversationId: string) => isAuto,
+}));
+
+mock.module("../jobs-store.js", () => ({
+  enqueueMemoryJob: (
+    type: string,
+    payload: Record<string, unknown>,
+    runAfter?: number,
+  ) => {
+    enqueueCalls.push({ type, payload, runAfter });
+    return "job-id";
+  },
+  upsertDebouncedJob: (
+    type: string,
+    payload: { conversationId: string },
+    runAfter: number,
+  ) => {
+    debouncedCalls.push({ type, payload, runAfter });
+  },
+}));
+
+import { enqueueAutoAnalysisIfEnabled } from "../auto-analysis-enqueue.js";
+
+describe("enqueueAutoAnalysisIfEnabled", () => {
+  beforeEach(() => {
+    flagEnabled = true;
+    isAuto = false;
+    getConfigThrows = false;
+    configValue = { analysis: { idleTimeoutMs: 600_000 } };
+    enqueueCalls.length = 0;
+    debouncedCalls.length = 0;
+  });
+
+  test("flag off — no job is enqueued for any trigger", () => {
+    flagEnabled = false;
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("flag on, trigger = 'batch', normal source — enqueueMemoryJob called", () => {
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]).toMatchObject({
+      type: "conversation_analyze",
+      payload: { conversationId: "c1" },
+    });
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("flag on, trigger = 'idle', normal source — upsertDebouncedJob called with runAfter ≈ now + idleTimeoutMs", () => {
+    configValue = { analysis: { idleTimeoutMs: 600_000 } };
+    const before = Date.now();
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
+    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + 600_000,
+    );
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after + 600_000);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("flag on, trigger = 'lifecycle', normal source — upsertDebouncedJob called (same as idle)", () => {
+    configValue = { analysis: { idleTimeoutMs: 600_000 } };
+    const before = Date.now();
+
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
+    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + 600_000,
+    );
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after + 600_000);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("flag on, source is auto-analysis — no job is enqueued", () => {
+    isAuto = true;
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("getConfig throws — skips silently without enqueueing", () => {
+    getConfigThrows = true;
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("uses fallback idleTimeoutMs (600_000) when config.analysis is absent", () => {
+    // Simulate an older config that doesn't declare `analysis` yet —
+    // `config.analysis?.idleTimeoutMs ?? 600_000` should take the fallback.
+    configValue = {};
+    const before = Date.now();
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + 600_000,
+    );
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after + 600_000);
+  });
+
+  test("respects a custom idleTimeoutMs from config", () => {
+    configValue = { analysis: { idleTimeoutMs: 1_000 } };
+    const before = Date.now();
+
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before + 1_000);
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after + 1_000);
+  });
+});

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -1,0 +1,79 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import { getLogger } from "../util/logger.js";
+import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
+import { enqueueMemoryJob, upsertDebouncedJob } from "./jobs-store.js";
+
+const log = getLogger("auto-analysis-enqueue");
+
+/**
+ * Trigger reason for an auto-analysis enqueue.
+ *   - `"batch"`: source conversation crossed the batch threshold — enqueue
+ *     immediately (no debounce).
+ *   - `"idle"`: source conversation has been idle long enough to warrant a
+ *     debounced analysis pass.
+ *   - `"lifecycle"`: a conversation lifecycle transition (e.g. resume,
+ *     close) should trigger a debounced analysis pass.
+ */
+export type AutoAnalysisTrigger = "batch" | "idle" | "lifecycle";
+
+/**
+ * Conditionally enqueue a `conversation_analyze` job for the given
+ * conversation. Skips silently when:
+ *   - the `auto-analyze` feature flag is disabled, OR
+ *   - the source conversation is itself an auto-analysis conversation
+ *     (recursion guard — we never analyze our own analysis output).
+ *
+ * Uses `upsertDebouncedJob()` for `"idle"` / `"lifecycle"` triggers and
+ * `enqueueMemoryJob()` for `"batch"` triggers, mirroring how
+ * `graph_extract` is enqueued in `indexer.ts`.
+ */
+export function enqueueAutoAnalysisIfEnabled(args: {
+  conversationId: string;
+  trigger: AutoAnalysisTrigger;
+}): void {
+  const { conversationId, trigger } = args;
+
+  let config;
+  try {
+    config = getConfig();
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Skipping auto-analysis enqueue: failed to load config",
+    );
+    return;
+  }
+
+  if (!isAssistantFeatureFlagEnabled("auto-analyze", config)) {
+    return;
+  }
+
+  if (isAutoAnalysisConversation(conversationId)) {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping auto-analysis enqueue: source is an auto-analysis conversation",
+    );
+    return;
+  }
+
+  const idleTimeoutMs = config.analysis?.idleTimeoutMs ?? 600_000;
+
+  try {
+    if (trigger === "batch") {
+      enqueueMemoryJob("conversation_analyze", { conversationId });
+    } else {
+      // "idle" or "lifecycle" — debounce against duplicate pending jobs.
+      upsertDebouncedJob(
+        "conversation_analyze",
+        { conversationId },
+        Date.now() + idleTimeoutMs,
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { err, conversationId, trigger },
+      "Failed to enqueue auto-analysis job",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `enqueueAutoAnalysisIfEnabled({ conversationId, trigger })` helper centralizing the flag check, recursion guard, and dedup behavior for the auto-analysis loop.
- Uses `enqueueMemoryJob` for "batch" trigger, `upsertDebouncedJob` for "idle" and "lifecycle" — matches the pattern in `indexer.ts` for `graph_extract`.
- No call sites yet — wired in PR 14 (indexer) and PR 15 (lifecycle) of the auto-analyze-loop plan.

Part of plan: auto-analyze-loop.md (PR 12 of 15)