### PR TITLE
fix(tests): unbreak memory-item-routes.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -60,7 +60,6 @@ KNOWN_BROKEN_FILES=(
   "email-send.test.ts"
   "email-status.test.ts"
   "email-unregister.test.ts"
-  "memory-item-routes.test.ts"
   "qdrant-manager.test.ts"
   "skill-feature-flags-integration.test.ts"
   "terminal-tools.test.ts"

--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -868,14 +868,15 @@ describe("Memory Item Routes", () => {
       const res = await handler(ctx);
       expect(res.status).toBe(204);
 
-      // Verify the node is gone
+      // Verify the node is soft-deleted (fidelity='gone')
       const db = getDb();
       const node = db
         .select()
         .from(memoryGraphNodes)
         .where(eq(memoryGraphNodes.id, "i1"))
         .get();
-      expect(node).toBeUndefined();
+      expect(node).toBeDefined();
+      expect(node?.fidelity).toBe("gone");
     });
 
     test("returns 404 for non-existent item", async () => {


### PR DESCRIPTION
## Summary
- DELETE handler was changed to soft-delete in #24055 (fidelity='gone') but the test still expected hard-delete (node undefined). Updated the test to assert the node remains with `fidelity === 'gone'`.
- Removed `memory-item-routes.test.ts` entry from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
