### PR TITLE
fix(runtime): tighten auto-analyze service (concurrent loops, constants, group_id)

### DIFF
--- a/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
@@ -8,6 +8,7 @@ mock.module("../../util/logger.js", () => ({
 }));
 
 import {
+  AUTO_ANALYSIS_GROUP_ID,
   AUTO_ANALYSIS_SOURCE,
   isAutoAnalysisConversation,
 } from "../auto-analysis-guard.js";
@@ -21,6 +22,16 @@ function resetTables(): void {
   db.run(`DELETE FROM messages`);
   db.run(`DELETE FROM conversations`);
 }
+
+describe("auto-analysis constants", () => {
+  test("AUTO_ANALYSIS_SOURCE is the canonical 'auto-analysis' string", () => {
+    expect(AUTO_ANALYSIS_SOURCE).toBe("auto-analysis");
+  });
+
+  test("AUTO_ANALYSIS_GROUP_ID is 'system:reflections' so rolling analysis conversations stay out of system:all", () => {
+    expect(AUTO_ANALYSIS_GROUP_ID).toBe("system:reflections");
+  });
+});
 
 describe("isAutoAnalysisConversation", () => {
   beforeEach(() => {

--- a/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
+++ b/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
@@ -143,6 +143,37 @@ describe("findAnalysisConversationFor", () => {
 
     expect(findAnalysisConversationFor(parent.id)).toEqual({ id: analysis.id });
   });
+
+  test("finds rolling analysis conversation regardless of group_id (backward-compat across the dedicated-group migration)", () => {
+    const parent = createConversation("parent");
+
+    // Conversations created BEFORE the dedicated `system:reflections` group
+    // landed will have the default `system:all` group_id.
+    const legacyAnalysis = createConversation({
+      title: "legacy rolling analysis",
+      source: "auto-analysis",
+      forkParentConversationId: parent.id,
+    });
+    setUpdatedAt(legacyAnalysis.id, 1_000);
+
+    expect(findAnalysisConversationFor(parent.id)).toEqual({
+      id: legacyAnalysis.id,
+    });
+
+    // Conversations created AFTER use the dedicated group. The lookup must
+    // still find them — the source filter alone is the contract.
+    const newAnalysis = createConversation({
+      title: "new rolling analysis",
+      source: "auto-analysis",
+      groupId: "system:reflections",
+      forkParentConversationId: parent.id,
+    });
+    setUpdatedAt(newAnalysis.id, 2_000);
+
+    expect(findAnalysisConversationFor(parent.id)).toEqual({
+      id: newAnalysis.id,
+    });
+  });
 });
 
 describe("getConversationSource", () => {

--- a/assistant/src/memory/auto-analysis-guard.ts
+++ b/assistant/src/memory/auto-analysis-guard.ts
@@ -9,6 +9,14 @@ import { getConversationSource } from "./conversation-crud.js";
 export const AUTO_ANALYSIS_SOURCE = "auto-analysis";
 
 /**
+ * Dedicated `group_id` value for auto-analysis rolling conversations. They
+ * are an internal continuity surface and must not appear in the default
+ * `system:all` group that non-macOS clients (CLI, gateway, web) render
+ * without filtering on `source`.
+ */
+export const AUTO_ANALYSIS_GROUP_ID = "system:reflections";
+
+/**
  * Returns true if the conversation's `source` column is `"auto-analysis"`,
  * meaning it was produced by the auto-analysis loop. Callers use this to
  * skip both `graph_extract` and `conversation_analyze` enqueues so we

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -30,6 +30,7 @@ import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
 } from "./attachments-store.js";
+import { AUTO_ANALYSIS_SOURCE } from "./auto-analysis-guard.js";
 import {
   projectAssistantMessage,
   seedForkedConversationAttention,
@@ -402,7 +403,7 @@ export function findAnalysisConversationFor(
     .from(conversations)
     .where(
       and(
-        eq(conversations.source, "auto-analysis"),
+        eq(conversations.source, AUTO_ANALYSIS_SOURCE),
         eq(conversations.forkParentConversationId, parentConversationId),
       ),
     )

--- a/assistant/src/memory/conversation-group-migration.ts
+++ b/assistant/src/memory/conversation-group-migration.ts
@@ -57,7 +57,13 @@ export function ensureGroupMigration(): void {
     }
   }
 
-  // 3. Seed system groups (four: pinned, scheduled, background, all)
+  // 3. Seed system groups.
+  //
+  // `system:reflections` holds rolling auto-analysis conversations. It is an
+  // internal continuity surface — clients that don't filter on `source` can
+  // hide this group from their main list. It is parked at a high
+  // `sort_position` so it never displaces user-visible groups in the
+  // ordering; the value just has to be deterministic.
   const now = Math.floor(Date.now() / 1000);
   rawExec(`
     INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group, created_at, updated_at)
@@ -65,7 +71,8 @@ export function ensureGroupMigration(): void {
       ('system:pinned', 'Pinned', 0, TRUE, ${now}, ${now}),
       ('system:scheduled', 'Scheduled', 1, TRUE, ${now}, ${now}),
       ('system:background', 'Background', 2, TRUE, ${now}, ${now}),
-      ('system:all', 'Recents', 3, TRUE, ${now}, ${now})
+      ('system:all', 'Recents', 3, TRUE, ${now}, ${now}),
+      ('system:reflections', 'Reflections', 100, TRUE, ${now}, ${now})
   `);
 
   // One-time migration: move system:all to sortPosition 3 (from 999999).

--- a/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
@@ -231,7 +231,7 @@ describe("analyzeConversation", () => {
 
   // ── Auto trigger ──────────────────────────────────────────────────
 
-  test("auto: creates a new analysis conversation when none exists, with source=auto-analysis and forkParentConversationId", async () => {
+  test("auto: creates a new analysis conversation when none exists, with source=auto-analysis, dedicated groupId, and forkParentConversationId", async () => {
     mockFindAnalysisConversationFor.mockImplementation(() => null);
     const conversation = makeConversation();
     const deps = makeDeps(conversation);
@@ -248,14 +248,60 @@ describe("analyzeConversation", () => {
     expect(mockFindAnalysisConversationFor).toHaveBeenCalledWith("conv-1");
 
     // Created exactly one new conversation row, with the expected shape.
+    // The dedicated `system:reflections` group keeps rolling analysis
+    // conversations out of the default `system:all` group used by clients
+    // that do not filter on `source`.
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
     expect(mockCreateConversation).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "Analysis: Source",
         source: "auto-analysis",
+        groupId: "system:reflections",
         forkParentConversationId: "conv-1",
       }),
     );
+  });
+
+  test("auto: skips the run (no agent loop, no message persisted) when the rolling analysis conversation is already processing", async () => {
+    const conversation = makeConversation();
+    conversation.processing = true;
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+
+    // Returns a successful no-op result tagged with `skipped: true`.
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.analysisConversationId).toBe("analysis-new");
+    expect(result.skipped).toBe(true);
+
+    // Critically, none of the mutating side effects should have run: no
+    // message persisted, no trust context overwritten, no agent loop fired.
+    expect(mockAddMessage).not.toHaveBeenCalled();
+    expect(conversation.setTrustContext).not.toHaveBeenCalled();
+    expect(conversation.runAgentLoop).not.toHaveBeenCalled();
+    expect(conversation.abortController).toBeNull();
+  });
+
+  test("manual: does NOT skip when the conversation reports processing (guard is auto-only)", async () => {
+    const conversation = makeConversation();
+    conversation.processing = true;
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.skipped).toBeUndefined();
+
+    // Manual trigger always proceeds — it creates a fresh conversation per
+    // invocation, so there is no shared-state concurrency hazard.
+    expect(mockAddMessage).toHaveBeenCalled();
+    expect(conversation.runAgentLoop).toHaveBeenCalled();
   });
 
   test("auto: reuses an existing rolling analysis conversation (no new row)", async () => {

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -19,6 +19,10 @@
 import { getConfig } from "../../config/loader.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
+  AUTO_ANALYSIS_GROUP_ID,
+  AUTO_ANALYSIS_SOURCE,
+} from "../../memory/auto-analysis-guard.js";
+import {
   addMessage,
   createConversation,
   findAnalysisConversationFor,
@@ -35,9 +39,6 @@ import type { SendMessageDeps } from "../http-types.js";
 import { buildAutoAnalysisPrompt } from "./auto-analysis-prompt.js";
 
 const log = getLogger("analyze-conversation-service");
-
-/** Source column marker used to tag auto-analysis rolling conversations. */
-const AUTO_ANALYSIS_SOURCE = "auto-analysis";
 
 // ---------------------------------------------------------------------------
 // Dependency types — injected by the caller (route handler / future triggers)
@@ -64,6 +65,13 @@ export type AnalyzeOptions =
 
 export interface AnalyzeResult {
   analysisConversationId: string;
+  /**
+   * Set when the auto branch found the rolling analysis conversation already
+   * processing and skipped this run to avoid stomping its in-flight agent
+   * loop. Callers that care can distinguish "started a new run" from "no-op
+   * skip"; everyone else can ignore it.
+   */
+  skipped?: true;
 }
 
 export interface AnalyzeError {
@@ -179,9 +187,14 @@ export async function analyzeConversation(
     if (existing) {
       analysisConversationId = existing.id;
     } else {
+      // New rolling analysis conversations land in a dedicated group so they
+      // do not appear in the default `system:all` list rendered by clients
+      // that don't filter on `source` (CLI, gateway, web). Existing rolling
+      // conversations stay where they were — no migration needed.
       const newConv = createConversation({
         title: `Analysis: ${conversation.title ?? "Untitled"}`,
         source: AUTO_ANALYSIS_SOURCE,
+        groupId: AUTO_ANALYSIS_GROUP_ID,
         forkParentConversationId: resolvedId,
       });
       analysisConversationId = newConv.id;
@@ -195,7 +208,41 @@ export async function analyzeConversation(
     modelOverride = analysisConfig.modelOverride;
   }
 
-  // h. Persist the user message (with provenance snapshot matching the
+  // h. Load the conversation into memory with the appropriate trust
+  // context. Manual analysis runs untrusted over attacker-influenced
+  // transcript content; auto analysis runs as guardian so it can act on
+  // what it learns.
+  //
+  // Hoisted ahead of message persistence so the auto branch can detect a
+  // still-running prior agent loop on the rolling conversation and bail out
+  // before mutating any state. See concurrency guard below.
+  const analysisConversation =
+    await deps.sendMessageDeps.getOrCreateConversation(
+      analysisConversationId,
+      {
+        ...(modelIntent !== undefined ? { modelIntent } : {}),
+        ...(modelOverride !== undefined ? { modelOverride } : {}),
+      },
+    );
+
+  // h.1. Concurrency guard (auto trigger only). The rolling analysis
+  // conversation is reused across runs; if a prior agent loop is still in
+  // flight, starting another would overwrite `abortController` /
+  // `currentRequestId` and let two loops mutate the same Conversation
+  // state. Skip this run instead — the next upstream trigger will
+  // re-enqueue once the in-flight loop finishes.
+  if (opts.trigger === "auto" && analysisConversation.processing) {
+    log.info(
+      {
+        sourceConversationId: resolvedId,
+        analysisConversationId,
+      },
+      "Skipping auto-analysis run: rolling conversation already processing",
+    );
+    return { analysisConversationId, skipped: true };
+  }
+
+  // i. Persist the user message (with provenance snapshot matching the
   // trust context we will run under).
   const message = await addMessage(
     analysisConversationId,
@@ -205,18 +252,6 @@ export async function analyzeConversation(
   );
   const messageId = message.id;
 
-  // i. Load the conversation into memory with the appropriate trust
-  // context. Manual analysis runs untrusted over attacker-influenced
-  // transcript content; auto analysis runs as guardian so it can act on
-  // what it learns.
-  const analysisConversation =
-    await deps.sendMessageDeps.getOrCreateConversation(
-      analysisConversationId,
-      {
-        ...(modelIntent !== undefined ? { modelIntent } : {}),
-        ...(modelOverride !== undefined ? { modelOverride } : {}),
-      },
-    );
   analysisConversation.setTrustContext({
     trustClass,
     sourceChannel: "vellum",


### PR DESCRIPTION
## Summary
Fixes three gaps from plan review for auto-analyze-loop.md, all clustered in the auto branch of `analyzeConversation()`:
- **Concurrent loops:** Skip the run when the rolling analysis conversation is already `processing` — prevents two agent loops from mutating the same Conversation state.
- **Single source of truth:** Drop the local `AUTO_ANALYSIS_SOURCE` declaration in favor of the canonical export from `auto-analysis-guard.ts`. Same for the hardcoded literal in `conversation-crud.ts`.
- **Group ID:** New auto-analysis conversations are created in a dedicated `system:reflections` group so non-macOS clients (CLI, gateway, web) don't see them in the main `system:all` list.