### PR TITLE
meet-bot: DOM selectors module + recorded Meet fixtures

### DIFF
--- a/meet-bot/README.md
+++ b/meet-bot/README.md
@@ -33,3 +33,41 @@ To build the container image (requires Docker):
 ```bash
 ./scripts/build-meet-bot-image.sh
 ```
+
+## Refreshing Meet DOM fixtures
+
+The bot interacts with Google Meet through CSS/attribute selectors centralized in
+`src/browser/dom-selectors.ts`. Because Meet's web UI drifts without notice,
+we commit HTML fixtures in `__tests__/fixtures/` and test every selector
+against those fixtures. The shipped fixtures are **plausible approximations**
+of Meet's DOM authored by hand — they exercise the selectors but are not
+literal snapshots.
+
+When Meet's UI changes (failing tests, broken bot behavior in production, or
+just on a scheduled cadence), a human developer should refresh the fixtures
+against a live Meet session. The refresh procedure:
+
+1. **Join a real Google Meet** with at least two participants (one speaking,
+   one sharing screen if the presenter indicator needs verification). Use a
+   throwaway test meeting, not a live customer call.
+2. **Capture outer-HTML** of the relevant DOM regions via Chrome DevTools:
+   - Prejoin: right-click the prejoin panel root → Inspect → copy outer HTML
+     into `__tests__/fixtures/meet-dom-prejoin.html`.
+   - In-meeting: capture the main meeting grid + toolbar + participant panel
+     into `__tests__/fixtures/meet-dom-ingame.html`.
+   - Chat: open the chat panel, send one test message, then capture the
+     panel into `__tests__/fixtures/meet-dom-chat.html`.
+   - Scrub any real names, avatars, message content, and meeting IDs from the
+     captured HTML — the fixtures are committed to the public repo.
+3. **Update `GOOGLE_MEET_SELECTOR_VERSION`** in `src/browser/dom-selectors.ts`
+   to today's ISO date (`YYYY-MM-DD`). This records which Meet revision the
+   selectors are calibrated against.
+4. **Re-run the selector tests**:
+   ```bash
+   bun test __tests__/dom-selectors.test.ts
+   ```
+5. **Fix any selector drift.** Selectors marked `// TODO(meet-dom)` are the
+   most likely to need adjustment — they are the ones we already knew were
+   best-guesses. Update the selector constant, re-run the test, and commit
+   the combined fixture-plus-selector refresh in a single PR so the diff is
+   reviewable as one unit.

--- a/meet-bot/__tests__/dom-selectors.test.ts
+++ b/meet-bot/__tests__/dom-selectors.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import {
+  GOOGLE_MEET_SELECTOR_VERSION,
+  chatSelectors,
+  controlSelectors,
+  INGAME_ACTIVE_SPEAKER_INDICATOR,
+  participantSelectors,
+  prejoinSelectors,
+  selectors,
+} from "../src/browser/dom-selectors.js";
+
+/**
+ * Verifies every selector exported from `dom-selectors.ts` resolves against
+ * the committed fixtures. When Meet's DOM drifts and a human developer
+ * recaptures the fixture HTML, this suite is what tells us whether our
+ * selectors still match — see README § "Refreshing Meet DOM fixtures".
+ */
+
+const FIXTURE_DIR = join(import.meta.dir, "fixtures");
+
+function loadFixture(name: string): Document {
+  const html = readFileSync(join(FIXTURE_DIR, name), "utf8");
+  return new JSDOM(html).window.document;
+}
+
+describe("GOOGLE_MEET_SELECTOR_VERSION", () => {
+  test("is a non-empty ISO-date-shaped string", () => {
+    expect(typeof GOOGLE_MEET_SELECTOR_VERSION).toBe("string");
+    expect(GOOGLE_MEET_SELECTOR_VERSION.length).toBeGreaterThan(0);
+    // YYYY-MM-DD shape — doesn't validate the calendar, just the format.
+    expect(GOOGLE_MEET_SELECTOR_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("prejoin selectors", () => {
+  const doc = loadFixture("meet-dom-prejoin.html");
+
+  test("NAME_INPUT resolves the name textbox", () => {
+    const nodes = doc.querySelectorAll(prejoinSelectors.NAME_INPUT);
+    expect(nodes.length).toBe(1);
+    const input = nodes[0] as HTMLInputElement;
+    expect(input.tagName).toBe("INPUT");
+    expect(input.getAttribute("aria-label")).toBe("Your name");
+  });
+
+  test("ASK_TO_JOIN_BUTTON resolves the ask-to-join button", () => {
+    const nodes = doc.querySelectorAll(prejoinSelectors.ASK_TO_JOIN_BUTTON);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe("Ask to join");
+  });
+
+  test("JOIN_NOW_BUTTON resolves the join-now button", () => {
+    const nodes = doc.querySelectorAll(prejoinSelectors.JOIN_NOW_BUTTON);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe("Join now");
+  });
+});
+
+describe("in-meeting selectors", () => {
+  const doc = loadFixture("meet-dom-ingame.html");
+
+  test("CAMERA_TOGGLE resolves exactly one toolbar button", () => {
+    const nodes = doc.querySelectorAll(controlSelectors.CAMERA_TOGGLE);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).getAttribute("aria-label")).toBe(
+      "Turn off camera",
+    );
+  });
+
+  test("MIC_TOGGLE resolves exactly one toolbar button", () => {
+    const nodes = doc.querySelectorAll(controlSelectors.MIC_TOGGLE);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).getAttribute("aria-label")).toBe(
+      "Turn off microphone",
+    );
+  });
+
+  test("LEAVE_BUTTON resolves the red hang-up button", () => {
+    const nodes = doc.querySelectorAll(controlSelectors.LEAVE_BUTTON);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe("Leave call");
+  });
+
+  test("participant panel toggle resolves", () => {
+    const nodes = doc.querySelectorAll(participantSelectors.PANEL_BUTTON);
+    expect(nodes.length).toBe(1);
+  });
+
+  test("chat panel toggle resolves", () => {
+    const nodes = doc.querySelectorAll(chatSelectors.PANEL_BUTTON);
+    expect(nodes.length).toBe(1);
+  });
+
+  test("INGAME_ACTIVE_SPEAKER_INDICATOR only matches the speaking tile", () => {
+    const nodes = doc.querySelectorAll(INGAME_ACTIVE_SPEAKER_INDICATOR);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).getAttribute("data-participant-id")).toBe(
+      "p-alice",
+    );
+  });
+
+  test("participant LIST resolves the side-panel list container", () => {
+    const nodes = doc.querySelectorAll(participantSelectors.LIST);
+    expect(nodes.length).toBe(1);
+  });
+
+  test("participant NODE resolves every participant row", () => {
+    const list = doc.querySelector(participantSelectors.LIST);
+    expect(list).not.toBeNull();
+    const nodes = list?.querySelectorAll(participantSelectors.NODE) ?? [];
+    expect(nodes.length).toBe(3);
+  });
+
+  test("participant NAME subselector resolves within each participant row", () => {
+    const list = doc.querySelector(participantSelectors.LIST);
+    const rows = list?.querySelectorAll(participantSelectors.NODE) ?? [];
+    const names = Array.from(rows).map(
+      (row) =>
+        row.querySelector(participantSelectors.NAME)?.textContent?.trim() ??
+        null,
+    );
+    expect(names).toEqual(["Alice", "Bob", "You"]);
+  });
+
+  test("presenter and speaking indicators only match the flagged row", () => {
+    const presenters = doc.querySelectorAll(
+      participantSelectors.PRESENTER_INDICATOR,
+    );
+    const speakers = doc.querySelectorAll(
+      participantSelectors.SPEAKING_INDICATOR,
+    );
+    // Alice is the only presenter + speaker in the fixture; she appears in
+    // both the grid tile and the participant-panel row for the speaking
+    // indicator (data-active-speaker is a distinct attribute used by the
+    // tile selector, so the panel-side speaking selector only matches the
+    // participant row).
+    expect(presenters.length).toBe(1);
+    expect(speakers.length).toBe(1);
+    expect(
+      (presenters[0] as HTMLElement).getAttribute("data-participant-id"),
+    ).toBe("p-alice");
+    expect(
+      (speakers[0] as HTMLElement).getAttribute("data-participant-id"),
+    ).toBe("p-alice");
+  });
+});
+
+describe("chat panel selectors", () => {
+  const doc = loadFixture("meet-dom-chat.html");
+
+  test("INPUT resolves the composer textarea", () => {
+    const nodes = doc.querySelectorAll(chatSelectors.INPUT);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLTextAreaElement).tagName).toBe("TEXTAREA");
+  });
+
+  test("SEND_BUTTON resolves the send button", () => {
+    const nodes = doc.querySelectorAll(chatSelectors.SEND_BUTTON);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).tagName).toBe("BUTTON");
+    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe("Send");
+  });
+
+  test("MESSAGE_NODE resolves each rendered message", () => {
+    const nodes = doc.querySelectorAll(chatSelectors.MESSAGE_NODE);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).getAttribute("data-message-id")).toBe(
+      "msg-001",
+    );
+  });
+
+  test("MESSAGE_SENDER/TEXT/TIMESTAMP subselectors extract message fields", () => {
+    const message = doc.querySelector(chatSelectors.MESSAGE_NODE);
+    expect(message).not.toBeNull();
+    const sender = message?.querySelector(chatSelectors.MESSAGE_SENDER);
+    const text = message?.querySelector(chatSelectors.MESSAGE_TEXT);
+    const timestamp = message?.querySelector(chatSelectors.MESSAGE_TIMESTAMP);
+
+    expect(sender?.textContent?.trim()).toBe("Alice");
+    expect(text?.textContent?.trim()).toBe(
+      "Hello everyone, welcome to the meeting.",
+    );
+    expect((timestamp as HTMLTimeElement | null)?.getAttribute("datetime")).toBe(
+      "2026-04-15T12:34:00Z",
+    );
+  });
+});
+
+describe("flat selectors aggregate", () => {
+  test("exposes each named constant from the individual groups", () => {
+    const cases: Array<[keyof typeof selectors, string]> = [
+      ["PREJOIN_NAME_INPUT", prejoinSelectors.NAME_INPUT],
+      ["PREJOIN_ASK_TO_JOIN_BUTTON", prejoinSelectors.ASK_TO_JOIN_BUTTON],
+      ["PREJOIN_JOIN_NOW_BUTTON", prejoinSelectors.JOIN_NOW_BUTTON],
+      ["INGAME_CHAT_PANEL_BUTTON", chatSelectors.PANEL_BUTTON],
+      ["INGAME_CHAT_INPUT", chatSelectors.INPUT],
+      ["INGAME_CHAT_SEND_BUTTON", chatSelectors.SEND_BUTTON],
+      ["INGAME_CHAT_MESSAGE_NODE", chatSelectors.MESSAGE_NODE],
+      ["INGAME_CHAT_MESSAGE_SENDER", chatSelectors.MESSAGE_SENDER],
+      ["INGAME_CHAT_MESSAGE_TEXT", chatSelectors.MESSAGE_TEXT],
+      ["INGAME_CHAT_MESSAGE_TIMESTAMP", chatSelectors.MESSAGE_TIMESTAMP],
+      ["INGAME_PARTICIPANTS_PANEL_BUTTON", participantSelectors.PANEL_BUTTON],
+      ["INGAME_PARTICIPANT_LIST", participantSelectors.LIST],
+      ["INGAME_PARTICIPANT_NODE", participantSelectors.NODE],
+      ["INGAME_PARTICIPANT_NAME", participantSelectors.NAME],
+      [
+        "INGAME_PARTICIPANT_PRESENTER_INDICATOR",
+        participantSelectors.PRESENTER_INDICATOR,
+      ],
+      [
+        "INGAME_PARTICIPANT_SPEAKING_INDICATOR",
+        participantSelectors.SPEAKING_INDICATOR,
+      ],
+      ["INGAME_ACTIVE_SPEAKER_INDICATOR", INGAME_ACTIVE_SPEAKER_INDICATOR],
+      ["INGAME_CAMERA_TOGGLE", controlSelectors.CAMERA_TOGGLE],
+      ["INGAME_MIC_TOGGLE", controlSelectors.MIC_TOGGLE],
+      ["INGAME_LEAVE_BUTTON", controlSelectors.LEAVE_BUTTON],
+    ];
+
+    for (const [key, expected] of cases) {
+      // Compare as plain strings — `selectors[key]` is typed with narrow
+      // literal types via `as const`, so widen both sides to `string` before
+      // asserting equality.
+      expect(String(selectors[key])).toBe(expected);
+    }
+  });
+});

--- a/meet-bot/__tests__/fixtures/meet-dom-chat.html
+++ b/meet-bot/__tests__/fixtures/meet-dom-chat.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet chat side panel, opened.
+
+  Covers the composer (textarea + send) and a rendered message list with a
+  single message containing the sender/text/timestamp subnodes. Shape
+  approximation — see README § "Refreshing Meet DOM fixtures".
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — Chat panel</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <aside aria-label="Side panel">
+        <header>
+          <h2>In-call messages</h2>
+        </header>
+
+        <!-- Rendered message history. -->
+        <div role="list" aria-label="Chat messages">
+          <div
+            role="listitem"
+            data-message-id="msg-001"
+          >
+            <span data-sender-name>Alice</span>
+            <time datetime="2026-04-15T12:34:00Z">12:34 PM</time>
+            <p data-message-text>Hello everyone, welcome to the meeting.</p>
+          </div>
+        </div>
+
+        <!-- Composer. -->
+        <div class="chat-composer" role="group">
+          <textarea
+            aria-label="Send a message"
+            placeholder="Send a message"
+            rows="1"
+          ></textarea>
+          <button type="button" aria-label="Send a message">
+            Send
+          </button>
+        </div>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/meet-bot/__tests__/fixtures/meet-dom-ingame.html
+++ b/meet-bot/__tests__/fixtures/meet-dom-ingame.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet in-meeting UI.
+
+  Includes the meeting toolbar (camera/mic/leave + chat/people panel toggles)
+  and a sample participant tile carrying the active-speaker and speaking
+  indicators. Shape approximation — see README § "Refreshing Meet DOM
+  fixtures" before relying on it as a production reference.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — In meeting</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <main aria-label="Meeting">
+        <!-- Grid of participant video tiles. -->
+        <div class="meeting-grid" role="grid" aria-label="Video tiles">
+          <!-- Active speaker tile. -->
+          <div
+            role="gridcell"
+            data-participant-tile
+            data-participant-id="p-alice"
+            data-active-speaker="true"
+          >
+            <div class="tile-name">Alice</div>
+          </div>
+          <!-- Non-speaking tile (sanity-check that the active-speaker
+               selector does not match it). -->
+          <div
+            role="gridcell"
+            data-participant-tile
+            data-participant-id="p-bob"
+            data-active-speaker="false"
+          >
+            <div class="tile-name">Bob</div>
+          </div>
+        </div>
+
+        <!-- Bottom control bar. -->
+        <div class="meeting-toolbar" role="toolbar" aria-label="Call controls">
+          <button type="button" aria-label="Turn off microphone">
+            Microphone
+          </button>
+          <button type="button" aria-label="Turn off camera">
+            Camera
+          </button>
+          <button type="button" aria-label="Leave call">
+            Leave call
+          </button>
+          <button type="button" aria-label="Show everyone">
+            People
+          </button>
+          <button type="button" aria-label="Chat with everyone">
+            Chat
+          </button>
+        </div>
+
+        <!--
+          People side panel (opened). Meet renders this as a list of
+          participant rows with per-row name, presenter, and speaking state.
+        -->
+        <aside aria-label="Side panel">
+          <div role="list" aria-label="Participants">
+            <div
+              role="listitem"
+              data-participant-id="p-alice"
+              data-is-speaking="true"
+              data-is-presenting="true"
+            >
+              <span data-participant-name>Alice</span>
+            </div>
+            <div
+              role="listitem"
+              data-participant-id="p-bob"
+              data-is-speaking="false"
+              data-is-presenting="false"
+            >
+              <span data-participant-name>Bob</span>
+            </div>
+            <div
+              role="listitem"
+              data-participant-id="p-you"
+              data-is-speaking="false"
+              data-is-presenting="false"
+            >
+              <span data-self-name>You</span>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  </body>
+</html>

--- a/meet-bot/__tests__/fixtures/meet-dom-prejoin.html
+++ b/meet-bot/__tests__/fixtures/meet-dom-prejoin.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet prejoin screen ("Ready to join?").
+
+  Shape approximation — this is NOT a literal snapshot of production Meet;
+  it is a minimal structure that exercises the prejoin selectors in
+  `src/browser/dom-selectors.ts`. Refresh against a live Meet session when
+  Meet's DOM drifts (see README § "Refreshing Meet DOM fixtures").
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — Ready to join?</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <div role="main" aria-label="Ready to join?">
+        <h1>Ready to join?</h1>
+
+        <div class="prejoin-video-preview">
+          <video aria-hidden="true"></video>
+        </div>
+
+        <!-- Name input (shown to unauthenticated joiners). -->
+        <label>
+          <span>Your name</span>
+          <input
+            type="text"
+            aria-label="Your name"
+            autocomplete="off"
+            maxlength="60"
+            value=""
+          />
+        </label>
+
+        <!--
+          Meet shows exactly one of the two join buttons depending on the
+          meeting's admission policy. For fixture coverage we include both so
+          either selector matches.
+        -->
+        <div class="prejoin-actions" role="group">
+          <button type="button" aria-label="Ask to join">
+            Ask to join
+          </button>
+          <button type="button" aria-label="Join now">
+            Join now
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/meet-bot/bun.lock
+++ b/meet-bot/bun.lock
@@ -11,29 +11,115 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.9",
+        "@types/jsdom": "28.0.1",
+        "jsdom": "29.0.2",
         "typescript": "5.9.3",
       },
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.10", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.9", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
+
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
+    "undici-types": ["undici-types@7.25.0", "", {}, "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
   }
 }

--- a/meet-bot/package.json
+++ b/meet-bot/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.9",
+    "@types/jsdom": "28.0.1",
+    "jsdom": "29.0.2",
     "typescript": "5.9.3"
   }
 }

--- a/meet-bot/src/browser/dom-selectors.ts
+++ b/meet-bot/src/browser/dom-selectors.ts
@@ -1,0 +1,204 @@
+/**
+ * Centralized Google Meet DOM selectors.
+ *
+ * This module is the single source of truth for every CSS/attribute selector
+ * the meet-bot uses to interact with Google Meet's web UI. Consolidating them
+ * here means that when Meet's DOM drifts (which happens frequently, often
+ * without warning) we only need to patch this one file and refresh the HTML
+ * fixtures under `__tests__/fixtures/`.
+ *
+ * ## Conventions
+ *
+ * - Prefer stable attributes (ARIA, role, data-*) over class names or positional
+ *   CSS selectors. Class names in Meet are frequently minified and change across
+ *   releases; aria-labels and roles are comparatively stable because they are
+ *   part of Google's accessibility contract.
+ * - Where a stable attribute is not available, fall back to a descriptive
+ *   selector and tag the constant with `// TODO(meet-dom)`. These are the
+ *   candidates most likely to break on the next Meet refresh and should be
+ *   re-verified each time fixtures are recaptured.
+ * - Every selector MUST be exercised by a fixture in `dom-selectors.test.ts`.
+ *   If a new selector is added without a matching fixture assertion, the test
+ *   suite will fail.
+ *
+ * ## Downstream consumers
+ *
+ * - PR 11 — join flow (prejoin selectors)
+ * - PR 12 — participant scraper (participant selectors)
+ * - PR 13 — speaker scraper (active-speaker selector)
+ * - PR 14 — chat reader (chat selectors)
+ *
+ * See `README.md` § "Refreshing Meet DOM fixtures" for the manual refresh
+ * process.
+ */
+
+/**
+ * ISO-date string marking when the committed fixtures were captured.
+ *
+ * When a human developer refreshes the fixture HTML files from a live Meet
+ * session, they should update this value to match the day of capture. That
+ * lets us trace any fixture vs. production mismatch to a concrete date and
+ * decide whether to recapture.
+ */
+export const GOOGLE_MEET_SELECTOR_VERSION = "2026-04-15";
+
+/**
+ * Prejoin-surface selectors — the "Ready to join?" screen shown before the bot
+ * enters the meeting room.
+ */
+export const prejoinSelectors = {
+  /**
+   * Text input where the joining participant types their display name. Meet
+   * exposes this with `aria-label="Your name"` when the user is not signed in.
+   */
+  NAME_INPUT: 'input[aria-label="Your name"]',
+
+  /**
+   * "Ask to join" button shown when the meeting is locked and the bot needs
+   * the host to admit it. Matches by aria-label for stability across locales
+   * (callers should be aware of localization — see TODO below).
+   */
+  // TODO(meet-dom): aria-label is localized. Future versions may need to
+  // match multiple locales or fall back to role=button + text content.
+  ASK_TO_JOIN_BUTTON: 'button[aria-label="Ask to join"]',
+
+  /**
+   * "Join now" button shown when the meeting is open or the bot is already
+   * trusted (e.g. same-domain policy). Distinct from Ask-to-join so the caller
+   * can branch on which flow Meet presented.
+   */
+  JOIN_NOW_BUTTON: 'button[aria-label="Join now"]',
+} as const;
+
+/**
+ * In-meeting chat panel selectors. The chat panel is collapsed by default and
+ * must be opened by clicking the chat toggle button before the input/send
+ * controls become visible.
+ */
+export const chatSelectors = {
+  /** Toggle button in the meeting toolbar that opens the chat side panel. */
+  PANEL_BUTTON: 'button[aria-label="Chat with everyone"]',
+
+  /** Textarea for composing an outgoing chat message. */
+  INPUT: 'textarea[aria-label="Send a message"]',
+
+  /** Send button adjacent to the chat composer. */
+  SEND_BUTTON: 'button[aria-label="Send a message"]',
+
+  /**
+   * Root node for a single rendered chat message. We use a data attribute
+   * rather than a class because Meet's message-list classes change often.
+   */
+  // TODO(meet-dom): Meet does not currently expose a stable per-message data
+  // attribute. The selector below assumes we either inject a MutationObserver-
+  // driven marker or rely on a recognizable ARIA structure. Verify during
+  // fixture refresh and swap to whatever Meet actually emits.
+  MESSAGE_NODE: 'div[role="listitem"][data-message-id]',
+
+  /** Subselectors applied within a MESSAGE_NODE to extract rendered fields. */
+  MESSAGE_SENDER: '[data-sender-name]',
+  MESSAGE_TEXT: '[data-message-text]',
+  MESSAGE_TIMESTAMP: "time[datetime]",
+} as const;
+
+/**
+ * Participant-panel selectors. Like the chat panel, the participant list is
+ * typically collapsed behind a toolbar toggle button.
+ */
+export const participantSelectors = {
+  /** Toolbar toggle that opens the "People" side panel. */
+  PANEL_BUTTON: 'button[aria-label="Show everyone"]',
+
+  /** Container holding the list of participant rows. */
+  LIST: '[role="list"][aria-label="Participants"]',
+
+  /** A single participant row within the list. */
+  NODE: '[role="listitem"][data-participant-id]',
+
+  /** Subselectors applied within a NODE. */
+  NAME: '[data-self-name], [data-participant-name]',
+
+  /** Shown when a participant is currently presenting (screen-share). */
+  // TODO(meet-dom): Meet varies between class-based and aria-based presenter
+  // indicators across releases. Verify during fixture refresh.
+  PRESENTER_INDICATOR: '[data-is-presenting="true"]',
+
+  /**
+   * Shown when a participant's mic level indicates they are speaking. Meet
+   * toggles a class/attribute on the participant tile during speech; we target
+   * it via a data attribute to keep the selector stable.
+   */
+  SPEAKING_INDICATOR: '[data-is-speaking="true"]',
+} as const;
+
+/**
+ * Active-speaker indicator on the main meeting grid (not the participant
+ * panel). Meet applies a border/outline class to the tile of the currently
+ * loudest speaker; we read a corresponding data attribute.
+ */
+// TODO(meet-dom): In older Meet versions this was `.rG0ybd-tile-active`
+// (minified class). The data attribute below is what we'd inject or observe;
+// verify during fixture refresh.
+export const INGAME_ACTIVE_SPEAKER_INDICATOR =
+  '[data-participant-tile][data-active-speaker="true"]';
+
+/**
+ * In-meeting control-bar selectors (camera, microphone, leave).
+ */
+export const controlSelectors = {
+  /**
+   * Camera on/off toggle. Meet switches the aria-label between "Turn on
+   * camera" and "Turn off camera" depending on state; we match either so the
+   * selector works in both states.
+   */
+  CAMERA_TOGGLE:
+    'button[aria-label="Turn off camera"], button[aria-label="Turn on camera"]',
+
+  /**
+   * Microphone on/off toggle. Same dual-aria-label pattern as the camera.
+   */
+  MIC_TOGGLE:
+    'button[aria-label="Turn off microphone"], button[aria-label="Turn on microphone"]',
+
+  /** Red "leave call" button in the center of the control bar. */
+  LEAVE_BUTTON: 'button[aria-label="Leave call"]',
+} as const;
+
+/**
+ * Flat convenience object aggregating every selector group. Consumers can
+ * destructure either the individual groups or the flat view depending on
+ * which reads better at the call site.
+ */
+export const selectors = {
+  // Prejoin
+  PREJOIN_NAME_INPUT: prejoinSelectors.NAME_INPUT,
+  PREJOIN_ASK_TO_JOIN_BUTTON: prejoinSelectors.ASK_TO_JOIN_BUTTON,
+  PREJOIN_JOIN_NOW_BUTTON: prejoinSelectors.JOIN_NOW_BUTTON,
+
+  // Chat
+  INGAME_CHAT_PANEL_BUTTON: chatSelectors.PANEL_BUTTON,
+  INGAME_CHAT_INPUT: chatSelectors.INPUT,
+  INGAME_CHAT_SEND_BUTTON: chatSelectors.SEND_BUTTON,
+  INGAME_CHAT_MESSAGE_NODE: chatSelectors.MESSAGE_NODE,
+  INGAME_CHAT_MESSAGE_SENDER: chatSelectors.MESSAGE_SENDER,
+  INGAME_CHAT_MESSAGE_TEXT: chatSelectors.MESSAGE_TEXT,
+  INGAME_CHAT_MESSAGE_TIMESTAMP: chatSelectors.MESSAGE_TIMESTAMP,
+
+  // Participants
+  INGAME_PARTICIPANTS_PANEL_BUTTON: participantSelectors.PANEL_BUTTON,
+  INGAME_PARTICIPANT_LIST: participantSelectors.LIST,
+  INGAME_PARTICIPANT_NODE: participantSelectors.NODE,
+  INGAME_PARTICIPANT_NAME: participantSelectors.NAME,
+  INGAME_PARTICIPANT_PRESENTER_INDICATOR: participantSelectors.PRESENTER_INDICATOR,
+  INGAME_PARTICIPANT_SPEAKING_INDICATOR: participantSelectors.SPEAKING_INDICATOR,
+
+  // Speaker
+  INGAME_ACTIVE_SPEAKER_INDICATOR,
+
+  // Controls
+  INGAME_CAMERA_TOGGLE: controlSelectors.CAMERA_TOGGLE,
+  INGAME_MIC_TOGGLE: controlSelectors.MIC_TOGGLE,
+  INGAME_LEAVE_BUTTON: controlSelectors.LEAVE_BUTTON,
+} as const;
+
+export type SelectorKey = keyof typeof selectors;


### PR DESCRIPTION
## Summary
- Centralized Meet DOM selectors in `dom-selectors.ts` with a versioned capture date.
- Fixture HTML files for prejoin, in-meeting, and chat surfaces.
- Test verifies every selector resolves against committed fixtures.
- README documents how to refresh fixtures when Meet UI drifts.

Part of plan: meet-phase-1-listen.md (PR 7 of 24)