### PR TITLE
fix(tests): unbreak provider-adapters.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -52,7 +52,6 @@ KNOWN_BROKEN_FILES=(
   "feature-flag-registry-bundled.test.ts"
   "guard-tests.test.ts"
   "memory-item-routes.test.ts"
-  "provider-adapters.test.ts"
   "qdrant-manager.test.ts"
   "skill-feature-flags-integration.test.ts"
   "status.test.ts"

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -172,10 +172,10 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(provider.id).toBe("elevenlabs");
   });
 
-  test("advertises mp3 format support without streaming", () => {
+  test("advertises mp3 and pcm format support without streaming", () => {
     const provider = createElevenLabsProvider();
     expect(provider.capabilities.supportsStreaming).toBe(false);
-    expect(provider.capabilities.supportedFormats).toEqual(["mp3"]);
+    expect(provider.capabilities.supportedFormats).toEqual(["mp3", "pcm"]);
   });
 
   // -- Request mapping -----------------------------------------------------


### PR DESCRIPTION
## Summary
- ElevenLabs provider gained PCM format support; test still expected `["mp3"]` only. Updated assertion to match the source (`["mp3", "pcm"]`).
- Removed `provider-adapters.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
