### PR TITLE
fix: update synthesizeAndPlay JSDoc to reflect conditional fallback behavior

### DIFF
--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -69,8 +69,14 @@ export function speakSystemPrompt(
 
 /**
  * Synthesize text via a streaming TTS provider and send the play URL
- * to the relay. Falls back to sendTextToken on synthesis failure so the
- * caller always hears something.
+ * to the relay.
+ *
+ * On synthesis failure the behavior depends on the provider:
+ * - Providers with a native Twilio TTS fallback (e.g. Fish Audio) fall
+ *   back to `sendTextToken(text)` so the caller still hears the message.
+ * - Providers without a native fallback (e.g. Deepgram) log the error
+ *   and send only an empty end-of-turn signal — the caller hears nothing
+ *   but the relay transitions back to listening state.
  */
 async function synthesizeAndPlay(
   relay: CallTransport,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-tts-provider.md.

**Gap:** Stale JSDoc on synthesizeAndPlay
**What was expected:** JSDoc should describe current behavior
**What was found:** JSDoc claims caller always hears something, but Deepgram path sends only end-of-turn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
