### PR TITLE
fix(memory): refresh payload on upsertDebouncedJob for graph_extract

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -517,10 +517,9 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
     const source = createConversation("cadence-source-graph");
 
     // extraction.batchSize = 2 → second message trips the batch
-    // trigger. Before the fix, the idle upsert that runs on the same
-    // tick would overwrite the batch job's runAfter with
-    // (now + idleTimeoutMs), silently debouncing it. Assert the single
-    // coalesced pending row ends up at ~now.
+    // trigger. The batch enqueue runs last and pulls `runAfter` back
+    // to `Date.now()`, overriding the per-message idle debounce. The
+    // single coalesced pending row should end up at ~now.
     await indexMessages(source.id, 1);
     const before = Date.now();
     await indexMessages(source.id, 1, 1);

--- a/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
+++ b/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
@@ -1,0 +1,141 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({}),
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+}));
+
+import { eq } from "drizzle-orm";
+
+import { getDb, initializeDb } from "../memory/db.js";
+import {
+  enqueueMemoryJob,
+  upsertDebouncedJob,
+} from "../memory/jobs-store.js";
+import { memoryJobs } from "../memory/schema.js";
+
+describe("upsertDebouncedJob payload refresh", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM memory_jobs");
+  });
+
+  test("merges new payload keys into existing pending row (upgrade scenario)", () => {
+    // Simulate a legacy pending row enqueued before `scopeId` was
+    // added to the payload shape.
+    const legacyId = enqueueMemoryJob(
+      "graph_extract",
+      { conversationId: "conv-1" },
+      Date.now() + 300_000,
+    );
+
+    // A batch trigger from the current build passes `scopeId`.
+    upsertDebouncedJob(
+      "graph_extract",
+      { conversationId: "conv-1", scopeId: "private-scope" },
+      Date.now(),
+    );
+
+    const db = getDb();
+    const rows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_extract"))
+      .all();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(legacyId);
+    const payload = JSON.parse(rows[0]!.payload) as {
+      conversationId: string;
+      scopeId?: string;
+    };
+    expect(payload.conversationId).toBe("conv-1");
+    expect(payload.scopeId).toBe("private-scope");
+  });
+
+  test("later call overrides existing payload keys", () => {
+    enqueueMemoryJob(
+      "graph_extract",
+      { conversationId: "conv-2", scopeId: "default" },
+      Date.now() + 300_000,
+    );
+
+    upsertDebouncedJob(
+      "graph_extract",
+      { conversationId: "conv-2", scopeId: "newer-scope" },
+      Date.now(),
+    );
+
+    const db = getDb();
+    const rows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_extract"))
+      .all();
+
+    expect(rows).toHaveLength(1);
+    const payload = JSON.parse(rows[0]!.payload) as { scopeId?: string };
+    expect(payload.scopeId).toBe("newer-scope");
+  });
+
+  test("updates runAfter on match", () => {
+    const runAfterOriginal = Date.now() + 300_000;
+    enqueueMemoryJob(
+      "graph_extract",
+      { conversationId: "conv-3", scopeId: "default" },
+      runAfterOriginal,
+    );
+
+    const runAfterNew = Date.now();
+    upsertDebouncedJob(
+      "graph_extract",
+      { conversationId: "conv-3", scopeId: "default" },
+      runAfterNew,
+    );
+
+    const db = getDb();
+    const rows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_extract"))
+      .all();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.runAfter).toBe(runAfterNew);
+  });
+
+  test("inserts a new row when no pending job matches", () => {
+    upsertDebouncedJob(
+      "graph_extract",
+      { conversationId: "conv-4", scopeId: "default" },
+      Date.now(),
+    );
+
+    const db = getDb();
+    const rows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_extract"))
+      .all();
+
+    expect(rows).toHaveLength(1);
+    const payload = JSON.parse(rows[0]!.payload) as {
+      conversationId: string;
+      scopeId?: string;
+    };
+    expect(payload.conversationId).toBe("conv-4");
+    expect(payload.scopeId).toBe("default");
+  });
+});

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -190,9 +190,9 @@ export async function indexMessageNow(
       // Single pending `graph_extract` row per conversation. If the
       // batch threshold just fired, pull `runAfter` back to now so the
       // job runs immediately; otherwise debounce by the idle timeout.
-      // Using `upsertDebouncedJob` in both paths avoids the previous
-      // bug where the idle call would overwrite a just-enqueued batch
-      // job's `runAfter` and silently debounce it.
+      // Routing both paths through `upsertDebouncedJob` ensures the
+      // row's `runAfter` reflects whichever trigger ran last, so a
+      // batch crossing always takes effect immediately.
       upsertDebouncedJob(
         "graph_extract",
         {

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -90,8 +90,12 @@ export function enqueueMemoryJob(
 
 /**
  * Upsert a debounced job: if a pending job of the same type and conversation
- * already exists, push its `runAfter` forward instead of creating a duplicate.
- * This prevents rapid message indexing from spawning redundant jobs.
+ * already exists, merge the new payload into the existing row and update
+ * `runAfter` instead of creating a duplicate. This prevents rapid message
+ * indexing from spawning redundant jobs while ensuring the latest payload
+ * keys (e.g. `scopeId`) reach the handler — including on upgraded instances
+ * where the existing pending row was enqueued by an older build that did
+ * not write those keys.
  *
  * Pass a `dbOverride` (transaction handle) to make this call atomic with
  * surrounding writes.
@@ -119,8 +123,19 @@ export function upsertDebouncedJob(
     )
     .get();
   if (existing) {
+    let existingPayload: Record<string, unknown> = {};
+    try {
+      existingPayload = JSON.parse(existing.payload) as Record<string, unknown>;
+    } catch {
+      existingPayload = {};
+    }
+    const mergedPayload = { ...existingPayload, ...payload };
     db.update(memoryJobs)
-      .set({ runAfter, updatedAt: Date.now() })
+      .set({
+        payload: JSON.stringify(mergedPayload),
+        runAfter,
+        updatedAt: Date.now(),
+      })
       .where(eq(memoryJobs.id, existing.id))
       .run();
   } else {


### PR DESCRIPTION
Addresses Codex P1 + Devin 🟡 feedback on #25686.

**Codex P1 (upgrade-scenario correctness):** `upsertDebouncedJob` only updated `runAfter` on a matching pending row, so a legacy `graph_extract` row enqueued by an older build (without `scopeId`) would coalesce with a new batch trigger and keep the stale payload — `graph/extraction-job.ts` then fell back to `scope="default"` for private/non-default conversations and wrote extracted memories into the wrong scope. Now merges the new payload into the existing row (new keys win) alongside the `runAfter` update. Added `jobs-store-upsert-debounced.test.ts` covering the legacy-row-without-scopeId upgrade path plus three adjacent cases (override, runAfter-only, fresh insert).

**Devin 🟡 (AGENTS.md comment hygiene):** Rewrote the two comments in `indexer.ts` and `auto-analysis-end-to-end.test.ts` that narrated pre-fix behavior; they now describe current code only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
