### PR TITLE
meet: cross-check DOM active speaker with Deepgram labels + migrate bridge to dispatcher

### DIFF
--- a/assistant/src/meet/__tests__/conversation-bridge.test.ts
+++ b/assistant/src/meet/__tests__/conversation-bridge.test.ts
@@ -2,9 +2,18 @@
  * Unit tests for MeetConversationBridge.
  *
  * The bridge is tested with a recording shim for `addMessage`, a local
- * router instance (no singleton state leaks), and a stub event hub —
+ * dispatcher shim (no singleton state leaks), and a stub event hub —
  * so the whole surface is exercised without touching SQLite or the
  * real process-level hub.
+ *
+ * Notable shapes covered here:
+ *   - Final transcripts go through the speaker resolver before insert —
+ *     resolved name + confidence appear in the metadata.
+ *   - The bridge subscribes via `subscribeToMeetingEvents` (PR 19 multi-
+ *     subscriber dispatcher), not `MeetSessionEventRouter` directly.
+ *   - The resolver observes `speaker.change` through the same dispatcher
+ *     stream, so a DOM snapshot just before a transcript binds the
+ *     Deepgram label for future resolutions.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -23,7 +32,10 @@ import {
   type InsertMessageFn,
   MeetConversationBridge,
 } from "../conversation-bridge.js";
-import { MeetSessionEventRouter } from "../session-event-router.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures & helpers
@@ -61,30 +73,74 @@ function makeInsertRecorder(): {
   return { fn, calls };
 }
 
+/**
+ * Local dispatcher shim that mirrors the PR 19 `subscribeToMeetingEvents`
+ * API. Keeps a per-meeting subscriber set and exposes a `dispatch` helper
+ * that tests call to deliver an event to all current subscribers.
+ *
+ * The resolver subscribes in the bridge constructor and the bridge
+ * subscribes in `subscribe()`, so the shim has to handle multiple
+ * subscribers per meeting — exactly the point of migrating away from
+ * the single-handler router.
+ */
+function makeDispatcher() {
+  const subscribers = new Map<string, Set<MeetEventSubscriber>>();
+
+  const subscribe = (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ): MeetEventUnsubscribe => {
+    let set = subscribers.get(meetingId);
+    if (!set) {
+      set = new Set();
+      subscribers.set(meetingId, set);
+    }
+    set.add(cb);
+    return () => {
+      subscribers.get(meetingId)?.delete(cb);
+    };
+  };
+
+  const dispatch = (meetingId: string, event: MeetBotEvent): void => {
+    const set = subscribers.get(meetingId);
+    if (!set) return;
+    // Snapshot so a subscriber that self-unsubscribes mid-dispatch
+    // doesn't mutate the live iterator.
+    for (const cb of Array.from(set)) cb(event);
+  };
+
+  const subscriberCount = (meetingId: string): number =>
+    subscribers.get(meetingId)?.size ?? 0;
+
+  return { subscribe, dispatch, subscriberCount };
+}
+
+type Dispatcher = ReturnType<typeof makeDispatcher>;
+
 function makeBridge(
   overrides: {
     conversationId?: string;
     meetingId?: string;
     insertMessage?: InsertMessageFn;
-    router?: MeetSessionEventRouter;
+    dispatcher?: Dispatcher;
     hubPublish?: ReturnType<typeof mock>;
   } = {},
 ) {
   const recorder = overrides.insertMessage
     ? { fn: overrides.insertMessage, calls: [] as InsertCall[] }
     : makeInsertRecorder();
-  const router = overrides.router ?? new MeetSessionEventRouter();
+  const dispatcher = overrides.dispatcher ?? makeDispatcher();
   const hubPublish = overrides.hubPublish ?? mock(async () => {});
   const bridge = new MeetConversationBridge({
     meetingId: overrides.meetingId ?? MEETING_ID,
     conversationId: overrides.conversationId ?? CONVERSATION_ID,
     insertMessage: recorder.fn,
-    router,
+    subscribeToMeetingEvents: dispatcher.subscribe,
     assistantEventHub: {
       publish: hubPublish as unknown as (e: AssistantEvent) => Promise<void>,
     },
   });
-  return { bridge, router, calls: recorder.calls, hubPublish };
+  return { bridge, dispatcher, calls: recorder.calls, hubPublish };
 }
 
 function finalTranscript(
@@ -168,12 +224,8 @@ function lifecycle(overrides: Partial<LifecycleEvent> = {}): LifecycleEvent {
   };
 }
 
-function dispatch(router: MeetSessionEventRouter, event: MeetBotEvent): void {
-  router.dispatch(event.meetingId, event);
-}
-
 /**
- * Let all micro-tasks settle — the router dispatches synchronously but
+ * Let all micro-tasks settle — the dispatcher delivers synchronously but
  * the bridge's handler uses `void this.handleEvent(...)`, so we need a
  * microtask flush before asserting inserts / publishes.
  */
@@ -186,58 +238,71 @@ async function flush(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 describe("MeetConversationBridge subscription", () => {
-  test("subscribe() registers a router handler; unsubscribe() removes it", () => {
-    const { bridge, router } = makeBridge();
-    expect(router.registeredCount()).toBe(0);
+  test("bridge constructor registers the resolver; subscribe() adds a second subscriber", () => {
+    const dispatcher = makeDispatcher();
+    const { bridge } = makeBridge({ dispatcher });
+    // Resolver subscribed on construction.
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(1);
 
     bridge.subscribe();
-    expect(router.registeredCount()).toBe(1);
+    // Bridge handler is the second subscriber.
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(2);
     expect(bridge.isSubscribed()).toBe(true);
 
     bridge.unsubscribe();
-    expect(router.registeredCount()).toBe(0);
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(0);
     expect(bridge.isSubscribed()).toBe(false);
   });
 
   test("events dispatched before subscribe() are dropped", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
 
-    dispatch(router, finalTranscript());
+    dispatcher.dispatch(MEETING_ID, finalTranscript());
     await flush();
     expect(calls).toHaveLength(0);
 
     // Subscribe and dispatch again — now it should be recorded.
     bridge.subscribe();
-    dispatch(router, finalTranscript());
+    dispatcher.dispatch(MEETING_ID, finalTranscript());
     await flush();
     expect(calls).toHaveLength(1);
   });
 
   test("events dispatched after unsubscribe() are dropped", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
-    dispatch(router, finalTranscript());
+    dispatcher.dispatch(MEETING_ID, finalTranscript());
     await flush();
     expect(calls).toHaveLength(1);
 
     bridge.unsubscribe();
-    dispatch(router, finalTranscript());
+    dispatcher.dispatch(MEETING_ID, finalTranscript());
     await flush();
     expect(calls).toHaveLength(1);
+  });
+
+  test("subscribe() is idempotent — calling twice keeps one bridge subscriber", () => {
+    const dispatcher = makeDispatcher();
+    const { bridge } = makeBridge({ dispatcher });
+    bridge.subscribe();
+    bridge.subscribe();
+    // Resolver (1) + bridge (1) — subscribe twice must not stack another.
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(2);
+    bridge.unsubscribe();
   });
 });
 
 // ---------------------------------------------------------------------------
-// Transcript handling
+// Transcript handling — resolver integration
 // ---------------------------------------------------------------------------
 
-describe("MeetConversationBridge — transcript.chunk", () => {
-  test("final chunks become conversation messages with speaker metadata", async () => {
-    const { bridge, router, calls, hubPublish } = makeBridge();
+describe("MeetConversationBridge — transcript.chunk (resolver integration)", () => {
+  test("no DOM snapshot → resolver returns unknown; metadata reflects that", async () => {
+    const { bridge, dispatcher, calls, hubPublish } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       finalTranscript({
         text: "Let's kick off the sync.",
         speakerLabel: "Speaker 0",
@@ -254,62 +319,115 @@ describe("MeetConversationBridge — transcript.chunk", () => {
       type: string;
       text: string;
     }>;
+    // Without a DOM snapshot, the resolver falls back to "Unknown speaker".
     expect(parsed).toEqual([
-      { type: "text", text: "[Speaker 0]: Let's kick off the sync." },
+      { type: "text", text: "[Unknown speaker]: Let's kick off the sync." },
     ]);
     expect(call?.metadata).toMatchObject({
       meetingId: MEETING_ID,
       meetTimestamp: TIMESTAMP,
       meetSpeakerLabel: "Speaker 0",
       meetSpeakerId: "spk-0",
-      meetSpeakerName: "Speaker 0",
+      meetSpeakerName: "Unknown speaker",
+      meetSpeakerConfidence: "unknown",
     });
 
-    // Final transcripts must not go to the hub as interim events.
     expect(hubPublish).toHaveBeenCalledTimes(0);
   });
 
-  test("final chunks without a speakerLabel fall back to 'Unknown speaker'", async () => {
-    const { bridge, router, calls } = makeBridge();
+  test("DOM snapshot just before transcript → resolved name used in content + metadata", async () => {
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    // Deliver a DOM speaker-change within the correlation window.
+    dispatcher.dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: new Date(Date.parse(TIMESTAMP) - 100).toISOString(),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+
+    dispatcher.dispatch(
+      MEETING_ID,
       finalTranscript({
-        text: "Off-mic remark.",
-        speakerLabel: undefined,
-        speakerId: undefined,
+        text: "Let's kick off.",
+        speakerLabel: "Speaker 0",
+        speakerId: "spk-0",
+        timestamp: TIMESTAMP,
       }),
     );
     await flush();
 
     expect(calls).toHaveLength(1);
     const parsed = JSON.parse(calls[0]!.content) as Array<{ text: string }>;
-    expect(parsed[0]?.text).toBe("[Unknown speaker]: Off-mic remark.");
+    expect(parsed[0]?.text).toBe("[Alice]: Let's kick off.");
     expect(calls[0]?.metadata).toMatchObject({
-      meetSpeakerName: "Unknown speaker",
+      meetSpeakerName: "Alice",
+      meetSpeakerId: "p-alice",
+      meetSpeakerLabel: "Speaker 0",
+      meetSpeakerConfidence: "dom-override",
     });
-    expect(calls[0]?.metadata?.meetSpeakerLabel).toBeUndefined();
-    expect(calls[0]?.metadata?.meetSpeakerId).toBeUndefined();
+  });
+
+  test("learned mapping reused on subsequent transcripts → confidence 'deepgram'", async () => {
+    const { bridge, dispatcher, calls } = makeBridge();
+    bridge.subscribe();
+
+    // Bootstrap — DOM says Alice, Deepgram says Speaker 0.
+    dispatcher.dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: new Date(Date.parse(TIMESTAMP) - 200).toISOString(),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+    dispatcher.dispatch(
+      MEETING_ID,
+      finalTranscript({ text: "First", speakerLabel: "Speaker 0" }),
+    );
+
+    // Later — another Speaker 0 transcript, well outside the correlation
+    // window, with no new DOM event. Resolver should use the learned
+    // mapping and emit `deepgram` confidence.
+    const laterTs = new Date(Date.parse(TIMESTAMP) + 60_000).toISOString();
+    dispatcher.dispatch(
+      MEETING_ID,
+      finalTranscript({
+        text: "Later",
+        speakerLabel: "Speaker 0",
+        timestamp: laterTs,
+      }),
+    );
+    await flush();
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.metadata).toMatchObject({
+      meetSpeakerName: "Alice",
+      meetSpeakerId: "p-alice",
+      meetSpeakerConfidence: "deepgram",
+    });
   });
 
   test("empty / whitespace-only final chunks are skipped (no insert)", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(router, finalTranscript({ text: "" }));
-    dispatch(router, finalTranscript({ text: "   \n\t  " }));
+    dispatcher.dispatch(MEETING_ID, finalTranscript({ text: "" }));
+    dispatcher.dispatch(MEETING_ID, finalTranscript({ text: "   \n\t  " }));
     await flush();
 
     expect(calls).toHaveLength(0);
   });
 
   test("interim chunks publish to the hub but never persist", async () => {
-    const { bridge, router, calls, hubPublish } = makeBridge();
+    const { bridge, dispatcher, calls, hubPublish } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       interimTranscript({ text: "Hello tea", confidence: 0.72 }),
     );
     await flush();
@@ -335,14 +453,14 @@ describe("MeetConversationBridge — transcript.chunk", () => {
     const failingPublish = mock(async () => {
       throw new Error("hub offline");
     });
-    const { bridge, router, calls } = makeBridge({
+    const { bridge, dispatcher, calls } = makeBridge({
       hubPublish: failingPublish,
     });
     bridge.subscribe();
 
-    // Should not throw — the router would surface an unhandled rejection
+    // Should not throw — the dispatcher would surface an unhandled rejection
     // via the bridge's .catch otherwise.
-    dispatch(router, interimTranscript());
+    dispatcher.dispatch(MEETING_ID, interimTranscript());
     await flush();
 
     expect(failingPublish).toHaveBeenCalledTimes(1);
@@ -356,11 +474,11 @@ describe("MeetConversationBridge — transcript.chunk", () => {
 
 describe("MeetConversationBridge — chat.inbound", () => {
   test("chat messages persist with [Meet chat] prefix and chat metadata", async () => {
-    const { bridge, router, calls, hubPublish } = makeBridge();
+    const { bridge, dispatcher, calls, hubPublish } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       inboundChat({ fromName: "Alice", fromId: "u-alice", text: "Notes?" }),
     );
     await flush();
@@ -388,11 +506,11 @@ describe("MeetConversationBridge — chat.inbound", () => {
 
 describe("MeetConversationBridge — participant.change", () => {
   test("joined participants produce one short 'X joined' line each", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       participantChange({
         joined: [
           { id: "u-alice", name: "Alice" },
@@ -422,11 +540,11 @@ describe("MeetConversationBridge — participant.change", () => {
   });
 
   test("left participants produce one short 'X left' line each", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       participantChange({
         left: [{ id: "u-carol", name: "Carol" }],
       }),
@@ -445,21 +563,24 @@ describe("MeetConversationBridge — participant.change", () => {
   });
 
   test("empty joined/left arrays produce no inserts", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(router, participantChange({ joined: [], left: [] }));
+    dispatcher.dispatch(
+      MEETING_ID,
+      participantChange({ joined: [], left: [] }),
+    );
     await flush();
 
     expect(calls).toHaveLength(0);
   });
 
   test("simultaneous joins + leaves each produce their own line", async () => {
-    const { bridge, router, calls } = makeBridge();
+    const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       participantChange({
         joined: [{ id: "u-alice", name: "Alice" }],
         left: [{ id: "u-bob", name: "Bob" }],
@@ -474,15 +595,15 @@ describe("MeetConversationBridge — participant.change", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Ignored event types (speaker.change, lifecycle)
+// Ignored event types (speaker.change at bridge level, lifecycle)
 // ---------------------------------------------------------------------------
 
 describe("MeetConversationBridge — ignored events", () => {
-  test("speaker.change events do not persist or publish", async () => {
-    const { bridge, router, calls, hubPublish } = makeBridge();
+  test("speaker.change events do not persist or publish (resolver consumes them)", async () => {
+    const { bridge, dispatcher, calls, hubPublish } = makeBridge();
     bridge.subscribe();
 
-    dispatch(router, speakerChange());
+    dispatcher.dispatch(MEETING_ID, speakerChange());
     await flush();
 
     expect(calls).toHaveLength(0);
@@ -490,7 +611,7 @@ describe("MeetConversationBridge — ignored events", () => {
   });
 
   test("lifecycle events do not persist or publish (every state)", async () => {
-    const { bridge, router, calls, hubPublish } = makeBridge();
+    const { bridge, dispatcher, calls, hubPublish } = makeBridge();
     bridge.subscribe();
 
     for (const state of [
@@ -500,7 +621,7 @@ describe("MeetConversationBridge — ignored events", () => {
       "left",
       "error",
     ] as const) {
-      dispatch(router, lifecycle({ state }));
+      dispatcher.dispatch(MEETING_ID, lifecycle({ state }));
     }
     await flush();
 
@@ -514,7 +635,7 @@ describe("MeetConversationBridge — ignored events", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetConversationBridge — error isolation", () => {
-  test("an insert failure does not tear down the bridge or router", async () => {
+  test("an insert failure does not tear down the bridge or dispatcher", async () => {
     let shouldFail = true;
     const failingInsert: InsertMessageFn = async () => {
       if (shouldFail) {
@@ -523,34 +644,37 @@ describe("MeetConversationBridge — error isolation", () => {
       return { id: "recovered" };
     };
 
-    const router = new MeetSessionEventRouter();
+    const dispatcher = makeDispatcher();
     const hubPublish = mock(async () => {});
     const bridge = new MeetConversationBridge({
       meetingId: MEETING_ID,
       conversationId: CONVERSATION_ID,
       insertMessage: failingInsert,
-      router,
+      subscribeToMeetingEvents: dispatcher.subscribe,
       assistantEventHub: {
         publish: hubPublish as unknown as (e: AssistantEvent) => Promise<void>,
       },
     });
     bridge.subscribe();
 
-    // First dispatch fails inside the handler — router must survive.
-    dispatch(router, finalTranscript());
+    // First dispatch fails inside the handler — dispatcher must survive.
+    dispatcher.dispatch(MEETING_ID, finalTranscript());
     await flush();
 
     shouldFail = false;
-    dispatch(
-      router,
+    dispatcher.dispatch(
+      MEETING_ID,
       interimTranscript({ text: "still alive", isFinal: false }),
     );
     await flush();
 
     // Hub publish happened for the interim chunk even though the earlier
-    // insert threw — the bridge did not crash the router registration.
+    // insert threw — the bridge did not crash the dispatcher subscription.
     expect(hubPublish).toHaveBeenCalledTimes(1);
-    expect(router.registeredCount()).toBe(1);
+    // Resolver + bridge subscribers still alive.
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(2);
+
+    bridge.unsubscribe();
   });
 });
 
@@ -559,17 +683,21 @@ describe("MeetConversationBridge — error isolation", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetConversationBridge — cross-meeting isolation", () => {
-  let router: MeetSessionEventRouter;
+  let dispatcher: Dispatcher;
 
   beforeEach(() => {
-    router = new MeetSessionEventRouter();
+    dispatcher = makeDispatcher();
   });
 
   test("events for another meeting id do not reach this bridge", async () => {
-    const { bridge, calls } = makeBridge({ router });
+    const { bridge, calls } = makeBridge({ dispatcher });
     bridge.subscribe();
 
-    dispatch(router, { ...finalTranscript(), meetingId: "some-other-meet" });
+    // Explicitly dispatch an event keyed under a different meeting id.
+    dispatcher.dispatch("some-other-meet", {
+      ...finalTranscript(),
+      meetingId: "some-other-meet",
+    });
     await flush();
 
     expect(calls).toHaveLength(0);

--- a/assistant/src/meet/__tests__/speaker-resolver.test.ts
+++ b/assistant/src/meet/__tests__/speaker-resolver.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Unit tests for {@link MeetSpeakerResolver}.
+ *
+ * The resolver's hard parts are:
+ *   - The ±500ms correlation window between DOM speaker-change events and
+ *     Deepgram transcript chunks (tests drive timestamps explicitly).
+ *   - Lazy learning of `speakerLabel → identity` bindings on the first
+ *     near-in-time DOM event, and reusing them afterwards.
+ *   - DOM-override precedence when a known Deepgram mapping disagrees
+ *     with a freshly-correlated DOM snapshot.
+ *   - Forwarding resolved identities to the shared
+ *     {@link SpeakerIdentityTracker} so cross-surface speaker profiling
+ *     keeps working.
+ *
+ * Tests inject a local subscribe shim so they never touch the process
+ * dispatcher singleton.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  SpeakerChangeEvent,
+  TranscriptChunkEvent,
+} from "@vellumai/meet-contracts";
+
+import { SpeakerIdentityTracker } from "../../calls/speaker-identification.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
+import {
+  MeetSpeakerResolver,
+  UNKNOWN_SPEAKER_NAME,
+} from "../speaker-resolver.js";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const MEETING_ID = "m-resolver";
+
+function toIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function transcript(
+  overrides: Partial<TranscriptChunkEvent> = {},
+): TranscriptChunkEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId: MEETING_ID,
+    timestamp: toIso(1_000),
+    isFinal: true,
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function speakerChange(
+  overrides: Partial<SpeakerChangeEvent> = {},
+): SpeakerChangeEvent {
+  return {
+    type: "speaker.change",
+    meetingId: MEETING_ID,
+    timestamp: toIso(1_000),
+    speakerId: "p-alice",
+    speakerName: "Alice",
+    ...overrides,
+  };
+}
+
+/**
+ * Build a local dispatcher shim so each test starts with a clean slate.
+ * The resolver calls `subscribe(meetingId, cb)` once in its constructor;
+ * `dispatch()` simulates router-forwarded events landing on the stream.
+ */
+function makeDispatcher() {
+  const subscribers = new Map<string, Set<MeetEventSubscriber>>();
+
+  const subscribe = (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ): MeetEventUnsubscribe => {
+    let set = subscribers.get(meetingId);
+    if (!set) {
+      set = new Set();
+      subscribers.set(meetingId, set);
+    }
+    set.add(cb);
+    return () => {
+      subscribers.get(meetingId)?.delete(cb);
+    };
+  };
+
+  const dispatch = (
+    meetingId: string,
+    event: SpeakerChangeEvent | TranscriptChunkEvent,
+  ): void => {
+    const set = subscribers.get(meetingId);
+    if (!set) return;
+    for (const cb of set) cb(event);
+  };
+
+  const subscriberCount = (meetingId: string): number =>
+    subscribers.get(meetingId)?.size ?? 0;
+
+  return { subscribe, dispatch, subscriberCount };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 1 — Deepgram + DOM agree
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — Deepgram + DOM agree", () => {
+  test("a known-label transcript with agreeing DOM resolves via Deepgram mapping", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bootstrap: DOM says Alice is speaking at t=900, transcript lands at
+    // t=1_000 with speakerLabel `speaker-0` — this binds the mapping.
+    dispatch(
+      MEETING_ID,
+      speakerChange({ timestamp: toIso(900), speakerId: "p-alice" }),
+    );
+    const first = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_000),
+        speakerLabel: "speaker-0",
+        text: "first",
+      }),
+    );
+    expect(first.confidence).toBe("dom-override");
+    expect(first.speakerId).toBe("p-alice");
+
+    // Later: DOM emits another Alice-matching event just before the next
+    // transcript, and Deepgram keeps reporting `speaker-0`. Because the
+    // mapping is already bound *and* DOM still agrees, confidence is
+    // `"deepgram"` (the bound path is the canonical fast path).
+    dispatch(
+      MEETING_ID,
+      speakerChange({ timestamp: toIso(1_900), speakerId: "p-alice" }),
+    );
+    const second = resolver.resolve(
+      transcript({
+        timestamp: toIso(2_000),
+        speakerLabel: "speaker-0",
+        text: "second",
+      }),
+    );
+    expect(second.confidence).toBe("deepgram");
+    expect(second.speakerId).toBe("p-alice");
+    expect(second.speakerName).toBe("Alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 2 — Deepgram label unknown + DOM known → dom-override, bind mapping
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — learns mapping from DOM", () => {
+  test("unknown Deepgram label + near-in-time DOM binds for future calls", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Alice's DOM snapshot at t=1_000.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_000),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+
+    // Deepgram speaker-0, first time seen, transcript at t=1_300 (inside
+    // the ±500ms window). → dom-override, plus the mapping is learned.
+    const first = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_300),
+        speakerLabel: "speaker-0",
+      }),
+    );
+    expect(first.confidence).toBe("dom-override");
+    expect(first.speakerId).toBe("p-alice");
+    expect(first.speakerName).toBe("Alice");
+
+    // Follow-up transcript with the same Deepgram label but NO new DOM
+    // event resolves via the learned mapping → confidence `"deepgram"`.
+    const second = resolver.resolve(
+      transcript({
+        timestamp: toIso(10_000),
+        speakerLabel: "speaker-0",
+        text: "later utterance",
+      }),
+    );
+    expect(second.confidence).toBe("deepgram");
+    expect(second.speakerId).toBe("p-alice");
+    expect(second.speakerName).toBe("Alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 3 — Neither signal available → unknown
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — unknown fallback", () => {
+  test("no Deepgram label + no DOM within window → unknown with default name", () => {
+    const { subscribe } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: toIso(5_000),
+        speakerLabel: undefined,
+        text: "orphaned utterance",
+      }),
+    );
+    expect(resolved.confidence).toBe("unknown");
+    expect(resolved.speakerId).toBeUndefined();
+    expect(resolved.speakerName).toBe(UNKNOWN_SPEAKER_NAME);
+
+    resolver.unsubscribe();
+  });
+
+  test("Deepgram label + stale DOM event (outside window) → unknown", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // DOM at t=1_000, transcript at t=5_000 — well outside the ±500ms window.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_000) }));
+
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: toIso(5_000),
+        speakerLabel: "speaker-7",
+      }),
+    );
+    expect(resolved.confidence).toBe("unknown");
+    expect(resolved.speakerId).toBeUndefined();
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 4 — Bound mapping works without a fresh DOM lookup
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — mapping sticks across transcripts", () => {
+  test("learned mapping survives once DOM snapshot ages out of the window", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind the mapping.
+    dispatch(
+      MEETING_ID,
+      speakerChange({ timestamp: toIso(1_000), speakerId: "p-alice" }),
+    );
+    resolver.resolve(
+      transcript({
+        timestamp: toIso(1_200),
+        speakerLabel: "speaker-0",
+      }),
+    );
+
+    // Now a long time later — no fresh DOM event, but the mapping should
+    // still apply.
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: toIso(60_000),
+        speakerLabel: "speaker-0",
+        text: "way later",
+      }),
+    );
+    expect(resolved.confidence).toBe("deepgram");
+    expect(resolved.speakerId).toBe("p-alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 5 — Conflict: Deepgram mapped to one, DOM says another → DOM wins
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — conflict resolution", () => {
+  test("known Deepgram mapping disagrees with near-in-time DOM → DOM wins", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Step 1 — bind speaker-0 → Alice.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_000),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+    const aliceBound = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_100),
+        speakerLabel: "speaker-0",
+        text: "Alice says hi",
+      }),
+    );
+    expect(aliceBound.speakerId).toBe("p-alice");
+
+    // Step 2 — a later transcript also labeled speaker-0, but the DOM has
+    // shifted to Bob within the correlation window. DOM must win.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(10_000),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const conflicted = resolver.resolve(
+      transcript({
+        timestamp: toIso(10_200),
+        speakerLabel: "speaker-0",
+        text: "but Bob is speaking now",
+      }),
+    );
+    expect(conflicted.confidence).toBe("dom-override");
+    expect(conflicted.speakerId).toBe("p-bob");
+    expect(conflicted.speakerName).toBe("Bob");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SpeakerIdentityTracker integration
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — forwards to SpeakerIdentityTracker", () => {
+  test("resolved identities are observed by the shared tracker", () => {
+    const tracker = new SpeakerIdentityTracker();
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+      tracker,
+    });
+
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_000),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+    resolver.resolve(
+      transcript({
+        timestamp: toIso(1_100),
+        speakerLabel: "speaker-0",
+      }),
+    );
+
+    const profiles = tracker.listProfiles();
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]).toMatchObject({
+      speakerId: "p-alice",
+      speakerLabel: "Alice",
+      source: "provider",
+    });
+
+    resolver.unsubscribe();
+  });
+
+  test("unknown resolutions do NOT pollute the tracker", () => {
+    const tracker = new SpeakerIdentityTracker();
+    const { subscribe } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+      tracker,
+    });
+
+    resolver.resolve(
+      transcript({
+        timestamp: toIso(5_000),
+        speakerLabel: undefined,
+      }),
+    );
+
+    expect(tracker.listProfiles()).toHaveLength(0);
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subscription lifecycle
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — subscription lifecycle", () => {
+  test("constructor subscribes; unsubscribe tears down", () => {
+    const { subscribe, subscriberCount } = makeDispatcher();
+    expect(subscriberCount(MEETING_ID)).toBe(0);
+
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+    expect(subscriberCount(MEETING_ID)).toBe(1);
+
+    resolver.unsubscribe();
+    expect(subscriberCount(MEETING_ID)).toBe(0);
+  });
+
+  test("unsubscribe is idempotent (safe to call twice)", () => {
+    const { subscribe, subscriberCount } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    resolver.unsubscribe();
+    resolver.unsubscribe();
+    expect(subscriberCount(MEETING_ID)).toBe(0);
+  });
+
+  test("non-speaker.change events do not perturb state", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Dispatching an interim transcript event through the shared stream
+    // should NOT be interpreted as a DOM snapshot.
+    dispatch(
+      MEETING_ID,
+      transcript({
+        timestamp: toIso(1_000),
+        isFinal: false,
+        speakerLabel: "speaker-0",
+      }),
+    );
+
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_050),
+        speakerLabel: "speaker-0",
+      }),
+    );
+    // No DOM snapshot was observed, so the resolver must treat the
+    // Deepgram label as unknown → unknown fallback.
+    expect(resolved.confidence).toBe("unknown");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — edge cases", () => {
+  test("unparsable transcript timestamp disables DOM correlation", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_000) }));
+
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: "not-a-real-timestamp",
+        speakerLabel: "speaker-0",
+      }),
+    );
+    // No correlation possible with NaN ms → unknown.
+    expect(resolved.confidence).toBe("unknown");
+
+    resolver.unsubscribe();
+  });
+
+  test("custom correlationWindowMs narrows the correlation window", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+      correlationWindowMs: 100,
+    });
+
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_000) }));
+
+    // ±101 ms is just outside a 100 ms window.
+    const outside = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_101),
+        speakerLabel: "speaker-0",
+      }),
+    );
+    expect(outside.confidence).toBe("unknown");
+
+    // ±50 ms is inside a 100 ms window.
+    const inside = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_050),
+        speakerLabel: "speaker-0",
+      }),
+    );
+    expect(inside.confidence).toBe("dom-override");
+
+    resolver.unsubscribe();
+  });
+
+  test("transcript without speakerLabel + DOM within window still returns dom-override", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_000),
+        speakerId: "p-alice",
+        speakerName: "Alice",
+      }),
+    );
+    const resolved = resolver.resolve(
+      transcript({ timestamp: toIso(1_100), speakerLabel: undefined }),
+    );
+    expect(resolved.confidence).toBe("dom-override");
+    expect(resolved.speakerId).toBe("p-alice");
+
+    resolver.unsubscribe();
+  });
+});

--- a/assistant/src/meet/conversation-bridge.ts
+++ b/assistant/src/meet/conversation-bridge.ts
@@ -2,16 +2,18 @@
  * MeetConversationBridge — turns bot-side meet events into conversation
  * messages and live ephemeral updates.
  *
- * The bridge is a single-meeting subscriber on
- * {@link MeetSessionEventRouter}. It fans incoming {@link MeetBotEvent}s
- * into three sinks:
+ * The bridge subscribes to a meeting's bot-event stream via
+ * {@link subscribeToMeetingEvents} (the PR 19 fan-out dispatcher). It fans
+ * incoming {@link MeetBotEvent}s into three sinks:
  *
  *   1. **Final transcripts** (`transcript.chunk` with `isFinal === true`)
- *      are persisted as `"user"` messages in the conversation with a
- *      `[<speakerName>]: <text>` attribution. Speaker metadata
+ *      are run through {@link MeetSpeakerResolver} to arbitrate Deepgram
+ *      vs DOM speaker attribution, then persisted as `"user"` messages
+ *      with a `[<speakerName>]: <text>` attribution. Speaker metadata
  *      (`meetSpeakerLabel`, `meetSpeakerId`, `meetSpeakerName`,
- *      `meetTimestamp`) rides in the message metadata so later PRs can
- *      surface the raw speaker context without re-parsing the content.
+ *      `meetSpeakerConfidence`, `meetTimestamp`) rides in the message
+ *      metadata so later PRs can surface the raw speaker context without
+ *      re-parsing the content.
  *
  *   2. **Interim transcripts** (`transcript.chunk` with `isFinal === false`)
  *      are NOT persisted. They are published via
@@ -31,15 +33,14 @@
  *
  * `speaker.change` and `lifecycle` are intentionally consumed elsewhere
  * (PR 18 storage writer, PR 19 lifecycle listener, PR 21 speaker
- * resolver); this bridge is a no-op for them.
+ * resolver); this bridge is a no-op for them at the top level, though
+ * the resolver transparently observes `speaker.change` via its own
+ * subscription.
  *
  * Dependency injection keeps the bridge test-friendly: the message-insert
- * function and the router / event-hub can all be supplied at construction
- * time so unit tests never need to spin up SQLite or the real singleton.
- * PR 21 will extend this bridge to call the speaker resolver before
- * every final-transcript insert to arbitrate Deepgram vs DOM speaker
- * attribution — the `speakerLabel` / `speakerName` / `speakerId`
- * carried on the event today are the raw Deepgram values.
+ * function, the dispatcher subscribe, the event hub, and the resolver
+ * can all be supplied at construction time so unit tests never need to
+ * spin up SQLite or the real singleton.
  */
 
 import type { MeetBotEvent } from "@vellumai/meet-contracts";
@@ -50,10 +51,11 @@ import { assistantEventHub as defaultAssistantEventHub } from "../runtime/assist
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import {
-  getMeetSessionEventRouter,
-  type MeetSessionEventHandler,
-  type MeetSessionEventRouter,
-} from "./session-event-router.js";
+  type MeetEventSubscriber,
+  type MeetEventUnsubscribe,
+  subscribeToMeetingEvents as defaultSubscribeToMeetingEvents,
+} from "./event-publisher.js";
+import { MeetSpeakerResolver } from "./speaker-resolver.js";
 
 const log = getLogger("meet-conversation-bridge");
 
@@ -80,17 +82,35 @@ export interface AssistantEventPublisher {
   publish: (event: ReturnType<typeof buildAssistantEvent>) => Promise<void>;
 }
 
+/**
+ * Subscribe shim — injected for tests so they can route events through a
+ * local dispatcher without hitting the process-level singleton.
+ */
+export type SubscribeToMeetingEventsFn = (
+  meetingId: string,
+  cb: MeetEventSubscriber,
+) => MeetEventUnsubscribe;
+
 export interface MeetConversationBridgeDeps {
-  /** Required: the per-meeting id the router keys on. */
+  /** Required: the per-meeting id the dispatcher keys on. */
   meetingId: string;
   /** Required: the target conversation to write into. */
   conversationId: string;
   /** Required: wrapper around `addMessage` — injected for tests. */
   insertMessage: InsertMessageFn;
-  /** Optional: override the router (defaults to the process singleton). */
-  router?: MeetSessionEventRouter;
+  /**
+   * Optional: override the dispatcher subscribe function. Defaults to the
+   * process singleton {@link subscribeToMeetingEvents}.
+   */
+  subscribeToMeetingEvents?: SubscribeToMeetingEventsFn;
   /** Optional: override the event hub (defaults to the process singleton). */
   assistantEventHub?: AssistantEventPublisher;
+  /**
+   * Optional: override the speaker resolver. The bridge constructs a
+   * default resolver using the same `subscribeToMeetingEvents` so tests
+   * that wire a custom dispatcher get a resolver on the same stream.
+   */
+  resolver?: MeetSpeakerResolver;
   /**
    * Optional: override the assistant id on emitted interim events. The
    * daemon normally uses `DAEMON_INTERNAL_ASSISTANT_ID` ("self"); tests
@@ -107,29 +127,37 @@ export class MeetConversationBridge {
   private readonly meetingId: string;
   private readonly conversationId: string;
   private readonly insertMessage: InsertMessageFn;
-  private readonly router: MeetSessionEventRouter;
+  private readonly subscribeFn: SubscribeToMeetingEventsFn;
   private readonly hub: AssistantEventPublisher;
+  private readonly resolver: MeetSpeakerResolver;
   private readonly assistantId: string;
-  private subscribed = false;
+  private unsubscribeFn: MeetEventUnsubscribe | null = null;
 
   constructor(deps: MeetConversationBridgeDeps) {
     this.meetingId = deps.meetingId;
     this.conversationId = deps.conversationId;
     this.insertMessage = deps.insertMessage;
-    this.router = deps.router ?? getMeetSessionEventRouter();
+    this.subscribeFn =
+      deps.subscribeToMeetingEvents ?? defaultSubscribeToMeetingEvents;
     this.hub = deps.assistantEventHub ?? defaultAssistantEventHub;
+    this.resolver =
+      deps.resolver ??
+      new MeetSpeakerResolver({
+        meetingId: deps.meetingId,
+        subscribe: this.subscribeFn,
+      });
     this.assistantId = deps.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
   }
 
   /**
-   * Register this bridge as the handler for its `meetingId` on the
-   * router. Overwrites any prior registration (the router logs a warning
-   * in that case). Idempotent within a single instance — calling twice
-   * just re-registers the same handler.
+   * Register this bridge as a subscriber on the dispatcher for its
+   * `meetingId`. Idempotent — calling twice while already subscribed is
+   * a no-op so callers don't need to track state themselves.
    */
   subscribe(): void {
-    const handler: MeetSessionEventHandler = (event) => {
-      // Defer to async-aware branch but don't block the router — late
+    if (this.unsubscribeFn) return;
+    this.unsubscribeFn = this.subscribeFn(this.meetingId, (event) => {
+      // Defer to async-aware branch but don't block the dispatcher — late
       // errors are logged, not surfaced.
       void this.handleEvent(event).catch((err) => {
         log.error(
@@ -137,23 +165,31 @@ export class MeetConversationBridge {
           "MeetConversationBridge: handler failed",
         );
       });
-    };
-    this.router.register(this.meetingId, handler);
-    this.subscribed = true;
+    });
   }
 
   /**
-   * Remove this bridge's registration from the router. Safe to call
-   * multiple times and before `subscribe()`.
+   * Drop the dispatcher subscription and dispose the resolver. Safe to
+   * call multiple times and before `subscribe()`.
    */
   unsubscribe(): void {
-    this.router.unregister(this.meetingId);
-    this.subscribed = false;
+    if (this.unsubscribeFn) {
+      try {
+        this.unsubscribeFn();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetConversationBridge: dispatcher unsubscribe threw",
+        );
+      }
+      this.unsubscribeFn = null;
+    }
+    this.resolver.unsubscribe();
   }
 
-  /** Whether this bridge currently holds a router registration. */
+  /** Whether this bridge currently holds a dispatcher subscription. */
   isSubscribed(): boolean {
-    return this.subscribed;
+    return this.unsubscribeFn !== null;
   }
 
   // ── Event dispatch ────────────────────────────────────────────────────────
@@ -174,7 +210,8 @@ export class MeetConversationBridge {
         await this.handleParticipantChange(event);
         return;
       case "speaker.change":
-        // PR 18 (storage writer) / PR 21 (speaker resolver) own this.
+        // The resolver is a separate subscriber on this stream — the
+        // bridge itself doesn't need to react to active-speaker changes.
         return;
       case "lifecycle":
         // PR 19 (lifecycle listener) owns this.
@@ -202,24 +239,28 @@ export class MeetConversationBridge {
       return;
     }
 
-    // PR 21 will replace `speakerName` / `speakerId` with resolver output
-    // before building the attribution; for now we use the raw Deepgram
-    // metadata the event carries.
-    const speakerName = event.speakerLabel ?? "Unknown speaker";
+    const resolved = this.resolver.resolve(event);
+    const speakerName = resolved.speakerName;
     const attributed = `[${speakerName}]: ${text}`;
     const content = JSON.stringify([{ type: "text", text: attributed }]);
 
     const metadata: Record<string, unknown> = {
       meetingId: this.meetingId,
       meetTimestamp: event.timestamp,
+      meetSpeakerName: speakerName,
+      meetSpeakerConfidence: resolved.confidence,
     };
     if (event.speakerLabel !== undefined) {
       metadata.meetSpeakerLabel = event.speakerLabel;
     }
-    if (event.speakerId !== undefined) {
+    if (resolved.speakerId !== undefined) {
+      metadata.meetSpeakerId = resolved.speakerId;
+    } else if (event.speakerId !== undefined) {
+      // Preserve the raw Deepgram speakerId even when the resolver didn't
+      // produce a binding — it can still help downstream consumers pair
+      // ASR segments to the same opaque speaker.
       metadata.meetSpeakerId = event.speakerId;
     }
-    metadata.meetSpeakerName = speakerName;
 
     await this.insertMessage(this.conversationId, "user", content, metadata);
   }

--- a/assistant/src/meet/speaker-resolver.ts
+++ b/assistant/src/meet/speaker-resolver.ts
@@ -1,0 +1,330 @@
+/**
+ * MeetSpeakerResolver — arbitrates between Deepgram speaker labels and the
+ * DOM-derived active-speaker stream to produce the best identity attribution
+ * for every final transcript chunk.
+ *
+ * Two signals feed into the resolver:
+ *
+ *   1. **Deepgram labels** — opaque `speaker-N` strings that are stable
+ *      *within* a session but carry no real-world identity. They ride in
+ *      `TranscriptChunkEvent.speakerLabel` (and occasionally `speakerId`).
+ *   2. **DOM active-speaker events** — real participant ids + names scraped
+ *      from the Meet UI, delivered as `SpeakerChangeEvent`s. These are
+ *      authoritative for *who* is on camera but arrive independently of
+ *      the audio stream, so they are only useful when correlated with a
+ *      transcript's timestamp.
+ *
+ * The resolver maintains an internal label → identity mapping that is built
+ * up across the meeting: the first time Deepgram says `speaker-0` while the
+ * DOM says Alice is active, we bind `speaker-0 → Alice` and the next
+ * Deepgram-only transcript carrying that label resolves to Alice without
+ * a DOM round-trip.
+ *
+ * Resolution precedence for a given transcript:
+ *   - Bound mapping for the Deepgram label → `"deepgram"`
+ *   - DOM event within ±{@link DOM_CORRELATION_WINDOW_MS} of the transcript
+ *     timestamp → `"dom-override"` (and bind the mapping if the Deepgram
+ *     label was previously unmapped)
+ *   - Neither → `"unknown"` with a default name
+ *
+ * When Deepgram's mapped identity disagrees with a near-in-time DOM event,
+ * the DOM wins and the discrepancy is logged — the DOM source has higher
+ * confidence because it carries the participant's actual display name.
+ *
+ * The resolver **wraps** (not replaces) the shared {@link SpeakerIdentityTracker}
+ * from the calls module: each resolved identity is forwarded via
+ * `tracker.identifySpeaker` so the cross-surface speaker profile list stays
+ * coherent across calls and meetings.
+ */
+
+import type {
+  SpeakerChangeEvent,
+  TranscriptChunkEvent,
+} from "@vellumai/meet-contracts";
+
+import type { PromptSpeakerMetadata } from "../calls/speaker-identification.js";
+import { SpeakerIdentityTracker } from "../calls/speaker-identification.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type MeetEventSubscriber,
+  type MeetEventUnsubscribe,
+  subscribeToMeetingEvents,
+} from "./event-publisher.js";
+
+const log = getLogger("meet-speaker-resolver");
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Window within which a DOM `SpeakerChangeEvent` is considered correlated
+ * with a transcript chunk. ±500ms matches the plan's call-out — Deepgram's
+ * final chunks usually trail the DOM update by a few hundred ms as the
+ * buffer flushes, so a symmetric window is the conservative choice.
+ */
+export const DOM_CORRELATION_WINDOW_MS = 500;
+
+/** Returned as `speakerName` when neither signal produced a binding. */
+export const UNKNOWN_SPEAKER_NAME = "Unknown speaker";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Source of the resolved identity.
+ *
+ * - `"deepgram"`: a previously-learned `speakerLabel → identity` mapping
+ *   was applied.
+ * - `"dom-override"`: a DOM `SpeakerChangeEvent` fell inside the
+ *   correlation window and supplied the identity.
+ * - `"unknown"`: neither signal produced a binding — the caller should
+ *   treat this as an unattributed utterance.
+ */
+export type ResolvedSpeakerConfidence =
+  | "deepgram"
+  | "dom-override"
+  | "unknown";
+
+export interface ResolvedSpeaker {
+  /** Stable speaker identifier, if resolved. */
+  speakerId: string | undefined;
+  /** Display name — falls back to {@link UNKNOWN_SPEAKER_NAME}. */
+  speakerName: string;
+  /** Which signal produced the identity. See {@link ResolvedSpeakerConfidence}. */
+  confidence: ResolvedSpeakerConfidence;
+}
+
+export interface MeetSpeakerResolverDeps {
+  /** Meeting id — used to subscribe to the matching event stream. */
+  meetingId: string;
+  /**
+   * Optional shared {@link SpeakerIdentityTracker}. Defaults to a fresh
+   * per-resolver instance; callers who want the Meet stream to feed the
+   * same tracker used by calls should pass theirs here.
+   */
+  tracker?: SpeakerIdentityTracker;
+  /**
+   * Optional correlation-window override (milliseconds). Defaults to
+   * {@link DOM_CORRELATION_WINDOW_MS}. Tests set this to 0 to make the
+   * fallback path deterministic.
+   */
+  correlationWindowMs?: number;
+  /**
+   * Optional subscribe override. Defaults to the process-level
+   * {@link subscribeToMeetingEvents}. Tests inject a local shim so they
+   * don't need to touch the singleton dispatcher.
+   */
+  subscribe?: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** Most recent DOM active-speaker — stored as an absolute epoch-ms. */
+interface ActiveSpeakerSnapshot {
+  speakerId: string;
+  speakerName: string;
+  timestampMs: number;
+}
+
+/** A bound `speakerLabel → identity` mapping learned from the DOM stream. */
+interface LabelBinding {
+  speakerId: string;
+  speakerName: string;
+}
+
+// ---------------------------------------------------------------------------
+// MeetSpeakerResolver
+// ---------------------------------------------------------------------------
+
+export class MeetSpeakerResolver {
+  private readonly meetingId: string;
+  private readonly tracker: SpeakerIdentityTracker;
+  private readonly correlationWindowMs: number;
+  private readonly unsubscribeFn: MeetEventUnsubscribe;
+
+  /** Most-recent DOM active speaker — updated on every `speaker.change`. */
+  private activeSpeaker: ActiveSpeakerSnapshot | null = null;
+
+  /**
+   * Bound `speakerLabel → identity` map. Once a label has been bound by a
+   * near-in-time DOM event, the mapping sticks until the resolver is
+   * disposed — callers drop and recreate the resolver per meeting so
+   * stale bindings from a prior meeting can't leak.
+   */
+  private readonly labelBindings = new Map<string, LabelBinding>();
+
+  constructor(deps: MeetSpeakerResolverDeps) {
+    this.meetingId = deps.meetingId;
+    this.tracker = deps.tracker ?? new SpeakerIdentityTracker();
+    this.correlationWindowMs =
+      deps.correlationWindowMs ?? DOM_CORRELATION_WINDOW_MS;
+
+    const subscribe = deps.subscribe ?? subscribeToMeetingEvents;
+    this.unsubscribeFn = subscribe(this.meetingId, (event) => {
+      if (event.type === "speaker.change") {
+        this.onSpeakerChange(event);
+      }
+    });
+  }
+
+  /**
+   * Resolve a transcript chunk to its best-available speaker identity.
+   *
+   * Mutates internal state (may bind a previously-unmapped
+   * `speakerLabel`), so callers should treat this as the single entry
+   * point per transcript — do not call twice on the same event.
+   */
+  resolve(transcript: TranscriptChunkEvent): ResolvedSpeaker {
+    const transcriptMs = parseTimestamp(transcript.timestamp);
+    const domMatch = this.correlatedActiveSpeaker(transcriptMs);
+    const label = transcript.speakerLabel;
+
+    // 1) Bound Deepgram label wins when no DOM disagreement is visible.
+    if (label !== undefined) {
+      const bound = this.labelBindings.get(label);
+      if (bound) {
+        // Deepgram says we already know this label → if DOM now disagrees,
+        // DOM takes precedence (participant identities outrank stable-but-
+        // opaque ASR labels). Log so the divergence is observable.
+        if (
+          domMatch &&
+          (domMatch.speakerId !== bound.speakerId ||
+            domMatch.speakerName !== bound.speakerName)
+        ) {
+          log.warn(
+            {
+              meetingId: this.meetingId,
+              speakerLabel: label,
+              deepgramSpeakerId: bound.speakerId,
+              deepgramSpeakerName: bound.speakerName,
+              domSpeakerId: domMatch.speakerId,
+              domSpeakerName: domMatch.speakerName,
+            },
+            "Meet speaker resolver: Deepgram/DOM disagree — DOM overrides",
+          );
+          return this.emit({
+            speakerId: domMatch.speakerId,
+            speakerName: domMatch.speakerName,
+            confidence: "dom-override",
+          });
+        }
+        return this.emit({
+          speakerId: bound.speakerId,
+          speakerName: bound.speakerName,
+          confidence: "deepgram",
+        });
+      }
+    }
+
+    // 2) Unbound label (or absent) + DOM match → DOM overrides, and if a
+    //    Deepgram label was present we learn it for next time.
+    if (domMatch) {
+      if (label !== undefined) {
+        this.labelBindings.set(label, {
+          speakerId: domMatch.speakerId,
+          speakerName: domMatch.speakerName,
+        });
+      }
+      return this.emit({
+        speakerId: domMatch.speakerId,
+        speakerName: domMatch.speakerName,
+        confidence: "dom-override",
+      });
+    }
+
+    // 3) Nothing — unattributed utterance.
+    return this.emit({
+      speakerId: undefined,
+      speakerName: UNKNOWN_SPEAKER_NAME,
+      confidence: "unknown",
+    });
+  }
+
+  /** Tear down the dispatcher subscription. Safe to call multiple times. */
+  unsubscribe(): void {
+    try {
+      this.unsubscribeFn();
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId },
+        "MeetSpeakerResolver: unsubscribe threw",
+      );
+    }
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────
+
+  private onSpeakerChange(event: SpeakerChangeEvent): void {
+    const timestampMs = parseTimestamp(event.timestamp);
+    this.activeSpeaker = {
+      speakerId: event.speakerId,
+      speakerName: event.speakerName,
+      timestampMs,
+    };
+  }
+
+  /**
+   * Return the most-recent DOM active speaker if their `timestamp` is
+   * within the correlation window of `transcriptMs`, otherwise `null`.
+   *
+   * If `transcriptMs` is NaN (unparsable ISO string) we refuse to match —
+   * an unbounded window would bind arbitrary labels to whoever spoke last,
+   * which is worse than leaving the transcript unattributed.
+   */
+  private correlatedActiveSpeaker(
+    transcriptMs: number,
+  ): ActiveSpeakerSnapshot | null {
+    if (!Number.isFinite(transcriptMs)) return null;
+    const snapshot = this.activeSpeaker;
+    if (!snapshot) return null;
+    const delta = Math.abs(snapshot.timestampMs - transcriptMs);
+    if (delta > this.correlationWindowMs) return null;
+    return snapshot;
+  }
+
+  /**
+   * Forward the resolved identity to the shared
+   * {@link SpeakerIdentityTracker} so cross-surface profile accounting
+   * (calls + meetings) stays coherent, then return it.
+   */
+  private emit(resolved: ResolvedSpeaker): ResolvedSpeaker {
+    if (resolved.confidence !== "unknown" && resolved.speakerId) {
+      const metadata: PromptSpeakerMetadata = {
+        speakerId: resolved.speakerId,
+        speakerName: resolved.speakerName,
+      };
+      try {
+        this.tracker.identifySpeaker(metadata);
+      } catch (err) {
+        // SpeakerIdentityTracker is in-memory only, but defend against a
+        // future implementation change — a tracker failure must never
+        // break transcript attribution.
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetSpeakerResolver: tracker.identifySpeaker threw",
+        );
+      }
+    }
+    return resolved;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an ISO-8601 timestamp (as produced by the bot) to epoch-ms.
+ * Returns `NaN` if the input is unparsable — callers should treat NaN as
+ * "cannot correlate" rather than "correlates with anything".
+ */
+function parseTimestamp(iso: string): number {
+  return Date.parse(iso);
+}


### PR DESCRIPTION
## Summary
- New `MeetSpeakerResolver` arbitrates Deepgram labels vs DOM speaker events, learns label→identity mappings, wraps `SpeakerIdentityTracker`.
- `MeetConversationBridge` now calls resolver before inserting transcripts; migrated from `MeetSessionEventRouter` to `subscribeToMeetingEvents` so multiple consumers can coexist.
- Confidence tag (`deepgram`/`dom-override`/`unknown`) carried in message metadata.

Part of plan: meet-phase-1-listen.md (PR 21 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
