### PR TITLE
meet-bot: DOM participant list scraper

### DIFF
--- a/meet-bot/__tests__/participant-scraper.test.ts
+++ b/meet-bot/__tests__/participant-scraper.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for the participant-panel scraper.
+ *
+ * The scraper is designed to run against a live Google Meet page, but we
+ * verify its logic here with a lightweight fake `Page` that responds to the
+ * same `$`, `$$eval`, and click surface the scraper exercises. This keeps
+ * the suite hermetic (no Xvfb, no Chromium, no Playwright launch) and lets
+ * us drive the DOM shape via plain JavaScript objects.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ParticipantChangeEvent } from "@vellumai/meet-contracts";
+
+import { selectors } from "../src/browser/dom-selectors.js";
+import { startParticipantScraper } from "../src/browser/participant-scraper.js";
+
+/**
+ * Minimal participant row shape the fake page returns from `$$eval`. Mirrors
+ * what the real extractor emits when it reads `data-participant-id` and the
+ * participant-name subselector from each row.
+ */
+interface ScrapedRow {
+  id: string | null;
+  name: string | null;
+}
+
+/**
+ * Fake `Page` stand-in covering the three surfaces the scraper touches:
+ *   - `page.$(selector)` for panel-open detection and toggle lookup
+ *   - `page.$$eval(selector, fn, arg)` for reading the participant rows
+ *   - a click on the toggle element returned by `page.$`
+ *
+ * Callers mutate `rows` between ticks to simulate Meet's DOM changing while
+ * the scraper is running.
+ */
+interface FakePage {
+  rows: ScrapedRow[];
+  panelOpen: boolean;
+  toggleClicks: number;
+  // Signatures intentionally `any` — Playwright's $$eval has several
+  // overloads that are painful to satisfy from a hand-rolled fake, and the
+  // scraper only cares about the run-time behavior we stub here.
+  $: (selector: string) => Promise<unknown>;
+  $$eval: (...args: unknown[]) => Promise<ScrapedRow[]>;
+}
+
+function makeFakePage(initialRows: ScrapedRow[] = []): FakePage {
+  const fake: FakePage = {
+    rows: [...initialRows],
+    panelOpen: false,
+    toggleClicks: 0,
+    $: async (selector: string) => {
+      if (selector === selectors.INGAME_PARTICIPANT_LIST) {
+        return fake.panelOpen ? {} : null;
+      }
+      if (selector === selectors.INGAME_PARTICIPANTS_PANEL_BUTTON) {
+        return {
+          click: async () => {
+            fake.toggleClicks += 1;
+            fake.panelOpen = true;
+          },
+        };
+      }
+      return null;
+    },
+    $$eval: async () => fake.rows,
+  };
+  return fake;
+}
+
+/** Wait `ms` milliseconds — small helper so tests read linearly. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Drain any microtasks so the scraper's initial kick-off (which calls
+ * `void poll()` synchronously) resolves before we assert on the first
+ * emission.
+ */
+async function drainMicrotasks(): Promise<void> {
+  // Two ticks is enough for: (1) $ resolving the panel check, (2) $$eval
+  // resolving the row extraction, (3) the onChange callback firing.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("startParticipantScraper", () => {
+  let events: ParticipantChangeEvent[];
+  let handles: Array<{ stop: () => void }>;
+
+  beforeEach(() => {
+    events = [];
+    handles = [];
+  });
+
+  afterEach(() => {
+    for (const handle of handles) handle.stop();
+  });
+
+  test("emits initial snapshot with every current participant as joined", async () => {
+    const page = makeFakePage([
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+
+    await drainMicrotasks();
+    // Give the initial poll's click + $$eval chain time to settle.
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const initial = events[0]!;
+    expect(initial.type).toBe("participant.change");
+    expect(initial.meetingId).toBe("m-1");
+    expect(initial.left).toHaveLength(0);
+    expect(initial.joined).toHaveLength(2);
+    const joinedIds = initial.joined.map((p) => p.id).sort();
+    expect(joinedIds).toEqual(["p-alice", "p-bob"]);
+  });
+
+  test("opens the participants panel when it starts closed", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    expect(page.panelOpen).toBe(false);
+
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(page.toggleClicks).toBe(1);
+    expect(page.panelOpen).toBe(true);
+  });
+
+  test("does not re-click the toggle when the panel is already open", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    page.panelOpen = true;
+
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(page.toggleClicks).toBe(0);
+  });
+
+  test("emits only a diff event when participants change between polls", async () => {
+    const page = makeFakePage([
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+
+    // Bob leaves, Carol joins.
+    page.rows = [
+      { id: "p-alice", name: "Alice" },
+      { id: "p-carol", name: "Carol" },
+    ];
+
+    // Wait for a couple of poll intervals to elapse.
+    await sleep(80);
+
+    expect(events.length).toBe(2);
+    const diff = events[1]!;
+    expect(diff.joined.map((p) => p.id)).toEqual(["p-carol"]);
+    expect(diff.left.map((p) => p.id)).toEqual(["p-bob"]);
+    expect(diff.meetingId).toBe("m-1");
+  });
+
+  test("does not emit when the participant set is unchanged", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+
+    // Let a few poll intervals elapse without mutating the row list.
+    await sleep(100);
+
+    expect(events.length).toBe(1);
+  });
+
+  test("stop() cancels further emissions", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    handle.stop();
+
+    // Mutate the page so a running poll *would* fire a diff event; since we
+    // stopped, the scraper must stay quiet.
+    page.rows = [
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ];
+    await sleep(100);
+
+    expect(events.length).toBe(1);
+  });
+
+  test("stop() is idempotent — calling it twice does not throw", () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handle.stop();
+    expect(() => handle.stop()).not.toThrow();
+  });
+
+  test("uses Date.now-derived ISO timestamp in emitted events", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    const before = new Date().toISOString();
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+    const after = new Date().toISOString();
+
+    expect(events[0]!.timestamp >= before).toBe(true);
+    expect(events[0]!.timestamp <= after).toBe(true);
+  });
+
+  test("falls back to name as id when a row has no data-participant-id", async () => {
+    const page = makeFakePage([
+      // Simulate a partially-rendered row with no stable id.
+      { id: null, name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joinedIds = events[0]!.joined.map((p) => p.id).sort();
+    expect(joinedIds).toEqual(["Alice", "p-bob"]);
+  });
+
+  test("swallows $$eval errors and keeps polling", async () => {
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    let callCount = 0;
+    const originalEval = page.$$eval.bind(page);
+    page.$$eval = async (...args: unknown[]) => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error("transient DOM error");
+      }
+      return originalEval(...args);
+    };
+
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handles.push(handle);
+
+    // First poll errors (no event). Subsequent polls should succeed.
+    await sleep(100);
+
+    expect(callCount).toBeGreaterThan(1);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("restarting a scraper on the same fake page does not re-emit known participants as joined", async () => {
+    // Simulates the idempotency requirement: if a caller stops and restarts
+    // the scraper on a DOM it has already seen, the *restart* should emit
+    // its initial snapshot but downstream consumers are responsible for
+    // matching against their own state. The scraper itself treats each
+    // lifecycle as independent — this test just pins that expectation.
+    const page = makeFakePage([{ id: "p-alice", name: "Alice" }]);
+    const first = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    await sleep(50);
+    first.stop();
+    const afterFirst = events.length;
+
+    // Restart — re-emits initial snapshot once, then stays quiet while the
+    // DOM is unchanged.
+    const second = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 30 },
+    );
+    handles.push(second);
+    await sleep(100);
+
+    // One new emission (the restart's initial snapshot), no spurious join/leave
+    // churn from the already-known participants.
+    expect(events.length - afterFirst).toBe(1);
+    const restart = events[events.length - 1]!;
+    expect(restart.left).toHaveLength(0);
+    expect(restart.joined.map((p) => p.id)).toEqual(["p-alice"]);
+  });
+});

--- a/meet-bot/src/browser/participant-scraper.ts
+++ b/meet-bot/src/browser/participant-scraper.ts
@@ -1,0 +1,183 @@
+/**
+ * Participant-panel scraper.
+ *
+ * Polls Google Meet's "People" side panel every `pollMs` milliseconds, diffs
+ * the current roster against the previous snapshot (by participant id), and
+ * emits a `ParticipantChangeEvent` whenever participants join or leave.
+ *
+ * Design notes:
+ *
+ *   - Meet collapses the participant panel by default. On `startParticipantScraper`
+ *     we check whether the list container is already mounted (`INGAME_PARTICIPANT_LIST`)
+ *     and only click the panel toggle if it is not. Without this guard, clicking
+ *     an already-open panel would *close* it.
+ *   - We read participant rows via `page.$$eval` and extract `{ id, name }` from
+ *     each row. The stable id comes from `data-participant-id`; the name is
+ *     pulled from the `data-participant-name` / `data-self-name` subselector.
+ *     We only fall back to using the name as the id when the row has no stable
+ *     attribute (see TODO below).
+ *   - The first successful poll treats *every* current participant as `joined`
+ *     (initial snapshot). Subsequent polls only emit participants whose id
+ *     set differs from the previous snapshot. That keeps downstream consumers
+ *     (conversation bridge, storage writer) from having to special-case the
+ *     "first event" vs. "delta event".
+ *   - Errors during a poll (e.g. selector timeout, panel auto-collapsed) are
+ *     swallowed so a transient DOM glitch doesn't kill the scraper. The next
+ *     poll will retry.
+ *
+ * Downstream consumers:
+ *
+ *   - PR 17 — conversation bridge (writes join/leave messages)
+ *   - PR 18 — storage writer (snapshots participants.json)
+ */
+
+import type { Page } from "playwright";
+
+import type { Participant, ParticipantChangeEvent } from "@vellumai/meet-contracts";
+
+import { selectors } from "./dom-selectors.js";
+
+/** Options for {@link startParticipantScraper}. */
+export interface ParticipantScraperOptions {
+  /** Meeting identifier embedded in every emitted event. */
+  meetingId: string;
+  /** Poll interval in milliseconds. Defaults to 1000. */
+  pollMs?: number;
+}
+
+/** Handle returned by {@link startParticipantScraper}. */
+export interface ParticipantScraperHandle {
+  /** Cancel the polling interval. Safe to call multiple times. */
+  stop: () => void;
+}
+
+/** Shape returned by the in-page `$$eval` extractor. */
+interface ScrapedRow {
+  id: string | null;
+  name: string | null;
+}
+
+/**
+ * Start polling the participant panel and invoke `onChange` whenever the
+ * participant set changes.
+ *
+ * The first poll emits a `ParticipantChangeEvent` with every currently-visible
+ * participant in `joined` and an empty `left`. Subsequent polls only fire when
+ * the id-set differs.
+ *
+ * @returns A handle whose `stop()` method cancels the poll interval.
+ */
+export function startParticipantScraper(
+  page: Page,
+  onChange: (event: ParticipantChangeEvent) => void,
+  opts: ParticipantScraperOptions = { meetingId: "" },
+): ParticipantScraperHandle {
+  const pollMs = opts.pollMs ?? 1000;
+  const meetingId = opts.meetingId;
+
+  /**
+   * Snapshot of the previous poll keyed by participant id, so we can
+   * build the joined/left diffs efficiently and preserve the full
+   * participant object for departed rows (which won't be in the current
+   * DOM anymore).
+   */
+  let previous: Map<string, Participant> = new Map();
+  let firstPollComplete = false;
+  let stopped = false;
+
+  const poll = async (): Promise<void> => {
+    if (stopped) return;
+
+    let rows: ScrapedRow[];
+    try {
+      // Open the participants panel if it isn't already. Checking the list
+      // container first avoids toggling a panel that is already visible.
+      const alreadyOpen = await page.$(selectors.INGAME_PARTICIPANT_LIST);
+      if (!alreadyOpen) {
+        const toggle = await page.$(selectors.INGAME_PARTICIPANTS_PANEL_BUTTON);
+        if (toggle) {
+          await toggle.click();
+        }
+      }
+
+      rows = await page.$$eval(
+        selectors.INGAME_PARTICIPANT_NODE,
+        (nodes, nameSelector) =>
+          nodes.map((node) => {
+            const el = node as HTMLElement;
+            const id = el.getAttribute("data-participant-id");
+            const nameEl = el.querySelector(nameSelector);
+            const name =
+              (nameEl?.textContent ?? "").trim() || null;
+            return { id: id ?? null, name };
+          }),
+        selectors.INGAME_PARTICIPANT_NAME,
+      );
+    } catch {
+      // Transient DOM error (navigation, panel auto-closed, etc.). Skip this
+      // tick and try again next interval.
+      return;
+    }
+
+    const current = new Map<string, Participant>();
+    for (const row of rows) {
+      const name = row.name ?? "";
+      // Prefer the stable `data-participant-id` attribute. If Meet hasn't
+      // attached one to this row, fall back to using the name as the id.
+      // TODO(meet-dom): drop the name-as-id fallback once we confirm Meet
+      // always emits a stable id on every participant row. For MVP this
+      // keeps the scraper resilient to partially-rendered rows.
+      const id = row.id ?? name;
+      if (!id) continue;
+      current.set(id, { id, name });
+    }
+
+    // First poll: everyone currently visible is a "joined" participant from
+    // the scraper's perspective. Subsequent polls compute deltas against the
+    // previous snapshot.
+    const joined: Participant[] = [];
+    const left: Participant[] = [];
+
+    if (!firstPollComplete) {
+      for (const participant of current.values()) {
+        joined.push(participant);
+      }
+    } else {
+      for (const [id, participant] of current) {
+        if (!previous.has(id)) joined.push(participant);
+      }
+      for (const [id, participant] of previous) {
+        if (!current.has(id)) left.push(participant);
+      }
+    }
+
+    previous = current;
+    firstPollComplete = true;
+
+    if (joined.length === 0 && left.length === 0) return;
+
+    const event: ParticipantChangeEvent = {
+      type: "participant.change",
+      meetingId,
+      timestamp: new Date().toISOString(),
+      joined,
+      left,
+    };
+    onChange(event);
+  };
+
+  const timer = setInterval(() => {
+    void poll();
+  }, pollMs);
+  // Kick off the first poll immediately so callers don't have to wait a
+  // full interval for the initial snapshot.
+  void poll();
+
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- `startParticipantScraper` polls the participant list every 1s, diffs against previous snapshot.
- Emits `ParticipantChangeEvent` with joined/left lists; initial poll emits all current participants as joined.
- Returns `stop()` to cancel cleanly.

Part of plan: meet-phase-1-listen.md (PR 12 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
