### PR TITLE
meet: conversation bridge turning transcript events into messages

### DIFF
--- a/assistant/src/meet/__tests__/conversation-bridge.test.ts
+++ b/assistant/src/meet/__tests__/conversation-bridge.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Unit tests for MeetConversationBridge.
+ *
+ * The bridge is tested with a recording shim for `addMessage`, a local
+ * router instance (no singleton state leaks), and a stub event hub —
+ * so the whole surface is exercised without touching SQLite or the
+ * real process-level hub.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  InboundChatEvent,
+  LifecycleEvent,
+  MeetBotEvent,
+  ParticipantChangeEvent,
+  SpeakerChangeEvent,
+  TranscriptChunkEvent,
+} from "@vellumai/meet-contracts";
+
+import type { AssistantEvent } from "../../runtime/assistant-event.js";
+import {
+  type InsertMessageFn,
+  MeetConversationBridge,
+} from "../conversation-bridge.js";
+import { MeetSessionEventRouter } from "../session-event-router.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures & helpers
+// ---------------------------------------------------------------------------
+
+const MEETING_ID = "meeting-abc";
+const CONVERSATION_ID = "conv-xyz";
+const TIMESTAMP = "2025-01-01T00:00:00.000Z";
+
+interface InsertCall {
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  opts?: { skipIndexing?: boolean };
+}
+
+function makeInsertRecorder(): {
+  fn: InsertMessageFn;
+  calls: InsertCall[];
+} {
+  const calls: InsertCall[] = [];
+  let counter = 0;
+  const fn: InsertMessageFn = async (
+    conversationId,
+    role,
+    content,
+    metadata,
+    opts,
+  ) => {
+    calls.push({ conversationId, role, content, metadata, opts });
+    counter += 1;
+    return { id: `msg-${counter}` };
+  };
+  return { fn, calls };
+}
+
+function makeBridge(
+  overrides: {
+    conversationId?: string;
+    meetingId?: string;
+    insertMessage?: InsertMessageFn;
+    router?: MeetSessionEventRouter;
+    hubPublish?: ReturnType<typeof mock>;
+  } = {},
+) {
+  const recorder = overrides.insertMessage
+    ? { fn: overrides.insertMessage, calls: [] as InsertCall[] }
+    : makeInsertRecorder();
+  const router = overrides.router ?? new MeetSessionEventRouter();
+  const hubPublish = overrides.hubPublish ?? mock(async () => {});
+  const bridge = new MeetConversationBridge({
+    meetingId: overrides.meetingId ?? MEETING_ID,
+    conversationId: overrides.conversationId ?? CONVERSATION_ID,
+    insertMessage: recorder.fn,
+    router,
+    assistantEventHub: { publish: hubPublish as unknown as (e: AssistantEvent) => Promise<void> },
+  });
+  return { bridge, router, calls: recorder.calls, hubPublish };
+}
+
+function finalTranscript(
+  overrides: Partial<TranscriptChunkEvent> = {},
+): TranscriptChunkEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    isFinal: true,
+    text: "Hello, team.",
+    speakerLabel: "Speaker 0",
+    speakerId: "spk-0",
+    ...overrides,
+  };
+}
+
+function interimTranscript(
+  overrides: Partial<TranscriptChunkEvent> = {},
+): TranscriptChunkEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    isFinal: false,
+    text: "Hello",
+    speakerLabel: "Speaker 0",
+    speakerId: "spk-0",
+    confidence: 0.5,
+    ...overrides,
+  };
+}
+
+function inboundChat(
+  overrides: Partial<InboundChatEvent> = {},
+): InboundChatEvent {
+  return {
+    type: "chat.inbound",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    fromId: "u-alice",
+    fromName: "Alice",
+    text: "Hey assistant, please take notes.",
+    ...overrides,
+  };
+}
+
+function participantChange(
+  overrides: Partial<ParticipantChangeEvent> = {},
+): ParticipantChangeEvent {
+  return {
+    type: "participant.change",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    joined: [],
+    left: [],
+    ...overrides,
+  };
+}
+
+function speakerChange(
+  overrides: Partial<SpeakerChangeEvent> = {},
+): SpeakerChangeEvent {
+  return {
+    type: "speaker.change",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    speakerId: "spk-1",
+    speakerName: "Bob",
+    ...overrides,
+  };
+}
+
+function lifecycle(overrides: Partial<LifecycleEvent> = {}): LifecycleEvent {
+  return {
+    type: "lifecycle",
+    meetingId: MEETING_ID,
+    timestamp: TIMESTAMP,
+    state: "joined",
+    ...overrides,
+  };
+}
+
+function dispatch(router: MeetSessionEventRouter, event: MeetBotEvent): void {
+  router.dispatch(event.meetingId, event);
+}
+
+/**
+ * Let all micro-tasks settle — the router dispatches synchronously but
+ * the bridge's handler uses `void this.handleEvent(...)`, so we need a
+ * microtask flush before asserting inserts / publishes.
+ */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Subscription lifecycle
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge subscription", () => {
+  test("subscribe() registers a router handler; unsubscribe() removes it", () => {
+    const { bridge, router } = makeBridge();
+    expect(router.registeredCount()).toBe(0);
+
+    bridge.subscribe();
+    expect(router.registeredCount()).toBe(1);
+    expect(bridge.isSubscribed()).toBe(true);
+
+    bridge.unsubscribe();
+    expect(router.registeredCount()).toBe(0);
+    expect(bridge.isSubscribed()).toBe(false);
+  });
+
+  test("events dispatched before subscribe() are dropped", async () => {
+    const { bridge, router, calls } = makeBridge();
+
+    dispatch(router, finalTranscript());
+    await flush();
+    expect(calls).toHaveLength(0);
+
+    // Subscribe and dispatch again — now it should be recorded.
+    bridge.subscribe();
+    dispatch(router, finalTranscript());
+    await flush();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("events dispatched after unsubscribe() are dropped", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+    dispatch(router, finalTranscript());
+    await flush();
+    expect(calls).toHaveLength(1);
+
+    bridge.unsubscribe();
+    dispatch(router, finalTranscript());
+    await flush();
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcript handling
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — transcript.chunk", () => {
+  test("final chunks become conversation messages with speaker metadata", async () => {
+    const { bridge, router, calls, hubPublish } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      finalTranscript({
+        text: "Let's kick off the sync.",
+        speakerLabel: "Speaker 0",
+        speakerId: "spk-0",
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call?.conversationId).toBe(CONVERSATION_ID);
+    expect(call?.role).toBe("user");
+    const parsed = JSON.parse(call!.content) as Array<{
+      type: string;
+      text: string;
+    }>;
+    expect(parsed).toEqual([
+      { type: "text", text: "[Speaker 0]: Let's kick off the sync." },
+    ]);
+    expect(call?.metadata).toMatchObject({
+      meetingId: MEETING_ID,
+      meetTimestamp: TIMESTAMP,
+      meetSpeakerLabel: "Speaker 0",
+      meetSpeakerId: "spk-0",
+      meetSpeakerName: "Speaker 0",
+    });
+
+    // Final transcripts must not go to the hub as interim events.
+    expect(hubPublish).toHaveBeenCalledTimes(0);
+  });
+
+  test("final chunks without a speakerLabel fall back to 'Unknown speaker'", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      finalTranscript({
+        text: "Off-mic remark.",
+        speakerLabel: undefined,
+        speakerId: undefined,
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    const parsed = JSON.parse(calls[0]!.content) as Array<{ text: string }>;
+    expect(parsed[0]?.text).toBe("[Unknown speaker]: Off-mic remark.");
+    expect(calls[0]?.metadata).toMatchObject({
+      meetSpeakerName: "Unknown speaker",
+    });
+    expect(calls[0]?.metadata?.meetSpeakerLabel).toBeUndefined();
+    expect(calls[0]?.metadata?.meetSpeakerId).toBeUndefined();
+  });
+
+  test("empty / whitespace-only final chunks are skipped (no insert)", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(router, finalTranscript({ text: "" }));
+    dispatch(router, finalTranscript({ text: "   \n\t  " }));
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("interim chunks publish to the hub but never persist", async () => {
+    const { bridge, router, calls, hubPublish } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      interimTranscript({ text: "Hello tea", confidence: 0.72 }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(0);
+    expect(hubPublish).toHaveBeenCalledTimes(1);
+
+    const published = hubPublish.mock.calls[0]?.[0] as AssistantEvent;
+    expect(published.conversationId).toBe(CONVERSATION_ID);
+    expect(published.message).toMatchObject({
+      type: "meet.transcript_interim",
+      meetingId: MEETING_ID,
+      conversationId: CONVERSATION_ID,
+      timestamp: TIMESTAMP,
+      text: "Hello tea",
+      speakerLabel: "Speaker 0",
+      speakerId: "spk-0",
+      confidence: 0.72,
+    });
+  });
+
+  test("interim hub failures are logged but do not throw", async () => {
+    const failingPublish = mock(async () => {
+      throw new Error("hub offline");
+    });
+    const { bridge, router, calls } = makeBridge({
+      hubPublish: failingPublish,
+    });
+    bridge.subscribe();
+
+    // Should not throw — the router would surface an unhandled rejection
+    // via the bridge's .catch otherwise.
+    dispatch(router, interimTranscript());
+    await flush();
+
+    expect(failingPublish).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inbound chat handling
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — chat.inbound", () => {
+  test("chat messages persist with [Meet chat] prefix and chat metadata", async () => {
+    const { bridge, router, calls, hubPublish } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      inboundChat({ fromName: "Alice", fromId: "u-alice", text: "Notes?" }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call?.role).toBe("user");
+    expect(call?.conversationId).toBe(CONVERSATION_ID);
+    const parsed = JSON.parse(call!.content) as Array<{ text: string }>;
+    expect(parsed[0]?.text).toBe("[Meet chat] Alice: Notes?");
+    expect(call?.metadata).toMatchObject({
+      meetingId: MEETING_ID,
+      meetTimestamp: TIMESTAMP,
+      meetChatFromId: "u-alice",
+      meetChatFromName: "Alice",
+      automated: true,
+    });
+    expect(hubPublish).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Participant change handling
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — participant.change", () => {
+  test("joined participants produce one short 'X joined' line each", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      participantChange({
+        joined: [
+          { id: "u-alice", name: "Alice" },
+          { id: "u-bob", name: "Bob" },
+        ],
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(2);
+    const [alice, bob] = calls;
+
+    const aliceText = JSON.parse(alice!.content)[0].text;
+    const bobText = JSON.parse(bob!.content)[0].text;
+    expect(aliceText).toBe("Alice joined");
+    expect(bobText).toBe("Bob joined");
+
+    expect(alice?.role).toBe("assistant");
+    expect(alice?.metadata).toMatchObject({
+      meetingId: MEETING_ID,
+      meetParticipantId: "u-alice",
+      meetParticipantChange: "joined",
+      automated: true,
+    });
+    expect(alice?.opts).toEqual({ skipIndexing: true });
+    expect(bob?.opts).toEqual({ skipIndexing: true });
+  });
+
+  test("left participants produce one short 'X left' line each", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      participantChange({
+        left: [{ id: "u-carol", name: "Carol" }],
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(1);
+    const text = JSON.parse(calls[0]!.content)[0].text;
+    expect(text).toBe("Carol left");
+    expect(calls[0]?.role).toBe("assistant");
+    expect(calls[0]?.metadata).toMatchObject({
+      meetParticipantId: "u-carol",
+      meetParticipantChange: "left",
+      automated: true,
+    });
+  });
+
+  test("empty joined/left arrays produce no inserts", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(router, participantChange({ joined: [], left: [] }));
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("simultaneous joins + leaves each produce their own line", async () => {
+    const { bridge, router, calls } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(
+      router,
+      participantChange({
+        joined: [{ id: "u-alice", name: "Alice" }],
+        left: [{ id: "u-bob", name: "Bob" }],
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(2);
+    const texts = calls.map((c) => JSON.parse(c.content)[0].text);
+    expect(texts).toEqual(["Alice joined", "Bob left"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ignored event types (speaker.change, lifecycle)
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — ignored events", () => {
+  test("speaker.change events do not persist or publish", async () => {
+    const { bridge, router, calls, hubPublish } = makeBridge();
+    bridge.subscribe();
+
+    dispatch(router, speakerChange());
+    await flush();
+
+    expect(calls).toHaveLength(0);
+    expect(hubPublish).toHaveBeenCalledTimes(0);
+  });
+
+  test("lifecycle events do not persist or publish (every state)", async () => {
+    const { bridge, router, calls, hubPublish } = makeBridge();
+    bridge.subscribe();
+
+    for (const state of [
+      "joining",
+      "joined",
+      "leaving",
+      "left",
+      "error",
+    ] as const) {
+      dispatch(router, lifecycle({ state }));
+    }
+    await flush();
+
+    expect(calls).toHaveLength(0);
+    expect(hubPublish).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error isolation
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — error isolation", () => {
+  test("an insert failure does not tear down the bridge or router", async () => {
+    let shouldFail = true;
+    const failingInsert: InsertMessageFn = async () => {
+      if (shouldFail) {
+        throw new Error("db offline");
+      }
+      return { id: "recovered" };
+    };
+
+    const router = new MeetSessionEventRouter();
+    const hubPublish = mock(async () => {});
+    const bridge = new MeetConversationBridge({
+      meetingId: MEETING_ID,
+      conversationId: CONVERSATION_ID,
+      insertMessage: failingInsert,
+      router,
+      assistantEventHub: { publish: hubPublish as unknown as (e: AssistantEvent) => Promise<void> },
+    });
+    bridge.subscribe();
+
+    // First dispatch fails inside the handler — router must survive.
+    dispatch(router, finalTranscript());
+    await flush();
+
+    shouldFail = false;
+    dispatch(
+      router,
+      interimTranscript({ text: "still alive", isFinal: false }),
+    );
+    await flush();
+
+    // Hub publish happened for the interim chunk even though the earlier
+    // insert threw — the bridge did not crash the router registration.
+    expect(hubPublish).toHaveBeenCalledTimes(1);
+    expect(router.registeredCount()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-meeting isolation
+// ---------------------------------------------------------------------------
+
+describe("MeetConversationBridge — cross-meeting isolation", () => {
+  let router: MeetSessionEventRouter;
+
+  beforeEach(() => {
+    router = new MeetSessionEventRouter();
+  });
+
+  test("events for another meeting id do not reach this bridge", async () => {
+    const { bridge, calls } = makeBridge({ router });
+    bridge.subscribe();
+
+    dispatch(router, { ...finalTranscript(), meetingId: "some-other-meet" });
+    await flush();
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/assistant/src/meet/conversation-bridge.ts
+++ b/assistant/src/meet/conversation-bridge.ts
@@ -1,0 +1,310 @@
+/**
+ * MeetConversationBridge — turns bot-side meet events into conversation
+ * messages and live ephemeral updates.
+ *
+ * The bridge is a single-meeting subscriber on
+ * {@link MeetSessionEventRouter}. It fans incoming {@link MeetBotEvent}s
+ * into three sinks:
+ *
+ *   1. **Final transcripts** (`transcript.chunk` with `isFinal === true`)
+ *      are persisted as `"user"` messages in the conversation with a
+ *      `[<speakerName>]: <text>` attribution. Speaker metadata
+ *      (`meetSpeakerLabel`, `meetSpeakerId`, `meetSpeakerName`,
+ *      `meetTimestamp`) rides in the message metadata so later PRs can
+ *      surface the raw speaker context without re-parsing the content.
+ *
+ *   2. **Interim transcripts** (`transcript.chunk` with `isFinal === false`)
+ *      are NOT persisted. They are published via
+ *      {@link assistantEventHub} as `meet.transcript_interim` so live
+ *      clients can render in-progress text and have it superseded once a
+ *      final chunk arrives.
+ *
+ *   3. **Inbound chat** (`chat.inbound`) is persisted as a `"user"`
+ *      message prefixed with `"[Meet chat] <fromName>: <text>"` — this is
+ *      the repo's existing "tag it in the content" pattern used by
+ *      pointer / call messages (see `assistant/src/calls/call-pointer-messages.ts`).
+ *
+ *   4. **Participant changes** (`participant.change`) are persisted as
+ *      short `"assistant"`-role lines (`"<name> joined"` / `"<name> left"`)
+ *      with `automated: true` in metadata so they don't pollute memory
+ *      indexing.
+ *
+ * `speaker.change` and `lifecycle` are intentionally consumed elsewhere
+ * (PR 18 storage writer, PR 19 lifecycle listener, PR 21 speaker
+ * resolver); this bridge is a no-op for them.
+ *
+ * Dependency injection keeps the bridge test-friendly: the message-insert
+ * function and the router / event-hub can all be supplied at construction
+ * time so unit tests never need to spin up SQLite or the real singleton.
+ * PR 21 will extend this bridge to call the speaker resolver before
+ * every final-transcript insert to arbitrate Deepgram vs DOM speaker
+ * attribution — the `speakerLabel` / `speakerName` / `speakerId`
+ * carried on the event today are the raw Deepgram values.
+ */
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub as defaultAssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getMeetSessionEventRouter,
+  type MeetSessionEventHandler,
+  type MeetSessionEventRouter,
+} from "./session-event-router.js";
+
+const log = getLogger("meet-conversation-bridge");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow shape of `addMessage` from `memory/conversation-crud.ts` — the
+ * bridge only needs the subset of fields that the conversation message
+ * insert path actually accepts. Declared locally so tests can supply a
+ * recording shim without importing the full database module.
+ */
+export type InsertMessageFn = (
+  conversationId: string,
+  role: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+  opts?: { skipIndexing?: boolean },
+) => Promise<{ id: string } & Record<string, unknown>>;
+
+/** Minimal hub surface the bridge depends on — matches `assistantEventHub`. */
+export interface AssistantEventPublisher {
+  publish: (event: ReturnType<typeof buildAssistantEvent>) => Promise<void>;
+}
+
+export interface MeetConversationBridgeDeps {
+  /** Required: the per-meeting id the router keys on. */
+  meetingId: string;
+  /** Required: the target conversation to write into. */
+  conversationId: string;
+  /** Required: wrapper around `addMessage` — injected for tests. */
+  insertMessage: InsertMessageFn;
+  /** Optional: override the router (defaults to the process singleton). */
+  router?: MeetSessionEventRouter;
+  /** Optional: override the event hub (defaults to the process singleton). */
+  assistantEventHub?: AssistantEventPublisher;
+  /**
+   * Optional: override the assistant id on emitted interim events. The
+   * daemon normally uses `DAEMON_INTERNAL_ASSISTANT_ID` ("self"); tests
+   * may want to verify scope behavior.
+   */
+  assistantId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Bridge
+// ---------------------------------------------------------------------------
+
+export class MeetConversationBridge {
+  private readonly meetingId: string;
+  private readonly conversationId: string;
+  private readonly insertMessage: InsertMessageFn;
+  private readonly router: MeetSessionEventRouter;
+  private readonly hub: AssistantEventPublisher;
+  private readonly assistantId: string;
+  private subscribed = false;
+
+  constructor(deps: MeetConversationBridgeDeps) {
+    this.meetingId = deps.meetingId;
+    this.conversationId = deps.conversationId;
+    this.insertMessage = deps.insertMessage;
+    this.router = deps.router ?? getMeetSessionEventRouter();
+    this.hub = deps.assistantEventHub ?? defaultAssistantEventHub;
+    this.assistantId = deps.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+  }
+
+  /**
+   * Register this bridge as the handler for its `meetingId` on the
+   * router. Overwrites any prior registration (the router logs a warning
+   * in that case). Idempotent within a single instance — calling twice
+   * just re-registers the same handler.
+   */
+  subscribe(): void {
+    const handler: MeetSessionEventHandler = (event) => {
+      // Defer to async-aware branch but don't block the router — late
+      // errors are logged, not surfaced.
+      void this.handleEvent(event).catch((err) => {
+        log.error(
+          { err, meetingId: this.meetingId, eventType: event.type },
+          "MeetConversationBridge: handler failed",
+        );
+      });
+    };
+    this.router.register(this.meetingId, handler);
+    this.subscribed = true;
+  }
+
+  /**
+   * Remove this bridge's registration from the router. Safe to call
+   * multiple times and before `subscribe()`.
+   */
+  unsubscribe(): void {
+    this.router.unregister(this.meetingId);
+    this.subscribed = false;
+  }
+
+  /** Whether this bridge currently holds a router registration. */
+  isSubscribed(): boolean {
+    return this.subscribed;
+  }
+
+  // ── Event dispatch ────────────────────────────────────────────────────────
+
+  private async handleEvent(event: MeetBotEvent): Promise<void> {
+    switch (event.type) {
+      case "transcript.chunk":
+        if (event.isFinal) {
+          await this.handleFinalTranscript(event);
+        } else {
+          await this.handleInterimTranscript(event);
+        }
+        return;
+      case "chat.inbound":
+        await this.handleInboundChat(event);
+        return;
+      case "participant.change":
+        await this.handleParticipantChange(event);
+        return;
+      case "speaker.change":
+        // PR 18 (storage writer) / PR 21 (speaker resolver) own this.
+        return;
+      case "lifecycle":
+        // PR 19 (lifecycle listener) owns this.
+        return;
+      default: {
+        const exhaustiveCheck: never = event;
+        log.warn(
+          { meetingId: this.meetingId, event: exhaustiveCheck },
+          "MeetConversationBridge: unknown event type",
+        );
+        return;
+      }
+    }
+  }
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
+  private async handleFinalTranscript(
+    event: Extract<MeetBotEvent, { type: "transcript.chunk" }>,
+  ): Promise<void> {
+    const text = event.text.trim();
+    if (text.length === 0) {
+      // Empty final chunks sometimes arrive from ASR at segment boundaries —
+      // skip them so they don't clutter the conversation.
+      return;
+    }
+
+    // PR 21 will replace `speakerName` / `speakerId` with resolver output
+    // before building the attribution; for now we use the raw Deepgram
+    // metadata the event carries.
+    const speakerName = event.speakerLabel ?? "Unknown speaker";
+    const attributed = `[${speakerName}]: ${text}`;
+    const content = JSON.stringify([{ type: "text", text: attributed }]);
+
+    const metadata: Record<string, unknown> = {
+      meetingId: this.meetingId,
+      meetTimestamp: event.timestamp,
+    };
+    if (event.speakerLabel !== undefined) {
+      metadata.meetSpeakerLabel = event.speakerLabel;
+    }
+    if (event.speakerId !== undefined) {
+      metadata.meetSpeakerId = event.speakerId;
+    }
+    metadata.meetSpeakerName = speakerName;
+
+    await this.insertMessage(this.conversationId, "user", content, metadata);
+  }
+
+  private async handleInterimTranscript(
+    event: Extract<MeetBotEvent, { type: "transcript.chunk" }>,
+  ): Promise<void> {
+    // Never persisted — interim chunks are hub-only so the UI can render
+    // live text that will be superseded by the next final chunk.
+    const message = {
+      type: "meet.transcript_interim",
+      meetingId: this.meetingId,
+      conversationId: this.conversationId,
+      timestamp: event.timestamp,
+      text: event.text,
+      speakerLabel: event.speakerLabel,
+      speakerId: event.speakerId,
+      confidence: event.confidence,
+    } as unknown as ServerMessage;
+
+    try {
+      await this.hub.publish(
+        buildAssistantEvent(this.assistantId, message, this.conversationId),
+      );
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId },
+        "MeetConversationBridge: interim publish failed",
+      );
+    }
+  }
+
+  private async handleInboundChat(
+    event: Extract<MeetBotEvent, { type: "chat.inbound" }>,
+  ): Promise<void> {
+    const prefixed = `[Meet chat] ${event.fromName}: ${event.text}`;
+    const content = JSON.stringify([{ type: "text", text: prefixed }]);
+
+    await this.insertMessage(this.conversationId, "user", content, {
+      meetingId: this.meetingId,
+      meetTimestamp: event.timestamp,
+      meetChatFromId: event.fromId,
+      meetChatFromName: event.fromName,
+      /** Marks the message as automated-source so memory indexing can downweight. */
+      automated: true,
+    });
+  }
+
+  private async handleParticipantChange(
+    event: Extract<MeetBotEvent, { type: "participant.change" }>,
+  ): Promise<void> {
+    // Emit one short status line per join/leave so the conversation
+    // stays readable — one batched summary would hide concurrent moves.
+    for (const participant of event.joined) {
+      const line = `${participant.name} joined`;
+      await this.insertMessage(
+        this.conversationId,
+        "assistant",
+        JSON.stringify([{ type: "text", text: line }]),
+        {
+          meetingId: this.meetingId,
+          meetTimestamp: event.timestamp,
+          meetParticipantId: participant.id,
+          meetParticipantChange: "joined",
+          automated: true,
+        },
+        { skipIndexing: true },
+      );
+    }
+
+    for (const participant of event.left) {
+      const line = `${participant.name} left`;
+      await this.insertMessage(
+        this.conversationId,
+        "assistant",
+        JSON.stringify([{ type: "text", text: line }]),
+        {
+          meetingId: this.meetingId,
+          meetTimestamp: event.timestamp,
+          meetParticipantId: participant.id,
+          meetParticipantChange: "left",
+          automated: true,
+        },
+        { skipIndexing: true },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `MeetConversationBridge` subscribes to `MeetSessionEventRouter`, inserts final transcripts as conversation messages with speaker metadata.
- Inbound chat messages inserted as `[Meet chat]` prefixed messages.
- Participant join/leave inserted as short system lines.
- Interim transcripts published via `assistantEventHub` (ephemeral; no persistence).

Part of plan: meet-phase-1-listen.md (PR 17 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
