### PR TITLE
fix(macos): scope reflection unread suppression + fix collapsed switcher a11y

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
@@ -11,6 +11,22 @@ struct CollapsedConversationSwitcherPresentation {
     /// the Reflections section, so hiding the entry point would orphan it.
     var showsSwitcher: Bool { totalRegularConversationCount > 0 || hasReflectionConversations }
 
+    /// What to render inside the switcher badge. Normally a numeric count, but
+    /// falls back to an icon when there are no regular conversations to count
+    /// yet reflections exist — rendering a literal "0" in that case reads as
+    /// a broken or dead affordance.
+    enum Badge: Equatable {
+        case count(String)
+        case reflectionIcon
+    }
+
+    var badge: Badge {
+        if totalRegularConversationCount == 0 && hasReflectionConversations {
+            return .reflectionIcon
+        }
+        return .count(badgeText)
+    }
+
     var badgeText: String {
         if totalRegularConversationCount > 99 { return "99+" }
         return "\(totalRegularConversationCount)"
@@ -24,7 +40,13 @@ struct CollapsedConversationSwitcherPresentation {
     }
 
     var accessibilityValue: String {
-        totalRegularConversationCount == 0 ? "" : "\(totalRegularConversationCount) conversations"
+        if totalRegularConversationCount > 0 {
+            return "\(totalRegularConversationCount) conversations"
+        }
+        if hasReflectionConversations {
+            return "Reflections available"
+        }
+        return ""
     }
 
     init(regularConversations: [ConversationModel], activeConversationId: UUID?, hasReflectionConversations: Bool = false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -277,7 +277,7 @@ final class ConversationListStore {
 
         unseenVisibleConversationCount = conversations.count {
             !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage
-                && !$0.shouldSuppressUnreadIndicator
+                && !$0.shouldSuppressGlobalUnreadAggregations
         }
 
         // Bucket visible conversations by group in a single pass (O(N)).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -98,14 +98,28 @@ struct ConversationModel: Identifiable, Hashable {
         source == "auto-analysis"
     }
 
-    /// Whether this conversation is automated (heartbeat, schedule, background/task,
-    /// auto-analysis) and should never show unread indicators. Per Apple HIG, badges
-    /// and unread indicators should only reflect content requiring user attention —
-    /// system-generated messages from automated threads do not qualify. Reflections
-    /// (auto-analysis) are a passive surface users browse on their own; they should
-    /// not drive the dock badge or the Conversations header unread dot.
+    /// Whether this conversation is automated (heartbeat, schedule, background/task)
+    /// and should never show unread indicators anywhere. Per Apple HIG, badges and
+    /// unread indicators should only reflect content requiring user attention —
+    /// system-generated messages from automated threads do not qualify.
+    ///
+    /// Auto-analysis ("reflection") conversations are intentionally NOT suppressed
+    /// here: the Reflections sidebar section surfaces its own collapsed-state
+    /// unread dot driven by `hasUnseenLatestAssistantMessage`. Reflections are
+    /// instead filtered out of global aggregations via
+    /// `shouldSuppressGlobalUnreadAggregations`.
     var shouldSuppressUnreadIndicator: Bool {
-        isScheduleConversation || shouldReturnToBackgroundOnUnpin || isAutoAnalysisConversation
+        isScheduleConversation || shouldReturnToBackgroundOnUnpin
+    }
+
+    /// Whether this conversation should be excluded from *global* unread
+    /// aggregations — the dock badge and the Conversations header unread dot.
+    /// A superset of `shouldSuppressUnreadIndicator` that also excludes
+    /// reflections. Reflections are a passive surface users browse on their
+    /// own; they should not drive app-wide attention UI, but the Reflections
+    /// section's own unread affordance still fires.
+    var shouldSuppressGlobalUnreadAggregations: Bool {
+        shouldSuppressUnreadIndicator || isAutoAnalysisConversation
     }
 
     var isChannelConversation: Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -616,18 +616,25 @@ extension MainWindowView {
                     showConversationSwitcher.toggle()
                 } label: {
                     ZStack(alignment: .bottomTrailing) {
-                        Text(switcher.badgeText)
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(VColor.primaryBase)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-                            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .fill(windowState.isShowingChat && conversationManager.activeConversation != nil
-                                        ? VColor.surfaceActive
-                                        : VColor.surfaceBase)
-                            )
+                        Group {
+                            switch switcher.badge {
+                            case .count(let text):
+                                Text(text)
+                                    .font(.system(size: 11, weight: .semibold))
+                            case .reflectionIcon:
+                                VIconView(.sparkles, size: 12)
+                            }
+                        }
+                        .foregroundStyle(VColor.primaryBase)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+                        .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .fill(windowState.isShowingChat && conversationManager.activeConversation != nil
+                                    ? VColor.surfaceActive
+                                    : VColor.surfaceBase)
+                        )
 
                         if switcher.switchTargets.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
                             Circle()


### PR DESCRIPTION
Addresses Codex P2 + Devin 🚩/🟡 feedback on #25683.

**#1 (Codex P2 + Devin 🚩) — suppression too broad.** The original fix added `isAutoAnalysisConversation` to `shouldSuppressUnreadIndicator`, which is consumed by per-conversation hydration and merge paths (`ConversationListStore.fromResponseItem`, `mergeAssistantAttention`, `ConversationRestorer`, `ConversationManager` notification/new-message). Those forcibly clear `hasUnseenLatestAssistantMessage`, making `SidebarReflectionsSection.hasUnread` (line 34–35) dead code.

Fix: split the predicate. `shouldSuppressUnreadIndicator` is reverted to schedule + background only (its original scope). A new `shouldSuppressGlobalUnreadAggregations` superset adds auto-analysis on top, and is used *only* at the single global-aggregation site — `ConversationListStore.unseenVisibleConversationCount` (the counter that drives the dock badge and the Conversations header unread dot). Reflection rows can now gain `hasUnseenLatestAssistantMessage` through the hydration and merge paths, so the Reflections section's collapsed-state unread dot fires as intended without polluting the global counter.

**#2 (Devin 🟡) — collapsed switcher "0" badge.** When `totalRegularConversationCount == 0 && hasReflectionConversations`, `showsSwitcher` is true (correct) but the badge rendered a literal "0" and `accessibilityValue` was empty.

Fix: add a `Badge` enum (`.count(String)` / `.reflectionIcon`) on `CollapsedConversationSwitcherPresentation`. The view switches on it and renders a `sparkles` `VIconView` instead of a "0" when only reflections exist. `accessibilityValue` announces "Reflections available" in that state. `badgeText` semantics preserved for the existing test cases.

## Files
- `clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift` — split predicate
- `clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift` — use new predicate for global counter
- `clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift` — `Badge` enum + a11y string
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift` — switch on `Badge`

## Test plan
- [ ] Smoke test on macOS: trigger a reflection while the Reflections section is collapsed — unread dot should appear next to the section header.
- [ ] Verify dock badge + Conversations header unread dot still ignore reflection unreads.
- [ ] Collapsed sidebar with reflections but no regular conversations — switcher should show `sparkles` icon, not "0"; VoiceOver should read "Reflections available".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
