### PR TITLE
meet: daemon HTTP routes receiving bot events

### DIFF
--- a/assistant/src/meet/__tests__/session-event-router.test.ts
+++ b/assistant/src/meet/__tests__/session-event-router.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the per-meeting event router consumed by the meet ingress
+ * route and downstream subscribers.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import {
+  __resetMeetSessionEventRouterForTests,
+  getMeetSessionEventRouter,
+  MeetSessionEventRouter,
+  setBotApiTokenResolver,
+} from "../session-event-router.js";
+
+function makeLifecycleEvent(
+  meetingId: string,
+  state: "joining" | "joined" | "leaving" | "left" | "error" = "joined",
+): MeetBotEvent {
+  return {
+    type: "lifecycle",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    state,
+  };
+}
+
+describe("MeetSessionEventRouter", () => {
+  let router: MeetSessionEventRouter;
+
+  beforeEach(() => {
+    router = new MeetSessionEventRouter();
+  });
+
+  test("register → dispatch → handler fires", () => {
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    const event = makeLifecycleEvent("m1");
+    router.dispatch("m1", event);
+
+    expect(received).toEqual([event]);
+    expect(router.registeredCount()).toBe(1);
+  });
+
+  test("unregister → dispatch → no-op (log only)", () => {
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+    router.unregister("m1");
+
+    router.dispatch("m1", makeLifecycleEvent("m1"));
+
+    expect(received).toEqual([]);
+    expect(router.registeredCount()).toBe(0);
+  });
+
+  test("dispatch to unregistered meeting is a no-op", () => {
+    // No registration at all — must not throw.
+    router.dispatch("never-registered", makeLifecycleEvent("never-registered"));
+  });
+
+  test("multiple meetings have independent handlers (no cross-talk)", () => {
+    const m1Events: MeetBotEvent[] = [];
+    const m2Events: MeetBotEvent[] = [];
+    router.register("m1", (event) => m1Events.push(event));
+    router.register("m2", (event) => m2Events.push(event));
+
+    const e1 = makeLifecycleEvent("m1", "joining");
+    const e2 = makeLifecycleEvent("m2", "joined");
+    const e3 = makeLifecycleEvent("m1", "leaving");
+
+    router.dispatch("m1", e1);
+    router.dispatch("m2", e2);
+    router.dispatch("m1", e3);
+
+    expect(m1Events).toEqual([e1, e3]);
+    expect(m2Events).toEqual([e2]);
+    expect(router.registeredCount()).toBe(2);
+  });
+
+  test("re-register replaces the prior handler for the same meetingId", () => {
+    const firstEvents: MeetBotEvent[] = [];
+    const secondEvents: MeetBotEvent[] = [];
+
+    router.register("m1", (event) => firstEvents.push(event));
+    router.register("m1", (event) => secondEvents.push(event));
+
+    const event = makeLifecycleEvent("m1");
+    router.dispatch("m1", event);
+
+    expect(firstEvents).toEqual([]);
+    expect(secondEvents).toEqual([event]);
+    expect(router.registeredCount()).toBe(1);
+  });
+
+  test("a thrown handler does not poison the router", () => {
+    router.register("m1", () => {
+      throw new Error("boom");
+    });
+
+    const m2Events: MeetBotEvent[] = [];
+    router.register("m2", (event) => m2Events.push(event));
+
+    // Dispatch to the throwing handler first — must not propagate.
+    router.dispatch("m1", makeLifecycleEvent("m1"));
+
+    const event = makeLifecycleEvent("m2");
+    router.dispatch("m2", event);
+    expect(m2Events).toEqual([event]);
+  });
+
+  test("default bot api token resolver rejects all", () => {
+    expect(router.resolveBotApiToken("anything")).toBeNull();
+  });
+
+  test("installed bot api token resolver is consulted", () => {
+    router.setBotApiTokenResolver((id) => (id === "m1" ? "tok-1" : null));
+
+    expect(router.resolveBotApiToken("m1")).toBe("tok-1");
+    expect(router.resolveBotApiToken("m2")).toBeNull();
+  });
+});
+
+describe("MeetSessionEventRouter singleton + setBotApiTokenResolver export", () => {
+  beforeEach(() => {
+    __resetMeetSessionEventRouterForTests();
+  });
+
+  test("getMeetSessionEventRouter returns the same instance", () => {
+    const a = getMeetSessionEventRouter();
+    const b = getMeetSessionEventRouter();
+    expect(a).toBe(b);
+  });
+
+  test("__resetMeetSessionEventRouterForTests produces a fresh singleton", () => {
+    const a = getMeetSessionEventRouter();
+    __resetMeetSessionEventRouterForTests();
+    const b = getMeetSessionEventRouter();
+    expect(a).not.toBe(b);
+  });
+
+  test("setBotApiTokenResolver installs resolver on the singleton", () => {
+    setBotApiTokenResolver((id) => (id === "live" ? "tok" : null));
+    expect(getMeetSessionEventRouter().resolveBotApiToken("live")).toBe("tok");
+    expect(getMeetSessionEventRouter().resolveBotApiToken("dead")).toBeNull();
+  });
+});

--- a/assistant/src/meet/session-event-router.ts
+++ b/assistant/src/meet/session-event-router.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-meeting event fan-out for the meet-bot → daemon ingress path.
+ *
+ * The meet-bot runs as an assistant-spawned subprocess on localhost and
+ * posts {@link MeetBotEvent} payloads to `POST /v1/internal/meet/:meetingId/events`.
+ * The route handler parses + validates the batch and hands each event off
+ * to this router, which fans the event out to the registered handler for
+ * that `meetingId`.
+ *
+ * Later PRs in the meet-phase-1 plan register handlers here:
+ *   - Conversation bridge (PR 17) — relays transcript/chat to the
+ *     assistant conversation.
+ *   - Storage writer (PR 18) — persists events for audit + replay.
+ *   - Lifecycle listener (PR 19) — reacts to join/leave transitions.
+ *   - Speaker resolver (PR 21) — attributes utterances to participants.
+ *   - Consent monitor (PR 22) — enforces recording consent invariants.
+ *
+ * The router is intentionally simple: one handler per meeting, synchronous
+ * fanout, no buffering. Fan-out *within* a meeting is expected to happen
+ * inside the registered handler (e.g. a single "session" handler that
+ * itself dispatches to the storage writer, bridge, etc.). Keeping the
+ * top-level router 1:1 avoids ordering ambiguity — exactly one
+ * registration, exactly one handler, deterministic dispatch.
+ *
+ * Late events (arriving after `unregister`) are logged and dropped so a
+ * slow in-flight POST from a just-terminated bot session can't explode the
+ * handler graph.
+ */
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("meet-session-event-router");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Callback invoked for every event dispatched to a registered meeting. */
+export type MeetSessionEventHandler = (event: MeetBotEvent) => void;
+
+/**
+ * Resolver that returns the bot API token for a given `meetingId`, or
+ * `null` when no active session exists for that id.
+ *
+ * The default resolver rejects all requests (returns `null`). PR 10 wires
+ * the real resolver from the session manager so only live meetings can
+ * accept bot events.
+ */
+export type BotApiTokenResolver = (meetingId: string) => string | null;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Fans meet-bot events out to per-meeting handlers.
+ *
+ * Singleton access is via {@link getMeetSessionEventRouter}. Tests should
+ * use {@link __resetMeetSessionEventRouterForTests} to start each test
+ * with a clean router.
+ */
+export class MeetSessionEventRouter {
+  private readonly handlers = new Map<string, MeetSessionEventHandler>();
+  private resolveBotApiTokenImpl: BotApiTokenResolver = () => null;
+
+  /**
+   * Register a handler for a meeting. Overwrites any existing handler
+   * for the same `meetingId`; callers are expected to pair `register`
+   * and `unregister` on the session lifecycle, so a double-register is
+   * treated as "replace" (logged at warn level so it's observable).
+   */
+  register(meetingId: string, handler: MeetSessionEventHandler): void {
+    if (this.handlers.has(meetingId)) {
+      log.warn(
+        { meetingId },
+        "MeetSessionEventRouter: overwriting existing handler registration",
+      );
+    }
+    this.handlers.set(meetingId, handler);
+  }
+
+  /**
+   * Remove the handler for a meeting, if any. Subsequent dispatches for
+   * this meeting log-and-drop until a new handler is registered.
+   */
+  unregister(meetingId: string): void {
+    this.handlers.delete(meetingId);
+  }
+
+  /**
+   * Dispatch an event to the registered handler for `meetingId`.
+   *
+   * If no handler is registered (e.g. the session was unregistered
+   * while an in-flight POST was still queued), the event is logged at
+   * info level and dropped. Handler errors are caught and logged so
+   * one handler failure cannot poison the dispatch loop.
+   */
+  dispatch(meetingId: string, event: MeetBotEvent): void {
+    const handler = this.handlers.get(meetingId);
+    if (!handler) {
+      log.info(
+        { meetingId, eventType: event.type },
+        "MeetSessionEventRouter: dropping event for unregistered meeting",
+      );
+      return;
+    }
+    try {
+      handler(event);
+    } catch (err) {
+      log.error(
+        { err, meetingId, eventType: event.type },
+        "MeetSessionEventRouter: handler threw",
+      );
+    }
+  }
+
+  /**
+   * Look up the bearer token a bot must present to post events for this
+   * meeting. Returns `null` when no active session exists — the ingress
+   * route uses this to reject 401 on stale/unknown meeting ids.
+   */
+  resolveBotApiToken(meetingId: string): string | null {
+    return this.resolveBotApiTokenImpl(meetingId);
+  }
+
+  /**
+   * Install the resolver used by {@link resolveBotApiToken}. Called once
+   * at daemon boot by the session manager (PR 10). The default resolver
+   * rejects every request.
+   */
+  setBotApiTokenResolver(resolver: BotApiTokenResolver): void {
+    this.resolveBotApiTokenImpl = resolver;
+  }
+
+  /** Number of currently registered meetings. Exposed for tests. */
+  registeredCount(): number {
+    return this.handlers.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton (matches the style of `ChromeExtensionRegistry` / `assistantEventHub`)
+// ---------------------------------------------------------------------------
+
+let instance: MeetSessionEventRouter | null = null;
+
+/**
+ * Process-level singleton router shared by the ingress route, the session
+ * manager, and all event subscribers.
+ */
+export function getMeetSessionEventRouter(): MeetSessionEventRouter {
+  if (!instance) instance = new MeetSessionEventRouter();
+  return instance;
+}
+
+/**
+ * Install the bot API token resolver on the module singleton. Shortcut for
+ * `getMeetSessionEventRouter().setBotApiTokenResolver(resolver)`; exported
+ * so PR 10's session manager can wire the resolver without importing the
+ * router class directly.
+ */
+export function setBotApiTokenResolver(resolver: BotApiTokenResolver): void {
+  getMeetSessionEventRouter().setBotApiTokenResolver(resolver);
+}
+
+/**
+ * Test helper: reset the module-level singleton so each test starts with
+ * a fresh router. Production code never calls this.
+ */
+export function __resetMeetSessionEventRouterForTests(): void {
+  instance = null;
+}

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -66,6 +66,7 @@ describe("route policy coverage", () => {
       "browser-extension-pair-routes.ts",
       "guardian-bootstrap-routes.ts",
       "guardian-refresh-routes.ts",
+      "meet-internal.ts",
     ]);
     const allSources = [httpServerSrc];
     try {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -194,6 +194,10 @@ import { twilioRouteDefinitions } from "./routes/integrations/twilio.js";
 import { vercelRouteDefinitions } from "./routes/integrations/vercel.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { logExportRouteDefinitions } from "./routes/log-export-routes.js";
+import {
+  handleMeetInternalEvents,
+  MEET_INTERNAL_EVENTS_PATH_RE,
+} from "./routes/meet-internal.js";
 import { memoryItemRouteDefinitions } from "./routes/memory-item-routes.js";
 import { migrationRollbackRouteDefinitions } from "./routes/migration-rollback-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
@@ -1058,6 +1062,29 @@ export class RuntimeHttpServer {
     }
     if (path === "/v1/guardian/refresh" && req.method === "POST") {
       return await handleGuardianRefresh(req);
+    }
+
+    // Meet-bot event ingress (subprocess → daemon). Handled before JWT
+    // auth because the bot presents a per-meeting bearer token minted by
+    // the session manager, not a daemon-minted JWT. The route handler
+    // validates the token against `MeetSessionEventRouter.resolveBotApiToken`
+    // — see the comment block in `routes/meet-internal.ts` explaining why
+    // this endpoint does not violate CLAUDE.md's "No New Daemon HTTP Port
+    // Consumers" rule (the bot is an assistant-spawned subprocess, not an
+    // out-of-process CLI tool or sibling service).
+    const meetInternalMatch = path.match(MEET_INTERNAL_EVENTS_PATH_RE);
+    if (meetInternalMatch && req.method === "POST") {
+      let meetingId: string;
+      try {
+        meetingId = decodeURIComponent(meetInternalMatch[1]);
+      } catch {
+        return httpError(
+          "BAD_REQUEST",
+          "Malformed percent-encoding in URL path parameter",
+          400,
+        );
+      }
+      return await handleMeetInternalEvents(req, meetingId);
     }
 
     // JWT bearer authentication — replaces the old shared-secret comparison.

--- a/assistant/src/runtime/routes/__tests__/meet-internal.test.ts
+++ b/assistant/src/runtime/routes/__tests__/meet-internal.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for the `/v1/internal/meet/:meetingId/events` ingress handler.
+ *
+ * The handler function is invoked directly against a real
+ * `MeetSessionEventRouter` wired with a synchronous test token resolver.
+ * This matches the style of other inline-dispatched pre-auth routes
+ * (e.g. `handleBrowserExtensionPair`) — simpler and faster than standing
+ * up the full HTTP server.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import { MeetSessionEventRouter } from "../../../meet/session-event-router.js";
+import { handleMeetInternalEvents } from "../meet-internal.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRequest(
+  meetingId: string,
+  {
+    method = "POST",
+    bearer,
+    body,
+    rawBody,
+  }: {
+    method?: string;
+    bearer?: string | null;
+    body?: unknown;
+    rawBody?: string;
+  } = {},
+): Request {
+  const headers = new Headers();
+  if (bearer !== undefined && bearer !== null) {
+    headers.set("authorization", `Bearer ${bearer}`);
+  }
+  let bodyStr: string | undefined;
+  if (rawBody !== undefined) {
+    bodyStr = rawBody;
+    headers.set("content-type", "application/json");
+  } else if (body !== undefined) {
+    bodyStr = JSON.stringify(body);
+    headers.set("content-type", "application/json");
+  }
+  return new Request(
+    `http://127.0.0.1:8765/v1/internal/meet/${encodeURIComponent(
+      meetingId,
+    )}/events`,
+    { method, headers, body: bodyStr },
+  );
+}
+
+function makeRouterWithToken(
+  meetingId: string,
+  token: string,
+): { router: MeetSessionEventRouter; seen: Map<string, MeetBotEvent[]> } {
+  const router = new MeetSessionEventRouter();
+  router.setBotApiTokenResolver((id) => (id === meetingId ? token : null));
+  const seen = new Map<string, MeetBotEvent[]>();
+  return { router, seen };
+}
+
+function transcriptEvent(
+  meetingId: string,
+  text: string,
+  isFinal = true,
+): MeetBotEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    isFinal,
+    text,
+  };
+}
+
+function lifecycleEvent(meetingId: string): MeetBotEvent {
+  return {
+    type: "lifecycle",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    state: "joined",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleMeetInternalEvents — auth", () => {
+  test("no active session for meetingId → 401", async () => {
+    const router = new MeetSessionEventRouter();
+    // Default resolver rejects all.
+    const req = buildRequest("m1", {
+      bearer: "anything",
+      body: [lifecycleEvent("m1")],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  test("missing Authorization header → 401", async () => {
+    const { router } = makeRouterWithToken("m1", "secret");
+    const req = buildRequest("m1", { body: [lifecycleEvent("m1")] });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(401);
+  });
+
+  test("wrong bearer token → 401", async () => {
+    const { router } = makeRouterWithToken("m1", "secret");
+    const req = buildRequest("m1", {
+      bearer: "not-the-real-one",
+      body: [lifecycleEvent("m1")],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(401);
+  });
+
+  test("non-Bearer Authorization scheme → 401", async () => {
+    const { router } = makeRouterWithToken("m1", "secret");
+    const req = new Request("http://127.0.0.1/v1/internal/meet/m1/events", {
+      method: "POST",
+      headers: {
+        authorization: "Basic c2VjcmV0Og==",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify([lifecycleEvent("m1")]),
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("handleMeetInternalEvents — success path", () => {
+  test("valid batch → 204, each event dispatched", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver((id) => (id === "m1" ? "tok-1" : null));
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    const batch: MeetBotEvent[] = [
+      lifecycleEvent("m1"),
+      transcriptEvent("m1", "hello"),
+      transcriptEvent("m1", "world", false),
+    ];
+    const req = buildRequest("m1", { bearer: "tok-1", body: batch });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(204);
+    expect(received).toEqual(batch);
+  });
+
+  test("empty batch → 204, no dispatches", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver(() => "tok-1");
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    const req = buildRequest("m1", { bearer: "tok-1", body: [] });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(204);
+    expect(received).toEqual([]);
+  });
+
+  test("valid batch with no registered handler → 204, events drop", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver(() => "tok-1");
+    // No register() call — dispatch is a no-op by design.
+
+    const req = buildRequest("m1", {
+      bearer: "tok-1",
+      body: [lifecycleEvent("m1")],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(204);
+  });
+
+  test("bearer with surrounding whitespace still matches", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver(() => "tok-1");
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    const req = new Request("http://127.0.0.1/v1/internal/meet/m1/events", {
+      method: "POST",
+      headers: {
+        authorization: "  Bearer   tok-1  ",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify([lifecycleEvent("m1")]),
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(204);
+    expect(received).toHaveLength(1);
+  });
+});
+
+describe("handleMeetInternalEvents — body validation", () => {
+  test("malformed JSON → 400", async () => {
+    const { router } = makeRouterWithToken("m1", "tok");
+    const req = buildRequest("m1", { bearer: "tok", rawBody: "not-json{" });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("body that is not an array → 400", async () => {
+    const { router } = makeRouterWithToken("m1", "tok");
+    const req = buildRequest("m1", {
+      bearer: "tok",
+      body: { not: "an array" },
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown event `type` → 400", async () => {
+    const { router } = makeRouterWithToken("m1", "tok");
+    const req = buildRequest("m1", {
+      bearer: "tok",
+      body: [
+        {
+          type: "mystery.event",
+          meetingId: "m1",
+          timestamp: new Date(0).toISOString(),
+        },
+      ],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+  });
+
+  test("transcript.chunk missing required `text` → 400", async () => {
+    const { router } = makeRouterWithToken("m1", "tok");
+    const req = buildRequest("m1", {
+      bearer: "tok",
+      body: [
+        {
+          type: "transcript.chunk",
+          meetingId: "m1",
+          timestamp: new Date(0).toISOString(),
+          isFinal: true,
+          // text omitted
+        },
+      ],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+  });
+
+  test("one invalid event in an otherwise-valid batch fails the whole batch", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver(() => "tok");
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    const req = buildRequest("m1", {
+      bearer: "tok",
+      body: [
+        lifecycleEvent("m1"),
+        { type: "not.a.real.type", meetingId: "m1", timestamp: "t" },
+      ],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+    // Importantly: the valid event was NOT dispatched — we reject the
+    // batch atomically to avoid leaking a partial event stream.
+    expect(received).toEqual([]);
+  });
+
+  test("event meetingId mismatch with path → 400, atomic reject (no dispatch)", async () => {
+    const router = new MeetSessionEventRouter();
+    router.setBotApiTokenResolver(() => "tok");
+    const received: MeetBotEvent[] = [];
+    router.register("m1", (event) => received.push(event));
+
+    // Register an m2 handler too, to make sure cross-routing is prevented.
+    const m2Events: MeetBotEvent[] = [];
+    router.register("m2", (event) => m2Events.push(event));
+
+    const req = buildRequest("m1", {
+      bearer: "tok",
+      body: [lifecycleEvent("m1"), lifecycleEvent("m2")],
+    });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(400);
+    // Atomic rejection: a mid-batch mismatch aborts the whole batch and
+    // no events are dispatched — neither the prior valid event nor
+    // anything after. This matches the schema-validation behavior.
+    expect(received).toEqual([]);
+    expect(m2Events).toEqual([]);
+  });
+});
+
+describe("handleMeetInternalEvents — method enforcement", () => {
+  test("GET → 405 with Allow: POST", async () => {
+    const { router } = makeRouterWithToken("m1", "tok");
+    const req = buildRequest("m1", { method: "GET", bearer: "tok" });
+
+    const res = await handleMeetInternalEvents(req, "m1", router);
+
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("POST");
+  });
+});

--- a/assistant/src/runtime/routes/meet-internal.ts
+++ b/assistant/src/runtime/routes/meet-internal.ts
@@ -1,0 +1,191 @@
+/**
+ * HTTP route handler for meet-bot → daemon event ingress.
+ *
+ * Serves `POST /v1/internal/meet/:meetingId/events`.
+ *
+ * The request body is a batched JSON array of {@link MeetBotEvent} values.
+ * Every event is validated with the Zod discriminated union schema from
+ * `@vellumai/meet-contracts`; one invalid entry fails the entire batch
+ * with 400 (mirrors how `meet-contracts` models the wire protocol as a
+ * union — partial acceptance would leak an inconsistent event stream to
+ * downstream subscribers).
+ *
+ * Auth: `Authorization: Bearer <token>`, where `<token>` matches
+ * {@link MeetSessionEventRouter.resolveBotApiToken} for the path's
+ * `meetingId`. If the resolver returns `null` (no active session for this
+ * id) or the token does not match, the route returns 401.
+ *
+ * ── Why this is NOT a "new daemon HTTP port consumer" ──
+ *
+ * CLAUDE.md's "No New Daemon HTTP Port Consumers" rule forbids adding new
+ * callers of the daemon's internal HTTP port from CLI commands or other
+ * out-of-process code that could use the in-process service/store layer
+ * directly.
+ *
+ * The meet-bot is neither of those. It is a subprocess spawned *by the
+ * assistant daemon itself* to join a conference call, and it runs in its
+ * own Docker container (or on the same host in local mode). It is, by
+ * construction, out-of-process — there is no in-process alternative to
+ * route its events through. Its lifecycle is bounded by the daemon that
+ * launched it, and it only talks to localhost (or the sibling container
+ * over a private bridge).
+ *
+ * Treat this as an "assistant-spawned subprocess ingress" endpoint — the
+ * same category as Twilio's voice webhook bridge or the STT streaming
+ * relay, not the category the rule is guarding against (external CLI
+ * tools or sibling services calling the daemon HTTP API).
+ */
+
+import { timingSafeEqual } from "node:crypto";
+
+import { MeetBotEventSchema } from "@vellumai/meet-contracts";
+import { z } from "zod";
+
+import {
+  getMeetSessionEventRouter,
+  type MeetSessionEventRouter,
+} from "../../meet/session-event-router.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+
+const log = getLogger("meet-internal-routes");
+
+/**
+ * Batched-event request body. The bot buffers events briefly and ships
+ * them in small arrays to amortize TLS / HTTP overhead.
+ */
+export const MeetIngressBatchSchema = z.array(MeetBotEventSchema);
+export type MeetIngressBatch = z.infer<typeof MeetIngressBatchSchema>;
+
+/**
+ * Handle `POST /v1/internal/meet/:meetingId/events`.
+ *
+ * Responsibilities:
+ *   1. Decode body as `MeetBotEvent[]`. Return 400 on invalid JSON or any
+ *      schema violation in the batch.
+ *   2. Authenticate the bearer token against the resolver using a
+ *      constant-time comparison. 401 on any mismatch.
+ *   3. Dispatch each validated event to the registered session handler.
+ *   4. Return 204 on success.
+ */
+export async function handleMeetInternalEvents(
+  req: Request,
+  meetingId: string,
+  router: MeetSessionEventRouter = getMeetSessionEventRouter(),
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  // ── Auth ─────────────────────────────────────────────────────────────
+  const expectedToken = router.resolveBotApiToken(meetingId);
+  if (!expectedToken) {
+    log.warn(
+      { meetingId },
+      "meet-internal: no active session for meetingId; rejecting",
+    );
+    return httpError("UNAUTHORIZED", "unauthorized", 401);
+  }
+
+  const presented = parseBearerToken(req.headers.get("authorization"));
+  if (!presented || !tokensMatch(presented, expectedToken)) {
+    log.warn(
+      { meetingId, tokenPresented: presented !== null },
+      "meet-internal: bearer token mismatch; rejecting",
+    );
+    return httpError("UNAUTHORIZED", "unauthorized", 401);
+  }
+
+  // ── Body parse ───────────────────────────────────────────────────────
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch {
+    return httpError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  const parsed = MeetIngressBatchSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    log.warn(
+      { meetingId, issues: parsed.error.issues },
+      "meet-internal: invalid event batch",
+    );
+    return httpError(
+      "BAD_REQUEST",
+      "invalid event batch",
+      400,
+      parsed.error.issues,
+    );
+  }
+
+  // ── Cross-field validation ───────────────────────────────────────────
+  // Defensive: the bot could post a batch tagged for a different
+  // meetingId than the path segment. Pre-scan the whole batch and
+  // reject atomically — matches the schema-validation behavior so
+  // downstream subscribers never see a partial stream from a mixed
+  // batch. The bot's session is pinned to exactly one meeting, so any
+  // mismatch is a protocol violation.
+  for (const event of parsed.data) {
+    if (event.meetingId !== meetingId) {
+      log.warn(
+        {
+          pathMeetingId: meetingId,
+          eventMeetingId: event.meetingId,
+          eventType: event.type,
+        },
+        "meet-internal: event meetingId does not match path",
+      );
+      return httpError(
+        "BAD_REQUEST",
+        "event meetingId does not match path",
+        400,
+      );
+    }
+  }
+
+  // ── Dispatch ─────────────────────────────────────────────────────────
+  for (const event of parsed.data) {
+    router.dispatch(meetingId, event);
+  }
+
+  return new Response(null, { status: 204 });
+}
+
+/**
+ * Extract the token from an `Authorization: Bearer <token>` header.
+ * Returns `null` when the header is missing, malformed, or uses a
+ * non-Bearer scheme. The scheme match is case-insensitive to match
+ * RFC 7235.
+ */
+function parseBearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = header.match(/^\s*Bearer\s+(\S+)\s*$/i);
+  if (!match) return null;
+  return match[1];
+}
+
+/**
+ * Constant-time token comparison. `timingSafeEqual` requires equal-length
+ * inputs, so we bail to `false` on a length mismatch. That length check
+ * itself leaks one bit (the expected length) but the expected value is
+ * server-minted and not attacker-chosen, so the leak is bounded and
+ * acceptable. This matches how `token-service.ts` compares credentials.
+ */
+function tokensMatch(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Regex used by the http-server router to match the ingress path and
+ * extract `meetingId`. Exported so the server-side matcher and tests stay
+ * in sync with a single definition. Matches (URL-encoded) `meetingId`
+ * values that contain no `/`.
+ */
+export const MEET_INTERNAL_EVENTS_PATH_RE =
+  /^\/v1\/internal\/meet\/([^/]+)\/events$/;


### PR DESCRIPTION
## Summary
- Adds `MeetSessionEventRouter` singleton for per-meeting event fan-out.
- New `POST /internal/meet/:meetingId/events` route validates batch + bearer auth and dispatches to registered handlers.
- Comment cites CLAUDE.md's 'No New Daemon HTTP Port Consumers' rule and explains scope (subprocess-only, localhost).

Part of plan: meet-phase-1-listen.md (PR 9 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
