### PR TITLE
fix(memory): gate auto-analyze pending-count writes behind feature flag

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -388,10 +388,9 @@ describe("auto-analysis end-to-end trigger path", () => {
 
 // ─────────────────────────────────────────────────────────────────
 // Independent cadence: analysis.batchSize gates the auto-analysis
-// batch trigger separately from extraction.batchSize. This regression
-// guards against a previous wiring bug where the indexer piggy-backed
-// on the extraction counter, causing analysis to fire at extraction's
-// cadence instead of its own (default 30 vs. 10).
+// batch trigger separately from extraction.batchSize, ensuring
+// analysis fires at its own cadence (default 30) rather than at the
+// extraction cadence (default 10).
 // ─────────────────────────────────────────────────────────────────
 
 describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 import { desc, eq } from "drizzle-orm";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { MemoryConfig } from "../config/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
@@ -213,20 +214,27 @@ export async function indexMessageNow(
       });
 
       // Auto-analysis cadence is tracked by its own pending-count
-      // checkpoint so it fires at `analysis.batchSize` (default 30)
-      // rather than piggy-backing on the extraction batch size.
-      // Reading config here is best-effort: if it fails we skip the
-      // batch trigger (the idle-debounced enqueue above still runs).
-      let analysisBatchSize: number | null = null;
+      // checkpoint so it fires at `analysis.batchSize` (default 30).
+      // Gated behind the `auto-analyze` feature flag so the counter
+      // does not accumulate stale counts while the flag is off — if it
+      // did, flipping the flag on would trigger an immediate batch from
+      // messages buffered during the disabled period. Reading config
+      // here is best-effort: if it fails we skip the batch trigger
+      // (the idle-debounced enqueue above still runs).
+      let analysisConfig: ReturnType<typeof getConfig> | null = null;
       try {
-        analysisBatchSize = getConfig().analysis.batchSize;
+        analysisConfig = getConfig();
       } catch (err) {
         log.debug(
           { err, conversationId: input.conversationId },
           "Skipping auto-analysis batch trigger: failed to load config",
         );
       }
-      if (analysisBatchSize != null) {
+      if (
+        analysisConfig != null &&
+        isAssistantFeatureFlagEnabled("auto-analyze", analysisConfig)
+      ) {
+        const analysisBatchSize = analysisConfig.analysis.batchSize;
         const analysisPendingKey = `conversation_analyze:${input.conversationId}:pending_count`;
         const analysisCurrentVal = getMemoryCheckpoint(analysisPendingKey);
         const analysisPendingCount =


### PR DESCRIPTION
Addresses Codex P2 + Devin 🟡 feedback on #25679.

- Gate the `conversation_analyze:<id>:pending_count` checkpoint write path in `indexer.ts` behind `isAssistantFeatureFlagEnabled('auto-analyze', config)`. Previously the counter ran for every extractable message regardless of the flag, so turning `auto-analyze` on after a quiet period could fire a stale batch trigger based on messages buffered while disabled.
- Rewrite two comments that narrated a removed wiring bug (AGENTS.md violation) to describe current behavior only.

Closes JARVIS-pending
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
