### PR TITLE
fix(tests): unbreak status.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -60,7 +60,6 @@ KNOWN_BROKEN_FILES=(
   "qdrant-manager.test.ts"
   "shell-tool-proxy-mode.test.ts"
   "skill-feature-flags-integration.test.ts"
-  "status.test.ts"
   "terminal-tools.test.ts"
   "tts-text-sanitizer.test.ts"
 )

--- a/assistant/src/cli/commands/platform/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/status.test.ts
@@ -61,11 +61,17 @@ mock.module("../../../../util/logger.js", () => ({
   truncateForLog: (value: string, maxLen = 500) =>
     value.length > maxLen ? value.slice(0, maxLen) + "..." : value,
   pruneOldLogFiles: () => 0,
+  LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
 }));
 
 mock.module("../../../../config/loader.js", () => ({
   API_KEY_PROVIDERS: [] as const,
   getConfig: () => ({
+    permissions: { mode: "workspace" },
+    skills: { load: { extraDirs: [] } },
+    sandbox: { enabled: true },
+  }),
+  getConfigReadOnly: () => ({
     permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
     sandbox: { enabled: true },


### PR DESCRIPTION
## Summary
- Add missing `LOG_FILE_PATTERN` and `getConfigReadOnly` exports to the `util/logger.js` and `config/loader.js` mocks in `src/cli/commands/platform/__tests__/status.test.ts` (transitive imports via `buildCliProgram` now resolve cleanly).
- Remove `status.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`; both `src/cli/commands/oauth/__tests__/status.test.ts` and `src/cli/commands/platform/__tests__/status.test.ts` pass.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test