### PR TITLE
fix(tests): unbreak email-register.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -50,7 +50,6 @@ KNOWN_BROKEN_FILES=(
   "email-attachment.test.ts"
   "email-download.test.ts"
   "email-list.test.ts"
-  "email-register.test.ts"
   "email-send.test.ts"
   "email-status.test.ts"
   "email-unregister.test.ts"

--- a/assistant/src/cli/commands/__tests__/email-register.test.ts
+++ b/assistant/src/cli/commands/__tests__/email-register.test.ts
@@ -10,6 +10,7 @@ import { setPlatformAssistantId } from "../../../config/env.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import {
   _resetBackend,
+  deleteSecureKeyAsync,
   setSecureKeyAsync,
 } from "../../../security/secure-keys.js";
 import { runAssistantCommand } from "../../__tests__/run-assistant-command.js";
@@ -52,7 +53,7 @@ describe("assistant email register", () => {
 
     const calls = getMockFetchCalls();
     expect(calls).toHaveLength(1);
-    expect(calls[0].path).toBe(
+    expect(calls[0].path).toContain(
       `/v1/assistants/${ASSISTANT_ID}/email-addresses/`,
     );
     expect(calls[0].init.method).toBe("POST");
@@ -115,9 +116,8 @@ describe("assistant email register", () => {
   });
 
   test("missing platform credentials returns error", async () => {
-    // Remove the API key so create() returns null
-    _resetBackend();
-    setPlatformAssistantId(undefined);
+    // Remove the API key so VellumPlatformClient.create() returns null.
+    await deleteSecureKeyAsync(API_KEY_CREDENTIAL);
 
     const output = await runAssistantCommand(
       "email",

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -242,8 +242,15 @@ async function fetchOverridesFromGateway(): Promise<Record<string, boolean>> {
  * On failure, the cache is left unset so subsequent sync calls fall
  * through to the file-based fallback rather than caching an empty map
  * that masks all overrides for the process lifetime.
+ *
+ * No-ops when the cache is already populated — callers that want to
+ * refresh must call `clearFeatureFlagOverridesCache()` first. This lets
+ * tests preseed flag state via `_setOverridesForTesting()` without the
+ * gateway fetch clobbering their setup or polluting fetch mocks.
  */
 export async function initFeatureFlagOverrides(): Promise<void> {
+  if (cachedOverrides != null) return;
+
   const gatewayOverrides = await fetchOverridesFromGateway();
   if (Object.keys(gatewayOverrides).length > 0) {
     cachedOverrides = gatewayOverrides;


### PR DESCRIPTION
## Summary
- Skip the gateway feature-flags fetch in `initFeatureFlagOverrides()` when the override cache is already populated (e.g. by `_setOverridesForTesting()`), so tests using preseeded flag state no longer pollute or miss `mockFetch` expectations.
- Fix `email-register.test.ts`: use `deleteSecureKeyAsync` to actually remove the API-key credential in the "missing platform credentials" case (a plain `_resetBackend()` only clears the cache), and switch the URL assertion to `toContain()` since the client now emits the full platform base URL.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
