### PR TITLE
stt: add supportsDiarization flag to provider catalog

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   listProviderEntries,
   listProviderIds,
   supportsBoundary,
+  supportsDiarization,
 } from "../provider-catalog.js";
 
 // ---------------------------------------------------------------------------
@@ -211,5 +212,40 @@ describe("STT provider catalog", () => {
 
   test("getCredentialProvider returns undefined for unknown ID", () => {
     expect(getCredentialProvider("nonexistent" as never)).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Speaker diarization capability
+  // -----------------------------------------------------------------------
+
+  test("supportsDiarization is set as a boolean for every entry", () => {
+    for (const entry of listProviderEntries()) {
+      expect(typeof entry.supportsDiarization).toBe("boolean");
+    }
+  });
+
+  test("deepgram supportsDiarization is true", () => {
+    const entry = getProviderEntry("deepgram");
+    expect(entry?.supportsDiarization).toBe(true);
+  });
+
+  test("google-gemini supportsDiarization is false", () => {
+    const entry = getProviderEntry("google-gemini");
+    expect(entry?.supportsDiarization).toBe(false);
+  });
+
+  test("openai-whisper supportsDiarization is false", () => {
+    const entry = getProviderEntry("openai-whisper");
+    expect(entry?.supportsDiarization).toBe(false);
+  });
+
+  test("supportsDiarization helper returns expected booleans per provider", () => {
+    expect(supportsDiarization("deepgram")).toBe(true);
+    expect(supportsDiarization("google-gemini")).toBe(false);
+    expect(supportsDiarization("openai-whisper")).toBe(false);
+  });
+
+  test("supportsDiarization helper returns false for unknown provider IDs", () => {
+    expect(supportsDiarization("nonexistent" as never)).toBe(false);
   });
 });

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -123,6 +123,19 @@ export interface SttProviderEntry {
   readonly conversationStreamingMode: ConversationStreamingMode;
 
   /**
+   * Whether the provider can attribute transcribed speech to distinct
+   * speakers (speaker diarization). When `true`, callers may opt in to
+   * per-utterance speaker labels via the provider's streaming/batch
+   * configuration. When `false`, speaker-label callers must fall back to
+   * single-speaker output.
+   *
+   * Flip this flag in the catalog if a provider gains diarization support;
+   * downstream code reads the capability from here via
+   * {@link supportsDiarization}.
+   */
+  readonly supportsDiarization: boolean;
+
+  /**
    * Telephony routing metadata — describes how this provider is wired
    * into Twilio call setup. This is the single source of truth for
    * strategy selection and Twilio-native mapping details.
@@ -158,6 +171,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "realtime-ws",
       conversationStreamingMode: "realtime-ws",
+      supportsDiarization: true,
       telephonyRouting: {
         strategyKind: "conversation-relay-native",
         twilioNativeMapping: {
@@ -178,6 +192,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "incremental-batch",
+      supportsDiarization: false,
       telephonyRouting: {
         strategyKind: "conversation-relay-native",
         twilioNativeMapping: {
@@ -198,6 +213,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       ]),
       telephonyMode: "batch-only",
       conversationStreamingMode: "incremental-batch",
+      supportsDiarization: false,
       telephonyRouting: {
         strategyKind: "media-stream-custom",
       },
@@ -248,6 +264,17 @@ export function supportsBoundary(
   boundary: SttBoundaryId,
 ): boolean {
   return CATALOG.get(id)?.supportedBoundaries.has(boundary) ?? false;
+}
+
+/**
+ * Check whether a provider supports speaker diarization.
+ *
+ * Returns `false` for unknown provider IDs. Callers use this to decide
+ * whether to request speaker labels from the provider's streaming or
+ * batch configuration.
+ */
+export function supportsDiarization(id: SttProviderId): boolean {
+  return CATALOG.get(id)?.supportsDiarization ?? false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `supportsDiarization: boolean` to `SttProviderEntry`. Set `true` for `deepgram`, `false` for `google-gemini` and `openai-whisper`.
- Export `supportsDiarization(providerId)` helper for ergonomic lookups.

Part of plan: meet-phase-1-6-speaker-labels.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
