### PR TITLE
fix: replace hardcoded deepgram fail-fast with catalog-driven allowNativeFallback

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -23,7 +23,8 @@ import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import type { TtsProvider } from "../tts/types.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
+import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import {
@@ -840,15 +841,15 @@ export class CallController {
             ? (err as Error & { code?: string }).code
             : undefined;
 
-        // Deepgram is a synthesized-only provider with no native Twilio
-        // TTS integration. Silently falling back to token-based speech
-        // would route audio through a path that cannot produce output,
-        // so we fail explicitly and let the outer error handler surface
-        // a user-facing recovery message.
-        if (provider.id === "deepgram") {
+        // Check whether this provider supports falling back to native
+        // Twilio token-based TTS. Providers without a native fallback
+        // (e.g. Deepgram) must propagate the error so the outer handler
+        // can surface a user-facing recovery message.
+        const catalogEntry = getCatalogProvider(provider.id as TtsProviderId);
+        if (!catalogEntry.allowNativeFallback) {
           log.error(
             { err, provider: provider.id, errName, errCode },
-            "Deepgram TTS synthesis failed — no native fallback available",
+            "TTS synthesis failed — no native fallback available",
           );
           throw err;
         }
@@ -860,8 +861,7 @@ export class CallController {
         // If synthesis fails before any audio has started, degrade to
         // token-based speech on ConversationRelay so the caller still
         // hears a response instead of silence. This fallback is only
-        // used for providers that have a viable native-twilio path
-        // (e.g. Fish Audio with ConversationRelay text tokens).
+        // used for providers whose catalog entry allows native fallback.
         if (!playUrlSent && !this.transport.requiresWavAudio) {
           this.transport.sendTextToken(text, false);
         }

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -16,7 +16,8 @@
 
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
-import type { TtsProvider } from "../tts/types.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
+import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
@@ -147,16 +148,17 @@ async function synthesizeAndPlay(
         ? (err as Error & { code?: string }).code
         : undefined;
 
-    // Deepgram is a synthesized-only provider with no native Twilio
-    // TTS integration. Silently falling back to token-based speech
-    // would route audio through a path that cannot produce output,
-    // so we log the error and return without sending any fallback.
+    // Check whether this provider supports falling back to native
+    // Twilio token-based TTS. Providers without a native fallback
+    // (e.g. Deepgram) must not attempt token-based speech — it would
+    // route audio through a path that cannot produce output.
     // Callers use fire-and-forget (`void speakSystemPrompt(...)`) so
     // throwing here would produce an unhandled promise rejection.
-    if (provider.id === "deepgram") {
+    const catalogEntry = getCatalogProvider(provider.id as TtsProviderId);
+    if (!catalogEntry.allowNativeFallback) {
       log.error(
         { err, provider: provider.id, errName, errCode },
-        "Deepgram system prompt TTS synthesis failed — no native fallback available",
+        "System prompt TTS synthesis failed — no native fallback available",
       );
       // Send the end-of-turn signal so ConversationRelay transitions from
       // "assistant speaking" to "caller speaking" state. Without this, the
@@ -172,8 +174,8 @@ async function synthesizeAndPlay(
     );
     // Fallback: send text via native TTS so the caller still hears the message.
     // sendTextToken with last:true includes the end-of-turn signal inherently.
-    // This fallback is only used for providers that have a viable
-    // native-twilio path.
+    // This fallback is only used for providers whose catalog entry allows
+    // native fallback.
     relay.sendTextToken(text, true);
   } finally {
     handle?.finalize();

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -74,6 +74,20 @@ export interface TtsProviderCatalogEntry {
   /** How this provider integrates with the telephony call path. */
   readonly callMode: TtsCallMode;
 
+  /**
+   * Whether the call path may fall back to native Twilio token-based
+   * TTS when synthesized audio fails.
+   *
+   * Providers with `callMode: "native-twilio"` always set this to `true`.
+   * Synthesized-play providers that also work through Twilio's built-in
+   * TTS (e.g. Fish Audio) set this to `true` so callers still hear
+   * a response if synthesis fails. Providers that have **no** native
+   * Twilio integration (e.g. Deepgram) set this to `false` — a synthesis
+   * failure must propagate so the outer error handler can surface a
+   * user-facing recovery message.
+   */
+  readonly allowNativeFallback: boolean;
+
   /** Static provider-level capabilities. */
   readonly capabilities: Readonly<TtsProviderCatalogCapabilities>;
 
@@ -95,6 +109,7 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     id: "elevenlabs",
     displayName: "ElevenLabs",
     callMode: "native-twilio",
+    allowNativeFallback: true,
     capabilities: {
       supportsStreaming: false,
       supportedFormats: ["mp3"],
@@ -112,6 +127,7 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     id: "fish-audio",
     displayName: "Fish Audio",
     callMode: "synthesized-play",
+    allowNativeFallback: true,
     capabilities: {
       supportsStreaming: true,
       supportedFormats: ["mp3", "wav", "opus"],
@@ -129,6 +145,7 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     id: "deepgram",
     displayName: "Deepgram",
     callMode: "synthesized-play",
+    allowNativeFallback: false,
     capabilities: {
       supportsStreaming: false,
       supportedFormats: ["mp3", "wav", "opus"],


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-tts-provider.md.

**Gap:** Hardcoded provider.id === deepgram fail-fast check
**What was expected:** Catalog-driven fail-fast behavior
**What was found:** Hardcoded provider ID checks in call-controller and call-speech-output

### Changes
- Added `allowNativeFallback` boolean to `TtsProviderCatalogEntry` (`true` for ElevenLabs/Fish Audio, `false` for Deepgram)
- Replaced `provider.id === "deepgram"` in `call-controller.ts` with catalog lookup
- Replaced `provider.id === "deepgram"` in `call-speech-output.ts` with catalog lookup

Adding a new TTS provider now only requires setting `allowNativeFallback` in the catalog entry — no downstream code changes needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
