### PR TITLE
fix(tests): unbreak email-status.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -52,7 +52,6 @@ KNOWN_BROKEN_FILES=(
   "email-list.test.ts"
   "email-register.test.ts"
   "email-send.test.ts"
-  "email-status.test.ts"
   "email-unregister.test.ts"
   "feature-flag-registry-bundled.test.ts"
   "guard-tests.test.ts"

--- a/assistant/src/cli/commands/__tests__/email-status.test.ts
+++ b/assistant/src/cli/commands/__tests__/email-status.test.ts
@@ -109,7 +109,11 @@ describe("assistant email status", () => {
 
     await runAssistantCommand("email", "--json", "status");
 
-    const calls = getMockFetchCalls();
+    // Filter out the feature-flags bootstrap call (initFeatureFlagOverrides
+    // fires on every CLI invocation to pre-populate the flag cache).
+    const calls = getMockFetchCalls().filter(
+      (c) => !c.path.includes("/v1/feature-flags"),
+    );
     expect(calls).toHaveLength(2);
     expect(calls[0].path).toContain(
       `/v1/assistants/${ASSISTANT_ID}/email-addresses/`,


### PR DESCRIPTION
## Summary
- Filter out the `/v1/feature-flags` bootstrap call from `getMockFetchCalls()` in the "calls correct URLs in order" test — `buildCliProgram()` now pre-populates the flag cache via gateway fetch, which added a third call that the test's length assertion did not expect.
- Remove `email-status.test.ts` from the `KNOWN_BROKEN_FILES` list in `scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
