### PR TITLE
meet: publish lifecycle events via assistantEventHub

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -29,6 +29,7 @@ export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
 export * from "./message-types/inbox.js";
 export * from "./message-types/integrations.js";
+export * from "./message-types/meet.js";
 export * from "./message-types/memory.js";
 export * from "./message-types/messages.js";
 export * from "./message-types/notifications.js";
@@ -94,6 +95,7 @@ import type {
   _IntegrationsClientMessages,
   _IntegrationsServerMessages,
 } from "./message-types/integrations.js";
+import type { _MeetServerMessages } from "./message-types/meet.js";
 import type { _MemoryServerMessages } from "./message-types/memory.js";
 import type {
   _MessagesClientMessages,
@@ -198,6 +200,7 @@ export type ServerMessage =
   | _HostBrowserServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages
+  | _MeetServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages
   | _SchedulesServerMessages

--- a/assistant/src/daemon/message-types/meet.ts
+++ b/assistant/src/daemon/message-types/meet.ts
@@ -1,0 +1,100 @@
+/**
+ * Meet — server → client push messages for live meeting state.
+ *
+ * Emitted by the assistant daemon as the Meet-bot progresses through its
+ * lifecycle (joining → joined → left) and as in-meeting state changes
+ * (participants, active speaker, transcript chunks).
+ *
+ * Keep payloads small and client-actionable: these events power the
+ * macOS "In meeting" status panel and the conversation bridge's live
+ * transcript feed. A client that missed an event can always refetch
+ * authoritative state from the daemon's HTTP routes.
+ */
+
+/** A single participant in a meeting. Shape mirrors the wire-level type. */
+export interface MeetParticipant {
+  /** Stable participant identifier (provider-specific). */
+  id: string;
+  /** Display name of the participant. */
+  name: string;
+  /** Whether the participant is the meeting host. */
+  isHost?: boolean;
+  /** Whether the participant is the bot itself. */
+  isSelf?: boolean;
+}
+
+/** The bot has started attempting to join a meeting. */
+export interface MeetJoining {
+  type: "meet.joining";
+  meetingId: string;
+  /** The Meet URL the bot was asked to join. */
+  url: string;
+}
+
+/** The bot has successfully joined and is live in the meeting. */
+export interface MeetJoined {
+  type: "meet.joined";
+  meetingId: string;
+}
+
+/** Participants joined and/or left the meeting since the last snapshot. */
+export interface MeetParticipantChanged {
+  type: "meet.participant_changed";
+  meetingId: string;
+  /** Participants who joined since the last snapshot. */
+  joined: MeetParticipant[];
+  /** Participants who left since the last snapshot. */
+  left: MeetParticipant[];
+}
+
+/** The active speaker in the meeting changed. */
+export interface MeetSpeakerChanged {
+  type: "meet.speaker_changed";
+  meetingId: string;
+  /** Stable speaker identifier for the new active speaker. */
+  speakerId: string;
+  /** Display name of the new active speaker. */
+  speakerName: string;
+}
+
+/**
+ * A finalized chunk of transcribed speech. Interim chunks are filtered
+ * out before publication so clients only render stable text.
+ */
+export interface MeetTranscriptChunk {
+  type: "meet.transcript_chunk";
+  meetingId: string;
+  /** The transcribed text. */
+  text: string;
+  /** Human-readable speaker label, if the ASR provided one. */
+  speakerLabel?: string;
+  /** Stable speaker identifier across the meeting, if available. */
+  speakerId?: string;
+  /** ASR confidence in [0, 1], if available. */
+  confidence?: number;
+}
+
+/** The bot has left the meeting. */
+export interface MeetLeft {
+  type: "meet.left";
+  meetingId: string;
+  /** Free-form reason passed to `leave()` (e.g. "user-requested", "timeout"). */
+  reason: string;
+}
+
+/** The bot hit a non-recoverable error (container crash, join failure, etc.). */
+export interface MeetError {
+  type: "meet.error";
+  meetingId: string;
+  /** Human-readable error detail. */
+  detail: string;
+}
+
+export type _MeetServerMessages =
+  | MeetJoining
+  | MeetJoined
+  | MeetParticipantChanged
+  | MeetSpeakerChanged
+  | MeetTranscriptChunk
+  | MeetLeft
+  | MeetError;

--- a/assistant/src/meet/__tests__/event-publisher.test.ts
+++ b/assistant/src/meet/__tests__/event-publisher.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Unit tests for the Meet event publisher + dispatcher.
+ *
+ * Covers:
+ *   - `publishMeetEvent` builds a proper `AssistantEvent` and hands it to
+ *     `assistantEventHub.publish` with the expected `type` + `meetingId` +
+ *     payload fields.
+ *   - `MeetEventDispatcher` supports multiple subscribers per meeting with
+ *     independent unsubscribe, and tolerates a throwing subscriber.
+ *   - `registerMeetingDispatcher` + `subscribeEventHubPublisher` turn
+ *     router-delivered bot events into the right `meet.*` event kinds.
+ *   - Interim transcript chunks are dropped; finals are published with the
+ *     full payload.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import type { AssistantEvent } from "../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
+import {
+  meetEventDispatcher,
+  publishMeetEvent,
+  registerMeetingDispatcher,
+  subscribeEventHubPublisher,
+  subscribeToMeetingEvents,
+  unregisterMeetingDispatcher,
+} from "../event-publisher.js";
+import {
+  __resetMeetSessionEventRouterForTests,
+  getMeetSessionEventRouter,
+} from "../session-event-router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to the event hub for a given assistantId and collect every
+ * published event. Returns the collected list + an unsubscribe function.
+ */
+function captureHub(assistantId: string) {
+  const received: AssistantEvent[] = [];
+  const sub = assistantEventHub.subscribe({ assistantId }, (event) => {
+    received.push(event);
+  });
+  return { received, dispose: () => sub.dispose() };
+}
+
+function makeTranscript(
+  meetingId: string,
+  isFinal: boolean,
+  overrides: Partial<{
+    text: string;
+    speakerLabel: string;
+    speakerId: string;
+    confidence: number;
+  }> = {},
+): MeetBotEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    isFinal,
+    text: overrides.text ?? "hello world",
+    speakerLabel: overrides.speakerLabel,
+    speakerId: overrides.speakerId,
+    confidence: overrides.confidence,
+  };
+}
+
+function makeSpeakerChange(meetingId: string): MeetBotEvent {
+  return {
+    type: "speaker.change",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    speakerId: "spk-1",
+    speakerName: "Alice",
+  };
+}
+
+function makeParticipantChange(meetingId: string): MeetBotEvent {
+  return {
+    type: "participant.change",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    joined: [{ id: "p1", name: "Alice" }],
+    left: [{ id: "p2", name: "Bob" }],
+  };
+}
+
+function makeLifecycle(
+  meetingId: string,
+  state: "joining" | "joined" | "leaving" | "left" | "error",
+  detail?: string,
+): MeetBotEvent {
+  return {
+    type: "lifecycle",
+    meetingId,
+    timestamp: new Date(0).toISOString(),
+    state,
+    detail,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  __resetMeetSessionEventRouterForTests();
+  meetEventDispatcher._resetForTests();
+});
+
+// ---------------------------------------------------------------------------
+// publishMeetEvent
+// ---------------------------------------------------------------------------
+
+describe("publishMeetEvent", () => {
+  test("wraps payload in a ServerMessage via buildAssistantEvent", async () => {
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    try {
+      await publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        "m-pub-1",
+        "meet.joining",
+        { url: "https://meet.google.com/abc-def-ghi" },
+      );
+
+      expect(received).toHaveLength(1);
+      const event = received[0]!;
+      expect(event.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+      expect(event.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(Number.isNaN(Date.parse(event.emittedAt))).toBe(false);
+      expect(event.message.type).toBe("meet.joining");
+      expect(
+        (event.message as { meetingId: string }).meetingId,
+      ).toBe("m-pub-1");
+      expect(
+        (event.message as { url: string }).url,
+      ).toBe("https://meet.google.com/abc-def-ghi");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("does not propagate subscriber failures", async () => {
+    // Subscribe with a throwing callback — the publish should still resolve.
+    const sub = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      () => {
+        throw new Error("boom");
+      },
+    );
+    try {
+      await expect(
+        publishMeetEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          "m-pub-2",
+          "meet.left",
+          { reason: "user-requested" },
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("each of the seven kinds round-trips as the message.type", async () => {
+    const kinds = [
+      "meet.joining",
+      "meet.joined",
+      "meet.participant_changed",
+      "meet.speaker_changed",
+      "meet.transcript_chunk",
+      "meet.left",
+      "meet.error",
+    ] as const;
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    try {
+      for (const kind of kinds) {
+        await publishMeetEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          "m-kinds",
+          kind,
+          {},
+        );
+      }
+      expect(received.map((e) => e.message.type)).toEqual([...kinds]);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MeetEventDispatcher
+// ---------------------------------------------------------------------------
+
+describe("meetEventDispatcher", () => {
+  test("supports multiple subscribers per meeting", () => {
+    const a: MeetBotEvent[] = [];
+    const b: MeetBotEvent[] = [];
+    const unsubA = subscribeToMeetingEvents("m1", (e) => a.push(e));
+    const unsubB = subscribeToMeetingEvents("m1", (e) => b.push(e));
+
+    const event = makeSpeakerChange("m1");
+    meetEventDispatcher.dispatch("m1", event);
+
+    expect(a).toEqual([event]);
+    expect(b).toEqual([event]);
+    expect(meetEventDispatcher.subscriberCount("m1")).toBe(2);
+
+    unsubA();
+    expect(meetEventDispatcher.subscriberCount("m1")).toBe(1);
+    meetEventDispatcher.dispatch("m1", makeSpeakerChange("m1"));
+    expect(a).toHaveLength(1); // no new delivery
+    expect(b).toHaveLength(2);
+
+    unsubB();
+    expect(meetEventDispatcher.subscriberCount("m1")).toBe(0);
+  });
+
+  test("a throwing subscriber does not poison its neighbors", () => {
+    subscribeToMeetingEvents("m2", () => {
+      throw new Error("boom");
+    });
+    const b: MeetBotEvent[] = [];
+    subscribeToMeetingEvents("m2", (e) => b.push(e));
+
+    const event = makeSpeakerChange("m2");
+    meetEventDispatcher.dispatch("m2", event);
+    expect(b).toEqual([event]);
+  });
+
+  test("subscribers are scoped per meeting (no cross-talk)", () => {
+    const m1: MeetBotEvent[] = [];
+    const m2: MeetBotEvent[] = [];
+    subscribeToMeetingEvents("m1", (e) => m1.push(e));
+    subscribeToMeetingEvents("m2", (e) => m2.push(e));
+
+    meetEventDispatcher.dispatch("m1", makeSpeakerChange("m1"));
+    meetEventDispatcher.dispatch("m2", makeSpeakerChange("m2"));
+
+    expect(m1).toHaveLength(1);
+    expect(m2).toHaveLength(1);
+  });
+
+  test("clear drops all subscribers for a single meeting", () => {
+    subscribeToMeetingEvents("m-clr", () => {});
+    subscribeToMeetingEvents("m-clr", () => {});
+    subscribeToMeetingEvents("m-other", () => {});
+
+    meetEventDispatcher.clear("m-clr");
+
+    expect(meetEventDispatcher.subscriberCount("m-clr")).toBe(0);
+    expect(meetEventDispatcher.subscriberCount("m-other")).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Router integration
+// ---------------------------------------------------------------------------
+
+describe("registerMeetingDispatcher / unregisterMeetingDispatcher", () => {
+  test("router forwards events into the dispatcher", () => {
+    registerMeetingDispatcher("m-router");
+
+    const seen: MeetBotEvent[] = [];
+    subscribeToMeetingEvents("m-router", (e) => seen.push(e));
+
+    const event = makeSpeakerChange("m-router");
+    getMeetSessionEventRouter().dispatch("m-router", event);
+
+    expect(seen).toEqual([event]);
+  });
+
+  test("unregister clears router + dispatcher state", () => {
+    registerMeetingDispatcher("m-u");
+    subscribeToMeetingEvents("m-u", () => {});
+    expect(meetEventDispatcher.subscriberCount("m-u")).toBe(1);
+
+    unregisterMeetingDispatcher("m-u");
+
+    // Router has no handler → dispatch is a no-op.
+    getMeetSessionEventRouter().dispatch("m-u", makeSpeakerChange("m-u"));
+    expect(meetEventDispatcher.subscriberCount("m-u")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeEventHubPublisher — router event → meet.* fan-out
+// ---------------------------------------------------------------------------
+
+describe("subscribeEventHubPublisher", () => {
+  test("participant.change → meet.participant_changed with joined/left arrays", async () => {
+    registerMeetingDispatcher("m-p");
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const unsub = subscribeEventHubPublisher(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      "m-p",
+    );
+    try {
+      const event = makeParticipantChange("m-p");
+      getMeetSessionEventRouter().dispatch("m-p", event);
+
+      // Give the fire-and-forget publish a microtask to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(received).toHaveLength(1);
+      const msg = received[0]!.message as {
+        type: string;
+        meetingId: string;
+        joined: Array<{ id: string; name: string }>;
+        left: Array<{ id: string; name: string }>;
+      };
+      expect(msg.type).toBe("meet.participant_changed");
+      expect(msg.meetingId).toBe("m-p");
+      expect(msg.joined).toEqual([{ id: "p1", name: "Alice" }]);
+      expect(msg.left).toEqual([{ id: "p2", name: "Bob" }]);
+    } finally {
+      unsub();
+      unregisterMeetingDispatcher("m-p");
+      dispose();
+    }
+  });
+
+  test("speaker.change → meet.speaker_changed with id + name", async () => {
+    registerMeetingDispatcher("m-s");
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const unsub = subscribeEventHubPublisher(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      "m-s",
+    );
+    try {
+      getMeetSessionEventRouter().dispatch("m-s", makeSpeakerChange("m-s"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(received).toHaveLength(1);
+      const msg = received[0]!.message as {
+        type: string;
+        speakerId: string;
+        speakerName: string;
+      };
+      expect(msg.type).toBe("meet.speaker_changed");
+      expect(msg.speakerId).toBe("spk-1");
+      expect(msg.speakerName).toBe("Alice");
+    } finally {
+      unsub();
+      unregisterMeetingDispatcher("m-s");
+      dispose();
+    }
+  });
+
+  test("final transcript.chunk → meet.transcript_chunk; interims are dropped", async () => {
+    registerMeetingDispatcher("m-t");
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const unsub = subscribeEventHubPublisher(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      "m-t",
+    );
+    try {
+      // Interim — should NOT publish.
+      getMeetSessionEventRouter().dispatch(
+        "m-t",
+        makeTranscript("m-t", false, { text: "interim …" }),
+      );
+      // Final — SHOULD publish with all optional fields preserved.
+      getMeetSessionEventRouter().dispatch(
+        "m-t",
+        makeTranscript("m-t", true, {
+          text: "hello final",
+          speakerLabel: "Alice",
+          speakerId: "spk-1",
+          confidence: 0.92,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(received).toHaveLength(1);
+      const msg = received[0]!.message as {
+        type: string;
+        text: string;
+        speakerLabel: string;
+        speakerId: string;
+        confidence: number;
+      };
+      expect(msg.type).toBe("meet.transcript_chunk");
+      expect(msg.text).toBe("hello final");
+      expect(msg.speakerLabel).toBe("Alice");
+      expect(msg.speakerId).toBe("spk-1");
+      expect(msg.confidence).toBe(0.92);
+    } finally {
+      unsub();
+      unregisterMeetingDispatcher("m-t");
+      dispose();
+    }
+  });
+
+  test("lifecycle events are NOT fanned out via the publisher", async () => {
+    // The session manager publishes lifecycle events itself (at join start,
+    // first joined, leave, error). The router-hub bridge must stay quiet on
+    // lifecycle or we'd double-publish `meet.joined` etc.
+    registerMeetingDispatcher("m-l");
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const unsub = subscribeEventHubPublisher(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      "m-l",
+    );
+    try {
+      getMeetSessionEventRouter().dispatch(
+        "m-l",
+        makeLifecycle("m-l", "joined"),
+      );
+      getMeetSessionEventRouter().dispatch(
+        "m-l",
+        makeLifecycle("m-l", "left"),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(received).toEqual([]);
+    } finally {
+      unsub();
+      unregisterMeetingDispatcher("m-l");
+      dispose();
+    }
+  });
+
+  test("chat.inbound is dropped (not a meet.* event kind)", async () => {
+    registerMeetingDispatcher("m-c");
+    const { received, dispose } = captureHub(DAEMON_INTERNAL_ASSISTANT_ID);
+    const unsub = subscribeEventHubPublisher(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      "m-c",
+    );
+    try {
+      getMeetSessionEventRouter().dispatch("m-c", {
+        type: "chat.inbound",
+        meetingId: "m-c",
+        timestamp: new Date(0).toISOString(),
+        fromId: "p1",
+        fromName: "Alice",
+        text: "hi",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(received).toEqual([]);
+    } finally {
+      unsub();
+      unregisterMeetingDispatcher("m-c");
+      dispose();
+    }
+  });
+});

--- a/assistant/src/meet/__tests__/session-manager.test.ts
+++ b/assistant/src/meet/__tests__/session-manager.test.ts
@@ -10,6 +10,10 @@ import {
   test,
 } from "bun:test";
 
+import type { AssistantEvent } from "../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
+import { meetEventDispatcher } from "../event-publisher.js";
 import {
   __resetMeetSessionEventRouterForTests,
   getMeetSessionEventRouter,
@@ -65,6 +69,7 @@ let workspaceDir: string;
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "session-manager-test-"));
   __resetMeetSessionEventRouterForTests();
+  meetEventDispatcher._resetForTests();
 });
 
 afterEach(() => {
@@ -433,6 +438,177 @@ describe("MeetSessionManager max-minutes timeout", () => {
     } finally {
       globalThis.setTimeout = realSetTimeout;
       globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event-hub lifecycle publication (PR 19)
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager event-hub lifecycle publication", () => {
+  function captureHub() {
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      (event) => {
+        received.push(event);
+      },
+    );
+    return { received, dispose: () => sub.dispose() };
+  }
+
+  test("join publishes meet.joining; leave publishes meet.left with reason", async () => {
+    const runner = makeMockRunner();
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+      });
+
+      await manager.join({
+        url: "https://meet.google.com/aaa",
+        meetingId: "m-ev-1",
+        conversationId: "c",
+      });
+      await manager.leave("m-ev-1", "user-requested");
+
+      const meetTypes = received
+        .map((e) => e.message.type)
+        .filter((t) => t.startsWith("meet."));
+      expect(meetTypes).toContain("meet.joining");
+      expect(meetTypes).toContain("meet.left");
+
+      const joining = received.find((e) => e.message.type === "meet.joining")!;
+      expect(
+        (joining.message as { url: string }).url,
+      ).toBe("https://meet.google.com/aaa");
+
+      const left = received.find((e) => e.message.type === "meet.left")!;
+      expect(
+        (left.message as { reason: string }).reason,
+      ).toBe("user-requested");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("lifecycle:joined bot event publishes meet.joined exactly once", async () => {
+    const runner = makeMockRunner();
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-ev-2",
+        conversationId: "c",
+      });
+
+      // Simulate the bot delivering its lifecycle:joined event twice — the
+      // session manager should only fire `meet.joined` on the first one.
+      getMeetSessionEventRouter().dispatch("m-ev-2", {
+        type: "lifecycle",
+        meetingId: "m-ev-2",
+        timestamp: new Date(0).toISOString(),
+        state: "joined",
+      });
+      getMeetSessionEventRouter().dispatch("m-ev-2", {
+        type: "lifecycle",
+        meetingId: "m-ev-2",
+        timestamp: new Date(0).toISOString(),
+        state: "joined",
+      });
+
+      // Let the fire-and-forget publish calls settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const joined = received.filter((e) => e.message.type === "meet.joined");
+      expect(joined).toHaveLength(1);
+
+      await manager.leave("m-ev-2", "cleanup");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("container spawn failure publishes meet.error", async () => {
+    const runner = makeMockRunner({ runError: new Error("docker down") });
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+      });
+
+      await expect(
+        manager.join({
+          url: "u",
+          meetingId: "m-ev-err",
+          conversationId: "c",
+        }),
+      ).rejects.toThrow(/docker down/);
+
+      await Promise.resolve();
+
+      const errors = received.filter((e) => e.message.type === "meet.error");
+      expect(errors).toHaveLength(1);
+      expect(
+        (errors[0]!.message as { detail: string }).detail,
+      ).toContain("docker down");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("lifecycle:error bot event publishes meet.error with detail", async () => {
+    const runner = makeMockRunner();
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "k",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-ev-lerr",
+        conversationId: "c",
+      });
+
+      getMeetSessionEventRouter().dispatch("m-ev-lerr", {
+        type: "lifecycle",
+        meetingId: "m-ev-lerr",
+        timestamp: new Date(0).toISOString(),
+        state: "error",
+        detail: "join rejected by host",
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const errors = received.filter((e) => e.message.type === "meet.error");
+      expect(errors).toHaveLength(1);
+      expect(
+        (errors[0]!.message as { detail: string }).detail,
+      ).toBe("join rejected by host");
+
+      await manager.leave("m-ev-lerr", "cleanup");
+    } finally {
+      dispose();
     }
   });
 });

--- a/assistant/src/meet/event-publisher.ts
+++ b/assistant/src/meet/event-publisher.ts
@@ -1,0 +1,276 @@
+/**
+ * Meet event publisher — bridges the bot's wire-level events to
+ * `assistantEventHub`-shaped lifecycle / transcript / participant / speaker
+ * messages that macOS (and future) clients consume over the SSE route.
+ *
+ * Two concerns live here:
+ *
+ *  1. {@link publishMeetEvent} — builds a proper {@link AssistantEvent} via
+ *     {@link buildAssistantEvent} and hands it to `assistantEventHub.publish`.
+ *     Failures are swallowed and logged: a slow/broken SSE subscriber must
+ *     never break the meeting.
+ *
+ *  2. {@link MeetEventDispatcher} — a thin fan-out for per-meeting bot
+ *     events. The router upstream (`MeetSessionEventRouter`, PR 9) only
+ *     allows *one* handler per meeting, which means the session manager
+ *     must own the single registration and multiplex from there. Several
+ *     PRs in the plan want to observe the same live event stream (this
+ *     publisher for SSE, PR 17 for the conversation bridge, PR 18 for
+ *     storage, PR 22 for consent). They all subscribe through this
+ *     dispatcher rather than racing to replace each other at the router.
+ *
+ *     The dispatcher is intentionally cheap: a Map<meetingId, Set<cb>>,
+ *     synchronous fan-out, handler errors are caught and logged. No
+ *     buffering, no async queues — matches the router's ergonomics.
+ *
+ * Future PRs that want to read the stream should call
+ * `subscribeToMeetingEvents(meetingId, cb)` rather than calling
+ * `MeetSessionEventRouter.register` directly. That way adding a new
+ * consumer never steps on an existing one.
+ */
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import { getMeetSessionEventRouter } from "./session-event-router.js";
+
+const log = getLogger("meet-event-publisher");
+
+// ---------------------------------------------------------------------------
+// Event-kind discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Outbound meet-event `type` values. One per `meet.*` `ServerMessage`
+ * discriminator in `assistant/src/daemon/message-types/meet.ts`.
+ */
+export type MeetEventKind =
+  | "meet.joining"
+  | "meet.joined"
+  | "meet.participant_changed"
+  | "meet.speaker_changed"
+  | "meet.transcript_chunk"
+  | "meet.left"
+  | "meet.error";
+
+// ---------------------------------------------------------------------------
+// publishMeetEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Publish a Meet lifecycle/transcript/participant/speaker event to the
+ * in-process `assistantEventHub`. Clients subscribed via SSE receive the
+ * event in delivery order.
+ *
+ * `payload` is merged with `{ type: kind, meetingId }` to form the
+ * `ServerMessage` body — callers must not include `type` or `meetingId`
+ * in `payload` or they will conflict with the discriminator.
+ *
+ * Errors from subscribers are logged but never rethrown: a slow or broken
+ * consumer on the SSE side must not break the active meeting. Returns a
+ * promise that resolves when the publish call settles, for tests that
+ * want to await delivery. Production callers can fire-and-forget.
+ */
+export function publishMeetEvent(
+  assistantId: string,
+  meetingId: string,
+  kind: MeetEventKind,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  // Narrow the composed literal to `ServerMessage` — every `meet.*` kind
+  // has a matching variant in the `ServerMessage` discriminated union, but
+  // TypeScript can't infer the runtime match from a string-keyed payload.
+  const message = { type: kind, meetingId, ...payload } as ServerMessage;
+  const event = buildAssistantEvent(assistantId, message);
+  return assistantEventHub.publish(event).catch((err) => {
+    log.warn({ err, meetingId, kind }, "Failed to publish meet event");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// MeetEventDispatcher — per-meeting fan-out shim
+// ---------------------------------------------------------------------------
+
+/** Callback invoked for each bot event on a subscribed meeting. */
+export type MeetEventSubscriber = (event: MeetBotEvent) => void;
+
+/** Unsubscribe handle returned by {@link subscribeToMeetingEvents}. */
+export type MeetEventUnsubscribe = () => void;
+
+/**
+ * Process-wide fan-out map for per-meeting bot events. One instance, many
+ * subscribers per meeting id. Singleton so cross-cutting subscribers
+ * (publisher, bridge, storage, consent) agree on the same dispatch target.
+ */
+class MeetEventDispatcher {
+  private readonly subs = new Map<string, Set<MeetEventSubscriber>>();
+
+  subscribe(meetingId: string, cb: MeetEventSubscriber): MeetEventUnsubscribe {
+    let set = this.subs.get(meetingId);
+    if (!set) {
+      set = new Set();
+      this.subs.set(meetingId, set);
+    }
+    set.add(cb);
+    return () => {
+      const existing = this.subs.get(meetingId);
+      if (!existing) return;
+      existing.delete(cb);
+      if (existing.size === 0) this.subs.delete(meetingId);
+    };
+  }
+
+  dispatch(meetingId: string, event: MeetBotEvent): void {
+    const set = this.subs.get(meetingId);
+    if (!set || set.size === 0) return;
+    // Snapshot so a callback removing itself mid-iteration doesn't skip
+    // a neighbor or trip a concurrent-modification hazard.
+    for (const cb of Array.from(set)) {
+      try {
+        cb(event);
+      } catch (err) {
+        log.error(
+          { err, meetingId, eventType: event.type },
+          "Meet event subscriber threw",
+        );
+      }
+    }
+  }
+
+  /** Drop all subscribers for a meeting. Called from the session manager on leave. */
+  clear(meetingId: string): void {
+    this.subs.delete(meetingId);
+  }
+
+  /** Current subscriber count for a meeting. Exposed for tests. */
+  subscriberCount(meetingId: string): number {
+    return this.subs.get(meetingId)?.size ?? 0;
+  }
+
+  /** Reset all state. Tests only. */
+  _resetForTests(): void {
+    this.subs.clear();
+  }
+}
+
+/** Process-level singleton dispatcher, shared across the meet subsystem. */
+export const meetEventDispatcher = new MeetEventDispatcher();
+
+/**
+ * Subscribe to raw bot events for a meeting. Safe for multiple callers.
+ * Returns an unsubscribe function.
+ *
+ * Use this from downstream consumers (conversation bridge, storage writer,
+ * consent monitor) instead of calling `MeetSessionEventRouter.register`
+ * directly — the router allows only one handler per meeting, and the
+ * session manager owns that registration.
+ */
+export function subscribeToMeetingEvents(
+  meetingId: string,
+  cb: MeetEventSubscriber,
+): MeetEventUnsubscribe {
+  return meetEventDispatcher.subscribe(meetingId, cb);
+}
+
+// ---------------------------------------------------------------------------
+// Router integration
+// ---------------------------------------------------------------------------
+
+/**
+ * Install the single `MeetSessionEventRouter` handler for a meeting. The
+ * handler forwards every incoming event into {@link meetEventDispatcher}
+ * so multiple subscribers can observe the stream.
+ *
+ * The session manager calls this once per `join()` and pairs it with
+ * {@link unregisterMeetingDispatcher} on `leave()`.
+ */
+export function registerMeetingDispatcher(meetingId: string): void {
+  getMeetSessionEventRouter().register(meetingId, (event) => {
+    meetEventDispatcher.dispatch(meetingId, event);
+  });
+}
+
+/**
+ * Tear down the router handler and drop all dispatcher subscribers for a
+ * meeting. Symmetric with {@link registerMeetingDispatcher}.
+ */
+export function unregisterMeetingDispatcher(meetingId: string): void {
+  getMeetSessionEventRouter().unregister(meetingId);
+  meetEventDispatcher.clear(meetingId);
+}
+
+// ---------------------------------------------------------------------------
+// Router → event-hub bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe the event-hub publisher to a meeting's bot-event stream so
+ * `participant.change`, `speaker.change`, and final transcript chunks
+ * fan out as `meet.participant_changed` / `meet.speaker_changed` /
+ * `meet.transcript_chunk` events on `assistantEventHub`.
+ *
+ * Lifecycle transitions are NOT handled here — the session manager
+ * publishes `meet.joining`, `meet.joined`, `meet.left`, and `meet.error`
+ * directly at the points it controls (join start, first joined lifecycle
+ * event, leave, error) since those fire outside the bot-event stream
+ * or carry richer context than the wire event provides.
+ *
+ * Returns an unsubscribe function the caller can invoke on leave.
+ */
+export function subscribeEventHubPublisher(
+  assistantId: string,
+  meetingId: string,
+): MeetEventUnsubscribe {
+  return subscribeToMeetingEvents(meetingId, (event) => {
+    switch (event.type) {
+      case "participant.change":
+        void publishMeetEvent(
+          assistantId,
+          meetingId,
+          "meet.participant_changed",
+          {
+            joined: event.joined,
+            left: event.left,
+          },
+        );
+        return;
+      case "speaker.change":
+        void publishMeetEvent(
+          assistantId,
+          meetingId,
+          "meet.speaker_changed",
+          {
+            speakerId: event.speakerId,
+            speakerName: event.speakerName,
+          },
+        );
+        return;
+      case "transcript.chunk": {
+        // Interim chunks are noisy and may be superseded by a later final
+        // chunk covering the same time range. Clients only want stable text.
+        if (!event.isFinal) return;
+        const payload: Record<string, unknown> = { text: event.text };
+        if (event.speakerLabel !== undefined)
+          payload.speakerLabel = event.speakerLabel;
+        if (event.speakerId !== undefined) payload.speakerId = event.speakerId;
+        if (event.confidence !== undefined)
+          payload.confidence = event.confidence;
+        void publishMeetEvent(
+          assistantId,
+          meetingId,
+          "meet.transcript_chunk",
+          payload,
+        );
+        return;
+      }
+      default:
+        // Ignore event kinds we don't fan out from the router path.
+        // Lifecycle transitions are published by the session manager.
+        // Inbound chat + interim transcripts are intentionally dropped.
+        return;
+    }
+  });
+}

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -10,18 +10,20 @@
  *     Phase 3) via the secure-keys abstraction.
  *   - Drive `DockerRunner` to create + start the Meet-bot container with the
  *     right env/binds/port mappings.
- *   - Register a per-meeting handler with `MeetSessionEventRouter`. Later
- *     PRs wire real consumers (PR 17 conversation bridge, PR 18 storage
- *     writer, PR 22 consent monitor).
+ *   - Register the per-meeting handler with `MeetSessionEventRouter` via
+ *     the shared `meetEventDispatcher` so multiple subscribers (this
+ *     manager, PR 17's conversation bridge, PR 18's storage writer,
+ *     PR 22's consent monitor) can observe the same live event stream.
+ *   - Publish `meet.joining` / `meet.joined` / `meet.left` / `meet.error`
+ *     lifecycle events on the assistant event hub so SSE-connected clients
+ *     can render live meeting state.
  *   - Enforce `services.meet.maxMeetingMinutes` via a hard-cap timeout that
  *     invokes `leave(id, "timeout")`.
  *   - On `leave`, best-effort hit the bot's `/leave` first; fall back to
  *     `DockerRunner.stop` + `remove` so stuck bots don't leak containers.
  *
- * Not yet wired in this PR — left as TODOs for their owning PRs:
+ * Not yet wired in this PR — left for their owning PRs:
  *   - PR 16 adds audio ingest server startup before the container spawns.
- *   - PR 19 adds a container-exit watcher that publishes `lifecycle:left`
- *     via `assistantEventHub`.
  *   - PR 22 instantiates the consent monitor and disposes it on leave.
  *   - PR 23 substitutes `{assistantName}` into `CONSENT_MESSAGE`.
  */
@@ -31,14 +33,20 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { DockerRunner, type DockerRunResult } from "./docker-runner.js";
 import {
-  getMeetSessionEventRouter,
-  type MeetSessionEventHandler,
-} from "./session-event-router.js";
+  type MeetEventUnsubscribe,
+  publishMeetEvent,
+  registerMeetingDispatcher,
+  subscribeEventHubPublisher,
+  subscribeToMeetingEvents,
+  unregisterMeetingDispatcher,
+} from "./event-publisher.js";
+import { getMeetSessionEventRouter } from "./session-event-router.js";
 
 const log = getLogger("meet-session-manager");
 
@@ -85,6 +93,10 @@ export interface JoinInput {
 interface ActiveSession extends MeetSession {
   /** Hard-cap timeout handle — cleared on leave. */
   timeoutHandle: ReturnType<typeof setTimeout> | null;
+  /** Unsubscribe handles for per-session dispatcher subscriptions. */
+  eventUnsubscribes: MeetEventUnsubscribe[];
+  /** True once the bot has emitted a `lifecycle.joined` event. */
+  joinedPublished: boolean;
 }
 
 export interface MeetSessionManagerDeps {
@@ -146,6 +158,13 @@ class MeetSessionManagerImpl {
   _resetForTests(): void {
     for (const session of this.sessions.values()) {
       if (session.timeoutHandle) clearTimeout(session.timeoutHandle);
+      for (const unsubscribe of session.eventUnsubscribes) {
+        try {
+          unsubscribe();
+        } catch {
+          /* best-effort */
+        }
+      }
     }
     this.sessions.clear();
   }
@@ -162,6 +181,17 @@ class MeetSessionManagerImpl {
         `MeetSession already exists for meetingId=${meetingId}; leave the existing session before re-joining`,
       );
     }
+
+    // Fire `meet.joining` before we start real work so clients can show the
+    // "attempting to join …" state immediately. Await the publish so any
+    // subscriber errors surface into the log stream before the container
+    // spin-up (which takes seconds) begins.
+    await publishMeetEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      meetingId,
+      "meet.joining",
+      { url },
+    );
 
     const config = getConfig();
     const meet = config.services.meet;
@@ -226,6 +256,12 @@ class MeetSessionManagerImpl {
         { err, meetingId, image: meet.containerImage },
         "Failed to spawn meet bot container",
       );
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
       throw err;
     }
 
@@ -236,23 +272,25 @@ class MeetSessionManagerImpl {
       // Roll back the container so we don't leak a started-but-unreachable
       // bot. Best-effort — surface the original error either way.
       await runner.remove(runResult.containerId).catch(() => {});
-      throw new Error(
-        `meet-bot container ${runResult.containerId} did not publish a host port for ${MEET_BOT_INTERNAL_PORT}/tcp`,
+      const detail = `meet-bot container ${runResult.containerId} did not publish a host port for ${MEET_BOT_INTERNAL_PORT}/tcp`;
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail },
       );
+      throw new Error(detail);
     }
 
     const botBaseUrl = `http://${MEET_BOT_HOST_IP}:${boundPort.hostPort}`;
     const joinTimeoutMs = meet.maxMeetingMinutes * 60_000;
 
-    // No-op handler for now — later PRs (17 conversation bridge, 18 storage
-    // writer, 22 consent monitor) swap in real consumers.
-    const handler: MeetSessionEventHandler = (event) => {
-      log.debug(
-        { meetingId, eventType: event.type },
-        "meet session handler received event (no-op stub)",
-      );
-    };
-    getMeetSessionEventRouter().register(meetingId, handler);
+    // Install the single router handler for this meeting. It fans incoming
+    // bot events out via `meetEventDispatcher` so multiple subscribers
+    // (this publisher, PR 17's bridge, PR 18's storage writer, PR 22's
+    // consent monitor) can observe the same stream without racing to
+    // replace each other at the router.
+    registerMeetingDispatcher(meetingId);
 
     const startedAt = Date.now();
     const session: ActiveSession = {
@@ -264,8 +302,43 @@ class MeetSessionManagerImpl {
       startedAt,
       joinTimeoutMs,
       timeoutHandle: null,
+      eventUnsubscribes: [],
+      joinedPublished: false,
     };
     this.sessions.set(meetingId, session);
+
+    // Fan `participant.change` / `speaker.change` / final transcript chunks
+    // out as `meet.*` events on the assistant event hub.
+    session.eventUnsubscribes.push(
+      subscribeEventHubPublisher(DAEMON_INTERNAL_ASSISTANT_ID, meetingId),
+    );
+
+    // Watch for the bot's first `lifecycle: joined` so we can emit a
+    // client-facing `meet.joined` at the precise moment the bot is live
+    // in the meeting. Lifecycle publish happens once per session.
+    session.eventUnsubscribes.push(
+      subscribeToMeetingEvents(meetingId, (event) => {
+        if (event.type !== "lifecycle") return;
+        if (event.state === "joined" && !session.joinedPublished) {
+          session.joinedPublished = true;
+          void publishMeetEvent(
+            DAEMON_INTERNAL_ASSISTANT_ID,
+            meetingId,
+            "meet.joined",
+            {},
+          );
+          return;
+        }
+        if (event.state === "error") {
+          void publishMeetEvent(
+            DAEMON_INTERNAL_ASSISTANT_ID,
+            meetingId,
+            "meet.error",
+            { detail: event.detail ?? "unknown error" },
+          );
+        }
+      }),
+    );
 
     // Max-meeting-minutes hard cap. Using setTimeout keeps this compatible
     // with Bun's fake-timer harness for tests.
@@ -278,8 +351,12 @@ class MeetSessionManagerImpl {
       });
     }, joinTimeoutMs);
 
-    // TODO(PR 19): wire a container-exit watcher here that publishes a
-    // `lifecycle:left` event via `assistantEventHub`.
+    // NOTE: a container-exit watcher still belongs here in a future PR —
+    // it would catch `docker stop`-driven exits that never emit a
+    // `lifecycle: left` event and synthesize a `meet.error` so the client
+    // doesn't hang in "joined" forever. Leaving as a follow-up; the
+    // timeout cap + explicit `leave()` path already cover the normal
+    // teardown routes.
 
     log.info(
       {
@@ -314,7 +391,21 @@ class MeetSessionManagerImpl {
       session.timeoutHandle = null;
     }
     this.sessions.delete(meetingId);
-    getMeetSessionEventRouter().unregister(meetingId);
+
+    // Tear down dispatcher subscribers BEFORE unregistering the router so no
+    // in-flight event slips through to a subscriber whose consumer is gone.
+    for (const unsubscribe of session.eventUnsubscribes) {
+      try {
+        unsubscribe();
+      } catch (err) {
+        log.warn(
+          { err, meetingId },
+          "Meet event subscriber unsubscribe threw during leave",
+        );
+      }
+    }
+    session.eventUnsubscribes = [];
+    unregisterMeetingDispatcher(meetingId);
 
     const runner = this.deps.dockerRunnerFactory();
 
@@ -351,6 +442,13 @@ class MeetSessionManagerImpl {
         "DockerRunner.remove failed — container may leak",
       );
     }
+
+    void publishMeetEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      meetingId,
+      "meet.left",
+      { reason },
+    );
 
     log.info(
       { meetingId, containerId: session.containerId, reason, gracefulOk },
@@ -407,6 +505,13 @@ function sessionView(session: ActiveSession): MeetSession {
  */
 export function generateBotApiToken(): string {
   return randomBytes(32).toString("hex");
+}
+
+/** Extract a human-readable message from an unknown thrown value. */
+function errorDetail(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "unknown error";
 }
 
 /**


### PR DESCRIPTION
## Summary
- `publishMeetEvent` wraps `buildAssistantEvent` + `assistantEventHub.publish` for Meet lifecycle/transcript/speaker/participant fan-out.
- `MeetSessionManager` now emits `meet.joining`, `meet.joined`, `meet.left`, `meet.error`; router subscription emits participant/speaker/transcript event kinds.

Part of plan: meet-phase-1-listen.md (PR 19 of 24)