### PR TITLE
fix(macos): Reflections a11y, collapsed switcher, and dock badge

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
@@ -4,8 +4,12 @@ struct CollapsedConversationSwitcherPresentation {
     let switchTargets: [ConversationModel]
     let activeConversationTitle: String?
     let totalRegularConversationCount: Int
+    let hasReflectionConversations: Bool
 
-    var showsSwitcher: Bool { totalRegularConversationCount > 0 }
+    /// Switcher stays visible when there's at least one regular conversation OR
+    /// at least one reflection conversation — the drawer it opens still surfaces
+    /// the Reflections section, so hiding the entry point would orphan it.
+    var showsSwitcher: Bool { totalRegularConversationCount > 0 || hasReflectionConversations }
 
     var badgeText: String {
         if totalRegularConversationCount > 99 { return "99+" }
@@ -23,8 +27,9 @@ struct CollapsedConversationSwitcherPresentation {
         totalRegularConversationCount == 0 ? "" : "\(totalRegularConversationCount) conversations"
     }
 
-    init(regularConversations: [ConversationModel], activeConversationId: UUID?) {
+    init(regularConversations: [ConversationModel], activeConversationId: UUID?, hasReflectionConversations: Bool = false) {
         self.totalRegularConversationCount = regularConversations.count
+        self.hasReflectionConversations = hasReflectionConversations
         if let activeId = activeConversationId {
             self.switchTargets = regularConversations.filter { $0.id != activeId }
             self.activeConversationTitle = regularConversations.first(where: { $0.id == activeId })?.title

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -98,12 +98,14 @@ struct ConversationModel: Identifiable, Hashable {
         source == "auto-analysis"
     }
 
-    /// Whether this conversation is automated (heartbeat, schedule, background/task)
-    /// and should never show unread indicators. Per Apple HIG, badges and unread
-    /// indicators should only reflect content requiring user attention — system-generated
-    /// messages from automated threads do not qualify.
+    /// Whether this conversation is automated (heartbeat, schedule, background/task,
+    /// auto-analysis) and should never show unread indicators. Per Apple HIG, badges
+    /// and unread indicators should only reflect content requiring user attention —
+    /// system-generated messages from automated threads do not qualify. Reflections
+    /// (auto-analysis) are a passive surface users browse on their own; they should
+    /// not drive the dock badge or the Conversations header unread dot.
     var shouldSuppressUnreadIndicator: Bool {
-        isScheduleConversation || shouldReturnToBackgroundOnUnpin
+        isScheduleConversation || shouldReturnToBackgroundOnUnpin || isAutoAnalysisConversation
     }
 
     var isChannelConversation: Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -608,7 +608,8 @@ extension MainWindowView {
             // MARK: Conversation Section (collapsed)
             let switcher = CollapsedConversationSwitcherPresentation(
                 regularConversations: regularConversations,
-                activeConversationId: conversationManager.activeConversationId
+                activeConversationId: conversationManager.activeConversationId,
+                hasReflectionConversations: !reflectionsPresentation.reflections.isEmpty
             )
             if switcher.showsSwitcher {
                 Button {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarReflectionsSection.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarReflectionsSection.swift
@@ -123,5 +123,8 @@ struct SidebarReflectionsSection: View {
         .accessibilityHint(Text(isExpanded ? "Collapse reflections section" : "Expand reflections section"))
         .accessibilityAddTraits(.isHeader)
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction(.default) {
+            withAnimation(VAnimation.fast) { onToggleExpand() }
+        }
     }
 }


### PR DESCRIPTION
Address Codex P1/P2 and Devin feedback on #25664. (1) Add .accessibilityAction(.default) to Reflections header per clients/AGENTS.md rule and SidebarSectionView pattern (label/hint were already present). (2) Keep collapsed sidebar switcher visible when only reflections exist — threaded hasReflectionConversations through CollapsedConversationSwitcherPresentation.showsSwitcher so the entry point survives an all-reflections state. (3) Suppress auto-analysis conversations from dock badge / Conversations header unread indicator via shouldSuppressUnreadIndicator — reflections are a passive surface and shouldn't nag; the Reflections section header retains its own unread dot via a direct check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
