### PR TITLE
fix(lint): sort meet schema exports in config/schema.ts

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -102,6 +102,11 @@ export {
   McpServerConfigSchema,
   McpTransportSchema,
 } from "./schemas/mcp.js";
+export type { MeetService } from "./schemas/meet.js";
+export {
+  DEFAULT_MEET_OBJECTION_KEYWORDS,
+  MeetServiceSchema,
+} from "./schemas/meet.js";
 export type { MemoryConfig } from "./schemas/memory.js";
 export { MemoryConfigSchema } from "./schemas/memory.js";
 export type {
@@ -138,11 +143,6 @@ export {
   MemorySegmentationConfigSchema,
   QdrantConfigSchema,
 } from "./schemas/memory-storage.js";
-export type { MeetService } from "./schemas/meet.js";
-export {
-  DEFAULT_MEET_OBJECTION_KEYWORDS,
-  MeetServiceSchema,
-} from "./schemas/meet.js";
 export type { NotificationsConfig } from "./schemas/notifications.js";
 export { NotificationsConfigSchema } from "./schemas/notifications.js";
 export type {


### PR DESCRIPTION
## Summary
- Move `./schemas/meet.js` exports above `./schemas/memory.js` to satisfy `simple-import-sort/exports`. The meet schema was added recently and ended up out of alphabetical order, breaking the Lint job on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24441749197/job/71408174218
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
