### PR TITLE
meet: feature flag registration + config schema

### DIFF
--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -6,7 +6,10 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../../config/loader.js";
-import type { Services } from "../../../config/schemas/services.js";
+import {
+  getServiceMode,
+  type Services,
+} from "../../../config/schemas/services.js";
 import {
   getProvider,
   listActiveConnectionsByProvider,
@@ -120,7 +123,10 @@ Examples:
 
           // Provider supports managed mode — read current config value
           const services: Services = getConfig().services;
-          const currentMode = services[managedKey as keyof Services].mode;
+          const currentMode = getServiceMode(
+            services,
+            managedKey as keyof Services,
+          );
 
           if (shouldOutputJson(cmd)) {
             writeOutput(cmd, {
@@ -189,7 +195,10 @@ Examples:
 
         // Read current mode
         const services: Services = getConfig().services;
-        const currentMode = services[managedKey as keyof Services].mode;
+        const currentMode = getServiceMode(
+          services,
+          managedKey as keyof Services,
+        );
 
         // Same mode — no-op
         if (currentMode === newMode) {

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 import { getConfig } from "../../../config/loader.js";
 import {
+  getServiceMode,
   type Services,
   ServicesSchema,
 } from "../../../config/schemas/services.js";
@@ -46,7 +47,7 @@ export function isManagedMode(provider: string): boolean {
   if (!managedKey) return false;
   try {
     const services: Services = getConfig().services;
-    return services[managedKey as keyof Services].mode === "managed";
+    return getServiceMode(services, managedKey as keyof Services) === "managed";
   } catch {
     return false;
   }

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -138,6 +138,11 @@ export {
   MemorySegmentationConfigSchema,
   QdrantConfigSchema,
 } from "./schemas/memory-storage.js";
+export type { MeetService } from "./schemas/meet.js";
+export {
+  DEFAULT_MEET_OBJECTION_KEYWORDS,
+  MeetServiceSchema,
+} from "./schemas/meet.js";
 export type { NotificationsConfig } from "./schemas/notifications.js";
 export { NotificationsConfigSchema } from "./schemas/notifications.js";
 export type {
@@ -166,6 +171,8 @@ export type {
   Services,
   WebSearchService,
 } from "./schemas/services.js";
+// Re-exported under services.* to document that `services.meet` is the
+// canonical config path even though the schema itself lives in `meet.ts`.
 export {
   ImageGenerationServiceSchema,
   InferenceServiceSchema,

--- a/assistant/src/config/schemas/__tests__/meet.test.ts
+++ b/assistant/src/config/schemas/__tests__/meet.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_MEET_OBJECTION_KEYWORDS,
+  MeetServiceSchema,
+} from "../meet.js";
+
+describe("MeetServiceSchema", () => {
+  test("empty object parses to the documented defaults (feature off by default)", () => {
+    const parsed = MeetServiceSchema.parse({});
+    expect(parsed).toEqual({
+      enabled: false,
+      containerImage: "vellum-meet-bot:dev",
+      joinName: null,
+      consentMessage:
+        "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.",
+      autoLeaveOnObjection: true,
+      objectionKeywords: [...DEFAULT_MEET_OBJECTION_KEYWORDS],
+      dockerNetwork: "bridge",
+      maxMeetingMinutes: 240,
+    });
+  });
+
+  test("default objection keyword list matches the exported constant", () => {
+    // Guards against accidental divergence between the schema default and the
+    // constant that downstream runtime code imports directly.
+    const parsed = MeetServiceSchema.parse({});
+    expect(parsed.objectionKeywords).toEqual([
+      ...DEFAULT_MEET_OBJECTION_KEYWORDS,
+    ]);
+    // The default must be a fresh array so a consumer mutating the parsed
+    // value can't poison the module-level constant.
+    expect(parsed.objectionKeywords).not.toBe(DEFAULT_MEET_OBJECTION_KEYWORDS);
+  });
+
+  test("valid custom values round-trip", () => {
+    const input = {
+      enabled: true,
+      containerImage: "registry.example.com/meet-bot:1.0.0",
+      joinName: "Notes Bot",
+      consentMessage: "Hi — I'll be taking notes. Say the word and I'll step out.",
+      autoLeaveOnObjection: false,
+      objectionKeywords: ["leave please", "go away bot"],
+      dockerNetwork: "vellum-meet",
+      maxMeetingMinutes: 60,
+    };
+    const parsed = MeetServiceSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects negative maxMeetingMinutes", () => {
+    const result = MeetServiceSchema.safeParse({ maxMeetingMinutes: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects zero maxMeetingMinutes (must be strictly positive)", () => {
+    const result = MeetServiceSchema.safeParse({ maxMeetingMinutes: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer maxMeetingMinutes", () => {
+    const result = MeetServiceSchema.safeParse({ maxMeetingMinutes: 12.5 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string joinName that isn't null (e.g. number, boolean)", () => {
+    const numberResult = MeetServiceSchema.safeParse({ joinName: 42 });
+    expect(numberResult.success).toBe(false);
+
+    const boolResult = MeetServiceSchema.safeParse({ joinName: true });
+    expect(boolResult.success).toBe(false);
+
+    const arrayResult = MeetServiceSchema.safeParse({ joinName: ["Bot"] });
+    expect(arrayResult.success).toBe(false);
+  });
+
+  test("joinName: null is accepted and stays null", () => {
+    const parsed = MeetServiceSchema.parse({ joinName: null });
+    expect(parsed.joinName).toBe(null);
+  });
+
+  test("joinName: '' is normalized to null (empty string = 'use assistant display name')", () => {
+    // Documented decision: empty/whitespace-only joinName values are treated
+    // identically to null — they both mean "fall back to the assistant's
+    // display name at runtime". This keeps downstream callers honest: they
+    // only have to check for null, never for empty strings.
+    const parsed = MeetServiceSchema.parse({ joinName: "" });
+    expect(parsed.joinName).toBe(null);
+
+    const whitespaceParsed = MeetServiceSchema.parse({ joinName: "   " });
+    expect(whitespaceParsed.joinName).toBe(null);
+  });
+
+  test("joinName with surrounding whitespace is trimmed", () => {
+    const parsed = MeetServiceSchema.parse({ joinName: "  Notes Bot  " });
+    expect(parsed.joinName).toBe("Notes Bot");
+  });
+
+  test("rejects empty containerImage", () => {
+    const result = MeetServiceSchema.safeParse({ containerImage: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty dockerNetwork", () => {
+    const result = MeetServiceSchema.safeParse({ dockerNetwork: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string entries in objectionKeywords", () => {
+    const result = MeetServiceSchema.safeParse({
+      objectionKeywords: ["please leave", 42],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("objectionKeywords: [] parses as an explicit empty array (opts out of keyword matching)", () => {
+    const parsed = MeetServiceSchema.parse({ objectionKeywords: [] });
+    expect(parsed.objectionKeywords).toEqual([]);
+  });
+
+  test("partial config with only enabled: true fills in remaining defaults", () => {
+    const parsed = MeetServiceSchema.parse({ enabled: true });
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.containerImage).toBe("vellum-meet-bot:dev");
+    expect(parsed.joinName).toBe(null);
+    expect(parsed.autoLeaveOnObjection).toBe(true);
+    expect(parsed.maxMeetingMinutes).toBe(240);
+  });
+});

--- a/assistant/src/config/schemas/meet.ts
+++ b/assistant/src/config/schemas/meet.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+/**
+ * Default keywords that signal an objection to the assistant's presence in a
+ * meeting. When any of these (case-insensitive substring match) appear in
+ * captured transcript text, the bot should auto-leave if
+ * `autoLeaveOnObjection` is enabled.
+ */
+export const DEFAULT_MEET_OBJECTION_KEYWORDS: readonly string[] = [
+  "please leave",
+  "stop recording",
+  "no bots",
+  "no recording",
+  "I don't consent",
+  "can the bot leave",
+];
+
+/**
+ * Normalize `joinName` — coerce empty or whitespace-only strings to `null` so
+ * downstream code only has to check for `null` when deciding whether to fall
+ * back to the assistant's display name. This keeps the semantic invariant
+ * that `joinName === null` means "use the assistant display name at runtime".
+ */
+function normalizeJoinName(value: string | null): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+export const MeetServiceSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "services.meet.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the Google Meet joining bot is enabled. Even when true, the top-level `meet` feature flag must also be on for the feature to surface.",
+      ),
+    containerImage: z
+      .string({ error: "services.meet.containerImage must be a string" })
+      .min(1, "services.meet.containerImage must not be empty")
+      .default("vellum-meet-bot:dev")
+      .describe(
+        "Docker image tag used to spawn the Meet bot container for each joined meeting",
+      ),
+    joinName: z
+      .string({ error: "services.meet.joinName must be a string" })
+      .nullable()
+      .default(null)
+      .transform(normalizeJoinName)
+      .describe(
+        'Display name the bot uses when joining a meeting. When null (the default) the assistant\'s display name is used at runtime. Empty or whitespace-only strings are normalized to null.',
+      ),
+    consentMessage: z
+      .string({ error: "services.meet.consentMessage must be a string" })
+      .default(
+        "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.",
+      )
+      .describe(
+        "Message the bot posts in meeting chat on join. `{assistantName}` is substituted at runtime.",
+      ),
+    autoLeaveOnObjection: z
+      .boolean({
+        error: "services.meet.autoLeaveOnObjection must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether the bot automatically leaves the meeting when a participant voices one of the objection keywords",
+      ),
+    objectionKeywords: z
+      .array(
+        z.string({
+          error: "services.meet.objectionKeywords values must be strings",
+        }),
+      )
+      .default([...DEFAULT_MEET_OBJECTION_KEYWORDS])
+      .describe(
+        "Case-insensitive substrings that trigger auto-leave when detected in live transcript text",
+      ),
+    dockerNetwork: z
+      .string({ error: "services.meet.dockerNetwork must be a string" })
+      .min(1, "services.meet.dockerNetwork must not be empty")
+      .default("bridge")
+      .describe("Docker network the Meet bot container attaches to"),
+    maxMeetingMinutes: z
+      .number({ error: "services.meet.maxMeetingMinutes must be a number" })
+      .int("services.meet.maxMeetingMinutes must be an integer")
+      .positive("services.meet.maxMeetingMinutes must be a positive integer")
+      .default(240)
+      .describe(
+        "Hard ceiling in minutes — the bot container is killed once this elapses, regardless of meeting state",
+      ),
+  })
+  .describe(
+    "Google Meet bot configuration — controls the containerized Meet joining bot, consent messaging, and objection handling",
+  );
+
+export type MeetService = z.infer<typeof MeetServiceSchema>;

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { MeetServiceSchema } from "./meet.js";
 import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
 
@@ -111,5 +112,26 @@ export const ServicesSchema = z.object({
   "twitter-oauth": TwitterOAuthServiceSchema.default(
     TwitterOAuthServiceSchema.parse({}),
   ),
+  meet: MeetServiceSchema.default(MeetServiceSchema.parse({})),
 });
 export type Services = z.infer<typeof ServicesSchema>;
+
+/**
+ * Safely read the `mode` of a `services.*` entry.
+ *
+ * Most service entries (OAuth providers, inference, etc.) extend
+ * `BaseServiceSchema` and therefore carry a `mode: "managed" | "your-own"`
+ * field. A few entries (currently `services.meet`) do not — they are
+ * feature-specific configs that don't model a managed-vs-BYO toggle.
+ *
+ * Returns `undefined` when the requested service entry has no `mode` field,
+ * so callers can treat those entries as implicitly "your-own" without the
+ * compiler tripping on a union widened by non-BaseService members.
+ */
+export function getServiceMode(
+  services: Services,
+  key: keyof Services,
+): ServiceMode | undefined {
+  const entry = services[key] as { mode?: ServiceMode };
+  return entry.mode;
+}

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,5 +1,9 @@
 import { getConfig } from "../config/loader.js";
-import { type Services, ServicesSchema } from "../config/schemas/services.js";
+import {
+  getServiceMode,
+  type Services,
+  ServicesSchema,
+} from "../config/schemas/services.js";
 import { VellumPlatformClient } from "../platform/client.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
@@ -47,7 +51,7 @@ export async function resolveOAuthConnection(
 
   if (managedKey && managedKey in ServicesSchema.shape) {
     const services: Services = getConfig().services;
-    if (services[managedKey as keyof Services].mode === "managed") {
+    if (getServiceMode(services, managedKey as keyof Services) === "managed") {
       const client = await VellumPlatformClient.create();
       if (!client || !client.platformAssistantId) {
         const detail = !client

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -352,6 +352,14 @@
       "label": "Channel Avatar Sync",
       "description": "Automatically sync the assistant's avatar to connected channels (Slack) when the avatar changes or a new channel is connected",
       "defaultEnabled": true
+    },
+    {
+      "id": "meet",
+      "scope": "assistant",
+      "key": "meet",
+      "label": "Google Meet",
+      "description": "Enables the Google Meet joining bot and the meet-join skill.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `meet` feature flag (scope: assistant, default: false) to registry.
- Adds `services.meet` config schema (container image, join name, consent message, objection keywords, max minutes).
- Defaults keep the feature off until end-to-end verification.

**Cross-repo follow-up**: a companion PR in vellum-assistant-platform is needed to provision the `meet` flag in LaunchDarkly Terraform.

Part of plan: meet-phase-1-listen.md (PR 3 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
