### PR TITLE
fix(tests): unbreak tts-text-sanitizer.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -63,7 +63,6 @@ KNOWN_BROKEN_FILES=(
   "email-unregister.test.ts"
   "qdrant-manager.test.ts"
   "skill-feature-flags-integration.test.ts"
-  "tts-text-sanitizer.test.ts"
 )
 
 # Collect test files, filtering experimental if needed

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -10,9 +10,10 @@ export function sanitizeForTts(text: string): string {
   // 1. Markdown links: [text](url) → text
   //    Only matches the full [...](...) pattern — plain brackets like
   //    Fish Audio S2 annotations ([laughter], [breath]) pass through.
-  //    Handles one level of balanced parentheses in URLs (e.g. Wikipedia links).
+  //    Handles multiple balanced parentheses groups in URLs (e.g. Wikipedia
+  //    links, URL-encoded paths with multiple `(...)` segments).
   result = result.replace(
-    /\[([^\]]+)\]\([^()]*(?:\([^()]*\))*[^()]*\)/g,
+    /\[([^\]]+)\]\((?:[^()]*\([^()]*\))*[^()]*\)/g,
     "$1",
   );
 
@@ -24,36 +25,51 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
   result = result.replace(/_{2}(.+?)_{2}/g, "$1");
 
-  // 4. Code fences: strip ```...``` fences but keep content
-  //    Must run before header stripping so # comments inside code blocks are preserved.
-  result = result.replace(/```[^\n]*\n([\s\S]*?)```\n?/g, "$1");
+  // 4. Code fences + headers: strip ```...``` fences keeping content, and
+  //    strip leading `#` header characters at line starts — but ONLY outside
+  //    code fences so `# comment` / `## comment` lines inside code blocks are
+  //    preserved verbatim.
+  {
+    const fenceRe = /(```[^\n]*\n[\s\S]*?```\n?)/g;
+    const parts = result.split(fenceRe);
+    for (let i = 0; i < parts.length; i++) {
+      if (i % 2 === 0) {
+        // Non-fence segment: strip headers.
+        parts[i] = parts[i].replace(/^#{1,6}\s+/gm, "");
+      } else {
+        // Fence segment: strip the ``` markers but keep content untouched.
+        parts[i] = parts[i].replace(
+          /```[^\n]*\n([\s\S]*?)```\n?/,
+          "$1",
+        );
+      }
+    }
+    result = parts.join("");
+  }
 
-  // 5. Headers: strip leading # characters at line starts
-  result = result.replace(/^#{1,6}\s+/gm, "");
-
-  // 6. Inline code: strip single backticks
+  // 5. Inline code: strip single backticks
   result = result.replace(/`([^`]+)`/g, "$1");
 
-  // 7. Bullet markers: strip `- ` or `* ` at line starts
+  // 6. Bullet markers: strip `- ` or `* ` at line starts
   //    Must run before italic stripping so `* item` is treated as a bullet.
   result = result.replace(/^[-*]\s+/gm, "");
 
-  // 8. Italic: *text* or _text_ → text
+  // 7. Italic: *text* or _text_ → text
   //    Word-boundary-aware to preserve arithmetic like `5 * 3` and identifiers like `my_var`.
   result = result.replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, "$1");
   result = result.replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1");
 
-  // 9. Emojis: strip extended pictographic characters, variation selectors,
+  // 8. Emojis: strip extended pictographic characters, variation selectors,
   //    zero-width joiners, skin tone modifiers, and regional indicator symbols (flags).
   result = result.replace(/[\u200D\uFE00-\uFE0F]/gu, "");
   result = result.replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
   result = result.replace(/\p{Extended_Pictographic}/gu, "");
   result = result.replace(/[\u{1F1E6}-\u{1F1FF}]/gu, "");
 
-  // 10. Collapse whitespace: multiple spaces → single space,
-  //     multiple blank lines → single newline.
-  //     Does NOT trim trailing whitespace — callers handle trimming so that
-  //     streaming chunks preserve inter-word spaces (e.g. "Hello " + "world").
+  // 9. Collapse whitespace: multiple spaces → single space,
+  //    multiple blank lines → single newline.
+  //    Does NOT trim trailing whitespace — callers handle trimming so that
+  //    streaming chunks preserve inter-word spaces (e.g. "Hello " + "world").
   result = result.replace(/ {2,}/g, " ");
   result = result.replace(/\n{3,}/g, "\n\n");
 


### PR DESCRIPTION
## Summary
- Fix markdown link regex in `sanitizeForTts` to handle URLs with multiple balanced parenthesis groups (e.g. `a_(b)_c_(d)`), and preserve `#` / `##` comment lines that live inside code fences by splitting on fences before stripping headers.
- Remove `tts-text-sanitizer.test.ts` from `KNOWN_BROKEN_FILES` now that all 45 cases pass.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
