### PR TITLE
feat(memory): fire auto-analysis on context compaction

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -39,6 +39,7 @@ import {
 } from "../instrument.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
+import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import {
   addMessage,
   deleteMessageById,
@@ -551,6 +552,13 @@ export async function runAgentLoopImpl(
         compacted.summaryText,
         ctx.contextCompactedMessageCount,
       );
+      // Fire auto-analysis on compaction so the reflective agent can
+      // crystallize anything worth remembering before the context window
+      // narrows further.
+      enqueueAutoAnalysisOnCompaction(
+        ctx.conversationId,
+        ctx.trustContext?.trustClass,
+      );
       onEvent({
         type: "context_compacted",
         previousEstimatedInputTokens: compacted.previousEstimatedInputTokens,
@@ -939,6 +947,11 @@ export async function runAgentLoopImpl(
             step.compactionResult.summaryText,
             ctx.contextCompactedMessageCount,
           );
+          // Fire auto-analysis on compaction — see forceCompact() for rationale.
+          enqueueAutoAnalysisOnCompaction(
+            ctx.conversationId,
+            ctx.trustContext?.trustClass,
+          );
           onEvent({
             type: "context_compacted",
             previousEstimatedInputTokens:
@@ -1142,6 +1155,11 @@ export async function runAgentLoopImpl(
           ctx.conversationId,
           midLoopCompact.summaryText,
           ctx.contextCompactedMessageCount,
+        );
+        // Fire auto-analysis on compaction — see forceCompact() for rationale.
+        enqueueAutoAnalysisOnCompaction(
+          ctx.conversationId,
+          ctx.trustContext?.trustClass,
         );
         onEvent({
           type: "context_compacted",
@@ -1361,6 +1379,11 @@ export async function runAgentLoopImpl(
             step.compactionResult.summaryText,
             ctx.contextCompactedMessageCount,
           );
+          // Fire auto-analysis on compaction — see forceCompact() for rationale.
+          enqueueAutoAnalysisOnCompaction(
+            ctx.conversationId,
+            ctx.trustContext?.trustClass,
+          );
           onEvent({
             type: "context_compacted",
             previousEstimatedInputTokens:
@@ -1485,6 +1508,11 @@ export async function runAgentLoopImpl(
                 emergencyCompact.summaryText,
                 ctx.contextCompactedMessageCount,
               );
+              // Fire auto-analysis on compaction — see forceCompact() for rationale.
+              enqueueAutoAnalysisOnCompaction(
+                ctx.conversationId,
+                ctx.trustContext?.trustClass,
+              );
               onEvent({
                 type: "context_compacted",
                 previousEstimatedInputTokens:
@@ -1604,6 +1632,11 @@ export async function runAgentLoopImpl(
               ctx.conversationId,
               emergencyCompact.summaryText,
               ctx.contextCompactedMessageCount,
+            );
+            // Fire auto-analysis on compaction — see forceCompact() for rationale.
+            enqueueAutoAnalysisOnCompaction(
+              ctx.conversationId,
+              ctx.trustContext?.trustClass,
             );
             onEvent({
               type: "context_compacted",

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -44,6 +44,7 @@ import {
 } from "../events/tool-profiling-listener.js";
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
+import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import {
   updateConversationContextWindow,
@@ -1179,6 +1180,13 @@ export class Conversation {
         this.conversationId,
         result.summaryText,
         this.contextCompactedMessageCount,
+      );
+      // Fire auto-analysis on compaction so the reflective agent can
+      // crystallize anything worth remembering before the context window
+      // narrows further.
+      enqueueAutoAnalysisOnCompaction(
+        this.conversationId,
+        this.trustContext?.trustClass,
       );
     }
     return result;

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -69,7 +69,15 @@ mock.module("../jobs-store.js", () => ({
   },
 }));
 
-import { enqueueAutoAnalysisIfEnabled } from "../auto-analysis-enqueue.js";
+mock.module("../../runtime/actor-trust-resolver.js", () => ({
+  isUntrustedTrustClass: (trustClass: string | undefined) =>
+    trustClass === "unknown" || trustClass === "untrusted",
+}));
+
+import {
+  enqueueAutoAnalysisIfEnabled,
+  enqueueAutoAnalysisOnCompaction,
+} from "../auto-analysis-enqueue.js";
 
 describe("enqueueAutoAnalysisIfEnabled", () => {
   beforeEach(() => {
@@ -225,5 +233,90 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before + 1_000);
     expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after + 1_000);
+  });
+
+  test("flag on, trigger = 'compaction', normal source — fires immediately like 'batch'", () => {
+    const before = Date.now();
+
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "compaction",
+    });
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
+    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    // "compaction" fires immediately (runAfter ≈ now) so the reflective
+    // agent runs before the narrowed context window pushes more detail out.
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+});
+
+describe("enqueueAutoAnalysisOnCompaction", () => {
+  beforeEach(() => {
+    flagEnabled = true;
+    isAuto = false;
+    conversationType = "standard";
+    getConfigThrows = false;
+    configValue = { analysis: { idleTimeoutMs: 600_000 } };
+    enqueueCalls.length = 0;
+    debouncedCalls.length = 0;
+  });
+
+  test("guardian trust class — enqueues compaction-triggered job immediately", () => {
+    const before = Date.now();
+
+    enqueueAutoAnalysisOnCompaction("c1", "guardian");
+
+    const after = Date.now();
+
+    expect(debouncedCalls).toHaveLength(1);
+    expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
+    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
+    expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
+  });
+
+  test("undefined trust class (treated as guardian for internal call paths) — enqueues", () => {
+    enqueueAutoAnalysisOnCompaction("c1", undefined);
+
+    expect(debouncedCalls).toHaveLength(1);
+  });
+
+  test("unknown trust class — skips (mirrors memory-extraction trust boundary)", () => {
+    enqueueAutoAnalysisOnCompaction("c1", "unknown");
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("trusted_contact trust class — enqueues (not untrusted)", () => {
+    // trusted_contact is not in the untrusted set per
+    // isUntrustedTrustClass, so compaction-triggered analysis still fires.
+    enqueueAutoAnalysisOnCompaction("c1", "trusted_contact");
+
+    expect(debouncedCalls).toHaveLength(1);
+  });
+
+  test("guardian trust but flag off — helper still gates via enqueueAutoAnalysisIfEnabled", () => {
+    flagEnabled = false;
+
+    enqueueAutoAnalysisOnCompaction("c1", "guardian");
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("guardian trust but source is auto-analysis — helper skips via recursion guard", () => {
+    isAuto = true;
+
+    enqueueAutoAnalysisOnCompaction("c1", "guardian");
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -1,5 +1,9 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import {
+  isUntrustedTrustClass,
+  type TrustClass,
+} from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
 import { getConversationType } from "./conversation-crud.js";
@@ -16,8 +20,16 @@ const log = getLogger("auto-analysis-enqueue");
  *     debounced analysis pass.
  *   - `"lifecycle"`: a conversation lifecycle transition (e.g. resume,
  *     close) should trigger a debounced analysis pass.
+ *   - `"compaction"`: context was just compacted — some recent turns are
+ *     now hidden behind a summary, so crystallize anything worth
+ *     remembering before the window narrows further. Fires immediately
+ *     (`runAfter = now`) like `"batch"`.
  */
-export type AutoAnalysisTrigger = "batch" | "idle" | "lifecycle";
+export type AutoAnalysisTrigger =
+  | "batch"
+  | "idle"
+  | "lifecycle"
+  | "compaction";
 
 /**
  * Conditionally enqueue a `conversation_analyze` job for the given
@@ -72,8 +84,8 @@ export function enqueueAutoAnalysisIfEnabled(args: {
   }
 
   const idleTimeoutMs = config.analysis?.idleTimeoutMs ?? 600_000;
-  const runAfter =
-    trigger === "batch" ? Date.now() : Date.now() + idleTimeoutMs;
+  const runImmediately = trigger === "batch" || trigger === "compaction";
+  const runAfter = runImmediately ? Date.now() : Date.now() + idleTimeoutMs;
 
   try {
     upsertDebouncedJob(
@@ -86,5 +98,30 @@ export function enqueueAutoAnalysisIfEnabled(args: {
       { err, conversationId, trigger },
       "Failed to enqueue auto-analysis job",
     );
+  }
+}
+
+/**
+ * Fire an auto-analysis enqueue from a compaction site. Wraps
+ * `enqueueAutoAnalysisIfEnabled` with the trust-class gate and
+ * best-effort error handling used at every compaction call site, so
+ * the six compaction paths (forceCompact, preflight, overflow reducer,
+ * mid-loop, and two emergency paths) stay in sync.
+ *
+ * Trust gate mirrors the memory-extraction trust boundary applied in
+ * `disposeConversation` — we don't trigger analysis (which runs with
+ * guardian trust + full tools) for conversations with an untrusted actor.
+ */
+export function enqueueAutoAnalysisOnCompaction(
+  conversationId: string,
+  trustClass: TrustClass | undefined,
+): void {
+  if (isUntrustedTrustClass(trustClass)) {
+    return;
+  }
+  try {
+    enqueueAutoAnalysisIfEnabled({ conversationId, trigger: "compaction" });
+  } catch {
+    // Best-effort — never block compaction on enqueue failures.
   }
 }


### PR DESCRIPTION
## Summary
- Add `"compaction"` trigger to `AutoAnalysisTrigger` — fires immediately (like `"batch"`) via `upsertDebouncedJob` so rapid compactions coalesce.
- New `enqueueAutoAnalysisOnCompaction(conversationId, trustClass)` helper in `auto-analysis-enqueue.ts` wraps the trust-class gate + best-effort error handling used at every compaction site.
- Hook into all six compaction paths: `Conversation.forceCompact`, preflight compaction, overflow-reducer compaction (×2 identical call sites), mid-loop compaction, and two emergency-compact sites. Fires after `updateConversationContextWindow` and before the `context_compacted` event.
- Closes the last gap from the earlier auto-analyze-loop review: long sessions that never dispose but compact repeatedly now get reflected on every time the window narrows.

## Original prompt
this should also fire during compaction