### PR TITLE
fix(memory): apply immediate-batch fix to graph_extract enqueues

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -499,4 +499,40 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
     expect(row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
     expect(row.runAfter).toBeLessThanOrEqual(after + 1_000);
   });
+
+  test("crossing extraction.batchSize → graph_extract pending row has immediate runAfter", async () => {
+    const source = createConversation("cadence-source-graph");
+
+    // extraction.batchSize = 2 → second message trips the batch
+    // trigger. Before the fix, the idle upsert that runs on the same
+    // tick would overwrite the batch job's runAfter with
+    // (now + idleTimeoutMs), silently debouncing it. Assert the single
+    // coalesced pending row ends up at ~now.
+    await indexMessages(source.id, 1);
+    const before = Date.now();
+    await indexMessages(source.id, 1, 1);
+    const after = Date.now();
+
+    const db = getDb();
+    const graphRows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_extract"))
+      .all()
+      .filter((row) => {
+        try {
+          const payload = JSON.parse(row.payload) as {
+            conversationId?: string;
+          };
+          return payload.conversationId === source.id;
+        } catch {
+          return false;
+        }
+      });
+
+    expect(graphRows.length).toBe(1);
+    const row = graphRows[0]!;
+    expect(row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
+    expect(row.runAfter).toBeLessThanOrEqual(after + 1_000);
+  });
 });

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -181,18 +181,24 @@ export async function indexMessageNow(
         (graphCurrentVal ? parseInt(graphCurrentVal, 10) : 0) + 1;
       setMemoryCheckpoint(graphPendingKey, String(graphPendingCount));
 
-      if (graphPendingCount >= batchSize) {
-        enqueueMemoryJob("graph_extract", {
-          conversationId: input.conversationId,
-          scopeId: input.scopeId ?? "default",
-        });
+      const graphBatchFired = graphPendingCount >= batchSize;
+      if (graphBatchFired) {
         setMemoryCheckpoint(graphPendingKey, "0");
       }
 
+      // Single pending `graph_extract` row per conversation. If the
+      // batch threshold just fired, pull `runAfter` back to now so the
+      // job runs immediately; otherwise debounce by the idle timeout.
+      // Using `upsertDebouncedJob` in both paths avoids the previous
+      // bug where the idle call would overwrite a just-enqueued batch
+      // job's `runAfter` and silently debounce it.
       upsertDebouncedJob(
         "graph_extract",
-        { conversationId: input.conversationId },
-        Date.now() + idleTimeoutMs,
+        {
+          conversationId: input.conversationId,
+          scopeId: input.scopeId ?? "default",
+        },
+        graphBatchFired ? Date.now() : Date.now() + idleTimeoutMs,
       );
 
       // ── Auto-analysis triggers ─────────────────────────────────────

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -98,7 +98,7 @@ export function enqueueMemoryJob(
  */
 export function upsertDebouncedJob(
   type: MemoryJobType,
-  payload: { conversationId: string },
+  payload: { conversationId: string } & Record<string, unknown>,
   runAfter: number,
   dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
     tx: infer T,


### PR DESCRIPTION
Follow-up to #25669. Feedback items 1 and 2 (Codex P2 + Devin BUG / ANALYSIS on \`conversation_analyze\`) were already addressed in #25679. This PR addresses the remaining Devin ANALYSIS comment on #25669: \`graph_extract\` had the same batch-then-debounce overwrite pattern that #25679 fixed for \`conversation_analyze\`.

## Summary
- Route the \`graph_extract\` batch trigger through \`upsertDebouncedJob\` with \`runAfter = now\` instead of calling \`enqueueMemoryJob\` followed by a debounced upsert that overwrote \`runAfter\` with \`now + idleTimeoutMs\`. Now a single pending row per conversation either runs immediately (batch crossed) or is debounced (idle only).
- Broaden \`upsertDebouncedJob\`'s payload type to \`{ conversationId: string } & Record<string, unknown>\` so \`scopeId\` can ride along in the payload (matches the prior \`enqueueMemoryJob\` shape).
- Regression test in \`auto-analysis-end-to-end.test.ts\` asserts the coalesced \`graph_extract\` pending row's \`runAfter\` is ~now after the batch threshold is crossed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
