### PR TITLE
fix(tests): unbreak byo-connection.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -40,7 +40,6 @@ EXPERIMENTAL_FILES=(
 # underlying code or tests until the file is green, then remove it here.
 KNOWN_BROKEN_FILES=(
   "backup-routes.test.ts"
-  "byo-connection.test.ts"
   "connect.test.ts"
   "conversation-tool-setup.test.ts"
   "credentials-cli.test.ts"

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -77,6 +77,7 @@ const mockConnections = new Map<
     expiresAt: number | null;
     grantedScopes?: string;
     accountInfo?: string | null;
+    status?: string;
   }
 >();
 const mockApps = new Map<
@@ -92,15 +93,26 @@ const mockProviders = new Map<
   string,
   {
     key: string;
+    provider: string;
     tokenExchangeUrl: string;
     tokenEndpointAuthMethod?: string;
     tokenExchangeBodyFormat?: string;
     baseUrl?: string;
+    managedServiceConfigKey?: string | null;
   }
 >();
 
 mock.module("./oauth-store.js", () => ({
   getConnectionByProvider: (service: string) => mockConnections.get(service),
+  getActiveConnection: (
+    service: string,
+    opts?: { clientId?: string; account?: string },
+  ) => {
+    const conn = mockConnections.get(service);
+    if (!conn) return undefined;
+    if (opts?.account && conn.accountInfo !== opts.account) return undefined;
+    return conn;
+  },
   getConnection: (id: string) => {
     for (const conn of mockConnections.values()) {
       if (conn.id === id) return conn;
@@ -193,6 +205,7 @@ async function setupCredential(
   const connId = `conn-${service}`;
   mockProviders.set(service, {
     key: service,
+    provider: service,
     tokenExchangeUrl: "https://oauth2.googleapis.com/token",
     tokenExchangeBodyFormat: "form",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
@@ -200,6 +213,7 @@ async function setupCredential(
       service === "google"
         ? "https://gmail.googleapis.com/gmail/v1/users/me"
         : undefined,
+    managedServiceConfigKey: null,
   });
   mockApps.set(appId, {
     id: appId,
@@ -214,6 +228,7 @@ async function setupCredential(
     expiresAt: opts?.expiresAt ?? Date.now() + 3600 * 1000,
     grantedScopes: JSON.stringify(opts?.grantedScopes ?? ["read", "write"]),
     accountInfo: null,
+    status: "active",
   });
   // Store access token in oauth-store key format
   await setSecureKeyAsync(
@@ -511,7 +526,7 @@ describe("resolveOAuthConnection", () => {
   test("throws when no base URL configured", async () => {
     await setupCredential("custom-service");
     await expect(resolveOAuthConnection("custom-service")).rejects.toThrow(
-      /No base URL configured for "custom-service"/,
+      /OAuth provider "custom-service" has no base URL configured/,
     );
   });
 });


### PR DESCRIPTION
## Summary
- Update mock of `./oauth-store.js` to include `getActiveConnection` (the current API used by `connection-resolver.ts`), set `status: "active"` on seeded connections, and add `managedServiceConfigKey: null` to provider rows so the BYO code path runs.
- Fix the "no base URL configured" regex to match the resolver's current wording (`OAuth provider "X" has no base URL configured`).

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
