### PR TITLE
fix(tests): unbreak host-shell-tool.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -56,7 +56,6 @@ KNOWN_BROKEN_FILES=(
   "email-unregister.test.ts"
   "feature-flag-registry-bundled.test.ts"
   "guard-tests.test.ts"
-  "host-shell-tool.test.ts"
   "memory-item-routes.test.ts"
   "provider-adapters.test.ts"
   "providers-delete.test.ts"


### PR DESCRIPTION
## Summary
- `src/__tests__/host-shell-tool.test.ts` already passes (43 pass, 0 fail) — the `KNOWN_BROKEN_FILES` entry was stale.
- Remove the stale entry from `assistant/scripts/test.sh` so the file runs in CI.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
