### PR TITLE
fix(tests): unbreak attachment-routes.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -39,7 +39,6 @@ EXPERIMENTAL_FILES=(
 # To triage an entry: run `bun test <path>` from `assistant/` and fix the
 # underlying code or tests until the file is green, then remove it here.
 KNOWN_BROKEN_FILES=(
-  "attachment-routes.test.ts"
   "backup-routes.test.ts"
   "byo-connection.test.ts"
   "callback-routes-list.test.ts"

--- a/assistant/src/runtime/routes/attachment-routes.test.ts
+++ b/assistant/src/runtime/routes/attachment-routes.test.ts
@@ -1,6 +1,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -9,10 +10,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 
-const testWorkspaceDir = mkdtempSync(
-  join(tmpdir(), "attachment-routes-workspace-"),
+// realpathSync resolves the macOS /var → /private/var symlink so the paths
+// match what resolveAllowedFileBackedAttachmentPath returns (it canonicalizes
+// via realpathSync internally).
+const testWorkspaceDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "attachment-routes-workspace-")),
 );
-const testHomeDir = mkdtempSync(join(tmpdir(), "attachment-routes-home-"));
+const testHomeDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "attachment-routes-home-")),
+);
 
 const attachmentsDir = join(testWorkspaceDir, "data", "attachments");
 const conversationsDir = join(testWorkspaceDir, "conversations");


### PR DESCRIPTION
## Summary
- The test was failing on macOS because temp dirs created under `/var/folders/...` get canonicalized to `/private/var/folders/...` by `realpathSync`, which `resolveAllowedFileBackedAttachmentPath` calls internally. Test expectations used the un-canonicalized path.
- Fix: call `realpathSync` on the `mkdtempSync` results so the test's expected paths match what the production code returns.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
