### PR TITLE
meet/stt: route google-gemini through Live API streaming adapter

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -10,6 +10,12 @@ _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
 
+<!-- vellum-update-release:gemini-live-stt -->
+## Google Gemini speech-to-text now uses the Live API
+
+If your user is configured with `services.stt.provider: "google-gemini"`, transcription now streams over the Gemini Live WebSocket API and emits true partial transcripts in real time, instead of the previous polling approximation that re-uploaded the full audio buffer every second. Same Gemini API key, same setup — only the transport changed. Latency for partials should drop noticeably.
+<!-- /vellum-update-release:gemini-live-stt -->
+
 <!-- vellum-update-release:rm-dangerous-skip-perms -->
 ## `dangerouslySkipPermissions` removed
 

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -126,9 +126,9 @@ describe("STT provider catalog", () => {
     expect(entry?.conversationStreamingMode).toBe("realtime-ws");
   });
 
-  test("google-gemini has incremental-batch conversation streaming mode", () => {
+  test("google-gemini has realtime-ws conversation streaming mode", () => {
     const entry = getProviderEntry("google-gemini");
-    expect(entry?.conversationStreamingMode).toBe("incremental-batch");
+    expect(entry?.conversationStreamingMode).toBe("realtime-ws");
   });
 
   test("openai-whisper has incremental-batch conversation streaming mode", () => {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -531,10 +531,10 @@ describe("resolveConversationStreamingSttCapability", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Google Gemini — incremental-batch streaming
+  // Google Gemini — realtime-ws streaming (Live API)
   // -------------------------------------------------------------------------
 
-  test("returns 'supported' with incremental-batch mode for google-gemini", async () => {
+  test("returns 'supported' with realtime-ws mode for google-gemini", async () => {
     mockProviderKeys["gemini"] = "gemini-stream-key";
     mockConfig = buildConfig({ provider: "google-gemini" });
 
@@ -543,7 +543,7 @@ describe("resolveConversationStreamingSttCapability", () => {
     expect(result.status).toBe("supported");
     if (result.status === "supported") {
       expect(result.providerId).toBe("google-gemini");
-      expect(result.streamingMode).toBe("incremental-batch");
+      expect(result.streamingMode).toBe("realtime-ws");
     }
   });
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -191,7 +191,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
         "daemon-streaming",
       ]),
       telephonyMode: "batch-only",
-      conversationStreamingMode: "incremental-batch",
+      conversationStreamingMode: "realtime-ws",
       supportsDiarization: false,
       telephonyRouting: {
         strategyKind: "conversation-relay-native",

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -313,9 +313,10 @@ async function createStreamingTranscriber(
       });
     }
     case "google-gemini": {
-      const { GoogleGeminiStreamingTranscriber } =
-        await import("./google-gemini-stream.js");
-      return new GoogleGeminiStreamingTranscriber(apiKey, {
+      const { GoogleGeminiLiveStreamingTranscriber } = await import(
+        "./google-gemini-live-stream.js"
+      );
+      return new GoogleGeminiLiveStreamingTranscriber(apiKey, {
         pcmSampleRate: options.sampleRate,
       });
     }

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -192,7 +192,7 @@ private let fallbackRegistry = STTProviderRegistry(
             setupMode: .apiKey,
             setupHint: "Enter your Gemini API key to enable Google Gemini transcription.",
             apiKeyProviderName: "gemini",
-            conversationStreamingMode: .incrementalBatch,
+            conversationStreamingMode: .realtimeWs,
             credentialsGuide: STTCredentialsGuide(
                 description: "Visit Google AI Studio, sign in with your Google account, and create an API key.",
                 url: "https://aistudio.google.com/apikey",

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -22,7 +22,7 @@
       "setupMode": "api-key",
       "setupHint": "Enter your Gemini API key to enable Google Gemini transcription.",
       "apiKeyProviderName": "gemini",
-      "conversationStreamingMode": "incremental-batch",
+      "conversationStreamingMode": "realtime-ws",
       "credentialsGuide": {
         "description": "Visit Google AI Studio, sign in with your Google account, and create an API key.",
         "url": "https://aistudio.google.com/apikey",


### PR DESCRIPTION
## Summary
- Wires GoogleGeminiLiveStreamingTranscriber into resolve.ts as the active google-gemini streaming adapter
- Promotes google-gemini conversationStreamingMode from 'incremental-batch' to 'realtime-ws' across daemon catalog, client JSON, and Swift fallback
- Updates affected catalog/resolve unit tests and adds a release note in UPDATES.md
- Old batch-polling adapter file remains on disk for now (removed in PR 3)

Part of plan: gemini-live-stt.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
