### PR TITLE
fix(tests): unbreak callback-routes-list.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -41,7 +41,6 @@ EXPERIMENTAL_FILES=(
 KNOWN_BROKEN_FILES=(
   "backup-routes.test.ts"
   "byo-connection.test.ts"
-  "callback-routes-list.test.ts"
   "connect.test.ts"
   "contact-routes.test.ts"
   "conversation-tool-setup.test.ts"

--- a/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
@@ -39,7 +39,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
   }),
 }));
 
+const realLogger = await import("../../../../util/logger.js");
 mock.module("../../../../util/logger.js", () => ({
+  ...realLogger,
   getLogger: () => ({
     info: () => {},
     warn: () => {},
@@ -53,13 +55,12 @@ mock.module("../../../../util/logger.js", () => ({
     debug: () => {},
   }),
   initLogger: () => {},
-  truncateForLog: (value: string, maxLen = 500) =>
-    value.length > maxLen ? value.slice(0, maxLen) + "..." : value,
   pruneOldLogFiles: () => 0,
 }));
 
+const realConfigLoader = await import("../../../../config/loader.js");
 mock.module("../../../../config/loader.js", () => ({
-  API_KEY_PROVIDERS: [] as const,
+  ...realConfigLoader,
   getConfig: () => ({
     permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
@@ -70,12 +71,6 @@ mock.module("../../../../config/loader.js", () => ({
   saveConfig: () => {},
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
-  getNestedValue: () => undefined,
-  setNestedValue: () => {},
-  applyNestedDefaults: (config: unknown) => config,
-  deepMergeMissing: () => false,
-  deepMergeOverwrite: () => {},
-  mergeDefaultWorkspaceConfig: () => {},
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Test mocked `util/logger.js` and `config/loader.js` but omitted newly-added exports (`LOG_FILE_PATTERN`, `getConfigReadOnly`) used transitively by the CLI program, causing `SyntaxError: Export named ... not found`.
- Fix spreads the real module exports into the mocks, so future export additions don't re-break this test. Removed entry from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
