### PR TITLE
fix(slack): broaden link-start matching to any URL scheme

### DIFF
--- a/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/runtime/__tests__/slack-block-formatting.test.ts
@@ -129,11 +129,11 @@ describe("splitLongTextSegment", () => {
   });
 
   test("plain `<` in technical prose does not protect trailing sentence boundaries from being used as split points", () => {
-    // Regression: `computeMrkdwnSpans` used to treat every `<` as a link
-    // span start. For prose like `a < b. Another sentence. ...`, an
-    // unmatched `<` near the front of the window extended a "protected"
-    // span to the window edge, rejecting every `. ` boundary after it and
-    // forcing a mid-word hard slice.
+    // `computeMrkdwnSpans` only treats `<` as a link span start when
+    // followed by a recognized Slack link/mention prefix. A plain `<` in
+    // prose like `a < b. Another sentence. ...` must not create a
+    // protected span that extends to the window edge, or every `. `
+    // boundary after it would be rejected, forcing a mid-word hard slice.
     const sentence = "a < b. ";
     // Repeat enough to comfortably exceed maxChars so the splitter must
     // pick a boundary inside the window.
@@ -153,6 +153,31 @@ describe("splitLongTextSegment", () => {
     expect(chunks.join(" ").replace(/\s+/g, " ").trim()).toBe(
       text.replace(/\s+/g, " ").trim(),
     );
+  });
+
+  test("protects `<scheme://...>` link spans for schemes beyond the http/https whitelist", () => {
+    // `markdownToMrkdwn` wraps any markdown link target in `<url|text>`,
+    // including schemes like ftp, ssh, or custom app schemes. The splitter
+    // must recognize those as protected spans so it does not bisect the
+    // URL token when deciding where to cut a long chunk.
+    const filler = "lorem ipsum dolor sit amet. ".repeat(200);
+    const longUrl =
+      "ftp://example.com/" + "segment/".repeat(30) + "final-path";
+    const linkToken = `<${longUrl}|download>`;
+    const text = filler + linkToken + " " + filler;
+    expect(text.length).toBeGreaterThan(SLACK_SECTION_MAX_CHARS);
+
+    const chunks = splitLongTextSegment(text);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_SECTION_MAX_CHARS);
+      // If the splitter ever landed inside the `<...>` token, some chunk
+      // would contain a `<` without the matching `>` (or vice versa).
+      const opens = (chunk.match(/</g) ?? []).length;
+      const closes = (chunk.match(/>/g) ?? []).length;
+      expect(opens).toBe(closes);
+    }
   });
 });
 

--- a/assistant/src/runtime/slack-block-formatting.ts
+++ b/assistant/src/runtime/slack-block-formatting.ts
@@ -410,6 +410,11 @@ const SLACK_LINK_PREFIXES = [
   "!date",
 ];
 
+// Matches `scheme://` at the start of a string where `scheme` follows RFC 3986
+// syntax: `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`. Covers http, https,
+// ftp, ssh, git+ssh, custom app schemes, etc.
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 function looksLikeLinkStart(window: string, openIdx: number): boolean {
   const rest = window.slice(openIdx + 1);
   if (rest.length === 0) return false;
@@ -425,6 +430,20 @@ function looksLikeLinkStart(window: string, openIdx: number): boolean {
     // known link prefix, treat it as link-shaped so the continuation
     // past the window is still protected from mid-token hard slicing.
     if (rest.length < prefix.length && prefix.startsWith(rest)) return true;
+  }
+  // `markdownToMrkdwn` wraps any markdown link target in `<url|text>`,
+  // including schemes beyond the whitelist above (ftp, ssh, custom app
+  // schemes, etc.). Recognize any `scheme://` prefix so those spans are
+  // protected too. Also treat a truncated `<scheme` at the window edge as
+  // link-shaped so the continuation past the window is not hard-sliced.
+  if (URL_SCHEME_RE.test(rest)) return true;
+  const colonIdx = rest.indexOf(":");
+  if (colonIdx < 0) {
+    if (/^[a-z][a-z0-9+.-]*$/i.test(rest)) return true;
+  } else if (colonIdx + 1 === rest.length) {
+    if (/^[a-z][a-z0-9+.-]*:$/i.test(rest)) return true;
+  } else if (rest[colonIdx + 1] === "/" && colonIdx + 2 === rest.length) {
+    if (/^[a-z][a-z0-9+.-]*:\/$/i.test(rest)) return true;
   }
   return false;
 }


### PR DESCRIPTION
Address Codex P2 + Devin review on #25653. Broaden looksLikeLinkStart to recognize any scheme://... pattern (not just http/https/mailto), so markdown links with custom schemes aren't split mid-URL. Rewrite history-narrating test comment per assistant/AGENTS.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
