### PR TITLE
fix(tests): unbreak terminal-tools.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -63,7 +63,6 @@ KNOWN_BROKEN_FILES=(
   "memory-item-routes.test.ts"
   "qdrant-manager.test.ts"
   "skill-feature-flags-integration.test.ts"
-  "terminal-tools.test.ts"
   "tts-text-sanitizer.test.ts"
 )
 

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -532,12 +532,21 @@ describe("Native sandbox backend", () => {
       expect(result.sandboxed).toBe(true);
     });
 
-    test("rejects working dir with SBPL metacharacters", () => {
+    test("escapes working dir with SBPL metacharacters", () => {
+      // SBPL metacharacters (", (, ), ;, \) are backslash-escaped inside the
+      // profile string rather than rejected, so wrap() should succeed.
       const backend = new NativeBackend();
-      expect(() => backend.wrap("echo hi", '/tmp/foo"bar')).toThrow(ToolError);
-      expect(() => backend.wrap("echo hi", "/tmp/foo(bar")).toThrow(ToolError);
-      expect(() => backend.wrap("echo hi", "/tmp/foo;bar")).toThrow(ToolError);
-      expect(() => backend.wrap("echo hi", "/tmp/foo\\bar")).toThrow(ToolError);
+      expect(backend.wrap("echo hi", '/tmp/foo"bar').sandboxed).toBe(true);
+      expect(backend.wrap("echo hi", "/tmp/foo(bar").sandboxed).toBe(true);
+      expect(backend.wrap("echo hi", "/tmp/foo;bar").sandboxed).toBe(true);
+      expect(backend.wrap("echo hi", "/tmp/foo\\bar").sandboxed).toBe(true);
+    });
+
+    test("rejects working dir with newline characters", () => {
+      // Newlines/CRs cannot appear in real paths and would break the profile.
+      const backend = new NativeBackend();
+      expect(() => backend.wrap("echo hi", "/tmp/foo\nbar")).toThrow(ToolError);
+      expect(() => backend.wrap("echo hi", "/tmp/foo\rbar")).toThrow(ToolError);
     });
 
     test("accepts working dir with safe special characters", () => {


### PR DESCRIPTION
## Summary
- Update stale `SBPL metacharacters` test: source now escapes `"`, `(`, `)`, `;`, `\` instead of rejecting (per commit a88e68aebb). Test now asserts these paths succeed with escaping, and adds a new case asserting newline/CR still throw.
- Remove `terminal-tools.test.ts` from `KNOWN_BROKEN_FILES`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
