### PR TITLE
fix(tests): unbreak platform client.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -43,7 +43,6 @@ KNOWN_BROKEN_FILES=(
   "backup-routes.test.ts"
   "byo-connection.test.ts"
   "callback-routes-list.test.ts"
-  "client.test.ts"
   "connect.test.ts"
   "contact-routes.test.ts"
   "conversation-tool-setup.test.ts"

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -23,6 +23,16 @@ mock.module("../config/env.js", () => ({
   getPlatformAssistantId: () => mockAssistantId,
 }));
 
+// Stub the credential-store fallback so tests stay hermetic and do not
+// read real values from the host credential backend.
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => null,
+}));
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (namespace: string, key: string) => `${namespace}:${key}`,
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Mock the credential-store fallback (`getSecureKeyAsync` / `credentialKey`) in `src/platform/client.test.ts` so the `create()` tests stay hermetic. Without the stub the source fallback was reading real host credentials, causing `managed proxy disabled` and `missing assistant ID` assertions to fail.
- Remove `client.test.ts` from `KNOWN_BROKEN_FILES` in `scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
