### PR TITLE
meet-bot: DOM active-speaker scraper

### DIFF
--- a/meet-bot/__tests__/speaker-scraper.test.ts
+++ b/meet-bot/__tests__/speaker-scraper.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for the DOM active-speaker scraper.
+ *
+ * We don't spin up a real browser here — that's what `XVFB_TEST=1` style
+ * integration tests are for. Instead we:
+ *
+ *   1. Build a jsdom document from the committed in-meeting fixture.
+ *   2. Wrap it in a minimal Playwright-`Page`-shaped mock that redirects
+ *      `evaluate` / `exposeFunction` into the jsdom window.
+ *   3. Flip `data-active-speaker` attributes on the fixture tiles to
+ *      simulate Meet promoting/demoting participants, and assert the
+ *      scraper turns those transitions into `SpeakerChangeEvent`s.
+ *
+ * Every mutation in this file goes through jsdom's real MutationObserver,
+ * so the test exercises the same in-page observer wiring that runs in
+ * production.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import {
+  SpeakerChangeEventSchema,
+  type SpeakerChangeEvent,
+} from "@vellumai/meet-contracts";
+
+import {
+  startSpeakerScraper,
+  type ScraperPage,
+} from "../src/browser/speaker-scraper.js";
+
+const FIXTURE_PATH = join(
+  import.meta.dir,
+  "fixtures",
+  "meet-dom-ingame.html",
+);
+
+interface JsdomPageHarness {
+  page: ScraperPage;
+  dom: JSDOM;
+  /** Replace the current active-speaker tile by id; setting `null` clears. */
+  setActiveSpeaker: (participantId: string | null) => void;
+  /** Tear the fake page down — mirrors Playwright's `page.close()`. */
+  close: () => void;
+}
+
+/**
+ * Build a jsdom-backed `ScraperPage` seeded with the ingame fixture.
+ *
+ * The harness wires `evaluate` / `exposeFunction` into the jsdom window so
+ * the scraper's in-page code executes against a real MutationObserver.
+ * That means attribute flips on the fixture DOM actually trigger the
+ * observer, which then invokes the exposed callback — the same flow the
+ * production scraper takes against a live Playwright page.
+ */
+function makeJsdomPage(): JsdomPageHarness {
+  const html = readFileSync(FIXTURE_PATH, "utf8");
+  const dom = new JSDOM(html, { runScripts: "outside-only" });
+  const { window } = dom;
+  let closed = false;
+
+  // Install jsdom's window, document, and MutationObserver onto the Node
+  // globalThis for the lifetime of this page. The real Playwright bridge
+  // executes page functions inside the page's JS realm, which means the
+  // MutationObserver's async callbacks always see the browser's globals.
+  // Here we mimic that by keeping the globals live from start to close —
+  // restoring them between `evaluate` calls would leave the async
+  // callback's `document.querySelector` pointing at `undefined`.
+  const previousGlobals = {
+    window: (globalThis as { window?: unknown }).window,
+    document: (globalThis as { document?: unknown }).document,
+    MutationObserver: (globalThis as { MutationObserver?: unknown })
+      .MutationObserver,
+  };
+  (globalThis as { window?: unknown }).window = window;
+  (globalThis as { document?: unknown }).document = window.document;
+  (globalThis as { MutationObserver?: unknown }).MutationObserver =
+    window.MutationObserver;
+
+  const page: ScraperPage = {
+    /**
+     * Mirror `Page.evaluate` by invoking the caller-supplied function in
+     * the Node context with jsdom globals already installed on
+     * `globalThis`. The globals stay live for the whole page lifetime so
+     * async observer callbacks can still find them.
+     */
+    evaluate: (async (fn: unknown, arg: unknown) => {
+      if (closed) throw new Error("page closed");
+      // Accept both function refs and string expressions; the scraper
+      // only uses function refs, so that's the only path we need.
+      if (typeof fn !== "function") {
+        throw new Error("string evaluate not supported by test harness");
+      }
+      return await (fn as (a: unknown) => unknown)(arg);
+    }) as ScraperPage["evaluate"],
+
+    /**
+     * Mirror `Page.exposeFunction` by installing the callback on the
+     * jsdom window under the given name. The in-page scraper code reads
+     * it back through `window[name]`.
+     */
+    exposeFunction: (async (
+      name: string,
+      callback: (...args: unknown[]) => unknown,
+    ) => {
+      if (closed) throw new Error("page closed");
+      (window as unknown as Record<string, unknown>)[name] = callback;
+    }) as ScraperPage["exposeFunction"],
+
+    isClosed: () => closed,
+  };
+
+  const setActiveSpeaker = (participantId: string | null): void => {
+    const tiles = window.document.querySelectorAll("[data-participant-tile]");
+    for (const tile of Array.from(tiles)) {
+      const id = tile.getAttribute("data-participant-id");
+      tile.setAttribute(
+        "data-active-speaker",
+        id === participantId ? "true" : "false",
+      );
+    }
+  };
+
+  return {
+    page,
+    dom,
+    setActiveSpeaker,
+    close: () => {
+      closed = true;
+      // Restore the pre-test globals so the next test (or unrelated
+      // modules run by the test runner) sees a pristine environment.
+      (globalThis as { window?: unknown }).window = previousGlobals.window;
+      (globalThis as { document?: unknown }).document =
+        previousGlobals.document;
+      (globalThis as { MutationObserver?: unknown }).MutationObserver =
+        previousGlobals.MutationObserver;
+      dom.window.close();
+    },
+  };
+}
+
+/**
+ * Drain pending microtasks plus a short wall-clock wait so jsdom's
+ * MutationObserver callbacks (which are scheduled as microtasks) can
+ * fire before the test asserts.
+ */
+async function tick(ms = 5): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("startSpeakerScraper", () => {
+  let harness: JsdomPageHarness;
+  let events: SpeakerChangeEvent[];
+  let stopScraper: (() => void) | null = null;
+
+  beforeEach(() => {
+    harness = makeJsdomPage();
+    events = [];
+    stopScraper = null;
+  });
+
+  afterEach(() => {
+    stopScraper?.();
+    harness.close();
+  });
+
+  test("emits the initial active speaker when the fixture already has one", async () => {
+    // Fixture starts with Alice (p-alice) flagged active. The scraper
+    // should surface that as the first event on startup.
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "meeting-1" },
+    );
+    stopScraper = stop;
+
+    // Allow the exposeFunction promise + initial evaluate to resolve.
+    await tick(20);
+
+    expect(events.length).toBe(1);
+    const event = events[0]!;
+    expect(event.type).toBe("speaker.change");
+    expect(event.meetingId).toBe("meeting-1");
+    expect(event.speakerId).toBe("p-alice");
+    expect(event.speakerName).toBe("Alice");
+    // Schema compliance: timestamp must be a non-empty ISO string.
+    expect(typeof event.timestamp).toBe("string");
+    expect(event.timestamp.length).toBeGreaterThan(0);
+    // Full shape must round-trip through the wire-protocol schema.
+    expect(() => SpeakerChangeEventSchema.parse(event)).not.toThrow();
+  });
+
+  test("emits a new event when the active-speaker attribute moves to a different tile", async () => {
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "meeting-1" },
+    );
+    stopScraper = stop;
+
+    await tick(20);
+
+    // Clear the initial Alice emission so the test focuses on transitions.
+    expect(events.length).toBe(1);
+    events.length = 0;
+
+    // Alice → Bob.
+    harness.setActiveSpeaker("p-bob");
+    await tick(20);
+
+    // Bob → Alice.
+    harness.setActiveSpeaker("p-alice");
+    await tick(20);
+
+    expect(events.map((e) => e.speakerId)).toEqual(["p-bob", "p-alice"]);
+    expect(events.map((e) => e.speakerName)).toEqual(["Bob", "Alice"]);
+    // Every event still validates against the schema.
+    for (const event of events) {
+      expect(() => SpeakerChangeEventSchema.parse(event)).not.toThrow();
+    }
+  });
+
+  test("dedupes consecutive identical activations", async () => {
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "meeting-1" },
+    );
+    stopScraper = stop;
+
+    await tick(20);
+    expect(events.length).toBe(1);
+    events.length = 0;
+
+    // Re-emit Alice repeatedly. Meet can toggle attributes on the same
+    // tile (e.g. between true/true via a DOM patch) without actually
+    // changing who's speaking; we must not amplify those into events.
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+
+    expect(events.length).toBe(0);
+  });
+
+  test("emits nothing during the first 200ms of a static fixture (no changes)", async () => {
+    // Start with NO active speaker so even the initial-emit path is a
+    // no-op; this isolates the "no spurious events" guarantee.
+    harness.setActiveSpeaker(null);
+
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "meeting-1", pollMs: 50 },
+    );
+    stopScraper = stop;
+
+    // Wait well past 200ms — enough for multiple poll ticks at 50ms.
+    await tick(220);
+
+    expect(events).toEqual([]);
+  });
+
+  test("stop() silences further events even when the DOM keeps changing", async () => {
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "meeting-1" },
+    );
+    stopScraper = stop;
+
+    await tick(20);
+    events.length = 0;
+
+    stop();
+
+    // Further attribute flips must not produce any more events.
+    harness.setActiveSpeaker("p-bob");
+    await tick(20);
+    harness.setActiveSpeaker("p-alice");
+    await tick(20);
+
+    expect(events).toEqual([]);
+  });
+
+  test("stop() is idempotent", async () => {
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      () => {},
+      { meetingId: "meeting-1" },
+    );
+    stopScraper = stop;
+
+    // Calling stop() twice must not throw.
+    stop();
+    expect(() => stop()).not.toThrow();
+  });
+
+  test("stamps the meetingId and a valid timestamp on every event", async () => {
+    const { stop } = startSpeakerScraper(
+      harness.page,
+      (event) => events.push(event),
+      { meetingId: "my-meeting-xyz" },
+    );
+    stopScraper = stop;
+
+    await tick(20);
+    harness.setActiveSpeaker("p-bob");
+    await tick(20);
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    for (const event of events) {
+      expect(event.meetingId).toBe("my-meeting-xyz");
+      // ISO-8601 strings parse into a finite Date.
+      const parsed = new Date(event.timestamp);
+      expect(Number.isNaN(parsed.getTime())).toBe(false);
+    }
+  });
+});

--- a/meet-bot/src/browser/speaker-scraper.ts
+++ b/meet-bot/src/browser/speaker-scraper.ts
@@ -1,0 +1,304 @@
+/**
+ * DOM active-speaker scraper.
+ *
+ * Watches Google Meet's participant-tile grid for changes to the
+ * active-speaker indicator ({@link INGAME_ACTIVE_SPEAKER_INDICATOR}) and
+ * emits a {@link SpeakerChangeEvent} every time the active speaker
+ * transitions to a new participant.
+ *
+ * ## Strategy
+ *
+ * Meet toggles `data-active-speaker="true"` on exactly one participant tile
+ * at a time. Rather than poll from the Node side (which would require a
+ * Playwright round-trip every {@link ScraperOptions.pollMs}ms), we install
+ * a `MutationObserver` *inside the page* that fires whenever the
+ * active-speaker attribute changes on any tile. The observer invokes a
+ * Node-side callback (registered via {@link Page.exposeFunction}) with the
+ * new speaker's ID/name.
+ *
+ * Because `exposeFunction` setup is occasionally fragile (e.g. if the page
+ * is mid-navigation when we install), the scraper also falls back to
+ * straight polling of {@link INGAME_ACTIVE_SPEAKER_INDICATOR} every
+ * {@link ScraperOptions.pollMs}ms. Both paths converge on the same dedupe
+ * logic — a repeat activation of the same speaker produces no event.
+ *
+ * ## Contract
+ *
+ * - Only emits events on transitions. A static fixture (no active-speaker
+ *   changes) must produce zero events, no matter how long we observe.
+ * - Emits `SpeakerChangeEvent` with `timestamp` as an ISO-8601 string so
+ *   the payload validates against `SpeakerChangeEventSchema`.
+ * - `stop()` is idempotent and must not throw; subsequent invocations are
+ *   no-ops.
+ */
+
+import type { Page } from "playwright";
+import type { SpeakerChangeEvent } from "@vellumai/meet-contracts";
+
+import { INGAME_ACTIVE_SPEAKER_INDICATOR } from "./dom-selectors.js";
+
+/**
+ * Narrow slice of the Playwright `Page` surface the scraper actually uses.
+ * Accepting this interface (instead of the full `Page`) keeps unit tests
+ * mockable without pulling in a real browser.
+ */
+export type ScraperPage = Pick<
+  Page,
+  "evaluate" | "exposeFunction" | "isClosed"
+>;
+
+/**
+ * Payload the in-page observer sends out to the Node-side callback. Kept
+ * deliberately small and primitive so it serializes cleanly across the
+ * Playwright bridge.
+ */
+export interface SpeakerTileSnapshot {
+  speakerId: string;
+  speakerName: string;
+}
+
+export interface ScraperOptions {
+  /** Meeting ID stamped onto every emitted event. */
+  meetingId: string;
+
+  /**
+   * Poll cadence, in ms. Drives both the polling fallback and the interval
+   * at which the MutationObserver's in-page queue is drained. Defaults to
+   * 150ms — fast enough that a normal conversational turn doesn't slip
+   * between polls, slow enough to keep wakeups cheap.
+   */
+  pollMs?: number;
+}
+
+export interface SpeakerScraperHandle {
+  /**
+   * Stop the scraper. Tears down the in-page observer + polling loop and
+   * detaches the exposed callback. Idempotent — calling twice is safe.
+   */
+  stop: () => void;
+}
+
+/** Default poll cadence. Exported so tests and callers can reference it. */
+export const DEFAULT_POLL_MS = 150;
+
+/**
+ * Monotonically-increasing suffix so multiple concurrent scrapers on the
+ * same page each get a unique `window.__meetBotSpeakerChange_<n>__` handle.
+ * Playwright's `exposeFunction` rejects duplicate names.
+ */
+let exposeCounter = 0;
+
+/**
+ * Begin observing active-speaker transitions on `page` and invoke
+ * `onChange` with a fully-formed `SpeakerChangeEvent` on each transition.
+ *
+ * Returns `{ stop }` — the caller owns teardown.
+ */
+export function startSpeakerScraper(
+  page: ScraperPage,
+  onChange: (event: SpeakerChangeEvent) => void,
+  opts: ScraperOptions,
+): SpeakerScraperHandle {
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
+  const meetingId = opts.meetingId;
+
+  // Track the last-emitted speaker so we can dedupe consecutive identical
+  // activations. `null` means we haven't emitted anything yet (including
+  // during a same-speaker re-announce at t=0, which is still a no-op).
+  let lastSpeakerId: string | null = null;
+  let stopped = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  // Unique identifier for this scraper instance's in-page globals. Using a
+  // counter (instead of e.g. a timestamp) keeps the name deterministic for
+  // tests and avoids collisions when two scrapers start in the same tick.
+  const instanceId = ++exposeCounter;
+  const exposedName = `__meetBotSpeakerChange_${instanceId}__`;
+  const observerGlobal = `__meetBotSpeakerObserver_${instanceId}__`;
+
+  /**
+   * Dedupe + forward. Both the MutationObserver-driven path and the
+   * polling-fallback path funnel through here so we can't double-emit even
+   * if both fire for the same transition.
+   */
+  const handleSnapshot = (snapshot: SpeakerTileSnapshot | null): void => {
+    if (stopped) return;
+    if (!snapshot) return;
+    if (snapshot.speakerId === lastSpeakerId) return;
+
+    lastSpeakerId = snapshot.speakerId;
+
+    // `SpeakerChangeEventSchema` types `timestamp` as a non-empty string,
+    // so we format "now" as ISO-8601. Downstream consumers can
+    // `Date.parse(event.timestamp)` to recover millis if needed.
+    const event: SpeakerChangeEvent = {
+      type: "speaker.change",
+      meetingId,
+      timestamp: new Date().toISOString(),
+      speakerId: snapshot.speakerId,
+      speakerName: snapshot.speakerName,
+    };
+
+    try {
+      onChange(event);
+    } catch {
+      // Never let a caller's error crash the scraper — the caller's
+      // observability pipeline is responsible for reporting onChange
+      // failures.
+    }
+  };
+
+  // ----- Primary path: in-page MutationObserver -----
+
+  // Expose the Node-side callback so the observer can call it directly.
+  // Best-effort — if `exposeFunction` fails (page closed, duplicate name,
+  // etc.), the polling fallback still guarantees we emit events.
+  void page
+    .exposeFunction(exposedName, (snapshot: SpeakerTileSnapshot | null) => {
+      handleSnapshot(snapshot);
+    })
+    .catch(() => {
+      // Swallow — polling fallback covers us.
+    });
+
+  // Install the MutationObserver. Guarded by a try/catch because the page
+  // may have closed between the caller obtaining the handle and us
+  // reaching this line.
+  void page
+    .evaluate(
+      ({ selector, callbackName, observerName }) => {
+        // Skip if somehow already installed (e.g. hot reload, duplicate
+        // start). We key on a window-level global keyed by observerName.
+        const w = window as unknown as Record<string, unknown>;
+        if (w[observerName]) return;
+
+        const extractSnapshot = (): {
+          speakerId: string;
+          speakerName: string;
+        } | null => {
+          const tile = document.querySelector(selector);
+          if (!tile) return null;
+          const speakerId = tile.getAttribute("data-participant-id") ?? "";
+          if (!speakerId) return null;
+          // Prefer the in-tile name label; fall back to the tile's aria /
+          // text content. Keeping this mirror-image simple — callers
+          // downstream can normalize or enrich with participant-panel
+          // info (see PR 21's speaker resolver).
+          const nameEl =
+            tile.querySelector("[data-participant-name]") ??
+            tile.querySelector("[data-self-name]") ??
+            tile.querySelector(".tile-name");
+          const speakerName =
+            nameEl?.textContent?.trim() ??
+            tile.getAttribute("aria-label")?.trim() ??
+            "";
+          return { speakerId, speakerName };
+        };
+
+        const callback = (w[callbackName] as
+          | ((
+              snapshot: { speakerId: string; speakerName: string } | null,
+            ) => void)
+          | undefined);
+
+        // Emit the initial active speaker (if any) so Node-side state is
+        // primed. Dedupe on the Node side means this is a no-op unless the
+        // page already has a speaker highlighted at scraper-start.
+        if (callback) callback(extractSnapshot());
+
+        const observer = new MutationObserver(() => {
+          const fresh = (w[callbackName] as
+            | ((
+                snapshot: { speakerId: string; speakerName: string } | null,
+              ) => void)
+            | undefined);
+          if (fresh) fresh(extractSnapshot());
+        });
+
+        observer.observe(document.body, {
+          subtree: true,
+          attributes: true,
+          attributeFilter: ["data-active-speaker"],
+          childList: true,
+        });
+
+        w[observerName] = observer;
+      },
+      {
+        selector: INGAME_ACTIVE_SPEAKER_INDICATOR,
+        callbackName: exposedName,
+        observerName: observerGlobal,
+      },
+    )
+    .catch(() => {
+      // Swallow — the polling fallback still emits transitions.
+    });
+
+  // ----- Fallback path: Node-side polling of the same selector -----
+
+  const pollOnce = async (): Promise<void> => {
+    if (stopped) return;
+    if (page.isClosed()) return;
+    try {
+      const snapshot = await page.evaluate((selector) => {
+        const tile = document.querySelector(selector);
+        if (!tile) return null;
+        const speakerId = tile.getAttribute("data-participant-id") ?? "";
+        if (!speakerId) return null;
+        const nameEl =
+          tile.querySelector("[data-participant-name]") ??
+          tile.querySelector("[data-self-name]") ??
+          tile.querySelector(".tile-name");
+        const speakerName =
+          nameEl?.textContent?.trim() ??
+          tile.getAttribute("aria-label")?.trim() ??
+          "";
+        return { speakerId, speakerName };
+      }, INGAME_ACTIVE_SPEAKER_INDICATOR);
+      handleSnapshot(snapshot);
+    } catch {
+      // Page may have navigated or closed between ticks; skip this tick
+      // and let the next one retry.
+    }
+  };
+
+  pollTimer = setInterval(() => {
+    void pollOnce();
+  }, pollMs);
+
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+
+      // Best-effort teardown of the in-page observer. We don't wait on it
+      // because `stop()` is synchronous by contract and the callback
+      // pipeline is already short-circuited by the `stopped` flag.
+      if (!page.isClosed()) {
+        void page
+          .evaluate((observerName) => {
+            const w = window as unknown as Record<string, unknown>;
+            const observer = w[observerName] as
+              | { disconnect: () => void }
+              | undefined;
+            if (observer && typeof observer.disconnect === "function") {
+              observer.disconnect();
+            }
+            delete w[observerName];
+          }, observerGlobal)
+          .catch(() => {
+            // Swallow.
+          });
+      }
+
+      // We intentionally leave the exposed function registered — Playwright
+      // doesn't expose an `unexposeFunction`, and the instance-unique name
+      // means it cannot collide with a later scraper. The `stopped` flag
+      // prevents any late in-page callback from reaching `onChange`.
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- `startSpeakerScraper` watches the active-speaker indicator via in-page MutationObserver (polling fallback); dedupes consecutive identical activations.
- Emits `SpeakerChangeEvent` on transitions.
- Returns `stop()` for clean teardown.

Part of plan: meet-phase-1-listen.md (PR 13 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
