### PR TITLE
test: allow meet/session-manager.ts in secure-keys importer allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -215,6 +215,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
+      "meet/session-manager.ts", // Meet bot container provisioning (provider API key lookup for Deepgram/TTS)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- The newly-added `meet/session-manager.ts` (#25761) imports `getProviderKeyAsync` from `security/secure-keys` to resolve Deepgram + TTS API keys when provisioning Meet bot containers, but was not in the `credential-security-invariants` test allowlist, breaking CI on main.
- Adds the file to `ALLOWED_IMPORTERS` with a note about its purpose.

## Original prompt
`--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24442562634/job/71410862323`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
