### PR TITLE
meet-bot: PulseAudio null-sink + virtual-source setup

### DIFF
--- a/meet-bot/Dockerfile
+++ b/meet-bot/Dockerfile
@@ -46,6 +46,12 @@ RUN bunx playwright install chromium
 
 COPY src ./src
 
+# The PulseAudio bootstrap script is shelled out to at container start by
+# `src/media/pulse.ts`; ensure the executable bit is set in the image so the
+# runtime `bash` invocation succeeds. The script is NOT run at build time —
+# PulseAudio needs a live container environment (runtime, not image layer).
+RUN chmod +x /app/src/media/pulse-setup.sh
+
 # The placeholder probe lives at src/health.ts and exits 0; real health
 # logic lands in a later PR (see meet-phase-1 plan PR 8).
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/meet-bot/__tests__/boot.test.ts
+++ b/meet-bot/__tests__/boot.test.ts
@@ -15,6 +15,10 @@ describe("meet-bot boot", () => {
     const result = spawnSync("bun", ["run", "src/main.ts"], {
       cwd: pkgRoot,
       encoding: "utf8",
+      // PulseAudio is not available on macOS dev machines / typical CI
+      // runners; SKIP_PULSE=1 short-circuits the setup call in main.ts so the
+      // smoke test can still verify the boot path.
+      env: { ...process.env, SKIP_PULSE: "1" },
     });
 
     expect(result.status).toBe(0);

--- a/meet-bot/__tests__/pulse.test.ts
+++ b/meet-bot/__tests__/pulse.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import {
+  PULSE_SETUP_SCRIPT_PATH,
+  setupPulseAudio,
+  teardownPulseAudio,
+} from "../src/media/pulse.js";
+
+/**
+ * Unit tests for the PulseAudio wrapper.
+ *
+ * PulseAudio itself is unavailable on macOS developer machines and typical
+ * CI runners, so these tests never invoke the real script. Instead they
+ * inject a narrow shim mirroring the slice of `Bun.spawn` that `pulse.ts`
+ * depends on, and verify the wrapper invokes bash with the right script
+ * path and propagates exit codes / stderr correctly.
+ */
+
+type SpawnArgs = Parameters<typeof Bun.spawn>;
+type SpawnReturn = ReturnType<typeof Bun.spawn>;
+
+interface FakeProcess {
+  cmd: string[];
+  stderrText: string;
+  exitCode: number;
+}
+
+function makeFakeSpawn(
+  processes: FakeProcess[],
+): { spawn: typeof Bun.spawn; calls: SpawnArgs[] } {
+  const calls: SpawnArgs[] = [];
+  let index = 0;
+
+  const spawn = ((...args: SpawnArgs): SpawnReturn => {
+    calls.push(args);
+    const fake = processes[index++];
+    if (!fake) {
+      throw new Error(`fake spawn invoked more times than expected`);
+    }
+    // Record the argv we were called with so callers can assert on it.
+    fake.cmd = args[0] as string[];
+
+    const stderrStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (fake.stderrText.length > 0) {
+          controller.enqueue(new TextEncoder().encode(fake.stderrText));
+        }
+        controller.close();
+      },
+    });
+
+    return {
+      stderr: stderrStream,
+      exited: Promise.resolve(fake.exitCode),
+    } as unknown as SpawnReturn;
+  }) as typeof Bun.spawn;
+
+  return { spawn, calls };
+}
+
+describe("setupPulseAudio", () => {
+  test("resolves the script path relative to the module file", () => {
+    // The script must live next to pulse.ts so the Dockerfile COPY and the
+    // runtime resolution agree. If this ever breaks, pulse.ts needs to be
+    // updated in lock-step with the Dockerfile.
+    expect(PULSE_SETUP_SCRIPT_PATH.endsWith("/media/pulse-setup.sh")).toBe(
+      true,
+    );
+    expect(existsSync(PULSE_SETUP_SCRIPT_PATH)).toBe(true);
+    // Sanity: the script must be executable in the repo as well, since the
+    // Dockerfile relies on preserving the executable bit from COPY.
+    const mode = statSync(PULSE_SETUP_SCRIPT_PATH).mode;
+    expect((mode & 0o111) !== 0).toBe(true);
+  });
+
+  test("invokes bash with the setup script and resolves on exit 0", async () => {
+    const fake: FakeProcess = {
+      cmd: [],
+      stderrText: "",
+      exitCode: 0,
+    };
+    const { spawn, calls } = makeFakeSpawn([fake]);
+
+    await setupPulseAudio(spawn);
+
+    expect(calls.length).toBe(1);
+    const [argv] = calls[0]!;
+    expect(argv).toEqual(["bash", PULSE_SETUP_SCRIPT_PATH]);
+  });
+
+  test("rejects with exit code + stderr when the script fails", async () => {
+    const fake: FakeProcess = {
+      cmd: [],
+      stderrText: "pulse-setup: PulseAudio daemon did not come up\n",
+      exitCode: 1,
+    };
+    const { spawn } = makeFakeSpawn([fake]);
+
+    let thrown: unknown;
+    try {
+      await setupPulseAudio(spawn);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const msg = (thrown as Error).message;
+    expect(msg).toContain("exit code 1");
+    expect(msg).toContain("PulseAudio daemon did not come up");
+  });
+
+  test("error message omits the colon when stderr is empty", async () => {
+    const fake: FakeProcess = {
+      cmd: [],
+      stderrText: "",
+      exitCode: 42,
+    };
+    const { spawn } = makeFakeSpawn([fake]);
+
+    let thrown: unknown;
+    try {
+      await setupPulseAudio(spawn);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(
+      "pulse-setup.sh failed with exit code 42",
+    );
+  });
+});
+
+describe("teardownPulseAudio", () => {
+  test("invokes `pulseaudio --kill`", async () => {
+    const fake: FakeProcess = {
+      cmd: [],
+      stderrText: "",
+      exitCode: 0,
+    };
+    const { spawn, calls } = makeFakeSpawn([fake]);
+
+    await teardownPulseAudio(spawn);
+
+    expect(calls.length).toBe(1);
+    const [argv] = calls[0]!;
+    expect(argv).toEqual(["pulseaudio", "--kill"]);
+  });
+
+  test("swallows spawn errors (best-effort)", async () => {
+    const spawn = (() => {
+      throw new Error("spawn failed");
+    }) as unknown as typeof Bun.spawn;
+
+    // Must not throw.
+    await teardownPulseAudio(spawn);
+  });
+
+  test("tolerates a non-zero exit from pulseaudio --kill", async () => {
+    const fake: FakeProcess = {
+      cmd: [],
+      stderrText: "no daemon running",
+      exitCode: 1,
+    };
+    const { spawn } = makeFakeSpawn([fake]);
+
+    // Must not throw even if the daemon was already gone.
+    await teardownPulseAudio(spawn);
+  });
+});

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -1,21 +1,35 @@
 /**
  * meet-bot entry point.
  *
- * This is the bootstrap skeleton for the Meet bot — the container-side process
- * that will join a Google Meet session on behalf of an AI assistant so the
+ * This is the bootstrap for the Meet bot — the container-side process that
+ * will join a Google Meet session on behalf of an AI assistant so the
  * assistant can listen in (and eventually participate).
  *
  * The real implementation (Playwright-driven Meet join flow, audio capture
  * via PulseAudio, Hono HTTP control surface, etc.) lands in later PRs of the
  * meet-phase-1 plan. See `meet-bot/README.md` for links.
  *
- * For now this just logs a boot marker and exits cleanly so the Docker image
- * build, the package scripts, and the boot test can all verify the package
- * structure is valid end-to-end.
+ * At boot we bring up the PulseAudio virtual devices (null-sinks + a
+ * virtual-source) so TTS can be routed into Chrome as a microphone and
+ * Chrome's output can be captured for STT. Pulse setup is skipped when
+ * `SKIP_PULSE=1` — the CI/local boot smoke test sets this so it can run on
+ * macOS developer machines where PulseAudio is unavailable.
  */
 
-function main(): void {
+import { setupPulseAudio } from "./media/pulse.js";
+
+async function main(): Promise<void> {
+  if (process.env.SKIP_PULSE !== "1") {
+    try {
+      await setupPulseAudio();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`meet-bot: PulseAudio setup failed: ${msg}`);
+      process.exit(1);
+    }
+  }
+
   console.log("meet-bot booted");
 }
 
-main();
+void main();

--- a/meet-bot/src/media/pulse-setup.sh
+++ b/meet-bot/src/media/pulse-setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# PulseAudio setup for the meet-bot container.
+#
+# Creates the virtual audio topology the bot needs to participate in a Google
+# Meet call:
+#
+#   TTS output  ->  bot_out (null-sink)
+#                    \_ bot_out.monitor
+#                         \_ bot_mic (virtual-source, fed into Chrome as mic)
+#
+#   Meet audio  ->  meet_capture (null-sink; its .monitor is captured for STT)
+#
+# The script is idempotent — each `pactl load-module` is guarded by a check
+# against the existing sink/source list so repeated invocations are no-ops.
+#
+# Intended to be invoked once at container start. See `pulse.ts` for the
+# TypeScript wrapper that shells out to this script.
+
+set -euo pipefail
+
+# Start the PulseAudio daemon in the background if it is not already running.
+# `--exit-idle-time=-1` prevents it from exiting when no clients are connected,
+# which happens briefly between the daemon launching and Chrome attaching.
+if ! pactl info >/dev/null 2>&1; then
+  pulseaudio --start --exit-idle-time=-1
+fi
+
+# Wait for the daemon to become reachable. `pulseaudio --start` returns before
+# the socket is necessarily accepting connections, so poll pactl briefly.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if pactl info >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+
+if ! pactl info >/dev/null 2>&1; then
+  echo "pulse-setup: PulseAudio daemon did not come up" >&2
+  exit 1
+fi
+
+# ---- Helpers --------------------------------------------------------------
+
+sink_exists() {
+  pactl list short sinks | awk '{print $2}' | grep -Fxq "$1"
+}
+
+source_exists() {
+  pactl list short sources | awk '{print $2}' | grep -Fxq "$1"
+}
+
+# ---- bot_out: null-sink the bot's TTS output is written into --------------
+if ! sink_exists bot_out; then
+  pactl load-module module-null-sink \
+    sink_name=bot_out \
+    sink_properties=device.description=BotOutput >/dev/null
+fi
+
+# ---- bot_mic: virtual-source Chrome uses as its microphone ----------------
+# Master is bot_out.monitor so whatever is played to bot_out shows up on
+# bot_mic as captured audio.
+if ! source_exists bot_mic; then
+  pactl load-module module-virtual-source \
+    source_name=bot_mic \
+    master=bot_out.monitor \
+    source_properties=device.description=BotMic >/dev/null
+fi
+
+# ---- meet_capture: null-sink Chrome's output is routed into ---------------
+# The monitor of this sink is what Phase 3 / PR 15 taps for STT.
+if ! sink_exists meet_capture; then
+  pactl load-module module-null-sink \
+    sink_name=meet_capture \
+    sink_properties=device.description=MeetCapture >/dev/null
+fi
+
+# ---- Defaults -------------------------------------------------------------
+# Chrome picks up the default source as its microphone and the default sink
+# as its playback target. Setting them here means we don't have to configure
+# the browser separately.
+pactl set-default-source bot_mic
+pactl set-default-sink meet_capture
+
+exit 0

--- a/meet-bot/src/media/pulse.ts
+++ b/meet-bot/src/media/pulse.ts
@@ -1,0 +1,69 @@
+/**
+ * PulseAudio setup/teardown helpers for the meet-bot container.
+ *
+ * The audio plumbing (null-sinks and a virtual-source) is created by
+ * `pulse-setup.sh`; this module just shells out to the script at container
+ * boot so the TypeScript side has a single `await setupPulseAudio()` entry
+ * point to call from `main.ts`.
+ *
+ * The script is idempotent — calling `setupPulseAudio` multiple times in the
+ * same container is a no-op after the first invocation.
+ */
+
+import { join } from "node:path";
+
+const SCRIPT_PATH = join(import.meta.dir, "pulse-setup.sh");
+
+/**
+ * Run `pulse-setup.sh` to bring up PulseAudio and the virtual devices the
+ * bot needs. Resolves on exit code 0, rejects with a descriptive error on
+ * any non-zero exit.
+ *
+ * The test suite injects a spawn shim via the optional argument so it can
+ * verify invocation without actually running PulseAudio.
+ */
+export async function setupPulseAudio(
+  spawn: typeof Bun.spawn = Bun.spawn,
+): Promise<void> {
+  const proc = spawn(["bash", SCRIPT_PATH], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderrText, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const trimmed = stderrText.trim();
+    const detail = trimmed.length > 0 ? `: ${trimmed}` : "";
+    throw new Error(
+      `pulse-setup.sh failed with exit code ${exitCode}${detail}`,
+    );
+  }
+}
+
+/**
+ * Best-effort teardown. Called on container shutdown paths; we don't want a
+ * failure here (e.g. the daemon already gone) to mask the real exit cause.
+ */
+export async function teardownPulseAudio(
+  spawn: typeof Bun.spawn = Bun.spawn,
+): Promise<void> {
+  try {
+    const proc = spawn(["pulseaudio", "--kill"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+  } catch {
+    // Intentional: teardown is best-effort.
+  }
+}
+
+/**
+ * Exported for tests — the absolute path of the shell script this module
+ * invokes. Not part of the public runtime surface.
+ */
+export const PULSE_SETUP_SCRIPT_PATH = SCRIPT_PATH;


### PR DESCRIPTION
## Summary
- Adds `pulse-setup.sh` idempotently creating `bot_out` null-sink, `bot_mic` virtual-source, and `meet_capture` null-sink inside the container.
- `setupPulseAudio` wrapper spawns the script; invoked at bot boot unless `SKIP_PULSE=1`.
- Unit test mocks the spawn; boot test sets `SKIP_PULSE=1` to remain portable.

Part of plan: meet-phase-1-listen.md (PR 5 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
