### PR TITLE
fix(runtime): requeue skipped concurrent auto-analyze runs

### DIFF
--- a/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
+++ b/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
@@ -31,7 +31,7 @@ type AnalyzeArgs = {
 };
 const analyzeCalls: AnalyzeArgs[] = [];
 type AnalyzeResultStub =
-  | { analysisConversationId: string }
+  | { analysisConversationId: string; skipped?: true }
   | { error: { kind: string; status: number; message: string } };
 const mockAnalyzeConversation = mock(
   async (
@@ -46,6 +46,20 @@ const mockAnalyzeConversation = mock(
 
 mock.module("../../runtime/services/analyze-conversation.js", () => ({
   analyzeConversation: mockAnalyzeConversation,
+}));
+
+// Mock auto-analysis-enqueue — track calls so we can verify requeue behavior.
+type EnqueueArgs = {
+  conversationId: string;
+  trigger: string;
+};
+const enqueueCalls: EnqueueArgs[] = [];
+const mockEnqueueAutoAnalysisIfEnabled = mock((args: EnqueueArgs) => {
+  enqueueCalls.push(args);
+});
+
+mock.module("../auto-analysis-enqueue.js", () => ({
+  enqueueAutoAnalysisIfEnabled: mockEnqueueAutoAnalysisIfEnabled,
 }));
 
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
@@ -76,6 +90,7 @@ function makeJob(payload: Record<string, unknown>): MemoryJob<{
 describe("conversationAnalyzeJob", () => {
   beforeEach(() => {
     analyzeCalls.length = 0;
+    enqueueCalls.length = 0;
     mockGetAnalysisDeps.mockReset();
     mockGetAnalysisDeps.mockImplementation(() => null);
     mockAnalyzeConversation.mockReset();
@@ -137,6 +152,62 @@ describe("conversationAnalyzeJob", () => {
     expect(analyzeCalls[0]!.conversationId).toBe("conv-42");
     expect(analyzeCalls[0]!.opts).toEqual({ trigger: "auto" });
     expect(analyzeCalls[0]!.deps).toBe(depsStub);
+  });
+
+  test("requeues a follow-up idle trigger when the service returns skipped=true", async () => {
+    // If the rolling analysis conversation is already processing, the
+    // service returns { skipped: true } without running. The job handler
+    // completes successfully (no retry), so we must enqueue a follow-up
+    // ourselves — otherwise, if no later batch/idle/lifecycle trigger
+    // arrives, new source messages would never be analyzed.
+    mockGetAnalysisDeps.mockImplementation(() => ({ _tag: "deps" }));
+    mockAnalyzeConversation.mockImplementation(async () => ({
+      analysisConversationId: "analysis-1",
+      skipped: true as const,
+    }));
+
+    await conversationAnalyzeJob(
+      makeJob({ conversationId: "conv-busy" }),
+      TEST_CONFIG,
+    );
+
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]).toEqual({
+      conversationId: "conv-busy",
+      trigger: "idle",
+    });
+  });
+
+  test("does not requeue on a normal (non-skipped) successful run", async () => {
+    mockGetAnalysisDeps.mockImplementation(() => ({ _tag: "deps" }));
+    mockAnalyzeConversation.mockImplementation(async () => ({
+      analysisConversationId: "analysis-1",
+    }));
+
+    await conversationAnalyzeJob(
+      makeJob({ conversationId: "conv-ok" }),
+      TEST_CONFIG,
+    );
+
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("does not requeue when the service returns an error result", async () => {
+    mockGetAnalysisDeps.mockImplementation(() => ({ _tag: "deps" }));
+    mockAnalyzeConversation.mockImplementation(async () => ({
+      error: {
+        kind: "BAD_REQUEST",
+        status: 400,
+        message: "Cannot auto-analyze an auto-analysis conversation",
+      },
+    }));
+
+    await conversationAnalyzeJob(
+      makeJob({ conversationId: "conv-err" }),
+      TEST_CONFIG,
+    );
+
+    expect(enqueueCalls).toHaveLength(0);
   });
 
   test("swallows (does not throw) when the service returns an error result", async () => {

--- a/assistant/src/memory/conversation-analyze-job.ts
+++ b/assistant/src/memory/conversation-analyze-job.ts
@@ -16,6 +16,7 @@ import type { AssistantConfig } from "../config/types.js";
 import { analyzeConversation } from "../runtime/services/analyze-conversation.js";
 import { getAnalysisDeps } from "../runtime/services/analyze-deps-singleton.js";
 import { getLogger } from "../util/logger.js";
+import { enqueueAutoAnalysisIfEnabled } from "./auto-analysis-enqueue.js";
 import type { MemoryJob } from "./jobs-store.js";
 
 const log = getLogger("conversation-analyze-job");
@@ -54,6 +55,19 @@ export async function conversationAnalyzeJob(
     log.warn(
       { jobId: job.id, conversationId, error: result.error },
       "Auto-analysis service rejected source conversation",
+    );
+    return;
+  }
+  if (result.skipped) {
+    // The rolling analysis conversation was still processing a prior run, so
+    // this invocation was a no-op. Schedule a debounced follow-up ourselves
+    // — otherwise, if no later batch/idle/lifecycle trigger arrives (e.g.
+    // the conversation goes quiet after a long in-flight analysis), new
+    // source messages would stay un-analyzed indefinitely.
+    enqueueAutoAnalysisIfEnabled({ conversationId, trigger: "idle" });
+    log.debug(
+      { jobId: job.id, conversationId },
+      "Auto-analysis skipped (rolling conversation busy); requeued follow-up",
     );
   }
 }


### PR DESCRIPTION
Addresses Codex P2 feedback on #25680.

When the auto-analyze service returns `{ skipped: true }` because the rolling analysis conversation is already processing, the `conversation_analyze` job handler previously completed silently. If no later batch/idle/lifecycle trigger arrived (e.g. the in-flight run exceeded the idle debounce and the source conversation then went quiet), new source messages would stay un-analyzed indefinitely.

Now the handler calls `enqueueAutoAnalysisIfEnabled({ trigger: "idle" })` on skip so a debounced follow-up is scheduled. The existing upsert logic in `upsertDebouncedJob` still coalesces with any external trigger that arrives in the meantime.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
