### PR TITLE
fix(tests): make oauth2-gateway-transport loopback test deterministic

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -215,15 +215,19 @@ describe("OAuth2 gateway transport", () => {
     test("falls back to loopback transport when ingress.publicBaseUrl is not configured", async () => {
       mockPublicBaseUrl = "";
 
-      let capturedAuthUrl = "";
+      let resolveOpenUrl!: (url: string) => void;
+      const openUrlPromise = new Promise<string>((resolve) => {
+        resolveOpenUrl = resolve;
+      });
       const flowPromise = startOAuth2Flow(BASE_OAUTH_CONFIG, {
         openUrl: (url) => {
-          capturedAuthUrl = url;
+          resolveOpenUrl(url);
         },
       });
 
-      // Give the loopback server time to start
-      await new Promise((r) => setTimeout(r, 50));
+      // Wait for the loopback server to bind and build the auth URL.
+      // Awaiting the openUrl callback instead of a fixed timer avoids CI-load flakes.
+      const capturedAuthUrl = await openUrlPromise;
 
       // Auth URL should use a localhost redirect_uri
       expect(capturedAuthUrl).toContain("redirect_uri=");


### PR DESCRIPTION
## Summary
- The \`falls back to loopback transport when ingress.publicBaseUrl is not configured\` test used a fixed 50ms sleep to wait for the loopback server to bind and call \`openUrl\`. Under CI load this race loses, leaving \`capturedAuthUrl\` empty and failing on \`expect(capturedAuthUrl).toContain(\"redirect_uri=\")\`.
- Replace the timer with a promise resolved inside the \`openUrl\` callback so the test waits for the real event instead of guessing at a duration.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24436847054/job/71392805434