### PR TITLE
meet-bot: package skeleton + Dockerfile with Xvfb, PulseAudio, Chromium

### DIFF
--- a/meet-bot/.dockerignore
+++ b/meet-bot/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+__tests__
+*.md
+.env*
+dist

--- a/meet-bot/Dockerfile
+++ b/meet-bot/Dockerfile
@@ -1,0 +1,54 @@
+# meet-bot container image.
+#
+# Runs the Meet bot inside a Debian-based Bun image with Xvfb (virtual
+# display), PulseAudio (virtual audio devices), Chromium + Playwright
+# dependencies, and ffmpeg for future audio capture/encoding needs.
+#
+# The real Meet-join + audio-capture logic lands in later PRs of the
+# meet-phase-1 plan; this image just needs to build cleanly and boot
+# `bun src/main.ts` to completion so CI can smoke-test the structure.
+
+FROM oven/bun:1-debian
+
+WORKDIR /app
+
+# System dependencies. Keep this list grouped and sorted so future PRs can
+# add/remove packages cleanly.
+#
+#   Xvfb + PulseAudio: virtual display and audio stack for headless Chromium.
+#   dbus-x11:          required at runtime by Chromium under Playwright.
+#   chromium:          browser binary (Playwright can also install its own,
+#                      but having it in the base image keeps first-run fast).
+#   ffmpeg:            audio/video encoding for transcript + recording paths.
+#   libnss3/libgbm1/libasound2: Chromium shared-library dependencies that
+#                      Playwright's Debian list normally expects to be present.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
+    dbus-x11 \
+    ffmpeg \
+    libasound2 \
+    libgbm1 \
+    libnss3 \
+    pulseaudio \
+    pulseaudio-utils \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install JS dependencies first so Docker can cache the layer when only
+# source files change.
+COPY package.json ./
+RUN bun install
+
+# Pull Playwright's Chromium build. This is kept separate from apt's
+# chromium install so the Playwright-controlled binary stays in sync with
+# the `playwright` package version pinned in package.json.
+RUN bunx playwright install chromium
+
+COPY src ./src
+
+# The placeholder probe lives at src/health.ts and exits 0; real health
+# logic lands in a later PR (see meet-phase-1 plan PR 8).
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD bun src/health.ts || exit 1
+
+CMD ["bun", "src/main.ts"]

--- a/meet-bot/README.md
+++ b/meet-bot/README.md
@@ -1,0 +1,35 @@
+# meet-bot
+
+Container bot that joins a Google Meet session on behalf of an AI assistant so the assistant can listen in (and eventually participate) in the call.
+
+## Role
+
+`meet-bot` runs inside a Linux Docker container with Xvfb, PulseAudio, and Playwright-driven Chromium. The assistant launches a bot instance when the user asks it to attend a meeting; the bot joins the Meet URL as a participant, captures audio through a virtual PulseAudio sink, and streams transcript/events back to the assistant.
+
+This package contains:
+
+- `src/main.ts` — process entry point.
+- `src/health.ts` — placeholder health probe invoked by the Dockerfile's `HEALTHCHECK`.
+- `Dockerfile` — container image with Xvfb, PulseAudio, Chromium, and Playwright dependencies.
+- `__tests__/` — smoke tests that run inside the Bun test runner.
+
+## Status
+
+This is the **skeleton** for the Meet bot. Today it does nothing but boot, log `meet-bot booted`, and exit 0. Real Meet-join, audio capture, and HTTP control-surface logic land in later PRs.
+
+See the plan at `.private/plans/meet-phase-1-listen.md` (repo-local, not committed) for the full rollout — this is PR 1 of 24.
+
+## Development
+
+```bash
+cd meet-bot
+bun install
+bunx tsc --noEmit
+bun test __tests__/boot.test.ts
+```
+
+To build the container image (requires Docker):
+
+```bash
+./scripts/build-meet-bot-image.sh
+```

--- a/meet-bot/__tests__/boot.test.ts
+++ b/meet-bot/__tests__/boot.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+/**
+ * Smoke test that validates the meet-bot package can boot.
+ *
+ * Real Meet-join, audio capture, and Playwright orchestration land in later
+ * PRs of the meet-phase-1 plan; for now we only confirm that `bun src/main.ts`
+ * runs to completion, exits 0, and emits the expected boot marker on stdout.
+ */
+describe("meet-bot boot", () => {
+  test("runs src/main.ts and logs the boot marker", () => {
+    const pkgRoot = join(import.meta.dir, "..");
+    const result = spawnSync("bun", ["run", "src/main.ts"], {
+      cwd: pkgRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("meet-bot booted");
+  });
+});

--- a/meet-bot/bun.lock
+++ b/meet-bot/bun.lock
@@ -1,0 +1,39 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/meet-bot",
+      "dependencies": {
+        "hono": "4.12.14",
+        "playwright": "1.58.2",
+        "zod": "3.25.76",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.9",
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/meet-bot/package.json
+++ b/meet-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vellumai/meet-bot",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "src/main.ts",
+  "scripts": {
+    "build": "bun build src/main.ts --outdir dist --target bun",
+    "start": "bun run src/main.ts",
+    "test": "bun test __tests__/",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "4.12.14",
+    "playwright": "1.58.2",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.9",
+    "typescript": "5.9.3"
+  }
+}

--- a/meet-bot/src/health.ts
+++ b/meet-bot/src/health.ts
@@ -1,0 +1,10 @@
+/**
+ * Placeholder health probe for the meet-bot container.
+ *
+ * Invoked by the Dockerfile's HEALTHCHECK directive. Exits 0 to indicate the
+ * container is healthy. The real probe (which will hit an in-process `/health`
+ * endpoint served by Hono and confirm Playwright/Xvfb/PulseAudio are up)
+ * lands in a later PR of the meet-phase-1 plan.
+ */
+
+process.exit(0);

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -1,0 +1,21 @@
+/**
+ * meet-bot entry point.
+ *
+ * This is the bootstrap skeleton for the Meet bot — the container-side process
+ * that will join a Google Meet session on behalf of an AI assistant so the
+ * assistant can listen in (and eventually participate).
+ *
+ * The real implementation (Playwright-driven Meet join flow, audio capture
+ * via PulseAudio, Hono HTTP control surface, etc.) lands in later PRs of the
+ * meet-phase-1 plan. See `meet-bot/README.md` for links.
+ *
+ * For now this just logs a boot marker and exits cleanly so the Docker image
+ * build, the package scripts, and the boot test can all verify the package
+ * structure is valid end-to-end.
+ */
+
+function main(): void {
+  console.log("meet-bot booted");
+}
+
+main();

--- a/meet-bot/tsconfig.json
+++ b/meet-bot/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/build-meet-bot-image.sh
+++ b/scripts/build-meet-bot-image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# build-meet-bot-image.sh — Build the meet-bot container image locally.
+#
+# This is the dev-loop image build; CI has its own publishing pipeline. It
+# tags the image as `vellum-meet-bot:dev` so local smoke tests can reference
+# a stable tag without colliding with whatever CI produces.
+#
+# Usage:
+#   ./scripts/build-meet-bot-image.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+docker build -t vellum-meet-bot:dev -f meet-bot/Dockerfile meet-bot/


### PR DESCRIPTION
## Summary
- Scaffolds new `meet-bot/` package (Bun + TypeScript) with Playwright, Hono, Zod.
- Dockerfile installs Xvfb, PulseAudio, Chromium deps for future Meet bot container.
- Minimal main.ts + boot test validating package structure; real Meet logic lands in later PRs.

Part of plan: meet-phase-1-listen.md (PR 1 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
