### PR TITLE
fix(tests): unbreak skill-feature-flags-integration.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -60,7 +60,6 @@ KNOWN_BROKEN_FILES=(
   "email-send.test.ts"
   "email-unregister.test.ts"
   "qdrant-manager.test.ts"
-  "skill-feature-flags-integration.test.ts"
 )
 
 # Collect test files, filtering experimental if needed

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -350,12 +350,18 @@ export function clearFeatureFlagOverridesCache(): void {
  * flag state without writing to disk. Production code should never call this;
  * use `clearFeatureFlagOverridesCache()` instead and let the resolver
  * re-read from the appropriate source.
+ *
+ * Forces `cachedRemoteValues` to an empty record (not `null`) so the resolver
+ * does not fall through to reading `feature-flags-remote.json` from disk. This
+ * matters because a developer's local remote-cache file can leak platform-set
+ * values into the test environment (e.g. `email-channel: true`), defeating
+ * test isolation.
  */
 export function _setOverridesForTesting(
   overrides: Record<string, boolean>,
 ): void {
   cachedOverrides = { ...overrides };
-  cachedRemoteValues = null;
+  cachedRemoteValues = {};
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix test leak from developer's local `feature-flags-remote.json`: `_setOverridesForTesting({})` now clears `cachedRemoteValues` to `{}` (empty record) instead of `null`, so the resolver no longer falls through to reading `~/.vellum/protected/feature-flags-remote.json` from disk — a dev had `"email-channel": true` there, which masked the registry default (`defaultEnabled: false`) that the test asserts.
- Remove `skill-feature-flags-integration.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
