### PR TITLE
fix(tests): isolate encrypted store per test file

### DIFF
--- a/assistant/src/__tests__/test-preload.ts
+++ b/assistant/src/__tests__/test-preload.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { afterAll } from "bun:test";
 
 import { resetDb } from "../memory/db-connection.js";
+import { _setStorePath } from "../security/encrypted-store.js";
 
 const testDir = realpathSync(
   mkdtempSync(join(tmpdir(), "vellum-test-workspace-")),
@@ -24,6 +25,11 @@ const testDir = realpathSync(
 process.env.VELLUM_WORKSPACE_DIR = testDir;
 process.env.VELLUM_PLATFORM_URL = "https://test-platform.vellum.ai";
 process.exitCode = 0;
+
+// Isolate the encrypted credential store per test file. Without this,
+// parallel test processes all read/write the same ~/.vellum/protected/keys.enc,
+// causing races when one file deletes a key while another sets it.
+_setStorePath(join(testDir, "keys.enc"));
 
 // Force-close any DB connection inherited from the parent process (e.g. when
 // the test runner is spawned by the running assistant via a pre-push hook).


### PR DESCRIPTION
## Summary
- Parallel test processes shared `~/.vellum/protected/keys.enc`, racing on sets/deletes and flaking six email CLI tests in CI (`email-download`, `email-list`, `email-send`, `email-unregister`, `email-attachment`, `email-status`).
- `test-preload.ts` now calls `_setStorePath` to point at `<per-file-temp-workspace>/keys.enc`, giving each test file its own isolated encrypted store while still honoring explicit `_setStorePath` overrides in tests like `credential-vault.test.ts`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24434800483/job/71386643819
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
