### PR TITLE
deepgram: add diarize option to config schema + constructor options

### DIFF
--- a/assistant/src/config/schemas/__tests__/stt.test.ts
+++ b/assistant/src/config/schemas/__tests__/stt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DeepgramProviderConfigSchema,
+  SttProvidersSchema,
+  SttServiceSchema,
+  VALID_STT_PROVIDERS,
+} from "../stt.js";
+
+describe("DeepgramProviderConfigSchema", () => {
+  test("empty object parses to documented defaults (diarize: false)", () => {
+    const parsed = DeepgramProviderConfigSchema.parse({});
+    expect(parsed).toEqual({ diarize: false });
+  });
+
+  test("diarize: true round-trips", () => {
+    const parsed = DeepgramProviderConfigSchema.parse({ diarize: true });
+    expect(parsed).toEqual({ diarize: true });
+  });
+
+  test("diarize: false is accepted explicitly", () => {
+    const parsed = DeepgramProviderConfigSchema.parse({ diarize: false });
+    expect(parsed).toEqual({ diarize: false });
+  });
+
+  test("rejects non-boolean diarize values", () => {
+    const stringResult = DeepgramProviderConfigSchema.safeParse({
+      diarize: "true",
+    });
+    expect(stringResult.success).toBe(false);
+
+    const numberResult = DeepgramProviderConfigSchema.safeParse({
+      diarize: 1,
+    });
+    expect(numberResult.success).toBe(false);
+
+    const nullResult = DeepgramProviderConfigSchema.safeParse({
+      diarize: null,
+    });
+    expect(nullResult.success).toBe(false);
+  });
+});
+
+describe("SttProvidersSchema", () => {
+  test("accepts a Deepgram entry with diarize set via the dedicated schema", () => {
+    const deepgramCfg = DeepgramProviderConfigSchema.parse({ diarize: true });
+    const parsed = SttProvidersSchema.parse({ deepgram: deepgramCfg });
+    expect(parsed).toEqual({ deepgram: { diarize: true } });
+  });
+
+  test("forward-compatible: unknown provider keys still pass validation", () => {
+    const parsed = SttProvidersSchema.parse({
+      "future-provider": { someField: 42 },
+    });
+    expect(parsed).toEqual({ "future-provider": { someField: 42 } });
+  });
+
+  test("empty providers map parses to {}", () => {
+    const parsed = SttProvidersSchema.parse({});
+    expect(parsed).toEqual({});
+  });
+});
+
+describe("SttServiceSchema", () => {
+  test("stt.provider=deepgram with providers.deepgram.diarize round-trips", () => {
+    const parsed = SttServiceSchema.parse({
+      provider: "deepgram",
+      providers: { deepgram: { diarize: true } },
+    });
+    expect(parsed.provider).toBe("deepgram");
+    expect(parsed.providers.deepgram).toEqual({ diarize: true });
+  });
+
+  test("VALID_STT_PROVIDERS includes deepgram so the diarize option has a home", () => {
+    expect(VALID_STT_PROVIDERS).toContain("deepgram");
+  });
+});

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -11,6 +11,28 @@ export const VALID_STT_PROVIDERS = [
 ] as const;
 
 /**
+ * Deepgram-specific provider options under
+ * `services.stt.providers.deepgram`.
+ *
+ * Kept as a standalone schema (rather than inlining into the generic
+ * `SttProvidersSchema` record) so known Deepgram fields carry types and
+ * defaults, while still round-tripping cleanly through the forward-compatible
+ * parent record.
+ */
+export const DeepgramProviderConfigSchema = z
+  .object({
+    // Enables Deepgram's built-in speaker diarization. Adds no measurable
+    // latency; slight cost implications in some tiers.
+    diarize: z.boolean().default(false),
+  })
+  .describe(
+    "Deepgram-specific provider options under services.stt.providers.deepgram",
+  );
+export type DeepgramProviderConfig = z.infer<
+  typeof DeepgramProviderConfigSchema
+>;
+
+/**
  * Sparse provider config map under `services.stt.providers`.
  *
  * This is a forward-compatible record that accepts any provider ID as key
@@ -20,7 +42,10 @@ export const VALID_STT_PROVIDERS = [
  * `services.stt.providers.<id>`.
  *
  * The map only holds entries the user has explicitly configured — it is
- * NOT required to enumerate every known provider.
+ * NOT required to enumerate every known provider. Typed validation for
+ * known providers (e.g. {@link DeepgramProviderConfigSchema}) lives on
+ * those schemas and is applied at the call site — this record is only
+ * responsible for accepting the sparse shape.
  */
 export const SttProvidersSchema = z.record(
   z.string(),

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -89,6 +89,16 @@ export interface DeepgramRealtimeOptions {
   inactivityTimeoutMs?: number;
   /** Audio sample rate in Hz (default: 16000). Passed through from the client WebSocket connection. */
   sampleRate?: number;
+  /**
+   * Enable Deepgram's built-in speaker diarization. Default: false.
+   *
+   * NOTE: Accepted and stored today but NOT yet forwarded to the Deepgram
+   * WebSocket. Runtime wiring lands in the adapter PR that emits
+   * `speakerLabel` on streaming events (meet-phase-1-6 PR 4). This option
+   * is plumbed here first so the config schema and constructor surface are
+   * available for downstream callers without changing transcriber behavior.
+   */
+  diarize?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -182,6 +192,12 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private readonly connectTimeoutMs: number;
   private readonly inactivityTimeoutMs: number;
   private readonly sampleRate: number;
+  /**
+   * Whether speaker diarization is requested. Stored here but not yet
+   * forwarded to the Deepgram WebSocket — see the comment on
+   * {@link DeepgramRealtimeOptions.diarize}.
+   */
+  private readonly diarize: boolean;
 
   /** The live WebSocket connection, set during start(). */
   private ws: WsLike | null = null;
@@ -214,6 +230,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.inactivityTimeoutMs =
       options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.sampleRate = options.sampleRate ?? 16_000;
+    this.diarize = options.diarize ?? false;
   }
 
   // ── StreamingTranscriber interface ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `diarize: z.boolean().default(false)` to the Deepgram STT config schema.
- Add `diarize?: boolean` to `DeepgramRealtimeOptions` (constructor accepts and stores it; not yet passed to the WebSocket — that lands in PR 4).

Part of plan: meet-phase-1-6-speaker-labels.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
