### PR TITLE
fix(daemon): skip lifecycle auto-analyze enqueue for private chats

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -13,7 +13,7 @@
  *
  * Two recursion guards apply when the source conversation is itself an
  * auto-analysis conversation:
- *   1. `enqueueAutoAnalysisIfEnabled` short-circuits internally (PR 12),
+ *   1. `enqueueAutoAnalysisIfEnabled` short-circuits internally,
  *      preventing the analyzer from analyzing its own output.
  *   2. `disposeConversation` skips `graph_extract` directly via
  *      `isAutoAnalysisConversation()`, mirroring the guard the indexer

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -13,6 +13,7 @@ mock.module("../../util/logger.js", () => ({
 
 let flagEnabled = true;
 let isAuto = false;
+let conversationType: "standard" | "private" = "standard";
 let configValue: { analysis?: { idleTimeoutMs?: number } } = {
   analysis: { idleTimeoutMs: 600_000 },
 };
@@ -46,6 +47,10 @@ mock.module("../auto-analysis-guard.js", () => ({
   isAutoAnalysisConversation: (_conversationId: string) => isAuto,
 }));
 
+mock.module("../conversation-crud.js", () => ({
+  getConversationType: (_conversationId: string) => conversationType,
+}));
+
 mock.module("../jobs-store.js", () => ({
   enqueueMemoryJob: (
     type: string,
@@ -70,6 +75,7 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
   beforeEach(() => {
     flagEnabled = true;
     isAuto = false;
+    conversationType = "standard";
     getConfigThrows = false;
     configValue = { analysis: { idleTimeoutMs: 600_000 } };
     enqueueCalls.length = 0;
@@ -149,6 +155,23 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
 
   test("flag on, source is auto-analysis — no job is enqueued", () => {
     isAuto = true;
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("flag on, source is private — no job is enqueued for any trigger", () => {
+    // `analyzeConversation` rejects private conversations with FORBIDDEN, so
+    // enqueueing a job for one is guaranteed to fail. Skip silently instead
+    // so we don't create queue/log churn on every private-chat eviction.
+    conversationType = "private";
 
     enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
     enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -2,6 +2,7 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
+import { getConversationType } from "./conversation-crud.js";
 import { upsertDebouncedJob } from "./jobs-store.js";
 
 const log = getLogger("auto-analysis-enqueue");
@@ -23,7 +24,9 @@ export type AutoAnalysisTrigger = "batch" | "idle" | "lifecycle";
  * conversation. Skips silently when:
  *   - the `auto-analyze` feature flag is disabled, OR
  *   - the source conversation is itself an auto-analysis conversation
- *     (recursion guard — we never analyze our own analysis output).
+ *     (recursion guard — we never analyze our own analysis output), OR
+ *   - the source conversation is private (`analyzeConversation` rejects
+ *     private conversations, so enqueueing would guarantee a failed job).
  *
  * All triggers route through `upsertDebouncedJob()` so a pending job for
  * the same conversation coalesces additional enqueue attempts into a
@@ -56,6 +59,14 @@ export function enqueueAutoAnalysisIfEnabled(args: {
     log.debug(
       { conversationId, trigger },
       "Skipping auto-analysis enqueue: source is an auto-analysis conversation",
+    );
+    return;
+  }
+
+  if (getConversationType(conversationId) === "private") {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping auto-analysis enqueue: source is a private conversation",
     );
     return;
   }


### PR DESCRIPTION
Address Codex P2 + Devin review on #25668. (1) Skip the lifecycle auto-analysis enqueue for private conversations — analyzeConversation rejects them anyway, so enqueueing creates guaranteed failures and log churn on every private-chat eviction. (2) Drop (PR 12) historical reference from test comment per assistant/AGENTS.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
