### PR TITLE
fix(macos): store bounceTask + apply a11y/Task.sleep to ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -79,6 +79,7 @@ struct ChatBubble: View, Equatable {
     private static let heuristicUserPreviewLineLimit = 24
 
     @State private var avatarBounceScale: CGFloat = 1.0
+    @State private var bounceTask: Task<Void, Never>?
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
     /// standalone thinking row (which would stack a duplicate avatar).
@@ -514,13 +515,24 @@ struct ChatBubble: View, Equatable {
         // Ensure the tap-triggered bounce animation is preserved despite the
         // parent LazyVStack's .transaction { $0.animation = nil } suppression.
         .animation(.spring(response: 0.3, dampingFraction: 0.5), value: avatarBounceScale)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Poke assistant")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            SoundManager.shared.play(.characterPoke)
+            triggerBounce()
+        }
+        .onDisappear { bounceTask?.cancel() }
     }
 
     private func triggerBounce() {
         withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
             avatarBounceScale = 1.15
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+        bounceTask?.cancel()
+        bounceTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                 avatarBounceScale = 1.0
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -36,6 +36,7 @@ struct ChatEmptyStateView: View {
     @State private var visible = false
     @State private var fallbackPlaceholder: String = placeholderTexts.randomElement()!
     @State private var avatarBounceScale: CGFloat = 1.0
+    @State private var bounceTask: Task<Void, Never>?
 
     // Stable random pick from SOUL.md (loaded asynchronously, computed once per view lifecycle)
     @State private var soulGreeting: String?
@@ -82,7 +83,10 @@ struct ChatEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear(perform: handleAppear)
-        .onDisappear { visible = false }
+        .onDisappear {
+            visible = false
+            bounceTask?.cancel()
+        }
         .task {
             guard !soulGreetingLoaded else { return }
             let greetings = await IdentityInfo.loadGreetingsAsync()
@@ -212,7 +216,8 @@ struct ChatEmptyStateView: View {
         withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
             avatarBounceScale = 1.15
         }
-        Task { @MainActor in
+        bounceTask?.cancel()
+        bounceTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard !Task.isCancelled else { return }
             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {


### PR DESCRIPTION
Address Devin review on #25649. Store the Task from triggerBounce in a @State property so it can be cancelled in onDisappear (AGENTS.md rule). Apply the same stored-Task pattern and accessibility traits (.isButton label/action) to ChatBubble.swift, which still had the old DispatchQueue.main.asyncAfter pattern and missing a11y modifiers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
