### PR TITLE
feat(tts): add deepgram provider schema, adapter, and registry wiring

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1009,6 +1009,10 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.tts.providers["fish-audio"].chunkLength).toBe(200);
     expect(result.services.tts.providers["fish-audio"].format).toBe("mp3");
     expect(result.services.tts.providers["fish-audio"].speed).toBe(1.0);
+    expect(result.services.tts.providers.deepgram.model).toBe(
+      "aura-asteria-en",
+    );
+    expect(result.services.tts.providers.deepgram.format).toBe("mp3");
   });
 
   test("accepts valid services.tts provider override", () => {
@@ -1016,6 +1020,14 @@ describe("AssistantConfigSchema", () => {
       services: { tts: { provider: "fish-audio" } },
     });
     expect(result.services.tts.provider).toBe("fish-audio");
+    expect(result.services.tts.mode).toBe("your-own");
+  });
+
+  test("accepts deepgram as services.tts.provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: { tts: { provider: "deepgram" } },
+    });
+    expect(result.services.tts.provider).toBe("deepgram");
     expect(result.services.tts.mode).toBe("your-own");
   });
 
@@ -1053,6 +1065,20 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.tts.providers["fish-audio"].format).toBe("wav");
     // Defaults preserved
     expect(result.services.tts.providers["fish-audio"].chunkLength).toBe(200);
+  });
+
+  test("accepts valid services.tts.providers.deepgram overrides", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        tts: {
+          providers: {
+            deepgram: { model: "aura-luna-en", format: "opus" },
+          },
+        },
+      },
+    });
+    expect(result.services.tts.providers.deepgram.model).toBe("aura-luna-en");
+    expect(result.services.tts.providers.deepgram.format).toBe("opus");
   });
 
   test("rejects services.tts.mode = managed", () => {

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -215,6 +215,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
+      "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -206,12 +206,14 @@ export {
   TimeoutConfigSchema,
 } from "./schemas/timeouts.js";
 export type {
+  TtsDeepgramProviderConfig,
   TtsElevenLabsProviderConfig,
   TtsFishAudioProviderConfig,
   TtsProviders,
   TtsService,
 } from "./schemas/tts.js";
 export {
+  TtsDeepgramProviderConfigSchema,
   TtsElevenLabsProviderConfigSchema,
   TtsFishAudioProviderConfigSchema,
   TtsProvidersSchema,

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -144,12 +144,38 @@ export type TtsFishAudioProviderConfig = z.infer<
   typeof TtsFishAudioProviderConfigSchema
 >;
 
+export const TtsDeepgramProviderConfigSchema = z
+  .object({
+    model: z
+      .string({
+        error: "services.tts.providers.deepgram.model must be a string",
+      })
+      .min(1, "services.tts.providers.deepgram.model must not be empty")
+      .default("aura-asteria-en")
+      .describe("Deepgram TTS model identifier"),
+    format: z
+      .enum(["mp3", "wav", "opus"], {
+        error:
+          "services.tts.providers.deepgram.format must be one of: mp3, wav, opus",
+      })
+      .default("mp3")
+      .describe("Output audio format for call/runtime playback"),
+  })
+  .describe("Deepgram provider configuration under services.tts");
+
+export type TtsDeepgramProviderConfig = z.infer<
+  typeof TtsDeepgramProviderConfigSchema
+>;
+
 export const TtsProvidersSchema = z.object({
   elevenlabs: TtsElevenLabsProviderConfigSchema.default(
     TtsElevenLabsProviderConfigSchema.parse({}),
   ),
   "fish-audio": TtsFishAudioProviderConfigSchema.default(
     TtsFishAudioProviderConfigSchema.parse({}),
+  ),
+  deepgram: TtsDeepgramProviderConfigSchema.default(
+    TtsDeepgramProviderConfigSchema.parse({}),
   ),
 });
 export type TtsProviders = z.infer<typeof TtsProvidersSchema>;

--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -7,8 +7,13 @@ import { API_KEY_PROVIDERS } from "../provider-secret-catalog.js";
 // ---------------------------------------------------------------------------
 
 describe("API_KEY_PROVIDERS", () => {
-  test("includes deepgram (STT catalog-derived)", () => {
+  test("includes deepgram (shared by STT and TTS catalogs)", () => {
     expect(API_KEY_PROVIDERS).toContain("deepgram");
+  });
+
+  test("includes deepgram exactly once despite appearing in both STT and TTS catalogs", () => {
+    const occurrences = API_KEY_PROVIDERS.filter((p) => p === "deepgram");
+    expect(occurrences.length).toBe(1);
   });
 
   test("includes openai exactly once (shared by LLM and STT)", () => {

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -73,21 +73,27 @@ function sttApiKeyProviderNames(): string[] {
 const CREDENTIAL_KEY_PREFIX = "credential/";
 
 /**
- * Derive the set of TTS provider IDs that use the `api_key` secret type
- * by inspecting the catalog's secret requirements.
+ * Derive the set of TTS bare-name credential store keys that use the
+ * `api_key` secret type by inspecting the catalog's secret requirements.
  *
- * A TTS provider is considered API-key-addressable when it declares at
- * least one secret whose `credentialStoreKey` is a bare name (i.e. does
- * NOT start with the `credential/` prefix).
+ * A TTS provider entry is API-key-addressable when it declares at least
+ * one secret whose `credentialStoreKey` is a bare name (i.e. does NOT
+ * start with the `credential/` prefix). The bare key name is returned
+ * rather than the provider ID because the key name is what appears in
+ * the credential store (e.g. `deepgram` not `deepgram-tts`).
  */
-function catalogApiKeyProviderIds(): string[] {
+function catalogApiKeyNames(): string[] {
   return listCatalogProviders()
     .filter((entry) =>
       entry.secretRequirements.some(
         (s) => !s.credentialStoreKey.startsWith(CREDENTIAL_KEY_PREFIX),
       ),
     )
-    .map((entry) => entry.id);
+    .flatMap((entry) =>
+      entry.secretRequirements
+        .filter((s) => !s.credentialStoreKey.startsWith(CREDENTIAL_KEY_PREFIX))
+        .map((s) => s.credentialStoreKey),
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -108,12 +114,26 @@ function catalogApiKeyProviderIds(): string[] {
  * requirement automatically includes it here. Adding a new STT
  * provider to the STT catalog automatically includes it here (shared
  * credential names like `openai` are deduplicated against the LLM
- * list). Adding a new LLM or search provider requires appending to
+ * list). Shared credential names across STT and TTS (e.g. `deepgram`)
+ * are deduplicated so the list contains no duplicates. Adding a new
+ * LLM or search provider requires appending to
  * {@link LLM_AND_SEARCH_API_KEY_PROVIDERS} until those domains get
  * their own catalog modules.
  */
-export const API_KEY_PROVIDERS: readonly string[] = [
-  ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
-  ...sttApiKeyProviderNames(),
-  ...catalogApiKeyProviderIds(),
-] as const;
+export const API_KEY_PROVIDERS: readonly string[] = (() => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const name of [
+    ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
+    ...sttApiKeyProviderNames(),
+    ...catalogApiKeyNames(),
+  ]) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      result.push(name);
+    }
+  }
+
+  return result;
+})();

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -30,6 +30,11 @@ let mockFishAudioConfig = {
   speed: 1.0,
 };
 
+let mockDeepgramConfig = {
+  model: "aura-asteria-en",
+  format: "mp3" as "mp3" | "wav" | "opus",
+};
+
 mock.module("../../config/loader.js", () => ({
   getConfig: () => ({
     services: {
@@ -37,6 +42,7 @@ mock.module("../../config/loader.js", () => ({
         providers: {
           elevenlabs: mockElevenLabsConfig,
           "fish-audio": mockFishAudioConfig,
+          deepgram: mockDeepgramConfig,
         },
       },
     },
@@ -46,9 +52,14 @@ mock.module("../../config/loader.js", () => ({
 // -- Secure keys mock ------------------------------------------------------
 
 let mockApiKey: string | null = "test-elevenlabs-api-key";
+let mockDeepgramApiKey: string | null = "test-deepgram-api-key";
 
 mock.module("../../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => mockApiKey,
+  getProviderKeyAsync: async (provider: string) => {
+    if (provider === "deepgram") return mockDeepgramApiKey;
+    return mockApiKey;
+  },
 }));
 
 mock.module("../../security/credential-key.js", () => ({
@@ -86,6 +97,10 @@ import {
   getTtsProvider,
   listTtsProviders,
 } from "../provider-registry.js";
+import {
+  createDeepgramProvider,
+  DeepgramTtsError,
+} from "../providers/deepgram-provider.js";
 import { createElevenLabsProvider } from "../providers/elevenlabs-provider.js";
 import { ElevenLabsTtsError } from "../providers/elevenlabs-provider.js";
 import { createFishAudioProvider } from "../providers/fish-audio-provider.js";
@@ -106,6 +121,7 @@ let originalFetch: typeof globalThis.fetch;
 beforeEach(() => {
   originalFetch = globalThis.fetch;
   mockApiKey = "test-elevenlabs-api-key";
+  mockDeepgramApiKey = "test-deepgram-api-key";
   mockElevenLabsConfig = {
     voiceId: "test-voice-id",
     voiceModelId: "",
@@ -120,6 +136,10 @@ beforeEach(() => {
     format: "mp3",
     latency: "normal",
     speed: 1.0,
+  };
+  mockDeepgramConfig = {
+    model: "aura-asteria-en",
+    format: "mp3",
   };
   mockSynthesizeWithFishAudio.mockClear();
 });
@@ -541,17 +561,213 @@ describe("Fish Audio TTS provider adapter", () => {
 });
 
 // ===========================================================================
+// Deepgram TTS provider adapter
+// ===========================================================================
+
+describe("Deepgram TTS provider adapter", () => {
+  // -- Interface conformance -----------------------------------------------
+
+  test("has correct provider ID", () => {
+    const provider = createDeepgramProvider();
+    expect(provider.id).toBe("deepgram");
+  });
+
+  test("advertises mp3, wav, opus format support without streaming", () => {
+    const provider = createDeepgramProvider();
+    expect(provider.capabilities.supportsStreaming).toBe(false);
+    expect(provider.capabilities.supportedFormats).toEqual([
+      "mp3",
+      "wav",
+      "opus",
+    ]);
+  });
+
+  // -- Request mapping -----------------------------------------------------
+
+  test("synthesize sends request to Deepgram REST TTS API with correct model", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedUrl = "";
+    let capturedHeaders: Headers | null = null;
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedUrl = typeof input === "string" ? input : input.toString();
+        capturedHeaders = new Headers(init?.headers);
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, {
+          status: 200,
+          headers: { "Content-Type": "audio/mpeg" },
+        });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    await provider.synthesize(makeRequest());
+
+    expect(capturedUrl).toContain("/v1/speak");
+    expect(capturedUrl).toContain("model=aura-asteria-en");
+    expect(capturedUrl).toContain("encoding=mp3");
+    expect(capturedHeaders!.get("Authorization")).toBe(
+      "Token test-deepgram-api-key",
+    );
+    expect(capturedHeaders!.get("Content-Type")).toBe("application/json");
+
+    const body = JSON.parse(capturedBody);
+    expect(body.text).toBe("Hello world");
+  });
+
+  test("uses linear16 encoding when outputFormat is pcm", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01, 0x02]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm" }),
+    );
+
+    expect(capturedUrl).toContain("encoding=linear16");
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("uses configured format when no outputFormat override", async () => {
+    mockDeepgramConfig.format = "wav";
+    const audioPayload = new Uint8Array([0x52, 0x49, 0x46, 0x46]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    const result = await provider.synthesize(makeRequest());
+
+    expect(capturedUrl).toContain("encoding=wav");
+    expect(result.contentType).toBe("audio/wav");
+  });
+
+  test("uses configured model", async () => {
+    mockDeepgramConfig.model = "aura-luna-en";
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    await provider.synthesize(makeRequest());
+
+    expect(capturedUrl).toContain("model=aura-luna-en");
+  });
+
+  // -- Content type / format -----------------------------------------------
+
+  test("returns audio/mpeg content type for mp3 format", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    mockFetchReturning(audioPayload);
+
+    const provider = createDeepgramProvider();
+    const result = await provider.synthesize(makeRequest());
+
+    expect(result.contentType).toBe("audio/mpeg");
+    expect(result.audio.byteLength).toBeGreaterThan(0);
+  });
+
+  // -- Required config validation ------------------------------------------
+
+  test("throws DEEPGRAM_TTS_NO_API_KEY when API key is missing", async () => {
+    mockDeepgramApiKey = null;
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe("DEEPGRAM_TTS_NO_API_KEY");
+      expect((err as DeepgramTtsError).message).toContain(
+        "API key not configured",
+      );
+    }
+  });
+
+  // -- Error handling ------------------------------------------------------
+
+  test("throws DEEPGRAM_TTS_HTTP_ERROR on non-200 response", async () => {
+    mockFetchError(401, "Unauthorized");
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe("DEEPGRAM_TTS_HTTP_ERROR");
+      expect((err as DeepgramTtsError).statusCode).toBe(401);
+    }
+  });
+
+  test("throws DEEPGRAM_TTS_EMPTY_RESPONSE on empty audio body", async () => {
+    mockFetchReturning(new Uint8Array(0));
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe(
+        "DEEPGRAM_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("throws DEEPGRAM_TTS_REQUEST_FAILED on network error", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("Network unreachable");
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe(
+        "DEEPGRAM_TTS_REQUEST_FAILED",
+      );
+      expect((err as DeepgramTtsError).message).toContain(
+        "Network unreachable",
+      );
+    }
+  });
+});
+
+// ===========================================================================
 // Built-in registration
 // ===========================================================================
 
 describe("registerBuiltinTtsProviders", () => {
-  test("registers elevenlabs and fish-audio providers", () => {
+  test("registers elevenlabs, fish-audio, and deepgram providers", () => {
     registerBuiltinTtsProviders();
 
     const providers = listTtsProviders();
     const ids = providers.map((p) => p.id);
     expect(ids).toContain("elevenlabs");
     expect(ids).toContain("fish-audio");
+    expect(ids).toContain("deepgram");
   });
 
   test("providers are discoverable via getTtsProvider after registration", () => {
@@ -562,6 +778,9 @@ describe("registerBuiltinTtsProviders", () => {
 
     const fa = getTtsProvider("fish-audio");
     expect(fa.id).toBe("fish-audio");
+
+    const dg = getTtsProvider("deepgram");
+    expect(dg.id).toBe("deepgram");
   });
 
   test("idempotent — calling twice does not throw", () => {

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -617,7 +617,7 @@ describe("Deepgram TTS provider adapter", () => {
     expect(body.text).toBe("Hello world");
   });
 
-  test("uses linear16 encoding when outputFormat is pcm", async () => {
+  test("uses linear16 encoding with container=none and sample_rate=16000 when outputFormat is pcm", async () => {
     const audioPayload = new Uint8Array([0x00, 0x01, 0x02]);
     let capturedUrl = "";
 
@@ -632,10 +632,12 @@ describe("Deepgram TTS provider adapter", () => {
     );
 
     expect(capturedUrl).toContain("encoding=linear16");
+    expect(capturedUrl).toContain("container=none");
+    expect(capturedUrl).toContain("sample_rate=16000");
     expect(result.contentType).toBe("audio/pcm");
   });
 
-  test("uses configured format when no outputFormat override", async () => {
+  test("translates wav config format to linear16 encoding with container=wav", async () => {
     mockDeepgramConfig.format = "wav";
     const audioPayload = new Uint8Array([0x52, 0x49, 0x46, 0x46]);
     let capturedUrl = "";
@@ -648,7 +650,9 @@ describe("Deepgram TTS provider adapter", () => {
     const provider = createDeepgramProvider();
     const result = await provider.synthesize(makeRequest());
 
-    expect(capturedUrl).toContain("encoding=wav");
+    expect(capturedUrl).toContain("encoding=linear16");
+    expect(capturedUrl).toContain("container=wav");
+    expect(capturedUrl).not.toContain("sample_rate=");
     expect(result.contentType).toBe("audio/wav");
   });
 

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -154,3 +154,30 @@ describe("Fish Audio catalog entry", () => {
     expect(apiKeySecret!.displayName).toContain("Fish Audio");
   });
 });
+
+describe("Deepgram catalog entry", () => {
+  const entry = getCatalogProvider("deepgram");
+
+  test("uses synthesized-play call mode", () => {
+    expect(entry.callMode).toBe("synthesized-play");
+  });
+
+  test("does not support streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(false);
+  });
+
+  test("supports mp3, wav, and opus formats", () => {
+    expect(entry.capabilities.supportedFormats).toContain("mp3");
+    expect(entry.capabilities.supportedFormats).toContain("wav");
+    expect(entry.capabilities.supportedFormats).toContain("opus");
+  });
+
+  test("requires a bare API key stored under 'deepgram'", () => {
+    const apiKeySecret = entry.secretRequirements.find(
+      (s) => s.credentialStoreKey === "deepgram",
+    );
+    expect(apiKeySecret).toBeDefined();
+    expect(apiKeySecret!.displayName).toContain("Deepgram");
+    expect(apiKeySecret!.setCommand).toContain("assistant keys set deepgram");
+  });
+});

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -125,6 +125,22 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       },
     ],
   },
+  {
+    id: "deepgram",
+    displayName: "Deepgram",
+    callMode: "synthesized-play",
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    secretRequirements: [
+      {
+        credentialStoreKey: "deepgram",
+        displayName: "Deepgram API Key",
+        setCommand: "assistant keys set deepgram <key>",
+      },
+    ],
+  },
 ] as const;
 
 /** Index for O(1) lookup by provider ID. */

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -1,0 +1,169 @@
+/**
+ * Deepgram TTS provider adapter.
+ *
+ * Wraps the Deepgram REST text-to-speech API (`/v1/speak`) behind the uniform
+ * {@link TtsProvider} interface. Reads the API key from the secure credential
+ * store using the shared `deepgram` bare key (shared with STT) and the model
+ * configuration from `services.tts.providers.deepgram` config section.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import type { TtsDeepgramProviderConfig } from "../../config/schemas/tts.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import type {
+  TtsProvider,
+  TtsProviderCapabilities,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../types.js";
+
+const log = getLogger("tts:deepgram");
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type DeepgramTtsErrorCode =
+  | "DEEPGRAM_TTS_NO_API_KEY"
+  | "DEEPGRAM_TTS_HTTP_ERROR"
+  | "DEEPGRAM_TTS_EMPTY_RESPONSE"
+  | "DEEPGRAM_TTS_REQUEST_FAILED";
+
+export class DeepgramTtsError extends Error {
+  readonly code: DeepgramTtsErrorCode;
+  readonly statusCode?: number;
+
+  constructor(
+    code: DeepgramTtsErrorCode,
+    message: string,
+    statusCode?: number,
+  ) {
+    super(message);
+    this.name = "DeepgramTtsError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEEPGRAM_API_BASE = "https://api.deepgram.com";
+
+/** Map from Deepgram encoding names to MIME content types. */
+const FORMAT_CONTENT_TYPE: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  opus: "audio/opus",
+  linear16: "audio/pcm",
+};
+
+// ---------------------------------------------------------------------------
+// Provider implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Deepgram output encoding and container based on the request.
+ *
+ * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
+ * transport which needs raw PCM for mu-law transcoding), we use `linear16`
+ * — 16-bit signed little-endian. The media-stream transport's
+ * `audioBufferToFrames` handles the sample rate conversion.
+ *
+ * Otherwise the configured format is used.
+ */
+function resolveEncoding(
+  request: TtsSynthesisRequest,
+  config: TtsDeepgramProviderConfig,
+): string {
+  if (request.outputFormat === "pcm") {
+    return "linear16";
+  }
+  return config.format;
+}
+
+export function createDeepgramProvider(): TtsProvider {
+  const capabilities: TtsProviderCapabilities = {
+    supportsStreaming: false,
+    supportedFormats: ["mp3", "wav", "opus"],
+  };
+
+  return {
+    id: "deepgram",
+    capabilities,
+
+    async synthesize(
+      request: TtsSynthesisRequest,
+    ): Promise<TtsSynthesisResult> {
+      const apiKey = await getProviderKeyAsync("deepgram");
+      if (!apiKey) {
+        throw new DeepgramTtsError(
+          "DEEPGRAM_TTS_NO_API_KEY",
+          "Deepgram API key not configured. " +
+            "Add it in Settings → Voice or via: assistant keys set deepgram <key>",
+        );
+      }
+
+      const config = getConfig().services.tts.providers.deepgram;
+      const encoding = resolveEncoding(request, config);
+      const model = config.model;
+
+      const url = `${DEEPGRAM_API_BASE}/v1/speak?model=${encodeURIComponent(model)}&encoding=${encodeURIComponent(encoding)}`;
+
+      log.info(
+        { model, encoding, textLength: request.text.length },
+        "Starting Deepgram TTS synthesis",
+      );
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Token ${apiKey}`,
+          },
+          body: JSON.stringify({ text: request.text }),
+          signal: request.signal,
+        });
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") throw err;
+        throw new DeepgramTtsError(
+          "DEEPGRAM_TTS_REQUEST_FAILED",
+          `Deepgram TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new DeepgramTtsError(
+          "DEEPGRAM_TTS_HTTP_ERROR",
+          `Deepgram TTS returned ${response.status}: ${errorText}`,
+          response.status,
+        );
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      if (arrayBuffer.byteLength === 0) {
+        throw new DeepgramTtsError(
+          "DEEPGRAM_TTS_EMPTY_RESPONSE",
+          "Deepgram TTS returned an empty audio response",
+        );
+      }
+
+      const contentType = FORMAT_CONTENT_TYPE[encoding] ?? "audio/mpeg";
+
+      log.debug(
+        { bytes: arrayBuffer.byteLength },
+        "Deepgram TTS synthesis complete",
+      );
+
+      return {
+        audio: Buffer.from(arrayBuffer),
+        contentType,
+      };
+    },
+  };
+}

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -64,24 +64,58 @@ const FORMAT_CONTENT_TYPE: Record<string, string> = {
 // Provider implementation
 // ---------------------------------------------------------------------------
 
+/** Parameters for Deepgram's `/v1/speak` encoding query string. */
+interface DeepgramOutputParams {
+  /** Deepgram encoding name (e.g. `mp3`, `linear16`, `opus`). */
+  encoding: string;
+  /** Container override (`wav` or `none`). Omitted lets Deepgram choose. */
+  container?: string;
+  /** Sample rate in Hz. Required for raw PCM to avoid Deepgram's 24 kHz default. */
+  sample_rate?: number;
+  /** Content-type key for the FORMAT_CONTENT_TYPE lookup. */
+  contentTypeKey: string;
+}
+
 /**
- * Resolve the Deepgram output encoding and container based on the request.
+ * Resolve the Deepgram output encoding, container, and sample rate based on
+ * the synthesis request and provider config.
  *
- * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
- * transport which needs raw PCM for mu-law transcoding), we use `linear16`
- * — 16-bit signed little-endian. The media-stream transport's
- * `audioBufferToFrames` handles the sample rate conversion.
+ * **PCM path** (`outputFormat: "pcm"`):
+ *   The media-stream transport needs raw headerless PCM for mu-law transcoding.
+ *   We request `encoding=linear16&container=none&sample_rate=16000` — 16-bit
+ *   signed little-endian at 16 kHz with no WAV header. This matches the
+ *   ElevenLabs `pcm_16000` convention and the downstream
+ *   `audioBufferToFrames` expectation (16 kHz -> 8 kHz downsample).
  *
- * Otherwise the configured format is used.
+ * **WAV path** (`config.format === "wav"`):
+ *   Deepgram treats WAV as a container, not an encoding. We translate to
+ *   `encoding=linear16&container=wav` so the API returns a valid WAV file.
+ *
+ * **Other formats** (mp3, opus):
+ *   Passed through directly as encoding values.
  */
-function resolveEncoding(
+function resolveOutputParams(
   request: TtsSynthesisRequest,
   config: TtsDeepgramProviderConfig,
-): string {
+): DeepgramOutputParams {
   if (request.outputFormat === "pcm") {
-    return "linear16";
+    return {
+      encoding: "linear16",
+      container: "none",
+      sample_rate: 16_000,
+      contentTypeKey: "linear16",
+    };
   }
-  return config.format;
+
+  if (config.format === "wav") {
+    return {
+      encoding: "linear16",
+      container: "wav",
+      contentTypeKey: "wav",
+    };
+  }
+
+  return { encoding: config.format, contentTypeKey: config.format };
 }
 
 export function createDeepgramProvider(): TtsProvider {
@@ -107,13 +141,28 @@ export function createDeepgramProvider(): TtsProvider {
       }
 
       const config = getConfig().services.tts.providers.deepgram;
-      const encoding = resolveEncoding(request, config);
+      const outputParams = resolveOutputParams(request, config);
       const model = config.model;
 
-      const url = `${DEEPGRAM_API_BASE}/v1/speak?model=${encodeURIComponent(model)}&encoding=${encodeURIComponent(encoding)}`;
+      const params = new URLSearchParams({
+        model,
+        encoding: outputParams.encoding,
+      });
+      if (outputParams.container) {
+        params.set("container", outputParams.container);
+      }
+      if (outputParams.sample_rate != null) {
+        params.set("sample_rate", String(outputParams.sample_rate));
+      }
+      const url = `${DEEPGRAM_API_BASE}/v1/speak?${params.toString()}`;
 
       log.info(
-        { model, encoding, textLength: request.text.length },
+        {
+          model,
+          encoding: outputParams.encoding,
+          container: outputParams.container,
+          textLength: request.text.length,
+        },
         "Starting Deepgram TTS synthesis",
       );
 
@@ -153,7 +202,8 @@ export function createDeepgramProvider(): TtsProvider {
         );
       }
 
-      const contentType = FORMAT_CONTENT_TYPE[encoding] ?? "audio/mpeg";
+      const contentType =
+        FORMAT_CONTENT_TYPE[outputParams.contentTypeKey] ?? "audio/mpeg";
 
       log.debug(
         { bytes: arrayBuffer.byteLength },

--- a/assistant/src/tts/providers/index.ts
+++ b/assistant/src/tts/providers/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { TtsProvider, TtsProviderId } from "../types.js";
+import { createDeepgramProvider } from "./deepgram-provider.js";
 import { createElevenLabsProvider } from "./elevenlabs-provider.js";
 import { createFishAudioProvider } from "./fish-audio-provider.js";
 
@@ -37,4 +38,5 @@ export const providerFactories: ReadonlyMap<TtsProviderId, TtsProviderFactory> =
   new Map<TtsProviderId, TtsProviderFactory>([
     ["elevenlabs", createElevenLabsProvider],
     ["fish-audio", createFishAudioProvider],
+    ["deepgram", createDeepgramProvider],
   ]);

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -24,6 +24,18 @@
         "url": "https://fish.audio/app/api-keys/",
         "linkLabel": "Open Fish Audio API Keys"
       }
+    },
+    {
+      "id": "deepgram",
+      "displayName": "Deepgram",
+      "subtitle": "Fast, accurate text-to-speech synthesis. Uses the same API key as Deepgram speech-to-text.",
+      "setupMode": "cli",
+      "setupHint": "Run the setup command in your terminal to configure your Deepgram API key.",
+      "credentialsGuide": {
+        "description": "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key.",
+        "url": "https://console.deepgram.com/",
+        "linkLabel": "Open Deepgram Console"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Deepgram TTS provider schema with model and format defaults
- Implement Deepgram REST TTS adapter using shared deepgram API key
- Wire into provider catalog and registry with synthesized-play call mode

Part of plan: deepgram-tts-provider.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
