### PR TITLE
fix(meet): sort imports in storage-writer.test.ts to fix lint

### DIFF
--- a/assistant/src/meet/__tests__/storage-writer.test.ts
+++ b/assistant/src/meet/__tests__/storage-writer.test.ts
@@ -7,6 +7,7 @@
  * `MeetSessionEventRouter` handler.
  */
 
+import { EventEmitter } from "node:events";
 import {
   existsSync,
   mkdtempSync,
@@ -15,7 +16,6 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { EventEmitter } from "node:events";
 import {
   afterEach,
   beforeEach,


### PR DESCRIPTION
## Summary
- Sort imports in `assistant/src/meet/__tests__/storage-writer.test.ts` so `node:events` precedes `node:fs`, unbreaking `bun run lint` on main.
- The lint failure slipped through on commit 68f1ee28 (PR #25768) because the PR CI wasn't bundling the lint check for the new test file.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24443063550/job/71412522596
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
