### PR TITLE
meet: MeetAudioIngest resolves STT provider from config

### DIFF
--- a/assistant/src/meet/__tests__/audio-ingest.test.ts
+++ b/assistant/src/meet/__tests__/audio-ingest.test.ts
@@ -2,8 +2,8 @@
  * Unit tests for {@link MeetAudioIngest}.
  *
  * These tests exercise the ingest in isolation by injecting fake factories
- * for both the Deepgram session and the Unix-socket server. No real network
- * or filesystem socket is opened.
+ * for both the streaming transcriber and the Unix-socket server. No real
+ * network or filesystem socket is opened.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -14,8 +14,8 @@ import type {
 } from "../../stt/types.js";
 import {
   BOT_CONNECT_TIMEOUT_MS,
-  type DeepgramIngestOptions,
   MeetAudioIngest,
+  MeetAudioIngestError,
   type UnixSocketConnection,
   type UnixSocketServer,
 } from "../audio-ingest.js";
@@ -29,11 +29,10 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Fake Deepgram streaming session. Records every audio chunk it receives
- * and exposes an `emit` helper so tests can inject synthetic transcript
- * events.
+ * Fake streaming transcriber. Records every audio chunk it receives and
+ * exposes an `emit` helper so tests can inject synthetic transcript events.
  */
-class FakeDeepgramSession implements StreamingTranscriber {
+class FakeStreamingTranscriber implements StreamingTranscriber {
   readonly providerId = "deepgram" as const;
   readonly boundaryId = "daemon-streaming" as const;
 
@@ -41,13 +40,8 @@ class FakeDeepgramSession implements StreamingTranscriber {
   startCalls = 0;
   stopCalls = 0;
   started = false;
-  options: DeepgramIngestOptions;
 
   private listener: ((event: SttStreamServerEvent) => void) | null = null;
-
-  constructor(options: DeepgramIngestOptions) {
-    this.options = options;
-  }
 
   async start(
     onEvent: (event: SttStreamServerEvent) => void,
@@ -150,21 +144,33 @@ class FakeUnixSocketServer implements UnixSocketServer {
 // Test helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Flush multiple microtask ticks so callers can let the ingest's internal
+ * await chain settle before asserting that its connection listener is
+ * registered. Keep this larger than the ingest's actual chain depth so
+ * changes to the number of internal awaits don't make the tests flake.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
 function newIngestSetup(): {
   server: FakeUnixSocketServer;
-  session: FakeDeepgramSession;
+  session: FakeStreamingTranscriber;
   ingest: MeetAudioIngest;
   listenCalls: string[];
-  deepgramCalls: DeepgramIngestOptions[];
+  createTranscriberCalls: number;
 } {
   const server = new FakeUnixSocketServer();
-  let session: FakeDeepgramSession | null = null;
+  let session: FakeStreamingTranscriber | null = null;
   const listenCalls: string[] = [];
-  const deepgramCalls: DeepgramIngestOptions[] = [];
+  let createTranscriberCalls = 0;
   const ingest = new MeetAudioIngest({
-    createDeepgramSession: (opts) => {
-      deepgramCalls.push(opts);
-      session = new FakeDeepgramSession(opts);
+    createTranscriber: async () => {
+      createTranscriberCalls++;
+      session = new FakeStreamingTranscriber();
       return session;
     },
     listen: async (path) => {
@@ -175,18 +181,20 @@ function newIngestSetup(): {
   return {
     server,
     get session() {
-      if (!session) throw new Error("Deepgram session not created yet");
+      if (!session) throw new Error("Streaming transcriber not created yet");
       return session;
     },
     ingest,
     listenCalls,
-    deepgramCalls,
+    get createTranscriberCalls() {
+      return createTranscriberCalls;
+    },
   } as unknown as {
     server: FakeUnixSocketServer;
-    session: FakeDeepgramSession;
+    session: FakeStreamingTranscriber;
     ingest: MeetAudioIngest;
     listenCalls: string[];
-    deepgramCalls: DeepgramIngestOptions[];
+    createTranscriberCalls: number;
   };
 }
 
@@ -207,28 +215,18 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("MeetAudioIngest.start", () => {
-  test("opens Deepgram with smart-format + interim, opens socket server, resolves on bot connect", async () => {
+  test("opens streaming transcriber, opens socket server, resolves on bot connect", async () => {
     const setup = newIngestSetup();
 
-    const startPromise = setup.ingest.start(
-      "m1",
-      "/tmp/fake-audio.sock",
-      "dg-api-key",
-    );
+    const startPromise = setup.ingest.start("m1", "/tmp/fake-audio.sock");
 
     // The listen factory was called with the provided path.
     // The ingest awaits `listen()` before registering its connection
     // listener, so we need to let microtasks run before connecting.
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushMicrotasks();
 
     expect(setup.listenCalls).toEqual(["/tmp/fake-audio.sock"]);
-    expect(setup.deepgramCalls).toHaveLength(1);
-    expect(setup.deepgramCalls[0]).toEqual({
-      apiKey: "dg-api-key",
-      smartFormatting: true,
-      interimResults: true,
-    });
+    expect(setup.createTranscriberCalls).toBe(1);
 
     // Simulate the bot dialing in.
     setup.server.connectBot();
@@ -237,35 +235,35 @@ describe("MeetAudioIngest.start", () => {
     expect(setup.session.started).toBe(true);
   });
 
-  test("rejects when Deepgram fails to connect (and does not open the socket)", async () => {
+  test("rejects when the transcriber fails to connect (and does not open the socket)", async () => {
     const listen = mock(async () => new FakeUnixSocketServer());
-    const failingFactory = () => ({
+    const createTranscriber = mock(async () => ({
       providerId: "deepgram" as const,
       boundaryId: "daemon-streaming" as const,
       start: async () => {
-        throw new Error("dg auth failed");
+        throw new Error("stt auth failed");
       },
       sendAudio: () => {},
       stop: () => {},
-    });
+    }));
 
     const ingest = new MeetAudioIngest({
-      createDeepgramSession: failingFactory,
+      createTranscriber,
       listen,
     });
 
-    await expect(
-      ingest.start("m1", "/tmp/x.sock", "bad-key"),
-    ).rejects.toThrow(/dg auth failed/);
+    await expect(ingest.start("m1", "/tmp/x.sock")).rejects.toThrow(
+      /stt auth failed/,
+    );
     expect(listen).toHaveBeenCalledTimes(0);
   });
 
-  test("rejects and tears Deepgram down when the socket server fails to open", async () => {
+  test("rejects and tears the transcriber down when the socket server fails to open", async () => {
     const sessionsStopped: number[] = [];
-    let session: FakeDeepgramSession | null = null;
+    let session: FakeStreamingTranscriber | null = null;
     const ingest = new MeetAudioIngest({
-      createDeepgramSession: (opts) => {
-        session = new FakeDeepgramSession(opts);
+      createTranscriber: async () => {
+        session = new FakeStreamingTranscriber();
         const origStop = session.stop.bind(session);
         session.stop = () => {
           sessionsStopped.push(Date.now());
@@ -278,11 +276,56 @@ describe("MeetAudioIngest.start", () => {
       },
     });
 
-    await expect(
-      ingest.start("m1", "/tmp/x.sock", "k"),
-    ).rejects.toThrow(/EADDRINUSE/);
+    await expect(ingest.start("m1", "/tmp/x.sock")).rejects.toThrow(
+      /EADDRINUSE/,
+    );
     expect(session).not.toBeNull();
     expect(sessionsStopped).toHaveLength(1);
+  });
+
+  test("rejects with MeetAudioIngestError when no streaming provider is configured, cleaning up the socket path", async () => {
+    const unlinkCalls: string[] = [];
+    const closedServers: FakeUnixSocketServer[] = [];
+    const server = new FakeUnixSocketServer();
+    // Wrap close so we can verify the server is not opened (close is never called)
+    // on the missing-provider path.
+    const origClose = server.close.bind(server);
+    server.close = async () => {
+      closedServers.push(server);
+      await origClose();
+    };
+
+    const ingest = new MeetAudioIngest({
+      createTranscriber: async () => {
+        throw new MeetAudioIngestError(
+          "No streaming-capable STT provider is configured. " +
+            "Set services.stt.provider to deepgram, google-gemini, or openai-whisper " +
+            "and ensure credentials are present.",
+        );
+      },
+      listen: async (path) => {
+        unlinkCalls.push(path);
+        return server;
+      },
+    });
+
+    const rejection = ingest.start("m-missing", "/tmp/missing.sock");
+    await expect(rejection).rejects.toThrow(
+      /No streaming-capable STT provider is configured/,
+    );
+    await expect(rejection).rejects.toBeInstanceOf(MeetAudioIngestError);
+    try {
+      await rejection;
+    } catch (err) {
+      expect(MeetAudioIngestError.isMeetAudioIngestError(err)).toBe(true);
+    }
+
+    // listen() was never called — socket path is uncreated and does not leak.
+    expect(unlinkCalls).toHaveLength(0);
+    expect(closedServers).toHaveLength(0);
+
+    // stop() is idempotent and safe to call on a failed-to-start ingest.
+    await ingest.stop();
   });
 
   test("rejects start() when the bot does not connect within the timeout", async () => {
@@ -310,17 +353,11 @@ describe("MeetAudioIngest.start", () => {
 
     try {
       const setup = newIngestSetup();
-      const startPromise = setup.ingest.start(
-        "m1",
-        "/tmp/timeout.sock",
-        "dg-key",
-      );
+      const startPromise = setup.ingest.start("m1", "/tmp/timeout.sock");
 
       // Let microtasks settle so the ingest has called `listen()` and
       // registered its watchdog.
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushMicrotasks();
 
       // The watchdog is the only pending timer — locate it and fire it.
       const pending = timers.filter((t) => !t.fired);
@@ -344,15 +381,10 @@ describe("MeetAudioIngest.start", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
-  test("forwards PCM bytes from the bot to Deepgram", async () => {
+  test("forwards PCM bytes from the bot to the transcriber", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start(
-      "m-forward",
-      "/tmp/audio.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-forward", "/tmp/audio.sock");
+    await flushMicrotasks();
 
     const conn = setup.server.connectBot();
     await startPromise;
@@ -369,7 +401,7 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     await setup.ingest.stop();
   });
 
-  test("dispatches partial Deepgram events as non-final transcript chunks", async () => {
+  test("dispatches partial transcriber events as non-final transcript chunks", async () => {
     const setup = newIngestSetup();
     const captured: Array<Parameters<typeof dispatchMock>[1]> = [];
     const dispatchMock = mock((_meetingId: string, event: unknown) => {
@@ -380,13 +412,8 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
       dispatchMock("m-partial", e),
     );
 
-    const startPromise = setup.ingest.start(
-      "m-partial",
-      "/tmp/partial.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-partial", "/tmp/partial.sock");
+    await flushMicrotasks();
     setup.server.connectBot();
     await startPromise;
 
@@ -411,18 +438,13 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     await setup.ingest.stop();
   });
 
-  test("dispatches final Deepgram events as final transcript chunks", async () => {
+  test("dispatches final transcriber events as final transcript chunks", async () => {
     const setup = newIngestSetup();
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-final", (e) => captured.push(e));
 
-    const startPromise = setup.ingest.start(
-      "m-final",
-      "/tmp/final.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-final", "/tmp/final.sock");
+    await flushMicrotasks();
     setup.server.connectBot();
     await startPromise;
 
@@ -446,13 +468,8 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     const captured: Array<unknown> = [];
     getMeetSessionEventRouter().register("m-ignore", (e) => captured.push(e));
 
-    const startPromise = setup.ingest.start(
-      "m-ignore",
-      "/tmp/ignore.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-ignore", "/tmp/ignore.sock");
+    await flushMicrotasks();
     setup.server.connectBot();
     await startPromise;
 
@@ -474,15 +491,10 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetAudioIngest.stop", () => {
-  test("destroys connection, stops Deepgram, closes server", async () => {
+  test("destroys connection, stops transcriber, closes server", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start(
-      "m-stop",
-      "/tmp/stop.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-stop", "/tmp/stop.sock");
+    await flushMicrotasks();
     const conn = setup.server.connectBot();
     await startPromise;
 
@@ -495,13 +507,8 @@ describe("MeetAudioIngest.stop", () => {
 
   test("is idempotent", async () => {
     const setup = newIngestSetup();
-    const startPromise = setup.ingest.start(
-      "m-idem",
-      "/tmp/idem.sock",
-      "dg",
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+    const startPromise = setup.ingest.start("m-idem", "/tmp/idem.sock");
+    await flushMicrotasks();
     setup.server.connectBot();
     await startPromise;
 
@@ -517,10 +524,8 @@ describe("MeetAudioIngest.stop", () => {
     const startPromise = setup.ingest.start(
       "m-afterstop",
       "/tmp/afterstop.sock",
-      "dg",
     );
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushMicrotasks();
     const conn = setup.server.connectBot();
     await startPromise;
 

--- a/assistant/src/meet/__tests__/session-manager.test.ts
+++ b/assistant/src/meet/__tests__/session-manager.test.ts
@@ -115,7 +115,6 @@ describe("MeetSessionManager.join", () => {
   test("generates BOT_API_TOKEN, creates sockets dir, registers router, spawns container", async () => {
     const runner = makeMockRunner();
     const getProviderKey = mock(async (provider: string) => {
-      if (provider === "deepgram") return "deepgram-secret";
       if (provider === "tts") return "tts-secret";
       return undefined;
     });
@@ -153,9 +152,11 @@ describe("MeetSessionManager.join", () => {
       session.botApiToken,
     );
 
-    // Credentials resolved.
-    expect(getProviderKey).toHaveBeenCalledWith("deepgram");
+    // TTS credential is still resolved via getProviderKey. STT credentials
+    // are now owned by the audio-ingest's own provider resolver, so the
+    // session manager no longer fetches a Deepgram key.
     expect(getProviderKey).toHaveBeenCalledWith("tts");
+    expect(getProviderKey).not.toHaveBeenCalledWith("deepgram");
 
     // Runner invoked with the expected env/binds/ports/name/network.
     expect(runner.run).toHaveBeenCalledTimes(1);
@@ -502,13 +503,10 @@ describe("MeetSessionManager max-minutes timeout", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetSessionManager audio ingest wiring", () => {
-  test("join starts the audio ingest with the meetingId, socket path, and Deepgram key", async () => {
+  test("join starts the audio ingest with the meetingId and socket path (no API key threaded through)", async () => {
     const runner = makeMockRunner();
     const audioIngestFactory = makeFakeAudioIngestFactory();
-    const getProviderKey = mock(async (provider: string) => {
-      if (provider === "deepgram") return "deepgram-secret";
-      return "";
-    });
+    const getProviderKey = mock(async () => "");
 
     const manager = _createMeetSessionManagerForTests({
       dockerRunnerFactory: () => runner,
@@ -527,13 +525,16 @@ describe("MeetSessionManager audio ingest wiring", () => {
     const ingest = audioIngestFactory.getLastIngest();
     expect(ingest).not.toBeNull();
     expect(ingest!.start).toHaveBeenCalledTimes(1);
-    const [meetingId, socketPath, apiKey] = ingest!.start.mock
-      .calls[0] as unknown as [string, string, string];
+    const call = ingest!.start.mock.calls[0] as unknown as [string, string];
+    expect(call).toHaveLength(2);
+    const [meetingId, socketPath] = call;
     expect(meetingId).toBe("m-audio");
     expect(socketPath).toBe(
       join(workspaceDir, "meets", "m-audio", "sockets", "audio.sock"),
     );
-    expect(apiKey).toBe("deepgram-secret");
+    // Session manager no longer fetches a Deepgram key — STT resolution
+    // lives inside the audio ingest.
+    expect(getProviderKey).not.toHaveBeenCalledWith("deepgram");
 
     await manager.leave("m-audio", "cleanup");
   });

--- a/assistant/src/meet/audio-ingest.ts
+++ b/assistant/src/meet/audio-ingest.ts
@@ -4,16 +4,17 @@
  * Flow:
  *   1. The session manager calls {@link MeetAudioIngest.start} **before** the
  *      bot container is spawned. `start()` opens a Unix-domain-socket server
- *      (the bot connects as the client once it boots) and opens a Deepgram
- *      realtime streaming session reusing the existing
- *      {@link DeepgramRealtimeTranscriber}.
+ *      (the bot connects as the client once it boots) and opens a streaming
+ *      STT session via the configured provider (resolved from
+ *      `services.stt.provider`).
  *   2. When the bot connects to the socket, its raw PCM frames are forwarded
- *      byte-for-byte to the Deepgram session.
- *   3. Deepgram's `partial` / `final` transcript events are wrapped in a
- *      {@link TranscriptChunkEvent} and dispatched through
+ *      byte-for-byte to the streaming transcriber.
+ *   3. The transcriber's `partial` / `final` transcript events are wrapped
+ *      in a {@link TranscriptChunkEvent} and dispatched through
  *      {@link MeetSessionEventRouter} keyed by `meetingId`.
- *   4. On session teardown, {@link MeetAudioIngest.stop} closes the Deepgram
- *      session, tears down the socket server, and unlinks the socket file.
+ *   4. On session teardown, {@link MeetAudioIngest.stop} closes the
+ *      streaming session, tears down the socket server, and unlinks the
+ *      socket file.
  *
  * Timeouts:
  *   - If the bot has not connected within {@link BOT_CONNECT_TIMEOUT_MS},
@@ -21,15 +22,17 @@
  *     so we do not leave a zombie container running against a dead ingest.
  *
  * Design notes:
- *   - The existing Deepgram realtime module is consumed **unchanged**. This
- *     means we only surface the information that module emits today —
- *     `speakerLabel` and `confidence` are left unset on the wire because the
- *     existing transcriber normalises Deepgram's frames to plain text plus
- *     is-final. That is intentionally conservative; later PRs can widen the
- *     transcriber's event shape and populate those fields here.
- *   - All external dependencies (Deepgram session, socket listener) are
+ *   - The STT provider is resolved at runtime via
+ *     {@link resolveStreamingTranscriber}, which reads
+ *     `services.stt.provider` and looks up credentials through the provider
+ *     catalog. Meet transcription therefore honors the same provider
+ *     selection as the rest of the assistant.
+ *   - Provider-specific options (e.g. Deepgram's `smartFormatting` /
+ *     `interimResults`) are now owned by the individual provider's config
+ *     schema; this module no longer threads them through.
+ *   - All external dependencies (transcriber factory, socket listener) are
  *     swapped via constructor-level factories so tests can drive the class
- *     without touching real sockets or a real Deepgram account.
+ *     without touching real sockets or a real STT provider account.
  */
 
 import { existsSync, unlinkSync } from "node:fs";
@@ -41,7 +44,7 @@ import {
 
 import type { TranscriptChunkEvent } from "@vellumai/meet-contracts";
 
-import { DeepgramRealtimeTranscriber } from "../providers/speech-to-text/deepgram-realtime.js";
+import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -58,6 +61,53 @@ const log = getLogger("meet-audio-ingest");
  * container.
  */
 export const BOT_CONNECT_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+/**
+ * Symbol brand for {@link MeetAudioIngestError}. Declared at module scope
+ * (not nested in the class) so `readonly [MEET_AUDIO_INGEST_ERROR_BRAND]`
+ * can reference it without TDZ issues.
+ */
+const MEET_AUDIO_INGEST_ERROR_BRAND: unique symbol = Symbol.for(
+  "MeetAudioIngestError",
+);
+
+/**
+ * Marker error thrown by {@link MeetAudioIngest} when the ingest cannot
+ * start because no streaming-capable STT provider is configured or the
+ * configured provider lacks credentials.
+ *
+ * The session manager uses {@link MeetAudioIngestError.isMeetAudioIngestError}
+ * to distinguish this from generic ingest errors when composing the
+ * user-facing join-failure message.
+ */
+export class MeetAudioIngestError extends Error {
+  readonly name = "MeetAudioIngestError";
+  /**
+   * Symbol-based brand so structural checks (e.g. across module boundaries
+   * where `instanceof` may mis-report after module reload) can still
+   * reliably identify instances of this error.
+   */
+  readonly [MEET_AUDIO_INGEST_ERROR_BRAND] = true as const;
+
+  constructor(message: string) {
+    super(message);
+  }
+
+  static isMeetAudioIngestError(err: unknown): err is MeetAudioIngestError {
+    if (err instanceof MeetAudioIngestError) return true;
+    return (
+      typeof err === "object" &&
+      err !== null &&
+      (err as { [MEET_AUDIO_INGEST_ERROR_BRAND]?: boolean })[
+        MEET_AUDIO_INGEST_ERROR_BRAND
+      ] === true
+    );
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Minimal socket-server abstraction
@@ -104,41 +154,26 @@ export type UnixSocketListenFn = (
 ) => Promise<UnixSocketServer>;
 
 // ---------------------------------------------------------------------------
-// Deepgram factory
+// Streaming transcriber factory
 // ---------------------------------------------------------------------------
 
 /**
- * Options forwarded to the Deepgram factory. Mirrors the option surface of
- * {@link DeepgramRealtimeTranscriber} so tests can assert on what the
- * ingest configured.
- */
-export interface DeepgramIngestOptions {
-  /** Deepgram API key used to authenticate the streaming session. */
-  apiKey: string;
-  /** Whether to request smart-formatting (punctuation, numerals). */
-  smartFormatting: boolean;
-  /** Whether to request interim (partial) transcript events. */
-  interimResults: boolean;
-}
-
-/**
- * Factory signature for constructing the Deepgram streaming session.
+ * Factory signature for constructing the streaming STT session.
  *
  * Returning a {@link StreamingTranscriber} keeps the audio-ingest code
- * decoupled from the concrete Deepgram class — tests pass an in-memory
- * fake that conforms to the same contract.
+ * decoupled from any specific provider — production wiring uses the
+ * configured provider via {@link resolveStreamingTranscriber}; tests pass
+ * an in-memory fake that conforms to the same contract.
  */
-export type DeepgramSessionFactory = (
-  options: DeepgramIngestOptions,
-) => StreamingTranscriber;
+export type StreamingTranscriberFactory = () => Promise<StreamingTranscriber>;
 
 // ---------------------------------------------------------------------------
 // MeetAudioIngest
 // ---------------------------------------------------------------------------
 
 export interface MeetAudioIngestDeps {
-  /** Override for the Deepgram session factory (tests). */
-  createDeepgramSession?: DeepgramSessionFactory;
+  /** Override for the streaming-transcriber factory (tests). */
+  createTranscriber?: StreamingTranscriberFactory;
   /** Override for the Unix-socket listener factory (tests). */
   listen?: UnixSocketListenFn;
   /** Override the bot-connect timeout (tests). */
@@ -151,7 +186,7 @@ export interface MeetAudioIngestDeps {
  * an ingest across meetings.
  */
 export class MeetAudioIngest {
-  private readonly createDeepgramSession: DeepgramSessionFactory;
+  private readonly createTranscriber: StreamingTranscriberFactory;
   private readonly listen: UnixSocketListenFn;
   private readonly botConnectTimeoutMs: number;
 
@@ -164,29 +199,27 @@ export class MeetAudioIngest {
   private stopped = false;
 
   constructor(deps: MeetAudioIngestDeps = {}) {
-    this.createDeepgramSession =
-      deps.createDeepgramSession ?? defaultCreateDeepgramSession;
+    this.createTranscriber =
+      deps.createTranscriber ?? defaultCreateTranscriber;
     this.listen = deps.listen ?? defaultListen;
     this.botConnectTimeoutMs =
       deps.botConnectTimeoutMs ?? BOT_CONNECT_TIMEOUT_MS;
   }
 
   /**
-   * Open the Unix-socket server the bot will connect to, start a Deepgram
-   * realtime session, and wire PCM frames into it.
+   * Open the Unix-socket server the bot will connect to, start a streaming
+   * STT session, and wire PCM frames into it.
    *
    * The promise resolves once:
    *   - the socket server is listening, AND
-   *   - the Deepgram streaming session has connected.
+   *   - the streaming session has connected.
    *
    * It rejects if either step fails or if the bot has not connected within
-   * {@link BOT_CONNECT_TIMEOUT_MS} of `start()` being called.
+   * {@link BOT_CONNECT_TIMEOUT_MS} of `start()` being called. Rejections
+   * due to missing provider configuration surface as
+   * {@link MeetAudioIngestError}.
    */
-  async start(
-    meetingId: string,
-    socketPath: string,
-    apiKey: string,
-  ): Promise<void> {
+  async start(meetingId: string, socketPath: string): Promise<void> {
     if (this.meetingId) {
       throw new Error(
         `MeetAudioIngest: start() called twice (meetingId=${this.meetingId})`,
@@ -208,14 +241,17 @@ export class MeetAudioIngest {
       }
     }
 
-    // Open the Deepgram streaming session first. We want the socket server
-    // to be able to pump audio into an already-connected Deepgram session
-    // as soon as the bot connects.
-    const transcriber = this.createDeepgramSession({
-      apiKey,
-      smartFormatting: true,
-      interimResults: true,
-    });
+    // Open the streaming STT session first. We want the socket server
+    // to be able to pump audio into an already-connected session as
+    // soon as the bot connects.
+    let transcriber: StreamingTranscriber;
+    try {
+      transcriber = await this.createTranscriber();
+    } catch (err) {
+      this.meetingId = null;
+      this.socketPath = null;
+      throw err;
+    }
     this.transcriber = transcriber;
 
     try {
@@ -235,7 +271,7 @@ export class MeetAudioIngest {
     try {
       server = await this.listen(socketPath);
     } catch (err) {
-      // Deepgram is already up — tear it down before propagating the error.
+      // Streaming session is already up — tear it down before propagating.
       try {
         transcriber.stop();
       } catch {
@@ -296,7 +332,7 @@ export class MeetAudioIngest {
   /**
    * Tear down the ingest:
    *   1. Stop forwarding audio.
-   *   2. Close the Deepgram session (provider may flush remaining finals).
+   *   2. Close the streaming session (provider may flush remaining finals).
    *   3. Close the socket server.
    *   4. Unlink the socket file.
    *
@@ -317,9 +353,9 @@ export class MeetAudioIngest {
       }
     }
 
-    // Close the Deepgram session. The transcriber signals `closed` via its
-    // event callback — we don't need to await that signal here because the
-    // ingress is shutting down regardless.
+    // Close the streaming session. The transcriber signals `closed` via
+    // its event callback — we don't need to await that signal here because
+    // the ingress is shutting down regardless.
     const transcriber = this.transcriber;
     this.transcriber = null;
     if (transcriber) {
@@ -376,8 +412,8 @@ export class MeetAudioIngest {
       const transcriber = this.transcriber;
       if (!transcriber) return;
       try {
-        // Deepgram's live endpoint accepts raw PCM bytes. The mimeType is
-        // informational for other providers; pass a sensible default.
+        // The streaming endpoint accepts raw PCM bytes. The mimeType is
+        // informational for provider adapters; pass a sensible default.
         transcriber.sendAudio(chunk, "audio/pcm");
       } catch (err) {
         log.warn(
@@ -397,7 +433,7 @@ export class MeetAudioIngest {
   }
 
   /**
-   * Translate a Deepgram streaming event into a TranscriptChunkEvent and
+   * Translate a streaming STT event into a TranscriptChunkEvent and
    * dispatch it through the session router. Errors, closes, and other
    * non-transcript events are ignored — the session manager owns the
    * provider's lifecycle, not the ingest.
@@ -412,7 +448,7 @@ export class MeetAudioIngest {
       return;
     }
 
-    // The existing Deepgram transcriber does not yet surface speaker /
+    // The existing streaming transcribers do not yet surface speaker /
     // confidence metadata; leave those optional fields unset.
     const transcript: TranscriptChunkEvent = {
       type: "transcript.chunk",
@@ -427,26 +463,28 @@ export class MeetAudioIngest {
 }
 
 // ---------------------------------------------------------------------------
-// Defaults — real Deepgram + real node:net socket server
+// Defaults — resolve the configured STT provider + real node:net socket
 // ---------------------------------------------------------------------------
 
 /**
- * Default Deepgram factory — constructs the production
- * {@link DeepgramRealtimeTranscriber} with the options mirrored from the
- * existing provider module (smart formatting + interim results on).
+ * Default streaming-transcriber factory — resolves the provider via the
+ * assistant's STT catalog (reads `services.stt.provider` and looks up
+ * credentials centrally).
  *
- * Phase 1 does **not** require diarization; the existing transcriber does
- * not expose a `diarize` knob, and the plan is explicit that the module is
- * consumed unchanged. A later PR can widen the transcriber's option
- * surface when we need speaker labels.
+ * Throws {@link MeetAudioIngestError} when no streaming-capable provider
+ * is configured so the session manager can surface a clear join-failure
+ * message pointing at `services.stt.provider`.
  */
-function defaultCreateDeepgramSession(
-  options: DeepgramIngestOptions,
-): StreamingTranscriber {
-  return new DeepgramRealtimeTranscriber(options.apiKey, {
-    smartFormatting: options.smartFormatting,
-    interimResults: options.interimResults,
-  });
+async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
+  const transcriber = await resolveStreamingTranscriber();
+  if (!transcriber) {
+    throw new MeetAudioIngestError(
+      "No streaming-capable STT provider is configured. " +
+        "Set services.stt.provider to deepgram, google-gemini, or openai-whisper " +
+        "and ensure credentials are present.",
+    );
+  }
+  return transcriber;
 }
 
 /**

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -6,8 +6,11 @@
  *     (PR 9) can authenticate inbound bot callbacks.
  *   - Stage per-meeting artifact directories (`sockets/`, `out/`) on the
  *     workspace volume.
- *   - Resolve the Deepgram API key (and a placeholder TTS key reserved for
- *     Phase 3) via the secure-keys abstraction.
+ *   - Resolve a placeholder TTS key reserved for Phase 3 via the
+ *     secure-keys abstraction. STT credentials are resolved inside the
+ *     audio-ingest via the configured `services.stt.provider` — the
+ *     session manager no longer needs to know which STT provider is in
+ *     use or how to fetch its key.
  *   - Drive `DockerRunner` to create + start the Meet-bot container with the
  *     right env/binds/port mappings.
  *   - Register the per-meeting handler with `MeetSessionEventRouter` via
@@ -23,7 +26,9 @@
  *     `DockerRunner.stop` + `remove` so stuck bots don't leak containers.
  *   - Start a {@link MeetAudioIngest} before the container spawns so the
  *     bot has a socket to connect to the moment it boots, and tear the
- *     ingest down after the container is removed on leave.
+ *     ingest down after the container is removed on leave. The ingest
+ *     resolves the STT provider from `services.stt.provider` on its own
+ *     — this class does not pass any API keys through.
  *   - Spin up a {@link MeetConsentMonitor} per meeting so objection
  *     phrases on transcript/chat trigger an auto-leave when
  *     `services.meet.autoLeaveOnObjection` is enabled.
@@ -118,8 +123,8 @@ interface ActiveSession extends MeetSession {
   /** Hard-cap timeout handle — cleared on leave. */
   timeoutHandle: ReturnType<typeof setTimeout> | null;
   /**
-   * The audio-ingest instance owning the Unix-socket server and Deepgram
-   * session for this meeting. Created in `join()` and torn down in
+   * The audio-ingest instance owning the Unix-socket server and streaming
+   * STT session for this meeting. Created in `join()` and torn down in
    * `leave()` after the container is removed.
    */
   audioIngest: MeetAudioIngestLike;
@@ -138,10 +143,10 @@ interface ActiveSession extends MeetSession {
 
 /**
  * Thin interface for the audio-ingest surface the session manager uses.
- * Lets tests swap in a fake without needing the real Deepgram/socket stack.
+ * Lets tests swap in a fake without needing the real STT/socket stack.
  */
 export interface MeetAudioIngestLike {
-  start(meetingId: string, socketPath: string, apiKey: string): Promise<void>;
+  start(meetingId: string, socketPath: string): Promise<void>;
   stop(): Promise<void>;
 }
 
@@ -295,15 +300,16 @@ class MeetSessionManagerImpl {
 
     const botApiToken = generateBotApiToken();
 
-    const deepgramKey = (await this.deps.getProviderKey("deepgram")) ?? "";
     // Placeholder — Phase 3 (PR 23+) will resolve the real TTS credential.
     const ttsKey = (await this.deps.getProviderKey("tts")) ?? "";
 
     const daemonUrl = this.deps.resolveDaemonUrl();
 
     // Audio ingest + container spawn are started concurrently:
-    //   1. The ingest opens its Unix-socket server and a Deepgram session,
-    //      then waits for the bot to connect (bounded by a 30s timeout).
+    //   1. The ingest opens its Unix-socket server and a streaming STT
+    //      session (provider resolved from `services.stt.provider` via
+    //      the provider catalog), then waits for the bot to connect
+    //      (bounded by a 30s timeout).
     //   2. The container is started in parallel; once it boots, the bot
     //      process inside dials the shared socket.
     //
@@ -311,14 +317,11 @@ class MeetSessionManagerImpl {
     // what lets the bot connect as soon as its process comes up. Running
     // them concurrently keeps the total latency bounded — the join
     // completes once both steps succeed, or fails fast if either step
-    // rejects.
+    // rejects (e.g. with a {@link MeetAudioIngestError} when no
+    // streaming-capable STT provider is configured).
     const audioSocketPath = join(socketsDir, "audio.sock");
     const audioIngest = this.deps.audioIngestFactory();
-    const audioIngestPromise = audioIngest.start(
-      meetingId,
-      audioSocketPath,
-      deepgramKey,
-    );
+    const audioIngestPromise = audioIngest.start(meetingId, audioSocketPath);
 
     const env: Record<string, string> = {
       MEET_URL: url,
@@ -370,7 +373,7 @@ class MeetSessionManagerImpl {
         "Failed to spawn meet bot container",
       );
       // Tear down the concurrently-started audio ingest so we don't leak
-      // a listening socket or a Deepgram session on the spawn-failure path.
+      // a listening socket or a streaming STT session on the spawn-failure path.
       // Swallow its in-flight promise before stopping to prevent unhandled
       // rejections from surfacing in the caller's context.
       audioIngestPromise.catch(() => {});
@@ -404,9 +407,14 @@ class MeetSessionManagerImpl {
     }
 
     // Now that the container is up, wait for the ingest to finish setup
-    // (Deepgram connected + bot connected via the shared socket). If the
-    // bot never connects within the 30s timeout, the promise rejects and
-    // we roll the container back before re-throwing.
+    // (streaming STT session opened + bot connected via the shared
+    // socket). If the bot never connects within the 30s timeout — or the
+    // ingest fails to open a streaming session (e.g. no STT provider
+    // configured; surfaced as `MeetAudioIngestError`) — the promise
+    // rejects and we roll the container back before re-throwing. The
+    // error's `message` is forwarded to the caller via both the `throw`
+    // and the `meet.error` event, so the user sees a pointer at
+    // `services.stt.provider` when that's the cause.
     try {
       await audioIngestPromise;
     } catch (err) {
@@ -627,7 +635,7 @@ class MeetSessionManagerImpl {
     } catch (err) {
       log.warn(
         { err, meetingId },
-        "MeetAudioIngest.stop failed — socket or Deepgram session may leak",
+        "MeetAudioIngest.stop failed — socket or streaming STT session may leak",
       );
     }
 


### PR DESCRIPTION
## Summary
- `MeetAudioIngest` now uses `resolveStreamingTranscriber()` from the provider catalog instead of hardcoded Deepgram — Meet transcription honors `services.stt.provider` (deepgram | google-gemini | openai-whisper).
- Drop `apiKey` param from `start()`; credentials are handled by each provider's own resolver.
- Introduce `MeetAudioIngestError` so the session manager surfaces a clear error when no streaming-capable provider is configured.
- Remove `getProviderKey("deepgram")` from `MeetSessionManager`.
- Tests: rename `FakeDeepgramSession` → `FakeStreamingTranscriber`; drop `apiKey` fixtures; add a new case for missing-provider rejection + socket cleanup.

Part of plan: meet-phase-1-5-stt-provider.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
