### PR TITLE
chore(tts): add parity guards and update voice tooling/docs for deepgram

### DIFF
--- a/assistant/src/__tests__/tts-catalog-parity.test.ts
+++ b/assistant/src/__tests__/tts-catalog-parity.test.ts
@@ -1,0 +1,339 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCatalogProvider,
+  listCatalogProviderIds,
+} from "../tts/provider-catalog.js";
+import type { TtsProviderId } from "../tts/types.js";
+
+/**
+ * Parity guard: daemon TTS provider catalog vs client TTS catalog JSON.
+ *
+ * The daemon maintains its canonical provider catalog in
+ * `assistant/src/tts/provider-catalog.ts`.
+ * The client-facing metadata lives in `meta/tts-provider-catalog.json` and is
+ * bundled into native clients at build time.
+ *
+ * These tests enforce that both catalogs stay in sync on the fields they
+ * share: provider IDs, ordering, and credential metadata needed for client
+ * key handling. CI will fail when they drift, forcing the developer to update
+ * whichever side fell behind.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve repo root (tests run from assistant/) */
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+interface ClientCatalogCredentialsGuide {
+  description: string;
+  url: string;
+  linkLabel: string;
+}
+
+interface ClientCatalogEntry {
+  id: string;
+  displayName: string;
+  subtitle: string;
+  setupMode: string;
+  setupHint: string;
+  credentialMode: "api-key" | "credential";
+  /** Present when credentialMode is "api-key". */
+  apiKeyProviderName?: string;
+  /** Present when credentialMode is "credential". */
+  credentialNamespace?: string;
+  credentialsGuide: ClientCatalogCredentialsGuide;
+}
+
+interface ClientCatalog {
+  version: number;
+  providers: ClientCatalogEntry[];
+}
+
+function loadClientCatalog(): ClientCatalog {
+  const catalogPath = join(getRepoRoot(), "meta", "tts-provider-catalog.json");
+  const raw = readFileSync(catalogPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+/**
+ * Derive the expected credentialMode and associated metadata from a daemon
+ * catalog entry's secret requirements.
+ *
+ * Convention:
+ * - If the first secretRequirement.credentialStoreKey starts with "credential/",
+ *   the client uses credentialMode "credential" and credentialNamespace is the
+ *   second path segment.
+ * - Otherwise, the client uses credentialMode "api-key" and apiKeyProviderName
+ *   is the bare key.
+ */
+function deriveCredentialMetadata(daemonEntry: {
+  secretRequirements: readonly { readonly credentialStoreKey: string }[];
+}): {
+  credentialMode: "api-key" | "credential";
+  apiKeyProviderName?: string;
+  credentialNamespace?: string;
+} {
+  const key = daemonEntry.secretRequirements[0]?.credentialStoreKey ?? "";
+  if (key.startsWith("credential/")) {
+    const parts = key.split("/");
+    return { credentialMode: "credential", credentialNamespace: parts[1] };
+  }
+  return { credentialMode: "api-key", apiKeyProviderName: key };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TTS catalog parity: daemon vs client", () => {
+  // -----------------------------------------------------------------------
+  // Provider ID parity
+  // -----------------------------------------------------------------------
+
+  test("client catalog provider IDs match daemon catalog provider IDs", () => {
+    const daemonIds = listCatalogProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    // Every daemon provider ID must appear in the client catalog
+    const missingInClient = daemonIds.filter((id) => !clientIds.includes(id));
+    if (missingInClient.length > 0) {
+      const message = [
+        "Daemon catalog has provider IDs not present in meta/tts-provider-catalog.json.",
+        "",
+        "Missing in client catalog:",
+        ...missingInClient.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to meta/tts-provider-catalog.json.",
+      ].join("\n");
+      expect(missingInClient, message).toEqual([]);
+    }
+
+    // Every client catalog provider ID must appear in the daemon catalog
+    const missingInDaemon = clientIds.filter(
+      (id) => !daemonIds.includes(id as never),
+    );
+    if (missingInDaemon.length > 0) {
+      const message = [
+        "Client catalog (meta/tts-provider-catalog.json) has provider IDs not present in daemon catalog.",
+        "",
+        "Missing in daemon catalog:",
+        ...missingInDaemon.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to assistant/src/tts/provider-catalog.ts.",
+      ].join("\n");
+      expect(missingInDaemon, message).toEqual([]);
+    }
+  });
+
+  test("daemon and client catalog list providers in the same order", () => {
+    const daemonIds = listCatalogProviderIds();
+    const clientCatalog = loadClientCatalog();
+    const clientIds = clientCatalog.providers.map((p) => p.id);
+
+    expect(clientIds).toEqual([...daemonIds]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Credential metadata parity
+  // -----------------------------------------------------------------------
+
+  test("each client catalog entry credentialMode matches its daemon counterpart", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      const daemonEntry = getCatalogProvider(clientEntry.id as TtsProviderId);
+      if (!daemonEntry) {
+        // Covered by the provider ID parity test above
+        continue;
+      }
+      const expected = deriveCredentialMetadata(daemonEntry);
+      if (clientEntry.credentialMode !== expected.credentialMode) {
+        violations.push(
+          `Provider "${clientEntry.id}": client credentialMode="${clientEntry.credentialMode}" ` +
+            `!= expected "${expected.credentialMode}" (derived from daemon credentialStoreKey)`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Credential mode mismatch between daemon and client TTS catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/tts-provider-catalog.json or assistant/src/tts/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("api-key providers: client apiKeyProviderName matches daemon credentialStoreKey", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      if (clientEntry.credentialMode !== "api-key") continue;
+
+      const daemonEntry = getCatalogProvider(clientEntry.id as TtsProviderId);
+      if (!daemonEntry) continue;
+
+      const expected = deriveCredentialMetadata(daemonEntry);
+      if (clientEntry.apiKeyProviderName !== expected.apiKeyProviderName) {
+        violations.push(
+          `Provider "${clientEntry.id}": client apiKeyProviderName="${clientEntry.apiKeyProviderName}" ` +
+            `!= expected "${expected.apiKeyProviderName}" (derived from daemon credentialStoreKey)`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "apiKeyProviderName mismatch between daemon and client TTS catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/tts-provider-catalog.json or assistant/src/tts/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("credential providers: client credentialNamespace matches daemon credentialStoreKey namespace", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      if (clientEntry.credentialMode !== "credential") continue;
+
+      const daemonEntry = getCatalogProvider(clientEntry.id as TtsProviderId);
+      if (!daemonEntry) continue;
+
+      const expected = deriveCredentialMetadata(daemonEntry);
+      if (clientEntry.credentialNamespace !== expected.credentialNamespace) {
+        violations.push(
+          `Provider "${clientEntry.id}": client credentialNamespace="${clientEntry.credentialNamespace}" ` +
+            `!= expected "${expected.credentialNamespace}" (derived from daemon credentialStoreKey)`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "credentialNamespace mismatch between daemon and client TTS catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/tts-provider-catalog.json or assistant/src/tts/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Display name parity
+  // -----------------------------------------------------------------------
+
+  test("each client catalog entry displayName matches its daemon counterpart", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const clientEntry of clientCatalog.providers) {
+      const daemonEntry = getCatalogProvider(clientEntry.id as TtsProviderId);
+      if (!daemonEntry) continue;
+
+      if (clientEntry.displayName !== daemonEntry.displayName) {
+        violations.push(
+          `Provider "${clientEntry.id}": client displayName="${clientEntry.displayName}" ` +
+            `!= daemon displayName="${daemonEntry.displayName}"`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Display name mismatch between daemon and client TTS catalogs.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Update meta/tts-provider-catalog.json or assistant/src/tts/provider-catalog.ts to match.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Structural sanity
+  // -----------------------------------------------------------------------
+
+  test("client catalog JSON has a version field", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(typeof clientCatalog.version).toBe("number");
+    expect(clientCatalog.version).toBeGreaterThanOrEqual(1);
+  });
+
+  test("client catalog has at least one provider", () => {
+    const clientCatalog = loadClientCatalog();
+    expect(clientCatalog.providers.length).toBeGreaterThan(0);
+  });
+
+  test("every client catalog entry has required fields", () => {
+    const clientCatalog = loadClientCatalog();
+    const violations: string[] = [];
+
+    for (const entry of clientCatalog.providers) {
+      if (!entry.id || typeof entry.id !== "string") {
+        violations.push(`Entry missing or invalid 'id'`);
+      }
+      if (!entry.displayName || typeof entry.displayName !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'displayName'`);
+      }
+      if (!entry.setupMode || typeof entry.setupMode !== "string") {
+        violations.push(`${entry.id}: missing or invalid 'setupMode'`);
+      }
+      if (
+        !entry.credentialMode ||
+        !["api-key", "credential"].includes(entry.credentialMode)
+      ) {
+        violations.push(
+          `${entry.id}: missing or invalid 'credentialMode' (expected "api-key" or "credential")`,
+        );
+      }
+      if (entry.credentialMode === "api-key" && !entry.apiKeyProviderName) {
+        violations.push(
+          `${entry.id}: credentialMode is "api-key" but apiKeyProviderName is missing`,
+        );
+      }
+      if (entry.credentialMode === "credential" && !entry.credentialNamespace) {
+        violations.push(
+          `${entry.id}: credentialMode is "credential" but credentialNamespace is missing`,
+        );
+      }
+      if (!entry.credentialsGuide || !entry.credentialsGuide.url) {
+        violations.push(`${entry.id}: missing or invalid 'credentialsGuide'`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Client catalog entries have missing or invalid required fields.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+});

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -314,6 +314,41 @@ describe("voice_config_update — validation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: deepgram tts_provider integration
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — deepgram", () => {
+  test("accepts deepgram as tts_provider", async () => {
+    writeConfig({});
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_provider", value: "deepgram" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("updated to");
+    const config = readConfig();
+    expect((config.services as any)?.tts?.provider).toBe("deepgram");
+  });
+
+  test("broadcasts deepgram ttsProvider to client", async () => {
+    const messages: any[] = [];
+    const ctx = makeContext({
+      sendToClient: (msg: any) => messages.push(msg),
+    });
+
+    await run({ setting: "tts_provider", value: "deepgram" }, ctx);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe("client_settings_update");
+    expect(messages[0].key).toBe("ttsProvider");
+    expect(messages[0].value).toBe("deepgram");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: catalog-driven provider validation
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
@@ -15,8 +15,20 @@ All call-related settings can be managed via `assistant config`:
 | `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                                                                                                                                                   | _(empty)_                                                                                                |
 | `calls.voice.language`                      | Language code for TTS and transcription                                                                                                                                                                                                   | `en-US`                                                                                                  |
 | `services.stt.provider`                     | STT provider for transcription and telephony. Determines the Twilio integration path at call setup time (Deepgram/Google use native ConversationRelay; OpenAI Whisper uses media-stream).                                                 | `deepgram`                                                                                               |
-| `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (e.g. `elevenlabs`, `fish-audio`). New providers can be added via the catalog without code changes to call routing.                                      | `elevenlabs`                                                                                             |
+| `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (`elevenlabs`, `fish-audio`, `deepgram`). New providers can be added via the catalog without code changes to call routing.                               | `elevenlabs`                                                                                             |
 | `services.tts.providers.<id>.*`             | Provider-specific settings block. Each catalog provider has its own settings namespace under `services.tts.providers.<id>`. See voice settings in the desktop/iOS app or run `assistant config list` for available settings per provider. | _(per-provider defaults)_                                                                                |
+
+## TTS provider call-path behavior
+
+Each TTS provider uses one of two call-path modes during phone calls:
+
+| Provider     | Call mode          | Description                                                                                                                                                           |
+| ------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `elevenlabs` | `native-twilio`    | Text tokens are forwarded to Twilio's ConversationRelay, which synthesizes audio via its built-in ElevenLabs integration.                                             |
+| `fish-audio` | `synthesized-play` | The assistant synthesizes audio server-side via Fish Audio's HTTP API and streams chunks to Twilio via play messages.                                                 |
+| `deepgram`   | `synthesized-play` | The assistant synthesizes audio server-side via Deepgram's HTTP API and streams chunks to Twilio via play messages. Uses the same API key as Deepgram speech-to-text. |
+
+Providers using `synthesized-play` add a small amount of latency compared to `native-twilio` because audio must be synthesized server-side before playback. The assistant handles chunk buffering and streaming automatically.
 
 ## Adjusting settings
 

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers are defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Changes persist to services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers: elevenlabs, fish-audio, deepgram — defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Changes persist to services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -18,10 +18,10 @@
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog. tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference."
+            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (elevenlabs, fish-audio, deepgram). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: a valid provider ID from the provider catalog. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
+            "description": "The new value for the setting. For tts_provider: a valid provider ID from the provider catalog (elevenlabs, fish-audio, deepgram). For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog-consistency.test.ts
@@ -1,18 +1,27 @@
 /**
- * Consistency guard: assistant catalog vs client artifact provider IDs.
+ * Consistency guard: assistant catalog vs client artifact.
  *
  * The assistant-side canonical catalog (`provider-catalog.ts`) and the
- * client-facing artifact (`meta/tts-provider-catalog.json`) must list
- * exactly the same set of provider IDs. This test fails if the two
- * sources drift — for example, if a new provider is added to the
- * assistant catalog but forgotten in the client artifact, or vice versa.
+ * client-facing artifact (`meta/tts-provider-catalog.json`) must agree on
+ * provider IDs, ordering, and display names. This test fails when the two
+ * sources drift — for example, if a new provider is added to the assistant
+ * catalog but forgotten in the client artifact, or if display names diverge.
+ *
+ * These checks complement the full parity guard in
+ * `assistant/src/__tests__/tts-catalog-parity.test.ts`, which validates
+ * credential metadata and deeper structural invariants. This file focuses
+ * on fast, local assertions that live next to the catalog source.
  */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { listCatalogProviderIds } from "../provider-catalog.js";
+import {
+  getCatalogProvider,
+  listCatalogProviderIds,
+  listCatalogProviders,
+} from "../provider-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Load the client artifact
@@ -21,6 +30,8 @@ import { listCatalogProviderIds } from "../provider-catalog.js";
 interface ClientCatalogProvider {
   id: string;
   displayName: string;
+  credentialMode?: string;
+  credentialsGuide?: { url: string };
 }
 
 interface ClientCatalog {
@@ -49,31 +60,91 @@ function loadClientArtifact(): ClientCatalog {
 // ---------------------------------------------------------------------------
 
 describe("TTS provider catalog / client artifact consistency", () => {
-  const assistantIds = listCatalogProviderIds().slice().sort();
+  const assistantIds = listCatalogProviderIds();
   const clientCatalog = loadClientArtifact();
-  const clientIds = clientCatalog.providers.map((p) => p.id).sort();
+  const clientIds = clientCatalog.providers.map((p) => p.id);
+
+  // -- Loadability ----------------------------------------------------------
 
   test("client artifact file is loadable and has providers", () => {
     expect(clientCatalog.providers.length).toBeGreaterThan(0);
   });
 
-  test("assistant catalog and client artifact have the same provider IDs", () => {
-    expect(assistantIds).toEqual(clientIds);
+  // -- Provider ID parity ---------------------------------------------------
+
+  test("assistant catalog and client artifact have the same provider IDs (sorted)", () => {
+    expect(assistantIds.slice().sort()).toEqual(clientIds.slice().sort());
   });
 
   test("no provider IDs in assistant catalog are missing from client artifact", () => {
     const missingFromClient = assistantIds.filter(
       (id) => !clientIds.includes(id),
     );
-    expect(missingFromClient).toEqual([]);
+    if (missingFromClient.length > 0) {
+      const message = [
+        "Assistant catalog has provider IDs not present in meta/tts-provider-catalog.json.",
+        "",
+        "Missing from client artifact:",
+        ...missingFromClient.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to meta/tts-provider-catalog.json.",
+      ].join("\n");
+      expect(missingFromClient, message).toEqual([]);
+    }
   });
 
   test("no provider IDs in client artifact are missing from assistant catalog", () => {
     const missingFromAssistant = clientIds.filter(
       (id) => !assistantIds.includes(id),
     );
-    expect(missingFromAssistant).toEqual([]);
+    if (missingFromAssistant.length > 0) {
+      const message = [
+        "Client artifact (meta/tts-provider-catalog.json) has provider IDs not present in assistant catalog.",
+        "",
+        "Missing from assistant catalog:",
+        ...missingFromAssistant.map((id) => `  - ${id}`),
+        "",
+        "Add entries for these providers to assistant/src/tts/provider-catalog.ts.",
+      ].join("\n");
+      expect(missingFromAssistant, message).toEqual([]);
+    }
   });
+
+  // -- Ordering parity ------------------------------------------------------
+
+  test("assistant catalog and client artifact list providers in the same order", () => {
+    expect(clientIds).toEqual([...assistantIds]);
+  });
+
+  // -- Display name parity --------------------------------------------------
+
+  test("display names match between assistant catalog and client artifact", () => {
+    const violations: string[] = [];
+    for (const clientEntry of clientCatalog.providers) {
+      try {
+        const assistantEntry = getCatalogProvider(clientEntry.id as any);
+        if (clientEntry.displayName !== assistantEntry.displayName) {
+          violations.push(
+            `"${clientEntry.id}": client="${clientEntry.displayName}" vs assistant="${assistantEntry.displayName}"`,
+          );
+        }
+      } catch {
+        // Unknown ID — covered by provider ID parity tests above.
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Display name mismatch between assistant catalog and client artifact.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -- Structural sanity ----------------------------------------------------
 
   test("client artifact version is a positive integer", () => {
     expect(Number.isInteger(clientCatalog.version)).toBe(true);
@@ -85,5 +156,41 @@ describe("TTS provider catalog / client artifact consistency", () => {
       expect(entry.id.length).toBeGreaterThan(0);
       expect(entry.displayName.length).toBeGreaterThan(0);
     }
+  });
+
+  test("every client artifact entry has a credentialMode and credentialsGuide", () => {
+    const violations: string[] = [];
+    for (const entry of clientCatalog.providers) {
+      if (
+        !entry.credentialMode ||
+        !["api-key", "credential"].includes(entry.credentialMode)
+      ) {
+        violations.push(
+          `${entry.id}: missing or invalid credentialMode (got "${entry.credentialMode}")`,
+        );
+      }
+      if (!entry.credentialsGuide?.url) {
+        violations.push(`${entry.id}: missing credentialsGuide.url`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Client artifact entries have missing required fields.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  // -- Catalog size guard ---------------------------------------------------
+
+  test("assistant catalog has at least as many providers as expected", () => {
+    const providers = listCatalogProviders();
+    // Guard: adding a provider to the catalog without updating this
+    // lower-bound forces the developer to acknowledge the growth.
+    expect(providers.length).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary
- Add daemon-vs-client TTS catalog parity guard test
- Tighten catalog consistency test for drift detection
- Make voice-config-update tooling catalog-driven with Deepgram

Part of plan: deepgram-tts-provider.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
