### PR TITLE
fix(tests): remove stale KNOWN_BROKEN_FILES entries restored by bad rebase

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -52,8 +52,6 @@ EXPERIMENTAL_FILES=(
 # To triage an entry: run `bun test <path>` from `assistant/` and fix the
 # underlying code or tests until the file is green, then remove it here.
 KNOWN_BROKEN_FILES=(
-  "byo-connection.test.ts"
-  "conversation-tool-setup.test.ts"
 )
 
 # Collect test files, filtering experimental if needed


### PR DESCRIPTION
## Summary
- PRs #25693 (conversation-tool-setup) and #25694 (byo-connection) fixed both tests and removed them from KNOWN_BROKEN_FILES, but PR #25697 (connect.test.ts) resolved a rebase conflict incorrectly and re-added both entries even though the underlying test fixes were preserved.
- Both tests pass cleanly on current main (verified locally: 16/16 byo-connection, 12/12 conversation-tool-setup). This PR just removes the stale exclusion entries so the tests actually run in CI.

## Original prompt
fix the broken tests in KNOWN_BROKEN_FILES using 1 worktree / agent per broken test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
