### PR TITLE
feat(macos): support deepgram tts setup with shared stt key semantics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -902,52 +902,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func saveElevenLabsKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        APIKeyManager.setCredential(trimmed, service: "elevenlabs", field: "api_key")
-        removeDeletionTombstone(type: "credential", name: "elevenlabs:api_key")
-        Task {
-            let result = await APIKeyManager.setCredential(trimmed, service: "elevenlabs", field: "api_key")
-            if result.success {
-                onSuccess?()
-            } else if let error = result.error {
-                log.error("Failed to sync ElevenLabs key to daemon: \(error, privacy: .public)")
-            }
-        }
-    }
-
-    func clearElevenLabsKey() {
-        APIKeyManager.deleteCredential(service: "elevenlabs", field: "api_key")
-        Task {
-            let deleted = await APIKeyManager.deleteCredential(service: "elevenlabs", field: "api_key")
-            if !deleted { addDeletionTombstone(type: "credential", name: "elevenlabs:api_key") }
-        }
-    }
-
-    func saveFishAudioKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
-        removeDeletionTombstone(type: "credential", name: "fish-audio:api_key")
-        Task {
-            let result = await APIKeyManager.setCredential(trimmed, service: "fish-audio", field: "api_key")
-            if result.success {
-                onSuccess?()
-            } else if let error = result.error {
-                log.error("Failed to sync Fish Audio key to daemon: \(error, privacy: .public)")
-            }
-        }
-    }
-
-    func clearFishAudioKey() {
-        APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
-        Task {
-            let deleted = await APIKeyManager.deleteCredential(service: "fish-audio", field: "api_key")
-            if !deleted { addDeletionTombstone(type: "credential", name: "fish-audio:api_key") }
-        }
-    }
-
     func clearAPIKeyForProvider(_ provider: String) {
         APIKeyManager.deleteKey(for: provider)
         scheduleRoutingSourceRefresh()
@@ -3138,6 +3092,137 @@ public final class SettingsStore: ObservableObject {
     /// that depends on it.
     static func sttKeyIsShared(for sttProviderId: String) -> Bool {
         !sttKeyIsExclusive(for: sttProviderId)
+    }
+
+    // MARK: - TTS Credential Mapping
+
+    /// Checks whether a TTS credential exists for the given provider using
+    /// the registry's credential metadata. Credential-mode providers are
+    /// looked up via `APIKeyManager.getCredential(service:field:)`; api-key
+    /// mode providers via `APIKeyManager.getKey(for:)`.
+    static func ttsCredentialExists(for ttsProviderId: String) -> Bool {
+        let entry = loadTTSProviderRegistry().provider(withId: ttsProviderId)
+        guard let entry else { return false }
+        switch entry.credentialMode {
+        case .credential:
+            let namespace = entry.credentialNamespace ?? entry.id
+            return APIKeyManager.getCredential(service: namespace, field: "api_key") != nil
+        case .apiKey:
+            let keyProvider = entry.apiKeyProviderName ?? entry.id
+            return APIKeyManager.getKey(for: keyProvider) != nil
+        }
+    }
+
+    /// Saves a TTS API key for the given provider using the registry's
+    /// credential metadata to route to the correct storage mechanism.
+    func saveTTSKey(_ raw: String, ttsProviderId: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let entry = loadTTSProviderRegistry().provider(withId: ttsProviderId)
+        guard let entry else {
+            log.warning("Unknown TTS provider \(ttsProviderId, privacy: .public) — cannot save key")
+            return
+        }
+        switch entry.credentialMode {
+        case .credential:
+            let namespace = entry.credentialNamespace ?? entry.id
+            APIKeyManager.setCredential(trimmed, service: namespace, field: "api_key")
+            removeDeletionTombstone(type: "credential", name: "\(namespace):api_key")
+            Task {
+                let result = await APIKeyManager.setCredential(trimmed, service: namespace, field: "api_key")
+                if result.success {
+                    onSuccess?()
+                } else if let error = result.error {
+                    log.error("Failed to sync TTS key for \(ttsProviderId, privacy: .public): \(error, privacy: .public)")
+                }
+            }
+        case .apiKey:
+            let keyProvider = entry.apiKeyProviderName ?? entry.id
+            APIKeyManager.setKey(trimmed, for: keyProvider)
+            removeDeletionTombstone(type: "api_key", name: keyProvider)
+            Task {
+                let result = await APIKeyManager.setKey(trimmed, for: keyProvider)
+                if result.success {
+                    onSuccess?()
+                } else if let error = result.error {
+                    log.error("Failed to sync TTS key for \(ttsProviderId, privacy: .public): \(error, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    /// Clears the stored TTS credential for the given provider using the
+    /// registry's credential metadata to route to the correct storage.
+    func clearTTSKey(ttsProviderId: String) {
+        let entry = loadTTSProviderRegistry().provider(withId: ttsProviderId)
+        guard let entry else { return }
+        switch entry.credentialMode {
+        case .credential:
+            let namespace = entry.credentialNamespace ?? entry.id
+            APIKeyManager.deleteCredential(service: namespace, field: "api_key")
+            Task {
+                let deleted = await APIKeyManager.deleteCredential(service: namespace, field: "api_key")
+                if !deleted { addDeletionTombstone(type: "credential", name: "\(namespace):api_key") }
+            }
+        case .apiKey:
+            let keyProvider = entry.apiKeyProviderName ?? entry.id
+            APIKeyManager.deleteKey(for: keyProvider)
+            Task {
+                let deleted = await APIKeyManager.deleteKey(for: keyProvider)
+                if !deleted { addDeletionTombstone(type: "api_key", name: keyProvider) }
+            }
+        }
+    }
+
+    /// Whether the given TTS provider owns its API key exclusively — i.e. the
+    /// key is not shared with any other service. Exclusive-key providers can
+    /// safely have their key cleared through the TTS reset flow without
+    /// affecting other features.
+    ///
+    /// Credential-mode providers (ElevenLabs, Fish Audio) are always exclusive
+    /// because their credential namespace is provider-specific. Api-key mode
+    /// providers are exclusive when their `apiKeyProviderName` matches their
+    /// own `id` — shared-key providers map to a different name (e.g. a
+    /// hypothetical provider sharing the `openai` key).
+    ///
+    /// Deepgram TTS uses api-key mode with `apiKeyProviderName: "deepgram"`.
+    /// The key is shared with Deepgram STT, so the TTS card should not offer
+    /// a destructive reset — clearing the key would break STT. The sharing is
+    /// detected because another service (STT) also references the `deepgram`
+    /// key provider name.
+    static func ttsKeyIsExclusive(for ttsProviderId: String) -> Bool {
+        let entry = loadTTSProviderRegistry().provider(withId: ttsProviderId)
+        guard let entry else {
+            // Unknown providers are assumed exclusive — clearing an unknown
+            // key cannot collide with a known service.
+            return true
+        }
+        switch entry.credentialMode {
+        case .credential:
+            // Credential-mode providers use their own namespace — always exclusive.
+            return true
+        case .apiKey:
+            // Api-key mode: check whether the key name is shared across services.
+            // Deepgram TTS shares its key with Deepgram STT, so it is NOT exclusive.
+            let keyProvider = entry.apiKeyProviderName ?? entry.id
+            return !Self.isApiKeySharedAcrossServices(keyProvider)
+        }
+    }
+
+    /// Whether the given TTS provider's API key is shared with another
+    /// service. The inverse of `ttsKeyIsExclusive(for:)`.
+    static func ttsKeyIsShared(for ttsProviderId: String) -> Bool {
+        !ttsKeyIsExclusive(for: ttsProviderId)
+    }
+
+    /// Checks whether a given API key provider name is used by both a TTS and
+    /// an STT provider, indicating a cross-service shared credential.
+    private static func isApiKeySharedAcrossServices(_ keyProviderName: String) -> Bool {
+        let sttRegistry = loadSTTProviderRegistry()
+        let sttUsesKey = sttRegistry.providers.contains { entry in
+            entry.apiKeyProviderName == keyProviderName
+        }
+        return sttUsesKey
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -70,6 +70,12 @@ struct VoiceSettingsView: View {
         sttRegistry.provider(withId: draftSTTProvider) ?? sttRegistry.providers.first
     }
 
+    /// Whether the currently selected TTS provider uses a shared API key
+    /// (e.g. Deepgram TTS shares the `deepgram` key with Deepgram STT).
+    private var ttsProviderUsesSharedKey: Bool {
+        SettingsStore.ttsKeyIsShared(for: draftTTSProvider)
+    }
+
     private var currentActivator: PTTActivator {
         // Read activationKey to establish SwiftUI dependency tracking —
         // without this, SwiftUI doesn't know the body depends on this
@@ -103,7 +109,7 @@ struct VoiceSettingsView: View {
             // Initialize TTS draft state from persisted values
             draftTTSProvider = ttsProviderRaw
             initialTTSProvider = ttsProviderRaw
-            ttsProviderHasKey = ttsCredentialExists(for: ttsProviderRaw)
+            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: ttsProviderRaw)
 
             // Load the stored voice ID for the current TTS provider so
             // the field reflects the daemon-configured value on page load.
@@ -121,7 +127,7 @@ struct VoiceSettingsView: View {
             // newly selected provider so the field shows its current value.
             ttsApiKeyText = ""
             ttsSaveError = nil
-            ttsProviderHasKey = ttsCredentialExists(for: draftTTSProvider)
+            ttsProviderHasKey = SettingsStore.ttsCredentialExists(for: draftTTSProvider)
             let voiceId = storedVoiceId(for: draftTTSProvider)
             ttsVoiceIdText = voiceId
             initialVoiceId = voiceId
@@ -373,6 +379,20 @@ struct VoiceSettingsView: View {
         return providerChanged || hasNewKey || voiceIdChanged
     }
 
+    /// Whether the TTS reset button should be shown for the current provider.
+    ///
+    /// The reset button is only shown when:
+    /// 1. A key already exists for the provider, AND
+    /// 2. The provider owns its key exclusively (not shared with another
+    ///    service like STT).
+    ///
+    /// This prevents accidental clearing of shared credentials — e.g.
+    /// resetting Deepgram TTS must not delete the `deepgram` key that
+    /// STT also depends on.
+    private var ttsResetAllowed: Bool {
+        ttsProviderHasKey && SettingsStore.ttsKeyIsExclusive(for: draftTTSProvider)
+    }
+
     private var ttsProviderCard: some View {
         SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -390,34 +410,61 @@ struct VoiceSettingsView: View {
                     )
                 }
 
-                // Unified API key field
-                ttsApiKeyField
+                // Shared-key explanatory note for providers like Deepgram
+                // that reuse an API key configured in another settings card.
+                ttsSharedKeyNote
 
-                // Voice ID / Reference ID field (provider-specific)
+                // API key field — hidden for shared-key providers since
+                // the key is managed through the sibling service card.
+                if !ttsProviderUsesSharedKey {
+                    ttsApiKeyField
+                }
+
+                // Voice ID / Reference ID field (provider-specific) —
+                // hidden for providers like Deepgram that use a built-in
+                // default model and do not expose voice selection.
                 ttsVoiceIdField
 
                 // Credentials guide — contextual help for obtaining an API key
                 ttsCredentialsGuideView
 
-                // Save + Reset actions
+                // Save + Reset actions — reset is gated by ttsResetAllowed
+                // to prevent destructive actions on shared-key providers.
                 ServiceCardActions(
                     hasChanges: ttsHasChanges,
                     isSaving: ttsSaving,
                     onSave: { saveTTS() },
                     savingLabel: "Saving...",
                     onReset: {
-                        clearTTSCredential(for: draftTTSProvider)
+                        store.clearTTSKey(ttsProviderId: draftTTSProvider)
                         ttsProviderHasKey = false
                         ttsApiKeyText = ""
                     },
-                    showReset: ttsProviderHasKey
+                    showReset: ttsResetAllowed
                 )
+            }
+        }
+    }
+
+    // MARK: - TTS Shared Key Note
+
+    @ViewBuilder
+    private var ttsSharedKeyNote: some View {
+        if ttsProviderUsesSharedKey {
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                VIconView(.info, size: 10)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text("This provider uses the same API key as \(selectedTTSProvider?.displayName ?? "the provider") speech-to-text. Manage the key in the Speech-to-Text section below.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineSpacing(1)
             }
         }
     }
 
     // MARK: - TTS API Key Field
 
+    @ViewBuilder
     private var ttsApiKeyField: some View {
         let placeholder: String = {
             if ttsProviderHasKey {
@@ -425,7 +472,7 @@ struct VoiceSettingsView: View {
             }
             return "Enter your API key"
         }()
-        return VTextField(
+        VTextField(
             "\(selectedTTSProvider?.displayName ?? "Provider") API Key",
             placeholder: placeholder,
             text: $ttsApiKeyText,
@@ -494,21 +541,14 @@ struct VoiceSettingsView: View {
             break
         }
 
-        // Persist API key if entered. Clear the field and update hasKey
-        // optimistically so the UI reflects the save immediately; the
-        // async daemon sync validates the key in the background.
+        // Persist API key if entered and the provider manages its own key
+        // (not shared). Shared-key providers do not show the key field, so
+        // trimmedKey will always be empty for them.
         let trimmedKey = ttsApiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
             ttsApiKeyText = ""
             ttsProviderHasKey = true
-            switch draftTTSProvider {
-            case "elevenlabs":
-                store.saveElevenLabsKey(trimmedKey)
-            case "fish-audio":
-                store.saveFishAudioKey(trimmedKey)
-            default:
-                break
-            }
+            store.saveTTSKey(trimmedKey, ttsProviderId: draftTTSProvider)
         }
 
         ttsSaving = false
@@ -528,18 +568,6 @@ struct VoiceSettingsView: View {
             return store.fishAudioReferenceId
         default:
             return ""
-        }
-    }
-
-    /// Checks whether a TTS credential exists for the given provider.
-    private func ttsCredentialExists(for provider: String) -> Bool {
-        switch provider {
-        case "elevenlabs":
-            return APIKeyManager.getCredential(service: "elevenlabs", field: "api_key") != nil
-        case "fish-audio":
-            return APIKeyManager.getCredential(service: "fish-audio", field: "api_key") != nil
-        default:
-            return false
         }
     }
 
@@ -567,18 +595,6 @@ struct VoiceSettingsView: View {
     /// catalog entry, not a new conditional here.
     private var sttResetAllowed: Bool {
         sttProviderHasKey && SettingsStore.sttKeyIsExclusive(for: draftSTTProvider)
-    }
-
-    /// Clears the stored TTS credential for the given provider.
-    private func clearTTSCredential(for provider: String) {
-        switch provider {
-        case "elevenlabs":
-            store.clearElevenLabsKey()
-        case "fish-audio":
-            store.clearFishAudioKey()
-        default:
-            break
-        }
     }
 
     // MARK: - STT Provider Card

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -710,4 +710,264 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
             "A non-empty persisted sttProvider must be treated as configured"
         )
     }
+
+    // MARK: - Deepgram TTS Provider Selection
+
+    func testSetTTSProviderDeepgramEmitsExpectedPatch() {
+        store.setTTSProvider("deepgram")
+
+        waitForPatchCount(1)
+
+        let patch = lastTTSPatch()
+        XCTAssertNotNil(patch, "expected a services.tts patch payload for deepgram")
+        XCTAssertEqual(patch?["provider"] as? String, "deepgram")
+    }
+
+    func testSetTTSProviderDeepgramDoesNotEmitSTTPatch() {
+        store.setTTSProvider("deepgram")
+
+        waitForPatchCount(1)
+
+        let sttPatch = lastSTTPatch()
+        XCTAssertNil(sttPatch, "setTTSProvider(deepgram) must not emit an STT patch")
+    }
+
+    func testApplyDaemonConfigSyncsDeepgramTTSProvider() {
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "deepgram"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "ttsProvider"),
+            "deepgram"
+        )
+    }
+
+    func testApplyDaemonConfigSyncsDeepgramTTSWithExistingElevenLabs() {
+        UserDefaults.standard.set("elevenlabs", forKey: "ttsProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "deepgram"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "ttsProvider"),
+            "deepgram",
+            "Daemon config should overwrite the persisted TTS provider"
+        )
+    }
+
+    func testSequentialTTSProviderPatchesIncludingDeepgram() {
+        store.setTTSProvider("elevenlabs")
+        waitForPatchCount(1)
+
+        store.setTTSProvider("deepgram")
+        waitForPatchCount(2)
+
+        let patch = lastTTSPatch()
+        XCTAssertEqual(
+            patch?["provider"] as? String,
+            "deepgram",
+            "Most recent TTS patch should reflect the deepgram provider"
+        )
+    }
+
+    // MARK: - TTS Key Ownership Semantics
+
+    func testTTSElevenLabsKeyIsExclusive() {
+        // ElevenLabs uses credential mode with its own namespace — always exclusive.
+        XCTAssertTrue(
+            SettingsStore.ttsKeyIsExclusive(for: "elevenlabs"),
+            "ElevenLabs TTS owns its own credential namespace and must be exclusive"
+        )
+    }
+
+    func testTTSElevenLabsKeyIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.ttsKeyIsShared(for: "elevenlabs"),
+            "ElevenLabs TTS must not be classified as shared"
+        )
+    }
+
+    func testTTSFishAudioKeyIsExclusive() {
+        // Fish Audio uses credential mode with its own namespace — always exclusive.
+        XCTAssertTrue(
+            SettingsStore.ttsKeyIsExclusive(for: "fish-audio"),
+            "Fish Audio TTS owns its own credential namespace and must be exclusive"
+        )
+    }
+
+    func testTTSFishAudioKeyIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.ttsKeyIsShared(for: "fish-audio"),
+            "Fish Audio TTS must not be classified as shared"
+        )
+    }
+
+    func testTTSDeepgramKeyIsShared() {
+        // Deepgram TTS uses api-key mode with apiKeyProviderName "deepgram",
+        // which is also used by Deepgram STT — the key is shared.
+        XCTAssertTrue(
+            SettingsStore.ttsKeyIsShared(for: "deepgram"),
+            "Deepgram TTS shares the 'deepgram' key with STT and must be classified as shared"
+        )
+    }
+
+    func testTTSDeepgramKeyIsNotExclusive() {
+        XCTAssertFalse(
+            SettingsStore.ttsKeyIsExclusive(for: "deepgram"),
+            "Deepgram TTS shares the 'deepgram' key with STT and must not be exclusive"
+        )
+    }
+
+    func testTTSDeepgramSharedKeyCannotBeResetThroughTTSFlow() {
+        // The UI checks ttsKeyIsExclusive before allowing the reset action.
+        // For deepgram the guard must prevent the reset because clearing the
+        // "deepgram" key would break STT.
+        let allowReset = SettingsStore.ttsKeyIsExclusive(for: "deepgram")
+        XCTAssertFalse(
+            allowReset,
+            "The TTS reset flow must not be allowed for deepgram (shared key with STT)"
+        )
+    }
+
+    func testTTSUnknownProviderDefaultsToExclusive() {
+        XCTAssertTrue(
+            SettingsStore.ttsKeyIsExclusive(for: "future-tts-provider"),
+            "Unknown TTS providers should default to exclusive"
+        )
+    }
+
+    func testTTSUnknownProviderIsNotShared() {
+        XCTAssertFalse(
+            SettingsStore.ttsKeyIsShared(for: "future-tts-provider"),
+            "Unknown TTS providers should not be classified as shared"
+        )
+    }
+
+    // MARK: - TTS Credential Exists (Registry-Driven)
+
+    func testTTSCredentialExistsReturnsFalseForUnknownProvider() {
+        XCTAssertFalse(
+            SettingsStore.ttsCredentialExists(for: "nonexistent-provider"),
+            "Unknown TTS provider must return false for credential existence"
+        )
+    }
+
+    // MARK: - TTS + STT Deepgram Coexistence
+
+    func testApplyDaemonConfigSyncsBothDeepgramTTSAndSTT() {
+        UserDefaults.standard.removeObject(forKey: "ttsProvider")
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let config: [String: Any] = [
+            "services": [
+                "tts": [
+                    "provider": "deepgram"
+                ],
+                "stt": [
+                    "provider": "deepgram"
+                ]
+            ]
+        ]
+
+        mockSettingsClient.fetchConfigResponse = config
+        let expectation = XCTestExpectation(description: "config loaded")
+        Task {
+            await store.loadConfigFromDaemon()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "ttsProvider"),
+            "deepgram",
+            "TTS provider must be synced to deepgram"
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "sttProvider"),
+            "deepgram",
+            "STT provider must be synced to deepgram"
+        )
+    }
+
+    func testSetTTSProviderDeepgramAndSTTProviderDeepgramEmitSeparatePatches() {
+        store.setTTSProvider("deepgram")
+        waitForPatchCount(1)
+
+        store.setSTTProvider("deepgram")
+        waitForPatchCount(2)
+
+        // Verify the TTS patch
+        let ttsPatch = lastTTSPatch()
+        XCTAssertEqual(ttsPatch?["provider"] as? String, "deepgram")
+
+        // Verify the STT patch
+        let sttPatch = lastSTTPatch()
+        XCTAssertEqual(sttPatch?["provider"] as? String, "deepgram")
+    }
+
+    // MARK: - TTS Provider Registry Consistency
+
+    /// Ensures every TTS provider in the registry has the expected credential
+    /// metadata fields set. This test fails fast when a new provider is added
+    /// with incomplete credential metadata.
+    func testAllTTSRegistryProvidersHaveCredentialMetadata() {
+        let registry = loadTTSProviderRegistry()
+        for provider in registry.providers {
+            switch provider.credentialMode {
+            case .credential:
+                XCTAssertNotNil(
+                    provider.credentialNamespace,
+                    "Credential-mode TTS provider \"\(provider.id)\" must have a credentialNamespace"
+                )
+            case .apiKey:
+                XCTAssertNotNil(
+                    provider.apiKeyProviderName,
+                    "Api-key-mode TTS provider \"\(provider.id)\" must have an apiKeyProviderName"
+                )
+            }
+        }
+    }
+
+    /// Ensures the TTS key ownership classification is consistent with the
+    /// provider's credential mode and metadata.
+    func testAllTTSRegistryProvidersHaveConsistentOwnership() {
+        let registry = loadTTSProviderRegistry()
+        for provider in registry.providers {
+            let isExclusive = SettingsStore.ttsKeyIsExclusive(for: provider.id)
+            let isShared = SettingsStore.ttsKeyIsShared(for: provider.id)
+            XCTAssertNotEqual(
+                isExclusive,
+                isShared,
+                "TTS provider \"\(provider.id)\" must be either exclusive or shared, not both"
+            )
+        }
+    }
 }

--- a/clients/shared/Utilities/TTSProviderRegistry.swift
+++ b/clients/shared/Utilities/TTSProviderRegistry.swift
@@ -16,6 +16,20 @@ public enum TTSProviderSetupMode: String, Decodable {
     case cli
 }
 
+/// How the provider's API key is stored and looked up.
+///
+/// - `credential`: Stored as a service/field pair via
+///   `APIKeyManager.setCredential(_:service:field:)`. The `credentialNamespace`
+///   field on the catalog entry supplies the service name; the field is always
+///   `"api_key"`.
+/// - `apiKey`: Stored as a flat provider key via
+///   `APIKeyManager.setKey(_:for:)`. The `apiKeyProviderName` field on the
+///   catalog entry supplies the key name.
+public enum TTSCredentialMode: String, Decodable {
+    case credential
+    case apiKey = "api-key"
+}
+
 /// Guide for obtaining API credentials from a TTS provider.
 ///
 /// Contains a short description of the steps, a URL to the provider's
@@ -32,10 +46,10 @@ public struct TTSCredentialsGuide: Decodable {
 /// A single entry in the client-facing TTS provider catalog.
 ///
 /// This struct captures the subset of provider metadata that client apps
-/// need for display and setup UX — identity, display strings, and hints
-/// about how the provider is configured.
+/// need for display and setup UX — identity, display strings, hints
+/// about how the provider is configured, and credential storage semantics.
 public struct TTSProviderCatalogEntry: Decodable {
-    /// Unique provider identifier (e.g. `"elevenlabs"`, `"fish-audio"`).
+    /// Unique provider identifier (e.g. `"elevenlabs"`, `"fish-audio"`, `"deepgram"`).
     public let id: String
     /// Human-readable name for display in settings UI.
     public let displayName: String
@@ -45,6 +59,22 @@ public struct TTSProviderCatalogEntry: Decodable {
     public let setupMode: TTSProviderSetupMode
     /// Brief help text guiding the user through setup.
     public let setupHint: String
+    /// How the provider's API key is stored — as a credential (service/field
+    /// pair) or as a flat provider key. Defaults to `.credential` for
+    /// backwards compatibility with existing providers.
+    public let credentialMode: TTSCredentialMode
+    /// The credential service name used when `credentialMode` is `.credential`.
+    /// For example, `"elevenlabs"` maps to
+    /// `APIKeyManager.getCredential(service: "elevenlabs", field: "api_key")`.
+    /// `nil` when the provider uses api-key mode.
+    public let credentialNamespace: String?
+    /// The key provider name used when `credentialMode` is `.apiKey`.
+    /// For example, `"deepgram"` maps to `APIKeyManager.getKey(for: "deepgram")`.
+    /// When a TTS provider shares an API key with another service (e.g.
+    /// Deepgram TTS shares the `deepgram` key with Deepgram STT), this
+    /// field names the shared credential.
+    /// `nil` when the provider uses credential mode.
+    public let apiKeyProviderName: String?
     /// Guide for obtaining API credentials from this provider.
     public let credentialsGuide: TTSCredentialsGuide?
 }
@@ -78,6 +108,9 @@ private let fallbackRegistry = TTSProviderRegistry(
             subtitle: "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key.",
             setupMode: .apiKey,
             setupHint: "Enter your ElevenLabs API key to get started.",
+            credentialMode: .credential,
+            credentialNamespace: "elevenlabs",
+            apiKeyProviderName: nil,
             credentialsGuide: TTSCredentialsGuide(
                 description: "Sign in to ElevenLabs, go to your Profile, and copy your API key.",
                 url: "https://elevenlabs.io/app/settings/api-keys",
@@ -90,10 +123,28 @@ private let fallbackRegistry = TTSProviderRegistry(
             subtitle: "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID.",
             setupMode: .cli,
             setupHint: "Run the setup commands in your terminal to configure Fish Audio.",
+            credentialMode: .credential,
+            credentialNamespace: "fish-audio",
+            apiKeyProviderName: nil,
             credentialsGuide: TTSCredentialsGuide(
                 description: "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
                 url: "https://fish.audio/app/api-keys/",
                 linkLabel: "Open Fish Audio API Keys"
+            )
+        ),
+        TTSProviderCatalogEntry(
+            id: "deepgram",
+            displayName: "Deepgram",
+            subtitle: "Fast, accurate text-to-speech synthesis. Uses the same API key as Deepgram speech-to-text.",
+            setupMode: .cli,
+            setupHint: "Run the setup command in your terminal to configure your Deepgram API key.",
+            credentialMode: .apiKey,
+            credentialNamespace: nil,
+            apiKeyProviderName: "deepgram",
+            credentialsGuide: TTSCredentialsGuide(
+                description: "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key. This is the same key used for speech-to-text.",
+                url: "https://console.deepgram.com/",
+                linkLabel: "Open Deepgram Console"
             )
         ),
     ]

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "providers": [
     {
       "id": "elevenlabs",
@@ -7,6 +7,8 @@
       "subtitle": "High-quality voice synthesis for conversations and read-aloud. Requires an ElevenLabs API key.",
       "setupMode": "cli",
       "setupHint": "Run the setup commands in your terminal to configure ElevenLabs credentials.",
+      "credentialMode": "credential",
+      "credentialNamespace": "elevenlabs",
       "credentialsGuide": {
         "description": "Sign in to ElevenLabs, go to your Profile, and copy your API key.",
         "url": "https://elevenlabs.io/app/settings/api-keys",
@@ -19,6 +21,8 @@
       "subtitle": "Natural-sounding voice synthesis with custom voice cloning. Requires a Fish Audio API key and voice reference ID.",
       "setupMode": "cli",
       "setupHint": "Run the setup commands in your terminal to configure Fish Audio.",
+      "credentialMode": "credential",
+      "credentialNamespace": "fish-audio",
       "credentialsGuide": {
         "description": "Sign in to Fish Audio, navigate to API Keys in your dashboard, and create a new key.",
         "url": "https://fish.audio/app/api-keys/",
@@ -31,8 +35,10 @@
       "subtitle": "Fast, accurate text-to-speech synthesis. Uses the same API key as Deepgram speech-to-text.",
       "setupMode": "cli",
       "setupHint": "Run the setup command in your terminal to configure your Deepgram API key.",
+      "credentialMode": "api-key",
+      "apiKeyProviderName": "deepgram",
       "credentialsGuide": {
-        "description": "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key.",
+        "description": "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key. This is the same key used for speech-to-text.",
         "url": "https://console.deepgram.com/",
         "linkLabel": "Open Deepgram Console"
       }


### PR DESCRIPTION
## Summary
- Extend TTSProviderRegistry with credential metadata for shared-key handling
- Add Deepgram to macOS TTS provider dropdown with shared-key UX
- Replace hardcoded key save/clear checks with mapping-driven resolution

Part of plan: deepgram-tts-provider.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
