### PR TITLE
fix(tests): unbreak providers-delete.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -59,7 +59,6 @@ KNOWN_BROKEN_FILES=(
   "host-shell-tool.test.ts"
   "memory-item-routes.test.ts"
   "provider-adapters.test.ts"
-  "providers-delete.test.ts"
   "qdrant-manager.test.ts"
   "shell-tool-proxy-mode.test.ts"
   "skill-feature-flags-integration.test.ts"

--- a/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
@@ -67,6 +67,7 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   },
   listProviders: () => [],
   registerProvider: () => ({}),
+  updateProvider: () => ({}),
   seedProviders: () => {},
   upsertApp: async () => ({}),
   getApp: () => undefined,


### PR DESCRIPTION
## Summary
- Add missing `updateProvider` export to the `oauth-store.js` mock so `providers.ts` import resolves
- Remove `providers-delete.test.ts` from `KNOWN_BROKEN_FILES` in `scripts/test.sh`

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test