### PR TITLE
fix(memory): wire analysis.batchSize and dedupe batch-trigger jobs

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -17,7 +17,15 @@
  * dispatch would also claim embed_segment and graph_extract jobs whose
  * real backends would time out in this test context.
  */
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import { and, eq } from "drizzle-orm";
 
@@ -184,19 +192,21 @@ function seedMessage(
 async function indexMessages(
   conversationId: string,
   count: number,
+  offset = 0,
 ): Promise<void> {
   const now = Date.now();
   for (let i = 0; i < count; i++) {
-    const messageId = `${conversationId}-msg-${i}`;
-    const text = longEnoughText(`${conversationId}-${i}`);
-    seedMessage(conversationId, messageId, text, now + i);
+    const idx = offset + i;
+    const messageId = `${conversationId}-msg-${idx}`;
+    const text = longEnoughText(`${conversationId}-${idx}`);
+    seedMessage(conversationId, messageId, text, now + idx);
     await indexMessageNow(
       {
         messageId,
         conversationId,
         role: "user",
         content: JSON.stringify([{ type: "text", text }]),
-        createdAt: now + i,
+        createdAt: now + idx,
       },
       TEST_CONFIG.memory,
     );
@@ -373,5 +383,120 @@ describe("auto-analysis end-to-end trigger path", () => {
     // retrieval and aren't recursion-prone).
     expect(countJobsOfType("conversation_analyze", analysisConv.id)).toBe(0);
     expect(countJobsOfType("graph_extract", analysisConv.id)).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Independent cadence: analysis.batchSize gates the auto-analysis
+// batch trigger separately from extraction.batchSize. This regression
+// guards against a previous wiring bug where the indexer piggy-backed
+// on the extraction counter, causing analysis to fire at extraction's
+// cadence instead of its own (default 30 vs. 10).
+// ─────────────────────────────────────────────────────────────────
+
+describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
+  // Mutate the shared TEST_CONFIG batch sizes for this block. The
+  // mocked `getConfig()` returns the same reference, so changes are
+  // observed by the indexer immediately.
+  const originalExtractionBatch = TEST_CONFIG.memory.extraction.batchSize;
+  const originalAnalysisBatch = TEST_CONFIG.analysis.batchSize;
+
+  beforeEach(() => {
+    _setOverridesForTesting({ "auto-analyze": true });
+    TEST_CONFIG.memory.extraction.batchSize = 2;
+    TEST_CONFIG.analysis.batchSize = 5;
+  });
+
+  afterEach(() => {
+    TEST_CONFIG.memory.extraction.batchSize = originalExtractionBatch;
+    TEST_CONFIG.analysis.batchSize = originalAnalysisBatch;
+  });
+
+  test("4 messages: extraction trips twice, analysis stays below threshold (0 jobs)", async () => {
+    const source = createConversation("cadence-source-4");
+    await indexMessages(source.id, 4);
+
+    // Extraction batch (size 2) is crossed at messages 2 and 4 → at
+    // least one graph_extract job should exist for this conversation.
+    // (The exact count depends on whether the per-message
+    // upsertDebouncedJob coalesced them with the immediate enqueues.)
+    expect(countJobsOfType("graph_extract", source.id)).toBeGreaterThanOrEqual(
+      1,
+    );
+
+    // Analysis batch (size 5) is NOT crossed by 4 messages → zero
+    // batch-triggered analysis jobs. The idle-debounced enqueue
+    // upserts a single far-future row; that's not a duplicate.
+    expect(countJobsOfType("conversation_analyze", source.id)).toBeLessThanOrEqual(
+      1,
+    );
+
+    // Stronger: any pending analysis job must be debounced (runAfter
+    // far in the future), not the immediate batch fire.
+    const db = getDb();
+    const analysisRows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "conversation_analyze"))
+      .all()
+      .filter((row) => {
+        try {
+          const payload = JSON.parse(row.payload) as {
+            conversationId?: string;
+          };
+          return payload.conversationId === source.id;
+        } catch {
+          return false;
+        }
+      });
+    for (const row of analysisRows) {
+      // idleTimeoutMs = 600_000 → all rows here should be debounced
+      // (runAfter ≫ now). Allow a small clock-skew margin.
+      expect(row.runAfter).toBeGreaterThan(Date.now() + 60_000);
+    }
+  });
+
+  test("5th message crosses analysis.batchSize → conversation_analyze enqueued for immediate run", async () => {
+    const source = createConversation("cadence-source-5");
+
+    // First 4 messages: analysis batch threshold not yet reached.
+    await indexMessages(source.id, 4);
+
+    // Fifth message: crosses analysis.batchSize=5 → batch-triggered
+    // upsert should produce a row whose runAfter is roughly "now"
+    // (the immediate-fire path), not pushed into the future by the
+    // idle debounce.
+    const before = Date.now();
+    await indexMessages(source.id, 1, 4);
+    const after = Date.now();
+
+    const db = getDb();
+    const analysisRows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "conversation_analyze"))
+      .all()
+      .filter((row) => {
+        try {
+          const payload = JSON.parse(row.payload) as {
+            conversationId?: string;
+          };
+          return payload.conversationId === source.id;
+        } catch {
+          return false;
+        }
+      });
+
+    // Exactly one row — the dedupe in upsertDebouncedJob coalesces the
+    // batch trigger and the per-message idle upsert into a single
+    // pending job.
+    expect(analysisRows.length).toBe(1);
+
+    // The row's runAfter is "now" (batch trigger ran AFTER the idle
+    // upsert this iteration, so it pulled the runAfter back to now).
+    // Allow a 1s margin on either side for clock skew.
+    const row = analysisRows[0]!;
+    expect(row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
+    expect(row.runAfter).toBeLessThanOrEqual(after + 1_000);
   });
 });

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -90,15 +90,22 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
     expect(debouncedCalls).toHaveLength(0);
   });
 
-  test("flag on, trigger = 'batch', normal source — enqueueMemoryJob called", () => {
+  test("flag on, trigger = 'batch', normal source — upsertDebouncedJob called with runAfter ≈ now", () => {
+    const before = Date.now();
+
     enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
 
-    expect(enqueueCalls).toHaveLength(1);
-    expect(enqueueCalls[0]).toMatchObject({
-      type: "conversation_analyze",
-      payload: { conversationId: "c1" },
-    });
-    expect(debouncedCalls).toHaveLength(0);
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
+    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    // "batch" fires immediately (no debounce), so runAfter ≈ now. We use
+    // upsertDebouncedJob so two consecutive batch crossings coalesce into
+    // a single pending job rather than spawning duplicates.
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
+    expect(enqueueCalls).toHaveLength(0);
   });
 
   test("flag on, trigger = 'idle', normal source — upsertDebouncedJob called with runAfter ≈ now + idleTimeoutMs", () => {

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -2,14 +2,15 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
-import { enqueueMemoryJob, upsertDebouncedJob } from "./jobs-store.js";
+import { upsertDebouncedJob } from "./jobs-store.js";
 
 const log = getLogger("auto-analysis-enqueue");
 
 /**
  * Trigger reason for an auto-analysis enqueue.
  *   - `"batch"`: source conversation crossed the batch threshold — enqueue
- *     immediately (no debounce).
+ *     immediately (`runAfter = now`) but still upsert so a pending job
+ *     coalesces rapid threshold crossings into one.
  *   - `"idle"`: source conversation has been idle long enough to warrant a
  *     debounced analysis pass.
  *   - `"lifecycle"`: a conversation lifecycle transition (e.g. resume,
@@ -24,9 +25,11 @@ export type AutoAnalysisTrigger = "batch" | "idle" | "lifecycle";
  *   - the source conversation is itself an auto-analysis conversation
  *     (recursion guard — we never analyze our own analysis output).
  *
- * Uses `upsertDebouncedJob()` for `"idle"` / `"lifecycle"` triggers and
- * `enqueueMemoryJob()` for `"batch"` triggers, mirroring how
- * `graph_extract` is enqueued in `indexer.ts`.
+ * All triggers route through `upsertDebouncedJob()` so a pending job for
+ * the same conversation coalesces additional enqueue attempts into a
+ * single row (no duplicates). `"batch"` fires immediately
+ * (`runAfter = now`); `"idle"` / `"lifecycle"` debounce by
+ * `analysis.idleTimeoutMs`.
  */
 export function enqueueAutoAnalysisIfEnabled(args: {
   conversationId: string;
@@ -58,18 +61,15 @@ export function enqueueAutoAnalysisIfEnabled(args: {
   }
 
   const idleTimeoutMs = config.analysis?.idleTimeoutMs ?? 600_000;
+  const runAfter =
+    trigger === "batch" ? Date.now() : Date.now() + idleTimeoutMs;
 
   try {
-    if (trigger === "batch") {
-      enqueueMemoryJob("conversation_analyze", { conversationId });
-    } else {
-      // "idle" or "lifecycle" — debounce against duplicate pending jobs.
-      upsertDebouncedJob(
-        "conversation_analyze",
-        { conversationId },
-        Date.now() + idleTimeoutMs,
-      );
-    }
+    upsertDebouncedJob(
+      "conversation_analyze",
+      { conversationId },
+      runAfter,
+    );
   } catch (err) {
     log.warn(
       { err, conversationId, trigger },

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -187,10 +187,6 @@ export async function indexMessageNow(
           scopeId: input.scopeId ?? "default",
         });
         setMemoryCheckpoint(graphPendingKey, "0");
-        enqueueAutoAnalysisIfEnabled({
-          conversationId: input.conversationId,
-          trigger: "batch",
-        });
       }
 
       upsertDebouncedJob(
@@ -198,10 +194,47 @@ export async function indexMessageNow(
         { conversationId: input.conversationId },
         Date.now() + idleTimeoutMs,
       );
+
+      // ── Auto-analysis triggers ─────────────────────────────────────
+      // Both triggers route through `upsertDebouncedJob` in the helper,
+      // so a single pending row is shared. Order matters: the idle
+      // upsert runs first (pushing `runAfter` into the future); the
+      // batch trigger runs last so a threshold crossing pulls
+      // `runAfter` back to "now" and overrides the idle debounce.
       enqueueAutoAnalysisIfEnabled({
         conversationId: input.conversationId,
         trigger: "idle",
       });
+
+      // Auto-analysis cadence is tracked by its own pending-count
+      // checkpoint so it fires at `analysis.batchSize` (default 30)
+      // rather than piggy-backing on the extraction batch size.
+      // Reading config here is best-effort: if it fails we skip the
+      // batch trigger (the idle-debounced enqueue above still runs).
+      let analysisBatchSize: number | null = null;
+      try {
+        analysisBatchSize = getConfig().analysis.batchSize;
+      } catch (err) {
+        log.debug(
+          { err, conversationId: input.conversationId },
+          "Skipping auto-analysis batch trigger: failed to load config",
+        );
+      }
+      if (analysisBatchSize != null) {
+        const analysisPendingKey = `conversation_analyze:${input.conversationId}:pending_count`;
+        const analysisCurrentVal = getMemoryCheckpoint(analysisPendingKey);
+        const analysisPendingCount =
+          (analysisCurrentVal ? parseInt(analysisCurrentVal, 10) : 0) + 1;
+        setMemoryCheckpoint(analysisPendingKey, String(analysisPendingCount));
+
+        if (analysisPendingCount >= analysisBatchSize) {
+          setMemoryCheckpoint(analysisPendingKey, "0");
+          enqueueAutoAnalysisIfEnabled({
+            conversationId: input.conversationId,
+            trigger: "batch",
+          });
+        }
+      }
     }
 
     // ── Conversation summarization (independent of extraction) ────────


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for auto-analyze-loop.md:
- Wire `analysis.batchSize` into the indexer via a dedicated pending-count checkpoint so analysis fires at its configured cadence, not extraction's.
- Switch the `"batch"` enqueue trigger to `upsertDebouncedJob` so rapid threshold crossings coalesce into one job (matches `"idle"` and `"lifecycle"` behavior).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
