### PR TITLE
fix(tests): unbreak disconnect.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -48,7 +48,6 @@ KNOWN_BROKEN_FILES=(
   "contact-routes.test.ts"
   "conversation-tool-setup.test.ts"
   "credentials-cli.test.ts"
-  "disconnect.test.ts"
   "email-attachment.test.ts"
   "email-download.test.ts"
   "email-list.test.ts"

--- a/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
@@ -30,7 +30,7 @@ mock.module("../../../../config/env-registry.js", () => ({
   getIsContainerized: () => false,
   isPlatformRemote: () => mockIsPlatformRemote,
   getDebugStdoutLogs: () => false,
-  getWorkspaceDirOverride: () => undefined,
+  getWorkspaceDirOverride: () => process.env.VELLUM_WORKSPACE_DIR,
   checkUnrecognizedEnvVars: () => [],
 }));
 
@@ -81,11 +81,17 @@ mock.module("../../../../util/logger.js", () => ({
   truncateForLog: (value: string, maxLen = 500) =>
     value.length > maxLen ? value.slice(0, maxLen) + "..." : value,
   pruneOldLogFiles: () => 0,
+  LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
 }));
 
 mock.module("../../../../config/loader.js", () => ({
   API_KEY_PROVIDERS: [] as const,
   getConfig: () => ({
+    permissions: { mode: "workspace" },
+    skills: { load: { extraDirs: [] } },
+    sandbox: { enabled: true },
+  }),
+  getConfigReadOnly: () => ({
     permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
     sandbox: { enabled: true },


### PR DESCRIPTION
## Summary
- Add missing `LOG_FILE_PATTERN` and `getConfigReadOnly` exports to the platform disconnect test's module mocks (CLI program imports now pull these in transitively).
- Route the mocked `getWorkspaceDirOverride` to the preload-set `VELLUM_WORKSPACE_DIR` so the emitted `platform_disconnected` signal lands in the per-test workspace dir where the assertion reads it.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test