### PR TITLE
fix: guard STT key reset for shared-key providers (deepgram TTS)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3068,9 +3068,11 @@ public final class SettingsStore: ObservableObject {
     /// safely have their key cleared through the STT reset flow without
     /// affecting other features.
     ///
-    /// A provider's key is exclusive when its `apiKeyProviderName` matches its
-    /// own `id` (e.g. `deepgram` → `deepgram`). Shared-key providers map to a
-    /// different credential name (e.g. `openai-whisper` → `openai`).
+    /// A provider's key is non-exclusive when either:
+    /// 1. Its `apiKeyProviderName` differs from its `id` (e.g.
+    ///    `openai-whisper` → `openai`), meaning the key is shared within STT.
+    /// 2. A TTS provider also references the same key name (e.g.
+    ///    `deepgram` STT + `deepgram` TTS both use the `deepgram` key).
     ///
     /// This helper is provider-agnostic: adding a new provider only requires a
     /// catalog entry — no new conditionals here or in the UI layer.
@@ -3081,7 +3083,10 @@ public final class SettingsStore: ObservableObject {
             // key cannot collide with a known service.
             return true
         }
-        return entry.apiKeyProviderName == entry.id
+        // First check: different key name means shared within STT scope.
+        guard entry.apiKeyProviderName == entry.id else { return false }
+        // Second check: same key name but might be shared with a TTS provider.
+        return !Self.isApiKeySharedAcrossServices(entry.apiKeyProviderName)
     }
 
     /// Whether the given STT provider's API key is shared with another
@@ -3217,12 +3222,21 @@ public final class SettingsStore: ObservableObject {
 
     /// Checks whether a given API key provider name is used by both a TTS and
     /// an STT provider, indicating a cross-service shared credential.
+    ///
+    /// Checks both registries so the result is symmetric — calling this from
+    /// either `sttKeyIsExclusive` or `ttsKeyIsExclusive` correctly detects
+    /// cross-service sharing (e.g. deepgram STT + deepgram TTS).
     private static func isApiKeySharedAcrossServices(_ keyProviderName: String) -> Bool {
         let sttRegistry = loadSTTProviderRegistry()
         let sttUsesKey = sttRegistry.providers.contains { entry in
             entry.apiKeyProviderName == keyProviderName
         }
-        return sttUsesKey
+        let ttsRegistry = loadTTSProviderRegistry()
+        let ttsUsesKey = ttsRegistry.providers.contains { entry in
+            guard entry.credentialMode == .apiKey else { return false }
+            return (entry.apiKeyProviderName ?? entry.id) == keyProviderName
+        }
+        return sttUsesKey && ttsUsesKey
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the

--- a/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreVoiceServiceTests.swift
@@ -426,18 +426,31 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
         )
     }
 
-    func testExclusiveKeyProviderIsExclusive() {
-        // deepgram maps to "deepgram" — its own credential, not shared.
-        XCTAssertTrue(
+    func testDeepgramSTTKeyIsNotExclusive() {
+        // deepgram STT maps to "deepgram" — but deepgram TTS also uses the
+        // same "deepgram" key, so it is shared across services.
+        XCTAssertFalse(
             SettingsStore.sttKeyIsExclusive(for: "deepgram"),
-            "deepgram owns its own key and must be classified as exclusive"
+            "deepgram STT shares the 'deepgram' key with TTS and must not be exclusive"
         )
     }
 
-    func testExclusiveKeyProviderIsNotShared() {
-        XCTAssertFalse(
+    func testDeepgramSTTKeyIsShared() {
+        // deepgram STT shares the "deepgram" key with deepgram TTS.
+        XCTAssertTrue(
             SettingsStore.sttKeyIsShared(for: "deepgram"),
-            "deepgram owns its own key and must not be classified as shared"
+            "deepgram STT shares the 'deepgram' key with TTS and must be classified as shared"
+        )
+    }
+
+    func testDeepgramSTTSharedKeyCannotBeResetThroughSTTFlow() {
+        // The UI checks sttKeyIsExclusive before allowing the reset action.
+        // For deepgram the guard must prevent the reset because clearing the
+        // "deepgram" key would break TTS.
+        let allowReset = SettingsStore.sttKeyIsExclusive(for: "deepgram")
+        XCTAssertFalse(
+            allowReset,
+            "The STT reset flow must not be allowed for deepgram (shared key with TTS)"
         )
     }
 
@@ -505,18 +518,25 @@ final class SettingsStoreVoiceServiceTests: XCTestCase {
     }
 
     /// Ensures the ownership classification for every registered provider
-    /// is consistent with the catalog's `apiKeyProviderName` field.
+    /// is consistent: a provider is exclusive only when its key name matches
+    /// its id AND no TTS provider shares the same key.
     func testAllRegistryProvidersHaveConsistentOwnership() {
-        let registry = loadSTTProviderRegistry()
-        for provider in registry.providers {
+        let sttRegistry = loadSTTProviderRegistry()
+        let ttsRegistry = loadTTSProviderRegistry()
+        for provider in sttRegistry.providers {
             let isExclusive = SettingsStore.sttKeyIsExclusive(for: provider.id)
-            let expectedExclusive = (provider.apiKeyProviderName == provider.id)
+            let nameMatchesId = (provider.apiKeyProviderName == provider.id)
+            let ttsSharesKey = ttsRegistry.providers.contains { ttsEntry in
+                guard ttsEntry.credentialMode == .apiKey else { return false }
+                return (ttsEntry.apiKeyProviderName ?? ttsEntry.id) == provider.apiKeyProviderName
+            }
+            let expectedExclusive = nameMatchesId && !ttsSharesKey
             XCTAssertEqual(
                 isExclusive,
                 expectedExclusive,
                 "Ownership mismatch for \"\(provider.id)\": sttKeyIsExclusive returned "
-                + "\(isExclusive) but apiKeyProviderName=\"\(provider.apiKeyProviderName)\" "
-                + "implies exclusive=\(expectedExclusive)"
+                + "\(isExclusive) but expected \(expectedExclusive) "
+                + "(apiKeyProviderName=\"\(provider.apiKeyProviderName)\", ttsSharesKey=\(ttsSharesKey))"
             )
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-tts-provider.md.

**Gap:** STT key reset silently breaks Deepgram TTS
**What was expected:** sttKeyIsExclusive should check TTS providers for shared keys
**What was found:** sttKeyIsExclusive only checks STT registry, misses TTS key sharing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
