### PR TITLE
ci: install meet-contracts deps in assistant CI workflows

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -40,7 +40,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -76,7 +78,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -112,7 +116,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -44,7 +44,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -83,7 +85,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -119,7 +123,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install linked package dependencies
-        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../meet-contracts && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts


### PR DESCRIPTION
## Summary
- Add \`bun install\` for \`packages/meet-contracts\` alongside the existing \`packages/ces-contracts\` install in both \`pr-assistant.yaml\` and \`ci-main-assistant.yaml\` (lint, typecheck, and test jobs).
- Fixes the Type Check failure on main caused by tsc not finding \`zod\` when resolving through the linked \`@vellumai/meet-contracts\` package.

## Original prompt
\`--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24442314917/job/71410029728\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
