### PR TITLE
fix(tests): unbreak credentials-cli.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -41,7 +41,6 @@ EXPERIMENTAL_FILES=(
 KNOWN_BROKEN_FILES=(
   "backup-routes.test.ts"
   "connect.test.ts"
-  "credentials-cli.test.ts"
   "email-attachment.test.ts"
   "email-download.test.ts"
   "email-list.test.ts"

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -20,40 +20,64 @@ function nextUUID(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Mock secure-keys
+// Mock daemon-credential-client
+//
+// The credentials CLI routes secret read/write through the daemon HTTP API
+// (see src/cli/lib/daemon-credential-client.ts). Mocking the daemon client
+// directly is the cleanest way to isolate the CLI from the real daemon or a
+// running daemon on localhost (which would otherwise be reached via the HTTP
+// healthz fallback in daemon-credential-client).
 // ---------------------------------------------------------------------------
 
-mock.module("../security/secure-keys.js", () => ({
-  setSecureKeyAsync: async (
-    account: string,
+function normalizeCredentialAccount(
+  type: string,
+  name: string,
+): string {
+  if (type !== "credential") return name;
+  if (name.startsWith("credential/")) return name;
+  const colonIdx = name.lastIndexOf(":");
+  if (colonIdx > 0 && colonIdx < name.length - 1) {
+    return `credential/${name.slice(0, colonIdx)}/${name.slice(colonIdx + 1)}`;
+  }
+  return name;
+}
+
+mock.module("../cli/lib/daemon-credential-client.js", () => ({
+  setSecureKeyViaDaemon: async (
+    type: string,
+    name: string,
     value: string,
   ): Promise<boolean> => {
-    secureKeyStore.set(account, value);
+    secureKeyStore.set(normalizeCredentialAccount(type, name), value);
     return true;
   },
-  deleteSecureKeyAsync: async (
-    account: string,
+  deleteSecureKeyViaDaemon: async (
+    type: string,
+    name: string,
   ): Promise<"deleted" | "not-found" | "error"> => {
-    if (secureKeyStore.has(account)) {
-      secureKeyStore.delete(account);
+    const key = normalizeCredentialAccount(type, name);
+    if (secureKeyStore.has(key)) {
+      secureKeyStore.delete(key);
       return "deleted";
     }
     return "not-found";
   },
-  listSecureKeysAsync: async () => ({
-    accounts: [...secureKeyStore.keys()],
-    unreachable: false,
-  }),
-  getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
+  getSecureKeyViaDaemon: async (
+    account: string,
+  ): Promise<string | undefined> => {
     return secureKeyStore.get(account);
   },
-  getSecureKeyResultAsync: async (
+  getSecureKeyResultViaDaemon: async (
     account: string,
   ): Promise<{ value: string | undefined; unreachable: boolean }> => ({
     value: secureKeyStore.get(account),
     unreachable: mockBrokerUnreachable,
   }),
-  _resetBackend: (): void => {},
+  getProviderKeyViaDaemon: async (
+    provider: string,
+  ): Promise<string | undefined> => {
+    return secureKeyStore.get(provider);
+  },
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switch the credentials CLI test's secure-store mock from `security/secure-keys.js` to `cli/lib/daemon-credential-client.js`, matching the production code path. The old mock was bypassed whenever a real daemon was listening on `127.0.0.1:7821`, causing 13 flakes/hard-fails.
- Remove `credentials-cli.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
