### PR TITLE
fix(tests): unbreak guard-tests.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -50,7 +50,6 @@ KNOWN_BROKEN_FILES=(
   "email-status.test.ts"
   "email-unregister.test.ts"
   "feature-flag-registry-bundled.test.ts"
-  "guard-tests.test.ts"
   "memory-item-routes.test.ts"
   "provider-adapters.test.ts"
   "qdrant-manager.test.ts"

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -466,6 +466,16 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "filing", scopes: ["settings.read"] },
   { endpoint: "filing:POST", scopes: ["settings.write"] },
 
+  // Heartbeat (config, runs, checklist — all share the "heartbeat" policyKey)
+  { endpoint: "heartbeat", scopes: ["settings.write"] },
+
+  // Notification delivery ack from clients
+  { endpoint: "notification-intent-result", scopes: ["settings.write"] },
+
+  // Platform config (base URL)
+  { endpoint: "config/platform:GET", scopes: ["settings.read"] },
+  { endpoint: "config/platform", scopes: ["settings.write"] },
+
   // Diagnostics
   { endpoint: "export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/env-vars", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Register missing route policies for `heartbeat`, `notification-intent-result`, and `config/platform` (GET/PUT) so route policy coverage guard test passes.
- Drop `guard-tests.test.ts` from `KNOWN_BROKEN_FILES`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
