### PR TITLE
fix(filing): emit active-hours refine issue on both fields

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -2073,6 +2073,37 @@ describe("loadConfig with schema validation", () => {
     expect(config.calls.provider).toBe("twilio");
   });
 
+  test("recovers from partial filing.activeHours without wiping unrelated fields", () => {
+    // Only activeHoursStart is set. The superRefine must emit the issue so
+    // the loader's delete-and-retry can strip the set field; otherwise the
+    // mismatch persists and the config falls back to full defaults (which
+    // would reset maxTokens below to 64000).
+    writeConfig({
+      maxTokens: 4096,
+      filing: { activeHoursStart: 8 },
+    });
+    const config = loadConfig();
+    expect(config.maxTokens).toBe(4096);
+    expect(config.filing.activeHoursStart).toBeNull();
+    expect(config.filing.activeHoursEnd).toBeNull();
+  });
+
+  test("recovers from partial heartbeat.activeHours without wiping unrelated fields", () => {
+    // activeHoursStart is explicitly nulled while activeHoursEnd defaults to
+    // 22 — a mismatch. Without emitting on both paths, delete-and-retry can't
+    // resolve this (deleting the null side is a no-op) and the whole config
+    // would be reset to defaults.
+    writeConfig({
+      maxTokens: 4096,
+      heartbeat: { activeHoursStart: null },
+    });
+    const config = loadConfig();
+    expect(config.maxTokens).toBe(4096);
+    // Both fall back to the heartbeat defaults (8, 22).
+    expect(config.heartbeat.activeHoursStart).toBe(8);
+    expect(config.heartbeat.activeHoursEnd).toBe(22);
+  });
+
   test("applies calls defaults when not specified", () => {
     writeConfig({});
     const config = loadConfig();

--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -47,11 +47,20 @@ export const FilingConfigSchema = z
     const startNull = config.activeHoursStart == null;
     const endNull = config.activeHoursEnd == null;
     if (startNull !== endNull) {
+      // Emit on both fields so validateWithSchema's delete-and-retry repair
+      // can strip whichever side was set (and no-op the null side), letting
+      // the config fall back to both-null defaults without a full reset.
+      const message =
+        "filing.activeHoursStart and filing.activeHoursEnd must both be set or both be null";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
-        message:
-          "filing.activeHoursStart and filing.activeHoursEnd must both be set or both be null",
+        path: ["activeHoursStart"],
+        message,
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursEnd"],
+        message,
       });
       return;
     }

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -43,11 +43,20 @@ export const HeartbeatConfigSchema = z
     const startNull = config.activeHoursStart == null;
     const endNull = config.activeHoursEnd == null;
     if (startNull !== endNull) {
+      // Emit on both fields so validateWithSchema's delete-and-retry repair
+      // can strip whichever side was set (and no-op the null side), letting
+      // the config fall back to the schema defaults without a full reset.
+      const message =
+        "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be null";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
-        message:
-          "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be null",
+        path: ["activeHoursStart"],
+        message,
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursEnd"],
+        message,
       });
       return;
     }


### PR DESCRIPTION
Address Codex P1 on #25648.

When only one of `activeHoursStart`/`activeHoursEnd` is set, `filing`'s (and `heartbeat`'s) `superRefine` previously emitted the validation issue on the *null/missing* side. The config loader's `validateWithSchema` repair deletes `issue.path` and retries — but deleting a missing/defaulted key cannot resolve the mismatch, so the loader would fall through to a full-config reset.

Fix: emit the issue on **both** field paths. `validateWithSchema`'s delete step strips whichever side was actually set (no-op on the null side), and the retry re-validates with both fields falling back to their schema defaults. This preserves unrelated user settings that would otherwise be reset to defaults.

Heartbeat had the same buggy pattern — fixed it there too.

Added two loader-level regression tests covering both schemas: one for `filing` (defaults null/null, user sets one side to a number) and one for `heartbeat` (defaults 8/22, user sets one side to `null`). Both verify that an unrelated field (`maxTokens: 4096`) survives the repair, which proves no full-config reset occurred.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
