### PR TITLE
fix(tests): keep email-list hermetic; don't delete real secure-store credentials

### DIFF
--- a/assistant/src/cli/commands/__tests__/email-list.test.ts
+++ b/assistant/src/cli/commands/__tests__/email-list.test.ts
@@ -17,7 +17,6 @@ import { runAssistantCommand } from "../../__tests__/run-assistant-command.js";
 
 const ASSISTANT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const API_KEY_CREDENTIAL = credentialKey("vellum", "assistant_api_key");
-const ASSISTANT_ID_CREDENTIAL = credentialKey("vellum", "platform_assistant_id");
 
 /**
  * Return the recorded fetch calls, excluding the feature-flag fetch that
@@ -84,10 +83,6 @@ beforeEach(async () => {
   _setOverridesForTesting({ "email-channel": true });
   setPlatformAssistantId(ASSISTANT_ID);
   await setSecureKeyAsync(API_KEY_CREDENTIAL, "test-api-key");
-  // Ensure the credential store does not contain a stray platform_assistant_id
-  // from dev machine state — the "missing assistant ID" test relies on the
-  // fallback lookup returning empty.
-  await deleteSecureKeyAsync(ASSISTANT_ID_CREDENTIAL);
 });
 
 afterEach(() => {


### PR DESCRIPTION
Addresses Codex P2 feedback on #25714.

The `beforeEach` added in #25714 called `deleteSecureKeyAsync(ASSISTANT_ID_CREDENTIAL)` to guarantee the "missing assistant ID" fallback path was exercised. At the time, `test-preload` did not redirect the encrypted store, so this delete ran against the real backend at `~/.vellum/protected/keys.enc` and wiped the developer's platform assistant ID on every run.

Since then, #25717 isolated the encrypted store per test file via `_setStorePath` in `test-preload`, so every test file gets a fresh empty store. The beforeEach delete is now redundant — the missing-ID fallback is already exercised by the empty temp store — and removing it eliminates the stale hazard entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
