### PR TITLE
meet: remove dead DEEPGRAM_API_KEY passthrough to bot container

### DIFF
--- a/assistant/src/meet/__tests__/session-manager.test.ts
+++ b/assistant/src/meet/__tests__/session-manager.test.ts
@@ -179,7 +179,6 @@ describe("MeetSessionManager.join", () => {
     expect(runOpts.env.CONSENT_MESSAGE).toContain("{assistantName}");
     expect(runOpts.env.DAEMON_URL).toBe("http://host.docker.internal:7821");
     expect(runOpts.env.BOT_API_TOKEN).toBe(session.botApiToken);
-    expect(runOpts.env.DEEPGRAM_API_KEY).toBe("deepgram-secret");
     expect(runOpts.env.TTS_API_KEY).toBe("tts-secret");
     expect(runOpts.env.SKIP_PULSE).toBe("0");
 

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -335,7 +335,7 @@ class MeetSessionManagerImpl {
       CONSENT_MESSAGE: consentMessage ?? meet.consentMessage,
       DAEMON_URL: daemonUrl,
       BOT_API_TOKEN: botApiToken,
-      DEEPGRAM_API_KEY: deepgramKey,
+      // STT credentials live on the daemon, not the bot — bot connects via Unix socket.
       TTS_API_KEY: ttsKey,
       // Enable the in-container Pulse null-sink by default (set to "1" to
       // disable in dev). Match the meet-bot image expectation.


### PR DESCRIPTION
## Summary
- Drop dead `DEEPGRAM_API_KEY` env var from the Meet bot container spawn — the bot never reads it; STT happens on the daemon side after audio comes in over the Unix socket.
- Remove the matching test assertion.
- Leave `getProviderKey("deepgram")` in place; it's still consumed by `audioIngest.start()` (dropped in a follow-up PR).

Part of plan: meet-phase-1-5-stt-provider.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
