### PR TITLE
deepgram: pass diarize to websocket + extract and emit speaker labels

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -86,7 +86,11 @@ class MockWebSocket {
 /** Build a Deepgram streaming "Results" JSON frame. */
 function resultsFrame(
   transcript: string,
-  options: { is_final?: boolean; speech_final?: boolean } = {},
+  options: {
+    is_final?: boolean;
+    speech_final?: boolean;
+    words?: { word: string; speaker?: number }[];
+  } = {},
 ): string {
   return JSON.stringify({
     type: "Results",
@@ -96,7 +100,13 @@ function resultsFrame(
     is_final: options.is_final ?? false,
     speech_final: options.speech_final ?? false,
     channel: {
-      alternatives: [{ transcript, confidence: 0.95 }],
+      alternatives: [
+        {
+          transcript,
+          confidence: 0.95,
+          ...(options.words ? { words: options.words } : {}),
+        },
+      ],
     },
   });
 }
@@ -312,6 +322,176 @@ describe("DeepgramRealtimeTranscriber", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual({ type: "final", text: "" });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Diarization: speakerLabel extraction
+  // ─────────────────────────────────────────────────────────────────
+
+  // Fixture A: diarize disabled (default) — baseline shape unchanged.
+  test("omits speakerLabel when diarization is disabled", async () => {
+    const { events } = await startSession();
+
+    mockWs.simulateMessage(resultsFrame("hello world", { is_final: true }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: "final", text: "hello world" });
+    // `in` check: the key must not exist at all, not just be undefined.
+    expect("speakerLabel" in events[0]).toBe(false);
+  });
+
+  // Fixture B: single-speaker segment with diarize on.
+  test("emits speakerLabel '0' for a single-speaker segment", async () => {
+    const { events } = await startSession({ diarize: true });
+
+    mockWs.simulateMessage(
+      resultsFrame("hello world", {
+        is_final: true,
+        words: [
+          { word: "hello", speaker: 0 },
+          { word: "world", speaker: 0 },
+        ],
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "hello world",
+      speakerLabel: "0",
+    });
+  });
+
+  // Fixture C: two speakers with one dominant — mode wins.
+  test("emits speakerLabel for the dominant speaker in a two-speaker segment", async () => {
+    const { events } = await startSession({ diarize: true });
+
+    // Speaker 1 says three words, speaker 0 says one — speaker 1 is the mode.
+    mockWs.simulateMessage(
+      resultsFrame("yes exactly right here", {
+        is_final: true,
+        words: [
+          { word: "yes", speaker: 0 },
+          { word: "exactly", speaker: 1 },
+          { word: "right", speaker: 1 },
+          { word: "here", speaker: 1 },
+        ],
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "yes exactly right here",
+      speakerLabel: "1",
+    });
+  });
+
+  // Fixture D: tied segment — first-word speaker wins.
+  test("breaks ties by picking the first word's speaker", async () => {
+    const { events } = await startSession({ diarize: true });
+
+    // 2 words for each speaker — tie. First word is speaker 2, so 2 wins.
+    mockWs.simulateMessage(
+      resultsFrame("alpha beta gamma delta", {
+        is_final: true,
+        words: [
+          { word: "alpha", speaker: 2 },
+          { word: "beta", speaker: 3 },
+          { word: "gamma", speaker: 2 },
+          { word: "delta", speaker: 3 },
+        ],
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "final",
+      text: "alpha beta gamma delta",
+      speakerLabel: "2",
+    });
+  });
+
+  // Also verify partials carry the label.
+  test("emits speakerLabel on partial events when diarization is enabled", async () => {
+    const { events } = await startSession({ diarize: true });
+
+    mockWs.simulateMessage(
+      resultsFrame("hel", {
+        is_final: false,
+        words: [{ word: "hel", speaker: 0 }],
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "partial",
+      text: "hel",
+      speakerLabel: "0",
+    });
+  });
+
+  // Diarize on, but the provider response carries no per-word speakers —
+  // speakerLabel must stay undefined/absent.
+  test("omits speakerLabel when words have no speaker field", async () => {
+    const { events } = await startSession({ diarize: true });
+
+    mockWs.simulateMessage(
+      resultsFrame("no speakers here", {
+        is_final: true,
+        words: [{ word: "no" }, { word: "speakers" }, { word: "here" }],
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: "final", text: "no speakers here" });
+    expect("speakerLabel" in events[0]).toBe(false);
+  });
+
+  test("forwards diarize=true to the Deepgram WebSocket URL", async () => {
+    let capturedUrl: string | undefined;
+    const origWs = (globalThis as Record<string, unknown>).WebSocket;
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(url: string) {
+        capturedUrl = url;
+        return mockWs;
+      }
+    };
+
+    const transcriber = new DeepgramRealtimeTranscriber(TEST_API_KEY, {
+      diarize: true,
+    });
+    const { onEvent } = createEventCollector();
+    const startPromise = transcriber.start(onEvent);
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get("diarize")).toBe("true");
+
+    (globalThis as Record<string, unknown>).WebSocket = origWs;
+  });
+
+  test("omits diarize param when diarization is disabled (default)", async () => {
+    let capturedUrl: string | undefined;
+    const origWs = (globalThis as Record<string, unknown>).WebSocket;
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(url: string) {
+        capturedUrl = url;
+        return mockWs;
+      }
+    };
+
+    const transcriber = new DeepgramRealtimeTranscriber(TEST_API_KEY);
+    const { onEvent } = createEventCollector();
+    const startPromise = transcriber.start(onEvent);
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get("diarize")).toBeNull();
+
+    (globalThis as Record<string, unknown>).WebSocket = origWs;
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -92,11 +92,11 @@ export interface DeepgramRealtimeOptions {
   /**
    * Enable Deepgram's built-in speaker diarization. Default: false.
    *
-   * NOTE: Accepted and stored today but NOT yet forwarded to the Deepgram
-   * WebSocket. Runtime wiring lands in the adapter PR that emits
-   * `speakerLabel` on streaming events (meet-phase-1-6 PR 4). This option
-   * is plumbed here first so the config schema and constructor surface are
-   * available for downstream callers without changing transcriber behavior.
+   * When true, `diarize=true` is appended to the Deepgram WebSocket URL,
+   * which causes Deepgram to include a `speaker` integer on each word in
+   * the response. The adapter aggregates per-segment speakers (mode, with
+   * first-word tiebreaker) into a `speakerLabel` emitted on partial/final
+   * events.
    */
   diarize?: boolean;
 }
@@ -105,10 +105,21 @@ export interface DeepgramRealtimeOptions {
 // Deepgram streaming response types (subset relevant to transcript events)
 // ---------------------------------------------------------------------------
 
+/**
+ * A single word within a Deepgram streaming alternative. When diarization is
+ * enabled, each word carries a `speaker` integer identifying the detected
+ * speaker turn.
+ */
+interface DeepgramStreamWord {
+  word?: string;
+  speaker?: number;
+}
+
 /** A single transcript alternative within a Deepgram streaming response. */
 interface DeepgramStreamAlternative {
   transcript?: string;
   confidence?: number;
+  words?: DeepgramStreamWord[];
 }
 
 /** A channel within a Deepgram streaming response. */
@@ -169,6 +180,56 @@ interface WsLike {
 const WS_OPEN = 1;
 
 // ---------------------------------------------------------------------------
+// Speaker-label aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick a representative speaker label from a Deepgram alternative's `words`
+ * array.
+ *
+ * Deepgram tags each word with a `speaker` integer when diarization is on.
+ * A single transcript segment can span multiple speakers if the endpointer
+ * didn't cleanly break between turns, so we aggregate:
+ *
+ * 1. Count occurrences of each `speaker` value across the words.
+ * 2. Pick the most common (mode).
+ * 3. On tie, pick the speaker of the first word in the segment.
+ * 4. If no word carries a `speaker` (diarization disabled or response variant),
+ *    return `undefined`.
+ *
+ * The returned label is `String(speaker)` to match the `speakerLabel` contract
+ * on {@link SttStreamServerPartialEvent} / {@link SttStreamServerFinalEvent}.
+ */
+function pickSpeakerLabel(
+  words: DeepgramStreamWord[] | undefined,
+): string | undefined {
+  if (!words || words.length === 0) return undefined;
+
+  const counts = new Map<number, number>();
+  let firstSpeaker: number | undefined;
+
+  for (const word of words) {
+    if (typeof word?.speaker !== "number") continue;
+    if (firstSpeaker === undefined) firstSpeaker = word.speaker;
+    counts.set(word.speaker, (counts.get(word.speaker) ?? 0) + 1);
+  }
+
+  if (counts.size === 0 || firstSpeaker === undefined) return undefined;
+
+  // Find the max count; on ties, prefer the first-word speaker.
+  let bestSpeaker = firstSpeaker;
+  let bestCount = counts.get(firstSpeaker) ?? 0;
+  for (const [speaker, count] of counts) {
+    if (count > bestCount) {
+      bestSpeaker = speaker;
+      bestCount = count;
+    }
+  }
+
+  return String(bestSpeaker);
+}
+
+// ---------------------------------------------------------------------------
 // Adapter implementation
 // ---------------------------------------------------------------------------
 
@@ -193,9 +254,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private readonly inactivityTimeoutMs: number;
   private readonly sampleRate: number;
   /**
-   * Whether speaker diarization is requested. Stored here but not yet
-   * forwarded to the Deepgram WebSocket — see the comment on
-   * {@link DeepgramRealtimeOptions.diarize}.
+   * Whether speaker diarization is requested. When true, `diarize=true` is
+   * forwarded to the Deepgram WebSocket and per-word `speaker` values are
+   * aggregated into a `speakerLabel` on each emitted transcript event.
    */
   private readonly diarize: boolean;
 
@@ -459,19 +520,34 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * We emit:
    * - `partial` for `is_final: false` frames (if interim results enabled).
    * - `final` for `is_final: true` frames.
+   *
+   * When diarization is enabled, Deepgram attaches a per-word `speaker`
+   * integer; we aggregate these into a single `speakerLabel` via
+   * {@link pickSpeakerLabel}.
    */
   private handleTranscriptFrame(frame: DeepgramStreamResponse): void {
-    const transcript = frame.channel?.alternatives?.[0]?.transcript;
+    const alternative = frame.channel?.alternatives?.[0];
+    const transcript = alternative?.transcript;
 
     // Extract text, defaulting to empty string for silence segments.
     const text = typeof transcript === "string" ? transcript.trim() : "";
 
+    const speakerLabel = pickSpeakerLabel(alternative?.words);
+
     if (frame.is_final) {
       // Committed transcript — emit as final.
-      this.emitEvent({ type: "final", text });
+      this.emitEvent(
+        speakerLabel !== undefined
+          ? { type: "final", text, speakerLabel }
+          : { type: "final", text },
+      );
     } else if (this.interimResults) {
       // Interim transcript — emit as partial.
-      this.emitEvent({ type: "partial", text });
+      this.emitEvent(
+        speakerLabel !== undefined
+          ? { type: "partial", text, speakerLabel }
+          : { type: "partial", text },
+      );
     }
   }
 
@@ -638,6 +714,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     }
     if (this.utteranceEndMs !== undefined) {
       params.set("utterance_end_ms", String(this.utteranceEndMs));
+    }
+    if (this.diarize) {
+      params.set("diarize", "true");
     }
 
     // Enable punctuation for cleaner transcript output.


### PR DESCRIPTION
## Summary
- When `diarize: true` is set, append `diarize=true` to the Deepgram WebSocket query.
- Aggregate per-word `speaker` values per segment (mode, ties broken by first word) and emit as `speakerLabel` on partial/final events.
- With `diarize: false` (default), event shape is unchanged.

Part of plan: meet-phase-1-6-speaker-labels.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
