### PR TITLE
meet-bot: Xvfb + Playwright Chromium launcher

### DIFF
--- a/meet-bot/__tests__/session.test.ts
+++ b/meet-bot/__tests__/session.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for the browser-session primitive.
+ *
+ * We mock Playwright and the Xvfb lifecycle helpers so the tests run on any
+ * host (macOS included) without spawning a real X server or Chromium. A
+ * heavier integration test that actually exec's Xvfb + Chromium is gated
+ * behind `XVFB_TEST=1` and skipped by default — CI and macOS developers
+ * would fail trying to exec a Linux binary.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { CHROMIUM_ARGS } from "../src/browser/session.js";
+
+type MockFn = ReturnType<typeof mock>;
+
+interface MockPage {
+  goto: MockFn;
+  screenshot: MockFn;
+  close: MockFn;
+}
+
+interface MockContext {
+  newPage: MockFn;
+  close: MockFn;
+}
+
+interface MockBrowser {
+  newContext: MockFn;
+  close: MockFn;
+}
+
+interface LaunchCall {
+  options: {
+    headless?: boolean;
+    args?: readonly string[];
+    env?: Record<string, string | undefined>;
+  };
+}
+
+/**
+ * Build a freshly-mocked Playwright + Xvfb surface and register them via
+ * Bun's module mocker. Returns handles into the mocks so each test can
+ * assert on the calls made through them.
+ */
+function installMocks(): {
+  page: MockPage;
+  context: MockContext;
+  browser: MockBrowser;
+  launchCalls: LaunchCall[];
+  startXvfb: MockFn;
+  stopXvfb: MockFn;
+} {
+  const page: MockPage = {
+    goto: mock(async () => undefined),
+    screenshot: mock(async () => Buffer.alloc(0)),
+    close: mock(async () => undefined),
+  };
+  const context: MockContext = {
+    newPage: mock(async () => page),
+    close: mock(async () => undefined),
+  };
+  const browser: MockBrowser = {
+    newContext: mock(async () => context),
+    close: mock(async () => undefined),
+  };
+
+  const launchCalls: LaunchCall[] = [];
+  const launch = mock(async (options: LaunchCall["options"]) => {
+    launchCalls.push({ options });
+    return browser;
+  });
+
+  mock.module("playwright", () => ({
+    chromium: { launch },
+  }));
+
+  const startXvfb = mock(async (display = ":99") => ({
+    display,
+    process: null,
+  }));
+  const stopXvfb = mock(async () => undefined);
+  mock.module("../src/browser/xvfb.js", () => ({
+    startXvfb,
+    stopXvfb,
+  }));
+
+  return { page, context, browser, launchCalls, startXvfb, stopXvfb };
+}
+
+describe("createBrowserSession", () => {
+  let mocks: ReturnType<typeof installMocks>;
+
+  beforeEach(() => {
+    mocks = installMocks();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("launches Chromium with the expected args, env, and headless flag", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const session = await createBrowserSession("https://meet.google.com/abc-defg-hij");
+
+    expect(mocks.launchCalls.length).toBe(1);
+    const { options } = mocks.launchCalls[0]!;
+
+    // Non-headless so Xvfb can host the window and Meet's bot-detection
+    // doesn't flag us.
+    expect(options.headless).toBe(false);
+
+    // Args should include every flag the container runtime needs.
+    for (const arg of CHROMIUM_ARGS) {
+      expect(options.args).toContain(arg);
+    }
+
+    // Env must point Chromium at Xvfb + the Pulse virtual devices.
+    expect(options.env?.DISPLAY).toBe(":99");
+    expect(options.env?.PULSE_SOURCE).toBe("bot_mic");
+    expect(options.env?.PULSE_SINK).toBe("meet_capture");
+    // process.env should still be forwarded so PATH etc. survive.
+    expect(options.env?.PATH).toBe(process.env.PATH);
+
+    await session.close();
+  });
+
+  test("calls page.goto with the provided URL", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const url = "https://meet.google.com/xyz-uvwx-yzz";
+    const session = await createBrowserSession(url);
+
+    expect(mocks.page.goto).toHaveBeenCalledTimes(1);
+    const [gotoUrl, gotoOpts] = mocks.page.goto.mock.calls[0]!;
+    expect(gotoUrl).toBe(url);
+    // `load` is the agreed waitUntil for a live webapp; `networkidle` never
+    // settles for Meet.
+    expect((gotoOpts as { waitUntil?: string }).waitUntil).toBe("load");
+
+    await session.close();
+  });
+
+  test("close() tears down page, context, and browser in order", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const session = await createBrowserSession("https://meet.google.com/abc");
+
+    // Reset call trackers after the navigation step so we only see what
+    // close() does.
+    mocks.page.close.mockClear();
+    mocks.context.close.mockClear();
+    mocks.browser.close.mockClear();
+
+    await session.close();
+
+    expect(mocks.page.close).toHaveBeenCalledTimes(1);
+    expect(mocks.context.close).toHaveBeenCalledTimes(1);
+    expect(mocks.browser.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("close() tolerates already-closed components", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const session = await createBrowserSession("https://meet.google.com/abc");
+
+    mocks.page.close.mockImplementation(async () => {
+      throw new Error("page already closed");
+    });
+    mocks.context.close.mockImplementation(async () => {
+      throw new Error("context already closed");
+    });
+    mocks.browser.close.mockImplementation(async () => {
+      throw new Error("browser already closed");
+    });
+
+    // Should not throw — swallowing is the contract.
+    await session.close();
+  });
+
+  test("ensures Xvfb is started before launching Chromium", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const session = await createBrowserSession("https://meet.google.com/abc");
+
+    expect(mocks.startXvfb).toHaveBeenCalledTimes(1);
+    // Default display should be ":99" when caller doesn't override it.
+    expect(mocks.startXvfb.mock.calls[0]?.[0]).toBe(":99");
+
+    await session.close();
+  });
+
+  test("honors a custom xvfbDisplay option", async () => {
+    const { createBrowserSession } = await import(
+      "../src/browser/session.js"
+    );
+
+    const session = await createBrowserSession(
+      "https://meet.google.com/abc",
+      { xvfbDisplay: ":42" },
+    );
+
+    expect(mocks.startXvfb.mock.calls[0]?.[0]).toBe(":42");
+    expect(mocks.launchCalls[0]?.options.env?.DISPLAY).toBe(":42");
+
+    await session.close();
+  });
+});
+
+/**
+ * Integration test gated behind `XVFB_TEST=1`. Runs only on Linux hosts
+ * with Xvfb + Chromium available; skipped by default so macOS and generic
+ * CI stays green.
+ */
+const runIntegration =
+  process.env.XVFB_TEST === "1" && process.platform === "linux";
+
+(runIntegration ? describe : describe.skip)(
+  "createBrowserSession [XVFB_TEST=1]",
+  () => {
+    test("can launch a real browser and navigate to a data URL", async () => {
+      // Dynamically import *without* the module mocks above. Bun resets
+      // mocks per-test-file, but guard anyway by delaying the import.
+      const { createBrowserSession } = await import(
+        "../src/browser/session.js"
+      );
+      const session = await createBrowserSession(
+        "data:text/html,<title>meet-bot-integration</title>",
+      );
+      try {
+        const title = await session.page.title();
+        expect(title).toBe("meet-bot-integration");
+      } finally {
+        await session.close();
+      }
+    });
+  },
+);

--- a/meet-bot/src/browser/session.ts
+++ b/meet-bot/src/browser/session.ts
@@ -1,0 +1,147 @@
+/**
+ * Browser session primitive for the meet-bot.
+ *
+ * `createBrowserSession(url)` brings up Xvfb (if not already running),
+ * launches Playwright Chromium with the flags Google Meet expects from a
+ * bot-tolerant browser, opens a page, navigates to `url`, and hands the
+ * caller back `{ browser, context, page, close }`.
+ *
+ * Design notes:
+ *
+ *   - `headless: false` — we render into Xvfb instead. Meet's bot-detection
+ *     is friendlier to a browser with a real display, and we need a window
+ *     for getUserMedia permission UI to auto-accept via
+ *     `--use-fake-ui-for-media-stream`.
+ *   - `--use-fake-ui-for-media-stream` — auto-grants mic/camera without a
+ *     permission prompt. Required for the Pulse-backed audio pipeline PR 5
+ *     wires up.
+ *   - `--no-sandbox` / `--disable-setuid-sandbox` — required inside the
+ *     unprivileged Debian container; Chromium's sandbox needs capabilities
+ *     we don't want to grant.
+ *   - `--disable-dev-shm-usage` — `/dev/shm` in containers defaults to 64MB,
+ *     which Chromium will overrun and crash. This flag moves the shared
+ *     memory store to `/tmp`.
+ *   - `PULSE_SOURCE=bot_mic` / `PULSE_SINK=meet_capture` — point Chromium at
+ *     the virtual Pulse devices PR 5 provisions, so the bot's mic input
+ *     comes from our TTS stream and the meeting's audio lands in a sink we
+ *     can tap for transcription.
+ *
+ * Real Meet-join flow (lobby handling, name entry, participant waiting
+ * logic) lands in PR 11 on top of this primitive.
+ */
+
+import { chromium } from "playwright";
+import type { Browser, BrowserContext, Page } from "playwright";
+
+import type { XvfbHandle } from "./xvfb.js";
+import { startXvfb } from "./xvfb.js";
+
+export interface BrowserSessionOptions {
+  /** Xvfb display to render into. Defaults to `":99"`. */
+  xvfbDisplay?: string;
+}
+
+export interface BrowserSession {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+  /**
+   * Close the page, context, and browser in order. Tolerates already-closed
+   * states — individual step failures are swallowed so `close` itself never
+   * throws. Xvfb is intentionally *not* stopped here: higher-level callers
+   * may reuse the same display for multiple sessions.
+   */
+  close: () => Promise<void>;
+}
+
+/** Chromium launch args used for every meet-bot browser session. */
+export const CHROMIUM_ARGS: readonly string[] = [
+  "--use-fake-ui-for-media-stream",
+  "--no-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-setuid-sandbox",
+  "--window-size=1280,720",
+];
+
+/**
+ * Launch a Playwright Chromium browser pointed at `url` and return the
+ * resulting session handle.
+ *
+ * Caller owns lifecycle: they must invoke `close()` when done. Xvfb is
+ * started on demand (idempotent — `startXvfb` no-ops if the lock file
+ * already exists), but left running past `close()` so the next session on
+ * this process can reuse the display.
+ */
+export async function createBrowserSession(
+  url: string,
+  opts: BrowserSessionOptions = {},
+): Promise<BrowserSession> {
+  const display = opts.xvfbDisplay ?? ":99";
+
+  // Fire-and-forget the lifetime of the Xvfb handle — we don't stop it when
+  // the session closes (see docstring above). Keeping the reference local is
+  // fine; process exit will tear it down.
+  const xvfb: XvfbHandle = await startXvfb(display);
+  void xvfb;
+
+  const browser = await chromium.launch({
+    headless: false,
+    args: [...CHROMIUM_ARGS],
+    env: {
+      ...process.env,
+      DISPLAY: display,
+      PULSE_SOURCE: "bot_mic",
+      PULSE_SINK: "meet_capture",
+    },
+  });
+
+  let context: BrowserContext | undefined;
+  let page: Page | undefined;
+  try {
+    context = await browser.newContext();
+    page = await context.newPage();
+    // `load` is a reasonable default for Meet — `networkidle` never settles
+    // for a live webapp with ongoing websocket/XHR traffic. PR 11 will
+    // follow up with its own selector-based readiness waits.
+    await page.goto(url, { waitUntil: "load" });
+  } catch (err) {
+    // Best-effort cleanup so we don't leak a running browser if navigation
+    // (or context creation) blows up before we hand the session off.
+    try {
+      if (page) await page.close();
+    } catch {
+      // swallow
+    }
+    try {
+      if (context) await context.close();
+    } catch {
+      // swallow
+    }
+    try {
+      await browser.close();
+    } catch {
+      // swallow
+    }
+    throw err;
+  }
+
+  const close = async (): Promise<void> => {
+    try {
+      await page.close();
+    } catch {
+      // Page may already be closed (browser crash, manual close, etc.).
+    }
+    try {
+      await context.close();
+    } catch {
+      // Ditto.
+    }
+    try {
+      await browser.close();
+    } catch {
+      // Ditto.
+    }
+  };
+
+  return { browser, context, page, close };
+}

--- a/meet-bot/src/browser/xvfb.ts
+++ b/meet-bot/src/browser/xvfb.ts
@@ -1,0 +1,160 @@
+/**
+ * Xvfb (X Virtual Framebuffer) lifecycle helpers.
+ *
+ * The meet-bot runs inside a Linux container without a real display; Xvfb
+ * provides a headless X server that Chromium can render into. We keep
+ * Chromium non-headless because Meet's bot-detection is friendlier toward
+ * browsers that have a window manager and a real display, and Xvfb lets us
+ * do that without a GPU.
+ *
+ * These helpers are intentionally small:
+ *
+ *   - `startXvfb(display)` spawns `Xvfb :99 -screen 0 1280x720x24` and waits
+ *     for the corresponding X lock file (`/tmp/.X<N>-lock`) to appear before
+ *     resolving. If the lock file is already present we assume Xvfb is up and
+ *     return a no-op handle without spawning a second server.
+ *   - `stopXvfb(handle)` sends SIGTERM, then escalates to SIGKILL after 2s.
+ *
+ * Everything heavier (integration against real Xvfb + Chromium) is gated
+ * behind `XVFB_TEST=1` in the test suite so CI and macOS developers don't
+ * accidentally try to exec a Linux binary.
+ */
+
+import type { Subprocess } from "bun";
+import { existsSync } from "node:fs";
+
+/** Opaque handle returned by `startXvfb`, consumed by `stopXvfb`. */
+export interface XvfbHandle {
+  /** The X display string we started on, e.g. `":99"`. */
+  readonly display: string;
+  /**
+   * The Xvfb child process, or `null` if we detected an existing server via
+   * the lock file and skipped spawning our own.
+   */
+  readonly process: Subprocess | null;
+}
+
+const LOCK_WAIT_TIMEOUT_MS = 10_000;
+const LOCK_POLL_INTERVAL_MS = 100;
+const SIGKILL_GRACE_MS = 2_000;
+
+/**
+ * Parse the numeric display index out of an X display string.
+ *
+ * Accepts `":99"`, `"99"`, or `":99.0"`-style inputs. Throws on anything we
+ * can't parse cleanly rather than guessing — a bad display string will hang
+ * Chromium later in a way that's much harder to debug.
+ */
+function parseDisplayIndex(display: string): number {
+  const trimmed = display.startsWith(":") ? display.slice(1) : display;
+  // Strip optional screen suffix (e.g. ":99.0" -> "99").
+  const [head] = trimmed.split(".");
+  const n = Number.parseInt(head ?? "", 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`startXvfb: invalid display string: ${display}`);
+  }
+  return n;
+}
+
+/** Path Xvfb uses for its per-display lock file. */
+function lockFilePath(displayIndex: number): string {
+  return `/tmp/.X${displayIndex}-lock`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Start Xvfb on `display` (default `":99"`) and wait for its lock file to
+ * appear. If the lock file already exists we assume another process owns
+ * Xvfb on this display and return a handle with `process: null` — `stopXvfb`
+ * will then be a no-op.
+ */
+export async function startXvfb(display = ":99"): Promise<XvfbHandle> {
+  const displayIndex = parseDisplayIndex(display);
+  const lockPath = lockFilePath(displayIndex);
+
+  if (existsSync(lockPath)) {
+    // Another process already owns this display; don't fight it. Returning a
+    // handle with `process: null` keeps the call idempotent — callers can
+    // still call `stopXvfb` unconditionally without tracking who started what.
+    return { display, process: null };
+  }
+
+  const proc = Bun.spawn(
+    ["Xvfb", display, "-screen", "0", "1280x720x24"],
+    {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+    },
+  );
+
+  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (existsSync(lockPath)) {
+      return { display, process: proc };
+    }
+    // If Xvfb died during startup, bail out with a useful error instead of
+    // spinning until the timeout.
+    if (proc.exitCode !== null) {
+      const stderr = proc.stderr
+        ? await new Response(proc.stderr).text()
+        : "";
+      throw new Error(
+        `startXvfb: Xvfb exited during startup (code=${proc.exitCode}): ${stderr.trim()}`,
+      );
+    }
+    await sleep(LOCK_POLL_INTERVAL_MS);
+  }
+
+  // Timed out — try to kill what we spawned so we don't leak a process.
+  try {
+    proc.kill("SIGKILL");
+  } catch {
+    // Best effort; the process may have already exited.
+  }
+  throw new Error(
+    `startXvfb: lock file ${lockPath} did not appear within ${LOCK_WAIT_TIMEOUT_MS}ms`,
+  );
+}
+
+/**
+ * Stop an Xvfb instance started by `startXvfb`. Sends SIGTERM first, then
+ * SIGKILL after a short grace period if the process hasn't exited. A no-op
+ * when the handle represents an externally-owned Xvfb (`process: null`).
+ */
+export async function stopXvfb(handle: XvfbHandle): Promise<void> {
+  const proc = handle.process;
+  if (!proc) return;
+  if (proc.exitCode !== null) return;
+
+  try {
+    proc.kill("SIGTERM");
+  } catch {
+    // Ignore — process may have already exited between the exitCode check
+    // and the kill call.
+  }
+
+  // Wait up to SIGKILL_GRACE_MS for a clean shutdown.
+  const deadline = Date.now() + SIGKILL_GRACE_MS;
+  while (Date.now() < deadline && proc.exitCode === null) {
+    await sleep(50);
+  }
+
+  if (proc.exitCode === null) {
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // Ditto — best effort.
+    }
+  }
+
+  // Let `exited` settle so we don't leak the Subprocess promise.
+  try {
+    await proc.exited;
+  } catch {
+    // Ignored — we only care that the process is no longer running.
+  }
+}

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -5,17 +5,40 @@
  * that will join a Google Meet session on behalf of an AI assistant so the
  * assistant can listen in (and eventually participate).
  *
- * The real implementation (Playwright-driven Meet join flow, audio capture
- * via PulseAudio, Hono HTTP control surface, etc.) lands in later PRs of the
- * meet-phase-1 plan. See `meet-bot/README.md` for links.
+ * Current behavior:
  *
- * For now this just logs a boot marker and exits cleanly so the Docker image
- * build, the package scripts, and the boot test can all verify the package
- * structure is valid end-to-end.
+ *   - Logs a boot marker so the boot smoke test and the Docker `CMD` can
+ *     verify the package structure.
+ *   - If `MEET_URL` is set, brings up Xvfb + Chromium, navigates to the URL,
+ *     drops a screenshot at `/tmp/boot-screenshot.png`, closes the session,
+ *     and exits 0. This is the browser-runtime smoke path; the real Meet
+ *     join flow (lobby handling, name entry, join-button clicks) lands in
+ *     PR 11 of the meet-phase-1 plan.
+ *
+ * Anything heavier — Hono HTTP control surface, PulseAudio capture wiring,
+ * transcript streaming — lands in later PRs.
  */
 
-function main(): void {
+import { createBrowserSession } from "./browser/session.js";
+
+async function main(): Promise<void> {
   console.log("meet-bot booted");
+
+  const meetUrl = process.env.MEET_URL;
+  if (meetUrl) {
+    const session = await createBrowserSession(meetUrl);
+    try {
+      await session.page.screenshot({ path: "/tmp/boot-screenshot.png" });
+      console.log(
+        `meet-bot captured boot screenshot for ${meetUrl} at /tmp/boot-screenshot.png`,
+      );
+    } finally {
+      await session.close();
+    }
+  }
 }
 
-main();
+void main().catch((err) => {
+  console.error("meet-bot failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `startXvfb`/`stopXvfb` and `createBrowserSession` (Playwright Chromium with fake-UI + no-sandbox + Pulse env).
- main.ts now opens a browser session and screenshots the page when `MEET_URL` is set (real Meet-join in PR 11).
- Unit test mocks Playwright + Xvfb; heavier integration test gated behind `XVFB_TEST=1`.

Part of plan: meet-phase-1-listen.md (PR 6 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
