### PR TITLE
fix(tests): move conversation-list-source test into CI glob

### DIFF
--- a/assistant/src/__tests__/conversation-list-source.test.ts
+++ b/assistant/src/__tests__/conversation-list-source.test.ts
@@ -13,14 +13,14 @@
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-mock.module("../../util/logger.js", () => ({
+mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
 }));
 
-mock.module("../../config/env.js", () => ({
+mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   hasUngatedHttpAuthDisabled: () => false,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
@@ -32,7 +32,7 @@ mock.module("../../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
-mock.module("../../config/loader.js", () => ({
+mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
     model: "test",
@@ -43,9 +43,9 @@ mock.module("../../config/loader.js", () => ({
   }),
 }));
 
-import { createConversation } from "../../memory/conversation-crud.js";
-import { getDb, initializeDb, resetDb } from "../../memory/db.js";
-import { RuntimeHttpServer } from "../http-server.js";
+import { createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
 
 initializeDb();
 


### PR DESCRIPTION
Address Codex P2 on #25661. Move the regression test from src/runtime/__tests__ to src/__tests__ so assistant/scripts/test.sh (which only globs src/__tests__ with maxdepth 1) actually runs it. Update relative imports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
