### PR TITLE
fix(macos): streaming markdown tables no longer overlap surrounding text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -304,6 +304,12 @@ struct MarkdownTableView: View {
     let headers: [String]
     let rows: [[String]]
     var maxWidth: CGFloat = VSpacing.chatBubbleMaxWidth
+    /// When true, the table is the last still-growing block of a streaming
+    /// message. Bypasses the height cache because partial tables arriving
+    /// row-by-row must not have an intermediate height stamped in as the
+    /// final size for later passes — that would collapse the LazyVStack
+    /// slot and cause neighboring content to overlap.
+    var isStreamingTail: Bool = false
 
     // MARK: - Table Cell AttributedString Cache
 
@@ -387,7 +393,7 @@ struct MarkdownTableView: View {
     var body: some View {
         let usableWidth = maxWidth.isFinite
         let hash = usableWidth ? contentHash : 0
-        let cachedHeight = usableWidth ? Self.heightCache[hash] : nil
+        let cachedHeight = (usableWidth && !isStreamingTail) ? Self.heightCache[hash] : nil
 
         // Default alignment (.center) avoids explicitAlignment(.leading)
         // queries during sizing. Rows are full-width HStacks with
@@ -436,7 +442,7 @@ struct MarkdownTableView: View {
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.height
         } action: { newHeight in
-            if usableWidth {
+            if usableWidth && !isStreamingTail {
                 Self.heightCache[hash] = newHeight
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -59,15 +59,23 @@ struct MarkdownSegmentView: View, Equatable {
         #if os(macOS)
         let typographyGeneration = self.typographyGeneration ?? typographyObserver.generation
         #endif
+        // Identify the tail block that may still be growing during streaming.
+        // Only runs and tables cache layout measurements; images, code blocks,
+        // and horizontal rules self-size correctly and don't need a tail flag.
+        // Skipping those when scanning for the tail prevents a trailing image
+        // or rule from masking a still-streaming run/table above it.
+        let tailCacheableIndex: Int? = isStreaming ? lastCacheableGroupIndex(in: groups) : nil
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+            ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
+                let isTail = (index == tailCacheableIndex)
                 switch group {
                 case .selectableRun(let runSegments):
                     #if os(macOS)
                     SelectableRunView(
                         markdownView: self,
                         runSegments: runSegments,
-                        typographyGeneration: typographyGeneration
+                        typographyGeneration: typographyGeneration,
+                        isStreamingTail: isTail
                     )
                     #else
                     let attributed = buildCombinedAttributedString(from: runSegments)
@@ -95,7 +103,12 @@ struct MarkdownSegmentView: View, Equatable {
                     )
 
                 case .table(let headers, let rows):
-                    MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)
+                    MarkdownTableView(
+                        headers: headers,
+                        rows: rows,
+                        maxWidth: maxContentWidth ?? .infinity,
+                        isStreamingTail: isTail
+                    )
 
                 case .image(let alt, let url):
                     AnimatedImageView(urlString: url)
@@ -111,6 +124,18 @@ struct MarkdownSegmentView: View, Equatable {
                 }
             }
         }
+    }
+
+    private func lastCacheableGroupIndex(in groups: [SegmentGroup]) -> Int? {
+        for index in groups.indices.reversed() {
+            switch groups[index] {
+            case .selectableRun, .table:
+                return index
+            case .codeBlock, .image, .horizontalRule:
+                continue
+            }
+        }
+        return nil
     }
 
     // MARK: - Segment Grouping
@@ -131,11 +156,13 @@ struct MarkdownSegmentView: View, Equatable {
         let markdownView: MarkdownSegmentView
         let runSegments: [MarkdownSegment]
         let typographyGeneration: Int
+        var isStreamingTail: Bool = false
 
         var body: some View {
             let measurement = markdownView.resolveSelectableRunMeasurementResult(
                 runSegments,
-                typographyGeneration: typographyGeneration
+                typographyGeneration: typographyGeneration,
+                isStreamingTail: isStreamingTail
             )
 
             VSelectableTextView(
@@ -364,7 +391,8 @@ struct MarkdownSegmentView: View, Equatable {
 
     @MainActor func resolveSelectableRunMeasurementResult(
         _ runSegments: [MarkdownSegment],
-        typographyGeneration: Int? = nil
+        typographyGeneration: Int? = nil,
+        isStreamingTail: Bool = false
     ) -> SelectableRunMeasurementResult {
         let chatFonts = VFont.resolvedChatMarkdownFontSet()
         var hasher = Hasher()
@@ -383,7 +411,13 @@ struct MarkdownSegmentView: View, Equatable {
         let key = hasher.finalize()
 
         let keyNS = key as NSNumber
-        if let cached = Self.measuredTextCache.object(forKey: keyNS) {
+        // Streaming tail runs bypass the measurement cache. Reason: the
+        // run's content can change between passes while the cache key
+        // (segment hash) coincides with an earlier intermediate state,
+        // causing the applied .frame(height:) to be shorter than the
+        // actual rendered text and letting the next element (e.g. a
+        // MarkdownTableView) overlap the trailing lines.
+        if !isStreamingTail, let cached = Self.measuredTextCache.object(forKey: keyNS) {
             return SelectableRunMeasurementResult(
                 nsAttributedString: cached.nsAttributedString,
                 size: cached.size,
@@ -407,8 +441,10 @@ struct MarkdownSegmentView: View, Equatable {
 
         // Don't cache results where emphasis was expected but not applied —
         // the next render will rebuild from scratch, which may succeed.
+        // Also skip caching while this is the streaming tail: the value is
+        // for an intermediate state that may not match the final content.
         let textLen = Self.segmentTextLength(runSegments)
-        if !hasUnresolvedEmphasis && textLen <= Self.maxCacheableTextLength {
+        if !isStreamingTail && !hasUnresolvedEmphasis && textLen <= Self.maxCacheableTextLength {
             Self.measuredTextCache.setObject(
                 MeasuredTextCacheEntry(nsAttributedString: nsAttributed, size: size),
                 forKey: keyNS,


### PR DESCRIPTION
## Summary

- During streaming, the tail run's cached measurement and the tail table's cached height could carry over stale layout state, causing the table to draw on top of the preceding text run.
- Added an `isStreamingTail` flag that's set on the last still-cacheable block (selectable run or table) of a streaming message and bypasses the measurement / height caches for that block.
- Non-streaming renders and earlier blocks in the same streaming message keep using the caches, so `LazyVStack` scroll performance is preserved.

## Original prompt

the table here is overlapping with the text. can you figure out this rendering bug?

after reloading the conversation it renders correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
