### PR TITLE
meet-bot: Meet join flow with display-name + consent chat message

### DIFF
--- a/meet-bot/__tests__/join-flow.test.ts
+++ b/meet-bot/__tests__/join-flow.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the Meet join flow.
+ *
+ * We mock Playwright's `Page` entirely rather than driving a real browser
+ * (which would need Xvfb + Chromium on every test host). The mock records
+ * which selectors were filled, clicked, waited on, etc. so each test can
+ * assert that `joinMeet` takes the expected branch and that `postConsentMessage`
+ * is invoked with the right arguments.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { joinMeet } from "../src/browser/join-flow.js";
+import { selectors } from "../src/browser/dom-selectors.js";
+
+type MockFn = ReturnType<typeof mock>;
+
+interface FakePage {
+  waitForSelector: MockFn;
+  fill: MockFn;
+  click: MockFn;
+  press: MockFn;
+  locator: MockFn;
+  __locatorCounts: Map<string, number>;
+  __locatorCountCalls: string[];
+  __waitForSelectorRejectors: Map<string, Error>;
+}
+
+/**
+ * Build a mock `Page` with configurable behaviors. Each test tweaks the
+ * behavior through the returned handles (e.g. by setting a locator count for
+ * the "Join now" selector to 0 to force the "Ask to join" branch).
+ */
+function makePage(): FakePage {
+  const locatorCounts = new Map<string, number>();
+  // Default: both prejoin buttons + the leave button are present so tests can
+  // opt into the "only one branch visible" scenarios by overriding specific
+  // entries.
+  locatorCounts.set(selectors.PREJOIN_JOIN_NOW_BUTTON, 1);
+  locatorCounts.set(selectors.PREJOIN_ASK_TO_JOIN_BUTTON, 1);
+  // Chat input: present by default so postConsentMessage skips the toggle
+  // click. Tests that want to exercise the "open chat panel" step override
+  // this to 0.
+  locatorCounts.set(selectors.INGAME_CHAT_INPUT, 1);
+
+  const waitRejectors = new Map<string, Error>();
+
+  const page: FakePage = {
+    __locatorCounts: locatorCounts,
+    __locatorCountCalls: [],
+    __waitForSelectorRejectors: waitRejectors,
+    waitForSelector: mock(async (selector: string) => {
+      const err = waitRejectors.get(selector);
+      if (err) throw err;
+      return undefined;
+    }),
+    fill: mock(async () => undefined),
+    click: mock(async () => undefined),
+    press: mock(async () => undefined),
+    locator: mock((selector: string) => ({
+      count: mock(async () => {
+        page.__locatorCountCalls.push(selector);
+        return locatorCounts.get(selector) ?? 0;
+      }),
+    })),
+  };
+  return page;
+}
+
+/**
+ * Test helper — grab the list of selectors `click` was invoked with, in order.
+ */
+function clickedSelectors(page: FakePage): string[] {
+  return page.click.mock.calls.map((call) => String(call[0]));
+}
+
+/**
+ * Test helper — grab the list of selectors `waitForSelector` was invoked with.
+ */
+function waitedSelectors(page: FakePage): string[] {
+  return page.waitForSelector.mock.calls.map((call) => String(call[0]));
+}
+
+describe("joinMeet", () => {
+  test("takes the Join now branch when that button is present", async () => {
+    const page = makePage();
+    // Both buttons are present by default — Join now should win.
+    await joinMeet(page as never, {
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+    });
+
+    // Expected selector order:
+    //   1. wait for prejoin name input
+    //   2. wait for leave button (signals the bot is in the meeting)
+    //   3. wait for chat input (inside postConsentMessage)
+    const waits = waitedSelectors(page);
+    expect(waits).toContain(selectors.PREJOIN_NAME_INPUT);
+    expect(waits).toContain(selectors.INGAME_LEAVE_BUTTON);
+    expect(waits).toContain(selectors.INGAME_CHAT_INPUT);
+
+    // Display name was filled into the prejoin input.
+    expect(page.fill.mock.calls[0]?.[0]).toBe(selectors.PREJOIN_NAME_INPUT);
+    expect(page.fill.mock.calls[0]?.[1]).toBe("Vellum Bot");
+
+    // "Join now" clicked, "Ask to join" NOT clicked.
+    const clicks = clickedSelectors(page);
+    expect(clicks).toContain(selectors.PREJOIN_JOIN_NOW_BUTTON);
+    expect(clicks).not.toContain(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+
+    // Chat input was filled with the consent message and submitted.
+    const fillCalls = page.fill.mock.calls.map(
+      (call) => [String(call[0]), String(call[1])] as const,
+    );
+    expect(fillCalls).toContainEqual([
+      selectors.INGAME_CHAT_INPUT,
+      "Hi, Vellum is listening.",
+    ]);
+    expect(page.press.mock.calls[0]?.[0]).toBe(selectors.INGAME_CHAT_INPUT);
+    expect(page.press.mock.calls[0]?.[1]).toBe("Enter");
+  });
+
+  test("falls back to Ask to join when Join now is absent", async () => {
+    const page = makePage();
+    // Simulate a locked meeting: "Join now" is NOT rendered.
+    page.__locatorCounts.set(selectors.PREJOIN_JOIN_NOW_BUTTON, 0);
+
+    await joinMeet(page as never, {
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+    });
+
+    const clicks = clickedSelectors(page);
+    expect(clicks).toContain(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+    expect(clicks).not.toContain(selectors.PREJOIN_JOIN_NOW_BUTTON);
+  });
+
+  test("opens the chat panel when the composer is not yet mounted", async () => {
+    const page = makePage();
+    // Simulate a collapsed chat panel: the composer is not rendered until
+    // the toggle button is clicked.
+    page.__locatorCounts.set(selectors.INGAME_CHAT_INPUT, 0);
+
+    await joinMeet(page as never, {
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+    });
+
+    // The chat panel toggle button must have been clicked before the input
+    // was filled.
+    const clicks = clickedSelectors(page);
+    expect(clicks).toContain(selectors.INGAME_CHAT_PANEL_BUTTON);
+
+    // Chat input was waited for after the toggle clicked — present in the
+    // waitForSelector call list.
+    const waits = waitedSelectors(page);
+    expect(waits).toContain(selectors.INGAME_CHAT_INPUT);
+    expect(waits).toContain(selectors.INGAME_CHAT_PANEL_BUTTON);
+  });
+
+  test("throws a descriptive error when the in-meeting UI never appears", async () => {
+    const page = makePage();
+    // Simulate the host never admitting the bot — the leave button never
+    // mounts and `waitForSelector` throws.
+    page.__waitForSelectorRejectors.set(
+      selectors.INGAME_LEAVE_BUTTON,
+      new Error("Timeout 90000ms exceeded."),
+    );
+
+    await expect(
+      joinMeet(page as never, {
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+      }),
+    ).rejects.toThrow(/in-meeting UI did not appear/i);
+  });
+
+  test("throws a descriptive error when the prejoin name input never appears", async () => {
+    const page = makePage();
+    page.__waitForSelectorRejectors.set(
+      selectors.PREJOIN_NAME_INPUT,
+      new Error("Timeout 30000ms exceeded."),
+    );
+
+    await expect(
+      joinMeet(page as never, {
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+      }),
+    ).rejects.toThrow(/prejoin name input did not appear/i);
+  });
+
+  test("does not attempt the consent message when the join transition fails", async () => {
+    const page = makePage();
+    page.__waitForSelectorRejectors.set(
+      selectors.INGAME_LEAVE_BUTTON,
+      new Error("Timeout 90000ms exceeded."),
+    );
+
+    await expect(
+      joinMeet(page as never, {
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+      }),
+    ).rejects.toThrow();
+
+    // Chat input was never waited for, filled, or submitted.
+    const waits = waitedSelectors(page);
+    expect(waits).not.toContain(selectors.INGAME_CHAT_INPUT);
+    const fillCalls = page.fill.mock.calls.map((call) => String(call[0]));
+    expect(fillCalls).not.toContain(selectors.INGAME_CHAT_INPUT);
+  });
+});

--- a/meet-bot/src/browser/chat-bridge.ts
+++ b/meet-bot/src/browser/chat-bridge.ts
@@ -1,0 +1,83 @@
+/**
+ * Chat-panel bridge helpers.
+ *
+ * Wraps Playwright operations for the Google Meet chat side panel so the rest
+ * of the bot can send messages without having to know anything about the DOM
+ * or which panels need toggling.
+ *
+ * Two entry points are exposed:
+ *
+ *   - `postConsentMessage(page, consentMessage)` — opens the chat panel (if it
+ *     is collapsed) and then sends `consentMessage`. Invoked once by the join
+ *     flow in `join-flow.ts` immediately after the bot lands in the meeting.
+ *   - `sendChat(page, text)` — the core "type and send" routine. Assumes the
+ *     chat panel is already open (or will open implicitly when the input is
+ *     found). Phase 2's `/send_chat` HTTP endpoint will reuse this directly.
+ *
+ * `postConsentMessage` is implemented as a thin wrapper around `sendChat` plus
+ * an "ensure the panel is open" preamble; the typing routine itself is shared
+ * via `sendChat` so future callers don't end up duplicating the send logic.
+ */
+
+import type { Page } from "playwright";
+
+import { selectors } from "./dom-selectors.js";
+
+/**
+ * How long to wait for chat-panel UI elements (button, input) to appear. The
+ * panel opens synchronously but Meet can be slow to mount React trees on
+ * lower-end hardware; 10s is a conservative cap that still surfaces genuine
+ * DOM drift quickly.
+ */
+const CHAT_PANEL_TIMEOUT_MS = 10_000;
+
+/**
+ * Opens the chat side panel if it is not already open, then sends
+ * `consentMessage` via `sendChat`. Safe to call exactly once per session from
+ * the join flow; callers that want to send additional messages should call
+ * `sendChat` directly afterwards so we do not click the panel button (which
+ * would collapse the panel) on every send.
+ */
+export async function postConsentMessage(
+  page: Page,
+  consentMessage: string,
+): Promise<void> {
+  // Try to surface the panel first. If the composer is already visible (the
+  // panel was opened earlier in the session), the click is unnecessary — and
+  // clicking a second time would toggle the panel closed. To avoid that, we
+  // check for the input first and only click the toggle if it is missing.
+  const inputVisible = await page.locator(selectors.INGAME_CHAT_INPUT).count();
+  if (inputVisible === 0) {
+    await page.waitForSelector(selectors.INGAME_CHAT_PANEL_BUTTON, {
+      timeout: CHAT_PANEL_TIMEOUT_MS,
+    });
+    await page.click(selectors.INGAME_CHAT_PANEL_BUTTON);
+  }
+
+  await sendChat(page, consentMessage);
+}
+
+/**
+ * Types `text` into the chat composer and submits it.
+ *
+ * Assumes the chat panel is already open — the function waits for the input
+ * itself (not the panel toggle), so it is safe to call from the HTTP
+ * `/send_chat` endpoint where the panel may have been opened by an earlier
+ * request. If the input never appears, `waitForSelector` throws.
+ */
+export async function sendChat(page: Page, text: string): Promise<void> {
+  await page.waitForSelector(selectors.INGAME_CHAT_INPUT, {
+    timeout: CHAT_PANEL_TIMEOUT_MS,
+  });
+  await page.fill(selectors.INGAME_CHAT_INPUT, text);
+  // Press Enter on the input to submit. Meet's composer sends on Enter and
+  // inserts a newline on Shift+Enter, so a plain Enter is the send shortcut.
+  // We fall back to clicking the send button if pressing Enter fails (e.g. in
+  // locales where Meet has rebound the keyboard shortcut) — this keeps the
+  // happy path ergonomic without silently dropping messages.
+  try {
+    await page.press(selectors.INGAME_CHAT_INPUT, "Enter");
+  } catch {
+    await page.click(selectors.INGAME_CHAT_SEND_BUTTON);
+  }
+}

--- a/meet-bot/src/browser/join-flow.ts
+++ b/meet-bot/src/browser/join-flow.ts
@@ -1,0 +1,110 @@
+/**
+ * High-level Google Meet join flow.
+ *
+ * Builds on `createBrowserSession` (PR 6) and the centralized DOM selectors
+ * (PR 7) to drive Meet's prejoin surface, click through to the in-meeting UI,
+ * and drop a consent notice into chat.
+ *
+ * Call graph:
+ *
+ *   1. Wait for the prejoin name input.
+ *   2. Fill the name input with `displayName`.
+ *   3. Branch on the admission policy:
+ *        - If "Join now" is present, click it (signed-in / same-domain flow).
+ *        - Else click "Ask to join" (locked meeting — host admits the bot).
+ *   4. Wait for the in-meeting UI (the red "Leave call" button is the
+ *      canonical marker — it only mounts once the bot is actually in the
+ *      meeting room).
+ *   5. Post `consentMessage` in chat so human participants are informed that
+ *      an AI assistant is listening.
+ *
+ * Error strategy: every step throws a descriptive `Error` when a selector
+ * times out; `main.ts` converts thrown errors into `process.exit(1)` so the
+ * container orchestrator notices the failure.
+ */
+
+import type { Page } from "playwright";
+
+import { postConsentMessage } from "./chat-bridge.js";
+import { selectors } from "./dom-selectors.js";
+
+/** How long to wait for the prejoin name input to mount. */
+const PREJOIN_TIMEOUT_MS = 30_000;
+
+/**
+ * How long to wait for the meeting-room UI after clicking the join button.
+ * The "Ask to join" flow can block on the host manually admitting the bot,
+ * so the cap is intentionally generous.
+ */
+const MEETING_ROOM_TIMEOUT_MS = 90_000;
+
+export interface JoinMeetOptions {
+  /** Display name Meet will render next to the bot's tile. */
+  displayName: string;
+  /**
+   * Consent notice to post once the bot is in the meeting. Typically surfaced
+   * by the assistant to remind human participants that an AI is listening.
+   */
+  consentMessage: string;
+}
+
+/**
+ * Drive the Google Meet prejoin surface to completion and deliver the consent
+ * notice.
+ *
+ * Resolves once the consent message has been posted. Rejects with a
+ * descriptive `Error` if any step (prejoin input, join button, meeting-room
+ * transition, chat delivery) fails.
+ */
+export async function joinMeet(
+  page: Page,
+  opts: JoinMeetOptions,
+): Promise<void> {
+  const { displayName, consentMessage } = opts;
+
+  // Step 1 — wait for the prejoin name input so we know the page has reached
+  // the "Ready to join?" stage (rather than, say, a Google login redirect).
+  try {
+    await page.waitForSelector(selectors.PREJOIN_NAME_INPUT, {
+      timeout: PREJOIN_TIMEOUT_MS,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `meet-bot: prejoin name input did not appear within ${PREJOIN_TIMEOUT_MS}ms: ${msg}`,
+    );
+  }
+
+  // Step 2 — populate the display name.
+  await page.fill(selectors.PREJOIN_NAME_INPUT, displayName);
+
+  // Step 3 — choose the admission button. Prefer "Join now" because it is the
+  // happy-path branch for signed-in / same-domain sessions; fall back to
+  // "Ask to join" for locked meetings.
+  const joinNowCount = await page
+    .locator(selectors.PREJOIN_JOIN_NOW_BUTTON)
+    .count();
+  if (joinNowCount > 0) {
+    await page.click(selectors.PREJOIN_JOIN_NOW_BUTTON);
+  } else {
+    await page.click(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+  }
+
+  // Step 4 — wait for the in-meeting UI. The "Leave call" button only mounts
+  // once the bot is inside the meeting room, so it is our canonical signal
+  // that the admission flow succeeded.
+  try {
+    await page.waitForSelector(selectors.INGAME_LEAVE_BUTTON, {
+      timeout: MEETING_ROOM_TIMEOUT_MS,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `meet-bot: in-meeting UI did not appear within ${MEETING_ROOM_TIMEOUT_MS}ms (host may not have admitted the bot): ${msg}`,
+    );
+  }
+
+  // Step 5 — drop the consent notice. `postConsentMessage` handles opening
+  // the chat panel if it is still collapsed.
+  await postConsentMessage(page, consentMessage);
+}

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -14,16 +14,20 @@
  *     on macOS developer machines where PulseAudio is unavailable.
  *   - Logs a boot marker so the boot smoke test and the Docker `CMD` can
  *     verify the package structure.
- *   - If `MEET_URL` is set, brings up Xvfb + Chromium, navigates to the URL,
- *     drops a screenshot at `/tmp/boot-screenshot.png`, closes the session,
- *     and exits 0. This is the browser-runtime smoke path; the real Meet
- *     join flow (lobby handling, name entry, join-button clicks) lands in
- *     PR 11 of the meet-phase-1 plan.
+ *   - If `MEET_URL` is set, brings up Xvfb + Chromium and navigates to the
+ *     URL. When `JOIN_NAME` and `CONSENT_MESSAGE` are also set, runs the full
+ *     Meet join flow (name entry, Join/Ask-to-join branch, consent notice)
+ *     via `joinMeet`. When only `MEET_URL` is provided, drops a screenshot at
+ *     `/tmp/boot-screenshot.png`, closes the session, and exits 0 — this is
+ *     the browser-runtime smoke path the boot tests rely on.
+ *   - On join failure, logs the error and exits with status 1 so the
+ *     container orchestrator can observe the problem.
  *
  * Anything heavier — Hono HTTP control surface, live audio capture wiring,
  * transcript streaming — lands in later PRs.
  */
 
+import { joinMeet } from "./browser/join-flow.js";
 import { createBrowserSession } from "./browser/session.js";
 import { setupPulseAudio } from "./media/pulse.js";
 
@@ -44,10 +48,30 @@ async function main(): Promise<void> {
   if (meetUrl) {
     const session = await createBrowserSession(meetUrl);
     try {
-      await session.page.screenshot({ path: "/tmp/boot-screenshot.png" });
-      console.log(
-        `meet-bot captured boot screenshot for ${meetUrl} at /tmp/boot-screenshot.png`,
-      );
+      const displayName = process.env.JOIN_NAME;
+      const consentMessage = process.env.CONSENT_MESSAGE;
+
+      if (displayName && consentMessage) {
+        // Full join flow — drive the prejoin surface and post the consent
+        // message. Failures abort with exit(1) so the container orchestrator
+        // can restart or surface the error.
+        try {
+          await joinMeet(session.page, { displayName, consentMessage });
+          console.log(`meet-bot joined ${meetUrl} as ${displayName}`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`meet-bot: join flow failed: ${msg}`);
+          process.exit(1);
+        }
+      } else {
+        // Backward-compatible screenshot-only path — used by the boot smoke
+        // test which sets only `MEET_URL`. Confirms the browser runtime can
+        // reach Meet without actually entering a meeting.
+        await session.page.screenshot({ path: "/tmp/boot-screenshot.png" });
+        console.log(
+          `meet-bot captured boot screenshot for ${meetUrl} at /tmp/boot-screenshot.png`,
+        );
+      }
     } finally {
       await session.close();
     }


### PR DESCRIPTION
## Summary
- `joinMeet` handles prejoin name input, Join/Ask-to-join branch, waits for in-meeting UI, posts consent message.
- `chat-bridge` exposes `postConsentMessage` + reusable `sendChat` (consumed by Phase 2 /send_chat endpoint).
- main.ts now calls joinMeet when MEET_URL+JOIN_NAME+CONSENT_MESSAGE env are set.

Part of plan: meet-phase-1-listen.md (PR 11 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
