### PR TITLE
fix(daemon): skip graph_extract on dispose for auto-analysis conversations

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -11,10 +11,17 @@
  * can invoke `disposeConversation` with a minimal `DisposeContext` and assert
  * on the enqueue bookkeeping alone.
  *
- * Recursion guard — when the source conversation is itself an auto-analysis
- * conversation — is enforced inside `enqueueAutoAnalysisIfEnabled` (PR 12),
- * not here. We stub that helper to simulate "flag enabled / flag disabled /
- * recursion guard hit" states.
+ * Two recursion guards apply when the source conversation is itself an
+ * auto-analysis conversation:
+ *   1. `enqueueAutoAnalysisIfEnabled` short-circuits internally (PR 12),
+ *      preventing the analyzer from analyzing its own output.
+ *   2. `disposeConversation` skips `graph_extract` directly via
+ *      `isAutoAnalysisConversation()`, mirroring the guard the indexer
+ *      applies on the per-message path. The analysis agent writes memory
+ *      directly via tools, so extracting its reflective musings would
+ *      double-write the graph.
+ * We stub both the helper and the guard so the test can simulate "flag
+ * enabled / flag disabled / source is auto-analysis" states.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -43,6 +50,17 @@ const autoAnalyzeCalls: Array<{
 // when `autoAnalyzeEnabled` is false. When true, we record the call so the
 // test can assert the trigger and conversation id.
 let autoAnalyzeEnabled = true;
+
+// Tracks whether the conversation under test should be treated as an
+// auto-analysis source by `isAutoAnalysisConversation`. When true,
+// `disposeConversation` must skip the `graph_extract` enqueue.
+const autoAnalysisConversations = new Set<string>();
+
+mock.module("../../memory/auto-analysis-guard.js", () => ({
+  AUTO_ANALYSIS_SOURCE: "auto-analysis",
+  isAutoAnalysisConversation: (conversationId: string) =>
+    autoAnalysisConversations.has(conversationId),
+}));
 
 const realJobsStore = await import("../../memory/jobs-store.js");
 mock.module("../../memory/jobs-store.js", () => ({
@@ -149,6 +167,7 @@ describe("disposeConversation — auto-analysis enqueue", () => {
     memoryJobCalls.length = 0;
     autoAnalyzeCalls.length = 0;
     autoAnalyzeEnabled = true;
+    autoAnalysisConversations.clear();
   });
 
   test("guardian conversation with auto-analyze ON — enqueues both graph_extract and conversation_analyze (via helper)", () => {
@@ -190,15 +209,18 @@ describe("disposeConversation — auto-analysis enqueue", () => {
     expect(autoAnalyzeCalls).toHaveLength(0);
   });
 
-  test("auto-analysis conversation (recursion guard) — helper no-ops, so only graph_extract is enqueued", () => {
-    // The recursion guard lives inside `enqueueAutoAnalysisIfEnabled` (it
-    // checks `isAutoAnalysisConversation()`). From disposeConversation's
-    // vantage point the helper simply no-ops. We simulate that by flipping
-    // the shared flag — the stubbed helper respects it.
-    //
-    // graph_extract still fires here; suppressing graph_extract for
-    // auto-analysis conversations is a separate concern and not gated by
-    // this helper.
+  test("auto-analysis conversation — neither graph_extract nor conversation_analyze is enqueued", () => {
+    // Two recursion guards apply when the source conversation is itself an
+    // auto-analysis conversation:
+    //   1. `disposeConversation` skips the `graph_extract` enqueue directly
+    //      via `isAutoAnalysisConversation()` — mirroring the indexer's
+    //      per-message guard. Without this, evicting an auto-analysis
+    //      conversation from the LRU would double-write the memory graph
+    //      because the analysis agent already writes memory via tools.
+    //   2. `enqueueAutoAnalysisIfEnabled` no-ops internally for
+    //      auto-analysis conversations (its own recursion guard). We
+    //      simulate that by flipping `autoAnalyzeEnabled` off.
+    autoAnalysisConversations.add("conv-auto");
     autoAnalyzeEnabled = false;
     const ctx = makeDisposeContext({
       conversationId: "conv-auto",
@@ -207,8 +229,7 @@ describe("disposeConversation — auto-analysis enqueue", () => {
 
     disposeConversation(ctx);
 
-    expect(memoryJobCalls).toHaveLength(1);
-    expect(memoryJobCalls[0]!.type).toBe("graph_extract");
+    expect(memoryJobCalls).toHaveLength(0);
     expect(autoAnalyzeCalls).toHaveLength(0);
   });
 

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -10,6 +10,7 @@ import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import { enqueueAutoAnalysisIfEnabled } from "../memory/auto-analysis-enqueue.js";
+import { isAutoAnalysisConversation } from "../memory/auto-analysis-guard.js";
 import {
   getConversation,
   getMessages,
@@ -311,19 +312,29 @@ export function disposeConversation(ctx: DisposeContext): void {
   // Only extract from guardian conversations to preserve the memory trust
   // boundary — untrusted content must not influence future memory retrieval.
   if (!isUntrustedTrustClass(ctx.trustContext?.trustClass)) {
-    try {
-      enqueueMemoryJob("graph_extract", {
-        conversationId: ctx.conversationId,
-        scopeId: ctx.memoryScopeId ?? "default",
-        ...(ctx.activeContextNodeIds?.length
-          ? { activeContextNodeIds: ctx.activeContextNodeIds }
-          : {}),
-      });
-    } catch {
-      // Best-effort — don't block conversation disposal
+    // Recursion guard: skip graph_extract for auto-analysis conversations.
+    // The analysis agent writes memory directly via tools, so extracting
+    // from its reflective musings would double-write into the memory graph.
+    // Mirrors the same guard applied in `indexer.ts` for the per-message
+    // indexing path.
+    if (!isAutoAnalysisConversation(ctx.conversationId)) {
+      try {
+        enqueueMemoryJob("graph_extract", {
+          conversationId: ctx.conversationId,
+          scopeId: ctx.memoryScopeId ?? "default",
+          ...(ctx.activeContextNodeIds?.length
+            ? { activeContextNodeIds: ctx.activeContextNodeIds }
+            : {}),
+        });
+      } catch {
+        // Best-effort — don't block conversation disposal
+      }
     }
 
     try {
+      // `enqueueAutoAnalysisIfEnabled` has its own internal recursion guard
+      // (it checks `isAutoAnalysisConversation()`), so it's safe to call
+      // unconditionally here.
       enqueueAutoAnalysisIfEnabled({
         conversationId: ctx.conversationId,
         trigger: "lifecycle",


### PR DESCRIPTION
## Summary
Fix gap from plan review for auto-analyze-loop.md.

The indexer already guards against enqueueing `graph_extract` for auto-analysis conversations (the analysis agent writes memory directly via tools, so running extraction over its reflective musings would double-write). The end-of-conversation `disposeConversation` path was missing the same guard. Add it for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
