### PR TITLE
fix(runtime): reload reused analysis conversation messages + drop stale JSDoc

### DIFF
--- a/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
@@ -103,6 +103,7 @@ function makeConversation() {
     processing: false,
     abortController: null as AbortController | null,
     currentRequestId: null as string | null,
+    loadedHistoryTrustClass: undefined as string | undefined,
     runAgentLoop: mock(() => Promise.resolve()),
   };
 }
@@ -329,6 +330,34 @@ describe("analyzeConversation", () => {
       expect.any(String),
       { provenanceTrustClass: "guardian" },
     );
+  });
+
+  test("auto: invalidates loadedHistoryTrustClass before ensureActorScopedHistory on reuse so stale ctx.messages is reloaded", async () => {
+    // Simulate a reused rolling conversation whose prior run already cached
+    // a guardian-class history load. Without explicit invalidation,
+    // ensureActorScopedHistory would short-circuit and runAgentLoopImpl
+    // would execute against ctx.messages missing the newly-enqueued prompt.
+    mockFindAnalysisConversationFor.mockImplementation(() => ({
+      id: "analysis-existing",
+    }));
+    const conversation = makeConversation();
+    conversation.loadedHistoryTrustClass = "guardian";
+    let trustClassWhenEnsured: string | undefined = "sentinel";
+    conversation.ensureActorScopedHistory.mockImplementation(() => {
+      trustClassWhenEnsured = conversation.loadedHistoryTrustClass;
+      return Promise.resolve();
+    });
+    const deps = makeDeps(conversation);
+
+    const result = await analyzeConversation("conv-1", deps, {
+      trigger: "auto",
+    });
+
+    expect("error" in result).toBe(false);
+    // The invalidation must land before ensureActorScopedHistory runs so
+    // the reload inside it pulls the freshly-persisted user prompt.
+    expect(trustClassWhenEnsured).toBeUndefined();
+    expect(conversation.ensureActorScopedHistory).toHaveBeenCalledTimes(1);
   });
 
   test("auto: sets trustClass to guardian", async () => {

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -256,6 +256,15 @@ export async function analyzeConversation(
     trustClass,
     sourceChannel: "vellum",
   });
+  // Force a reload so the just-persisted user prompt lands in
+  // `ctx.messages`. On a freshly created conversation this is a no-op
+  // beyond the reload `ensureActorScopedHistory` would already perform
+  // (trustClass transitioned from undefined). On a reused rolling
+  // analysis conversation the cached `loadedHistoryTrustClass` already
+  // matches `trustClass`, so without this invalidation the ensure call
+  // short-circuits and `runAgentLoopImpl` would run on stale in-memory
+  // history missing the newly-enqueued prompt.
+  analysisConversation.loadedHistoryTrustClass = undefined;
   await analysisConversation.ensureActorScopedHistory();
   if (stripTools) {
     // Manual analysis runs over attacker-influenced transcript content, so

--- a/assistant/src/runtime/services/auto-analysis-prompt.ts
+++ b/assistant/src/runtime/services/auto-analysis-prompt.ts
@@ -5,9 +5,6 @@
  * conversation reaches a natural pause. The prompt treats the transcript as
  * observed data (not instructions) to defend against prompt injection from
  * arbitrary transcript content.
- *
- * No callers yet — will be wired in by a later PR of the auto-analyze-loop
- * plan from the auto-mode branch of the analyze service.
  */
 
 /**


### PR DESCRIPTION
Address Codex P1 + Devin review on #25665. (1) When findAnalysisConversationFor returns an existing row, reload ctx.messages from the DB before invoking runAgentLoopImpl so the newly-enqueued analysis prompt is actually consumed (previously the loop ran on stale in-memory history, ignoring the prompt after the first reuse). (2) Drop the 'No callers yet' JSDoc stanza from auto-analysis-prompt.ts — the helper is now wired into analyzeConversation's auto-trigger branch, per assistant/AGENTS.md comment rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
