### PR TITLE
fix(daemon): guard isAutoAnalysisConversation DB read during disposal

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -249,6 +249,41 @@ describe("disposeConversation — auto-analysis enqueue", () => {
     expect(autoAnalyzeCalls).toHaveLength(0);
   });
 
+  test("isAutoAnalysisConversation throws — fails open, still enqueues graph_extract and continues disposal", () => {
+    // If the DB read inside `isAutoAnalysisConversation` throws (e.g. SQLite
+    // unavailable during teardown), disposal must not abort. We fail open:
+    // default to NOT skipping, so graph_extract still fires and the rest of
+    // the cleanup chain runs.
+    autoAnalyzeEnabled = true;
+
+    mock.module("../../memory/auto-analysis-guard.js", () => ({
+      AUTO_ANALYSIS_SOURCE: "auto-analysis",
+      isAutoAnalysisConversation: () => {
+        throw new Error("db closed");
+      },
+    }));
+
+    const ctx = makeDisposeContext({
+      conversationId: "conv-guard-throws",
+      trustClass: "guardian",
+    });
+
+    expect(() => disposeConversation(ctx)).not.toThrow();
+
+    // Fail-open: graph_extract fires even though the guard threw.
+    expect(memoryJobCalls).toHaveLength(1);
+    expect(memoryJobCalls[0]!.type).toBe("graph_extract");
+    // The auto-analyze helper also still runs (separate try/catch).
+    expect(autoAnalyzeCalls).toHaveLength(1);
+
+    // Restore the non-throwing stub for subsequent tests.
+    mock.module("../../memory/auto-analysis-guard.js", () => ({
+      AUTO_ANALYSIS_SOURCE: "auto-analysis",
+      isAutoAnalysisConversation: (conversationId: string) =>
+        autoAnalysisConversations.has(conversationId),
+    }));
+  });
+
   test("helper throws — disposal continues (best-effort semantics)", () => {
     // The try/catch around `enqueueAutoAnalysisIfEnabled` must swallow
     // errors so a broken helper never blocks disposal. We verify by

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -317,7 +317,15 @@ export function disposeConversation(ctx: DisposeContext): void {
     // from its reflective musings would double-write into the memory graph.
     // Mirrors the same guard applied in `indexer.ts` for the per-message
     // indexing path.
-    if (!isAutoAnalysisConversation(ctx.conversationId)) {
+    // Fail open: if the guard lookup throws (e.g. DB unavailable during
+    // teardown), default to NOT skipping so the rest of disposal still runs.
+    let isAutoAnalysis = false;
+    try {
+      isAutoAnalysis = isAutoAnalysisConversation(ctx.conversationId);
+    } catch {
+      // Best-effort — don't block conversation disposal
+    }
+    if (!isAutoAnalysis) {
       try {
         enqueueMemoryJob("graph_extract", {
           conversationId: ctx.conversationId,


### PR DESCRIPTION
Addresses Codex P1 + Devin review feedback on #25677.

`disposeConversation` called `isAutoAnalysisConversation(ctx.conversationId)` outside the surrounding try/catch. That guard performs a DB read via `getConversationSource` and has no internal catch — if SQLite is unavailable or corrupt during teardown, the throw escaped and skipped `enqueueAutoAnalysisIfEnabled`, `abortConversation`, notifier/screencast unregistration, `eventBus.dispose()`, and in-memory data release, violating the documented best-effort semantics of disposal.

Wrapped the guard lookup in try/catch that fails open: a thrown error defaults `isAutoAnalysis` to `false`, so `graph_extract` still enqueues and the rest of disposal runs. Added a regression test that throws from the guard stub and asserts disposal completes without error and `graph_extract` fires.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
