### PR TITLE
fix(tests): unbreak feature-flag-registry-bundled.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -18,6 +18,19 @@ set -uo pipefail
 EXCLUDE_EXPERIMENTAL="${EXCLUDE_EXPERIMENTAL:-false}"
 WORKERS="${TEST_WORKERS:-$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 8)}"
 COVERAGE="${COVERAGE:-false}"
+
+# Ensure the bundled feature-flag-registry.json exists before running tests.
+# The canonical copy lives at meta/feature-flags/feature-flag-registry.json and
+# is synced into assistant/src/ and gateway/src/ by sync-bundled-copies.ts.
+# CI runs this as a dedicated step; locally, postinstall handles it — but when
+# node_modules is symlinked (e.g. worktrees) postinstall never fires, so the
+# bundled copy can be missing and feature-flag-registry-bundled.test.ts fails.
+# Running the sync here is idempotent and cheap (two file copies).
+repo_root_sync="$(cd .. && pwd)"
+if [[ -f "${repo_root_sync}/meta/feature-flags/sync-bundled-copies.ts" ]]; then
+  (cd "${repo_root_sync}" && bun run meta/feature-flags/sync-bundled-copies.ts >/dev/null 2>&1 || true)
+fi
+unset repo_root_sync
 # Per-test timeout (seconds). Kills bun processes that pass but don't exit due to open handles.
 PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-120}"
 # Longest-first scheduling: provide a durations file from a previous run to sort
@@ -47,7 +60,6 @@ KNOWN_BROKEN_FILES=(
   "email-send.test.ts"
   "email-status.test.ts"
   "email-unregister.test.ts"
-  "feature-flag-registry-bundled.test.ts"
   "memory-item-routes.test.ts"
   "qdrant-manager.test.ts"
   "skill-feature-flags-integration.test.ts"


### PR DESCRIPTION
## Summary
- Run `meta/feature-flags/sync-bundled-copies.ts` from `assistant/scripts/test.sh` so the bundled registry exists before tests run locally (worktrees skip postinstall via symlinked node_modules). CI already has a dedicated sync step, so this is purely additive.
- Remove `feature-flag-registry-bundled.test.ts` from `KNOWN_BROKEN_FILES`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
