### PR TITLE
fix(tests): align actor-trust-resolver mock with production semantics

### DIFF
--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -69,9 +69,15 @@ mock.module("../jobs-store.js", () => ({
   },
 }));
 
+// Mirror production semantics from `isUntrustedTrustClass` in
+// actor-trust-resolver.ts: anything that isn't `guardian` is untrusted.
+// Keeping these in sync guards the compaction trust boundary — a drifting
+// mock would let regressions pass as false positives.
 mock.module("../../runtime/actor-trust-resolver.js", () => ({
   isUntrustedTrustClass: (trustClass: string | undefined) =>
-    trustClass === "unknown" || trustClass === "untrusted",
+    trustClass === "trusted_contact" ||
+    trustClass === "unknown" ||
+    trustClass === undefined,
 }));
 
 import {
@@ -281,10 +287,14 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
     expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
   });
 
-  test("undefined trust class (treated as guardian for internal call paths) — enqueues", () => {
+  test("undefined trust class — skips (fail-closed when trust is unresolved)", () => {
+    // `isUntrustedTrustClass(undefined)` is true in production, so
+    // compaction-triggered analysis must NOT fire when the caller cannot
+    // establish a trust class.
     enqueueAutoAnalysisOnCompaction("c1", undefined);
 
-    expect(debouncedCalls).toHaveLength(1);
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
   });
 
   test("unknown trust class — skips (mirrors memory-extraction trust boundary)", () => {
@@ -294,12 +304,14 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
     expect(debouncedCalls).toHaveLength(0);
   });
 
-  test("trusted_contact trust class — enqueues (not untrusted)", () => {
-    // trusted_contact is not in the untrusted set per
-    // isUntrustedTrustClass, so compaction-triggered analysis still fires.
+  test("trusted_contact trust class — skips (only guardian is trusted)", () => {
+    // trusted_contact is in the untrusted set per production
+    // `isUntrustedTrustClass`, so compaction-triggered analysis must NOT
+    // fire. Only `guardian` passes the gate.
     enqueueAutoAnalysisOnCompaction("c1", "trusted_contact");
 
-    expect(debouncedCalls).toHaveLength(1);
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
   });
 
   test("guardian trust but flag off — helper still gates via enqueueAutoAnalysisIfEnabled", () => {


### PR DESCRIPTION
Addresses Codex P2 feedback on #25690.

The `isUntrustedTrustClass` mock in `auto-analysis-enqueue.test.ts` treated only `'unknown'` as untrusted. Production `isUntrustedTrustClass` in `assistant/src/runtime/actor-trust-resolver.ts` also treats `'trusted_contact'` and `undefined` as untrusted — only `'guardian'` passes the gate.

- Updated the mock to mirror production: `trusted_contact`, `unknown`, and `undefined` all return untrusted.
- Flipped the two compaction tests that asserted enqueue for `trusted_contact` / `undefined` to assert skip — matching real behavior and restoring the trust-boundary coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
