### PR TITLE
meet: shared wire-protocol types in packages/meet-contracts

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -15,6 +15,7 @@
         "@vellumai/ces-contracts": "file:../packages/ces-contracts",
         "@vellumai/credential-storage": "file:../packages/credential-storage",
         "@vellumai/egress-proxy": "file:../packages/egress-proxy",
+        "@vellumai/meet-contracts": "file:../packages/meet-contracts",
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "croner": "10.0.1",
@@ -362,6 +363,8 @@
 
     "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/type-utils": "8.57.0", "@typescript-eslint/utils": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g=="],
@@ -387,6 +390,8 @@
     "@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
 
     "@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
+
+    "@vellumai/meet-contracts": ["@vellumai/meet-contracts@file:../packages/meet-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -1094,6 +1099,10 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "@vellumai/meet-contracts/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "@vellumai/meet-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1177,6 +1186,8 @@
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
+
+    "@vellumai/meet-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -39,6 +39,7 @@
     "@vellumai/ces-contracts": "file:../packages/ces-contracts",
     "@vellumai/credential-storage": "file:../packages/credential-storage",
     "@vellumai/egress-proxy": "file:../packages/egress-proxy",
+    "@vellumai/meet-contracts": "file:../packages/meet-contracts",
     "archiver": "7.0.1",
     "commander": "13.1.0",
     "croner": "10.0.1",
@@ -67,7 +68,8 @@
   "bundledDependencies": [
     "@vellumai/ces-contracts",
     "@vellumai/credential-storage",
-    "@vellumai/egress-proxy"
+    "@vellumai/egress-proxy",
+    "@vellumai/meet-contracts"
   ],
   "overrides": {
     "lodash": "^4.18.0",

--- a/packages/meet-contracts/__tests__/events.test.ts
+++ b/packages/meet-contracts/__tests__/events.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Tests for @vellumai/meet-contracts
+ *
+ * These tests verify:
+ * 1. The package can be consumed independently (no assistant/ or meet-bot
+ *    imports).
+ * 2. Every event and command schema parses valid payloads and rejects
+ *    malformed ones.
+ * 3. The discriminated unions (MeetBotEvent, MeetBotCommand) correctly
+ *    narrow on `type`, including round-trip validation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  InboundChatEventSchema,
+  LeaveCommandSchema,
+  LifecycleEventSchema,
+  MEET_BOT_COMMAND_TYPES,
+  MEET_BOT_EVENT_TYPES,
+  MeetBotCommandSchema,
+  MeetBotEventSchema,
+  ParticipantChangeEventSchema,
+  ParticipantSchema,
+  PlayAudioCommandSchema,
+  SendChatCommandSchema,
+  SpeakerChangeEventSchema,
+  StatusCommandSchema,
+  TranscriptChunkEventSchema,
+  type MeetBotCommand,
+  type MeetBotEvent,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Independence guard — the package must not pull in assistant or meet-bot.
+// ---------------------------------------------------------------------------
+
+describe("package independence", () => {
+  const sourceFiles = ["../src/index.ts", "../src/events.ts", "../src/commands.ts"];
+
+  for (const file of sourceFiles) {
+    test(`${file} does not import from assistant/ or meet-bot/`, () => {
+      const src = require("node:fs").readFileSync(
+        require("node:path").resolve(__dirname, file),
+        "utf-8",
+      );
+      expect(src).not.toMatch(/from\s+['"].*assistant\//);
+      expect(src).not.toMatch(/from\s+['"].*meet-bot\//);
+      expect(src).not.toMatch(/require\(['"].*assistant\//);
+      expect(src).not.toMatch(/require\(['"].*meet-bot\//);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Event type const tuple
+// ---------------------------------------------------------------------------
+
+describe("MEET_BOT_EVENT_TYPES", () => {
+  test("includes every discriminator used by MeetBotEventSchema", () => {
+    expect(new Set(MEET_BOT_EVENT_TYPES)).toEqual(
+      new Set([
+        "transcript.chunk",
+        "speaker.change",
+        "participant.change",
+        "chat.inbound",
+        "lifecycle",
+      ]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TranscriptChunkEventSchema
+// ---------------------------------------------------------------------------
+
+describe("TranscriptChunkEventSchema", () => {
+  test("parses a minimal final chunk", () => {
+    const result = TranscriptChunkEventSchema.parse({
+      type: "transcript.chunk",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      isFinal: true,
+      text: "Hello world",
+    });
+    expect(result.isFinal).toBe(true);
+    expect(result.text).toBe("Hello world");
+    expect(result.speakerLabel).toBeUndefined();
+    expect(result.confidence).toBeUndefined();
+  });
+
+  test("parses a chunk with optional speaker + confidence fields", () => {
+    const result = TranscriptChunkEventSchema.parse({
+      type: "transcript.chunk",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      isFinal: false,
+      text: "partial...",
+      speakerLabel: "Alice",
+      speakerId: "spk-alice",
+      confidence: 0.87,
+    });
+    expect(result.speakerLabel).toBe("Alice");
+    expect(result.speakerId).toBe("spk-alice");
+    expect(result.confidence).toBe(0.87);
+  });
+
+  test("rejects missing isFinal", () => {
+    expect(() =>
+      TranscriptChunkEventSchema.parse({
+        type: "transcript.chunk",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        text: "oops",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects confidence out of [0, 1]", () => {
+    expect(() =>
+      TranscriptChunkEventSchema.parse({
+        type: "transcript.chunk",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        isFinal: true,
+        text: "hi",
+        confidence: 1.5,
+      }),
+    ).toThrow();
+    expect(() =>
+      TranscriptChunkEventSchema.parse({
+        type: "transcript.chunk",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        isFinal: true,
+        text: "hi",
+        confidence: -0.1,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects wrong type literal", () => {
+    expect(() =>
+      TranscriptChunkEventSchema.parse({
+        type: "transcript.final",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        isFinal: true,
+        text: "hi",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects empty meetingId", () => {
+    expect(() =>
+      TranscriptChunkEventSchema.parse({
+        type: "transcript.chunk",
+        meetingId: "",
+        timestamp: "2026-04-15T00:00:00Z",
+        isFinal: true,
+        text: "hi",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SpeakerChangeEventSchema
+// ---------------------------------------------------------------------------
+
+describe("SpeakerChangeEventSchema", () => {
+  test("parses a valid speaker change", () => {
+    const result = SpeakerChangeEventSchema.parse({
+      type: "speaker.change",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      speakerId: "spk-bob",
+      speakerName: "Bob",
+    });
+    expect(result.speakerId).toBe("spk-bob");
+    expect(result.speakerName).toBe("Bob");
+  });
+
+  test("rejects missing speakerName", () => {
+    expect(() =>
+      SpeakerChangeEventSchema.parse({
+        type: "speaker.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        speakerId: "spk-bob",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ParticipantSchema / ParticipantChangeEventSchema
+// ---------------------------------------------------------------------------
+
+describe("ParticipantSchema", () => {
+  test("parses a minimal participant", () => {
+    const result = ParticipantSchema.parse({ id: "p-1", name: "Alice" });
+    expect(result.id).toBe("p-1");
+    expect(result.isHost).toBeUndefined();
+    expect(result.isSelf).toBeUndefined();
+  });
+
+  test("parses participant with isHost/isSelf", () => {
+    const result = ParticipantSchema.parse({
+      id: "p-2",
+      name: "Bot",
+      isHost: false,
+      isSelf: true,
+    });
+    expect(result.isSelf).toBe(true);
+  });
+
+  test("rejects missing id", () => {
+    expect(() => ParticipantSchema.parse({ name: "Alice" })).toThrow();
+  });
+});
+
+describe("ParticipantChangeEventSchema", () => {
+  test("parses joined-only change", () => {
+    const result = ParticipantChangeEventSchema.parse({
+      type: "participant.change",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    });
+    expect(result.joined).toHaveLength(1);
+    expect(result.left).toHaveLength(0);
+  });
+
+  test("parses left-only change", () => {
+    const result = ParticipantChangeEventSchema.parse({
+      type: "participant.change",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      joined: [],
+      left: [{ id: "p-1", name: "Alice", isHost: true }],
+    });
+    expect(result.left[0]?.isHost).toBe(true);
+  });
+
+  test("rejects a malformed participant inside the arrays", () => {
+    expect(() =>
+      ParticipantChangeEventSchema.parse({
+        type: "participant.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        joined: [{ name: "Missing id" }],
+        left: [],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing joined/left arrays", () => {
+    expect(() =>
+      ParticipantChangeEventSchema.parse({
+        type: "participant.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InboundChatEventSchema
+// ---------------------------------------------------------------------------
+
+describe("InboundChatEventSchema", () => {
+  test("parses a valid inbound chat", () => {
+    const result = InboundChatEventSchema.parse({
+      type: "chat.inbound",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      fromId: "p-alice",
+      fromName: "Alice",
+      text: "hello bot",
+    });
+    expect(result.text).toBe("hello bot");
+  });
+
+  test("rejects missing fromId", () => {
+    expect(() =>
+      InboundChatEventSchema.parse({
+        type: "chat.inbound",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        fromName: "Alice",
+        text: "hello bot",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LifecycleEventSchema
+// ---------------------------------------------------------------------------
+
+describe("LifecycleEventSchema", () => {
+  test("parses every lifecycle state", () => {
+    for (const state of ["joining", "joined", "leaving", "left", "error"] as const) {
+      const result = LifecycleEventSchema.parse({
+        type: "lifecycle",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        state,
+      });
+      expect(result.state).toBe(state);
+    }
+  });
+
+  test("parses an error lifecycle with detail", () => {
+    const result = LifecycleEventSchema.parse({
+      type: "lifecycle",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      state: "error",
+      detail: "Bot failed to join: stream timeout",
+    });
+    expect(result.detail).toBe("Bot failed to join: stream timeout");
+  });
+
+  test("rejects unknown lifecycle state", () => {
+    expect(() =>
+      LifecycleEventSchema.parse({
+        type: "lifecycle",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        state: "dialing",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MeetBotEventSchema — discriminated union round-trip
+// ---------------------------------------------------------------------------
+
+describe("MeetBotEventSchema", () => {
+  test("round-trips a transcript chunk", () => {
+    const input: MeetBotEvent = {
+      type: "transcript.chunk",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      isFinal: true,
+      text: "hello",
+    };
+    const parsed = MeetBotEventSchema.parse(JSON.parse(JSON.stringify(input)));
+    expect(parsed).toEqual(input);
+    if (parsed.type === "transcript.chunk") {
+      // narrowing check
+      expect(parsed.text).toBe("hello");
+    } else {
+      throw new Error("expected transcript.chunk");
+    }
+  });
+
+  test("round-trips every event shape", () => {
+    const fixtures: MeetBotEvent[] = [
+      {
+        type: "transcript.chunk",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        isFinal: true,
+        text: "hi",
+      },
+      {
+        type: "speaker.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:01Z",
+        speakerId: "spk-1",
+        speakerName: "Alice",
+      },
+      {
+        type: "participant.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:02Z",
+        joined: [{ id: "p-1", name: "Alice" }],
+        left: [],
+      },
+      {
+        type: "chat.inbound",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:03Z",
+        fromId: "p-alice",
+        fromName: "Alice",
+        text: "hey bot",
+      },
+      {
+        type: "lifecycle",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:04Z",
+        state: "joined",
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      const parsed = MeetBotEventSchema.parse(
+        JSON.parse(JSON.stringify(fixture)),
+      );
+      expect(parsed).toEqual(fixture);
+    }
+  });
+
+  test("rejects an unknown event type", () => {
+    expect(() =>
+      MeetBotEventSchema.parse({
+        type: "transcript.preview",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        text: "hi",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an event missing the discriminator", () => {
+    expect(() =>
+      MeetBotEventSchema.parse({
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+        text: "hi",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Command type const tuple
+// ---------------------------------------------------------------------------
+
+describe("MEET_BOT_COMMAND_TYPES", () => {
+  test("includes every discriminator used by MeetBotCommandSchema", () => {
+    expect(new Set(MEET_BOT_COMMAND_TYPES)).toEqual(
+      new Set(["send_chat", "play_audio", "leave", "status"]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SendChatCommandSchema
+// ---------------------------------------------------------------------------
+
+describe("SendChatCommandSchema", () => {
+  test("parses a valid send_chat", () => {
+    const result = SendChatCommandSchema.parse({
+      type: "send_chat",
+      text: "thanks, team",
+    });
+    expect(result.text).toBe("thanks, team");
+  });
+
+  test("rejects an empty text", () => {
+    expect(() =>
+      SendChatCommandSchema.parse({ type: "send_chat", text: "" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlayAudioCommandSchema
+// ---------------------------------------------------------------------------
+
+describe("PlayAudioCommandSchema", () => {
+  test("parses metadata-only play_audio", () => {
+    const result = PlayAudioCommandSchema.parse({
+      type: "play_audio",
+      streamId: "stream-abc",
+    });
+    expect(result.streamId).toBe("stream-abc");
+  });
+
+  test("rejects missing streamId", () => {
+    expect(() => PlayAudioCommandSchema.parse({ type: "play_audio" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LeaveCommandSchema
+// ---------------------------------------------------------------------------
+
+describe("LeaveCommandSchema", () => {
+  test("parses a leave with no reason", () => {
+    const result = LeaveCommandSchema.parse({ type: "leave" });
+    expect(result.reason).toBeUndefined();
+  });
+
+  test("parses a leave with reason", () => {
+    const result = LeaveCommandSchema.parse({
+      type: "leave",
+      reason: "host ended meeting",
+    });
+    expect(result.reason).toBe("host ended meeting");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StatusCommandSchema
+// ---------------------------------------------------------------------------
+
+describe("StatusCommandSchema", () => {
+  test("parses a status command", () => {
+    const result = StatusCommandSchema.parse({ type: "status" });
+    expect(result.type).toBe("status");
+  });
+
+  test("rejects wrong type", () => {
+    expect(() => StatusCommandSchema.parse({ type: "ping" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MeetBotCommandSchema — discriminated union round-trip
+// ---------------------------------------------------------------------------
+
+describe("MeetBotCommandSchema", () => {
+  test("round-trips every command shape", () => {
+    const fixtures: MeetBotCommand[] = [
+      { type: "send_chat", text: "hi" },
+      { type: "play_audio", streamId: "s-1" },
+      { type: "leave" },
+      { type: "leave", reason: "done" },
+      { type: "status" },
+    ];
+
+    for (const fixture of fixtures) {
+      const parsed = MeetBotCommandSchema.parse(
+        JSON.parse(JSON.stringify(fixture)),
+      );
+      expect(parsed).toEqual(fixture);
+    }
+  });
+
+  test("rejects an unknown command type", () => {
+    expect(() =>
+      MeetBotCommandSchema.parse({ type: "mute", target: "self" }),
+    ).toThrow();
+  });
+
+  test("rejects a command missing the discriminator", () => {
+    expect(() => MeetBotCommandSchema.parse({ text: "oops" })).toThrow();
+  });
+});

--- a/packages/meet-contracts/bun.lock
+++ b/packages/meet-contracts/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/meet-contracts",
+      "dependencies": {
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "1.2.4",
+        "typescript": "5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+  }
+}

--- a/packages/meet-contracts/package.json
+++ b/packages/meet-contracts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vellumai/meet-contracts",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./events": "./src/events.ts",
+    "./commands": "./src/commands.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "1.2.4",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/meet-contracts/src/commands.ts
+++ b/packages/meet-contracts/src/commands.ts
@@ -1,0 +1,92 @@
+/**
+ * Commands sent from the assistant daemon to the meet-bot.
+ *
+ * All commands share a `type` discriminator. Consumers should parse
+ * incoming payloads with {@link MeetBotCommandSchema} before branching
+ * on `type`.
+ *
+ * Note on audio: `PlayAudioCommand` carries only metadata. The actual PCM
+ * stream is delivered out of band (see the Phase 3 audio channel), so
+ * large binary bodies never flow through this JSON schema.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// send_chat
+// ---------------------------------------------------------------------------
+
+/** Post a chat message from the bot into the meeting chat. */
+export const SendChatCommandSchema = z.object({
+  type: z.literal("send_chat"),
+  /** The chat message text to post. */
+  text: z.string().min(1),
+});
+export type SendChatCommand = z.infer<typeof SendChatCommandSchema>;
+
+// ---------------------------------------------------------------------------
+// play_audio
+// ---------------------------------------------------------------------------
+
+/**
+ * Instruct the bot to play an audio stream referenced by `streamId`.
+ *
+ * The PCM stream itself is delivered over a separate out-of-band channel
+ * (chunked transfer in Phase 3); this command only carries the metadata
+ * needed to correlate the stream with the bot's audio pipeline.
+ */
+export const PlayAudioCommandSchema = z.object({
+  type: z.literal("play_audio"),
+  /** Opaque identifier for the audio stream delivered out of band. */
+  streamId: z.string().min(1),
+});
+export type PlayAudioCommand = z.infer<typeof PlayAudioCommandSchema>;
+
+// ---------------------------------------------------------------------------
+// leave
+// ---------------------------------------------------------------------------
+
+/** Ask the bot to leave the meeting it is currently in. */
+export const LeaveCommandSchema = z.object({
+  type: z.literal("leave"),
+  /** Optional human-readable reason, surfaced in logs/telemetry. */
+  reason: z.string().optional(),
+});
+export type LeaveCommand = z.infer<typeof LeaveCommandSchema>;
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+/** Request a status snapshot from the bot (lifecycle + participants). */
+export const StatusCommandSchema = z.object({
+  type: z.literal("status"),
+});
+export type StatusCommand = z.infer<typeof StatusCommandSchema>;
+
+// ---------------------------------------------------------------------------
+// MeetBotCommand — discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * Every inbound command accepted by the meet-bot is one of these shapes.
+ * Consumers should parse incoming payloads with this schema to both
+ * validate and narrow on `type`.
+ */
+export const MeetBotCommandSchema = z.discriminatedUnion("type", [
+  SendChatCommandSchema,
+  PlayAudioCommandSchema,
+  LeaveCommandSchema,
+  StatusCommandSchema,
+]);
+export type MeetBotCommand = z.infer<typeof MeetBotCommandSchema>;
+
+/** All command `type` discriminator values as a const tuple. */
+export const MEET_BOT_COMMAND_TYPES = [
+  "send_chat",
+  "play_audio",
+  "leave",
+  "status",
+] as const;
+
+export type MeetBotCommandType = (typeof MEET_BOT_COMMAND_TYPES)[number];

--- a/packages/meet-contracts/src/events.ts
+++ b/packages/meet-contracts/src/events.ts
@@ -1,0 +1,177 @@
+/**
+ * Events emitted by the meet-bot and consumed by the assistant daemon.
+ *
+ * All events share a `type` discriminator, a `meetingId`, and a `timestamp`
+ * (ISO-8601 string). Consumers should parse incoming payloads with the
+ * {@link MeetBotEventSchema} discriminated union before branching on `type`.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/** Opaque identifier for the meeting the bot is participating in. */
+const MeetingIdSchema = z.string().min(1);
+
+/** ISO-8601 timestamp of when the event occurred on the bot side. */
+const TimestampSchema = z.string().min(1);
+
+// ---------------------------------------------------------------------------
+// transcript.chunk
+// ---------------------------------------------------------------------------
+
+/**
+ * A chunk of transcribed speech produced by the bot's ASR pipeline.
+ *
+ * `isFinal` indicates whether the ASR engine considers this chunk stable
+ * (i.e. will not be rewritten by later context). Interim chunks may be
+ * superseded by a later final chunk covering the same time range.
+ */
+export const TranscriptChunkEventSchema = z.object({
+  type: z.literal("transcript.chunk"),
+  meetingId: MeetingIdSchema,
+  timestamp: TimestampSchema,
+  /** Whether the ASR engine considers this chunk final (stable). */
+  isFinal: z.boolean(),
+  /** The transcribed text for this chunk. */
+  text: z.string(),
+  /** Human-readable label for the speaker, if the ASR provided one. */
+  speakerLabel: z.string().optional(),
+  /** Stable speaker identifier across the meeting, if available. */
+  speakerId: z.string().optional(),
+  /** ASR confidence in [0, 1], if available. */
+  confidence: z.number().min(0).max(1).optional(),
+});
+export type TranscriptChunkEvent = z.infer<typeof TranscriptChunkEventSchema>;
+
+// ---------------------------------------------------------------------------
+// speaker.change
+// ---------------------------------------------------------------------------
+
+/** Emitted when the active speaker changes in the meeting. */
+export const SpeakerChangeEventSchema = z.object({
+  type: z.literal("speaker.change"),
+  meetingId: MeetingIdSchema,
+  timestamp: TimestampSchema,
+  /** Stable speaker identifier for the new active speaker. */
+  speakerId: z.string(),
+  /** Display name of the new active speaker. */
+  speakerName: z.string(),
+});
+export type SpeakerChangeEvent = z.infer<typeof SpeakerChangeEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Participant + participant.change
+// ---------------------------------------------------------------------------
+
+/** A participant in the meeting. */
+export const ParticipantSchema = z.object({
+  /** Stable participant identifier (provider-specific). */
+  id: z.string(),
+  /** Display name of the participant. */
+  name: z.string(),
+  /** Whether the participant is the meeting host. */
+  isHost: z.boolean().optional(),
+  /** Whether the participant is the bot itself. */
+  isSelf: z.boolean().optional(),
+});
+export type Participant = z.infer<typeof ParticipantSchema>;
+
+/**
+ * Emitted when participants join or leave the meeting.
+ *
+ * `joined` and `left` are arrays so multiple simultaneous changes can be
+ * reported in a single event. Both arrays may be empty, but at least one
+ * should be non-empty when an event is emitted.
+ */
+export const ParticipantChangeEventSchema = z.object({
+  type: z.literal("participant.change"),
+  meetingId: MeetingIdSchema,
+  timestamp: TimestampSchema,
+  /** Participants who joined since the last snapshot. */
+  joined: z.array(ParticipantSchema),
+  /** Participants who left since the last snapshot. */
+  left: z.array(ParticipantSchema),
+});
+export type ParticipantChangeEvent = z.infer<
+  typeof ParticipantChangeEventSchema
+>;
+
+// ---------------------------------------------------------------------------
+// chat.inbound
+// ---------------------------------------------------------------------------
+
+/** Emitted when a chat message is received from another participant. */
+export const InboundChatEventSchema = z.object({
+  type: z.literal("chat.inbound"),
+  meetingId: MeetingIdSchema,
+  timestamp: TimestampSchema,
+  /** Stable identifier of the sender. */
+  fromId: z.string(),
+  /** Display name of the sender. */
+  fromName: z.string(),
+  /** The chat message text. */
+  text: z.string(),
+});
+export type InboundChatEvent = z.infer<typeof InboundChatEventSchema>;
+
+// ---------------------------------------------------------------------------
+// lifecycle
+// ---------------------------------------------------------------------------
+
+/** Lifecycle state values for the bot's connection to a meeting. */
+export const LifecycleStateSchema = z.enum([
+  "joining",
+  "joined",
+  "leaving",
+  "left",
+  "error",
+]);
+export type LifecycleState = z.infer<typeof LifecycleStateSchema>;
+
+/**
+ * Emitted on every bot lifecycle transition.
+ *
+ * `detail` is an optional free-form string (e.g. an error message when
+ * `state === "error"`).
+ */
+export const LifecycleEventSchema = z.object({
+  type: z.literal("lifecycle"),
+  meetingId: MeetingIdSchema,
+  timestamp: TimestampSchema,
+  state: LifecycleStateSchema,
+  /** Optional human-readable detail (required-ish for `error`). */
+  detail: z.string().optional(),
+});
+export type LifecycleEvent = z.infer<typeof LifecycleEventSchema>;
+
+// ---------------------------------------------------------------------------
+// MeetBotEvent — discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * Every event published by the meet-bot to the daemon is one of these
+ * shapes. Consumers should parse incoming payloads with this schema to
+ * both validate and narrow on `type`.
+ */
+export const MeetBotEventSchema = z.discriminatedUnion("type", [
+  TranscriptChunkEventSchema,
+  SpeakerChangeEventSchema,
+  ParticipantChangeEventSchema,
+  InboundChatEventSchema,
+  LifecycleEventSchema,
+]);
+export type MeetBotEvent = z.infer<typeof MeetBotEventSchema>;
+
+/** All event `type` discriminator values as a const tuple. */
+export const MEET_BOT_EVENT_TYPES = [
+  "transcript.chunk",
+  "speaker.change",
+  "participant.change",
+  "chat.inbound",
+  "lifecycle",
+] as const;
+
+export type MeetBotEventType = (typeof MEET_BOT_EVENT_TYPES)[number];

--- a/packages/meet-contracts/src/index.ts
+++ b/packages/meet-contracts/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @vellumai/meet-contracts
+ *
+ * Neutral wire-protocol contracts between the meet-bot (out-of-process
+ * container that joins a meeting) and the assistant daemon.
+ *
+ * This package is intentionally free of imports from `assistant/`,
+ * `meet-bot/`, or any implementation module so that both sides can
+ * depend on it without circular references.
+ *
+ * Two directions:
+ *
+ * - **Events** — bot → daemon. Transcript chunks, speaker changes,
+ *   participant join/leave, inbound chat, lifecycle transitions. See
+ *   {@link MeetBotEvent} and {@link MeetBotEventSchema}.
+ * - **Commands** — daemon → bot. Send chat, play audio (metadata only —
+ *   PCM is delivered out of band), leave, status request. See
+ *   {@link MeetBotCommand} and {@link MeetBotCommandSchema}.
+ */
+
+export * from "./events.js";
+export * from "./commands.js";

--- a/packages/meet-contracts/tsconfig.json
+++ b/packages/meet-contracts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- New `packages/meet-contracts` package with Zod schemas for bot ↔ daemon events + commands.
- Discriminated-union `MeetBotEvent` covers transcript, speaker, participant, chat, lifecycle.
- Consumed by later PRs (bot HTTP server, daemon ingress routes, conversation bridge).

Part of plan: meet-phase-1-listen.md (PR 2 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
