### PR TITLE
fix(tests): unbreak contact-routes.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -45,7 +45,6 @@ KNOWN_BROKEN_FILES=(
   "callback-routes-list.test.ts"
   "client.test.ts"
   "connect.test.ts"
-  "contact-routes.test.ts"
   "conversation-tool-setup.test.ts"
   "credentials-cli.test.ts"
   "disconnect.test.ts"

--- a/assistant/src/runtime/routes/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/contact-routes.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for POST /v1/contacts/guardian/channel endpoint.
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -23,7 +23,7 @@ mock.module("../../config/env.js", () => ({
 
 import { and, eq } from "drizzle-orm";
 
-import { getDb } from "../../memory/db.js";
+import { getDb, initializeDb } from "../../memory/db.js";
 import { contactChannels, contacts } from "../../memory/schema.js";
 import type { AuthContext } from "../auth/types.js";
 import { handleAddGuardianChannel } from "./contact-routes.js";
@@ -110,6 +110,10 @@ function seedGuardian(
 // ---------------------------------------------------------------------------
 
 describe("POST /v1/contacts/guardian/channel", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
   beforeEach(() => {
     const db = getDb();
     db.delete(contactChannels).run();


### PR DESCRIPTION
## Summary
- Added `initializeDb()` call in `beforeAll` hook so SQLite tables are created before the suite's `beforeEach` DELETE runs.
- Removed `contact-routes.test.ts` from `KNOWN_BROKEN_FILES` in `scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
