### PR TITLE
fix(memory): handle missing analyze deps without permanently failing job

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -121,7 +121,7 @@ mock.module("../runtime/services/analyze-conversation.js", () => ({
   },
 }));
 
-// Stub the deps singleton so the job handler doesn't throw
+// Stub the deps singleton so the job handler doesn't return early due to
 // "Analysis deps not yet initialized" — the stub above doesn't actually
 // touch the deps bundle, so any non-null shape suffices.
 mock.module("../runtime/services/analyze-deps-singleton.js", () => ({

--- a/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
+++ b/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
@@ -106,15 +106,22 @@ describe("conversationAnalyzeJob", () => {
     expect(mockGetAnalysisDeps).not.toHaveBeenCalled();
   });
 
-  test("throws when deps singleton is not yet initialized (worker reschedules)", async () => {
+  test("returns without calling the service when deps singleton is not yet initialized", async () => {
+    // Deps singleton is unset during slow daemon startup. The handler must
+    // NOT throw — a plain Error here is classified as fatal by
+    // classifyError() and the worker would mark the job permanently failed
+    // (failMemoryJob with maxAttempts: 1). Returning lets the next batch /
+    // idle / lifecycle trigger from enqueueAutoAnalysisIfEnabled() produce
+    // a fresh job once the daemon has fully started.
     mockGetAnalysisDeps.mockImplementation(() => null);
     await expect(
       conversationAnalyzeJob(
         makeJob({ conversationId: "conv-1" }),
         TEST_CONFIG,
       ),
-    ).rejects.toThrow(/not yet initialized/i);
+    ).resolves.toBeUndefined();
     expect(analyzeCalls).toHaveLength(0);
+    expect(mockGetAnalysisDeps).toHaveBeenCalled();
   });
 
   test("invokes analyzeConversation with trigger=auto and the conversationId", async () => {

--- a/assistant/src/memory/conversation-analyze-job.ts
+++ b/assistant/src/memory/conversation-analyze-job.ts
@@ -3,8 +3,9 @@
 //
 // Bridges the jobs worker to the shared analyzeConversation() service. The
 // deps bundle is stashed on a module singleton during daemon startup; if it
-// isn't set yet we throw so the worker reschedules via its normal retry
-// mechanism.
+// isn't set yet we skip this iteration. The next batch / idle / lifecycle
+// trigger from `enqueueAutoAnalysisIfEnabled()` will produce a fresh job
+// once the daemon has fully started.
 //
 // The service itself distinguishes manual vs. auto triggers: this handler
 // always invokes with `trigger: "auto"`, so the rolling analysis conversation
@@ -31,8 +32,19 @@ export async function conversationAnalyzeJob(
 
   const deps = getAnalysisDeps();
   if (!deps) {
-    // Daemon hasn't finished startup; throw so the worker reschedules.
-    throw new Error("Analysis deps not yet initialized");
+    // Daemon hasn't finished startup. Return without throwing — a plain
+    // Error here would be classified as fatal by `classifyError()` and the
+    // worker would mark the job permanently failed. Throwing
+    // `BackendUnavailableError` would defer, but defer counters cap out and
+    // would still permanently fail in the worst case. Since
+    // `enqueueAutoAnalysisIfEnabled()` re-enqueues on the next batch / idle
+    // / lifecycle trigger, dropping this iteration is the safest choice and
+    // avoids retry storms during slow daemon startup.
+    log.warn(
+      { jobId: job.id, conversationId },
+      "Skipping job: analysis deps not yet initialized; will retrigger",
+    );
+    return;
   }
 
   const result = await analyzeConversation(conversationId, deps, {


### PR DESCRIPTION
## Summary
Fix gap from plan review for auto-analyze-loop.md.

The previous handler threw a plain Error when the analyze-deps singleton was unpopulated, expecting the worker to reschedule. In reality, plain Errors are classified as fatal and immediately marked failed. This change returns gracefully so the next upstream trigger re-enqueues cleanly during slow daemon startup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
