### PR TITLE
meet-bot: HTTP server with /health, /status, /leave, command stubs

### DIFF
--- a/meet-bot/__tests__/http-server.test.ts
+++ b/meet-bot/__tests__/http-server.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for the meet-bot HTTP control surface.
+ *
+ * The server is started on an ephemeral localhost port (via `start(0)`) for
+ * every test so test cases are fully isolated and safe to run in parallel.
+ * All routes require Bearer auth; unauthorized requests must be rejected
+ * before any body validation runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { createHttpServer, type HttpServerHandle } from "../src/control/http-server.js";
+import { BotState } from "../src/control/state.js";
+
+const API_TOKEN = "test-token-abc";
+
+interface CallbackLog {
+  leaveCalls: Array<string | undefined>;
+  sendChatCalls: string[];
+  playAudioCalls: string[];
+}
+
+function makeServer(overrides: Partial<CallbackLog> = {}): {
+  server: HttpServerHandle;
+  log: CallbackLog;
+} {
+  const log: CallbackLog = {
+    leaveCalls: [],
+    sendChatCalls: [],
+    playAudioCalls: [],
+    ...overrides,
+  };
+  const server = createHttpServer({
+    apiToken: API_TOKEN,
+    onLeave: (reason) => {
+      log.leaveCalls.push(reason);
+    },
+    onSendChat: (text) => {
+      log.sendChatCalls.push(text);
+    },
+    onPlayAudio: (streamId) => {
+      log.playAudioCalls.push(streamId);
+    },
+  });
+  return { server, log };
+}
+
+async function startOnRandomPort(server: HttpServerHandle): Promise<string> {
+  const { port } = await server.start(0);
+  return `http://127.0.0.1:${port}`;
+}
+
+describe("http-server", () => {
+  let server: HttpServerHandle | null = null;
+
+  beforeEach(() => {
+    BotState.__resetForTests();
+  });
+
+  afterEach(async () => {
+    if (server !== null) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // auth middleware
+  // -------------------------------------------------------------------------
+
+  describe("auth", () => {
+    test("rejects requests with no authorization header", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/status`);
+      expect(res.status).toBe(401);
+    });
+
+    test("rejects a malformed authorization header", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/status`, {
+        headers: { authorization: "Basic abc" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("rejects a wrong bearer token", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/status`, {
+        headers: { authorization: "Bearer wrong-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /health
+  // -------------------------------------------------------------------------
+
+  describe("GET /health", () => {
+    test("returns 200 when phase is booting", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/health`, {
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; phase: string };
+      expect(body.ok).toBe(true);
+      expect(body.phase).toBe("booting");
+    });
+
+    test("returns 200 when phase is joined", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+      BotState.setPhase("joined");
+
+      const res = await fetch(`${base}/health`, {
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; phase: string };
+      expect(body.ok).toBe(true);
+      expect(body.phase).toBe("joined");
+    });
+
+    test("returns 503 when phase is error", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+      BotState.setPhase("error");
+
+      const res = await fetch(`${base}/health`, {
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { ok: boolean; phase: string };
+      expect(body.ok).toBe(false);
+      expect(body.phase).toBe("error");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /status
+  // -------------------------------------------------------------------------
+
+  describe("GET /status", () => {
+    test("returns the current snapshot", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+      BotState.setMeeting("meet-xyz");
+      BotState.setPhase("joined");
+
+      const res = await fetch(`${base}/status`, {
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        meetingId: string | null;
+        joinedAt: number | null;
+        phase: string;
+      };
+      expect(body.meetingId).toBe("meet-xyz");
+      expect(body.phase).toBe("joined");
+      expect(typeof body.joinedAt).toBe("number");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /leave
+  // -------------------------------------------------------------------------
+
+  describe("POST /leave", () => {
+    test("accepts a valid leave command and invokes onLeave", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/leave`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "leave", reason: "test done" }),
+      });
+      expect(res.status).toBe(202);
+      // Give the fire-and-forget callback a tick to run.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(instance.log.leaveCalls).toEqual(["test done"]);
+      expect(BotState.snapshot().phase).toBe("leaving");
+    });
+
+    test("accepts a leave with no reason", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/leave`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "leave" }),
+      });
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 10));
+      expect(instance.log.leaveCalls).toEqual([undefined]);
+    });
+
+    test("rejects unauthorized requests before validation", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/leave`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "leave" }),
+      });
+      expect(res.status).toBe(401);
+      expect(instance.log.leaveCalls).toEqual([]);
+      expect(BotState.snapshot().phase).toBe("booting");
+    });
+
+    test("rejects an invalid body with 400", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/leave`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "status" }),
+      });
+      expect(res.status).toBe(400);
+      expect(instance.log.leaveCalls).toEqual([]);
+    });
+
+    test("rejects a non-JSON body with 400", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/leave`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: "not json",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /send_chat (501 stub until Phase 2)
+  // -------------------------------------------------------------------------
+
+  describe("POST /send_chat", () => {
+    test("returns 501 Not Implemented for a valid body", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/send_chat`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "send_chat", text: "hello" }),
+      });
+      expect(res.status).toBe(501);
+    });
+
+    test("validates body shape before returning 501", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/send_chat`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "send_chat", text: "" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("requires auth", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/send_chat`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "send_chat", text: "hi" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /play_audio (501 stub until Phase 3)
+  // -------------------------------------------------------------------------
+
+  describe("POST /play_audio", () => {
+    test("returns 501 Not Implemented", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/play_audio`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ type: "play_audio", streamId: "s-1" }),
+      });
+      expect(res.status).toBe(501);
+    });
+
+    test("requires auth", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/play_audio`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "play_audio", streamId: "s-1" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // lifecycle hardening
+  // -------------------------------------------------------------------------
+
+  describe("server lifecycle", () => {
+    test("start() cannot be called twice on the same instance", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      await server.start(0);
+      await expect(server.start(0)).rejects.toThrow("already started");
+    });
+
+    test("stop() is idempotent", async () => {
+      const instance = makeServer();
+      server = instance.server;
+      await server.start(0);
+      await server.stop();
+      await server.stop();
+    });
+  });
+});

--- a/meet-bot/bun.lock
+++ b/meet-bot/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "@vellumai/meet-bot",
       "dependencies": {
+        "@vellumai/meet-contracts": "file:../packages/meet-contracts",
         "hono": "4.12.14",
         "playwright": "1.58.2",
-        "zod": "3.25.76",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@types/bun": "1.3.9",
@@ -19,6 +20,10 @@
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "@vellumai/meet-contracts": ["@vellumai/meet-contracts@file:../packages/meet-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
@@ -34,6 +39,12 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@vellumai/meet-contracts/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "@vellumai/meet-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "@vellumai/meet-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
   }
 }

--- a/meet-bot/package.json
+++ b/meet-bot/package.json
@@ -12,9 +12,10 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
+    "@vellumai/meet-contracts": "file:../packages/meet-contracts",
     "hono": "4.12.14",
     "playwright": "1.58.2",
-    "zod": "3.25.76"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/bun": "1.3.9",

--- a/meet-bot/src/control/http-server.ts
+++ b/meet-bot/src/control/http-server.ts
@@ -1,0 +1,210 @@
+/**
+ * HTTP control surface for the meet-bot container.
+ *
+ * Exposes a small Hono app that the assistant daemon talks to:
+ *
+ *   - `GET  /health`     — liveness/health probe (also used by Docker HEALTHCHECK).
+ *   - `GET  /status`     — full lifecycle snapshot.
+ *   - `POST /leave`      — ask the bot to leave the meeting.
+ *   - `POST /send_chat`  — post a chat message (Phase 2; stub returns 501 today).
+ *   - `POST /play_audio` — play an out-of-band audio stream (Phase 3; stub 501).
+ *
+ * Every mutating route validates its body against the corresponding Zod
+ * schema from `@vellumai/meet-contracts` so command shapes stay in sync with
+ * the daemon side of the wire protocol.
+ *
+ * Auth: every route (including `/health`, so the probe matches production)
+ * requires a `Authorization: Bearer <token>` header matching the `apiToken`
+ * injected at construction time. The token is provisioned per meeting by the
+ * daemon and passed to the container via environment variable.
+ */
+
+import {
+  LeaveCommandSchema,
+  SendChatCommandSchema,
+} from "@vellumai/meet-contracts";
+import { Hono, type Context } from "hono";
+
+import { BotState } from "./state.js";
+
+/**
+ * Callbacks the HTTP server invokes when commands arrive.
+ *
+ * The server is a thin wiring layer: it validates the incoming payload,
+ * updates the lifecycle phase where appropriate, and delegates the actual
+ * work (driving Playwright, talking to the ASR pipeline, etc.) to these
+ * callbacks. Phases 2 and 3 replace the 501 stubs with real implementations.
+ */
+export interface HttpServerCallbacks {
+  /** Called when `POST /leave` is received and the phase has been flipped. */
+  onLeave: (reason: string | undefined) => Promise<void> | void;
+  /**
+   * Called when `POST /send_chat` is received. Currently a stub — the HTTP
+   * route returns 501 regardless so the daemon can detect that Phase 2 has
+   * not landed yet.
+   */
+  onSendChat: (text: string) => Promise<void> | void;
+  /**
+   * Called when `POST /play_audio` is received. Currently a stub — the HTTP
+   * route returns 501. The real PCM stream is delivered out of band
+   * (chunked transfer in Phase 3); this callback will eventually be handed
+   * just the metadata.
+   */
+  onPlayAudio: (streamId: string) => Promise<void> | void;
+}
+
+export interface CreateHttpServerOptions extends HttpServerCallbacks {
+  /** Bearer token required on every request. */
+  apiToken: string;
+}
+
+export interface HttpServerHandle {
+  /** The underlying Hono app — exposed for tests that want to call `fetch`. */
+  readonly app: Hono;
+  /** Start listening on the given port. Pass `0` to pick a random free port. */
+  start: (port: number) => Promise<{ port: number }>;
+  /** Stop the listener (no-op if never started). */
+  stop: () => Promise<void>;
+}
+
+/** Build (but do not start) the HTTP server. */
+export function createHttpServer(
+  options: CreateHttpServerOptions,
+): HttpServerHandle {
+  const { apiToken, onLeave, onSendChat, onPlayAudio } = options;
+
+  const app = new Hono();
+
+  // -------------------------------------------------------------------------
+  // Auth middleware — applied to every route.
+  // -------------------------------------------------------------------------
+
+  app.use("*", async (c, next) => {
+    const header = c.req.header("authorization");
+    if (!header || !header.startsWith("Bearer ")) {
+      return c.json({ error: "missing or malformed authorization header" }, 401);
+    }
+    const token = header.slice("Bearer ".length).trim();
+    if (token !== apiToken) {
+      return c.json({ error: "invalid token" }, 401);
+    }
+    await next();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /health — 200 unless the bot is in the error phase.
+  // -------------------------------------------------------------------------
+
+  app.get("/health", (c) => {
+    const { phase } = BotState.snapshot();
+    if (phase === "error") {
+      return c.json({ ok: false, phase }, 503);
+    }
+    return c.json({ ok: true, phase }, 200);
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /status — expose the full lifecycle snapshot.
+  // -------------------------------------------------------------------------
+
+  app.get("/status", (c) => {
+    return c.json(BotState.snapshot(), 200);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /leave — transition to "leaving" and delegate.
+  // -------------------------------------------------------------------------
+
+  app.post("/leave", async (c) => {
+    const body = await readJson(c);
+    const parsed = LeaveCommandSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        { error: "invalid body", issues: parsed.error.issues },
+        400,
+      );
+    }
+    BotState.setPhase("leaving");
+    // Kick off the leave in the background — we want to ACK fast.
+    void Promise.resolve(onLeave(parsed.data.reason)).catch(() => {
+      // Swallowing here on purpose; the real main.ts will wire lifecycle
+      // error reporting to this callback.
+    });
+    return c.json({ accepted: true }, 202);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /send_chat — validate now, return 501 until Phase 2 lands.
+  // -------------------------------------------------------------------------
+
+  app.post("/send_chat", async (c) => {
+    const body = await readJson(c);
+    const parsed = SendChatCommandSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        { error: "invalid body", issues: parsed.error.issues },
+        400,
+      );
+    }
+    // Invoke the callback so integration tests can still observe the call;
+    // Phase 2 will change this route to return 200 once the real handler
+    // is wired in.
+    void Promise.resolve(onSendChat(parsed.data.text)).catch(() => {});
+    return c.json({ error: "not implemented" }, 501);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /play_audio — pure stub until Phase 3 lands.
+  // -------------------------------------------------------------------------
+
+  app.post("/play_audio", async (c) => {
+    // We don't validate the body here — the stream metadata shape may still
+    // change when the Phase 3 audio channel lands. The callback is invoked
+    // with a placeholder so its signature can stabilize in tests.
+    void Promise.resolve(onPlayAudio("")).catch(() => {});
+    return c.json({ error: "not implemented" }, 501);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle — Bun's native server as the listener.
+  // -------------------------------------------------------------------------
+
+  let server: ReturnType<typeof Bun.serve> | null = null;
+
+  return {
+    app,
+    async start(port) {
+      if (server !== null) {
+        throw new Error("http-server already started");
+      }
+      server = Bun.serve({
+        hostname: "0.0.0.0",
+        port,
+        fetch: app.fetch,
+      });
+      const boundPort = server.port;
+      if (boundPort === undefined) {
+        throw new Error("http-server failed to bind to a port");
+      }
+      return { port: boundPort };
+    },
+    async stop() {
+      if (server === null) return;
+      await server.stop(true);
+      server = null;
+    },
+  };
+}
+
+/**
+ * Read a JSON body, returning `undefined` when the body is missing or
+ * malformed so downstream schema validation produces a 400 rather than a
+ * 500.
+ */
+async function readJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return undefined;
+  }
+}

--- a/meet-bot/src/control/state.ts
+++ b/meet-bot/src/control/state.ts
@@ -1,0 +1,80 @@
+/**
+ * In-process bot state for the meet-bot control surface.
+ *
+ * The bot is a single-meeting process, so a module-level mutable singleton
+ * is a deliberate (and simple) fit here: the HTTP server, the Playwright
+ * driver, and the lifecycle emitter all read and write the same state.
+ * No persistence — the process is the source of truth for its own lifetime.
+ *
+ * External callers should prefer reading via {@link BotState.snapshot} so
+ * they receive a frozen copy rather than a live reference.
+ */
+
+/** Lifecycle phases the bot can be in. */
+export type BotPhase =
+  | "booting"
+  | "joining"
+  | "joined"
+  | "leaving"
+  | "left"
+  | "error";
+
+/**
+ * Frozen snapshot of the bot's current state.
+ *
+ * The shape is deliberately narrow — richer meeting metadata (participants,
+ * active speaker, etc.) lives elsewhere. This snapshot is just enough for
+ * `/status` and `/health` to answer "where is the bot in its lifecycle?".
+ */
+export interface BotStateSnapshot {
+  readonly meetingId: string | null;
+  readonly joinedAt: number | null;
+  readonly phase: BotPhase;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mutable state.
+// ---------------------------------------------------------------------------
+
+let meetingId: string | null = null;
+let joinedAt: number | null = null;
+let phase: BotPhase = "booting";
+
+/**
+ * Singleton accessor for the bot's lifecycle state.
+ *
+ * Exposed as an object (not a class) so the HTTP server and lifecycle
+ * publisher can share the same mutable state without having to thread a
+ * specific instance around; tests can still reset it via
+ * {@link BotState.__resetForTests}.
+ */
+export const BotState = {
+  /** Transition the bot to a new lifecycle phase. */
+  setPhase(next: BotPhase): void {
+    phase = next;
+    if (next === "joined" && joinedAt === null) {
+      joinedAt = Date.now();
+    }
+  },
+
+  /** Record which meeting the bot is (or was) attached to. */
+  setMeeting(id: string | null): void {
+    meetingId = id;
+  },
+
+  /** Return a frozen copy of the current state. */
+  snapshot(): Readonly<BotStateSnapshot> {
+    return Object.freeze({ meetingId, joinedAt, phase });
+  },
+
+  /**
+   * Reset the singleton to its initial values.
+   *
+   * Intended for tests only — production code should never need this.
+   */
+  __resetForTests(): void {
+    meetingId = null;
+    joinedAt = null;
+    phase = "booting";
+  },
+};

--- a/meet-bot/src/health.ts
+++ b/meet-bot/src/health.ts
@@ -1,10 +1,45 @@
 /**
- * Placeholder health probe for the meet-bot container.
+ * Real health probe for the meet-bot container.
  *
- * Invoked by the Dockerfile's HEALTHCHECK directive. Exits 0 to indicate the
- * container is healthy. The real probe (which will hit an in-process `/health`
- * endpoint served by Hono and confirm Playwright/Xvfb/PulseAudio are up)
- * lands in a later PR of the meet-phase-1 plan.
+ * Invoked by the Dockerfile's HEALTHCHECK directive. Hits the bot's
+ * in-process `/health` endpoint on loopback and exits 0 iff the response
+ * is HTTP 200 with `{ ok: true }`. Any other outcome (non-2xx, body
+ * missing `ok: true`, network error, timeout) exits 1 so Docker marks the
+ * container unhealthy.
+ *
+ * The target port defaults to 3000 (the in-container port the bot binds
+ * to) and can be overridden via `HEALTH_PORT` for local runs.
+ *
+ * This probe deliberately reads its own Bearer token from the
+ * `BOT_API_TOKEN` env — the HTTP server requires auth on every route so
+ * the daemon can trust the control plane even inside the container.
  */
 
-process.exit(0);
+async function main(): Promise<void> {
+  const port = Number(process.env.HEALTH_PORT ?? 3000);
+  const token = process.env.BOT_API_TOKEN ?? "";
+  const url = `http://127.0.0.1:${port}/health`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    if (res.status !== 200) {
+      process.exit(1);
+    }
+    const body = (await res.json().catch(() => null)) as { ok?: unknown } | null;
+    if (!body || body.ok !== true) {
+      process.exit(1);
+    }
+    process.exit(0);
+  } catch {
+    process.exit(1);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- Hono HTTP server exposing `/health`, `/status`, `/leave`, and 501 stubs for `/send_chat`/`/play_audio` (Phases 2/3).
- Bearer-token auth; per-meeting API token enforced via env.
- Real health probe replaces the placeholder in `health.ts` (used by Dockerfile HEALTHCHECK).
- Aligned meet-bot to `zod@4.3.6` + added `@vellumai/meet-contracts` workspace dep so command schemas validate at the boundary.

Part of plan: meet-phase-1-listen.md (PR 8 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
