### PR TITLE
meet-bot: main entrypoint wiring scrapers + audio + daemon client

### DIFF
--- a/meet-bot/__tests__/daemon-client.test.ts
+++ b/meet-bot/__tests__/daemon-client.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Unit tests for `DaemonClient`.
+ *
+ * The client only hits the network through an injected fetch, so the tests
+ * here run a canned fetch mock and assert on:
+ *
+ *   - URL shape (includes `/v1/internal/meet/<meetingId>/events`).
+ *   - `Authorization: Bearer <token>` header present on every POST.
+ *   - Batching: enqueue < maxBatchSize → one flush after flushIntervalMs.
+ *   - Batching: enqueue == maxBatchSize → immediate flush.
+ *   - Retry: 500 then 200 produces exactly one successful POST after retry.
+ *   - No retry on 4xx: surfaces via onError.
+ *   - `stop()` drains pending events before resolving.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import {
+  DaemonClient,
+  type FetchFn,
+} from "../src/control/daemon-client.js";
+
+/** Shape the mock records for every intercepted request. */
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** Response blueprint the mock plays back in order. */
+interface CannedResponse {
+  status: number;
+  bodyText?: string;
+  /** Throw instead of resolving — simulates a network failure. */
+  throw?: Error;
+}
+
+interface MockFetch {
+  fn: FetchFn;
+  calls: RecordedCall[];
+  queueResponses: (responses: CannedResponse[]) => void;
+}
+
+function makeMockFetch(initial: CannedResponse[] = []): MockFetch {
+  let queued: CannedResponse[] = [...initial];
+  const calls: RecordedCall[] = [];
+
+  const fn: FetchFn = async (url, init) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const bodyRaw = init?.body ?? "";
+    let body: unknown = bodyRaw;
+    if (typeof bodyRaw === "string" && bodyRaw.length > 0) {
+      try {
+        body = JSON.parse(bodyRaw);
+      } catch {
+        body = bodyRaw;
+      }
+    }
+    calls.push({
+      url,
+      method: init?.method ?? "GET",
+      headers,
+      body,
+    });
+    const next = queued.shift();
+    if (!next) {
+      throw new Error(
+        `mock fetch: no queued response for call #${calls.length}`,
+      );
+    }
+    if (next.throw) throw next.throw;
+    const bodyText = next.bodyText ?? "";
+    return {
+      ok: next.status >= 200 && next.status < 300,
+      status: next.status,
+      text: async () => bodyText,
+    };
+  };
+
+  return {
+    fn,
+    calls,
+    queueResponses: (responses) => {
+      queued = [...queued, ...responses];
+    },
+  };
+}
+
+/** Build a stub lifecycle event suitable for enqueue. */
+function makeLifecycleEvent(detail: string): MeetBotEvent {
+  return {
+    type: "lifecycle",
+    meetingId: "m-1",
+    timestamp: new Date().toISOString(),
+    state: "joined",
+    detail,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("DaemonClient", () => {
+  test("POSTs buffered events to the ingress URL with bearer auth", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local:1234",
+      meetingId: "m-abc",
+      botApiToken: "secret-token",
+      fetch: mock.fn,
+      flushIntervalMs: 50,
+    });
+
+    client.enqueue(makeLifecycleEvent("hello"));
+
+    // Wait past the flush interval.
+    await sleep(120);
+    await client.stop();
+
+    expect(mock.calls.length).toBe(1);
+    const call = mock.calls[0]!;
+    expect(call.url).toBe(
+      "http://daemon.local:1234/v1/internal/meet/m-abc/events",
+    );
+    expect(call.method).toBe("POST");
+    expect(call.headers.authorization).toBe("Bearer secret-token");
+    expect(call.headers["content-type"]).toBe("application/json");
+    // The wire shape is a bare array of events (matching PR 9's
+    // `MeetIngressBatchSchema = z.array(MeetBotEventSchema)`).
+    expect(Array.isArray(call.body)).toBe(true);
+    const body = call.body as MeetBotEvent[];
+    expect(body).toHaveLength(1);
+    expect(body[0]!.type).toBe("lifecycle");
+  });
+
+  test("flushes within the flush interval even for a single event", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 80,
+    });
+
+    const start = Date.now();
+    client.enqueue(makeLifecycleEvent("one"));
+
+    // Poll for the flush to land (stop polling as soon as it does).
+    while (mock.calls.length === 0 && Date.now() - start < 500) {
+      await sleep(10);
+    }
+    const elapsed = Date.now() - start;
+    expect(mock.calls.length).toBe(1);
+    // Should have flushed shortly after the 80ms timer — generous upper
+    // bound so CI jitter doesn't trip us.
+    expect(elapsed).toBeLessThan(300);
+
+    await client.stop();
+  });
+
+  test("flushes immediately when the batch reaches maxBatchSize", async () => {
+    const mock = makeMockFetch([{ status: 204 }, { status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      // Default is 20 — use it directly to match the PR spec.
+      flushIntervalMs: 10_000,
+    });
+
+    for (let i = 0; i < 25; i += 1) {
+      client.enqueue(makeLifecycleEvent(`ev-${i}`));
+    }
+
+    // Give the first (size-triggered) flush a moment to complete.
+    const deadline = Date.now() + 500;
+    while (mock.calls.length === 0 && Date.now() < deadline) {
+      await sleep(5);
+    }
+
+    expect(mock.calls.length).toBeGreaterThanOrEqual(1);
+    const firstBatch = mock.calls[0]!.body as MeetBotEvent[];
+    // First flush fires at exactly 20 (the default maxBatchSize).
+    expect(firstBatch.length).toBe(20);
+
+    // Drain the remainder — stop() flushes the last 5 events.
+    await client.stop();
+    expect(mock.calls.length).toBe(2);
+    const secondBatch = mock.calls[1]!.body as MeetBotEvent[];
+    expect(secondBatch.length).toBe(5);
+  });
+
+  test("retries on 5xx and succeeds on the next attempt", async () => {
+    const mock = makeMockFetch([
+      { status: 503 },
+      { status: 204 },
+    ]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 30,
+    });
+
+    client.enqueue(makeLifecycleEvent("retry-me"));
+    await client.stop();
+
+    // Two attempts total: 503 → retry → 204.
+    expect(mock.calls.length).toBe(2);
+    expect((mock.calls[0]!.body as MeetBotEvent[]).length).toBe(1);
+    expect((mock.calls[1]!.body as MeetBotEvent[]).length).toBe(1);
+  });
+
+  test("retries on network errors and surfaces after exhausting budget", async () => {
+    const mock = makeMockFetch([
+      { status: 0, throw: new Error("ECONNREFUSED") },
+      { status: 0, throw: new Error("ECONNREFUSED") },
+      { status: 0, throw: new Error("ECONNREFUSED") },
+      { status: 0, throw: new Error("ECONNREFUSED") },
+    ]);
+    const errors: Array<{ err: Error; batch: MeetBotEvent[] }> = [];
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 30,
+      onError: (err, batch) => errors.push({ err, batch }),
+    });
+
+    client.enqueue(makeLifecycleEvent("never-lands"));
+    await client.stop();
+
+    expect(mock.calls.length).toBe(4); // 1 original + 3 retries.
+    expect(errors.length).toBe(1);
+    expect(errors[0]!.err.message).toContain("ECONNREFUSED");
+    expect(errors[0]!.batch.length).toBe(1);
+  });
+
+  test("does not retry 4xx — surfaces via onError immediately", async () => {
+    const mock = makeMockFetch([
+      { status: 400, bodyText: "invalid event batch" },
+    ]);
+    const errors: Array<{ err: Error; batch: MeetBotEvent[] }> = [];
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 20,
+      onError: (err, batch) => errors.push({ err, batch }),
+    });
+
+    client.enqueue(makeLifecycleEvent("reject"));
+    await client.stop();
+
+    expect(mock.calls.length).toBe(1);
+    expect(errors.length).toBe(1);
+    expect(errors[0]!.err.message).toContain("400");
+    expect(errors[0]!.err.message).toContain("invalid event batch");
+  });
+
+  test("stop() drains pending events before resolving", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 5_000, // long — stop() is the only thing that can flush in time.
+    });
+
+    client.enqueue(makeLifecycleEvent("pending-1"));
+    client.enqueue(makeLifecycleEvent("pending-2"));
+
+    // Right after enqueue, nothing has been POSTed yet.
+    expect(mock.calls.length).toBe(0);
+
+    await client.stop();
+
+    expect(mock.calls.length).toBe(1);
+    const body = mock.calls[0]!.body as MeetBotEvent[];
+    expect(body.length).toBe(2);
+  });
+
+  test("stop() is idempotent — calling twice does not re-POST", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 5_000,
+    });
+
+    client.enqueue(makeLifecycleEvent("only"));
+    await client.stop();
+    await client.stop();
+
+    expect(mock.calls.length).toBe(1);
+  });
+
+  test("enqueue after stop() is a no-op", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 5_000,
+    });
+
+    client.enqueue(makeLifecycleEvent("pre-stop"));
+    await client.stop();
+
+    client.enqueue(makeLifecycleEvent("post-stop"));
+    // Give any errant timer a moment to fire.
+    await sleep(30);
+
+    expect(mock.calls.length).toBe(1);
+    const body = mock.calls[0]!.body as MeetBotEvent[];
+    expect(body.length).toBe(1);
+    expect((body[0] as { detail?: string }).detail).toBe("pre-stop");
+  });
+
+  test("URL encodes the meeting id", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local",
+      meetingId: "m/weird id",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 20,
+    });
+
+    client.enqueue({
+      type: "lifecycle",
+      meetingId: "m/weird id",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+    await client.stop();
+
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]!.url).toBe(
+      "http://daemon.local/v1/internal/meet/m%2Fweird%20id/events",
+    );
+  });
+
+  test("trims trailing slashes from the daemon URL", async () => {
+    const mock = makeMockFetch([{ status: 204 }]);
+    const client = new DaemonClient({
+      daemonUrl: "http://daemon.local:9000/",
+      meetingId: "m-1",
+      botApiToken: "tk",
+      fetch: mock.fn,
+      flushIntervalMs: 20,
+    });
+
+    client.enqueue(makeLifecycleEvent("x"));
+    await client.stop();
+
+    expect(mock.calls[0]!.url).toBe(
+      "http://daemon.local:9000/v1/internal/meet/m-1/events",
+    );
+  });
+});

--- a/meet-bot/__tests__/main.test.ts
+++ b/meet-bot/__tests__/main.test.ts
@@ -1,0 +1,658 @@
+/**
+ * Tests for `runBot` — the boot path that wires pulse → xvfb → browser →
+ * joinMeet → daemon client → scrapers → audio → http server.
+ *
+ * We don't spin up a real browser or daemon here. Every subsystem is
+ * stubbed with a recording mock that lets us assert on:
+ *
+ *   - Boot order (each subsystem only starts after its prerequisites).
+ *   - Callback wiring (scraper `onEvent` calls actually enqueue into the
+ *     daemon client).
+ *   - Shutdown ordering and dedup (SIGTERM + HTTP `/leave` don't double-stop).
+ *   - Error paths (join failure publishes `lifecycle:error` and exits 1).
+ *
+ * The separate boot smoke test (`boot.test.ts`) still covers the
+ * `SKIP_PULSE=1` + missing-MEET_URL path against a real `bun run src/main.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  LifecycleEvent,
+  MeetBotEvent,
+} from "@vellumai/meet-contracts";
+
+import { runBot, type BotDeps, type DaemonClientLike } from "../src/main.js";
+import { BotState } from "../src/control/state.js";
+
+/** -----------------------------------------------------------------------
+ * Mock factory
+ * ----------------------------------------------------------------------- */
+
+interface RecordedCall {
+  kind: string;
+  [k: string]: unknown;
+}
+
+interface MockHandles {
+  /**
+   * Recorded invocations in the order they were made — lets tests assert
+   * on boot order.
+   */
+  calls: RecordedCall[];
+  /** Events enqueued on the daemon client. */
+  daemonEvents: MeetBotEvent[];
+  /** Whether the daemon client was ever `stop`ped. */
+  daemonStopped: () => boolean;
+  /** Latest log messages, stderr-side. */
+  errors: string[];
+  /** Latest log messages, stdout-side. */
+  infos: string[];
+  /** Latest exit code, if exit was called. */
+  exitCode: () => number | null;
+  /** Invoke the SIGTERM handler captured during boot. */
+  fireSigterm: () => void;
+  /** Invoke the SIGINT handler captured during boot. */
+  fireSigint: () => void;
+  /** Page object the scrapers see. */
+  page: object;
+  /** HTTP callbacks the server captured. */
+  httpCallbacks: () => {
+    onLeave: (reason: string | undefined) => void | Promise<void>;
+  } | null;
+  /** Sessions created — primarily for asserting `close()` was called. */
+  sessionCloses: () => number;
+  /** Participant/speaker/chat/audio stop counters. */
+  stopCounts: () => {
+    participant: number;
+    speaker: number;
+    chat: number;
+    audio: number;
+    httpServer: number;
+  };
+}
+
+interface MakeDepsOpts {
+  /** Force `joinMeet` to reject with this error. */
+  joinError?: Error;
+  /** Force `setupPulseAudio` to reject. */
+  pulseError?: Error;
+}
+
+function makeDeps(
+  opts: MakeDepsOpts = {},
+): { deps: BotDeps; handles: MockHandles } {
+  const calls: RecordedCall[] = [];
+  const daemonEvents: MeetBotEvent[] = [];
+  let daemonStopped = false;
+  const errors: string[] = [];
+  const infos: string[] = [];
+  let exitCode: number | null = null;
+
+  let sigtermHandler: (() => void) | null = null;
+  let sigintHandler: (() => void) | null = null;
+
+  let sessionClosed = 0;
+  let participantStops = 0;
+  let speakerStops = 0;
+  let chatStops = 0;
+  let audioStops = 0;
+  let httpStops = 0;
+
+  let capturedHttpCallbacks: {
+    onLeave: (reason: string | undefined) => void | Promise<void>;
+  } | null = null;
+
+  const fakePage = { __fake: true };
+
+  // Full skipPulse default so only opt-in tests exercise the pulse path.
+  const defaultEnv = {
+    meetUrl: "https://meet.google.com/abc-defg-hij",
+    meetingId: "m-1",
+    joinName: "Vellum Bot",
+    consentMessage: "Hi, I'm an AI assistant listening in.",
+    daemonUrl: "http://daemon.local:7000",
+    botApiToken: "secret",
+    socketDir: "/sockets",
+    skipPulse: true,
+    httpPort: 0,
+  };
+
+  const daemonClient: DaemonClientLike = {
+    enqueue: (event) => {
+      calls.push({ kind: "daemon.enqueue", event });
+      daemonEvents.push(event);
+    },
+    flush: async () => {
+      calls.push({ kind: "daemon.flush" });
+    },
+    stop: async () => {
+      daemonStopped = true;
+      calls.push({ kind: "daemon.stop" });
+    },
+  };
+
+  const deps: BotDeps = {
+    env: () => ({ ...defaultEnv }),
+    setupPulseAudio: async () => {
+      calls.push({ kind: "pulse.setup" });
+      if (opts.pulseError) throw opts.pulseError;
+    },
+    createBrowserSession: async (url) => {
+      calls.push({ kind: "browser.create", url });
+      return {
+        browser: {} as never,
+        context: {} as never,
+        page: fakePage as never,
+        close: async () => {
+          sessionClosed += 1;
+          calls.push({ kind: "browser.close" });
+        },
+      };
+    },
+    joinMeet: async (page, joinOpts) => {
+      calls.push({
+        kind: "join.meet",
+        page,
+        displayName: joinOpts.displayName,
+        consentMessage: joinOpts.consentMessage,
+      });
+      if (opts.joinError) throw opts.joinError;
+    },
+    startParticipantScraper: (_page, _onEvent, scraperOpts) => {
+      calls.push({
+        kind: "scraper.participant.start",
+        meetingId: scraperOpts.meetingId,
+      });
+      return {
+        stop: () => {
+          participantStops += 1;
+          calls.push({ kind: "scraper.participant.stop" });
+        },
+      };
+    },
+    startSpeakerScraper: (_page, _onEvent, scraperOpts) => {
+      calls.push({
+        kind: "scraper.speaker.start",
+        meetingId: scraperOpts.meetingId,
+      });
+      return {
+        stop: () => {
+          speakerStops += 1;
+          calls.push({ kind: "scraper.speaker.stop" });
+        },
+      };
+    },
+    startChatReader: async (_page, _onEvent, scraperOpts) => {
+      calls.push({
+        kind: "scraper.chat.start",
+        meetingId: scraperOpts.meetingId,
+        selfName: scraperOpts.selfName,
+      });
+      return {
+        stop: async () => {
+          chatStops += 1;
+          calls.push({ kind: "scraper.chat.stop" });
+        },
+      };
+    },
+    startAudioCapture: async (audioOpts) => {
+      calls.push({ kind: "audio.start", socketPath: audioOpts.socketPath });
+      return {
+        stop: async () => {
+          audioStops += 1;
+          calls.push({ kind: "audio.stop" });
+        },
+      };
+    },
+    createDaemonClient: (clientOpts) => {
+      calls.push({
+        kind: "daemon.create",
+        daemonUrl: clientOpts.daemonUrl,
+        meetingId: clientOpts.meetingId,
+      });
+      return daemonClient;
+    },
+    createHttpServer: (serverOpts) => {
+      calls.push({
+        kind: "http.create",
+        apiToken: serverOpts.apiToken,
+      });
+      capturedHttpCallbacks = {
+        onLeave: serverOpts.onLeave,
+      };
+      return {
+        app: {} as never,
+        start: async (port: number) => {
+          calls.push({ kind: "http.start", port });
+          return { port };
+        },
+        stop: async () => {
+          httpStops += 1;
+          calls.push({ kind: "http.stop" });
+        },
+      };
+    },
+    onSignal: (signal, handler) => {
+      if (signal === "SIGTERM") sigtermHandler = handler;
+      else sigintHandler = handler;
+      return () => {
+        if (signal === "SIGTERM" && sigtermHandler === handler) {
+          sigtermHandler = null;
+        } else if (signal === "SIGINT" && sigintHandler === handler) {
+          sigintHandler = null;
+        }
+      };
+    },
+    joinedSettleMs: 0, // tests don't need the real 2s wait.
+    sleep: async (_ms: number) => {
+      // no-op in tests.
+    },
+    exit: ((code: number) => {
+      // Record the first exit code only — subsequent calls are
+      // tolerated (production `process.exit` never returns, so the
+      // bot's real flow never sees a double-exit, but in tests the
+      // mocked `exit` returns normally and we occasionally race).
+      if (exitCode === null) exitCode = code;
+      // `process.exit`'s real return type is `never`; we narrow to
+      // `never` via a non-returning path so the production code
+      // compiles. In tests we don't want to throw (that would leak
+      // unhandled rejections out of fire-and-forget `.then(exit)`
+      // chains), so just `return undefined as never`.
+      return undefined as never;
+    }) as BotDeps["exit"],
+    logInfo: (msg) => {
+      infos.push(msg);
+    },
+    logError: (msg) => {
+      errors.push(msg);
+    },
+  };
+
+  const handles: MockHandles = {
+    calls,
+    daemonEvents,
+    daemonStopped: () => daemonStopped,
+    errors,
+    infos,
+    exitCode: () => exitCode,
+    fireSigterm: () => {
+      if (sigtermHandler) sigtermHandler();
+    },
+    fireSigint: () => {
+      if (sigintHandler) sigintHandler();
+    },
+    page: fakePage,
+    httpCallbacks: () => capturedHttpCallbacks,
+    sessionCloses: () => sessionClosed,
+    stopCounts: () => ({
+      participant: participantStops,
+      speaker: speakerStops,
+      chat: chatStops,
+      audio: audioStops,
+      httpServer: httpStops,
+    }),
+  };
+
+  return { deps, handles };
+}
+
+/** Return the ordered list of `kind` tags from the recorded calls. */
+function kinds(calls: RecordedCall[]): string[] {
+  return calls.map((c) => c.kind);
+}
+
+/** -----------------------------------------------------------------------
+ * Tests
+ * ----------------------------------------------------------------------- */
+
+describe("runBot — boot sequence", () => {
+  test("wires subsystems in the correct order", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    const order = kinds(handles.calls);
+
+    // The boot order the implementation promises: browser session,
+    // daemon client (so we can report join failures), join, settle,
+    // scrapers, audio, http.
+    const indexOf = (kind: string): number => order.indexOf(kind);
+
+    expect(indexOf("browser.create")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("daemon.create")).toBeGreaterThan(
+      indexOf("browser.create"),
+    );
+    expect(indexOf("join.meet")).toBeGreaterThan(indexOf("daemon.create"));
+    expect(indexOf("scraper.participant.start")).toBeGreaterThan(
+      indexOf("join.meet"),
+    );
+    expect(indexOf("scraper.speaker.start")).toBeGreaterThan(
+      indexOf("join.meet"),
+    );
+    expect(indexOf("scraper.chat.start")).toBeGreaterThan(indexOf("join.meet"));
+    expect(indexOf("audio.start")).toBeGreaterThan(
+      indexOf("scraper.chat.start"),
+    );
+    expect(indexOf("http.create")).toBeGreaterThan(indexOf("audio.start"));
+    expect(indexOf("http.start")).toBeGreaterThan(indexOf("http.create"));
+  });
+
+  test("publishes lifecycle:joining before joinMeet and :joined after", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => e.state);
+
+    // We expect at least `joining` and `joined`. No `error` / `left` yet.
+    expect(lifecycleStates).toContain("joining");
+    expect(lifecycleStates).toContain("joined");
+    expect(lifecycleStates).not.toContain("error");
+    expect(lifecycleStates).not.toContain("left");
+
+    // Ordering: joining comes before joined.
+    const joiningIdx = lifecycleStates.indexOf("joining");
+    const joinedIdx = lifecycleStates.indexOf("joined");
+    expect(joiningIdx).toBeGreaterThanOrEqual(0);
+    expect(joinedIdx).toBeGreaterThan(joiningIdx);
+  });
+
+  test("passes the meetingId and selfName through to the scrapers", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    const participantCall = handles.calls.find(
+      (c) => c.kind === "scraper.participant.start",
+    );
+    const speakerCall = handles.calls.find(
+      (c) => c.kind === "scraper.speaker.start",
+    );
+    const chatCall = handles.calls.find(
+      (c) => c.kind === "scraper.chat.start",
+    );
+
+    expect(participantCall?.meetingId).toBe("m-1");
+    expect(speakerCall?.meetingId).toBe("m-1");
+    expect(chatCall?.meetingId).toBe("m-1");
+    expect(chatCall?.selfName).toBe("Vellum Bot");
+  });
+
+  test("passes socketDir/audio.sock into audio capture", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    const audioCall = handles.calls.find((c) => c.kind === "audio.start");
+    expect(audioCall?.socketPath).toBe("/sockets/audio.sock");
+  });
+});
+
+describe("runBot — shutdown", () => {
+  test("onLeave triggers the full shutdown path in the right order", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    // Exercise the /leave path.
+    const cbs = handles.httpCallbacks();
+    expect(cbs).not.toBeNull();
+
+    // onLeave schedules shutdown + exit via `void` — we catch the
+    // sentinel exit() throw via the shutdown promise.
+    await new Promise<void>((resolve) => {
+      void (async () => {
+        try {
+          await cbs!.onLeave("user requested");
+        } catch {
+          // swallow __test_exit
+        }
+        resolve();
+      })();
+    });
+
+    // Poll for shutdown completion — the exit-code sentinel lands after
+    // the shutdown chain resolves.
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    expect(handles.exitCode()).toBe(0);
+
+    const order = kinds(handles.calls);
+    const leaveStart = order.lastIndexOf("http.create") + 1;
+    const shutdownOrder = order.slice(leaveStart);
+
+    // HTTP server stops first (no new commands after /leave).
+    expect(shutdownOrder.indexOf("http.stop")).toBeGreaterThanOrEqual(0);
+    // Then scrapers.
+    expect(shutdownOrder.indexOf("scraper.participant.stop")).toBeGreaterThan(
+      shutdownOrder.indexOf("http.stop"),
+    );
+    expect(shutdownOrder.indexOf("scraper.speaker.stop")).toBeGreaterThan(
+      shutdownOrder.indexOf("http.stop"),
+    );
+    expect(shutdownOrder.indexOf("scraper.chat.stop")).toBeGreaterThan(
+      shutdownOrder.indexOf("http.stop"),
+    );
+    // Audio before browser.
+    expect(shutdownOrder.indexOf("audio.stop")).toBeGreaterThan(
+      shutdownOrder.indexOf("scraper.chat.stop"),
+    );
+    expect(shutdownOrder.indexOf("browser.close")).toBeGreaterThan(
+      shutdownOrder.indexOf("audio.stop"),
+    );
+    // Daemon stop comes last, and only after `lifecycle:left` is enqueued.
+    expect(shutdownOrder.indexOf("daemon.stop")).toBeGreaterThan(
+      shutdownOrder.indexOf("browser.close"),
+    );
+
+    // `lifecycle:left` was published before stop().
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => e.state);
+    expect(lifecycleStates).toContain("left");
+    expect(lifecycleStates[lifecycleStates.length - 1]).toBe("left");
+
+    // Shutdown counts: each subsystem stopped exactly once.
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.participant).toBe(1);
+    expect(counts.speaker).toBe(1);
+    expect(counts.chat).toBe(1);
+    expect(counts.audio).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
+    expect(handles.sessionCloses()).toBe(1);
+  });
+
+  test("SIGTERM triggers the same shutdown path", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    handles.fireSigterm();
+
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    expect(handles.exitCode()).toBe(0);
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.participant).toBe(1);
+    expect(counts.speaker).toBe(1);
+    expect(counts.chat).toBe(1);
+    expect(counts.audio).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
+  });
+
+  test("SIGTERM + /leave do not double-stop subsystems", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await runBot(deps);
+
+    handles.fireSigterm();
+    const cbs = handles.httpCallbacks();
+    try {
+      await cbs!.onLeave("redundant");
+    } catch {
+      // swallow __test_exit
+    }
+
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.participant).toBe(1);
+    expect(counts.speaker).toBe(1);
+    expect(counts.chat).toBe(1);
+    expect(counts.audio).toBe(1);
+  });
+});
+
+describe("runBot — error paths", () => {
+  test("join failure publishes lifecycle:error and exits 1", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      joinError: new Error("prejoin selector timed out"),
+    });
+
+    try {
+      await runBot(deps);
+    } catch (err) {
+      // The sentinel exit() throws — catch so the test continues.
+      const msg = (err as Error).message;
+      if (!msg.startsWith("__test_exit")) throw err;
+    }
+
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    expect(handles.exitCode()).toBe(1);
+
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => ({ state: e.state, detail: e.detail }));
+    expect(lifecycleStates.some((s) => s.state === "error")).toBe(true);
+    const errorEvent = lifecycleStates.find((s) => s.state === "error");
+    expect(errorEvent?.detail).toContain("prejoin selector timed out");
+
+    // Scrapers / audio / http must not have started.
+    const order = kinds(handles.calls);
+    expect(order).not.toContain("scraper.participant.start");
+    expect(order).not.toContain("audio.start");
+    expect(order).not.toContain("http.start");
+
+    // Browser was closed; daemon was flushed.
+    expect(handles.sessionCloses()).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
+  });
+
+  test("PulseAudio failure exits 1 without touching browser", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      pulseError: new Error("pulseaudio: connection refused"),
+    });
+    // Override skipPulse to force the setup call.
+    const realEnv = deps.env;
+    deps.env = () => ({ ...realEnv(), skipPulse: false });
+
+    try {
+      await runBot(deps);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (!msg.startsWith("__test_exit")) throw err;
+    }
+
+    expect(handles.exitCode()).toBe(1);
+    const order = kinds(handles.calls);
+    expect(order).toContain("pulse.setup");
+    expect(order).not.toContain("browser.create");
+    expect(
+      handles.errors.some((e) => e.includes("PulseAudio setup failed")),
+    ).toBe(true);
+  });
+});
+
+describe("runBot — event wiring", () => {
+  test("scraper onEvent callbacks enqueue events on the daemon client", async () => {
+    BotState.__resetForTests();
+
+    // Capture the participant-scraper onEvent so we can invoke it by hand.
+    let participantOnEvent:
+      | ((event: import("@vellumai/meet-contracts").ParticipantChangeEvent) => void)
+      | null = null;
+    let speakerOnEvent:
+      | ((event: import("@vellumai/meet-contracts").SpeakerChangeEvent) => void)
+      | null = null;
+    let chatOnEvent:
+      | ((event: import("@vellumai/meet-contracts").InboundChatEvent) => void)
+      | null = null;
+
+    const { deps, handles } = makeDeps();
+    const baseStart = deps.startParticipantScraper;
+    const baseSpeaker = deps.startSpeakerScraper;
+    const baseChat = deps.startChatReader;
+
+    deps.startParticipantScraper = (page, onEvent, opts) => {
+      participantOnEvent = onEvent;
+      return baseStart(page, onEvent, opts);
+    };
+    deps.startSpeakerScraper = (page, onEvent, opts) => {
+      speakerOnEvent = onEvent;
+      return baseSpeaker(page, onEvent, opts);
+    };
+    deps.startChatReader = (page, onEvent, opts) => {
+      chatOnEvent = onEvent;
+      return baseChat(page, onEvent, opts);
+    };
+
+    await runBot(deps);
+
+    const before = handles.daemonEvents.length;
+    expect(participantOnEvent).not.toBeNull();
+    expect(speakerOnEvent).not.toBeNull();
+    expect(chatOnEvent).not.toBeNull();
+
+    participantOnEvent!({
+      type: "participant.change",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    });
+    speakerOnEvent!({
+      type: "speaker.change",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      speakerId: "p-1",
+      speakerName: "Alice",
+    });
+    chatOnEvent!({
+      type: "chat.inbound",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      fromId: "p-2",
+      fromName: "Bob",
+      text: "hello",
+    });
+
+    expect(handles.daemonEvents.length).toBe(before + 3);
+    const newEvents = handles.daemonEvents.slice(before);
+    expect(newEvents.map((e) => e.type)).toEqual([
+      "participant.change",
+      "speaker.change",
+      "chat.inbound",
+    ]);
+  });
+});

--- a/meet-bot/src/control/daemon-client.ts
+++ b/meet-bot/src/control/daemon-client.ts
@@ -1,0 +1,285 @@
+/**
+ * Bot → daemon event publisher.
+ *
+ * Buffers `MeetBotEvent`s produced by the scrapers/lifecycle emitters and
+ * ships them to the daemon's ingress endpoint
+ * (`POST /v1/internal/meet/:meetingId/events`) in small batches. Batching
+ * amortizes HTTP overhead without introducing perceptible delay — the flush
+ * triggers on whichever comes first of:
+ *
+ *   - `MAX_BATCH_SIZE` queued events, or
+ *   - `FLUSH_INTERVAL_MS` since the first unflushed enqueue.
+ *
+ * Transient network / 5xx failures are retried with exponential backoff
+ * (3 attempts, 250/500/1000ms). A 4xx is treated as a caller bug and
+ * surfaced to the `onError` hook without retrying — the daemon has
+ * rejected the payload, so retransmitting the same bytes is pointless.
+ *
+ * The fetch implementation is injected so tests can assert on calls
+ * without hitting the network. In production the default is `globalThis.fetch`.
+ *
+ * ## Wire shape
+ *
+ * The daemon's ingress route in PR 9 decodes the request body as
+ * `MeetBotEvent[]` — a bare JSON array, not an object wrapper. We match
+ * that shape here so the two sides stay interoperable.
+ */
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+/** Default flush cadence and batch size — tuned in the PR description. */
+const MAX_BATCH_SIZE = 20;
+const FLUSH_INTERVAL_MS = 250;
+
+/**
+ * Exponential backoff schedule for retrying transient failures.
+ * Covers the three retry attempts (original + 3 retries = 4 total calls).
+ */
+const RETRY_BACKOFF_MS = [250, 500, 1000] as const;
+
+/** Fetch signature the client calls through. `globalThis.fetch`-shaped. */
+export type FetchFn = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+export interface DaemonClientOptions {
+  /**
+   * Base URL of the daemon's HTTP server (no trailing slash). The final
+   * URL the client POSTs to is
+   * `${daemonUrl}/v1/internal/meet/${meetingId}/events`.
+   */
+  daemonUrl: string;
+  /** Meeting identifier — segmented into the path. */
+  meetingId: string;
+  /** Bearer token the daemon verifies against its session registry. */
+  botApiToken: string;
+  /**
+   * Injectable fetch. Defaults to `globalThis.fetch` bound to globalThis
+   * so Node's fetch doesn't lose its receiver when called indirectly.
+   */
+  fetch?: FetchFn;
+  /**
+   * Called when a batch ultimately fails after exhausting retries or hits
+   * an unretryable 4xx. Receives the error and the batch that failed so
+   * callers can log / alert. If the callback throws it's swallowed to
+   * keep the flush loop alive.
+   */
+  onError?: (err: Error, batch: MeetBotEvent[]) => void;
+  /** Override batch size — tests use this to shrink or enlarge windows. */
+  maxBatchSize?: number;
+  /** Override flush cadence. */
+  flushIntervalMs?: number;
+}
+
+/**
+ * Batches and ships bot events to the daemon.
+ *
+ * Instance-per-meeting — the meeting id and bearer token are immutable for
+ * the client's lifetime. Call `enqueue` to append events and `stop` to
+ * drain pending events and tear down the flush timer.
+ */
+export class DaemonClient {
+  private readonly url: string;
+  private readonly authHeader: string;
+  private readonly doFetch: FetchFn;
+  private readonly onError?: (err: Error, batch: MeetBotEvent[]) => void;
+  private readonly maxBatchSize: number;
+  private readonly flushIntervalMs: number;
+
+  /**
+   * Pending events waiting for the next flush. We never slice this in
+   * place — a flush drains it fully and keeps a separate reference to
+   * the batch being shipped so new enqueues during the POST don't get
+   * mixed into the in-flight request.
+   */
+  private buffer: MeetBotEvent[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+
+  /**
+   * Chain of in-flight flushes. We serialize flushes so the daemon
+   * sees events in enqueue order even when two timers race (e.g. a
+   * manual `flush()` call overlaps the scheduled timer firing).
+   */
+  private flushChain: Promise<void> = Promise.resolve();
+
+  constructor(opts: DaemonClientOptions) {
+    // Trim a trailing slash so `${url}/v1/...` doesn't double up.
+    const base = opts.daemonUrl.replace(/\/+$/, "");
+    this.url = `${base}/v1/internal/meet/${encodeURIComponent(opts.meetingId)}/events`;
+    this.authHeader = `Bearer ${opts.botApiToken}`;
+    this.doFetch =
+      opts.fetch ??
+      ((...args) =>
+        (globalThis.fetch as unknown as FetchFn)(...args));
+    this.onError = opts.onError;
+    this.maxBatchSize = opts.maxBatchSize ?? MAX_BATCH_SIZE;
+    this.flushIntervalMs = opts.flushIntervalMs ?? FLUSH_INTERVAL_MS;
+  }
+
+  /**
+   * Append an event to the outgoing buffer. Schedules a flush at
+   * `flushIntervalMs` after the first buffered event, or flushes
+   * immediately once the buffer hits `maxBatchSize`.
+   *
+   * Enqueuing after `stop()` is a no-op — late DOM callbacks during
+   * shutdown shouldn't resurrect the flush loop.
+   */
+  enqueue(event: MeetBotEvent): void {
+    if (this.stopped) return;
+    this.buffer.push(event);
+
+    if (this.buffer.length >= this.maxBatchSize) {
+      // Tip over into immediate flush. Drain the buffer *synchronously*
+      // here so follow-on enqueues in the same tick start a fresh batch
+      // rather than piggybacking onto the in-flight POST. Without this,
+      // a caller emitting 25 events synchronously would ship all 25 in
+      // one batch instead of splitting at 20.
+      const batch = this.buffer;
+      this.buffer = [];
+      if (this.flushTimer !== null) {
+        clearTimeout(this.flushTimer);
+        this.flushTimer = null;
+      }
+      void this.shipBatch(batch);
+      return;
+    }
+
+    if (this.flushTimer === null) {
+      this.flushTimer = setTimeout(() => {
+        this.flushTimer = null;
+        void this.flush();
+      }, this.flushIntervalMs);
+    }
+  }
+
+  /**
+   * Drain the buffer and POST the events to the daemon. Returns once
+   * the POST (and retries) have settled.
+   *
+   * Callers normally don't invoke this directly — the timer/batch-size
+   * triggers handle it automatically. `stop()` calls `flush()` as its
+   * last step so pending events aren't lost at teardown.
+   */
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) {
+      // Nothing pending locally, but earlier enqueues may have scheduled
+      // in-flight shipments — wait for them so callers observing
+      // `flush()` resolution see a fully drained pipeline.
+      await this.flushChain.catch(() => undefined);
+      return;
+    }
+    const batch = this.buffer;
+    this.buffer = [];
+    await this.shipBatch(batch);
+  }
+
+  /**
+   * Stop the client: clear any pending timer, flush whatever is still
+   * buffered, and mark the instance as no-longer-enqueuing.
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) {
+      // Even when already stopped, awaiting the chain ensures callers
+      // observing `stop()` resolution see all prior flushes settled.
+      await this.flushChain.catch(() => undefined);
+      return;
+    }
+    this.stopped = true;
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.flush();
+  }
+
+  /**
+   * POST a pre-captured batch (with retries). Errors are reported
+   * through `onError` rather than thrown — the caller's call stack is
+   * not involved for fire-and-forget flushes.
+   */
+  private async shipBatch(batch: MeetBotEvent[]): Promise<void> {
+    // Serialize shipments so the daemon sees events in the same order
+    // the scrapers produced them. Without this, a size-triggered
+    // immediate flush could race a scheduled timer flush.
+    const prior = this.flushChain;
+    const next = prior.then(async () => {
+      try {
+        await this.postWithRetry(batch);
+      } catch (err) {
+        const wrapped = err instanceof Error ? err : new Error(String(err));
+        if (this.onError) {
+          try {
+            this.onError(wrapped, batch);
+          } catch {
+            // onError throwing is the caller's bug; keep the loop alive.
+          }
+        }
+      }
+    });
+    this.flushChain = next.catch(() => undefined);
+    await next;
+  }
+
+  /** POST with exponential backoff on retriable failures. */
+  private async postWithRetry(batch: MeetBotEvent[]): Promise<void> {
+    const body = JSON.stringify(batch);
+    let lastErr: Error | null = null;
+
+    // Four attempts: the initial try plus RETRY_BACKOFF_MS.length retries.
+    for (let attempt = 0; attempt <= RETRY_BACKOFF_MS.length; attempt += 1) {
+      let res: Awaited<ReturnType<FetchFn>>;
+      try {
+        res = await this.doFetch(this.url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: this.authHeader,
+          },
+          body,
+        });
+      } catch (err) {
+        // Network error: retriable.
+        lastErr = err instanceof Error ? err : new Error(String(err));
+        const backoff = RETRY_BACKOFF_MS[attempt];
+        if (backoff === undefined) break;
+        await sleep(backoff);
+        continue;
+      }
+
+      if (res.ok) return;
+
+      // 4xx is terminal — retrying the same bytes won't change the
+      // outcome. 5xx (and any other non-ok) is retriable.
+      if (res.status >= 400 && res.status < 500) {
+        const bodyText = await res.text().catch(() => "");
+        const detail = bodyText.length > 0 ? `: ${bodyText}` : "";
+        throw new Error(
+          `daemon-client: ingress rejected batch with status ${res.status}${detail}`,
+        );
+      }
+      lastErr = new Error(
+        `daemon-client: ingress returned status ${res.status}`,
+      );
+
+      const backoff = RETRY_BACKOFF_MS[attempt];
+      if (backoff === undefined) break;
+      await sleep(backoff);
+    }
+
+    throw (
+      lastErr ??
+      new Error("daemon-client: exhausted retries with no recorded error")
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -1,84 +1,569 @@
 /**
  * meet-bot entry point.
  *
- * This is the bootstrap for the Meet bot — the container-side process that
- * will join a Google Meet session on behalf of an AI assistant so the
- * assistant can listen in (and eventually participate).
+ * Bootstrap sequence for the container-side process that joins a Google
+ * Meet on behalf of an assistant. The boot path is deliberately linear:
  *
- * Current behavior:
+ *   1. Bring up PulseAudio virtual devices (null-sinks + virtual source).
+ *      Skipped under `SKIP_PULSE=1` so the boot smoke test can run on
+ *      macOS developer machines.
+ *   2. Start Xvfb + launch Chromium via `createBrowserSession(MEET_URL)`.
+ *   3. Drive the prejoin surface with `joinMeet(page, { displayName,
+ *      consentMessage })`.
+ *   4. Instantiate `DaemonClient`; publish `lifecycle:joining`, wait
+ *      briefly for the meeting-room UI to settle, then publish
+ *      `lifecycle:joined`.
+ *   5. Start the DOM scrapers (participant, speaker, chat) with callbacks
+ *      that funnel events into the daemon client.
+ *   6. Start the audio capture pipeline (`startAudioCapture`) so PCM is
+ *      shipped to the daemon over the Unix socket.
+ *   7. Stand up the HTTP control surface so the daemon can issue `/leave`,
+ *      `/send_chat` (Phase 2), `/play_audio` (Phase 3).
  *
- *   - At boot we bring up the PulseAudio virtual devices (null-sinks + a
- *     virtual-source) so TTS can be routed into Chrome as a microphone and
- *     Chrome's output can be captured for STT. Pulse setup is skipped when
- *     `SKIP_PULSE=1` — the CI/local boot smoke test sets this so it can run
- *     on macOS developer machines where PulseAudio is unavailable.
- *   - Logs a boot marker so the boot smoke test and the Docker `CMD` can
- *     verify the package structure.
- *   - If `MEET_URL` is set, brings up Xvfb + Chromium and navigates to the
- *     URL. When `JOIN_NAME` and `CONSENT_MESSAGE` are also set, runs the full
- *     Meet join flow (name entry, Join/Ask-to-join branch, consent notice)
- *     via `joinMeet`. When only `MEET_URL` is provided, drops a screenshot at
- *     `/tmp/boot-screenshot.png`, closes the session, and exits 0 — this is
- *     the browser-runtime smoke path the boot tests rely on.
- *   - On join failure, logs the error and exits with status 1 so the
- *     container orchestrator can observe the problem.
+ * `SIGTERM`, `SIGINT`, and an inbound `POST /leave` all converge on a
+ * single graceful-shutdown path. We guard against re-entry so multiple
+ * signals or an API-triggered leave overlapping with SIGTERM can't
+ * double-stop the subsystems.
  *
- * Anything heavier — Hono HTTP control surface, live audio capture wiring,
- * transcript streaming — lands in later PRs.
+ * Failures in the boot path publish a `lifecycle:error` to the daemon
+ * (best-effort — the daemon client may not be up yet), flush, and
+ * `process.exit(1)`.
+ *
+ * ## Testability
+ *
+ * Every subsystem is injected through `runBot(deps)` so the main-test
+ * suite can verify the boot order, the shutdown order, and the error
+ * paths without touching PulseAudio / Playwright / network sockets.
+ * `defaultDeps()` returns the real wiring; `runBot(defaultDeps())` is
+ * what `void main()` invokes at the bottom of this file.
  */
 
-import { joinMeet } from "./browser/join-flow.js";
-import { createBrowserSession } from "./browser/session.js";
+import type { Page } from "playwright";
+
+import type {
+  InboundChatEvent,
+  LifecycleEvent,
+  LifecycleState,
+  MeetBotEvent,
+  ParticipantChangeEvent,
+  SpeakerChangeEvent,
+} from "@vellumai/meet-contracts";
+
+import { startChatReader, type ChatReader } from "./browser/chat-reader.js";
+import { joinMeet, type JoinMeetOptions } from "./browser/join-flow.js";
+import {
+  startParticipantScraper,
+  type ParticipantScraperHandle,
+} from "./browser/participant-scraper.js";
+import {
+  startSpeakerScraper,
+  type SpeakerScraperHandle,
+} from "./browser/speaker-scraper.js";
+import { createBrowserSession, type BrowserSession } from "./browser/session.js";
+import { DaemonClient } from "./control/daemon-client.js";
+import {
+  createHttpServer,
+  type HttpServerCallbacks,
+  type HttpServerHandle,
+} from "./control/http-server.js";
+import { BotState } from "./control/state.js";
+import {
+  startAudioCapture,
+  type AudioCaptureHandle,
+  type AudioCaptureOptions,
+} from "./media/audio-capture.js";
 import { setupPulseAudio } from "./media/pulse.js";
 
-async function main(): Promise<void> {
-  if (process.env.SKIP_PULSE !== "1") {
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime configuration pulled from the environment. `main.ts` reads the
+ * env once at top of `runBot` so tests can pass their own config through
+ * `deps.env()` without mutating `process.env`.
+ */
+interface BotEnv {
+  meetUrl: string | undefined;
+  meetingId: string | undefined;
+  joinName: string | undefined;
+  consentMessage: string | undefined;
+  daemonUrl: string | undefined;
+  botApiToken: string | undefined;
+  /** Directory containing `audio.sock` — defaults to `/sockets`. */
+  socketDir: string;
+  /** When "1", skip PulseAudio setup — used by the boot smoke test. */
+  skipPulse: boolean;
+  /** Bind port for the HTTP control surface. Defaults to 3000. */
+  httpPort: number;
+}
+
+function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
+  return {
+    meetUrl: env.MEET_URL,
+    meetingId: env.MEETING_ID,
+    joinName: env.JOIN_NAME,
+    consentMessage: env.CONSENT_MESSAGE,
+    daemonUrl: env.DAEMON_URL,
+    botApiToken: env.BOT_API_TOKEN,
+    socketDir: env.SOCKET_DIR ?? "/sockets",
+    skipPulse: env.SKIP_PULSE === "1",
+    httpPort: env.HTTP_PORT ? Number(env.HTTP_PORT) : 3000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dep injection
+// ---------------------------------------------------------------------------
+
+/** Handle a scraper hands back to its caller for teardown. */
+interface ScraperStopHandle {
+  stop: () => void | Promise<void>;
+}
+
+/**
+ * Factories the main wiring calls through. Keeping them on a single
+ * `BotDeps` object lets tests override any subset with mocks while
+ * leaving the rest at their real implementations.
+ */
+export interface BotDeps {
+  env: () => BotEnv;
+  setupPulseAudio: () => Promise<void>;
+  createBrowserSession: (url: string) => Promise<BrowserSession>;
+  joinMeet: (page: Page, opts: JoinMeetOptions) => Promise<void>;
+  startParticipantScraper: (
+    page: Page,
+    onEvent: (event: ParticipantChangeEvent) => void,
+    opts: { meetingId: string },
+  ) => ParticipantScraperHandle;
+  startSpeakerScraper: (
+    page: Page,
+    onEvent: (event: SpeakerChangeEvent) => void,
+    opts: { meetingId: string },
+  ) => SpeakerScraperHandle;
+  startChatReader: (
+    page: Page,
+    onEvent: (event: InboundChatEvent) => void,
+    opts: { meetingId: string; selfName: string },
+  ) => Promise<ChatReader>;
+  startAudioCapture: (
+    opts: AudioCaptureOptions,
+  ) => Promise<AudioCaptureHandle>;
+  createDaemonClient: (opts: {
+    daemonUrl: string;
+    meetingId: string;
+    botApiToken: string;
+  }) => DaemonClientLike;
+  createHttpServer: (
+    opts: HttpServerCallbacks & { apiToken: string },
+  ) => HttpServerHandle;
+  /**
+   * Signal handler hooks. The test harness stubs these out so the
+   * Bun/Node signal machinery isn't wired up during unit tests.
+   */
+  onSignal: (
+    signal: "SIGTERM" | "SIGINT",
+    handler: () => void,
+  ) => () => void;
+  /**
+   * Short settle delay between `lifecycle:joining` and `lifecycle:joined`.
+   * Exposed as a dep so tests can pass 0 and not hang.
+   */
+  joinedSettleMs: number;
+  /** Sleep shim — tests can substitute a tick-accurate implementation. */
+  sleep: (ms: number) => Promise<void>;
+  /** Process exit — overridable so tests don't actually terminate. */
+  exit: (code: number) => never;
+  /** Logger — routed to console in production. Keep separate hooks so tests can capture. */
+  logInfo: (msg: string) => void;
+  logError: (msg: string) => void;
+}
+
+/** Minimal slice of `DaemonClient` the main wiring depends on. */
+export interface DaemonClientLike {
+  enqueue(event: MeetBotEvent): void;
+  flush(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+/** Real wiring — every factory forwards to the imported implementation. */
+export function defaultDeps(): BotDeps {
+  return {
+    env: () => readEnv(process.env),
+    setupPulseAudio,
+    createBrowserSession,
+    joinMeet,
+    startParticipantScraper,
+    startSpeakerScraper,
+    startChatReader,
+    startAudioCapture,
+    createDaemonClient: (opts) => new DaemonClient(opts),
+    createHttpServer,
+    onSignal: (signal, handler) => {
+      process.on(signal, handler);
+      return () => {
+        process.off(signal, handler);
+      };
+    },
+    joinedSettleMs: 2_000,
+    sleep: (ms) =>
+      new Promise<void>((resolve) => setTimeout(resolve, ms)),
+    exit: (code) => process.exit(code),
+    logInfo: (msg) => console.log(msg),
+    logError: (msg) => console.error(msg),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runBot
+// ---------------------------------------------------------------------------
+
+/** Publish a lifecycle event, falling back to a log if no client is up yet. */
+function publishLifecycle(
+  client: DaemonClientLike | null,
+  meetingId: string,
+  state: LifecycleState,
+  deps: BotDeps,
+  detail?: string,
+): void {
+  if (!client) {
+    deps.logError(
+      `meet-bot: lifecycle:${state} (no daemon client yet)${detail ? `: ${detail}` : ""}`,
+    );
+    return;
+  }
+  const event: LifecycleEvent = {
+    type: "lifecycle",
+    meetingId,
+    timestamp: new Date().toISOString(),
+    state,
+    ...(detail !== undefined ? { detail } : {}),
+  };
+  client.enqueue(event);
+}
+
+/**
+ * Boot the meet-bot. Returns a promise that settles when the bot has
+ * exited the meeting cleanly. In production the top-level `main()` at
+ * the bottom of this file kicks it off and wires the real subsystems.
+ * Tests call it directly with their own `deps`.
+ */
+export async function runBot(deps: BotDeps): Promise<void> {
+  const env = deps.env();
+
+  // -------------------------------------------------------------------------
+  // Step 0 — PulseAudio (unless skipped).
+  // -------------------------------------------------------------------------
+
+  if (!env.skipPulse) {
     try {
-      await setupPulseAudio();
+      await deps.setupPulseAudio();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`meet-bot: PulseAudio setup failed: ${msg}`);
-      process.exit(1);
+      deps.logError(`meet-bot: PulseAudio setup failed: ${errMsg(err)}`);
+      deps.exit(1);
+      return; // unreachable in production but keeps TS happy in tests.
     }
   }
 
-  console.log("meet-bot booted");
+  deps.logInfo("meet-bot booted");
 
-  const meetUrl = process.env.MEET_URL;
-  if (meetUrl) {
-    const session = await createBrowserSession(meetUrl);
+  // -------------------------------------------------------------------------
+  // Legacy screenshot-only boot path (used by the boot smoke test).
+  //
+  // If there's no MEET_URL at all, the boot test just wants to confirm the
+  // package can start and log the marker. Return without going further.
+  //
+  // If MEET_URL is set but MEETING_ID / DAEMON_URL / BOT_API_TOKEN / JOIN_NAME
+  // are missing, we fall back to the previous "open a browser and screenshot"
+  // behavior so existing smoke paths keep working. Full join + daemon wiring
+  // requires the full env.
+  // -------------------------------------------------------------------------
+
+  if (!env.meetUrl) {
+    return;
+  }
+
+  const needsFullWiring =
+    env.meetingId &&
+    env.joinName &&
+    env.consentMessage &&
+    env.daemonUrl &&
+    env.botApiToken;
+
+  if (!needsFullWiring) {
+    const session = await deps.createBrowserSession(env.meetUrl);
     try {
-      const displayName = process.env.JOIN_NAME;
-      const consentMessage = process.env.CONSENT_MESSAGE;
-
-      if (displayName && consentMessage) {
-        // Full join flow — drive the prejoin surface and post the consent
-        // message. Failures abort with exit(1) so the container orchestrator
-        // can restart or surface the error.
+      if (env.joinName && env.consentMessage) {
         try {
-          await joinMeet(session.page, { displayName, consentMessage });
-          console.log(`meet-bot joined ${meetUrl} as ${displayName}`);
+          await deps.joinMeet(session.page, {
+            displayName: env.joinName,
+            consentMessage: env.consentMessage,
+          });
+          deps.logInfo(`meet-bot joined ${env.meetUrl} as ${env.joinName}`);
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(`meet-bot: join flow failed: ${msg}`);
-          process.exit(1);
+          deps.logError(`meet-bot: join flow failed: ${errMsg(err)}`);
+          deps.exit(1);
+          return;
         }
       } else {
-        // Backward-compatible screenshot-only path — used by the boot smoke
-        // test which sets only `MEET_URL`. Confirms the browser runtime can
-        // reach Meet without actually entering a meeting.
         await session.page.screenshot({ path: "/tmp/boot-screenshot.png" });
-        console.log(
-          `meet-bot captured boot screenshot for ${meetUrl} at /tmp/boot-screenshot.png`,
+        deps.logInfo(
+          `meet-bot captured boot screenshot for ${env.meetUrl} at /tmp/boot-screenshot.png`,
         );
       }
     } finally {
       await session.close();
     }
+    return;
+  }
+
+  // TypeScript narrowing — `needsFullWiring` already verified these.
+  const meetingId = env.meetingId!;
+  const joinName = env.joinName!;
+  const consentMessage = env.consentMessage!;
+  const daemonUrl = env.daemonUrl!;
+  const botApiToken = env.botApiToken!;
+  const meetUrl = env.meetUrl;
+
+  BotState.setMeeting(meetingId);
+
+  // Shared shutdown state — read by signal handlers, `/leave`, and boot
+  // error paths. We construct it up-front so the error-reporting path can
+  // still produce a usable shutdown even if the daemon client never gets
+  // instantiated.
+  type Subsystems = {
+    session: BrowserSession | null;
+    daemonClient: DaemonClientLike | null;
+    participantScraper: ScraperStopHandle | null;
+    speakerScraper: ScraperStopHandle | null;
+    chatReader: ScraperStopHandle | null;
+    audioCapture: AudioCaptureHandle | null;
+    httpServer: HttpServerHandle | null;
+  };
+  const subsystems: Subsystems = {
+    session: null,
+    daemonClient: null,
+    participantScraper: null,
+    speakerScraper: null,
+    chatReader: null,
+    audioCapture: null,
+    httpServer: null,
+  };
+
+  // Dedup guard: signals, HTTP /leave, and boot errors can all race to
+  // trigger shutdown. Only the first one wins.
+  let shutdownInProgress = false;
+  let shutdownDonePromise: Promise<void> | null = null;
+
+  /**
+   * Graceful shutdown. Tears down subsystems in the reverse order of
+   * startup: HTTP server (so no new commands arrive) → scrapers → audio
+   * → browser → daemon client (flushed last so `lifecycle:left` is
+   * delivered). Safe to call multiple times.
+   */
+  async function shutdown(
+    finalState: "left" | "error",
+    detail?: string,
+  ): Promise<void> {
+    if (shutdownInProgress && shutdownDonePromise) {
+      await shutdownDonePromise;
+      return;
+    }
+    shutdownInProgress = true;
+    shutdownDonePromise = (async () => {
+      BotState.setPhase(finalState === "error" ? "error" : "leaving");
+
+      /** Run a subsystem teardown without letting its failure poison the rest. */
+      const stopSafely = async (
+        label: string,
+        handle: { stop: () => void | Promise<void> } | null,
+      ): Promise<void> => {
+        if (!handle) return;
+        try {
+          await handle.stop();
+        } catch (err) {
+          deps.logError(`meet-bot: ${label} stop failed: ${errMsg(err)}`);
+        }
+      };
+
+      // Teardown order (reverse of boot): HTTP first so no new commands
+      // arrive, then the scrapers (halts scraper-generated events), then
+      // audio (so parec sees clean EOF before Chrome tears down), then
+      // the browser. The daemon client is stopped last so the terminal
+      // lifecycle event gets flushed.
+      await stopSafely("http server", subsystems.httpServer);
+      await stopSafely("participant scraper", subsystems.participantScraper);
+      await stopSafely("speaker scraper", subsystems.speakerScraper);
+      await stopSafely("chat reader", subsystems.chatReader);
+      await stopSafely("audio capture", subsystems.audioCapture);
+      await stopSafely(
+        "browser session",
+        subsystems.session
+          ? { stop: () => subsystems.session!.close() }
+          : null,
+      );
+
+      publishLifecycle(
+        subsystems.daemonClient,
+        meetingId,
+        finalState,
+        deps,
+        detail,
+      );
+      await stopSafely("daemon client", subsystems.daemonClient);
+
+      BotState.setPhase(finalState);
+    })();
+
+    await shutdownDonePromise;
+  }
+
+  // Signal handlers — any arriving signal triggers shutdown once.
+  const detachSigterm = deps.onSignal("SIGTERM", () => {
+    void shutdown("left", "SIGTERM").then(() => deps.exit(0));
+  });
+  const detachSigint = deps.onSignal("SIGINT", () => {
+    void shutdown("left", "SIGINT").then(() => deps.exit(0));
+  });
+
+  // Everything below this line — PulseAudio is already up. On any thrown
+  // error we publish `lifecycle:error`, drain the daemon client, and
+  // exit 1.
+  try {
+    // ---------------------------------------------------------------------
+    // Step 2 — Xvfb + browser.
+    // ---------------------------------------------------------------------
+    BotState.setPhase("joining");
+    subsystems.session = await deps.createBrowserSession(meetUrl);
+
+    // ---------------------------------------------------------------------
+    // Step 3 — join the meeting.
+    //
+    // We need the daemon client up to *report* a join failure, so
+    // instantiate it before invoking joinMeet. That way a selector
+    // timeout (host never admits the bot, prejoin URL expired, etc.)
+    // still produces a `lifecycle:error` event on the wire.
+    // ---------------------------------------------------------------------
+    subsystems.daemonClient = deps.createDaemonClient({
+      daemonUrl,
+      meetingId,
+      botApiToken,
+    });
+
+    publishLifecycle(subsystems.daemonClient, meetingId, "joining", deps);
+
+    try {
+      await deps.joinMeet(subsystems.session.page, {
+        displayName: joinName,
+        consentMessage,
+      });
+    } catch (err) {
+      const msg = errMsg(err);
+      deps.logError(`meet-bot: join flow failed: ${msg}`);
+      publishLifecycle(
+        subsystems.daemonClient,
+        meetingId,
+        "error",
+        deps,
+        msg,
+      );
+      await shutdown("error", msg);
+      detachSigterm();
+      detachSigint();
+      deps.exit(1);
+      return;
+    }
+
+    // ---------------------------------------------------------------------
+    // Step 4 — settle, then publish `lifecycle:joined`.
+    // ---------------------------------------------------------------------
+    await deps.sleep(deps.joinedSettleMs);
+    BotState.setPhase("joined");
+    publishLifecycle(subsystems.daemonClient, meetingId, "joined", deps);
+
+    // ---------------------------------------------------------------------
+    // Step 5 — scrapers.
+    // ---------------------------------------------------------------------
+    const enqueue = (ev: MeetBotEvent): void => {
+      if (subsystems.daemonClient) subsystems.daemonClient.enqueue(ev);
+    };
+
+    subsystems.participantScraper = deps.startParticipantScraper(
+      subsystems.session.page,
+      (event) => enqueue(event),
+      { meetingId },
+    );
+    subsystems.speakerScraper = deps.startSpeakerScraper(
+      subsystems.session.page,
+      (event) => enqueue(event),
+      { meetingId },
+    );
+    subsystems.chatReader = await deps.startChatReader(
+      subsystems.session.page,
+      (event) => enqueue(event),
+      { meetingId, selfName: joinName },
+    );
+
+    // ---------------------------------------------------------------------
+    // Step 6 — audio capture.
+    // ---------------------------------------------------------------------
+    subsystems.audioCapture = await deps.startAudioCapture({
+      socketPath: `${env.socketDir}/audio.sock`,
+    });
+
+    // ---------------------------------------------------------------------
+    // Step 7 — HTTP control surface.
+    // ---------------------------------------------------------------------
+    subsystems.httpServer = deps.createHttpServer({
+      apiToken: botApiToken,
+      onLeave: (reason) => {
+        void shutdown("left", reason ?? "api:/leave").then(() => {
+          detachSigterm();
+          detachSigint();
+          deps.exit(0);
+        });
+      },
+      onSendChat: () => {
+        // Phase 2 will replace the 501 stub with a real implementation.
+      },
+      onPlayAudio: () => {
+        // Phase 3 will replace the 501 stub with a real implementation.
+      },
+    });
+    await subsystems.httpServer.start(env.httpPort);
+
+    deps.logInfo(`meet-bot ready (meetingId=${meetingId})`);
+  } catch (err) {
+    const msg = errMsg(err);
+    deps.logError(`meet-bot: boot failed: ${msg}`);
+    publishLifecycle(
+      subsystems.daemonClient,
+      meetingId,
+      "error",
+      deps,
+      msg,
+    );
+    await shutdown("error", msg);
+    detachSigterm();
+    detachSigint();
+    deps.exit(1);
   }
 }
 
-void main().catch((err) => {
-  console.error("meet-bot failed:", err);
-  process.exit(1);
-});
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level invocation
+// ---------------------------------------------------------------------------
+//
+// Skip under `import.meta.main` so test files that `import { runBot }` from
+// this module don't kick off the real bot when loaded.
+
+if (import.meta.main) {
+  void runBot(defaultDeps()).catch((err) => {
+    console.error("meet-bot failed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- New `DaemonClient` batches bot events (up to 20 / 250ms), POSTs to `/v1/internal/meet/:meetingId/events` with bearer auth + retry.
- `main.ts` rewritten as `runBot(deps)` — boots pulse → xvfb → browser → joinMeet → daemon client → lifecycle events → scrapers → audio capture → HTTP server.
- SIGTERM/SIGINT/`/leave` trigger a single graceful shutdown path.

Part of plan: meet-phase-1-listen.md (PR 20 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
