### PR TITLE
fix(memory): prevent batch auto-analysis coalescing with idle triggers

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -487,17 +487,31 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
         }
       });
 
-    // Exactly one row — the dedupe in upsertDebouncedJob coalesces the
-    // batch trigger and the per-message idle upsert into a single
-    // pending job.
-    expect(analysisRows.length).toBe(1);
+    // Two rows — the batch trigger writes an "immediate" triggerGroup
+    // row, while the per-message idle upserts write/update a separate
+    // "debounced" triggerGroup row. Keeping them distinct prevents an
+    // idle enqueue from pushing the batch-triggered runAfter forward.
+    expect(analysisRows.length).toBe(2);
 
-    // The row's runAfter is "now" (batch trigger ran AFTER the idle
-    // upsert this iteration, so it pulled the runAfter back to now).
-    // Allow a 1s margin on either side for clock skew.
-    const row = analysisRows[0]!;
-    expect(row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
-    expect(row.runAfter).toBeLessThanOrEqual(after + 1_000);
+    const withGroup = analysisRows.map((row) => {
+      const payload = JSON.parse(row.payload) as {
+        triggerGroup?: "immediate" | "debounced";
+      };
+      return { row, triggerGroup: payload.triggerGroup };
+    });
+    const immediate = withGroup.find((r) => r.triggerGroup === "immediate");
+    const debounced = withGroup.find((r) => r.triggerGroup === "debounced");
+    expect(immediate).toBeDefined();
+    expect(debounced).toBeDefined();
+
+    // Immediate row (batch trigger) has runAfter ≈ now — allow a 1s
+    // margin on either side for clock skew.
+    expect(immediate!.row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
+    expect(immediate!.row.runAfter).toBeLessThanOrEqual(after + 1_000);
+
+    // Debounced row (per-message idle) is pushed far into the future
+    // and is not affected by the immediate batch enqueue.
+    expect(debounced!.row.runAfter).toBeGreaterThan(Date.now() + 60_000);
   });
 
   test("crossing extraction.batchSize → graph_extract pending row has immediate runAfter", async () => {

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -26,7 +26,7 @@ const enqueueCalls: Array<{
 }> = [];
 const debouncedCalls: Array<{
   type: string;
-  payload: { conversationId: string };
+  payload: { conversationId: string; triggerGroup: "immediate" | "debounced" };
   runAfter: number;
 }> = [];
 
@@ -60,12 +60,18 @@ mock.module("../jobs-store.js", () => ({
     enqueueCalls.push({ type, payload, runAfter });
     return "job-id";
   },
-  upsertDebouncedJob: (
-    type: string,
-    payload: { conversationId: string },
+  upsertAutoAnalysisJob: (
+    payload: {
+      conversationId: string;
+      triggerGroup: "immediate" | "debounced";
+    },
     runAfter: number,
   ) => {
-    debouncedCalls.push({ type, payload, runAfter });
+    debouncedCalls.push({
+      type: "conversation_analyze",
+      payload,
+      runAfter,
+    });
   },
 }));
 
@@ -113,16 +119,20 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
 
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
-    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
-    // "batch" fires immediately (no debounce), so runAfter ≈ now. We use
-    // upsertDebouncedJob so two consecutive batch crossings coalesce into
-    // a single pending job rather than spawning duplicates.
+    expect(debouncedCalls[0]!.payload).toEqual({
+      conversationId: "c1",
+      triggerGroup: "immediate",
+    });
+    // "batch" fires immediately (no debounce), so runAfter ≈ now. The
+    // "immediate" triggerGroup keeps this row from coalescing with any
+    // "debounced" (idle/lifecycle) row — an idle enqueue cannot push
+    // this runAfter into the future.
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
     expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
     expect(enqueueCalls).toHaveLength(0);
   });
 
-  test("flag on, trigger = 'idle', normal source — upsertDebouncedJob called with runAfter ≈ now + idleTimeoutMs", () => {
+  test("flag on, trigger = 'idle', normal source — upsertAutoAnalysisJob called with runAfter ≈ now + idleTimeoutMs", () => {
     configValue = { analysis: { idleTimeoutMs: 600_000 } };
     const before = Date.now();
 
@@ -132,7 +142,10 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
 
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
-    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.payload).toEqual({
+      conversationId: "c1",
+      triggerGroup: "debounced",
+    });
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(
       before + 600_000,
     );
@@ -140,7 +153,7 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
     expect(enqueueCalls).toHaveLength(0);
   });
 
-  test("flag on, trigger = 'lifecycle', normal source — upsertDebouncedJob called (same as idle)", () => {
+  test("flag on, trigger = 'lifecycle', normal source — upsertAutoAnalysisJob called (same as idle)", () => {
     configValue = { analysis: { idleTimeoutMs: 600_000 } };
     const before = Date.now();
 
@@ -153,7 +166,10 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
 
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
-    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.payload).toEqual({
+      conversationId: "c1",
+      triggerGroup: "debounced",
+    });
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(
       before + 600_000,
     );
@@ -247,7 +263,10 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
 
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
-    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.payload).toEqual({
+      conversationId: "c1",
+      triggerGroup: "immediate",
+    });
     // "compaction" fires immediately (runAfter ≈ now) so the reflective
     // agent runs before the narrowed context window pushes more detail out.
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
@@ -276,7 +295,10 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
 
     expect(debouncedCalls).toHaveLength(1);
     expect(debouncedCalls[0]!.type).toBe("conversation_analyze");
-    expect(debouncedCalls[0]!.payload).toEqual({ conversationId: "c1" });
+    expect(debouncedCalls[0]!.payload).toEqual({
+      conversationId: "c1",
+      triggerGroup: "immediate",
+    });
     expect(debouncedCalls[0]!.runAfter).toBeGreaterThanOrEqual(before);
     expect(debouncedCalls[0]!.runAfter).toBeLessThanOrEqual(after);
   });

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -7,7 +7,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
 import { getConversationType } from "./conversation-crud.js";
-import { upsertDebouncedJob } from "./jobs-store.js";
+import { upsertAutoAnalysisJob } from "./jobs-store.js";
 
 const log = getLogger("auto-analysis-enqueue");
 
@@ -40,11 +40,12 @@ export type AutoAnalysisTrigger =
  *   - the source conversation is private (`analyzeConversation` rejects
  *     private conversations, so enqueueing would guarantee a failed job).
  *
- * All triggers route through `upsertDebouncedJob()` so a pending job for
- * the same conversation coalesces additional enqueue attempts into a
- * single row (no duplicates). `"batch"` fires immediately
- * (`runAfter = now`); `"idle"` / `"lifecycle"` debounce by
- * `analysis.idleTimeoutMs`.
+ * Immediate triggers (`"batch"`, `"compaction"`) and debounced triggers
+ * (`"idle"`, `"lifecycle"`) are written to separate rows keyed by a
+ * `triggerGroup` discriminator. This prevents an idle enqueue from
+ * pushing an already-scheduled batch row's `runAfter` into the future
+ * (and vice versa). Within each group, rapid enqueues still coalesce to
+ * a single pending row via `upsertAutoAnalysisJob`.
  */
 export function enqueueAutoAnalysisIfEnabled(args: {
   conversationId: string;
@@ -85,14 +86,13 @@ export function enqueueAutoAnalysisIfEnabled(args: {
 
   const idleTimeoutMs = config.analysis?.idleTimeoutMs ?? 600_000;
   const runImmediately = trigger === "batch" || trigger === "compaction";
+  const triggerGroup: "immediate" | "debounced" = runImmediately
+    ? "immediate"
+    : "debounced";
   const runAfter = runImmediately ? Date.now() : Date.now() + idleTimeoutMs;
 
   try {
-    upsertDebouncedJob(
-      "conversation_analyze",
-      { conversationId },
-      runAfter,
-    );
+    upsertAutoAnalysisJob({ conversationId, triggerGroup }, runAfter);
   } catch (err) {
     log.warn(
       { err, conversationId, trigger },

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -129,6 +129,50 @@ export function upsertDebouncedJob(
 }
 
 /**
+ * Upsert a pending `conversation_analyze` job keyed by both
+ * `conversationId` and `triggerGroup`. Immediate triggers (batch,
+ * compaction) and debounced triggers (idle, lifecycle) live in separate
+ * rows so an idle enqueue cannot push an already-scheduled immediate
+ * row's `runAfter` into the future (and vice versa). Each group still
+ * coalesces within itself: two batch crossings, or two idle triggers,
+ * collapse to a single pending row.
+ */
+export function upsertAutoAnalysisJob(
+  payload: {
+    conversationId: string;
+    triggerGroup: "immediate" | "debounced";
+  },
+  runAfter: number,
+  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+    tx: infer T,
+  ) => unknown
+    ? T
+    : never,
+): void {
+  const db = dbOverride ?? getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "conversation_analyze"),
+        eq(memoryJobs.status, "pending"),
+        sql`json_extract(${memoryJobs.payload}, '$.conversationId') = ${payload.conversationId}`,
+        sql`json_extract(${memoryJobs.payload}, '$.triggerGroup') = ${payload.triggerGroup}`,
+      ),
+    )
+    .get();
+  if (existing) {
+    db.update(memoryJobs)
+      .set({ runAfter, updatedAt: Date.now() })
+      .where(eq(memoryJobs.id, existing.id))
+      .run();
+  } else {
+    enqueueMemoryJob("conversation_analyze", payload, runAfter, dbOverride);
+  }
+}
+
+/**
  * Check whether a pending or running job of the given type already exists.
  * Used to prevent duplicate enqueues for long-running maintenance jobs.
  */


### PR DESCRIPTION
Addresses Codex P1 feedback on #25667.

Before this change, a sequence of batch→idle/lifecycle enqueues on the same conversation would have `upsertDebouncedJob` match the pending batch row (`runAfter=now`) and push its `runAfter` forward by `analysis.idleTimeoutMs` — the immediate batch analysis would be silently delayed and could be starved by a stream of idle enqueues.

Fix: add a `triggerGroup` discriminator to the `conversation_analyze` payload (`"immediate"` for batch/compaction, `"debounced"` for idle/lifecycle) and introduce `upsertAutoAnalysisJob` in `jobs-store` that matches on both `conversationId` and `triggerGroup`. Immediate and debounced rows now live side-by-side; each group still coalesces rapid re-enqueues within itself.

<details>

**Modified files**

- `assistant/src/memory/jobs-store.ts` — new `upsertAutoAnalysisJob` helper.
- `assistant/src/memory/auto-analysis-enqueue.ts` — tag payload with `triggerGroup`, switch to new helper.
- `assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts` — mock new helper, assert `triggerGroup` on each trigger.
- `assistant/src/__tests__/auto-analysis-end-to-end.test.ts` — assert two rows (immediate + debounced) after batch threshold crossing.

</details>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
