### PR TITLE
fix: clarify allowNativeFallback comment semantics in call error paths

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -841,15 +841,18 @@ export class CallController {
             ? (err as Error & { code?: string }).code
             : undefined;
 
-        // Check whether this provider supports falling back to native
-        // Twilio token-based TTS. Providers without a native fallback
-        // (e.g. Deepgram) must propagate the error so the outer handler
-        // can surface a user-facing recovery message.
+        // `allowNativeFallback` controls whether the LLM's original
+        // response text should be sent via native Twilio token-based
+        // TTS when synthesis fails. When false (e.g. Deepgram), the
+        // error is re-thrown so the outer catch handler sends a
+        // generic recovery message via native TTS instead — the
+        // caller still hears *something*, but not the LLM's text
+        // rendered in a mismatched voice.
         const catalogEntry = getCatalogProvider(provider.id as TtsProviderId);
         if (!catalogEntry.allowNativeFallback) {
           log.error(
             { err, provider: provider.id, errName, errCode },
-            "TTS synthesis failed — no native fallback available",
+            "TTS synthesis failed — native fallback disabled for this provider",
           );
           throw err;
         }

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -154,17 +154,18 @@ async function synthesizeAndPlay(
         ? (err as Error & { code?: string }).code
         : undefined;
 
-    // Check whether this provider supports falling back to native
-    // Twilio token-based TTS. Providers without a native fallback
-    // (e.g. Deepgram) must not attempt token-based speech — it would
-    // route audio through a path that cannot produce output.
+    // `allowNativeFallback` controls whether the system prompt text
+    // should be sent via native Twilio token-based TTS when synthesis
+    // fails. When false (e.g. Deepgram), the design choice is to
+    // send only an end-of-turn signal — the caller hears nothing for
+    // this prompt — rather than degrading to a mismatched voice.
     // Callers use fire-and-forget (`void speakSystemPrompt(...)`) so
     // throwing here would produce an unhandled promise rejection.
     const catalogEntry = getCatalogProvider(provider.id as TtsProviderId);
     if (!catalogEntry.allowNativeFallback) {
       log.error(
         { err, provider: provider.id, errName, errCode },
-        "System prompt TTS synthesis failed — no native fallback available",
+        "System prompt TTS synthesis failed — native fallback disabled for this provider",
       );
       // Send the end-of-turn signal so ConversationRelay transitions from
       // "assistant speaking" to "caller speaking" state. Without this, the


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-tts-provider.md.

**Gap:** Misleading comments about allowNativeFallback semantics
**What was expected:** Comments accurately describing the design intent
**What was found:** Comments claimed native TTS cannot produce output, but it can
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
