### PR TITLE
test: update always-loaded tools guard for meet_join/meet_leave

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 11 (no-client baseline excludes host tools)", async () => {
+  test("should be exactly 13 (no-client baseline excludes host tools)", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
@@ -56,6 +56,8 @@ describe("always-loaded tool count", () => {
       "file_edit",
       "file_read",
       "file_write",
+      "meet_join",
+      "meet_leave",
       "recall",
       "remember",
       "skill_execute",
@@ -65,6 +67,6 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(11);
+    expect(activeTools.length).toBe(13);
   });
 });


### PR DESCRIPTION
## Summary
- Updates \`always-loaded-tools-guard.test.ts\` to include \`meet_join\` and \`meet_leave\` in the expected baseline and bumps the count from 11 to 13.
- Fixes the failing test on main after the meet tools were registered in the first-party tool manifest.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24444255867/job/71416432480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
