### PR TITLE
feat(calls): route deepgram tts via synthesized-play with explicit failure policy

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -59,6 +59,10 @@ mock.module("../config/loader.js", () => {
             latency: "normal",
             speed: 1.0,
           },
+          deepgram: {
+            model: "aura-2-theia-en",
+            format: "mp3",
+          },
         },
       },
     },
@@ -206,6 +210,21 @@ function registerTestTtsProviders(): void {
     },
   };
   registerTtsProvider(fishAudio);
+
+  const deepgram: TtsProvider = {
+    id: "deepgram",
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    async synthesize() {
+      return {
+        audio: Buffer.from("fake-deepgram-audio"),
+        contentType: "audio/mpeg",
+      };
+    },
+  };
+  registerTtsProvider(deepgram);
 }
 
 // Register providers immediately so they're available for all tests
@@ -2501,6 +2520,109 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("Deepgram selected path resolves useSynthesizedPath to true", () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "deepgram";
+
+    const result = resolveCallTtsProvider();
+    expect(result.provider).not.toBeNull();
+    expect(result.provider!.id).toBe("deepgram");
+    expect(result.useSynthesizedPath).toBe(true);
+  });
+
+  test("Deepgram synthesis failure does NOT fall back to native token TTS", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "deepgram";
+
+    _resetTtsProviderRegistry();
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize() {
+        return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+      },
+    };
+    registerTtsProvider(elevenlabs);
+
+    const deepgramFailing: TtsProvider = {
+      id: "deepgram",
+      capabilities: {
+        supportsStreaming: false,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        const err = new Error("Deepgram TTS returned 503: service unavailable");
+        (err as Error & { code?: string }).code = "DEEPGRAM_TTS_HTTP_ERROR";
+        throw err;
+      },
+    };
+    registerTtsProvider(deepgramFailing);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from deepgram path"]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // No play URL should be emitted when synthesis fails.
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    // Deepgram should NOT have fallen back to sending the LLM text as
+    // native token TTS. Instead, the outer error handler should have
+    // produced a recovery message ("Could you repeat that?").
+    const allTokenText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allTokenText).not.toContain("Hello from deepgram path");
+    expect(allTokenText).toContain("technical issue");
+
+    controller.destroy();
+  });
+
+  test("Fish Audio synthesis failure still falls back to native token TTS (unchanged behavior)", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-abc";
+
+    _resetTtsProviderRegistry();
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize() {
+        return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+      },
+    };
+    registerTtsProvider(elevenlabs);
+
+    const fishAudioFailing: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        throw new Error("fish-audio synth failure");
+      },
+      async synthesizeStream() {
+        throw new Error("fish-audio stream failure");
+      },
+    };
+    registerTtsProvider(fishAudioFailing);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from fish path"]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // Fish Audio fallback: the LLM text should reach the caller
+    // via native token TTS despite synthesis failure.
+    const allTokenText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allTokenText).toContain("Hello from fish path");
+
+    controller.destroy();
+  });
+
   // ── TTS provider abstraction: interruption behavior ─────────────────
 
   test("handleInterrupt: cancels synthesis abort controller for native provider path", async () => {
@@ -2596,6 +2718,31 @@ describe("call-controller", () => {
       expect(relay.sentPlayUrls.length).toBe(0);
 
       controller.destroy();
+    });
+
+    test("returns synthesized path with deepgram provider", () => {
+      const cfg = loadConfig();
+      cfg.services.tts.provider = "deepgram";
+
+      const result = resolveCallTtsProvider();
+      expect(result.provider).not.toBeNull();
+      expect(result.provider!.id).toBe("deepgram");
+      expect(result.useSynthesizedPath).toBe(true);
+      expect(result.audioFormat).toBe("mp3");
+    });
+
+    test("Deepgram does not apply fish-audio referenceId gate", () => {
+      // Deepgram has no referenceId requirement. Verify the fish-audio
+      // config gate does not apply to deepgram resolution.
+      const cfg = loadConfig();
+      cfg.services.tts.provider = "deepgram";
+      // fish-audio referenceId left empty — should not affect deepgram.
+      cfg.services.tts.providers["fish-audio"].referenceId = "";
+
+      const result = resolveCallTtsProvider();
+      expect(result.provider).not.toBeNull();
+      expect(result.provider!.id).toBe("deepgram");
+      expect(result.useSynthesizedPath).toBe(true);
     });
   });
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -105,6 +105,7 @@ mock.module("../config/loader.js", () => ({
 let mockTtsProviderId: string = "elevenlabs";
 let mockTtsSupportsStreaming: boolean = false;
 let mockTtsSynthesizeStream: Mock<any> | null = null;
+let mockTtsSynthesize: Mock<any> | null = null;
 
 mock.module("../tts/tts-config-resolver.js", () => ({
   resolveTtsConfig: () => ({
@@ -124,10 +125,12 @@ mock.module("../tts/provider-registry.js", () => ({
       supportsStreaming: mockTtsSupportsStreaming,
       supportedFormats: ["mp3"],
     },
-    synthesize: async () => ({
-      audio: Buffer.from("fake-audio"),
-      contentType: "audio/mpeg",
-    }),
+    synthesize: mockTtsSynthesize
+      ? (...args: unknown[]) => mockTtsSynthesize!(...args)
+      : async () => ({
+          audio: Buffer.from("fake-audio"),
+          contentType: "audio/mpeg",
+        }),
     synthesizeStream: mockTtsSynthesizeStream
       ? (...args: unknown[]) => mockTtsSynthesizeStream!(...args)
       : undefined,
@@ -388,6 +391,7 @@ describe("relay-server", () => {
     mockTtsProviderId = "elevenlabs";
     mockTtsSupportsStreaming = false;
     mockTtsSynthesizeStream = null;
+    mockTtsSynthesize = null;
     setVoiceBridgeDeps({
       getOrCreateConversation: async (conversationId) => {
         const session = {
@@ -4530,6 +4534,66 @@ describe("relay-server", () => {
       expect(
         textMessages.some((m) => (m.token ?? "").includes("verification code")),
       ).toBe(true);
+
+      relay.destroy();
+    });
+
+    test("Deepgram TTS provider: synthesis failure does NOT fall back to text (fail-fast policy)", async () => {
+      // Configure Deepgram as the synthesized provider with failing synthesis.
+      // Deepgram uses buffer synthesis (no streaming), so we fail synthesize().
+      mockTtsProviderId = "deepgram";
+      mockTtsSupportsStreaming = false;
+      mockTtsSynthesizeStream = null;
+      mockTtsSynthesize = jest.fn(async () => {
+        const err = new Error("Deepgram TTS returned 503: service unavailable");
+        (err as Error & { code?: string }).code = "DEEPGRAM_TTS_HTTP_ERROR";
+        throw err;
+      });
+
+      ensureConversation("conv-deepgram-fail");
+      const session = createCallSession({
+        conversationId: "conv-deepgram-fail",
+        provider: "twilio",
+        fromNumber: "+15559990088",
+        toNumber: "+15551111111",
+      });
+
+      createPendingVoiceGuardianChallenge("123456");
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_deepgram_fail",
+          from: "+15559990088",
+          to: "+15551111111",
+        }),
+      );
+
+      // Allow async synthesis (and error propagation) to complete
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Deepgram failure should NOT have produced text fallback messages
+      // containing the verification prompt content, because Deepgram
+      // synthesis failures propagate rather than falling back to native TTS.
+      const textMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text");
+      const playMessages = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string })
+        .filter((m) => m.type === "play");
+
+      // No play URL should have been sent either (synthesis failed before
+      // first chunk).
+      expect(playMessages.length).toBe(0);
+
+      // Unlike Fish Audio which falls back to text, Deepgram should NOT
+      // have any text tokens containing the verification prompt.
+      const hasVerificationText = textMessages.some((m) =>
+        (m.token ?? "").includes("verification code"),
+      );
+      expect(hasVerificationText).toBe(false);
 
       relay.destroy();
     });

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -70,6 +70,18 @@ function registerTestVoiceSpecs(): void {
   };
   registerTtsProvider(fishAudio);
 
+  const deepgram: TtsProvider = {
+    id: "deepgram",
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3", "wav", "opus"],
+    },
+    async synthesize() {
+      return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+    },
+  };
+  registerTtsProvider(deepgram);
+
   // Register the ElevenLabs native Twilio voice-spec builder (mirrors
   // the production registration in register-builtins.ts).
   registerNativeTwilioVoiceSpec("elevenlabs", {
@@ -531,5 +543,58 @@ describe("resolveVoiceQualityProfile", () => {
     const profile = resolveVoiceQualityProfile();
     expect(profile.ttsProvider).toBe("ElevenLabs");
     expect(profile.voice).toBe(DEFAULT_ELEVENLABS_VOICE_ID);
+  });
+
+  // -- Deepgram synthesized-play path ------------------------------------
+
+  test("uses catalog callMode to select synthesized-play path for Deepgram", () => {
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "en-US",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "deepgram",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "" },
+            deepgram: { model: "aura-2-theia-en", format: "mp3" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    // Deepgram is synthesized-play in the catalog, so Twilio gets the
+    // placeholder ttsProvider and an empty voice string.
+    expect(profile.ttsProvider).toBe("Google");
+    expect(profile.voice).toBe("");
+  });
+
+  test("Deepgram preserves language setting on synthesized-play path", () => {
+    mockConfig = {
+      calls: {
+        voice: {
+          language: "fr-FR",
+          transcriptionProvider: "Deepgram",
+        },
+      },
+      services: {
+        tts: {
+          provider: "deepgram",
+          providers: {
+            elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
+            "fish-audio": { referenceId: "" },
+            deepgram: { model: "aura-2-theia-en", format: "mp3" },
+          },
+        },
+      },
+    };
+    const profile = resolveVoiceQualityProfile();
+    expect(profile.language).toBe("fr-FR");
+    expect(profile.ttsProvider).toBe("Google");
+    expect(profile.voice).toBe("");
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -833,13 +833,35 @@ export class CallController {
           "TTS synthesis aborted (barge-in)",
         );
       } else {
+        // Extract error class and code for diagnosable log entries.
+        const errName = err instanceof Error ? err.name : String(err);
+        const errCode =
+          err instanceof Error && "code" in err
+            ? (err as Error & { code?: string }).code
+            : undefined;
+
+        // Deepgram is a synthesized-only provider with no native Twilio
+        // TTS integration. Silently falling back to token-based speech
+        // would route audio through a path that cannot produce output,
+        // so we fail explicitly and let the outer error handler surface
+        // a user-facing recovery message.
+        if (provider.id === "deepgram") {
+          log.error(
+            { err, provider: provider.id, errName, errCode },
+            "Deepgram TTS synthesis failed — no native fallback available",
+          );
+          throw err;
+        }
+
         log.error(
-          { err, provider: provider.id },
-          "TTS synthesis failed — skipping",
+          { err, provider: provider.id, errName, errCode },
+          "TTS synthesis failed — falling back to native token TTS",
         );
         // If synthesis fails before any audio has started, degrade to
         // token-based speech on ConversationRelay so the caller still
-        // hears a response instead of silence.
+        // hears a response instead of silence. This fallback is only
+        // used for providers that have a viable native-twilio path
+        // (e.g. Fish Audio with ConversationRelay text tokens).
         if (!playUrlSent && !this.transport.requiresWavAudio) {
           this.transport.sendTextToken(text, false);
         }

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -150,13 +150,15 @@ async function synthesizeAndPlay(
     // Deepgram is a synthesized-only provider with no native Twilio
     // TTS integration. Silently falling back to token-based speech
     // would route audio through a path that cannot produce output,
-    // so we fail explicitly and propagate the error.
+    // so we log the error and return without sending any fallback.
+    // Callers use fire-and-forget (`void speakSystemPrompt(...)`) so
+    // throwing here would produce an unhandled promise rejection.
     if (provider.id === "deepgram") {
       log.error(
         { err, provider: provider.id, errName, errCode },
         "Deepgram system prompt TTS synthesis failed — no native fallback available",
       );
-      throw err;
+      return;
     }
 
     log.error(

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -158,6 +158,11 @@ async function synthesizeAndPlay(
         { err, provider: provider.id, errName, errCode },
         "Deepgram system prompt TTS synthesis failed — no native fallback available",
       );
+      // Send the end-of-turn signal so ConversationRelay transitions from
+      // "assistant speaking" to "caller speaking" state. Without this, the
+      // relay hangs waiting for the prompt to complete and the caller
+      // cannot interact.
+      relay.sendTextToken("", true);
       return;
     }
 

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -140,12 +140,33 @@ async function synthesizeAndPlay(
     // "caller speaking" state.
     relay.sendTextToken("", true);
   } catch (err) {
+    // Extract error class and code for diagnosable log entries.
+    const errName = err instanceof Error ? err.name : String(err);
+    const errCode =
+      err instanceof Error && "code" in err
+        ? (err as Error & { code?: string }).code
+        : undefined;
+
+    // Deepgram is a synthesized-only provider with no native Twilio
+    // TTS integration. Silently falling back to token-based speech
+    // would route audio through a path that cannot produce output,
+    // so we fail explicitly and propagate the error.
+    if (provider.id === "deepgram") {
+      log.error(
+        { err, provider: provider.id, errName, errCode },
+        "Deepgram system prompt TTS synthesis failed — no native fallback available",
+      );
+      throw err;
+    }
+
     log.error(
-      { err, provider: provider.id },
+      { err, provider: provider.id, errName, errCode },
       "System prompt TTS synthesis failed — falling back to native TTS",
     );
     // Fallback: send text via native TTS so the caller still hears the message.
     // sendTextToken with last:true includes the end-of-turn signal inherently.
+    // This fallback is only used for providers that have a viable
+    // native-twilio path.
     relay.sendTextToken(text, true);
   } finally {
     handle?.finalize();


### PR DESCRIPTION
## Summary
- Ensure Deepgram TTS resolves to synthesized-play routing via catalog-driven resolution
- Add explicit fail-fast policy for Deepgram synthesis failures (no silent fallback to native TTS)
- Verify voice-quality profile generation handles synthesized providers correctly

Part of plan: deepgram-tts-provider.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
