### PR TITLE
meet: first-party skill + meet_join / meet_leave tool registration

### DIFF
--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -27,7 +27,12 @@
  *
  * Not yet wired in this PR — left as TODOs for their owning PRs:
  *   - PR 22 instantiates the consent monitor and disposes it on leave.
- *   - PR 23 substitutes `{assistantName}` into `CONSENT_MESSAGE`.
+ *
+ * Caller contracts worth noting:
+ *   - `{assistantName}` substitution in `CONSENT_MESSAGE` is performed by the
+ *     `meet_join` tool (PR 23) before invoking `join()`. The tool passes the
+ *     substituted string via `input.consentMessage`. When that field is
+ *     omitted, the raw template from config is forwarded verbatim.
  */
 
 import { randomBytes } from "node:crypto";
@@ -87,6 +92,18 @@ export interface JoinInput {
   url: string;
   meetingId: string;
   conversationId: string;
+  /**
+   * Override for `services.meet.consentMessage`. When provided, this value is
+   * forwarded to the bot container via `CONSENT_MESSAGE` instead of the raw
+   * config template. Used by the `meet_join` tool (PR 23) to inject the
+   * substituted `{assistantName}` value before the bot spawns.
+   *
+   * When omitted, the session manager falls back to the config template
+   * verbatim — the bot itself will not perform template substitution, so
+   * callers that need `{assistantName}` resolved must pass the substituted
+   * string here.
+   */
+  consentMessage?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,7 +219,7 @@ class MeetSessionManagerImpl {
    * descriptor. Throws if a session for the same meeting already exists.
    */
   async join(input: JoinInput): Promise<MeetSession> {
-    const { url, meetingId, conversationId } = input;
+    const { url, meetingId, conversationId, consentMessage } = input;
 
     if (this.sessions.has(meetingId)) {
       throw new Error(
@@ -265,8 +282,12 @@ class MeetSessionManagerImpl {
       // runtime (PR 23 substitutes it). Forward an empty string so the bot
       // can distinguish "not set" from an explicit value.
       JOIN_NAME: meet.joinName ?? "",
-      // `{assistantName}` substitution is owned by PR 23.
-      CONSENT_MESSAGE: meet.consentMessage,
+      // `{assistantName}` substitution is owned by the `meet_join` tool
+      // (PR 23). The tool resolves the assistant name from IDENTITY.md and
+      // passes a substituted string via `input.consentMessage`. If no
+      // override is provided (e.g. direct callers bypassing the tool), the
+      // raw config template is forwarded as-is.
+      CONSENT_MESSAGE: consentMessage ?? meet.consentMessage,
       DAEMON_URL: daemonUrl,
       BOT_API_TOKEN: botApiToken,
       DEEPGRAM_API_KEY: deepgramKey,

--- a/assistant/src/tools/meet/__tests__/meet-join-tool.test.ts
+++ b/assistant/src/tools/meet/__tests__/meet-join-tool.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the `meet_join` tool.
+ *
+ * Exercises URL validation, feature-flag gating, `{assistantName}`
+ * substitution, and the happy-path call into `MeetSessionManager.join`.
+ * The session manager is swapped via `mock.module` rather than
+ * constructor injection so the tool under test continues to import the
+ * real singleton path — the same one production code uses — without
+ * having to thread a parameter through just for tests.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ----- Mocks wired BEFORE importing the tool ---------------------------------
+//
+// The tool pulls `MeetSessionManager` at module-eval time, so these mock
+// installations must precede the `await import(...)` of the tool module.
+// That ordering is why we keep mutable state (`flagEnabled`,
+// `assistantNameValue`, etc.) in module-scope closures: each test can
+// adjust them without having to re-invoke `mock.module`.
+
+let flagEnabled = true;
+let assistantNameValue: string | null = "Nova";
+let consentTemplate =
+  "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.";
+
+const joinMock = mock(
+  async (input: {
+    url: string;
+    meetingId: string;
+    conversationId: string;
+    consentMessage?: string;
+  }) => ({
+    meetingId: input.meetingId,
+    conversationId: input.conversationId,
+    containerId: "container-meet",
+    botBaseUrl: "http://127.0.0.1:49000",
+    botApiToken: "token",
+    startedAt: Date.now(),
+    joinTimeoutMs: 60_000,
+  }),
+);
+
+mock.module("../../../meet/session-manager.js", () => ({
+  MeetSessionManager: {
+    join: joinMock,
+    leave: async () => {},
+    activeSessions: () => [],
+    getSession: () => null,
+  },
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === "meet") return flagEnabled;
+    return true;
+  },
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    services: {
+      meet: {
+        consentMessage: consentTemplate,
+      },
+    },
+  }),
+}));
+
+mock.module("../../../daemon/identity-helpers.js", () => ({
+  getAssistantName: () => assistantNameValue,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Import AFTER the module mocks are installed.
+const {
+  meetJoinTool,
+  MEET_URL_REGEX,
+  substituteAssistantName,
+  DEFAULT_ASSISTANT_NAME,
+} = await import("../meet-join-tool.js");
+
+import type { ToolContext } from "../../types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  assistantNameValue = "Nova";
+  consentTemplate =
+    "Hi, I'm {assistantName}, an AI assistant joining to take notes. Let me know if you'd prefer I leave.";
+  joinMock.mockClear();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+describe("MEET_URL_REGEX", () => {
+  test.each([
+    "https://meet.google.com/abc-defg-hij",
+    "https://meet.google.com/abcd-efgh-ijkl",
+    "https://meet.google.com/abcdefghij", // no-hyphen variant
+    "https://Meet.Google.Com/abc-defg-hij", // case-insensitive host
+    "https://meet.google.com/abc-defg-hij?authuser=0",
+  ])("accepts valid Meet URL %s", (url) => {
+    expect(MEET_URL_REGEX.test(url)).toBe(true);
+  });
+
+  test.each([
+    "http://meet.google.com/abc-defg-hij", // not https
+    "https://zoom.us/j/12345",
+    "https://meet.google.com/",
+    "https://meet.google.com/abc-defg", // missing trailing block
+    "not-a-url",
+    "https://meet.google.com/abc-defg-hij/extra",
+  ])("rejects non-Meet URL %s", (url) => {
+    expect(MEET_URL_REGEX.test(url)).toBe(false);
+  });
+});
+
+describe("substituteAssistantName", () => {
+  test("replaces all occurrences of {assistantName}", () => {
+    const result = substituteAssistantName(
+      "Hi, I'm {assistantName}. {assistantName} here to help.",
+      "Nova",
+    );
+    expect(result).toBe("Hi, I'm Nova. Nova here to help.");
+  });
+
+  test("is a no-op when the template has no placeholder", () => {
+    const result = substituteAssistantName("Just a plain greeting.", "Nova");
+    expect(result).toBe("Just a plain greeting.");
+  });
+
+  test("tolerates regex-magic characters in the name", () => {
+    const result = substituteAssistantName(
+      "I am {assistantName}.",
+      "Bot$1(.*)",
+    );
+    expect(result).toBe("I am Bot$1(.*).");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_join feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(joinMock).not.toHaveBeenCalled();
+  });
+
+  test("proceeds to the session manager when the meet flag is on", async () => {
+    flagEnabled = true;
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(joinMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("meet_join input validation", () => {
+  test("rejects a missing url", async () => {
+    const result = await meetJoinTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    // Zod reports "expected string, received undefined" for a missing url;
+    // assert the error surfaces as an Error: … payload rather than leaking
+    // through to the session manager.
+    expect(result.content).toMatch(/^Error:/);
+    expect(joinMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-Meet url", async () => {
+    const result = await meetJoinTool.execute(
+      { url: "https://zoom.us/j/12345" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Google Meet");
+    expect(joinMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts a valid Meet url", async () => {
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assistantName substitution and delegation
+// ---------------------------------------------------------------------------
+
+describe("meet_join session-manager delegation", () => {
+  test("substitutes {assistantName} into the consent message before joining", async () => {
+    assistantNameValue = "Velissa";
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext({ conversationId: "conv-123" }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const call = joinMock.mock.calls[0][0];
+    expect(call.url).toBe("https://meet.google.com/abc-defg-hij");
+    expect(call.conversationId).toBe("conv-123");
+    expect(call.consentMessage).toBeDefined();
+    expect(call.consentMessage).not.toContain("{assistantName}");
+    expect(call.consentMessage).toContain("Velissa");
+    expect(call.meetingId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("falls back to the default assistant name when IDENTITY.md is missing", async () => {
+    assistantNameValue = null;
+    await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    const call = joinMock.mock.calls[0][0];
+    expect(call.consentMessage).toContain(DEFAULT_ASSISTANT_NAME);
+    expect(call.consentMessage).not.toContain("{assistantName}");
+  });
+
+  test("returns the generated meetingId and joining status", async () => {
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content) as {
+      meetingId: string;
+      status: string;
+    };
+    expect(payload.status).toBe("joining");
+    expect(payload.meetingId).toBe(joinMock.mock.calls[0][0].meetingId);
+  });
+
+  test("surfaces session-manager errors as tool errors rather than throwing", async () => {
+    joinMock.mockImplementationOnce(async () => {
+      throw new Error("docker is not running");
+    });
+    const result = await meetJoinTool.execute(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("docker is not running");
+  });
+});

--- a/assistant/src/tools/meet/__tests__/meet-leave-tool.test.ts
+++ b/assistant/src/tools/meet/__tests__/meet-leave-tool.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the `meet_leave` tool.
+ *
+ * Exercises feature-flag gating, disambiguation when the caller omits
+ * `meetingId` (0 / 1 / many active sessions), explicit-id pass-through,
+ * and reason-default behavior. Mirrors the mocking style used in the
+ * sibling `meet-join-tool.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let flagEnabled = true;
+let activeSessionsValue: Array<{
+  meetingId: string;
+  conversationId: string;
+  containerId: string;
+  botBaseUrl: string;
+  botApiToken: string;
+  startedAt: number;
+  joinTimeoutMs: number;
+}> = [];
+
+const leaveMock = mock(async (_meetingId: string, _reason: string) => {});
+
+const getSessionMock = mock((meetingId: string) => {
+  const found = activeSessionsValue.find((s) => s.meetingId === meetingId);
+  return found ?? null;
+});
+
+mock.module("../../../meet/session-manager.js", () => ({
+  MeetSessionManager: {
+    join: async () => {
+      throw new Error("join should not be invoked in leave tests");
+    },
+    leave: leaveMock,
+    activeSessions: () => activeSessionsValue,
+    getSession: getSessionMock,
+  },
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === "meet") return flagEnabled;
+    return true;
+  },
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    services: { meet: { consentMessage: "unused-in-leave-tests" } },
+  }),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const { meetLeaveTool, DEFAULT_LEAVE_REASON } = await import(
+  "../meet-leave-tool.js"
+);
+
+import type { ToolContext } from "../../types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+function fakeSession(meetingId: string) {
+  return {
+    meetingId,
+    conversationId: "conv-test",
+    containerId: `c-${meetingId}`,
+    botBaseUrl: "http://127.0.0.1:49000",
+    botApiToken: "token",
+    startedAt: Date.now(),
+    joinTimeoutMs: 60_000,
+  };
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  activeSessionsValue = [];
+  leaveMock.mockClear();
+  getSessionMock.mockClear();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_leave feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetLeaveTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(leaveMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disambiguation when meetingId is omitted
+// ---------------------------------------------------------------------------
+
+describe("meet_leave disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetLeaveTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(leaveMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetLeaveTool.execute(
+      { reason: "user-requested" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(leaveMock).toHaveBeenCalledTimes(1);
+    const [id, reason] = leaveMock.mock.calls[0];
+    expect(id).toBe("solo");
+    expect(reason).toBe("user-requested");
+    const payload = JSON.parse(result.content) as {
+      left: boolean;
+      meetingId: string;
+    };
+    expect(payload).toEqual({ left: true, meetingId: "solo" });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetLeaveTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(result.content).toContain("m1");
+    expect(result.content).toContain("m2");
+    expect(leaveMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetLeaveTool.execute(
+      { meetingId: "m2" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(leaveMock).toHaveBeenCalledTimes(1);
+    expect(leaveMock.mock.calls[0][0]).toBe("m2");
+  });
+
+  test("defaults the reason to DEFAULT_LEAVE_REASON when none provided", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    await meetLeaveTool.execute({}, makeContext());
+    expect(leaveMock.mock.calls[0][1]).toBe(DEFAULT_LEAVE_REASON);
+  });
+
+  test("trims whitespace-only reasons and falls back to the default", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    await meetLeaveTool.execute({ reason: "   " }, makeContext());
+    expect(leaveMock.mock.calls[0][1]).toBe(DEFAULT_LEAVE_REASON);
+  });
+
+  test("returns a left=false payload when the meetingId does not match any active session", async () => {
+    // Explicit id that the session manager has no record of — leave() is
+    // still called (it's idempotent) but the caller should know nothing
+    // happened.
+    activeSessionsValue = [];
+    const result = await meetLeaveTool.execute(
+      { meetingId: "unknown" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content) as {
+      left: boolean;
+      meetingId: string;
+    };
+    expect(payload.left).toBe(false);
+    expect(payload.meetingId).toBe("unknown");
+    expect(leaveMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error surfacing
+// ---------------------------------------------------------------------------
+
+describe("meet_leave error surfacing", () => {
+  test("surfaces session-manager errors as tool errors rather than throwing", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    leaveMock.mockImplementationOnce(async () => {
+      throw new Error("container stop timed out");
+    });
+    const result = await meetLeaveTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("container stop timed out");
+  });
+});

--- a/assistant/src/tools/meet/meet-join-tool.ts
+++ b/assistant/src/tools/meet/meet-join-tool.ts
@@ -1,0 +1,191 @@
+/**
+ * meet_join tool — join a Google Meet call via the managed meet-bot container.
+ *
+ * Why this is a registered tool rather than a skill-driven CLI (see
+ * `assistant/src/tools/AGENTS.md`, "New Non-Skill Tools Are Strongly
+ * Discouraged"):
+ *
+ *   The Meet feature hangs off `MeetSessionManager`, a process-lifecycle
+ *   resource owned by the daemon: it spawns Docker containers, holds
+ *   per-meeting audio-ingest sockets, manages bearer tokens, and fans
+ *   live events to connected clients. A skill running from a CLI would
+ *   not have in-process access to that state — every operation would
+ *   require a new HTTP surface that mirrors the in-process API. Keeping
+ *   `meet_join` / `meet_leave` as first-party tools lets the assistant
+ *   command the session manager directly, while the `meet-join` skill
+ *   (`skills/meet-join/SKILL.md`) provides the natural-language routing
+ *   guidance ("when to join / when not to join"). Tool + skill together
+ *   keep the model-facing surface idiomatic and the daemon-facing
+ *   surface in-process.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { getAssistantName } from "../../daemon/identity-helpers.js";
+import { MeetSessionManager } from "../../meet/session-manager.js";
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("meet-join-tool");
+
+/** Feature-flag key that gates the Meet joining bot end-to-end. */
+export const MEET_FLAG_KEY = "meet" as const;
+
+/** Fallback assistant name when `IDENTITY.md` has not been written yet. */
+export const DEFAULT_ASSISTANT_NAME = "Vellum";
+
+/**
+ * URL shape check for `https://meet.google.com/<xxx-yyyy-zzz>` style links.
+ * Accepts the typical three-segment form with the middle four-letter block
+ * and tolerates optional query strings (Meet occasionally appends tracking
+ * params like `?authuser=0`). Case-insensitive to keep paste-mangled URLs
+ * (e.g. from mobile share sheets) from failing unnecessarily.
+ */
+export const MEET_URL_REGEX =
+  /^https:\/\/meet\.google\.com\/[a-z]{3,4}-?[a-z]{4}-?[a-z]{3,4}(?:\?.*)?$/i;
+
+const MeetJoinInputSchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .min(1, "url is required")
+    .regex(MEET_URL_REGEX, {
+      message:
+        "url must be a Google Meet link (https://meet.google.com/xxx-yyyy-zzz)",
+    }),
+  note: z.string().optional(),
+});
+
+export type MeetJoinInput = z.infer<typeof MeetJoinInputSchema>;
+
+/**
+ * Substitute `{assistantName}` in a consent-message template. Safe against
+ * empty templates and against names that happen to contain regex-magic
+ * characters — uses a plain split/join rather than a RegExp.
+ */
+export function substituteAssistantName(
+  template: string,
+  assistantName: string,
+): string {
+  return template.split("{assistantName}").join(assistantName);
+}
+
+class MeetJoinTool implements Tool {
+  name = "meet_join";
+  description =
+    "Join a Google Meet call as an AI note-taker. The bot announces itself in the meeting chat, captures a live transcript, and can be asked to leave at any time. Only call this when the user explicitly asks the assistant to join a specific Meet URL.";
+  category = "meet";
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          url: {
+            type: "string",
+            description:
+              "The Google Meet URL to join, e.g. https://meet.google.com/xxx-yyyy-zzz.",
+          },
+          note: {
+            type: "string",
+            description:
+              "Optional free-form note about why the assistant is joining (recorded alongside the session for later reference).",
+          },
+        },
+        required: ["url"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate. Keep the error wording stable so the skill can
+    //    relay it verbatim to the user without surprises.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to join Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation.
+    const parsed = MeetJoinInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_join input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { url, note } = parsed.data;
+
+    // 3. Consent-message substitution. We resolve `{assistantName}` here so
+    //    the substituted string reaches the bot container via the session
+    //    manager — keeping the substitution in the tool lets the config
+    //    value remain a template (stable across renames) while the bot
+    //    sees a human-readable greeting.
+    const rawTemplate = config.services.meet.consentMessage;
+    const assistantName = getAssistantName() ?? DEFAULT_ASSISTANT_NAME;
+    const consentMessage = substituteAssistantName(rawTemplate, assistantName);
+
+    // 4. Generate a fresh meeting id. UUIDs give us the cryptographic
+    //    uniqueness the session manager's per-meeting token resolver
+    //    expects without having to coordinate ids across subsystems.
+    const meetingId = randomUUID();
+
+    // 5. Delegate to the session manager. Failures surface as tool errors
+    //    rather than throwing, so the agent loop can re-prompt the user
+    //    with a clear message instead of marking the whole turn as an
+    //    unexpected failure.
+    try {
+      const session = await MeetSessionManager.join({
+        url,
+        meetingId,
+        conversationId: context.conversationId,
+        consentMessage,
+      });
+
+      log.info(
+        {
+          meetingId: session.meetingId,
+          conversationId: session.conversationId,
+          containerId: session.containerId,
+          note: note ? "[present]" : undefined,
+        },
+        "meet_join tool spawned a Meet session",
+      );
+
+      return {
+        content: JSON.stringify({
+          meetingId: session.meetingId,
+          status: "joining",
+        }),
+        isError: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId, url },
+        "meet_join tool failed to start a Meet session",
+      );
+      return {
+        content: `Error: failed to join Meet — ${message}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+/** Exported singleton so the tool registry can re-register it after test resets. */
+export const meetJoinTool = new MeetJoinTool();

--- a/assistant/src/tools/meet/meet-leave-tool.ts
+++ b/assistant/src/tools/meet/meet-leave-tool.ts
@@ -1,0 +1,157 @@
+/**
+ * meet_leave tool — voluntary teardown of an active Meet session.
+ *
+ * Paired with {@link ./meet-join-tool.ts meet_join}; see that file for the
+ * justification of registering these as first-party tools rather than a
+ * skill-driven CLI. The short version: the Meet subsystem holds
+ * in-process lifecycle state (containers, sockets, event subscribers)
+ * that a CLI skill cannot command directly, so we keep the control
+ * surface in-process and use the `meet-join` skill for natural-language
+ * routing.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { MeetSessionManager } from "../../meet/session-manager.js";
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import { MEET_FLAG_KEY } from "./meet-join-tool.js";
+
+const log = getLogger("meet-leave-tool");
+
+/** Default reason recorded when the caller doesn't supply one. */
+export const DEFAULT_LEAVE_REASON = "requested";
+
+const MeetLeaveInputSchema = z.object({
+  meetingId: z.string().trim().min(1).optional(),
+  reason: z.string().optional(),
+});
+
+export type MeetLeaveInput = z.infer<typeof MeetLeaveInputSchema>;
+
+class MeetLeaveTool implements Tool {
+  name = "meet_leave";
+  description =
+    "Leave an active Google Meet call that the assistant previously joined. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting to leave, as returned by meet_join. Optional when exactly one session is active.",
+          },
+          reason: {
+            type: "string",
+            description:
+              "Free-form reason recorded with the leave event (e.g. 'user-requested', 'task-complete'). Defaults to 'requested'.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate — symmetric with meet_join so that disabling
+    //    the feature blocks both sides of the lifecycle instead of
+    //    leaking a half-working interface.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation. All fields are optional so a bare `{}` is valid;
+    //    Zod still catches wrong-type submissions and we surface the first
+    //    issue verbatim for debuggability.
+    const parsed = MeetLeaveInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_leave input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId, reason } = parsed.data;
+
+    // 3. Disambiguate the target session when no id is supplied. Ambiguity
+    //    (zero or multiple active sessions) is a caller error: we refuse
+    //    rather than guess, so the skill can prompt the user for the
+    //    specific meeting.
+    let targetMeetingId: string;
+    if (explicitId) {
+      targetMeetingId = explicitId;
+    } else {
+      const active = MeetSessionManager.activeSessions();
+      if (active.length === 0) {
+        return {
+          content: "Error: no active Meet session to leave.",
+          isError: true,
+        };
+      }
+      if (active.length > 1) {
+        const ids = active.map((s) => s.meetingId).join(", ");
+        return {
+          content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+          isError: true,
+        };
+      }
+      targetMeetingId = active[0].meetingId;
+    }
+
+    // 4. Delegate. `leave()` is idempotent for unknown meeting ids, so we
+    //    don't need a pre-flight existence check — but we do call it out
+    //    in the response when nothing matched, to avoid telling the
+    //    model "left" for a no-op.
+    const sessionBefore = MeetSessionManager.getSession(targetMeetingId);
+    const leaveReason = reason?.trim() ? reason.trim() : DEFAULT_LEAVE_REASON;
+
+    try {
+      await MeetSessionManager.leave(targetMeetingId, leaveReason);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId, reason: leaveReason },
+        "meet_leave tool failed",
+      );
+      return {
+        content: `Error: failed to leave Meet — ${message}`,
+        isError: true,
+      };
+    }
+
+    if (!sessionBefore) {
+      return {
+        content: JSON.stringify({
+          left: false,
+          meetingId: targetMeetingId,
+          note: "no active session matched that meetingId",
+        }),
+        isError: false,
+      };
+    }
+
+    return {
+      content: JSON.stringify({ left: true, meetingId: targetMeetingId }),
+      isError: false,
+    };
+  }
+}
+
+/** Exported singleton so the tool registry can re-register it after test resets. */
+export const meetLeaveTool = new MeetLeaveTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -19,6 +19,8 @@ import { fileEditTool } from "./filesystem/edit.js";
 import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
 import { fileWriteTool } from "./filesystem/write.js";
+import { meetJoinTool } from "./meet/meet-join-tool.js";
+import { meetLeaveTool } from "./meet/meet-leave-tool.js";
 import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";
@@ -91,6 +93,16 @@ export const explicitTools: Tool[] = [
   recallTool,
   credentialStoreTool,
   notifyParentTool,
+  // Meet tools: `meet_join` / `meet_leave` pair with the `meet-join` skill
+  // (see `skills/meet-join/SKILL.md`). They are registered as first-party
+  // tools rather than skill scripts because they command an in-process
+  // lifecycle resource (MeetSessionManager) — per the exception carve-out
+  // in `assistant/src/tools/AGENTS.md`, that in-process state cannot be
+  // managed over a CLI boundary without reintroducing the same surface
+  // via HTTP. The feature flag check inside each tool keeps the surface
+  // silent when `meet` is disabled.
+  meetJoinTool,
+  meetLeaveTool,
 ];
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -204,6 +204,18 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "meet-join",
+      "name": "meet-join",
+      "description": "Join a Google Meet call to take notes; only when the user explicitly asks.",
+      "metadata": {
+        "emoji": "📹",
+        "vellum": {
+          "display-name": "Meet Join"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "notion",
       "name": "notion",
       "description": "Read and write Notion pages and databases using the Notion API",

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: meet-join
+description: Join a Google Meet call to take notes; only when the user explicitly asks.
+metadata:
+  emoji: "📹"
+  vellum:
+    display-name: "Meet Join"
+---
+
+Use this skill when the user explicitly asks the assistant to join a Google Meet call (e.g. "join my meet", "can you join this call and take notes", usually with a `https://meet.google.com/...` URL in context). Joining a call causes the assistant to appear as a visible participant — never do it proactively.
+
+## When to join
+
+Trigger on clear, explicit user requests only:
+
+- "Join my meet", "join this call", "hop into this meeting" — paired with a Meet URL in the same turn or earlier in the conversation.
+- "Take notes on this Meet: https://meet.google.com/abc-defg-hij".
+
+Do NOT trigger on:
+
+- Ambient references to upcoming meetings on the user's calendar.
+- Users discussing a meeting they are in without asking you to join.
+- Anything without an explicit request verb and a Meet URL.
+
+If the request is ambiguous (e.g. no URL, or an unrelated URL), ask the user to confirm the Meet link before calling the tool.
+
+## How to join
+
+Call the `meet_join` tool with the Meet URL:
+
+```
+meet_join(url: "https://meet.google.com/abc-defg-hij")
+```
+
+Validate the URL looks like a Google Meet link before calling — the canonical shape is `https://meet.google.com/xxx-yyyy-zzz`. If the URL does not look like a Meet link, ask the user to confirm or paste the correct one.
+
+On join, the assistant bot announces itself in the Meet chat with the configured consent message so other participants know a note-taker is present. Any participant can ask the bot to leave; the bot auto-leaves when it detects objection keywords in the transcript.
+
+## How to leave
+
+Call `meet_leave` when the user says you can step out (e.g. "thanks, you can go now", "drop out of the call") or when you judge that continued presence is no longer useful:
+
+```
+meet_leave(reason: "user-requested")
+```
+
+When a single meeting is active, `meetingId` can be omitted — the tool targets that meeting automatically. When multiple meetings are active, pass the `meetingId` explicitly.
+
+## Important constraints
+
+- This skill NEVER joins a meeting based on calendar context alone. Always require an explicit user request.
+- Only one set of tools is exposed: `meet_join` and `meet_leave`. Future phases may add chat/speak capabilities; this skill will be updated when they land.
+- If the `meet` feature flag is disabled, both tools return a clear error — relay that to the user rather than retrying.


### PR DESCRIPTION
## Summary
- New `skills/meet-join/SKILL.md` describing when/how to join/leave a Meet.
- `meet_join` tool: validates URL, gates on `meet` feature flag, substitutes `{assistantName}` in consent message, calls `MeetSessionManager.join`.
- `meet_leave` tool: disambiguates single active session when meetingId omitted, otherwise calls `MeetSessionManager.leave`.
- Both registered in the tool registry with a comment justifying the non-skill tool registration per `assistant/src/tools/AGENTS.md`.
- Adds optional `consentMessage` field to `MeetSessionManager.JoinInput` so the tool can inject the substituted string; the raw config template is still used when no override is passed.
- Adds `meet-join` entry to `skills/catalog.json`.

## Non-skill tool justification
These tools command `MeetSessionManager`, an in-process lifecycle resource (Docker containers, per-meeting audio-ingest sockets, bearer tokens, live event fan-out). A skill running from a CLI cannot command that state without reintroducing the same surface via HTTP. Tool + skill together keep the model-facing surface idiomatic and the daemon-facing surface in-process. Pre-commit tool-registration hook bypassed via `--no-verify` with this rationale, per `assistant/src/tools/AGENTS.md`.

Part of plan: meet-phase-1-listen.md (PR 23 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
