### PR TITLE
fix(meet): pass 16kHz sampleRate to STT resolver; drop dead MeetAudioIngestError brand

### DIFF
--- a/assistant/src/meet/__tests__/audio-ingest.test.ts
+++ b/assistant/src/meet/__tests__/audio-ingest.test.ts
@@ -317,7 +317,7 @@ describe("MeetAudioIngest.start", () => {
     try {
       await rejection;
     } catch (err) {
-      expect(MeetAudioIngestError.isMeetAudioIngestError(err)).toBe(true);
+      expect(err).toBeInstanceOf(MeetAudioIngestError);
     }
 
     // listen() was never called — socket path is uncreated and does not leak.

--- a/assistant/src/meet/audio-ingest.ts
+++ b/assistant/src/meet/audio-ingest.ts
@@ -62,50 +62,35 @@ const log = getLogger("meet-audio-ingest");
  */
 export const BOT_CONNECT_TIMEOUT_MS = 30_000;
 
+/**
+ * Sample rate (Hz) of the PCM frames the meet-bot captures and forwards over
+ * the audio socket. Mirrors `DEFAULT_RATE_HZ` in
+ * `meet-bot/src/media/audio-capture.ts` — duplicated here rather than
+ * imported because the daemon does not import from the `meet-bot` package
+ * (they ship as separate artifacts). Must be kept in sync with the bot's
+ * capture rate; otherwise providers whose adapter default differs
+ * (e.g. Gemini defaults to 48 kHz) will decode at the wrong rate and
+ * produce garbled transcripts.
+ */
+const MEET_BOT_SAMPLE_RATE_HZ = 16_000;
+
 // ---------------------------------------------------------------------------
 // Error class
 // ---------------------------------------------------------------------------
-
-/**
- * Symbol brand for {@link MeetAudioIngestError}. Declared at module scope
- * (not nested in the class) so `readonly [MEET_AUDIO_INGEST_ERROR_BRAND]`
- * can reference it without TDZ issues.
- */
-const MEET_AUDIO_INGEST_ERROR_BRAND: unique symbol = Symbol.for(
-  "MeetAudioIngestError",
-);
 
 /**
  * Marker error thrown by {@link MeetAudioIngest} when the ingest cannot
  * start because no streaming-capable STT provider is configured or the
  * configured provider lacks credentials.
  *
- * The session manager uses {@link MeetAudioIngestError.isMeetAudioIngestError}
- * to distinguish this from generic ingest errors when composing the
- * user-facing join-failure message.
+ * Exported as a named subclass so callers that need to distinguish this
+ * from generic ingest errors can use `instanceof MeetAudioIngestError`.
  */
 export class MeetAudioIngestError extends Error {
   readonly name = "MeetAudioIngestError";
-  /**
-   * Symbol-based brand so structural checks (e.g. across module boundaries
-   * where `instanceof` may mis-report after module reload) can still
-   * reliably identify instances of this error.
-   */
-  readonly [MEET_AUDIO_INGEST_ERROR_BRAND] = true as const;
 
   constructor(message: string) {
     super(message);
-  }
-
-  static isMeetAudioIngestError(err: unknown): err is MeetAudioIngestError {
-    if (err instanceof MeetAudioIngestError) return true;
-    return (
-      typeof err === "object" &&
-      err !== null &&
-      (err as { [MEET_AUDIO_INGEST_ERROR_BRAND]?: boolean })[
-        MEET_AUDIO_INGEST_ERROR_BRAND
-      ] === true
-    );
   }
 }
 
@@ -471,12 +456,20 @@ export class MeetAudioIngest {
  * assistant's STT catalog (reads `services.stt.provider` and looks up
  * credentials centrally).
  *
+ * Passes the meet-bot's capture sample rate through to the resolver so
+ * provider adapters decode at the correct rate regardless of their
+ * per-adapter defaults (Deepgram/Whisper default to 16 kHz but Gemini
+ * defaults to 48 kHz — passing the rate explicitly keeps all three
+ * producing intelligible transcripts).
+ *
  * Throws {@link MeetAudioIngestError} when no streaming-capable provider
  * is configured so the session manager can surface a clear join-failure
  * message pointing at `services.stt.provider`.
  */
 async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
-  const transcriber = await resolveStreamingTranscriber();
+  const transcriber = await resolveStreamingTranscriber({
+    sampleRate: MEET_BOT_SAMPLE_RATE_HZ,
+  });
   if (!transcriber) {
     throw new MeetAudioIngestError(
       "No streaming-capable STT provider is configured. " +


### PR DESCRIPTION
## Summary
- `MeetAudioIngest.defaultCreateTranscriber()` now passes `{ sampleRate: 16_000 }` to `resolveStreamingTranscriber()`. Fixes garbled transcripts for users configured with `services.stt.provider: "google-gemini"` — Gemini's default is 48 kHz but the Meet bot captures at 16 kHz.
- Drop the unused `MEET_AUDIO_INGEST_ERROR_BRAND` symbol and `isMeetAudioIngestError` static helper on `MeetAudioIngestError`. The class JSDoc claimed the session manager used these to distinguish ingest errors, but the session manager never did. Use native `instanceof` in the one test that referenced the helper.

Fixes gap identified during plan review for meet-phase-1-5-stt-provider.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
