### PR TITLE
fix(tests): unbreak qdrant-manager.test.ts

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -54,7 +54,6 @@ EXPERIMENTAL_FILES=(
 KNOWN_BROKEN_FILES=(
   "byo-connection.test.ts"
   "conversation-tool-setup.test.ts"
-  "qdrant-manager.test.ts"
 )
 
 # Collect test files, filtering experimental if needed

--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -30,10 +30,16 @@ mock.module("../util/logger.js", () => ({
 
 import { QdrantManager } from "../memory/qdrant-manager.js";
 
-/** Short timeouts so tests complete fast but with enough headroom for CI. */
+/**
+ * Short timeouts so tests complete fast but with enough headroom for CI and
+ * for Bun's subprocess-exit detection. Bun's `proc.exited` promise can take
+ * ~80–150ms to resolve on macOS after a subprocess exits (especially the
+ * first cold spawn in a test run), so `readyzTimeoutMs` must be comfortably
+ * above that to reliably catch "exited before becoming ready" cases.
+ */
 const FAST_TIMEOUTS = {
   readyzPollIntervalMs: 5,
-  readyzTimeoutMs: 100,
+  readyzTimeoutMs: 500,
   shutdownGraceMs: 50,
 } as const;
 
@@ -252,15 +258,23 @@ describe("QdrantManager", () => {
       await mgr.stop();
       expect(existsSync(pidPath)).toBe(false);
 
-      // start() should now reject because process was killed
-      await expect(startPromise).rejects.toThrow("did not become ready");
+      // start() should now reject because process was killed. Either the
+      // readyz timeout fires first or waitForReady notices the process
+      // exited — accept both since the race depends on timing.
+      await expect(startPromise).rejects.toThrow(
+        /did not become ready|exited with code/,
+      );
     }, 10_000);
 
     test("stop() escalates to SIGKILL after grace period", async () => {
       const pidPath = join(testDataDir, "data", "qdrant", "qdrant.pid");
 
-      // Binary that ignores SIGTERM
-      placeFakeBinary('#!/bin/sh\ntrap "" TERM\nexec sleep 300');
+      // Binary that ignores SIGTERM. Cannot use `exec` here: `exec sleep 300`
+      // replaces the shell with `sleep`, dropping the trap and letting SIGTERM
+      // terminate the process immediately. Keep the shell alive as the
+      // foreground PID so the trap applies, and run sleep in a loop since the
+      // orphan gets reaped when the shell is SIGKILLed at the end.
+      placeFakeBinary('#!/bin/sh\ntrap "" TERM\nwhile :; do sleep 1; done');
 
       const port = getTestPort();
       const mgr = new QdrantManager({
@@ -269,7 +283,10 @@ describe("QdrantManager", () => {
       });
 
       const startPromise = mgr.start();
-      await Bun.sleep(50);
+      // Give the shell enough time to install its SIGTERM trap. 50ms is
+      // unreliable on cold spawns — bun takes ~100ms to fully settle the
+      // child before signals hit a trap-aware state.
+      await Bun.sleep(150);
 
       expect(existsSync(pidPath)).toBe(true);
 
@@ -281,7 +298,11 @@ describe("QdrantManager", () => {
       expect(stopElapsed).toBeGreaterThanOrEqual(30);
       expect(existsSync(pidPath)).toBe(false);
 
-      await expect(startPromise).rejects.toThrow("did not become ready");
+      // start() rejects because its in-progress waitForReady either times
+      // out or observes the SIGKILLed process exit. Accept either outcome.
+      await expect(startPromise).rejects.toThrow(
+        /did not become ready|exited with code/,
+      );
     }, 10_000);
   });
 

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -269,23 +269,50 @@ export class QdrantManager {
 
   private async waitForReady(): Promise<void> {
     const start = Date.now();
+    // Build a single exited-promise once so each race reuses the same handle.
+    // Reading `proc.exitCode` synchronously inside the poll loop is unreliable
+    // in Bun: while the loop is busy with fetch() + Bun.sleep(), the
+    // subprocess-exit event may not be processed on the event loop, so
+    // `exitCode` stays null even after the process has died. Racing
+    // `proc.exited` directly forces the loop to yield and observe the exit.
+    type ExitedOutcome = { type: "exited"; code: number };
+    const exitedRace: Promise<ExitedOutcome> =
+      this.process != null
+        ? this.process.exited.then((code) => ({ type: "exited", code }))
+        : new Promise<ExitedOutcome>(() => {});
+
+    const throwOnExit = async (code: number): Promise<never> => {
+      await this.stderrDrained;
+      const stderr = this.stderrBuffer.trim();
+      throw new Error(
+        `Qdrant process exited with code ${code} before becoming ready` +
+          (stderr ? `\nstderr:\n${stderr}` : ""),
+      );
+    };
+
     while (Date.now() - start < this.readyzTimeoutMs) {
-      // Fail fast if the managed process exited before becoming ready
-      if (this.process != null && this.process.exitCode != null) {
-        await this.stderrDrained;
-        const stderr = this.stderrBuffer.trim();
-        throw new Error(
-          `Qdrant process exited with code ${this.process.exitCode} before becoming ready` +
-            (stderr ? `\nstderr:\n${stderr}` : ""),
-        );
-      }
-      try {
-        const res = await fetch(`${this.url}/readyz`);
-        if (res.ok) return;
-      } catch {
-        // Not ready yet
-      }
-      await Bun.sleep(this.readyzPollIntervalMs);
+      const fetchOutcome = await Promise.race([
+        exitedRace,
+        fetch(`${this.url}/readyz`).then(
+          (r) => ({ type: "fetch" as const, ok: r.ok }),
+          () => ({ type: "fetch" as const, ok: false }),
+        ),
+      ]);
+      if (fetchOutcome.type === "exited") await throwOnExit(fetchOutcome.code);
+      if (fetchOutcome.type === "fetch" && fetchOutcome.ok) return;
+
+      // Race the poll-interval sleep with process exit so we don't waste time
+      // sleeping after the subprocess has already died.
+      const sleepOutcome = await Promise.race([
+        exitedRace,
+        new Promise<{ type: "timeout" }>((resolve) =>
+          setTimeout(
+            () => resolve({ type: "timeout" }),
+            this.readyzPollIntervalMs,
+          ),
+        ),
+      ]);
+      if (sleepOutcome.type === "exited") await throwOnExit(sleepOutcome.code);
     }
     const stderr = this.stderrBuffer.trim();
     throw new Error(


### PR DESCRIPTION
## Summary
- Fix flaky subprocess exit detection in `QdrantManager.waitForReady`: race `proc.exited` against `fetch()` and the poll-interval sleep instead of relying on `proc.exitCode`, which is unreliable in Bun while the event loop is busy.
- Correct the `stop() escalates to SIGKILL` test binary: dropped `exec`, which was replacing the shell with `sleep` and nullifying the `trap "" TERM`. Bumped the warmup to 150ms so the shell has time to install the trap before SIGTERM arrives.
- Raised `FAST_TIMEOUTS.readyzTimeoutMs` from 100ms to 500ms so tests reliably observe process exit on cold spawns (Bun \`proc.exited\` has ~80–150ms latency on macOS).
- Removed \`qdrant-manager.test.ts\` from KNOWN_BROKEN_FILES.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
