### PR TITLE
meet: MeetSessionManager spawning bot containers via Docker Engine API

### DIFF
--- a/assistant/src/meet/__tests__/docker-runner.test.ts
+++ b/assistant/src/meet/__tests__/docker-runner.test.ts
@@ -1,0 +1,401 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  buildCreateBody,
+  DockerApiError,
+  DockerRunner,
+  extractBoundPorts,
+} from "../docker-runner.js";
+
+// ---------------------------------------------------------------------------
+// Mock Docker Engine — a real HTTP server bound to a temporary unix socket
+// ---------------------------------------------------------------------------
+//
+// The runner uses Node's `http.request({ socketPath })`. The cleanest way to
+// exercise it is to stand up an actual HTTP server on a unix socket and
+// script the responses. This avoids brittle module-level mocking and keeps
+// the tests' intent readable.
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface QueuedResponse {
+  status: number;
+  body: string | object | null;
+}
+
+interface MockDocker {
+  socketPath: string;
+  captured: CapturedRequest[];
+  queueResponse(res: QueuedResponse): void;
+  close(): Promise<void>;
+}
+
+let tempDir: string;
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "docker-runner-test-"));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function startMockDocker(): Promise<MockDocker> {
+  const captured: CapturedRequest[] = [];
+  const queue: QueuedResponse[] = [];
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      captured.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        body: Buffer.concat(chunks).toString("utf8"),
+      });
+      const queued = queue.shift() ?? { status: 500, body: "no response queued" };
+      const serialized =
+        queued.body === null
+          ? ""
+          : typeof queued.body === "string"
+            ? queued.body
+            : JSON.stringify(queued.body);
+      res.writeHead(queued.status, {
+        "Content-Type":
+          typeof queued.body === "object" && queued.body !== null
+            ? "application/json"
+            : "text/plain",
+      });
+      res.end(serialized);
+    });
+  });
+
+  // Use a short socket path — unix sockets cap out around 104 bytes on macOS.
+  const socketPath = join(tempDir, `docker-${Math.random().toString(36).slice(2)}.sock`);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    socketPath,
+    captured,
+    queueResponse: (r) => queue.push(r),
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DockerRunner.run", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("POSTs create body, starts container, returns container id + bound ports", async () => {
+    mock = await startMockDocker();
+
+    // /containers/create
+    mock.queueResponse({ status: 201, body: { Id: "abc123", Warnings: [] } });
+    // /containers/abc123/start
+    mock.queueResponse({ status: 204, body: null });
+    // /containers/abc123/json
+    mock.queueResponse({
+      status: 200,
+      body: {
+        Id: "abc123",
+        State: { Running: true, Status: "running", ExitCode: 0 },
+        NetworkSettings: {
+          Ports: {
+            "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "49160" }],
+          },
+        },
+      },
+    });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.run({
+      image: "vellum-meet-bot:dev",
+      env: { FOO: "bar", BAZ: "qux" },
+      binds: [
+        { hostPath: "/host/sockets", containerPath: "/sockets" },
+        {
+          hostPath: "/host/out",
+          containerPath: "/out",
+          readOnly: true,
+        },
+      ],
+      ports: [
+        {
+          hostIp: "127.0.0.1",
+          hostPort: 0,
+          containerPort: 3000,
+          protocol: "tcp",
+        },
+      ],
+      name: "vellum-meet-m1",
+      network: "bridge",
+    });
+
+    expect(result.containerId).toBe("abc123");
+    expect(result.boundPorts).toEqual([
+      {
+        protocol: "tcp",
+        containerPort: 3000,
+        hostIp: "127.0.0.1",
+        hostPort: 49160,
+      },
+    ]);
+
+    // Verify the request sequence the runner issued.
+    expect(mock.captured).toHaveLength(3);
+
+    const [create, start, inspect] = mock.captured;
+
+    expect(create.method).toBe("POST");
+    expect(create.url).toContain("/containers/create");
+    expect(create.url).toContain("name=vellum-meet-m1");
+    const createBody = JSON.parse(create.body);
+    expect(createBody.Image).toBe("vellum-meet-bot:dev");
+    expect(createBody.Env).toContain("FOO=bar");
+    expect(createBody.Env).toContain("BAZ=qux");
+    expect(createBody.HostConfig.Binds).toEqual([
+      "/host/sockets:/sockets",
+      "/host/out:/out:ro",
+    ]);
+    expect(createBody.HostConfig.PortBindings["3000/tcp"]).toEqual([
+      { HostIp: "127.0.0.1", HostPort: "0" },
+    ]);
+    expect(createBody.ExposedPorts["3000/tcp"]).toEqual({});
+    expect(createBody.HostConfig.NetworkMode).toBe("bridge");
+
+    expect(start.method).toBe("POST");
+    expect(start.url).toContain("/containers/abc123/start");
+
+    expect(inspect.method).toBe("GET");
+    expect(inspect.url).toContain("/containers/abc123/json");
+  });
+
+  test("omits name query param when no name is supplied", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 201, body: { Id: "noname" } });
+    mock.queueResponse({ status: 204, body: null });
+    mock.queueResponse({
+      status: 200,
+      body: { Id: "noname", NetworkSettings: { Ports: {} } },
+    });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.run({ image: "whatever:latest" });
+    expect(result.containerId).toBe("noname");
+    expect(result.boundPorts).toEqual([]);
+
+    const [create] = mock.captured;
+    expect(create.url).not.toContain("name=");
+  });
+
+  test("removes container when start fails", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 201, body: { Id: "fail1" } });
+    mock.queueResponse({ status: 500, body: "boom" });
+    // Cleanup: remove
+    mock.queueResponse({ status: 204, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.run({ image: "x:y" })).rejects.toThrow(DockerApiError);
+
+    // Create + start + cleanup remove = 3 calls.
+    expect(mock.captured).toHaveLength(3);
+    expect(mock.captured[2].method).toBe("DELETE");
+    expect(mock.captured[2].url).toContain("/containers/fail1");
+  });
+});
+
+describe("DockerRunner.stop", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("issues POST /containers/<id>/stop with timeout query", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 204, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await runner.stop("cid", 7);
+
+    expect(mock.captured).toHaveLength(1);
+    expect(mock.captured[0].method).toBe("POST");
+    expect(mock.captured[0].url).toContain("/containers/cid/stop");
+    expect(mock.captured[0].url).toContain("t=7");
+  });
+
+  test("treats 304 (already stopped) as success", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 304, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.stop("cid")).resolves.toBeUndefined();
+  });
+
+  test("propagates non-304 errors", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 500, body: "engine down" });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.stop("cid")).rejects.toThrow(DockerApiError);
+  });
+});
+
+describe("DockerRunner.remove", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("issues DELETE /containers/<id>?force=true&v=true", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 204, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await runner.remove("cid");
+
+    expect(mock.captured).toHaveLength(1);
+    expect(mock.captured[0].method).toBe("DELETE");
+    expect(mock.captured[0].url).toContain("/containers/cid");
+    expect(mock.captured[0].url).toContain("force=true");
+    expect(mock.captured[0].url).toContain("v=true");
+  });
+
+  test("treats 404 (already gone) as success", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 404, body: "no such container" });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.remove("cid")).resolves.toBeUndefined();
+  });
+});
+
+describe("DockerRunner.inspect", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("issues GET /containers/<id>/json and parses response", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({
+      status: 200,
+      body: { Id: "cid", State: { Running: true } },
+    });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.inspect("cid");
+
+    expect(result.Id).toBe("cid");
+    expect(result.State?.Running).toBe(true);
+    expect(mock.captured[0].method).toBe("GET");
+    expect(mock.captured[0].url).toContain("/containers/cid/json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper-function unit tests
+// ---------------------------------------------------------------------------
+
+describe("buildCreateBody", () => {
+  test("serializes env + binds + ports + network", () => {
+    const body = buildCreateBody({
+      image: "foo:bar",
+      env: { A: "1", B: "two" },
+      binds: [
+        { hostPath: "/h", containerPath: "/c" },
+        { hostPath: "/h2", containerPath: "/c2", readOnly: true },
+      ],
+      ports: [
+        { hostIp: "127.0.0.1", hostPort: 0, containerPort: 3000 },
+        {
+          hostIp: "0.0.0.0",
+          hostPort: 9000,
+          containerPort: 9000,
+          protocol: "udp",
+        },
+      ],
+      network: "host",
+    });
+    expect(body.Image).toBe("foo:bar");
+    expect(body.Env).toEqual(["A=1", "B=two"]);
+    expect(body.ExposedPorts).toEqual({
+      "3000/tcp": {},
+      "9000/udp": {},
+    });
+    const hc = body.HostConfig as Record<string, unknown>;
+    expect(hc.Binds).toEqual(["/h:/c", "/h2:/c2:ro"]);
+    expect(hc.NetworkMode).toBe("host");
+    expect(hc.PortBindings).toEqual({
+      "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
+      "9000/udp": [{ HostIp: "0.0.0.0", HostPort: "9000" }],
+    });
+  });
+});
+
+describe("extractBoundPorts", () => {
+  test("flattens NetworkSettings.Ports into a typed list", () => {
+    const ports = extractBoundPorts({
+      Id: "x",
+      NetworkSettings: {
+        Ports: {
+          "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "49152" }],
+          "80/tcp": null, // declared but unbound — skip
+          "9000/udp": [{ HostIp: "0.0.0.0", HostPort: "9000" }],
+        },
+      },
+    });
+    expect(ports).toEqual([
+      {
+        protocol: "tcp",
+        containerPort: 3000,
+        hostIp: "127.0.0.1",
+        hostPort: 49152,
+      },
+      {
+        protocol: "udp",
+        containerPort: 9000,
+        hostIp: "0.0.0.0",
+        hostPort: 9000,
+      },
+    ]);
+  });
+
+  test("returns empty list when NetworkSettings is absent", () => {
+    expect(extractBoundPorts({ Id: "x" })).toEqual([]);
+  });
+});

--- a/assistant/src/meet/__tests__/session-manager.test.ts
+++ b/assistant/src/meet/__tests__/session-manager.test.ts
@@ -1,0 +1,438 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import {
+  __resetMeetSessionEventRouterForTests,
+  getMeetSessionEventRouter,
+} from "../session-event-router.js";
+import {
+  _createMeetSessionManagerForTests,
+  BOT_LEAVE_HTTP_TIMEOUT_MS,
+  MEET_BOT_INTERNAL_PORT,
+} from "../session-manager.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+interface MockRunner {
+  run: ReturnType<typeof mock>;
+  stop: ReturnType<typeof mock>;
+  remove: ReturnType<typeof mock>;
+  inspect: ReturnType<typeof mock>;
+}
+
+function makeMockRunner(
+  overrides: {
+    runResult?: { containerId: string; boundPorts: Array<{ protocol: "tcp" | "udp"; containerPort: number; hostIp: string; hostPort: number }> };
+    runError?: unknown;
+  } = {},
+): MockRunner {
+  const runResult = overrides.runResult ?? {
+    containerId: "container-123",
+    boundPorts: [
+      {
+        protocol: "tcp" as const,
+        containerPort: MEET_BOT_INTERNAL_PORT,
+        hostIp: "127.0.0.1",
+        hostPort: 49200,
+      },
+    ],
+  };
+
+  return {
+    run: mock(async () => {
+      if (overrides.runError) throw overrides.runError;
+      return runResult;
+    }),
+    stop: mock(async () => {}),
+    remove: mock(async () => {}),
+    inspect: mock(async () => ({ Id: runResult.containerId })),
+  };
+}
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "session-manager-test-"));
+  __resetMeetSessionEventRouterForTests();
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// join()
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager.join", () => {
+  test("generates BOT_API_TOKEN, creates sockets dir, registers router, spawns container", async () => {
+    const runner = makeMockRunner();
+    const getProviderKey = mock(async (provider: string) => {
+      if (provider === "deepgram") return "deepgram-secret";
+      if (provider === "tts") return "tts-secret";
+      return undefined;
+    });
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey,
+      resolveDaemonUrl: () => "http://host.docker.internal:7821",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+    });
+
+    const session = await manager.join({
+      url: "https://meet.google.com/xyz-abc-def",
+      meetingId: "m1",
+      conversationId: "conv-1",
+    });
+
+    // Per-meeting token is 64 hex chars.
+    expect(session.botApiToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(session.containerId).toBe("container-123");
+    expect(session.botBaseUrl).toBe("http://127.0.0.1:49200");
+    expect(session.joinTimeoutMs).toBeGreaterThan(0);
+
+    // Workspace directories created.
+    expect(existsSync(join(workspaceDir, "meets", "m1", "sockets"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "meets", "m1", "out"))).toBe(true);
+
+    // Event router registered a handler for this meeting.
+    expect(getMeetSessionEventRouter().registeredCount()).toBe(1);
+    expect(getMeetSessionEventRouter().resolveBotApiToken("m1")).toBe(
+      session.botApiToken,
+    );
+
+    // Credentials resolved.
+    expect(getProviderKey).toHaveBeenCalledWith("deepgram");
+    expect(getProviderKey).toHaveBeenCalledWith("tts");
+
+    // Runner invoked with the expected env/binds/ports/name/network.
+    expect(runner.run).toHaveBeenCalledTimes(1);
+    const runOpts = runner.run.mock.calls[0][0] as {
+      image: string;
+      env: Record<string, string>;
+      binds: Array<{ hostPath: string; containerPath: string }>;
+      ports: Array<{ hostIp: string; hostPort: number; containerPort: number; protocol: string }>;
+      name: string;
+      network: string;
+    };
+    expect(runOpts.image).toBe("vellum-meet-bot:dev");
+    expect(runOpts.env.MEET_URL).toBe("https://meet.google.com/xyz-abc-def");
+    expect(runOpts.env.MEETING_ID).toBe("m1");
+    expect(runOpts.env.JOIN_NAME).toBe("");
+    expect(runOpts.env.CONSENT_MESSAGE).toContain("{assistantName}");
+    expect(runOpts.env.DAEMON_URL).toBe("http://host.docker.internal:7821");
+    expect(runOpts.env.BOT_API_TOKEN).toBe(session.botApiToken);
+    expect(runOpts.env.DEEPGRAM_API_KEY).toBe("deepgram-secret");
+    expect(runOpts.env.TTS_API_KEY).toBe("tts-secret");
+    expect(runOpts.env.SKIP_PULSE).toBe("0");
+
+    expect(runOpts.binds).toEqual([
+      {
+        hostPath: join(workspaceDir, "meets", "m1", "sockets"),
+        containerPath: "/sockets",
+      },
+      {
+        hostPath: join(workspaceDir, "meets", "m1", "out"),
+        containerPath: "/out",
+      },
+    ]);
+
+    expect(runOpts.ports).toEqual([
+      {
+        hostIp: "127.0.0.1",
+        hostPort: 0,
+        containerPort: MEET_BOT_INTERNAL_PORT,
+        protocol: "tcp",
+      },
+    ]);
+
+    expect(runOpts.name).toBe("vellum-meet-m1");
+    expect(runOpts.network).toBe("bridge");
+
+    // activeSessions and getSession both reflect the new record.
+    expect(manager.activeSessions()).toHaveLength(1);
+    expect(manager.getSession("m1")?.containerId).toBe("container-123");
+
+    await manager.leave("m1", "test-cleanup");
+  });
+
+  test("token resolver returns null when the meeting is not active", async () => {
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => makeMockRunner(),
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+    });
+    // Before any join, the resolver installed in ctor returns null.
+    expect(getMeetSessionEventRouter().resolveBotApiToken("nope")).toBeNull();
+
+    await manager.join({
+      url: "u",
+      meetingId: "m2",
+      conversationId: "c2",
+    });
+    expect(
+      getMeetSessionEventRouter().resolveBotApiToken("m2"),
+    ).not.toBeNull();
+    expect(
+      getMeetSessionEventRouter().resolveBotApiToken("other"),
+    ).toBeNull();
+
+    await manager.leave("m2", "cleanup");
+  });
+
+  test("rejects a second join for the same meeting id", async () => {
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => makeMockRunner(),
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+    });
+    await manager.join({ url: "u", meetingId: "dup", conversationId: "c" });
+    await expect(
+      manager.join({ url: "u", meetingId: "dup", conversationId: "c" }),
+    ).rejects.toThrow(/already exists/);
+    await manager.leave("dup", "cleanup");
+  });
+
+  test("rolls back the container when no host port is bound", async () => {
+    const runner = makeMockRunner({
+      runResult: { containerId: "c-unbound", boundPorts: [] },
+    });
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+    });
+    await expect(
+      manager.join({
+        url: "u",
+        meetingId: "m-noport",
+        conversationId: "c",
+      }),
+    ).rejects.toThrow(/did not publish a host port/);
+    expect(runner.remove).toHaveBeenCalledTimes(1);
+    expect(manager.activeSessions()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// leave()
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager.leave", () => {
+  test("calls bot HTTP first, then removes — skips stop on graceful success", async () => {
+    const runner = makeMockRunner();
+    const botLeaveFetch = mock(async () => {});
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch,
+    });
+
+    const session = await manager.join({
+      url: "u",
+      meetingId: "leave1",
+      conversationId: "c",
+    });
+    await manager.leave("leave1", "user-requested");
+
+    expect(botLeaveFetch).toHaveBeenCalledTimes(1);
+    const [url, token] = botLeaveFetch.mock.calls[0] as unknown as [
+      string,
+      string,
+    ];
+    expect(url).toBe(`${session.botBaseUrl}/leave`);
+    expect(token).toBe(session.botApiToken);
+
+    // Graceful path skips stop.
+    expect(runner.stop).toHaveBeenCalledTimes(0);
+    expect(runner.remove).toHaveBeenCalledTimes(1);
+
+    // Session state cleared.
+    expect(manager.getSession("leave1")).toBeNull();
+    expect(getMeetSessionEventRouter().registeredCount()).toBe(0);
+  });
+
+  test("falls back to stop when bot HTTP fails", async () => {
+    const runner = makeMockRunner();
+    const botLeaveFetch = mock(async () => {
+      throw new Error("bot unreachable");
+    });
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch,
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "leave2",
+      conversationId: "c",
+    });
+    await manager.leave("leave2", "timeout");
+
+    expect(botLeaveFetch).toHaveBeenCalledTimes(1);
+    expect(runner.stop).toHaveBeenCalledTimes(1);
+    expect(runner.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to stop when bot HTTP times out past 10s", async () => {
+    const runner = makeMockRunner();
+
+    // Simulate a hanging fetch that rejects with AbortError semantics, mirroring
+    // what `AbortSignal.timeout(BOT_LEAVE_HTTP_TIMEOUT_MS)` would throw.
+    const botLeaveFetch = mock(async () => {
+      // The default fetch uses AbortSignal.timeout internally; simulate that
+      // timeout by surfacing an abort-style error. The session manager only
+      // cares that the promise rejects — it does not inspect the error type.
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    });
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch,
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "leave-timeout",
+      conversationId: "c",
+    });
+    await manager.leave("leave-timeout", "operator");
+
+    expect(runner.stop).toHaveBeenCalledTimes(1);
+    expect(runner.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test("is a no-op for an unknown meeting id", async () => {
+    const runner = makeMockRunner();
+    const botLeaveFetch = mock(async () => {});
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch,
+    });
+    await manager.leave("never-joined", "who-cares");
+    expect(botLeaveFetch).toHaveBeenCalledTimes(0);
+    expect(runner.stop).toHaveBeenCalledTimes(0);
+    expect(runner.remove).toHaveBeenCalledTimes(0);
+  });
+
+  test("BOT_LEAVE_HTTP_TIMEOUT_MS is exported and sensible", () => {
+    // Guard against accidental tightening that would cause flakes in CI.
+    expect(BOT_LEAVE_HTTP_TIMEOUT_MS).toBeGreaterThanOrEqual(5000);
+    expect(BOT_LEAVE_HTTP_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Max-meeting-minutes hard cap
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager max-minutes timeout", () => {
+  // We do not touch wall-clock sleep here — the max-minutes cap is exercised
+  // by reaching into the timeout handle state directly through a stable
+  // public surface (`joinTimeoutMs`), verifying that the manager registers a
+  // timer that, when fired, triggers the leave flow.
+  //
+  // Bun's `setSystemTime` fake timer support is still evolving; rather than
+  // depend on it we stub the manager's `setTimeout` behavior by triggering
+  // `leave` directly after confirming `joinTimeoutMs` matches the
+  // configuration value, then asserting the side-effects the timer would
+  // have produced.
+
+  test("joinTimeoutMs matches services.meet.maxMeetingMinutes * 60_000", async () => {
+    const runner = makeMockRunner();
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+    });
+
+    const session = await manager.join({
+      url: "u",
+      meetingId: "t1",
+      conversationId: "c",
+    });
+
+    // Default config is 240 minutes → 14_400_000 ms.
+    expect(session.joinTimeoutMs).toBe(240 * 60_000);
+
+    await manager.leave("t1", "cleanup");
+  });
+
+  test("timeout firing triggers leave(meetingId, 'timeout')", async () => {
+    const runner = makeMockRunner();
+    const botLeaveFetch = mock(async () => {});
+
+    // Monkey-patch global setTimeout so we can capture and fire the scheduled
+    // callback deterministically without leaning on fake-timer APIs.
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    let capturedCb: (() => void) | null = null;
+    const fakeHandle = Symbol("fake-handle");
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout =
+      ((cb: () => void, _ms: number) => {
+        capturedCb = cb;
+        return fakeHandle as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout;
+    (globalThis as unknown as { clearTimeout: typeof clearTimeout }).clearTimeout =
+      ((handle: unknown) => {
+        if (handle === fakeHandle) capturedCb = null;
+      }) as typeof clearTimeout;
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "fire-timeout",
+        conversationId: "c",
+      });
+
+      expect(capturedCb).not.toBeNull();
+
+      // Fire the timer — this is what would happen after maxMeetingMinutes.
+      capturedCb!();
+
+      // Give the async leave() a microtask to settle.
+      await new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+
+      expect(botLeaveFetch).toHaveBeenCalledTimes(1);
+      expect(runner.remove).toHaveBeenCalledTimes(1);
+      expect(manager.getSession("fire-timeout")).toBeNull();
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+});

--- a/assistant/src/meet/docker-runner.ts
+++ b/assistant/src/meet/docker-runner.ts
@@ -1,0 +1,355 @@
+/**
+ * DockerRunner — thin typed wrapper over the Docker Engine HTTP API exposed
+ * via the unix socket at `/var/run/docker.sock`.
+ *
+ * Used by `MeetSessionManager` to spawn per-meeting Meet-bot containers. The
+ * CLI (`cli/src/lib/docker.ts`) drives Docker via the `docker` binary for
+ * service orchestration; that pattern is not reused here because the runner
+ * lives inside the assistant process where shelling out to `docker` adds a
+ * dependency on the host PATH, forks an extra process per call, and blocks
+ * on stdio. The HTTP-socket API keeps everything in-process, returns
+ * structured JSON, and avoids the PATH/CLI surface entirely. See
+ * `cli/src/lib/docker.ts` for the broader service container lifecycle.
+ */
+
+import { request as httpRequest } from "node:http";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("meet-docker-runner");
+
+/** Path to the Docker Engine unix socket. */
+export const DEFAULT_DOCKER_SOCKET_PATH = "/var/run/docker.sock";
+
+/** Docker Engine API version used in request paths. */
+const DOCKER_API_VERSION = "v1.43";
+
+/** Host for unix-socket HTTP requests (ignored by the socket transport). */
+const UNIX_SOCKET_HOST = "localhost";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Describes an ephemeral host-port binding captured after container start. */
+export interface BoundPort {
+  /** Protocol — typically `"tcp"`. */
+  protocol: "tcp" | "udp";
+  /** Container-internal port (e.g. `3000`). */
+  containerPort: number;
+  /** Host interface the port was bound to (e.g. `"127.0.0.1"`). */
+  hostIp: string;
+  /** Host-side port chosen by the Docker daemon when the spec used port 0. */
+  hostPort: number;
+}
+
+/** A single port mapping request passed to `run`. */
+export interface PortMapping {
+  /** Host interface to bind to (e.g. `"127.0.0.1"`). */
+  hostIp: string;
+  /** Host port — use `0` to let Docker assign an ephemeral port. */
+  hostPort: number;
+  /** Container-internal port. */
+  containerPort: number;
+  /** Protocol — defaults to `"tcp"` when omitted. */
+  protocol?: "tcp" | "udp";
+}
+
+/** A single bind mount request passed to `run`. */
+export interface BindMount {
+  hostPath: string;
+  containerPath: string;
+  /** Whether the mount is read-only. Defaults to `false`. */
+  readOnly?: boolean;
+}
+
+/** Options for creating + starting a container. */
+export interface DockerRunOptions {
+  image: string;
+  env?: Record<string, string>;
+  binds?: BindMount[];
+  ports?: PortMapping[];
+  name?: string;
+  network?: string;
+  /** Extra HostConfig overrides — applied after standard fields. Use sparingly. */
+  hostConfigExtras?: Record<string, unknown>;
+}
+
+/** Minimal shape of the Docker `containers/<id>/json` response we rely on. */
+export interface ContainerInspect {
+  Id: string;
+  State?: {
+    Status?: string;
+    Running?: boolean;
+    ExitCode?: number;
+  };
+  NetworkSettings?: {
+    Ports?: Record<
+      string,
+      Array<{ HostIp?: string; HostPort?: string }> | null
+    >;
+  };
+  [key: string]: unknown;
+}
+
+/** Result of a successful `run`. */
+export interface DockerRunResult {
+  containerId: string;
+  boundPorts: BoundPort[];
+}
+
+// ---------------------------------------------------------------------------
+// DockerRunner
+// ---------------------------------------------------------------------------
+
+export interface DockerRunnerOptions {
+  /** Override the unix socket path. Primarily used in tests. */
+  socketPath?: string;
+}
+
+/**
+ * Error thrown when the Docker Engine returns a non-2xx response. The
+ * original status and body are preserved for diagnostics.
+ */
+export class DockerApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+  constructor(method: string, path: string, status: number, body: string) {
+    super(
+      `Docker API ${method} ${path} failed (${status}): ${body.slice(0, 300)}`,
+    );
+    this.name = "DockerApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class DockerRunner {
+  readonly socketPath: string;
+
+  constructor(options: DockerRunnerOptions = {}) {
+    this.socketPath = options.socketPath ?? DEFAULT_DOCKER_SOCKET_PATH;
+  }
+
+  /**
+   * Create + start a container. Returns the containerId and any host-side
+   * ports Docker bound after start.
+   */
+  async run(opts: DockerRunOptions): Promise<DockerRunResult> {
+    const createBody = buildCreateBody(opts);
+    const createPath = opts.name
+      ? `/${DOCKER_API_VERSION}/containers/create?name=${encodeURIComponent(opts.name)}`
+      : `/${DOCKER_API_VERSION}/containers/create`;
+
+    const createResp = await this.request<{ Id: string; Warnings?: string[] }>(
+      "POST",
+      createPath,
+      createBody,
+    );
+    const containerId = createResp.Id;
+    log.info({ containerId, image: opts.image }, "Created container");
+
+    try {
+      await this.request<void>(
+        "POST",
+        `/${DOCKER_API_VERSION}/containers/${containerId}/start`,
+        null,
+      );
+    } catch (err) {
+      // Best-effort cleanup so we don't leak a created-but-never-started
+      // container if start fails (e.g. image pull needed, bind failure).
+      log.warn(
+        { err, containerId },
+        "Container start failed; attempting cleanup",
+      );
+      await this.remove(containerId).catch(() => {});
+      throw err;
+    }
+
+    const inspection = await this.inspect(containerId);
+    const boundPorts = extractBoundPorts(inspection);
+    return { containerId, boundPorts };
+  }
+
+  /** Stop a running container. Wraps `POST /containers/<id>/stop`. */
+  async stop(containerId: string, timeoutSec = 10): Promise<void> {
+    const path = `/${DOCKER_API_VERSION}/containers/${containerId}/stop?t=${timeoutSec}`;
+    try {
+      await this.request<void>("POST", path, null);
+    } catch (err) {
+      // 304 means "already stopped" — not an error for our purposes.
+      if (err instanceof DockerApiError && err.status === 304) return;
+      throw err;
+    }
+  }
+
+  /** Force-remove a container. Wraps `DELETE /containers/<id>?force=true`. */
+  async remove(containerId: string): Promise<void> {
+    const path = `/${DOCKER_API_VERSION}/containers/${containerId}?force=true&v=true`;
+    try {
+      await this.request<void>("DELETE", path, null);
+    } catch (err) {
+      // 404 means "already gone" — not an error for our purposes.
+      if (err instanceof DockerApiError && err.status === 404) return;
+      throw err;
+    }
+  }
+
+  /** Inspect a container. Wraps `GET /containers/<id>/json`. */
+  async inspect(containerId: string): Promise<ContainerInspect> {
+    return this.request<ContainerInspect>(
+      "GET",
+      `/${DOCKER_API_VERSION}/containers/${containerId}/json`,
+      null,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /** Issue a unix-socket HTTP request and decode the JSON body, if any. */
+  private request<T>(
+    method: string,
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const payload =
+        body === null || body === undefined ? null : JSON.stringify(body);
+
+      const headers: Record<string, string | number> = {
+        Host: UNIX_SOCKET_HOST,
+        Accept: "application/json",
+      };
+      if (payload !== null) {
+        headers["Content-Type"] = "application/json";
+        headers["Content-Length"] = Buffer.byteLength(payload);
+      }
+
+      const req = httpRequest(
+        {
+          socketPath: this.socketPath,
+          method,
+          path,
+          headers,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk: Buffer) => chunks.push(chunk));
+          res.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            const status = res.statusCode ?? 0;
+            if (status < 200 || status >= 300) {
+              reject(new DockerApiError(method, path, status, raw));
+              return;
+            }
+            if (!raw) {
+              resolve(undefined as T);
+              return;
+            }
+            try {
+              resolve(JSON.parse(raw) as T);
+            } catch (err) {
+              reject(
+                new Error(
+                  `Failed to parse Docker API JSON response for ${method} ${path}: ${String(err)}`,
+                ),
+              );
+            }
+          });
+        },
+      );
+
+      req.on("error", (err) => reject(err));
+      if (payload !== null) req.write(payload);
+      req.end();
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate the high-level `DockerRunOptions` into the JSON body the Docker
+ * Engine's `/containers/create` endpoint expects.
+ */
+export function buildCreateBody(
+  opts: DockerRunOptions,
+): Record<string, unknown> {
+  const env = opts.env
+    ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`)
+    : [];
+  const binds = (opts.binds ?? []).map((b) =>
+    b.readOnly
+      ? `${b.hostPath}:${b.containerPath}:ro`
+      : `${b.hostPath}:${b.containerPath}`,
+  );
+
+  // ExposedPorts + PortBindings together tell Docker which ports to publish
+  // and where to bind them. `HostPort: "0"` asks for an ephemeral port.
+  // Docker's API expects `ExposedPorts` values to be empty object literals,
+  // which is what `Record<string, Record<string, never>>` represents here.
+  const exposedPorts: Record<string, Record<string, never>> = {};
+  const portBindings: Record<
+    string,
+    Array<{ HostIp: string; HostPort: string }>
+  > = {};
+  for (const p of opts.ports ?? []) {
+    const proto = p.protocol ?? "tcp";
+    const key = `${p.containerPort}/${proto}`;
+    exposedPorts[key] = {};
+    portBindings[key] = [
+      {
+        HostIp: p.hostIp,
+        HostPort: String(p.hostPort),
+      },
+    ];
+  }
+
+  const hostConfig: Record<string, unknown> = {
+    Binds: binds,
+    PortBindings: portBindings,
+    ...(opts.network ? { NetworkMode: opts.network } : {}),
+    ...(opts.hostConfigExtras ?? {}),
+  };
+
+  return {
+    Image: opts.image,
+    Env: env,
+    ExposedPorts: exposedPorts,
+    HostConfig: hostConfig,
+  };
+}
+
+/**
+ * Walk a container-inspect payload and flatten the port bindings into a
+ * simple list. Unbound entries (NetworkSettings.Ports value = null) are
+ * skipped — they represent declared `ExposedPorts` that were never published.
+ */
+export function extractBoundPorts(inspection: ContainerInspect): BoundPort[] {
+  const out: BoundPort[] = [];
+  const ports = inspection.NetworkSettings?.Ports ?? {};
+  for (const [key, bindings] of Object.entries(ports)) {
+    if (!bindings) continue;
+    const slash = key.indexOf("/");
+    if (slash <= 0) continue;
+    const containerPort = Number.parseInt(key.slice(0, slash), 10);
+    const protoRaw = key.slice(slash + 1);
+    if (!Number.isFinite(containerPort)) continue;
+    const protocol: "tcp" | "udp" = protoRaw === "udp" ? "udp" : "tcp";
+    for (const b of bindings) {
+      const hostPort = Number.parseInt(b.HostPort ?? "", 10);
+      if (!Number.isFinite(hostPort) || hostPort <= 0) continue;
+      out.push({
+        protocol,
+        containerPort,
+        hostIp: b.HostIp ?? "",
+        hostPort,
+      });
+    }
+  }
+  return out;
+}

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -1,0 +1,444 @@
+/**
+ * MeetSessionManager — orchestrates per-meeting bot container lifecycle.
+ *
+ * Responsibilities:
+ *   - Generate a unique `BOT_API_TOKEN` per meeting so the ingress route
+ *     (PR 9) can authenticate inbound bot callbacks.
+ *   - Stage per-meeting artifact directories (`sockets/`, `out/`) on the
+ *     workspace volume.
+ *   - Resolve the Deepgram API key (and a placeholder TTS key reserved for
+ *     Phase 3) via the secure-keys abstraction.
+ *   - Drive `DockerRunner` to create + start the Meet-bot container with the
+ *     right env/binds/port mappings.
+ *   - Register a per-meeting handler with `MeetSessionEventRouter`. Later
+ *     PRs wire real consumers (PR 17 conversation bridge, PR 18 storage
+ *     writer, PR 22 consent monitor).
+ *   - Enforce `services.meet.maxMeetingMinutes` via a hard-cap timeout that
+ *     invokes `leave(id, "timeout")`.
+ *   - On `leave`, best-effort hit the bot's `/leave` first; fall back to
+ *     `DockerRunner.stop` + `remove` so stuck bots don't leak containers.
+ *
+ * Not yet wired in this PR — left as TODOs for their owning PRs:
+ *   - PR 16 adds audio ingest server startup before the container spawns.
+ *   - PR 19 adds a container-exit watcher that publishes `lifecycle:left`
+ *     via `assistantEventHub`.
+ *   - PR 22 instantiates the consent monitor and disposes it on leave.
+ *   - PR 23 substitutes `{assistantName}` into `CONSENT_MESSAGE`.
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { getConfig } from "../config/loader.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { DockerRunner, type DockerRunResult } from "./docker-runner.js";
+import {
+  getMeetSessionEventRouter,
+  type MeetSessionEventHandler,
+} from "./session-event-router.js";
+
+const log = getLogger("meet-session-manager");
+
+/** Default internal port the bot's control API listens on inside the container. */
+export const MEET_BOT_INTERNAL_PORT = 3000;
+
+/** Default host interface to bind the bot's published port to. */
+export const MEET_BOT_HOST_IP = "127.0.0.1";
+
+/** Timeout for the best-effort bot `/leave` HTTP call before falling back to stop. */
+export const BOT_LEAVE_HTTP_TIMEOUT_MS = 10_000;
+
+/** Default daemon HTTP port when `RUNTIME_HTTP_PORT` is not set. */
+const DEFAULT_DAEMON_PORT = 7821;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface MeetSession {
+  meetingId: string;
+  conversationId: string;
+  containerId: string;
+  /** Host-side URL the daemon can use to talk to the bot's control API. */
+  botBaseUrl: string;
+  /** Per-meeting bearer token minted at join time. */
+  botApiToken: string;
+  /** Wall-clock ms since the epoch when the session was created. */
+  startedAt: number;
+  /** `services.meet.maxMeetingMinutes * 60_000` — captured at join time. */
+  joinTimeoutMs: number;
+}
+
+export interface JoinInput {
+  url: string;
+  meetingId: string;
+  conversationId: string;
+}
+
+// ---------------------------------------------------------------------------
+// MeetSessionManagerImpl
+// ---------------------------------------------------------------------------
+
+interface ActiveSession extends MeetSession {
+  /** Hard-cap timeout handle — cleared on leave. */
+  timeoutHandle: ReturnType<typeof setTimeout> | null;
+}
+
+export interface MeetSessionManagerDeps {
+  /** Factory for the Docker runner — swapped in tests. */
+  dockerRunnerFactory?: () => Pick<
+    DockerRunner,
+    "run" | "stop" | "remove" | "inspect"
+  >;
+  /** Override the function that fetches credentials. */
+  getProviderKey?: (provider: string) => Promise<string | undefined>;
+  /** Override the function that hits the bot's `/leave` endpoint. */
+  botLeaveFetch?: (url: string, token: string) => Promise<void>;
+  /** Override the daemon-URL resolver (used for `DAEMON_URL` env var). */
+  resolveDaemonUrl?: () => string;
+  /** Override workspace directory resolution (tests). */
+  getWorkspaceDir?: () => string;
+}
+
+class MeetSessionManagerImpl {
+  private sessions = new Map<string, ActiveSession>();
+  private deps: Required<MeetSessionManagerDeps>;
+
+  constructor(deps: MeetSessionManagerDeps = {}) {
+    this.deps = {
+      dockerRunnerFactory: deps.dockerRunnerFactory ?? (() => new DockerRunner()),
+      getProviderKey: deps.getProviderKey ?? getProviderKeyAsync,
+      botLeaveFetch: deps.botLeaveFetch ?? defaultBotLeaveFetch,
+      resolveDaemonUrl: deps.resolveDaemonUrl ?? defaultResolveDaemonUrl,
+      getWorkspaceDir: deps.getWorkspaceDir ?? getWorkspaceDir,
+    };
+
+    // The ingress route (PR 9) looks up per-meeting tokens through this
+    // resolver. Install it once at construction time — it reads live state
+    // from `this.sessions`, so it stays correct as sessions come and go.
+    getMeetSessionEventRouter().setBotApiTokenResolver((meetingId) => {
+      const session = this.sessions.get(meetingId);
+      return session ? session.botApiToken : null;
+    });
+  }
+
+  /** Swap dependencies at runtime. Tests only. */
+  _replaceDeps(deps: MeetSessionManagerDeps): void {
+    this.deps = {
+      dockerRunnerFactory:
+        deps.dockerRunnerFactory ?? this.deps.dockerRunnerFactory,
+      getProviderKey: deps.getProviderKey ?? this.deps.getProviderKey,
+      botLeaveFetch: deps.botLeaveFetch ?? this.deps.botLeaveFetch,
+      resolveDaemonUrl: deps.resolveDaemonUrl ?? this.deps.resolveDaemonUrl,
+      getWorkspaceDir: deps.getWorkspaceDir ?? this.deps.getWorkspaceDir,
+    };
+    // Re-install the token resolver in case `_resetForTests` cleared it.
+    getMeetSessionEventRouter().setBotApiTokenResolver((meetingId) => {
+      const session = this.sessions.get(meetingId);
+      return session ? session.botApiToken : null;
+    });
+  }
+
+  /** Reset internal state. Tests only. */
+  _resetForTests(): void {
+    for (const session of this.sessions.values()) {
+      if (session.timeoutHandle) clearTimeout(session.timeoutHandle);
+    }
+    this.sessions.clear();
+  }
+
+  /**
+   * Spawn a Meet-bot container for the given meeting and return the session
+   * descriptor. Throws if a session for the same meeting already exists.
+   */
+  async join(input: JoinInput): Promise<MeetSession> {
+    const { url, meetingId, conversationId } = input;
+
+    if (this.sessions.has(meetingId)) {
+      throw new Error(
+        `MeetSession already exists for meetingId=${meetingId}; leave the existing session before re-joining`,
+      );
+    }
+
+    const config = getConfig();
+    const meet = config.services.meet;
+
+    const workspaceDir = this.deps.getWorkspaceDir();
+    const meetingDir = join(workspaceDir, "meets", meetingId);
+    const socketsDir = join(meetingDir, "sockets");
+    const outDir = join(meetingDir, "out");
+    mkdirSync(socketsDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+
+    const botApiToken = generateBotApiToken();
+
+    const deepgramKey = (await this.deps.getProviderKey("deepgram")) ?? "";
+    // Placeholder — Phase 3 (PR 23+) will resolve the real TTS credential.
+    const ttsKey = (await this.deps.getProviderKey("tts")) ?? "";
+
+    const daemonUrl = this.deps.resolveDaemonUrl();
+
+    const env: Record<string, string> = {
+      MEET_URL: url,
+      MEETING_ID: meetingId,
+      // `joinName` is null → bot falls back to the assistant display name at
+      // runtime (PR 23 substitutes it). Forward an empty string so the bot
+      // can distinguish "not set" from an explicit value.
+      JOIN_NAME: meet.joinName ?? "",
+      // `{assistantName}` substitution is owned by PR 23.
+      CONSENT_MESSAGE: meet.consentMessage,
+      DAEMON_URL: daemonUrl,
+      BOT_API_TOKEN: botApiToken,
+      DEEPGRAM_API_KEY: deepgramKey,
+      TTS_API_KEY: ttsKey,
+      // Enable the in-container Pulse null-sink by default (set to "1" to
+      // disable in dev). Match the meet-bot image expectation.
+      SKIP_PULSE: "0",
+    };
+
+    const runner = this.deps.dockerRunnerFactory();
+
+    let runResult: DockerRunResult;
+    try {
+      runResult = await runner.run({
+        image: meet.containerImage,
+        env,
+        binds: [
+          { hostPath: socketsDir, containerPath: "/sockets" },
+          { hostPath: outDir, containerPath: "/out" },
+        ],
+        ports: [
+          {
+            hostIp: MEET_BOT_HOST_IP,
+            hostPort: 0,
+            containerPort: MEET_BOT_INTERNAL_PORT,
+            protocol: "tcp",
+          },
+        ],
+        name: `vellum-meet-${meetingId}`,
+        network: meet.dockerNetwork,
+      });
+    } catch (err) {
+      log.error(
+        { err, meetingId, image: meet.containerImage },
+        "Failed to spawn meet bot container",
+      );
+      throw err;
+    }
+
+    const boundPort = runResult.boundPorts.find(
+      (p) => p.containerPort === MEET_BOT_INTERNAL_PORT,
+    );
+    if (!boundPort) {
+      // Roll back the container so we don't leak a started-but-unreachable
+      // bot. Best-effort — surface the original error either way.
+      await runner.remove(runResult.containerId).catch(() => {});
+      throw new Error(
+        `meet-bot container ${runResult.containerId} did not publish a host port for ${MEET_BOT_INTERNAL_PORT}/tcp`,
+      );
+    }
+
+    const botBaseUrl = `http://${MEET_BOT_HOST_IP}:${boundPort.hostPort}`;
+    const joinTimeoutMs = meet.maxMeetingMinutes * 60_000;
+
+    // No-op handler for now — later PRs (17 conversation bridge, 18 storage
+    // writer, 22 consent monitor) swap in real consumers.
+    const handler: MeetSessionEventHandler = (event) => {
+      log.debug(
+        { meetingId, eventType: event.type },
+        "meet session handler received event (no-op stub)",
+      );
+    };
+    getMeetSessionEventRouter().register(meetingId, handler);
+
+    const startedAt = Date.now();
+    const session: ActiveSession = {
+      meetingId,
+      conversationId,
+      containerId: runResult.containerId,
+      botBaseUrl,
+      botApiToken,
+      startedAt,
+      joinTimeoutMs,
+      timeoutHandle: null,
+    };
+    this.sessions.set(meetingId, session);
+
+    // Max-meeting-minutes hard cap. Using setTimeout keeps this compatible
+    // with Bun's fake-timer harness for tests.
+    session.timeoutHandle = setTimeout(() => {
+      void this.leave(meetingId, "timeout").catch((err) => {
+        log.error(
+          { err, meetingId },
+          "Error during max-meeting-minutes timeout cleanup",
+        );
+      });
+    }, joinTimeoutMs);
+
+    // TODO(PR 19): wire a container-exit watcher here that publishes a
+    // `lifecycle:left` event via `assistantEventHub`.
+
+    log.info(
+      {
+        meetingId,
+        conversationId,
+        containerId: runResult.containerId,
+        botBaseUrl,
+        joinTimeoutMs,
+      },
+      "Meet session joined",
+    );
+
+    return sessionView(session);
+  }
+
+  /**
+   * Tear down a meeting: try the bot's `/leave` first, fall back to
+   * `stop` + `remove`. Idempotent — calling leave on an unknown meeting
+   * is a no-op.
+   */
+  async leave(meetingId: string, reason: string): Promise<void> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      log.debug({ meetingId, reason }, "leave(): no active session — no-op");
+      return;
+    }
+
+    // Immediately clear state so we don't re-enter this path via the timeout
+    // firing concurrently with a caller-initiated leave.
+    if (session.timeoutHandle) {
+      clearTimeout(session.timeoutHandle);
+      session.timeoutHandle = null;
+    }
+    this.sessions.delete(meetingId);
+    getMeetSessionEventRouter().unregister(meetingId);
+
+    const runner = this.deps.dockerRunnerFactory();
+
+    let gracefulOk = false;
+    try {
+      await this.deps.botLeaveFetch(
+        `${session.botBaseUrl}/leave`,
+        session.botApiToken,
+      );
+      gracefulOk = true;
+    } catch (err) {
+      log.warn(
+        { err, meetingId, reason },
+        "Bot /leave failed or timed out — falling back to container stop",
+      );
+    }
+
+    if (!gracefulOk) {
+      try {
+        await runner.stop(session.containerId);
+      } catch (err) {
+        log.warn(
+          { err, meetingId, containerId: session.containerId },
+          "DockerRunner.stop failed — proceeding to remove",
+        );
+      }
+    }
+
+    try {
+      await runner.remove(session.containerId);
+    } catch (err) {
+      log.warn(
+        { err, meetingId, containerId: session.containerId },
+        "DockerRunner.remove failed — container may leak",
+      );
+    }
+
+    log.info(
+      { meetingId, containerId: session.containerId, reason, gracefulOk },
+      "Meet session left",
+    );
+  }
+
+  /** Snapshot of currently-active sessions (excludes internal fields). */
+  activeSessions(): MeetSession[] {
+    return Array.from(this.sessions.values()).map(sessionView);
+  }
+
+  /** Look up a session by meeting id, or `null` when none is active. */
+  getSession(meetingId: string): MeetSession | null {
+    const session = this.sessions.get(meetingId);
+    return session ? sessionView(session) : null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+/** Process-wide session manager. */
+export const MeetSessionManager = new MeetSessionManagerImpl();
+
+/** Exposed for integration tests that need a clean instance. */
+export function _createMeetSessionManagerForTests(
+  deps?: MeetSessionManagerDeps,
+): MeetSessionManagerImpl {
+  return new MeetSessionManagerImpl(deps);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip internal fields (`timeoutHandle`) from a session before exposing it. */
+function sessionView(session: ActiveSession): MeetSession {
+  return {
+    meetingId: session.meetingId,
+    conversationId: session.conversationId,
+    containerId: session.containerId,
+    botBaseUrl: session.botBaseUrl,
+    botApiToken: session.botApiToken,
+    startedAt: session.startedAt,
+    joinTimeoutMs: session.joinTimeoutMs,
+  };
+}
+
+/**
+ * Generate a cryptographically random bearer token for per-meeting bot auth.
+ * 32 bytes → 64 hex chars — enough entropy for a shared secret.
+ */
+export function generateBotApiToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Default bot `/leave` hitter. Honors {@link BOT_LEAVE_HTTP_TIMEOUT_MS}.
+ * Throws on non-2xx or timeout so `leave()` can fall through to stop.
+ */
+async function defaultBotLeaveFetch(
+  url: string,
+  token: string,
+): Promise<void> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(BOT_LEAVE_HTTP_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Bot /leave returned ${response.status}: ${await response.text().catch(() => "")}`,
+    );
+  }
+}
+
+/**
+ * Resolve the daemon URL the bot container should use to post events back
+ * to the host. Docker containers reach the host via
+ * `host.docker.internal`; the port comes from `RUNTIME_HTTP_PORT` with a
+ * fallback to the default.
+ */
+function defaultResolveDaemonUrl(): string {
+  const portRaw = process.env.RUNTIME_HTTP_PORT;
+  const port = portRaw ? Number.parseInt(portRaw, 10) : DEFAULT_DAEMON_PORT;
+  const effectivePort =
+    Number.isFinite(port) && port > 0 ? port : DEFAULT_DAEMON_PORT;
+  return `http://host.docker.internal:${effectivePort}`;
+}


### PR DESCRIPTION
## Summary
- New `DockerRunner` wraps the Docker Engine unix socket (`run`, `stop`, `remove`, `inspect`).
- `MeetSessionManager` spawns per-meeting bot containers with per-meeting API tokens, bind-mounts for sockets + artifacts, and max-meeting-minutes hard cap.
- Wires auth-token resolver into PR 9's `MeetSessionEventRouter` so ingress routes can validate.
- `leave` tries bot HTTP first, falls back to container stop/remove.

Part of plan: meet-phase-1-listen.md (PR 10 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
