### PR TITLE
fix(tests): unbreak shell-tool-proxy-mode.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -58,7 +58,6 @@ KNOWN_BROKEN_FILES=(
   "provider-adapters.test.ts"
   "providers-delete.test.ts"
   "qdrant-manager.test.ts"
-  "shell-tool-proxy-mode.test.ts"
   "skill-feature-flags-integration.test.ts"
   "status.test.ts"
   "terminal-tools.test.ts"


### PR DESCRIPTION
## Summary
- Test file already passes as-is (9/9 tests green); removing stale KNOWN_BROKEN_FILES entry so it runs in CI again.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
