### PR TITLE
meet: consent monitor auto-leaves on objection + migrate storage writer to dispatcher

### DIFF
--- a/assistant/src/meet/__tests__/consent-monitor.test.ts
+++ b/assistant/src/meet/__tests__/consent-monitor.test.ts
@@ -1,0 +1,682 @@
+/**
+ * Unit tests for {@link MeetConsentMonitor}.
+ *
+ * These tests inject a fake dispatcher (recording subscribers by meeting),
+ * a scripted LLM client, a stub session manager, and manual timer hooks so
+ * each scenario is deterministic and cache-free. Real LLM providers are
+ * never constructed.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import {
+  DEDUPE_WINDOW_MS,
+  LLM_TICK_INTERVAL_MS,
+  MeetConsentMonitor,
+  type MeetSessionLeaver,
+  type ObjectionDecision,
+} from "../consent-monitor.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeFakeDispatcher(): {
+  subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  dispatch: (meetingId: string, event: MeetBotEvent) => void;
+  subscriberCount: (meetingId: string) => number;
+} {
+  const subs = new Map<string, Set<MeetEventSubscriber>>();
+  return {
+    subscribe(meetingId, cb) {
+      let set = subs.get(meetingId);
+      if (!set) {
+        set = new Set();
+        subs.set(meetingId, set);
+      }
+      set.add(cb);
+      return () => {
+        const existing = subs.get(meetingId);
+        if (!existing) return;
+        existing.delete(cb);
+        if (existing.size === 0) subs.delete(meetingId);
+      };
+    },
+    dispatch(meetingId, event) {
+      const set = subs.get(meetingId);
+      if (!set) return;
+      for (const cb of Array.from(set)) cb(event);
+    },
+    subscriberCount(meetingId) {
+      return subs.get(meetingId)?.size ?? 0;
+    },
+  };
+}
+
+function makeFakeSessionManager(): MeetSessionLeaver & {
+  leave: ReturnType<typeof mock>;
+} {
+  return {
+    leave: mock(async (_id: string, _reason: string) => {}),
+  };
+}
+
+interface TimerControl {
+  setIntervalFn: (cb: () => void, ms: number) => unknown;
+  clearIntervalFn: (handle: unknown) => void;
+  fire: () => void;
+  intervalMs: number | null;
+  fired: number;
+  cleared: boolean;
+}
+
+function makeTimerControl(): TimerControl {
+  let storedCb: (() => void) | undefined;
+  const state: TimerControl = {
+    intervalMs: null,
+    fired: 0,
+    cleared: false,
+    setIntervalFn(cb, ms) {
+      state.intervalMs = ms;
+      storedCb = cb;
+      return { id: "fake-timer" };
+    },
+    clearIntervalFn(_handle) {
+      state.cleared = true;
+      storedCb = undefined;
+    },
+    fire() {
+      if (!storedCb) return;
+      state.fired += 1;
+      storedCb();
+    },
+  };
+  return state;
+}
+
+function transcriptChunk(
+  meetingId: string,
+  timestamp: string,
+  text: string,
+  options: {
+    isFinal?: boolean;
+    speakerLabel?: string;
+    speakerId?: string;
+  } = {},
+): MeetBotEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId,
+    timestamp,
+    isFinal: options.isFinal ?? true,
+    text,
+    speakerLabel: options.speakerLabel,
+    speakerId: options.speakerId,
+  };
+}
+
+function inboundChat(
+  meetingId: string,
+  timestamp: string,
+  text: string,
+  fromName = "Alice",
+  fromId = "a",
+): MeetBotEvent {
+  return {
+    type: "chat.inbound",
+    meetingId,
+    timestamp,
+    fromId,
+    fromName,
+    text,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 3; i++) await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MeetConsentMonitor keyword fast-path → LLM confirm", () => {
+  test("chat keyword hit + LLM confirm triggers leave with objection reason", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: true,
+        reason: "participant asked the bot to leave",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave", "stop recording"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "Hey, please leave?"),
+    );
+
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(1);
+    const [id, reason] = session.leave.mock.calls[0] as unknown as [
+      string,
+      string,
+    ];
+    expect(id).toBe("m1");
+    expect(reason).toBe("objection: participant asked the bot to leave");
+    expect(monitor._isDecided()).toBe(true);
+
+    monitor.stop();
+    expect(timer.cleared).toBe(true);
+    expect(dispatcher.subscriberCount("m1")).toBe(0);
+  });
+
+  test("keyword hit but LLM says objected=false does NOT trigger leave", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "participant was quoting documentation",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:00.000Z",
+        "I'm reading from the docs, 'please leave on error'.",
+      ),
+    );
+
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(0);
+    expect(monitor._isDecided()).toBe(false);
+
+    monitor.stop();
+  });
+
+  test("autoLeaveOnObjection=false records decision but does not leave", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: true,
+        reason: "explicit opt-out",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: false,
+        objectionKeywords: ["no bots"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "no bots please"),
+    );
+
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(0);
+    // Decision was recorded — no further LLM calls should happen.
+    expect(monitor._isDecided()).toBe(true);
+
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:10.000Z", "no bots please"),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor dedupe", () => {
+  test("repeated identical chunks within 5s → LLM called only once", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const now = () => t;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now,
+    });
+    monitor.start();
+
+    // Three identical chunks within the dedupe window.
+    for (let i = 0; i < 3; i++) {
+      t = i * 100; // 0ms, 100ms, 200ms
+      dispatcher.dispatch(
+        "m1",
+        transcriptChunk(
+          "m1",
+          new Date(t).toISOString(),
+          "please leave the meeting",
+        ),
+      );
+      await flushPromises();
+    }
+
+    // Only the first chunk should have reached the keyword path → one LLM.
+    expect(llm).toHaveBeenCalledTimes(1);
+    // One transcript entry recorded (the others were deduped).
+    expect(monitor._bufferedTranscriptCount()).toBe(1);
+
+    // Past the dedupe window, the same text re-enters the keyword path.
+    t = DEDUPE_WINDOW_MS + 1;
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", new Date(t).toISOString(), "please leave the meeting"),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor timer tick", () => {
+  test("tick with buffered content calls LLM with the rolling buffer", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        // Phrase that's NOT in the keyword list — only the timer tick path
+        // gets a shot at escalating this.
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    // Timer interval was installed at the expected cadence.
+    expect(timer.intervalMs).toBe(LLM_TICK_INTERVAL_MS);
+
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:00.000Z",
+        "I'm not sure I want this recorded, can we turn it off?",
+        { speakerLabel: "Alice" },
+      ),
+    );
+
+    // No keyword match → no LLM yet.
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(0);
+
+    // Simulate the 20s timer firing — now the LLM runs against the buffer.
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // The prompt contains the speaker-tagged transcript line.
+    const prompt = llm.mock.calls[0]![0] as string;
+    expect(prompt).toContain("Alice: I'm not sure I want this recorded");
+
+    monitor.stop();
+  });
+
+  test("tick with empty buffers does NOT call LLM", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(0);
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor prompt content", () => {
+  test("includes last 5 chat messages and speaker-tagged transcript", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["KEYWORD"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    // Seed more than 5 chat messages — buffer should retain only the last 5.
+    for (let i = 0; i < 7; i++) {
+      dispatcher.dispatch(
+        "m1",
+        inboundChat(
+          "m1",
+          new Date(i * 1000).toISOString(),
+          `chat-${i}`,
+          `User${i}`,
+          `u${i}`,
+        ),
+      );
+    }
+    // Seed transcript.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:10.000Z", "hello there", {
+        speakerLabel: "Alice",
+      }),
+    );
+    // Trip the keyword path to force an LLM run on content we can inspect.
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:11.000Z", "KEYWORD is set", {
+        speakerLabel: "Alice",
+      }),
+    );
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    const prompt = llm.mock.calls[0]![0] as string;
+
+    // Earliest 2 chats dropped; last 5 retained.
+    expect(prompt).not.toContain("chat-0");
+    expect(prompt).not.toContain("chat-1");
+    expect(prompt).toContain("User2: chat-2");
+    expect(prompt).toContain("User6: chat-6");
+
+    // Transcript is speaker-tagged.
+    expect(prompt).toContain("Alice: hello there");
+    expect(prompt).toContain("Alice: KEYWORD is set");
+
+    // Prompt declares the strict-JSON contract.
+    expect(prompt).toContain("strictly JSON");
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor resilience", () => {
+  test("LLM errors do not throw through event dispatch", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(async (_prompt: string): Promise<ObjectionDecision> => {
+      throw new Error("llm exploded");
+    });
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    // Should not reject or crash the test.
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "please leave now"),
+    );
+    await flushPromises();
+
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(0);
+    // Monitor remains active and can try again on the next trigger.
+    expect(monitor._isDecided()).toBe(false);
+
+    monitor.stop();
+  });
+
+  test("start() is idempotent; stop() is idempotent", () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: [],
+      },
+      llmAsk: async () => ({ objected: false, reason: "" }),
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+    monitor.start();
+    expect(dispatcher.subscriberCount("m1")).toBe(1);
+
+    monitor.stop();
+    monitor.stop();
+    expect(dispatcher.subscriberCount("m1")).toBe(0);
+  });
+
+  test("interim transcript chunks are ignored", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: true,
+        reason: "r",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:00.000Z",
+        "please leave now",
+        { isFinal: false },
+      ),
+    );
+    await flushPromises();
+
+    // Interim finals don't reach the LLM.
+    expect(llm).toHaveBeenCalledTimes(0);
+
+    monitor.stop();
+  });
+
+  test("overlapping keyword hits collapse to a single in-flight LLM call", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let resolveFirst: (v: ObjectionDecision) => void = () => {};
+    const firstPromise = new Promise<ObjectionDecision>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let callCount = 0;
+    const llm = mock(async (_prompt: string): Promise<ObjectionDecision> => {
+      callCount += 1;
+      if (callCount === 1) return firstPromise;
+      return { objected: false, reason: "" };
+    });
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+    });
+    monitor.start();
+
+    // Two distinct keyword-hit events while the first LLM call is pending.
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "please leave first"),
+    );
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:01.000Z", "please leave second"),
+    );
+    await flushPromises();
+
+    // Only the first call was issued; the second collapsed because one was
+    // already in flight.
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    resolveFirst({ objected: false, reason: "" });
+    await flushPromises();
+
+    monitor.stop();
+  });
+});

--- a/assistant/src/meet/__tests__/storage-writer.test.ts
+++ b/assistant/src/meet/__tests__/storage-writer.test.ts
@@ -3,8 +3,10 @@
  *
  * These tests run against a tempdir workspace, bypass the real ffmpeg by
  * injecting a mock `spawn` that records bytes piped into the spawned
- * child's stdin, and drive the writer through its registered
- * `MeetSessionEventRouter` handler.
+ * child's stdin, and drive the writer by injecting a fake dispatcher
+ * subscription. The writer uses {@link subscribeToMeetingEvents} in
+ * production; tests replace that with an in-memory shim that records
+ * subscribers per meeting and lets the test dispatch events directly.
  */
 
 import { EventEmitter } from "node:events";
@@ -15,10 +17,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { MeetBotEvent, Participant } from "@vellumai/meet-contracts";
 
-import {
-  __resetMeetSessionEventRouterForTests,
-  getMeetSessionEventRouter,
-} from "../session-event-router.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
 import {
   FSYNC_INTERVAL_MS,
   FSYNC_WRITE_THRESHOLD,
@@ -106,6 +108,47 @@ function makeTestPcmSource(): {
   return state;
 }
 
+/**
+ * In-memory replacement for {@link subscribeToMeetingEvents}. Matches the
+ * dispatcher surface the writer depends on — multiple subscribers per
+ * meeting, independent unsubscribe handles — so tests can drive the writer
+ * without touching the real singleton dispatcher.
+ */
+function makeFakeDispatcher(): {
+  subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  dispatch: (meetingId: string, event: MeetBotEvent) => void;
+  subscriberCount: (meetingId: string) => number;
+} {
+  const subs = new Map<string, Set<MeetEventSubscriber>>();
+  return {
+    subscribe(meetingId, cb) {
+      let set = subs.get(meetingId);
+      if (!set) {
+        set = new Set();
+        subs.set(meetingId, set);
+      }
+      set.add(cb);
+      return () => {
+        const existing = subs.get(meetingId);
+        if (!existing) return;
+        existing.delete(cb);
+        if (existing.size === 0) subs.delete(meetingId);
+      };
+    },
+    dispatch(meetingId, event) {
+      const set = subs.get(meetingId);
+      if (!set) return;
+      for (const cb of Array.from(set)) cb(event);
+    },
+    subscriberCount(meetingId) {
+      return subs.get(meetingId)?.size ?? 0;
+    },
+  };
+}
+
 function participant(id: string, name: string): Participant {
   return { id, name };
 }
@@ -185,7 +228,6 @@ let workspaceDir: string;
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "meet-storage-writer-test-"));
-  __resetMeetSessionEventRouterForTests();
 });
 
 afterEach(() => {
@@ -196,52 +238,87 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("MeetStorageWriter.start / router handler registration", () => {
-  test("start() creates the meeting dir and registers with the router", () => {
+describe("MeetStorageWriter.start / dispatcher subscription", () => {
+  test("start() creates the meeting dir and subscribes on the dispatcher", () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
     expect(existsSync(join(workspaceDir, "meets", "m1"))).toBe(true);
-    expect(getMeetSessionEventRouter().registeredCount()).toBe(1);
+    expect(dispatcher.subscriberCount("m1")).toBe(1);
   });
 
   test("start() is idempotent", () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
     writer.start();
-    expect(getMeetSessionEventRouter().registeredCount()).toBe(1);
+    expect(dispatcher.subscriberCount("m1")).toBe(1);
   });
 
-  test("stop() unregisters from the router", async () => {
+  test("stop() unsubscribes from the dispatcher", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
-    expect(getMeetSessionEventRouter().registeredCount()).toBe(1);
+    expect(dispatcher.subscriberCount("m1")).toBe(1);
     await writer.stop();
-    expect(getMeetSessionEventRouter().registeredCount()).toBe(0);
+    expect(dispatcher.subscriberCount("m1")).toBe(0);
+  });
+
+  test("coexists with other dispatcher subscribers", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const other = mock((_event: MeetBotEvent) => {});
+    const otherUnsub = dispatcher.subscribe("m1", other);
+
+    const writer = new MeetStorageWriter("m1", {
+      getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
+    });
+    writer.start();
+    expect(dispatcher.subscriberCount("m1")).toBe(2);
+
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk("m1", "2024-01-01T00:00:00.000Z", "hello world", {
+        isFinal: true,
+      }),
+    );
+
+    // Both subscribers saw the event.
+    expect(other).toHaveBeenCalledTimes(1);
+
+    await writer.stop();
+    // The peer subscriber's slot survives the writer's unsubscribe.
+    expect(dispatcher.subscriberCount("m1")).toBe(1);
+    otherUnsub();
   });
 });
 
 describe("MeetStorageWriter transcript.jsonl", () => {
   test("appends final transcript chunks and ignores interim", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:00.000Z", "hello", {
         isFinal: false,
       }),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:01.000Z", "hello world", {
         isFinal: true,
@@ -249,7 +326,7 @@ describe("MeetStorageWriter transcript.jsonl", () => {
         speakerLabel: "Alice",
       }),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:02.000Z", "second final", {
         isFinal: true,
@@ -277,25 +354,26 @@ describe("MeetStorageWriter transcript.jsonl", () => {
 
 describe("MeetStorageWriter segments.jsonl", () => {
   test("closes previous segment at each new speaker.change", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       speakerChange("m1", "2024-01-01T00:00:00.000Z", "s1", "Alice"),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       speakerChange("m1", "2024-01-01T00:00:05.000Z", "s2", "Bob"),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       speakerChange("m1", "2024-01-01T00:00:12.000Z", "s1", "Alice"),
     );
-    router.dispatch("m1", lifecycleLeft("m1", "2024-01-01T00:00:20.000Z"));
+    dispatcher.dispatch("m1", lifecycleLeft("m1", "2024-01-01T00:00:20.000Z"));
 
     await writer.stop();
 
@@ -325,12 +403,14 @@ describe("MeetStorageWriter segments.jsonl", () => {
   });
 
   test("open span on stop() is closed at stop timestamp", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    getMeetSessionEventRouter().dispatch(
+    dispatcher.dispatch(
       "m1",
       speakerChange("m1", "2024-01-01T00:00:00.000Z", "s1", "Alice"),
     );
@@ -349,13 +429,14 @@ describe("MeetStorageWriter segments.jsonl", () => {
 
 describe("MeetStorageWriter participants.json", () => {
   test("overwrites with the latest full list (not a diff)", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       participantChange("m1", "2024-01-01T00:00:00.000Z", [
         participant("a", "Alice"),
@@ -374,7 +455,7 @@ describe("MeetStorageWriter participants.json", () => {
       { id: "b", name: "Bob" },
     ]);
 
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       participantChange(
         "m1",
@@ -402,32 +483,33 @@ describe("MeetStorageWriter participants.json", () => {
 
 describe("MeetStorageWriter meta.json", () => {
   test("lifecycle:left writes meta.json with aggregate counters", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       participantChange("m1", "2024-01-01T00:00:00.000Z", [
         participant("a", "Alice"),
         participant("b", "Bob"),
       ]),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:01.000Z", "hello", {
         isFinal: true,
       }),
     );
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:02.000Z", "world!!", {
         isFinal: true,
       }),
     );
-    router.dispatch("m1", lifecycleLeft("m1", "2024-01-01T00:00:30.000Z"));
+    dispatcher.dispatch("m1", lifecycleLeft("m1", "2024-01-01T00:00:30.000Z"));
 
     // meta.json is written on lifecycle:left, not stop()
     const meta = JSON.parse(
@@ -445,11 +527,13 @@ describe("MeetStorageWriter meta.json", () => {
 
 describe("MeetStorageWriter audio pipeline (mocked spawn)", () => {
   test("startAudio spawns ffmpeg with expected args and pipes PCM bytes", async () => {
+    const dispatcher = makeFakeDispatcher();
     const { spawn, lastChild, calls } = makeSpawnMock();
     const pcm = makeTestPcmSource();
 
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
       spawn: spawn as unknown as typeof import("node:child_process").spawn,
     });
     writer.start();
@@ -484,17 +568,19 @@ describe("MeetStorageWriter audio pipeline (mocked spawn)", () => {
   });
 
   test("lifecycle:left closes ffmpeg stdin even without stop()", async () => {
+    const dispatcher = makeFakeDispatcher();
     const { spawn, lastChild } = makeSpawnMock();
     const pcm = makeTestPcmSource();
 
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
       spawn: spawn as unknown as typeof import("node:child_process").spawn,
     });
     writer.start();
     await writer.startAudio(pcm.source);
 
-    getMeetSessionEventRouter().dispatch(
+    dispatcher.dispatch(
       "m1",
       lifecycleLeft("m1", "2024-01-01T00:00:00.000Z"),
     );
@@ -505,11 +591,13 @@ describe("MeetStorageWriter audio pipeline (mocked spawn)", () => {
   });
 
   test("startAudio is a no-op after the first spawn", async () => {
+    const dispatcher = makeFakeDispatcher();
     const { spawn } = makeSpawnMock();
     const pcm = makeTestPcmSource();
 
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
       spawn: spawn as unknown as typeof import("node:child_process").spawn,
     });
     writer.start();
@@ -525,10 +613,12 @@ describe("MeetStorageWriter audio pipeline (mocked spawn)", () => {
 describe("MeetStorageWriter fsync cadence", () => {
   test("fsyncs after FSYNC_WRITE_THRESHOLD writes", async () => {
     // Frozen clock so only the write-count threshold can trigger fsync.
+    const dispatcher = makeFakeDispatcher();
     const now = () => 0;
     const fsyncSyncMock = mock((_fd: number) => {});
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
       now,
       fs: {
         fsyncSync:
@@ -537,9 +627,8 @@ describe("MeetStorageWriter fsync cadence", () => {
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
     for (let i = 0; i < FSYNC_WRITE_THRESHOLD; i++) {
-      router.dispatch(
+      dispatcher.dispatch(
         "m1",
         transcriptChunk(
           "m1",
@@ -560,11 +649,13 @@ describe("MeetStorageWriter fsync cadence", () => {
   });
 
   test("fsyncs when FSYNC_INTERVAL_MS elapses between writes", async () => {
+    const dispatcher = makeFakeDispatcher();
     let t = 0;
     const now = () => t;
     const fsyncSyncMock = mock((_fd: number) => {});
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
       now,
       fs: {
         fsyncSync:
@@ -573,9 +664,8 @@ describe("MeetStorageWriter fsync cadence", () => {
     });
     writer.start();
 
-    const router = getMeetSessionEventRouter();
     // First write establishes the fd; lastFlushAtMs is set to 0.
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:00.000Z", "x", {
         isFinal: true,
@@ -585,7 +675,7 @@ describe("MeetStorageWriter fsync cadence", () => {
 
     // Jump the clock past the interval and write again — must trigger fsync.
     t = FSYNC_INTERVAL_MS + 1;
-    router.dispatch(
+    dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", "2024-01-01T00:00:10.000Z", "y", {
         isFinal: true,
@@ -599,14 +689,16 @@ describe("MeetStorageWriter fsync cadence", () => {
 
 describe("MeetStorageWriter error resilience", () => {
   test("events to an unrelated meetingId never reach this writer", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
 
-    // Dispatch to a different meeting — router simply logs & drops because
-    // m2 has no handler.
-    getMeetSessionEventRouter().dispatch(
+    // Dispatch to a different meeting — the fake dispatcher simply drops it
+    // because m2 has no subscribers.
+    dispatcher.dispatch(
       "m2",
       transcriptChunk("m2", "2024-01-01T00:00:00.000Z", "nope", {
         isFinal: true,
@@ -621,12 +713,14 @@ describe("MeetStorageWriter error resilience", () => {
   });
 
   test("stop() is idempotent", async () => {
+    const dispatcher = makeFakeDispatcher();
     const writer = new MeetStorageWriter("m1", {
       getWorkspaceDir: () => workspaceDir,
+      subscribe: dispatcher.subscribe,
     });
     writer.start();
     await writer.stop();
     await writer.stop();
-    expect(getMeetSessionEventRouter().registeredCount()).toBe(0);
+    expect(dispatcher.subscriberCount("m1")).toBe(0);
   });
 });

--- a/assistant/src/meet/consent-monitor.ts
+++ b/assistant/src/meet/consent-monitor.ts
@@ -1,0 +1,535 @@
+/**
+ * MeetConsentMonitor — watches transcript and inbound chat for signals that a
+ * participant does not want an AI note-taker in the meeting, and (when the
+ * `autoLeaveOnObjection` config flag is enabled) auto-invokes
+ * {@link MeetSessionManager.leave} on confirmation.
+ *
+ * Design:
+ *
+ *   1. **Fast path (deterministic)** — every inbound `TranscriptChunkEvent`
+ *      (finals only) and `InboundChatEvent` is lowercased and substring-
+ *      checked against `config.objectionKeywords`. A hit flags the event
+ *      for LLM confirmation; a miss simply buffers it for future context.
+ *
+ *   2. **Slow path (model-mediated)** — the rolling buffer (~30s of
+ *      transcript + last 5 chat messages) is sent to a latency-optimized
+ *      LLM call on every keyword hit, plus on a 20s timer cadence as a
+ *      safety net for phrasing the keyword list missed. The model returns
+ *      strict JSON `{ "objected": boolean, "reason": string }`.
+ *
+ *   3. **One decision per meeting** — as soon as the LLM returns
+ *      `objected: true`, the monitor disables further checks. If
+ *      `autoLeaveOnObjection` is true it invokes
+ *      `sessionManager.leave(meetingId, "objection: " + reason)`. If false
+ *      (dev/debug mode) the decision is logged but no leave is triggered.
+ *
+ * Dedupe: back-to-back identical chunks (same raw text) within a 5s window
+ * are collapsed so a repeated ASR chunk can't re-trigger the LLM path.
+ *
+ * Dependency injection keeps this testable: the LLM is reached via an
+ * `llmAsk(prompt)` callable; tests pass scripted responses. The subscribe
+ * hook defaults to the real dispatcher but can be swapped for an in-memory
+ * shim. The session-manager handle only needs a `leave(meetingId, reason)`
+ * method — the real {@link MeetSessionManager} satisfies this naturally.
+ */
+
+import type {
+  InboundChatEvent,
+  MeetBotEvent,
+  TranscriptChunkEvent,
+} from "@vellumai/meet-contracts";
+
+import {
+  createTimeout,
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import type { Provider, ToolDefinition } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type MeetEventSubscriber,
+  type MeetEventUnsubscribe,
+  subscribeToMeetingEvents,
+} from "./event-publisher.js";
+
+const log = getLogger("meet-consent-monitor");
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Sliding-window length for the rolling transcript buffer. */
+export const TRANSCRIPT_WINDOW_MS = 30_000;
+
+/** How many recent chat messages are kept for LLM context. */
+export const CHAT_BUFFER_SIZE = 5;
+
+/** Timer cadence for the safety-net LLM check. */
+export const LLM_TICK_INTERVAL_MS = 20_000;
+
+/** Window used to dedupe identical chunks. */
+export const DEDUPE_WINDOW_MS = 5_000;
+
+/** LLM call timeout — keeps the consent path bounded. */
+export const CONSENT_LLM_TIMEOUT_MS = 5_000;
+
+/** Max tokens for the LLM structured response. */
+export const CONSENT_LLM_MAX_TOKENS = 256;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Shape of the JSON the LLM returns. */
+export interface ObjectionDecision {
+  objected: boolean;
+  reason: string;
+}
+
+/**
+ * The minimal handle the monitor needs on the session manager. The real
+ * {@link MeetSessionManager} satisfies this.
+ */
+export interface MeetSessionLeaver {
+  leave(meetingId: string, reason: string): Promise<void>;
+}
+
+/** Callable returning a strict-JSON objection verdict for a prompt. */
+export type ObjectionLLMAsk = (prompt: string) => Promise<ObjectionDecision>;
+
+export interface MeetConsentMonitorConfig {
+  autoLeaveOnObjection: boolean;
+  objectionKeywords: readonly string[];
+}
+
+export interface MeetConsentMonitorDeps {
+  meetingId: string;
+  assistantId: string;
+  sessionManager: MeetSessionLeaver;
+  config: MeetConsentMonitorConfig;
+  /**
+   * Ask the LLM for an objection verdict. Defaults to a wrapper around the
+   * repo-wide provider abstraction using {@link CONSENT_LLM_MAX_TOKENS} and
+   * `modelIntent: "latency-optimized"`. Tests inject scripted responses.
+   */
+  llmAsk?: ObjectionLLMAsk;
+  /** Override the dispatcher subscribe (tests). */
+  subscribe?: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  /** Override setTimeout/clearTimeout for tests that capture the timer. */
+  setIntervalFn?: (cb: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
+  /** Override `Date.now` for tests that want deterministic dedupe timing. */
+  now?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// Rolling buffers
+// ---------------------------------------------------------------------------
+
+interface TranscriptEntry {
+  tMs: number;
+  timestamp: string;
+  speaker: string;
+  text: string;
+}
+
+interface ChatEntry {
+  timestamp: string;
+  fromName: string;
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// MeetConsentMonitor
+// ---------------------------------------------------------------------------
+
+export class MeetConsentMonitor {
+  private readonly meetingId: string;
+  private readonly assistantId: string;
+  private readonly sessionManager: MeetSessionLeaver;
+  private readonly config: MeetConsentMonitorConfig;
+  private readonly llmAsk: ObjectionLLMAsk;
+  private readonly subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  private readonly setIntervalFn: (cb: () => void, ms: number) => unknown;
+  private readonly clearIntervalFn: (handle: unknown) => void;
+  private readonly now: () => number;
+
+  private unsubscribe: MeetEventUnsubscribe | null = null;
+  private timerHandle: unknown = null;
+
+  /**
+   * Transcript entries within the rolling {@link TRANSCRIPT_WINDOW_MS}. Old
+   * entries are trimmed on each append.
+   */
+  private transcriptBuffer: TranscriptEntry[] = [];
+
+  /**
+   * Last {@link CHAT_BUFFER_SIZE} chat entries. FIFO.
+   */
+  private chatBuffer: ChatEntry[] = [];
+
+  /**
+   * Dedupe ledger: hash(`<kind>:<text>`) → last-seen timestamp (ms). Used
+   * to collapse back-to-back identical chunks within
+   * {@link DEDUPE_WINDOW_MS}.
+   */
+  private readonly recentHashes = new Map<string, number>();
+
+  /** Flips to true after the first positive objection verdict. */
+  private decided = false;
+
+  /** In-flight flag so overlapping keyword hits don't fan out LLM calls. */
+  private llmInFlight = false;
+
+  constructor(deps: MeetConsentMonitorDeps) {
+    this.meetingId = deps.meetingId;
+    this.assistantId = deps.assistantId;
+    this.sessionManager = deps.sessionManager;
+    this.config = deps.config;
+    this.llmAsk = deps.llmAsk ?? defaultLLMAsk;
+    this.subscribe = deps.subscribe ?? subscribeToMeetingEvents;
+    this.setIntervalFn =
+      deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+    this.clearIntervalFn =
+      deps.clearIntervalFn ??
+      ((handle) =>
+        clearInterval(handle as ReturnType<typeof setInterval>));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /**
+   * Begin observing the meeting. Idempotent.
+   *
+   * Subscribes to the dispatcher so the monitor coexists with the bridge,
+   * storage writer, and event-hub publisher. Starts a 20s safety-net timer
+   * that invokes the LLM path with whatever's in the buffers — this
+   * catches objection phrases the keyword list didn't anticipate.
+   */
+  start(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.subscribe(this.meetingId, (event) =>
+      this.onEvent(event),
+    );
+    this.timerHandle = this.setIntervalFn(() => {
+      // Fire-and-forget — callers never await the tick.
+      void this.maybeRunLLMCheck("tick");
+    }, LLM_TICK_INTERVAL_MS);
+  }
+
+  /**
+   * Tear down the subscription and timer. Idempotent.
+   */
+  stop(): void {
+    if (this.unsubscribe) {
+      try {
+        this.unsubscribe();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetConsentMonitor: unsubscribe threw during stop",
+        );
+      }
+      this.unsubscribe = null;
+    }
+    if (this.timerHandle !== null) {
+      try {
+        this.clearIntervalFn(this.timerHandle);
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetConsentMonitor: clearInterval threw during stop",
+        );
+      }
+      this.timerHandle = null;
+    }
+  }
+
+  // ── Event handling ────────────────────────────────────────────────────────
+
+  private onEvent(event: MeetBotEvent): void {
+    if (this.decided) return;
+    try {
+      if (event.type === "transcript.chunk") {
+        this.onTranscriptChunk(event);
+        return;
+      }
+      if (event.type === "chat.inbound") {
+        this.onInboundChat(event);
+        return;
+      }
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId, eventType: event.type },
+        "MeetConsentMonitor: event handler threw",
+      );
+    }
+  }
+
+  private onTranscriptChunk(event: TranscriptChunkEvent): void {
+    if (!event.isFinal) return;
+    const raw = event.text ?? "";
+    if (raw.trim().length === 0) return;
+
+    if (this.isDuplicate("t", raw)) return;
+
+    const speaker =
+      event.speakerLabel ?? event.speakerId ?? "Unknown speaker";
+    const entry: TranscriptEntry = {
+      tMs: this.now(),
+      timestamp: event.timestamp,
+      speaker,
+      text: raw,
+    };
+    this.transcriptBuffer.push(entry);
+    this.trimTranscriptBuffer();
+
+    if (this.matchesKeyword(raw)) {
+      void this.maybeRunLLMCheck("keyword:transcript");
+    }
+  }
+
+  private onInboundChat(event: InboundChatEvent): void {
+    const raw = event.text ?? "";
+    if (raw.trim().length === 0) return;
+
+    if (this.isDuplicate("c", raw)) return;
+
+    const entry: ChatEntry = {
+      timestamp: event.timestamp,
+      fromName: event.fromName,
+      text: raw,
+    };
+    this.chatBuffer.push(entry);
+    while (this.chatBuffer.length > CHAT_BUFFER_SIZE) this.chatBuffer.shift();
+
+    if (this.matchesKeyword(raw)) {
+      void this.maybeRunLLMCheck("keyword:chat");
+    }
+  }
+
+  // ── Fast path: keyword + dedupe ───────────────────────────────────────────
+
+  private matchesKeyword(text: string): boolean {
+    const lower = text.toLowerCase();
+    for (const kw of this.config.objectionKeywords) {
+      if (kw && lower.includes(kw.toLowerCase())) return true;
+    }
+    return false;
+  }
+
+  private isDuplicate(kind: "t" | "c", text: string): boolean {
+    const key = `${kind}:${text}`;
+    const now = this.now();
+    const prev = this.recentHashes.get(key);
+    if (prev !== undefined && now - prev < DEDUPE_WINDOW_MS) {
+      return true;
+    }
+    this.recentHashes.set(key, now);
+    this.pruneRecentHashes(now);
+    return false;
+  }
+
+  private pruneRecentHashes(now: number): void {
+    for (const [key, t] of this.recentHashes) {
+      if (now - t >= DEDUPE_WINDOW_MS) this.recentHashes.delete(key);
+    }
+  }
+
+  private trimTranscriptBuffer(): void {
+    const cutoff = this.now() - TRANSCRIPT_WINDOW_MS;
+    while (
+      this.transcriptBuffer.length > 0 &&
+      this.transcriptBuffer[0].tMs < cutoff
+    ) {
+      this.transcriptBuffer.shift();
+    }
+  }
+
+  // ── Slow path: LLM confirmation ───────────────────────────────────────────
+
+  /**
+   * Run one LLM check over the current buffer if one isn't already in
+   * flight and the monitor hasn't already decided. Overlapping calls are
+   * collapsed — the buffer the in-flight call saw is sufficient context.
+   */
+  private async maybeRunLLMCheck(trigger: string): Promise<void> {
+    if (this.decided || this.llmInFlight) return;
+    // Don't call the LLM on the tick path when both buffers are empty.
+    if (
+      trigger === "tick" &&
+      this.transcriptBuffer.length === 0 &&
+      this.chatBuffer.length === 0
+    ) {
+      return;
+    }
+
+    const prompt = this.buildPrompt();
+    this.llmInFlight = true;
+    try {
+      const decision = await this.llmAsk(prompt);
+      if (!decision.objected) {
+        log.debug(
+          {
+            meetingId: this.meetingId,
+            trigger,
+            reason: decision.reason,
+          },
+          "MeetConsentMonitor: LLM confirmed no objection",
+        );
+        return;
+      }
+      // Positive verdict — lock the monitor and act.
+      this.decided = true;
+      log.info(
+        {
+          meetingId: this.meetingId,
+          assistantId: this.assistantId,
+          trigger,
+          reason: decision.reason,
+          autoLeave: this.config.autoLeaveOnObjection,
+        },
+        "MeetConsentMonitor: objection detected",
+      );
+      if (this.config.autoLeaveOnObjection) {
+        try {
+          await this.sessionManager.leave(
+            this.meetingId,
+            `objection: ${decision.reason}`,
+          );
+        } catch (err) {
+          log.error(
+            { err, meetingId: this.meetingId },
+            "MeetConsentMonitor: session leave failed",
+          );
+        }
+      }
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId, trigger },
+        "MeetConsentMonitor: LLM call failed — staying in the meeting",
+      );
+    } finally {
+      this.llmInFlight = false;
+    }
+  }
+
+  private buildPrompt(): string {
+    const chatLines =
+      this.chatBuffer.length === 0
+        ? "(none)"
+        : this.chatBuffer
+            .map((e) => `${e.fromName}: ${e.text}`)
+            .join("\n");
+    const transcriptLines =
+      this.transcriptBuffer.length === 0
+        ? "(none)"
+        : this.transcriptBuffer
+            .map((e) => `${e.speaker}: ${e.text}`)
+            .join("\n");
+    return (
+      "Given this recent chat and transcript from a Google Meet, has any " +
+      "participant indicated they do not want an AI note-taker in this " +
+      'meeting? Return strictly JSON: { "objected": boolean, "reason": string }.\n\n' +
+      "Recent chat:\n" +
+      chatLines +
+      "\n\nRecent transcript:\n" +
+      transcriptLines +
+      "\n"
+    );
+  }
+
+  // ── Test-only introspection ──────────────────────────────────────────────
+
+  /** Exposed for tests: count of transcript entries currently buffered. */
+  _bufferedTranscriptCount(): number {
+    return this.transcriptBuffer.length;
+  }
+
+  /** Exposed for tests: count of chat entries currently buffered. */
+  _bufferedChatCount(): number {
+    return this.chatBuffer.length;
+  }
+
+  /** Exposed for tests: whether the monitor has locked on an objection. */
+  _isDecided(): boolean {
+    return this.decided;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default LLM binding
+// ---------------------------------------------------------------------------
+
+/** Tool schema used to force structured JSON output from the LLM. */
+const OBJECTION_TOOL: ToolDefinition = {
+  name: "report_objection",
+  description:
+    "Report whether any meeting participant has objected to the AI note-taker's presence.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      objected: {
+        type: "boolean",
+        description:
+          "True if any participant voiced a clear objection to the AI note-taker; false otherwise.",
+      },
+      reason: {
+        type: "string",
+        description:
+          "Brief explanation of the objection, or an empty string when no objection was raised.",
+      },
+    },
+    required: ["objected", "reason"],
+  },
+};
+
+/**
+ * Default {@link ObjectionLLMAsk} — routes through the repo-wide provider
+ * abstraction with `modelIntent: "latency-optimized"`, times out at
+ * {@link CONSENT_LLM_TIMEOUT_MS}, and extracts the tool-use input as the
+ * structured verdict.
+ *
+ * Hidden behind an injectable hook so tests never need to stand up a
+ * real provider.
+ */
+async function defaultLLMAsk(prompt: string): Promise<ObjectionDecision> {
+  const provider: Provider | null = await getConfiguredProvider();
+  if (!provider) {
+    // No provider available — conservatively assume no objection so the
+    // monitor doesn't interrupt a meeting based on missing infra.
+    return { objected: false, reason: "" };
+  }
+
+  const { signal, cleanup } = createTimeout(CONSENT_LLM_TIMEOUT_MS);
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(prompt)],
+      [OBJECTION_TOOL],
+      "You are a strict JSON classifier. Only respond via the report_objection tool.",
+      {
+        config: {
+          modelIntent: "latency-optimized",
+          max_tokens: CONSENT_LLM_MAX_TOKENS,
+          tool_choice: { type: "tool" as const, name: OBJECTION_TOOL.name },
+        },
+        signal,
+      },
+    );
+    const tool = extractToolUse(response);
+    if (!tool) return { objected: false, reason: "" };
+    const input = tool.input as { objected?: unknown; reason?: unknown };
+    return {
+      objected: input.objected === true,
+      reason: typeof input.reason === "string" ? input.reason : "",
+    };
+  } finally {
+    cleanup();
+  }
+}

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -24,9 +24,9 @@
  *   - Start a {@link MeetAudioIngest} before the container spawns so the
  *     bot has a socket to connect to the moment it boots, and tear the
  *     ingest down after the container is removed on leave.
- *
- * Not yet wired in this PR — left as TODOs for their owning PRs:
- *   - PR 22 instantiates the consent monitor and disposes it on leave.
+ *   - Spin up a {@link MeetConsentMonitor} per meeting so objection
+ *     phrases on transcript/chat trigger an auto-leave when
+ *     `services.meet.autoLeaveOnObjection` is enabled.
  *
  * Caller contracts worth noting:
  *   - `{assistantName}` substitution in `CONSENT_MESSAGE` is performed by the
@@ -45,6 +45,10 @@ import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { MeetAudioIngest } from "./audio-ingest.js";
+import {
+  MeetConsentMonitor,
+  type MeetSessionLeaver,
+} from "./consent-monitor.js";
 import { DockerRunner, type DockerRunResult } from "./docker-runner.js";
 import {
   type MeetEventUnsubscribe,
@@ -123,6 +127,13 @@ interface ActiveSession extends MeetSession {
   eventUnsubscribes: MeetEventUnsubscribe[];
   /** True once the bot has emitted a `lifecycle.joined` event. */
   joinedPublished: boolean;
+  /**
+   * Consent monitor for this meeting — watches transcript/chat for
+   * objection phrases and triggers auto-leave when confirmed by the LLM.
+   * Started in `join()` and stopped at the very top of `leave()` so no
+   * late event triggers a self-invoked leave while teardown is running.
+   */
+  consentMonitor: MeetConsentMonitorLike;
 }
 
 /**
@@ -132,6 +143,23 @@ interface ActiveSession extends MeetSession {
 export interface MeetAudioIngestLike {
   start(meetingId: string, socketPath: string, apiKey: string): Promise<void>;
   stop(): Promise<void>;
+}
+
+/**
+ * Thin interface for the consent-monitor surface the session manager
+ * uses. Lets tests swap in a fake without needing the real LLM stack.
+ */
+export interface MeetConsentMonitorLike {
+  start(): void;
+  stop(): void;
+}
+
+/** Arguments passed to {@link MeetSessionManagerDeps.consentMonitorFactory}. */
+export interface MeetConsentMonitorFactoryArgs {
+  meetingId: string;
+  assistantId: string;
+  sessionManager: MeetSessionLeaver;
+  config: { autoLeaveOnObjection: boolean; objectionKeywords: string[] };
 }
 
 export interface MeetSessionManagerDeps {
@@ -153,6 +181,14 @@ export interface MeetSessionManagerDeps {
    * {@link MeetAudioIngest} with its own defaults.
    */
   audioIngestFactory?: () => MeetAudioIngestLike;
+  /**
+   * Override the consent-monitor factory. Default constructs a
+   * {@link MeetConsentMonitor} with its own defaults. Tests can inject
+   * a fake to observe `start`/`stop` without spinning up the LLM path.
+   */
+  consentMonitorFactory?: (
+    args: MeetConsentMonitorFactoryArgs,
+  ) => MeetConsentMonitorLike;
 }
 
 class MeetSessionManagerImpl {
@@ -169,6 +205,8 @@ class MeetSessionManagerImpl {
       getWorkspaceDir: deps.getWorkspaceDir ?? getWorkspaceDir,
       audioIngestFactory:
         deps.audioIngestFactory ?? (() => new MeetAudioIngest()),
+      consentMonitorFactory:
+        deps.consentMonitorFactory ?? defaultConsentMonitorFactory,
     };
 
     // The ingress route (PR 9) looks up per-meeting tokens through this
@@ -191,6 +229,8 @@ class MeetSessionManagerImpl {
       getWorkspaceDir: deps.getWorkspaceDir ?? this.deps.getWorkspaceDir,
       audioIngestFactory:
         deps.audioIngestFactory ?? this.deps.audioIngestFactory,
+      consentMonitorFactory:
+        deps.consentMonitorFactory ?? this.deps.consentMonitorFactory,
     };
     // Re-install the token resolver in case `_resetForTests` cleared it.
     getMeetSessionEventRouter().setBotApiTokenResolver((meetingId) => {
@@ -209,6 +249,11 @@ class MeetSessionManagerImpl {
         } catch {
           /* best-effort */
         }
+      }
+      try {
+        session.consentMonitor.stop();
+      } catch {
+        /* best-effort */
       }
     }
     this.sessions.clear();
@@ -391,6 +436,19 @@ class MeetSessionManagerImpl {
     // replace each other at the router.
     registerMeetingDispatcher(meetingId);
 
+    // Consent monitor is constructed before the session record so it can
+    // be torn down deterministically from `leave()` — it subscribes on
+    // `start()` below, after the session is in the map.
+    const consentMonitor = this.deps.consentMonitorFactory({
+      meetingId,
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      sessionManager: this,
+      config: {
+        autoLeaveOnObjection: meet.autoLeaveOnObjection,
+        objectionKeywords: [...meet.objectionKeywords],
+      },
+    });
+
     const startedAt = Date.now();
     const session: ActiveSession = {
       meetingId,
@@ -404,6 +462,7 @@ class MeetSessionManagerImpl {
       audioIngest,
       eventUnsubscribes: [],
       joinedPublished: false,
+      consentMonitor,
     };
     this.sessions.set(meetingId, session);
 
@@ -439,6 +498,10 @@ class MeetSessionManagerImpl {
         }
       }),
     );
+
+    // Now that the other subscribers and the session record are in place,
+    // start the consent monitor so it has a live dispatcher to attach to.
+    consentMonitor.start();
 
     // Max-meeting-minutes hard cap. Using setTimeout keeps this compatible
     // with Bun's fake-timer harness for tests.
@@ -482,6 +545,19 @@ class MeetSessionManagerImpl {
     if (!session) {
       log.debug({ meetingId, reason }, "leave(): no active session — no-op");
       return;
+    }
+
+    // Stop the consent monitor first — any pending LLM call can finish
+    // harmlessly since `decided` is the only write path it has to the
+    // session manager, and we've already committed to leaving. This also
+    // clears the 20s tick timer so it can't fire during teardown.
+    try {
+      session.consentMonitor.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetConsentMonitor.stop threw during leave — continuing teardown",
+      );
     }
 
     // Immediately clear state so we don't re-enter this path via the timeout
@@ -597,6 +673,22 @@ export function _createMeetSessionManagerForTests(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Default {@link MeetConsentMonitor} factory — constructs a monitor wired
+ * to the production LLM path. Swapped out in tests via
+ * {@link MeetSessionManagerDeps.consentMonitorFactory}.
+ */
+function defaultConsentMonitorFactory(
+  args: MeetConsentMonitorFactoryArgs,
+): MeetConsentMonitorLike {
+  return new MeetConsentMonitor({
+    meetingId: args.meetingId,
+    assistantId: args.assistantId,
+    sessionManager: args.sessionManager,
+    config: args.config,
+  });
+}
 
 /** Strip internal fields (`timeoutHandle`) from a session before exposing it. */
 function sessionView(session: ActiveSession): MeetSession {

--- a/assistant/src/meet/storage-writer.ts
+++ b/assistant/src/meet/storage-writer.ts
@@ -24,11 +24,14 @@
  * the underlying fs primitives so the test suite doesn't need ffmpeg
  * installed and can run against a tempdir workspace.
  *
- * Registered as a `MeetSessionEventRouter` handler. Callers are responsible
- * for driving `startAudio` (when a PCM source is available) and `stop` on
- * session teardown — the writer itself cleans up its subscription and the
- * ffmpeg child when `stop` is invoked, and also closes the ffmpeg child on
- * `lifecycle:left`.
+ * Subscribes via {@link subscribeToMeetingEvents} on the meet event
+ * dispatcher (PR 19) — this lets the writer coexist with the conversation
+ * bridge (PR 17), event-hub publisher (PR 19), and consent monitor (PR 22)
+ * as peer subscribers on the same per-meeting event stream. Callers are
+ * responsible for driving `startAudio` (when a PCM source is available)
+ * and `stop` on session teardown — the writer itself tears down its
+ * dispatcher subscription and the ffmpeg child when `stop` is invoked, and
+ * also closes the ffmpeg child on `lifecycle:left`.
  */
 
 import {
@@ -55,7 +58,11 @@ import type {
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import { getMeetSessionEventRouter } from "./session-event-router.js";
+import {
+  type MeetEventSubscriber,
+  type MeetEventUnsubscribe,
+  subscribeToMeetingEvents,
+} from "./event-publisher.js";
 
 const log = getLogger("meet-storage-writer");
 
@@ -126,8 +133,15 @@ export interface MeetStorageWriterDeps {
   fs?: Partial<FsPrimitives>;
   /** Override monotonic clock used for flush scheduling (tests). */
   now?: () => number;
-  /** Override the event router lookup (tests). */
-  getRouter?: () => ReturnType<typeof getMeetSessionEventRouter>;
+  /**
+   * Override the dispatcher subscribe function (tests). Defaults to
+   * {@link subscribeToMeetingEvents} on the process-wide meet event
+   * dispatcher so the writer coexists with other per-meeting subscribers.
+   */
+  subscribe?: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
 }
 
 /**
@@ -186,8 +200,7 @@ export class MeetStorageWriter {
   private ffmpegChild: ChildProcessWithoutNullStreams | null = null;
   private pcmUnsubscribe: (() => void) | null = null;
 
-  private routerHandler: ((event: MeetBotEvent) => void) | null = null;
-  private routerRegistered = false;
+  private eventUnsubscribe: MeetEventUnsubscribe | null = null;
 
   private stopped = false;
 
@@ -201,7 +214,7 @@ export class MeetStorageWriter {
       spawn: deps.spawn ?? nodeSpawn,
       fs: deps.fs ?? {},
       now: deps.now ?? Date.now,
-      getRouter: deps.getRouter ?? getMeetSessionEventRouter,
+      subscribe: deps.subscribe ?? subscribeToMeetingEvents,
     };
     this.fs = { ...DEFAULT_FS, ...(deps.fs ?? {}) };
     this.meetingDir = join(
@@ -212,18 +225,17 @@ export class MeetStorageWriter {
   }
 
   /**
-   * Subscribe to the per-meeting event router. Idempotent. Callers should
-   * invoke this once, immediately after construction, so the writer catches
-   * the very first events of the session.
+   * Subscribe to the per-meeting event dispatcher. Idempotent. Callers
+   * should invoke this once, immediately after construction, so the writer
+   * catches the very first events of the session.
    */
   start(): void {
-    if (this.routerRegistered) return;
+    if (this.eventUnsubscribe) return;
     this.ensureMeetingDir();
     if (!this.startedAt) this.startedAt = new Date().toISOString();
-    const handler = (event: MeetBotEvent) => this.onEvent(event);
-    this.routerHandler = handler;
-    this.deps.getRouter().register(this.meetingId, handler);
-    this.routerRegistered = true;
+    this.eventUnsubscribe = this.deps.subscribe(this.meetingId, (event) =>
+      this.onEvent(event),
+    );
   }
 
   /**
@@ -272,8 +284,8 @@ export class MeetStorageWriter {
   }
 
   /**
-   * Flush buffers, close open segment, unsubscribe from the router, and
-   * close the ffmpeg child. Idempotent: subsequent calls are no-ops.
+   * Flush buffers, close open segment, unsubscribe from the dispatcher,
+   * and close the ffmpeg child. Idempotent: subsequent calls are no-ops.
    */
   async stop(): Promise<void> {
     if (this.stopped) return;
@@ -281,10 +293,16 @@ export class MeetStorageWriter {
 
     this.closeOpenSegmentAt(new Date().toISOString());
 
-    if (this.routerRegistered) {
-      this.deps.getRouter().unregister(this.meetingId);
-      this.routerRegistered = false;
-      this.routerHandler = null;
+    if (this.eventUnsubscribe) {
+      try {
+        this.eventUnsubscribe();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "dispatcher unsubscribe threw during stop",
+        );
+      }
+      this.eventUnsubscribe = null;
     }
 
     this.flushAndCloseFd(this.segmentsFd);


### PR DESCRIPTION
## Summary
- New `MeetConsentMonitor` watches transcript + chat for objection phrases; fast keyword pre-filter + latency-optimized LLM confirmation; triggers `MeetSessionManager.leave` on confirmation.
- Migrated `MeetStorageWriter` from `MeetSessionEventRouter.register` to `subscribeToMeetingEvents` so it coexists with bridge + consent monitor + event publisher.
- Respects `services.meet.autoLeaveOnObjection` config flag.

Part of plan: meet-phase-1-listen.md (PR 22 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
