### PR TITLE
workspace: migration creating meets/ storage directory

### DIFF
--- a/assistant/src/__tests__/workspace-migration-meets.test.ts
+++ b/assistant/src/__tests__/workspace-migration-meets.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for workspace migration `037-create-meets-dir`.
+ *
+ * The migration creates `<workspace>/meets/` (if missing) and seeds a
+ * `.keep` sentinel file. It must be idempotent and must not touch other
+ * workspace files.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { createMeetsDirMigration } from "../workspace/migrations/037-create-meets-dir.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-037-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Snapshot the (relative path -> mtimeMs, content) for every file inside a
+ * directory so we can assert a migration did not touch it.
+ */
+function snapshotTree(
+  root: string,
+): Record<string, { mtimeMs: number; content: string }> {
+  const out: Record<string, { mtimeMs: number; content: string }> = {};
+  function walk(dir: string): void {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs);
+      } else if (entry.isFile()) {
+        const rel = abs.slice(root.length + 1);
+        out[rel] = {
+          mtimeMs: statSync(abs).mtimeMs,
+          content: readFileSync(abs, "utf-8"),
+        };
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("037-create-meets-dir migration", () => {
+  test("has correct id and description", () => {
+    expect(createMeetsDirMigration.id).toBe("037-create-meets-dir");
+    expect(createMeetsDirMigration.description).toContain("meets/");
+  });
+
+  test("creates meets/ with .keep sentinel file on a fresh workspace", () => {
+    createMeetsDirMigration.run(workspaceDir);
+
+    const meetsDir = join(workspaceDir, "meets");
+    expect(existsSync(meetsDir)).toBe(true);
+    expect(statSync(meetsDir).isDirectory()).toBe(true);
+
+    const keepPath = join(meetsDir, ".keep");
+    expect(existsSync(keepPath)).toBe(true);
+    expect(statSync(keepPath).isFile()).toBe(true);
+  });
+
+  test("is idempotent — running twice does not error and does not overwrite .keep", () => {
+    createMeetsDirMigration.run(workspaceDir);
+
+    const keepPath = join(workspaceDir, "meets", ".keep");
+    expect(existsSync(keepPath)).toBe(true);
+
+    const firstContent = readFileSync(keepPath, "utf-8");
+    const firstMtime = statSync(keepPath).mtimeMs;
+
+    // Second run — should not throw, should not rewrite the .keep file.
+    createMeetsDirMigration.run(workspaceDir);
+
+    expect(existsSync(keepPath)).toBe(true);
+    expect(readFileSync(keepPath, "utf-8")).toBe(firstContent);
+    expect(statSync(keepPath).mtimeMs).toBe(firstMtime);
+  });
+
+  test("does not error when meets/ already exists with user content", () => {
+    // Simulate a pre-existing meets/ directory with a user meeting inside.
+    const meetsDir = join(workspaceDir, "meets");
+    const meetingDir = join(meetsDir, "meeting-abc");
+    mkdirSync(meetingDir, { recursive: true });
+    writeFileSync(join(meetingDir, "meta.json"), "{}", "utf-8");
+
+    createMeetsDirMigration.run(workspaceDir);
+
+    // Pre-existing content is preserved.
+    expect(existsSync(join(meetingDir, "meta.json"))).toBe(true);
+    expect(readFileSync(join(meetingDir, "meta.json"), "utf-8")).toBe("{}");
+
+    // .keep sentinel was added at the meets/ root.
+    expect(existsSync(join(meetsDir, ".keep"))).toBe(true);
+  });
+
+  test("does not overwrite a user-customized .keep file", () => {
+    const meetsDir = join(workspaceDir, "meets");
+    mkdirSync(meetsDir, { recursive: true });
+    const keepPath = join(meetsDir, ".keep");
+    const customContent = "# my notes about meets/\n";
+    writeFileSync(keepPath, customContent, "utf-8");
+
+    createMeetsDirMigration.run(workspaceDir);
+
+    expect(readFileSync(keepPath, "utf-8")).toBe(customContent);
+  });
+
+  test("does not touch other workspace files", () => {
+    // Pre-populate unrelated workspace files.
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({ hello: "world" }, null, 2),
+      "utf-8",
+    );
+    mkdirSync(join(workspaceDir, "users"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "users", "guardian.md"),
+      "# Guardian\n",
+      "utf-8",
+    );
+    mkdirSync(join(workspaceDir, "pkb"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "pkb", "INDEX.md"),
+      "# Knowledge Base\n",
+      "utf-8",
+    );
+
+    const before = snapshotTree(workspaceDir);
+
+    createMeetsDirMigration.run(workspaceDir);
+
+    const after = snapshotTree(workspaceDir);
+
+    // Everything that existed before should still exist with identical
+    // content and mtime (nothing touched).
+    for (const [rel, prev] of Object.entries(before)) {
+      expect(after[rel]).toBeDefined();
+      expect(after[rel].content).toBe(prev.content);
+      expect(after[rel].mtimeMs).toBe(prev.mtimeMs);
+    }
+
+    // Only the .keep under meets/ should be new.
+    const added = Object.keys(after).filter((rel) => !(rel in before));
+    expect(added).toEqual([join("meets", ".keep")]);
+  });
+
+  test("second run on a populated meets/ leaves user content untouched", () => {
+    createMeetsDirMigration.run(workspaceDir);
+
+    const meetsDir = join(workspaceDir, "meets");
+    const meetingDir = join(meetsDir, "meeting-xyz");
+    mkdirSync(meetingDir, { recursive: true });
+    const transcriptPath = join(meetingDir, "transcript.jsonl");
+    writeFileSync(
+      transcriptPath,
+      '{"t":0,"text":"hello"}\n',
+      "utf-8",
+    );
+    const before = snapshotTree(workspaceDir);
+
+    createMeetsDirMigration.run(workspaceDir);
+
+    const after = snapshotTree(workspaceDir);
+    expect(Object.keys(after).sort()).toEqual(Object.keys(before).sort());
+    for (const [rel, prev] of Object.entries(before)) {
+      expect(after[rel].content).toBe(prev.content);
+      expect(after[rel].mtimeMs).toBe(prev.mtimeMs);
+    }
+  });
+
+  // ─── down() ─────────────────────────────────────────────────────────────
+
+  describe("down()", () => {
+    test("removes seeded .keep and empty meets/ directory after a forward run", () => {
+      createMeetsDirMigration.run(workspaceDir);
+      expect(existsSync(join(workspaceDir, "meets", ".keep"))).toBe(true);
+
+      createMeetsDirMigration.down(workspaceDir);
+
+      expect(existsSync(join(workspaceDir, "meets", ".keep"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "meets"))).toBe(false);
+    });
+
+    test("preserves user-created meeting content on down()", () => {
+      createMeetsDirMigration.run(workspaceDir);
+
+      const meetsDir = join(workspaceDir, "meets");
+      const meetingDir = join(meetsDir, "meeting-abc");
+      mkdirSync(meetingDir, { recursive: true });
+      writeFileSync(join(meetingDir, "meta.json"), "{}", "utf-8");
+
+      createMeetsDirMigration.down(workspaceDir);
+
+      // .keep is removed but user content and the meets/ dir itself remain
+      // since the directory is non-empty.
+      expect(existsSync(join(meetsDir, ".keep"))).toBe(false);
+      expect(existsSync(meetsDir)).toBe(true);
+      expect(existsSync(join(meetingDir, "meta.json"))).toBe(true);
+    });
+
+    test("idempotent — down() twice does not throw", () => {
+      createMeetsDirMigration.run(workspaceDir);
+      createMeetsDirMigration.down(workspaceDir);
+      // Second call — should not throw.
+      createMeetsDirMigration.down(workspaceDir);
+      expect(existsSync(join(workspaceDir, "meets"))).toBe(false);
+    });
+
+    test("no-op when meets/ does not exist", () => {
+      expect(existsSync(join(workspaceDir, "meets"))).toBe(false);
+      createMeetsDirMigration.down(workspaceDir);
+      // Should not throw and should not create anything.
+      expect(existsSync(join(workspaceDir, "meets"))).toBe(false);
+    });
+  });
+});

--- a/assistant/src/workspace/migrations/037-create-meets-dir.ts
+++ b/assistant/src/workspace/migrations/037-create-meets-dir.ts
@@ -1,0 +1,61 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * `.keep` sentinel content. Keeps the directory tracked/visible even when
+ * empty and documents the purpose for anyone inspecting the workspace.
+ */
+const KEEP_CONTENT =
+  "# Per-meeting artifacts live under <workspace>/meets/<meeting-id>/.\n";
+
+export const createMeetsDirMigration: WorkspaceMigration = {
+  id: "037-create-meets-dir",
+  description:
+    "Create meets/ storage directory with a .keep sentinel file for per-meeting artifacts",
+
+  down(workspaceDir: string): void {
+    // Best-effort: only remove the seeded .keep file and the meets/ directory
+    // itself if it is otherwise empty. Never delete user/meeting content.
+    const meetsDir = join(workspaceDir, "meets");
+    if (!existsSync(meetsDir)) return;
+
+    const keepPath = join(meetsDir, ".keep");
+    if (existsSync(keepPath)) {
+      try {
+        unlinkSync(keepPath);
+      } catch {
+        // Best-effort — leave the file alone if we can't remove it.
+      }
+    }
+
+    try {
+      const entries = readdirSync(meetsDir);
+      if (entries.length === 0) {
+        rmdirSync(meetsDir);
+      }
+    } catch {
+      // Best-effort — directory missing or unreadable; skip.
+    }
+  },
+
+  run(workspaceDir: string): void {
+    const meetsDir = join(workspaceDir, "meets");
+    mkdirSync(meetsDir, { recursive: true });
+
+    // Seed the .keep sentinel only if it doesn't already exist so re-runs
+    // don't clobber user edits (idempotent).
+    const keepPath = join(meetsDir, ".keep");
+    if (!existsSync(keepPath)) {
+      writeFileSync(keepPath, KEEP_CONTENT, "utf-8");
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -34,6 +34,7 @@ import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-co
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
+import { createMeetsDirMigration } from "./037-create-meets-dir.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -79,4 +80,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   removeCallsVoiceTranscriptionProviderMigration,
   seedSlackChannelPersonaMigration,
   updatePkbIndexBarMigration,
+  createMeetsDirMigration,
 ];


### PR DESCRIPTION
## Summary
- New workspace migration creates `<workspace>/meets/` with a `.keep` sentinel file.
- Idempotent — safe on re-run.
- Registered append-only in `WORKSPACE_MIGRATIONS`; tested for no-op on pre-existing dir.

Part of plan: meet-phase-1-listen.md (PR 4 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
