### PR TITLE
fix(tests): unbreak email-download.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -50,7 +50,6 @@ KNOWN_BROKEN_FILES=(
   "credentials-cli.test.ts"
   "disconnect.test.ts"
   "email-attachment.test.ts"
-  "email-download.test.ts"
   "email-list.test.ts"
   "email-register.test.ts"
   "email-send.test.ts"

--- a/assistant/src/cli/commands/__tests__/email-download.test.ts
+++ b/assistant/src/cli/commands/__tests__/email-download.test.ts
@@ -39,6 +39,20 @@ function mockDetailSuccess(msg = SAMPLE_MESSAGE, status = 200): void {
   mockFetch(`/emails/${msg.id}/`, {}, { body: msg, status });
 }
 
+/**
+ * Intercept the gateway feature-flag pre-population fetch that
+ * `buildCliProgram()` triggers. Without this, the call either hits a real
+ * local gateway or counts against `getMockFetchCalls()`, skewing assertions.
+ */
+function mockFeatureFlagsFetch(): void {
+  mockFetch("/v1/feature-flags", { method: "GET" }, { body: { flags: [] }, status: 200 });
+}
+
+/** Filter out the feature-flag pre-population fetch from captured calls. */
+function emailFetchCalls(): { path: string; init: RequestInit }[] {
+  return getMockFetchCalls().filter((c) => !c.path.includes("/v1/feature-flags"));
+}
+
 let savedCesUrl: string | undefined;
 let savedContainerized: string | undefined;
 let tmpOutputPath: string;
@@ -53,6 +67,7 @@ beforeEach(async () => {
 
   _resetBackend();
   resetMockFetch();
+  mockFeatureFlagsFetch();
   _setOverridesForTesting({ "email-channel": true });
   setPlatformAssistantId(ASSISTANT_ID);
   await setSecureKeyAsync(API_KEY_CREDENTIAL, "test-api-key");
@@ -175,7 +190,7 @@ describe("assistant email download", () => {
 
     await runAssistantCommand("email", "download", MESSAGE_ID);
 
-    const calls = getMockFetchCalls();
+    const calls = emailFetchCalls();
     expect(calls).toHaveLength(1);
     expect(calls[0].path).toContain(
       `/v1/assistants/${ASSISTANT_ID}/emails/${MESSAGE_ID}/`,


### PR DESCRIPTION
## Summary
- Mock `/v1/feature-flags` in `beforeEach` so the gateway pre-population fetch triggered by `buildCliProgram()` doesn't count against `getMockFetchCalls()` (flake source: extra call inflated length + could hit a real local gateway).
- Filter that call out of the "calls correct URL" assertion via a new `emailFetchCalls()` helper.
- Remove `email-download.test.ts` from `KNOWN_BROKEN_FILES` in `assistant/scripts/test.sh`.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
