### PR TITLE
meet/stt: add Gemini Live API streaming transcriber adapter

### DIFF
--- a/assistant/src/providers/speech-to-text/google-gemini-live-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-live-stream.test.ts
@@ -1,0 +1,592 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { SttStreamServerEvent } from "../../stt/types.js";
+import { GoogleGeminiLiveStreamingTranscriber } from "./google-gemini-live-stream.js";
+
+const TEST_API_KEY = "google-live-test-key";
+
+// ---------------------------------------------------------------------------
+// Mock Live session
+// ---------------------------------------------------------------------------
+
+interface LiveCallbacksForTests {
+  onopen?: () => void;
+  onmessage: (msg: unknown) => void;
+  onerror?: (ev: unknown) => void;
+  onclose?: (ev: { code: number; reason: string }) => void;
+}
+
+interface CapturedConnect {
+  params: {
+    model: string;
+    config?: {
+      responseModalities?: unknown;
+      inputAudioTranscription?: unknown;
+      systemInstruction?: unknown;
+    };
+    callbacks: LiveCallbacksForTests;
+  };
+  session: MockLiveSession;
+}
+
+/**
+ * Minimal mock of the Live API Session returned by `ai.live.connect`.
+ * Tests drive behavior via the captured `callbacks` on the connect
+ * invocation plus helper methods (`simulateMessage`, `simulateClose`,
+ * `simulateError`).
+ */
+class MockLiveSession {
+  sentInputs: unknown[] = [];
+  closeCalled = false;
+  private readonly callbacks: LiveCallbacksForTests;
+
+  constructor(callbacks: LiveCallbacksForTests) {
+    this.callbacks = callbacks;
+  }
+
+  sendRealtimeInput(params: unknown): void {
+    this.sentInputs.push(params);
+  }
+
+  sendClientContent(_params: unknown): void {
+    // Not used by the adapter but present to satisfy structural typing.
+  }
+
+  close(): void {
+    this.closeCalled = true;
+  }
+
+  // ── Test helpers ──────────────────────────────────────────────────
+
+  simulateMessage(msg: Record<string, unknown>): void {
+    this.callbacks.onmessage(msg);
+  }
+
+  simulateClose(code = 1000, reason = ""): void {
+    this.callbacks.onclose?.({ code, reason });
+  }
+
+  simulateError(ev: unknown): void {
+    this.callbacks.onerror?.(ev);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all events emitted during a test. */
+function createEventCollector(): {
+  events: SttStreamServerEvent[];
+  onEvent: (event: SttStreamServerEvent) => void;
+} {
+  const events: SttStreamServerEvent[] = [];
+  return {
+    events,
+    onEvent: (event: SttStreamServerEvent) => events.push(event),
+  };
+}
+
+/**
+ * Install a mock GoogleGenAI constructor on the module's `client` field
+ * before `start()` runs. We patch the adapter's private client after
+ * construction to a minimal object that exposes `live.connect()`.
+ */
+function installMockClient(
+  transcriber: GoogleGeminiLiveStreamingTranscriber,
+  opts: {
+    /** Whether to invoke `onopen` on the next microtask. Default: true. */
+    autoOpen?: boolean;
+    /** If provided, delay the mock's `connect` resolution by N ms. */
+    resolveDelayMs?: number;
+  } = {},
+): {
+  capturedCalls: CapturedConnect[];
+} {
+  const capturedCalls: CapturedConnect[] = [];
+  const autoOpen = opts.autoOpen ?? true;
+
+  const mockLive = {
+    connect: (params: CapturedConnect["params"]): Promise<MockLiveSession> => {
+      const session = new MockLiveSession(params.callbacks);
+      capturedCalls.push({ params, session });
+
+      // Fire onopen on the next microtask by default.
+      if (autoOpen) {
+        queueMicrotask(() => {
+          params.callbacks.onopen?.();
+        });
+      }
+
+      if (opts.resolveDelayMs !== undefined) {
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(session), opts.resolveDelayMs),
+        );
+      }
+      return Promise.resolve(session);
+    },
+  };
+
+  (transcriber as unknown as { client: { live: typeof mockLive } }).client = {
+    live: mockLive,
+  };
+
+  return { capturedCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("GoogleGeminiLiveStreamingTranscriber", () => {
+  let transcriber: GoogleGeminiLiveStreamingTranscriber;
+
+  beforeEach(() => {
+    transcriber = new GoogleGeminiLiveStreamingTranscriber(TEST_API_KEY, {
+      // Long inactivity timeout to avoid test flakes.
+      inactivityTimeoutMs: 60_000,
+    });
+  });
+
+  afterEach(() => {
+    // Best-effort stop in case a test forgot.
+    try {
+      transcriber.stop();
+    } catch {
+      // ignore
+    }
+  });
+
+  // ── Helper: start a session ────────────────────────────────────────
+
+  async function startSession(
+    options?: {
+      transcriberOptions?: ConstructorParameters<
+        typeof GoogleGeminiLiveStreamingTranscriber
+      >[1];
+      installOptions?: Parameters<typeof installMockClient>[1];
+    },
+  ): Promise<{
+    transcriber: GoogleGeminiLiveStreamingTranscriber;
+    session: MockLiveSession;
+    events: SttStreamServerEvent[];
+    capturedCalls: CapturedConnect[];
+  }> {
+    const t = options?.transcriberOptions
+      ? new GoogleGeminiLiveStreamingTranscriber(
+          TEST_API_KEY,
+          options.transcriberOptions,
+        )
+      : transcriber;
+    const { capturedCalls } = installMockClient(t, options?.installOptions);
+    const { events, onEvent } = createEventCollector();
+    await t.start(onEvent);
+    const session = capturedCalls[0]?.session;
+    if (!session) throw new Error("No connect call captured");
+    return { transcriber: t, session, events, capturedCalls };
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Lifecycle
+  // ─────────────────────────────────────────────────────────────────
+
+  test("start() resolves after onopen fires", async () => {
+    installMockClient(transcriber);
+    const { onEvent } = createEventCollector();
+    await transcriber.start(onEvent);
+    // No error = success
+  });
+
+  test("start() rejects after connectTimeoutMs if open never fires", async () => {
+    const t = new GoogleGeminiLiveStreamingTranscriber(TEST_API_KEY, {
+      connectTimeoutMs: 30,
+    });
+    installMockClient(t, { autoOpen: false });
+
+    const { onEvent } = createEventCollector();
+    await expect(t.start(onEvent)).rejects.toThrow(
+      "Gemini Live connect timeout",
+    );
+  });
+
+  test("start() throws if called twice", async () => {
+    const { transcriber: t } = await startSession();
+    await expect(t.start(() => {})).rejects.toThrow("start() called twice");
+  });
+
+  test("sendAudio() is a no-op before start() resolves (session not yet set)", () => {
+    installMockClient(transcriber);
+    // Do not await start() — session is null.
+    transcriber.sendAudio(Buffer.from([1, 2, 3]), "audio/pcm;rate=16000");
+    // No throw; nothing else observable since no session was created yet.
+  });
+
+  test("stop() is idempotent", async () => {
+    const { transcriber: t, session, events } = await startSession();
+    t.stop();
+    session.simulateClose(1000, "normal");
+    t.stop(); // Second call should be a no-op.
+
+    const closedEvents = events.filter((e) => e.type === "closed");
+    expect(closedEvents).toHaveLength(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Setup config
+  // ─────────────────────────────────────────────────────────────────
+
+  test("connect() is called with TEXT-only modality and inputAudioTranscription enabled", async () => {
+    const { capturedCalls } = await startSession();
+
+    expect(capturedCalls).toHaveLength(1);
+    const params = capturedCalls[0].params;
+    expect(params.model).toBe("gemini-live-2.5-flash-preview");
+    expect(params.config?.responseModalities).toEqual(["TEXT"]);
+    expect(params.config?.inputAudioTranscription).toEqual({});
+    expect(typeof params.config?.systemInstruction).toBe("string");
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Audio forwarding
+  // ─────────────────────────────────────────────────────────────────
+
+  test("sendAudio() forwards base64-encoded PCM with the provided mimeType", async () => {
+    const { transcriber: t, session } = await startSession();
+
+    const audio = Buffer.from([1, 2, 3]);
+    t.sendAudio(audio, "audio/pcm;rate=16000");
+
+    expect(session.sentInputs).toHaveLength(1);
+    const input = session.sentInputs[0] as {
+      audio?: { data: string; mimeType: string };
+    };
+    expect(input.audio?.data).toBe(audio.toString("base64"));
+    expect(input.audio?.mimeType).toBe("audio/pcm;rate=16000");
+  });
+
+  test("sendAudio() normalizes bare audio/pcm to include the configured sample rate", async () => {
+    const { transcriber: t, session } = await startSession({
+      transcriberOptions: {
+        pcmSampleRate: 24_000,
+        inactivityTimeoutMs: 60_000,
+      },
+    });
+
+    t.sendAudio(Buffer.from([9, 9, 9]), "audio/pcm");
+
+    const input = session.sentInputs[0] as {
+      audio?: { data: string; mimeType: string };
+    };
+    expect(input.audio?.mimeType).toBe("audio/pcm;rate=24000");
+  });
+
+  test("sendAudio() passes non-PCM mime types through unchanged", async () => {
+    const { transcriber: t, session } = await startSession();
+
+    t.sendAudio(Buffer.from([1, 2]), "audio/webm");
+
+    const input = session.sentInputs[0] as {
+      audio?: { data: string; mimeType: string };
+    };
+    expect(input.audio?.mimeType).toBe("audio/webm");
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Transcription events: partial → final
+  // ─────────────────────────────────────────────────────────────────
+
+  test("emits partial events for accumulated inputTranscription text", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: {
+        inputTranscription: { text: "hello" },
+      },
+    });
+    session.simulateMessage({
+      serverContent: {
+        inputTranscription: { text: " world" },
+      },
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: "partial", text: "hello" });
+    expect(events[1]).toEqual({ type: "partial", text: "hello world" });
+  });
+
+  test("emits final event on generationComplete and resets accumulator", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "hello" } },
+    });
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: " world" } },
+    });
+    session.simulateMessage({
+      serverContent: { generationComplete: true },
+    });
+
+    expect(events).toEqual([
+      { type: "partial", text: "hello" },
+      { type: "partial", text: "hello world" },
+      { type: "final", text: "hello world" },
+    ]);
+
+    // New turn starts fresh.
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "again" } },
+    });
+    expect(events[events.length - 1]).toEqual({
+      type: "partial",
+      text: "again",
+    });
+  });
+
+  test("emits final event on turnComplete as well as generationComplete", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "done" } },
+    });
+    session.simulateMessage({
+      serverContent: { turnComplete: true },
+    });
+
+    expect(events.filter((e) => e.type === "final")).toEqual([
+      { type: "final", text: "done" },
+    ]);
+  });
+
+  test("dedupes repeated partials when the transcription text does not change", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "hello" } },
+    });
+    // Same text repeated — no new partial.
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "" } },
+    });
+    session.simulateMessage({
+      serverContent: { inputTranscription: {} },
+    });
+
+    const partials = events.filter((e) => e.type === "partial");
+    expect(partials).toHaveLength(1);
+    expect(partials[0]).toEqual({ type: "partial", text: "hello" });
+  });
+
+  test("ignores serverContent.modelTurn payloads that don't carry inputTranscription", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: {
+        modelTurn: { parts: [{ text: "I'm staying silent" }] },
+      },
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Stop lifecycle
+  // ─────────────────────────────────────────────────────────────────
+
+  test("stop() signals audioStreamEnd and emits final + closed after provider closes", async () => {
+    const { transcriber: t, session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "goodbye" } },
+    });
+
+    t.stop();
+
+    const endSignal = session.sentInputs.find(
+      (input) => (input as { audioStreamEnd?: boolean }).audioStreamEnd,
+    );
+    expect(endSignal).toEqual({ audioStreamEnd: true });
+
+    // Provider completes the turn then closes normally.
+    session.simulateClose(1000, "normal");
+
+    const finals = events.filter((e) => e.type === "final");
+    expect(finals).toEqual([{ type: "final", text: "goodbye" }]);
+
+    const closedEvents = events.filter((e) => e.type === "closed");
+    expect(closedEvents).toHaveLength(1);
+  });
+
+  test("stop() emits final from accumulated turn text even if provider closes without turnComplete", async () => {
+    const { transcriber: t, session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "partial only" } },
+    });
+    t.stop();
+    session.simulateClose(1000, "normal");
+
+    const finals = events.filter((e) => e.type === "final");
+    expect(finals).toEqual([{ type: "final", text: "partial only" }]);
+  });
+
+  test("stop() falls back to emitting empty final and closed if no audio was ever transcribed", async () => {
+    const { transcriber: t, session, events } = await startSession();
+
+    t.stop();
+    session.simulateClose(1000, "normal");
+
+    expect(events).toEqual([
+      { type: "final", text: "" },
+      { type: "closed" },
+    ]);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Close-code categorization
+  // ─────────────────────────────────────────────────────────────────
+
+  test("unexpected close with 1008 maps to auth error category", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateClose(1008, "auth failed");
+
+    const errs = events.filter((e) => e.type === "error");
+    expect(errs).toHaveLength(1);
+    expect((errs[0] as { category: string }).category).toBe("auth");
+    expect(events.filter((e) => e.type === "closed")).toHaveLength(1);
+  });
+
+  test("unexpected close with 4001 maps to auth error category", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateClose(4001, "invalid api key");
+
+    const errs = events.filter((e) => e.type === "error");
+    expect((errs[0] as { category: string }).category).toBe("auth");
+  });
+
+  test("unexpected close with 1013 maps to rate-limit error category", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateClose(1013, "try again later");
+
+    const errs = events.filter((e) => e.type === "error");
+    expect((errs[0] as { category: string }).category).toBe("rate-limit");
+  });
+
+  test("unexpected close with arbitrary code maps to provider-error", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateClose(1006, "abnormal closure");
+
+    const errs = events.filter((e) => e.type === "error");
+    expect((errs[0] as { category: string }).category).toBe("provider-error");
+    expect((errs[0] as { message: string }).message).toContain("1006");
+  });
+
+  test("session-level error event emits provider-error + closed", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateError({ message: "boom" });
+
+    const errs = events.filter((e) => e.type === "error");
+    const closedEvents = events.filter((e) => e.type === "closed");
+    expect(errs).toHaveLength(1);
+    expect((errs[0] as { category: string }).category).toBe("provider-error");
+    expect((errs[0] as { message: string }).message).toContain("boom");
+    expect(closedEvents).toHaveLength(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Inactivity timeout
+  // ─────────────────────────────────────────────────────────────────
+
+  test("inactivity timeout emits timeout error and closed", async () => {
+    const { events } = await startSession({
+      transcriberOptions: { inactivityTimeoutMs: 50 },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    const errs = events.filter((e) => e.type === "error");
+    const closedEvents = events.filter((e) => e.type === "closed");
+    expect(errs).toHaveLength(1);
+    expect((errs[0] as { category: string }).category).toBe("timeout");
+    expect((errs[0] as { message: string }).message).toContain("inactivity");
+    expect(closedEvents).toHaveLength(1);
+  });
+
+  test("inactivity timer resets on incoming server messages", async () => {
+    const { session, events } = await startSession({
+      transcriberOptions: { inactivityTimeoutMs: 100 },
+    });
+
+    // Send a message before the timer fires.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "hi" } },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    // Should not have timed out because the timer reset on the message.
+    expect(events.filter((e) => e.type === "error")).toHaveLength(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // No events after closed
+  // ─────────────────────────────────────────────────────────────────
+
+  test("no events are emitted between final and closed on stop()", async () => {
+    const { transcriber: t, session, events } = await startSession();
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "abc" } },
+    });
+    t.stop();
+
+    // Partial-style messages after stop() should not produce additional
+    // partial events (they are dropped because `stopping` is true) and
+    // never interleave between final and closed.
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: " late" } },
+    });
+
+    session.simulateClose(1000, "");
+
+    const types = events.map((e) => e.type);
+    const lastTwo = types.slice(-2);
+    expect(lastTwo).toEqual(["final", "closed"]);
+
+    // No partials after the final.
+    const finalIdx = types.indexOf("final");
+    const afterFinal = types.slice(finalIdx + 1);
+    expect(afterFinal).toEqual(["closed"]);
+  });
+
+  test("no events emitted after closed on unexpected close", async () => {
+    const { session, events } = await startSession();
+
+    session.simulateError(new Error("boom"));
+
+    const count = events.length;
+
+    session.simulateMessage({
+      serverContent: { inputTranscription: { text: "late" } },
+    });
+    session.simulateClose(1000, "");
+
+    expect(events.length).toBe(count);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Provider identity
+  // ─────────────────────────────────────────────────────────────────
+
+  test("reports correct providerId and boundaryId", () => {
+    const t = new GoogleGeminiLiveStreamingTranscriber(TEST_API_KEY);
+    expect(t.providerId).toBe("google-gemini");
+    expect(t.boundaryId).toBe("daemon-streaming");
+  });
+});

--- a/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
@@ -1,0 +1,589 @@
+/**
+ * Google Gemini Live API streaming STT adapter.
+ *
+ * Opens a bidirectional streaming session against Gemini's Live API
+ * (`ai.live.connect`), forwards PCM audio frames from the caller, and
+ * normalizes the server's `inputAudioTranscription` events into the
+ * daemon's {@link SttStreamServerEvent} contract with stable partial/final
+ * semantics.
+ *
+ * Key differences vs. the batch-polling `GoogleGeminiStreamingTranscriber`:
+ * - Uses a long-lived WebSocket-backed session (not periodic REST polls).
+ * - The server emits transcription events natively via
+ *   `serverContent.inputTranscription`; we do not diff responses ourselves.
+ * - Suppresses the model's text turn (`responseModalities: [TEXT]`,
+ *   system instruction telling the model to stay silent) so we only pay
+ *   for transcription work.
+ *
+ * Lifecycle:
+ * 1. {@link start} opens the Live session and resolves on `onopen`.
+ * 2. {@link sendAudio} forwards PCM chunks via `session.sendRealtimeInput`.
+ * 3. {@link stop} sends `audioStreamEnd: true` and waits for the server
+ *    to flush any remaining transcription before closing.
+ * 4. The `onEvent` callback receives `partial`, `final`, `error`, and
+ *    `closed` events throughout the session lifetime.
+ *
+ * Error handling mirrors {@link DeepgramRealtimeTranscriber}: close-code
+ * categorization (`auth` for 1008/4001, `rate-limit` for 1013,
+ * `provider-error` for everything else), a configurable inactivity
+ * timeout, and idempotent cleanup.
+ */
+
+import type { LiveServerMessage, Session } from "@google/genai";
+import { GoogleGenAI, Modality } from "@google/genai";
+
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("google-gemini-live-stream");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default Gemini Live-capable model. See the @google/genai SDK example at
+ * `@google/genai/dist/node/node.d.ts` (class `Live.connect`) — the Gemini
+ * Live API currently ships under the `gemini-live-2.5-flash-preview` id.
+ */
+const DEFAULT_MODEL = "gemini-live-2.5-flash-preview";
+
+/**
+ * Default timeout (ms) for the Live session handshake.
+ * If `onopen` does not fire within this window, start() rejects.
+ */
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Default inactivity timeout (ms). If no message is received from Gemini
+ * for this duration after the session is open, the adapter closes with a
+ * timeout error. This guards against provider-side hangs.
+ */
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 30_000;
+
+/**
+ * Grace period (ms) after signaling `audioStreamEnd` before we force-close
+ * the Live session. Gives Gemini time to flush any remaining transcription.
+ */
+const CLOSE_GRACE_MS = 5_000;
+
+/**
+ * System instruction asking the model not to generate output. The Live API
+ * always attempts to respond; telling it to stay silent minimizes wasted
+ * tokens and avoids polluting our event stream with unwanted model turns.
+ */
+const SILENT_SYSTEM_INSTRUCTION =
+  "You are a silent transcription service. Do not respond to the user. Only transcribe the audio input.";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface GoogleGeminiLiveStreamOptions {
+  /** Gemini Live model to use (default: "gemini-live-2.5-flash-preview"). */
+  model?: string;
+  /** Override the Google AI API base URL (useful for proxies or on-prem). */
+  baseUrl?: string;
+  /** Sample rate for raw PCM input; used when normalizing MIME types. */
+  pcmSampleRate?: number;
+  /** Channel count for raw PCM input; currently informational. */
+  pcmChannels?: number;
+  /** Connect timeout in milliseconds. Default: 10_000. */
+  connectTimeoutMs?: number;
+  /** Inactivity timeout in milliseconds. Default: 30_000. */
+  inactivityTimeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Google Gemini Live API streaming transcriber.
+ *
+ * Implements the daemon {@link StreamingTranscriber} contract on top of
+ * Gemini's bidirectional Live API with server-side input transcription.
+ */
+export class GoogleGeminiLiveStreamingTranscriber
+  implements StreamingTranscriber
+{
+  readonly providerId = "google-gemini" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private readonly client: GoogleGenAI;
+  private readonly model: string;
+  private readonly pcmSampleRate: number;
+  private readonly pcmChannels: number;
+  private readonly connectTimeoutMs: number;
+  private readonly inactivityTimeoutMs: number;
+
+  /** The live session, set during start(). */
+  private session: Session | null = null;
+
+  /** Callback for emitting events to the session orchestrator. */
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  /** Whether the session has been fully closed. */
+  private closed = false;
+
+  /** Whether stop() has been called. */
+  private stopping = false;
+
+  /** Inactivity timer handle. */
+  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Close grace timer handle. */
+  private closeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Last partial transcript we emitted; used to dedupe repeats. */
+  private lastEmittedPartial = "";
+
+  /** Accumulated input transcription for the current turn. */
+  private currentTurnText = "";
+
+  constructor(apiKey: string, options: GoogleGeminiLiveStreamOptions = {}) {
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.pcmSampleRate = options.pcmSampleRate ?? 16_000;
+    this.pcmChannels = options.pcmChannels ?? 1;
+    this.connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    this.inactivityTimeoutMs =
+      options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+
+    this.client = options.baseUrl
+      ? new GoogleGenAI({
+          apiKey,
+          httpOptions: { baseUrl: options.baseUrl },
+        })
+      : new GoogleGenAI({ apiKey });
+  }
+
+  // ── StreamingTranscriber interface ──────────────────────────────────
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    if (this.session || this.onEvent) {
+      throw new Error(
+        "GoogleGeminiLiveStreamingTranscriber: start() called twice",
+      );
+    }
+    this.onEvent = onEvent;
+    this.closed = false;
+    this.stopping = false;
+    this.lastEmittedPartial = "";
+    this.currentTurnText = "";
+
+    log.info({ model: this.model }, "Opening Gemini Live session");
+
+    // Open is complete when BOTH the session handle is returned by the
+    // SDK AND `onopen` has fired. The real SDK's `live.connect()` awaits
+    // `onopen` internally before resolving with a Session; we track the
+    // two signals separately so the adapter stays correct across SDK
+    // ordering changes and matches the test mock (which returns the
+    // session synchronously and fires `onopen` on the next microtask).
+    let openFired = false;
+    let resolveOpen: (() => void) | null = null;
+    let rejectOpen: ((err: Error) => void) | null = null;
+    const openSignal = new Promise<void>((res, rej) => {
+      resolveOpen = res;
+      rejectOpen = rej;
+    });
+
+    const finishOpen = (err?: Error): void => {
+      if (err) {
+        rejectOpen?.(err);
+      } else {
+        resolveOpen?.();
+      }
+      resolveOpen = null;
+      rejectOpen = null;
+    };
+
+    const connectPromise = this.client.live.connect({
+      model: this.model,
+      config: {
+        responseModalities: [Modality.TEXT],
+        inputAudioTranscription: {},
+        systemInstruction: SILENT_SYSTEM_INSTRUCTION,
+      },
+      callbacks: {
+        onopen: (): void => {
+          openFired = true;
+          finishOpen();
+        },
+        onmessage: (msg: LiveServerMessage): void => {
+          this.handleServerMessage(msg);
+        },
+        onerror: (ev: ErrorEvent): void => {
+          if (!openFired && !this.session) {
+            finishOpen(
+              new Error(
+                `Gemini Live connect error: ${this.describeError(ev)}`,
+              ),
+            );
+            return;
+          }
+          this.handleProviderError(ev);
+        },
+        onclose: (ev: CloseEvent): void => {
+          if (!openFired && !this.session) {
+            finishOpen(
+              new Error(
+                `Gemini Live session closed before open (code=${ev.code}, reason=${ev.reason})`,
+              ),
+            );
+            return;
+          }
+          this.handleProviderClose(ev.code, ev.reason);
+        },
+      },
+    });
+
+    // Capture the session as soon as the SDK returns it so subsequent
+    // methods have a handle. A failed connect (rejection) is surfaced
+    // below via the race path.
+    let timedOut = false;
+    connectPromise
+      .then((session) => {
+        if (timedOut) {
+          // Never assign a session after the start() timeout: if we did,
+          // `this.session` would persist past the failed start() and a
+          // retry would incorrectly trip the "start() called twice" guard.
+          try {
+            session.close();
+          } catch {
+            // best effort
+          }
+          return;
+        }
+        this.session = session;
+      })
+      .catch(() => {
+        // Surfaced through the Promise.race below.
+      });
+
+    // Timeout race.
+    const timeoutPromise = new Promise<never>((_, rej) => {
+      const timer = setTimeout(() => {
+        timedOut = true;
+        log.warn("Gemini Live connect timeout");
+        rej(new Error("Gemini Live connect timeout"));
+      }, this.connectTimeoutMs);
+      // Clear the timer only once open has actually fired; a resolved
+      // `connectPromise` alone does not mean the session is open (the
+      // test mock returns the session synchronously and defers onopen).
+      openSignal.finally(() => clearTimeout(timer)).catch(() => {});
+    });
+
+    try {
+      // Wait for the SDK's connect() to resolve (giving us `this.session`)
+      // AND for `onopen` to have fired, or for either a timeout or
+      // connect error to fail the race.
+      await Promise.race([
+        Promise.all([connectPromise, openSignal]),
+        timeoutPromise,
+      ]);
+    } catch (err) {
+      this.onEvent = null;
+      this.session = null;
+      throw err;
+    }
+
+    this.resetInactivityTimer();
+    log.info("Gemini Live session opened");
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    if (this.closed || this.stopping) return;
+
+    const session = this.session;
+    if (!session) return;
+
+    const normalizedMimeType = this.normalizePcmMimeType(mimeType);
+
+    try {
+      session.sendRealtimeInput({
+        audio: {
+          data: audio.toString("base64"),
+          mimeType: normalizedMimeType,
+        },
+      });
+    } catch (err) {
+      log.warn({ error: err }, "Failed to send audio to Gemini Live session");
+    }
+  }
+
+  stop(): void {
+    if (this.closed || this.stopping) return;
+    this.stopping = true;
+
+    log.info("Stopping Gemini Live session");
+
+    const session = this.session;
+    if (!session) {
+      this.emitClosedAndCleanup();
+      return;
+    }
+
+    // Signal end-of-audio so Gemini flushes any pending transcription.
+    try {
+      session.sendRealtimeInput({ audioStreamEnd: true });
+    } catch (err) {
+      // If the send fails, force-close immediately.
+      log.warn(
+        { error: err },
+        "Failed to send audioStreamEnd; forcing close",
+      );
+      this.flushFinalAndClose();
+      return;
+    }
+
+    // Start a grace timer — if the provider doesn't close within the
+    // grace window, we force-close to prevent session leaks.
+    this.closeGraceTimer = setTimeout(() => {
+      log.warn("Gemini Live close grace timeout — forcing close");
+      this.flushFinalAndClose();
+    }, CLOSE_GRACE_MS);
+  }
+
+  // ── Provider message handling ───────────────────────────────────────
+
+  private handleServerMessage(msg: LiveServerMessage): void {
+    if (this.closed) return;
+
+    this.resetInactivityTimer();
+
+    // Session-level setup/usage/goAway signals — log and proceed.
+    if (msg.setupComplete) {
+      log.debug("Gemini Live setupComplete received");
+    }
+    if (msg.usageMetadata) {
+      log.debug({ usage: msg.usageMetadata }, "Gemini Live usageMetadata");
+    }
+    if (msg.goAway) {
+      log.info(
+        { timeLeft: msg.goAway.timeLeft },
+        "Gemini Live goAway received — treating as graceful close",
+      );
+    }
+
+    const serverContent = msg.serverContent;
+    if (!serverContent) return;
+
+    // Append any new input transcription text to the current turn buffer.
+    const transcriptionText = serverContent.inputTranscription?.text;
+    if (typeof transcriptionText === "string" && transcriptionText.length > 0) {
+      this.currentTurnText += transcriptionText;
+    }
+
+    // Detect turn completion.
+    const isComplete =
+      serverContent.generationComplete === true ||
+      serverContent.turnComplete === true;
+
+    if (isComplete) {
+      const finalText = this.currentTurnText;
+      this.currentTurnText = "";
+      this.lastEmittedPartial = "";
+      this.emitEvent({ type: "final", text: finalText });
+      return;
+    }
+
+    // Otherwise emit a partial only if text has changed.
+    if (
+      this.currentTurnText.length > 0 &&
+      this.currentTurnText !== this.lastEmittedPartial
+    ) {
+      this.lastEmittedPartial = this.currentTurnText;
+      this.emitEvent({ type: "partial", text: this.currentTurnText });
+    }
+
+    // `modelTurn` content is ignored — we only care about input
+    // transcription, not the model's response.
+  }
+
+  /**
+   * Handle provider-side session close.
+   */
+  private handleProviderClose(code: number, reason: string): void {
+    if (this.closed) return;
+
+    // Normal close (1000) or going-away (1001) after stop() is expected.
+    if (this.stopping && (code === 1000 || code === 1001)) {
+      log.info({ code, reason }, "Gemini Live session closed normally");
+      this.flushFinalAndClose();
+      return;
+    }
+
+    log.warn({ code, reason }, "Gemini Live session closed unexpectedly");
+
+    const category =
+      code === 1008 || code === 4001
+        ? ("auth" as const)
+        : code === 1013
+          ? ("rate-limit" as const)
+          : ("provider-error" as const);
+
+    this.emitEvent({
+      type: "error",
+      category,
+      message: `Gemini Live session closed (code=${code}, reason=${reason})`,
+    });
+    this.emitClosedAndCleanup();
+  }
+
+  /**
+   * Handle provider-side error event.
+   */
+  private handleProviderError(ev: unknown): void {
+    if (this.closed) return;
+
+    const message = this.describeError(ev);
+    log.error({ error: ev }, "Gemini Live session error");
+
+    this.emitEvent({
+      type: "error",
+      category: "provider-error",
+      message: `Gemini Live session error: ${message}`,
+    });
+    this.emitClosedAndCleanup();
+  }
+
+  // ── Event emission & cleanup ────────────────────────────────────────
+
+  /**
+   * Emit a server event to the session orchestrator. Swallows listener
+   * errors to prevent tearing down the adapter.
+   *
+   * Drops events after `closed` to preserve the streaming contract.
+   */
+  private emitEvent(event: SttStreamServerEvent): void {
+    if (!this.onEvent) return;
+    if (this.closed && event.type !== "closed") return;
+    try {
+      this.onEvent(event);
+    } catch (err) {
+      log.warn({ error: err }, "Listener error in Gemini Live adapter");
+    }
+  }
+
+  /**
+   * Flush any pending transcription as a final event, then close. Used
+   * when the provider closes normally after stop() or when the close
+   * grace timer fires.
+   */
+  private flushFinalAndClose(): void {
+    if (this.closed) return;
+    const pending = this.currentTurnText;
+    this.currentTurnText = "";
+    this.lastEmittedPartial = "";
+    this.emitEvent({ type: "final", text: pending });
+    this.emitClosedAndCleanup();
+  }
+
+  /**
+   * Emit a `closed` event and clean up all resources (timers, session).
+   * Idempotent — safe to call multiple times.
+   */
+  private emitClosedAndCleanup(): void {
+    if (this.closed) return;
+    this.closed = true;
+
+    this.clearTimers();
+    this.forceCloseSession();
+
+    this.emitEvent({ type: "closed" });
+    this.onEvent = null;
+  }
+
+  /**
+   * Force-close the Live session without emitting events. Used during
+   * cleanup and timeout paths.
+   */
+  private forceCloseSession(): void {
+    const session = this.session;
+    this.session = null;
+    if (!session) return;
+
+    try {
+      session.close();
+    } catch {
+      // Best effort — already-closed sessions may throw.
+    }
+  }
+
+  /**
+   * Clear all active timers.
+   */
+  private clearTimers(): void {
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+    if (this.closeGraceTimer !== null) {
+      clearTimeout(this.closeGraceTimer);
+      this.closeGraceTimer = null;
+    }
+  }
+
+  /**
+   * Reset the inactivity timer. Called on inbound provider messages to
+   * detect provider-side hangs. Not reset on outbound audio sends —
+   * continuous audio from the caller must not mask a silent provider.
+   */
+  private resetInactivityTimer(): void {
+    if (this.closed || this.stopping) return;
+
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+    }
+
+    this.inactivityTimer = setTimeout(() => {
+      if (this.closed) return;
+
+      log.warn("Gemini Live inactivity timeout");
+      this.emitEvent({
+        type: "error",
+        category: "timeout",
+        message: "Gemini Live session timed out due to inactivity",
+      });
+      this.emitClosedAndCleanup();
+    }, this.inactivityTimeoutMs);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Normalize generic PCM MIME types to include the sample-rate hint that
+   * Gemini Live requires. Passes non-PCM MIME types through unchanged.
+   */
+  private normalizePcmMimeType(mimeType: string): string {
+    const base = mimeType.split(";")[0].trim().toLowerCase();
+    if (base !== "audio/pcm") return mimeType;
+    // Preserve an explicit rate= parameter if the caller supplied one.
+    if (/rate\s*=\s*\d+/i.test(mimeType)) return mimeType;
+    return `audio/pcm;rate=${this.pcmSampleRate}`;
+  }
+
+  /**
+   * Produce a human-readable message from an unknown error-like value.
+   */
+  private describeError(ev: unknown): string {
+    if (ev instanceof Error) return ev.message;
+    if (typeof ev === "object" && ev !== null) {
+      if ("message" in ev) {
+        const m = (ev as { message: unknown }).message;
+        if (m !== undefined && m !== null) return String(m);
+      }
+      if ("error" in ev) {
+        const e = (ev as { error: unknown }).error;
+        if (e instanceof Error) return e.message;
+        if (e !== undefined && e !== null) return String(e);
+      }
+    }
+    return "Gemini Live session error";
+  }
+}
+


### PR DESCRIPTION
## Summary
- Adds GoogleGeminiLiveStreamingTranscriber backed by @google/genai Live API (ai.live.connect with inputAudioTranscription)
- Implements the StreamingTranscriber contract with partial/final/error/closed event semantics matching DeepgramRealtimeTranscriber
- Pure additive: no consumers wired up yet; old batch-polling adapter untouched

Part of plan: gemini-live-stt.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
