### PR TITLE
fix(tests): unbreak email-attachment.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -54,7 +54,6 @@ EXPERIMENTAL_FILES=(
 KNOWN_BROKEN_FILES=(
   "byo-connection.test.ts"
   "conversation-tool-setup.test.ts"
-  "email-attachment.test.ts"
   "email-list.test.ts"
   "email-send.test.ts"
   "email-unregister.test.ts"

--- a/assistant/src/cli/__tests__/run-assistant-command.ts
+++ b/assistant/src/cli/__tests__/run-assistant-command.ts
@@ -25,10 +25,20 @@ export async function runAssistantCommandFull(
 
   const stdoutChunks: string[] = [];
   const originalWrite = process.stdout.write;
-  process.stdout.write = ((chunk: string | Uint8Array) => {
+  // Override must invoke the callback (when provided) so that `Writable` streams
+  // piped into `process.stdout` (e.g. pino's CLI destination) can drain.
+  // Without this, only the first write lands and subsequent writes hang in
+  // backpressure. The second arg can be either an encoding string or the callback.
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encoding?: unknown,
+    cb?: (err?: Error | null) => void,
+  ) => {
     stdoutChunks.push(
       typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
     );
+    const callback = typeof encoding === "function" ? encoding : cb;
+    if (typeof callback === "function") callback();
     return true;
   }) as typeof process.stdout.write;
 

--- a/assistant/src/cli/commands/__tests__/email-attachment.test.ts
+++ b/assistant/src/cli/commands/__tests__/email-attachment.test.ts
@@ -292,7 +292,11 @@ describe("assistant email attachment", () => {
       "--list",
     );
 
-    const calls = getMockFetchCalls();
+    // Filter out the CLI bootstrap fetch to /v1/feature-flags so this test
+    // focuses on the attachment-related calls it actually cares about.
+    const calls = getMockFetchCalls().filter(
+      (c) => !c.path.includes("/v1/feature-flags"),
+    );
     expect(calls).toHaveLength(1);
     expect(calls[0].path).toContain(
       `/v1/assistants/${ASSISTANT_ID}/emails/${MESSAGE_ID}/attachments/`,
@@ -312,7 +316,11 @@ describe("assistant email attachment", () => {
       tmpDir,
     );
 
-    const calls = getMockFetchCalls();
+    // Filter out the CLI bootstrap fetch to /v1/feature-flags so this test
+    // focuses on the attachment-related calls it actually cares about.
+    const calls = getMockFetchCalls().filter(
+      (c) => !c.path.includes("/v1/feature-flags"),
+    );
     expect(calls).toHaveLength(2);
     expect(calls[0].path).toContain(`/attachments/${ATT_ID_1}/`);
     expect(calls[1].path).toContain(`/attachments/${ATT_ID_1}/download/`);


### PR DESCRIPTION
## Summary
- Fix `process.stdout.write` override in `run-assistant-command` test helper to forward callbacks — without this, `Writable` streams (pino's CLI destination) hang in backpressure after the first write, which was silently dropping all but one log line in CLI command tests.
- Filter out the CLI bootstrap `/v1/feature-flags` fetch when counting calls in `email-attachment.test.ts` so the attachment call-count assertions stay focused on the command under test.
- Drop `email-attachment.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh` — all 16 tests pass.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
