### PR TITLE
fix: add deepgram to TtsProviderId union type

### DIFF
--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -16,7 +16,11 @@
  * (e.g. `"elevenlabs"`, `"fish-audio"`). New providers simply add a new
  * string to this union — the registry enforces uniqueness at runtime.
  */
-export type TtsProviderId = "elevenlabs" | "fish-audio" | (string & {});
+export type TtsProviderId =
+  | "elevenlabs"
+  | "fish-audio"
+  | "deepgram"
+  | (string & {});
 
 // ---------------------------------------------------------------------------
 // Call-mode discriminator


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-tts-provider.md.

**Gap:** TtsProviderId union type missing deepgram
**What was expected:** TtsProviderId should include deepgram as explicit union member
**What was found:** Only elevenlabs and fish-audio were explicit members
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
