### PR TITLE
fix(meet-bot): fix Docker build by moving context to repo root

### DIFF
--- a/meet-bot/.dockerignore
+++ b/meet-bot/.dockerignore
@@ -1,5 +1,0 @@
-node_modules
-__tests__
-*.md
-.env*
-dist

--- a/meet-bot/Dockerfile
+++ b/meet-bot/Dockerfile
@@ -7,10 +7,25 @@
 # The real Meet-join + audio-capture logic lands in later PRs of the
 # meet-phase-1 plan; this image just needs to build cleanly and boot
 # `bun src/main.ts` to completion so CI can smoke-test the structure.
+#
+# Build context: the REPO ROOT (not `meet-bot/`). The meet-bot package
+# depends on the sibling workspace package `packages/meet-contracts` via
+# `file:../packages/meet-contracts` in its package.json. For `bun install`
+# to resolve that relative path inside the image, the sibling package has
+# to be copied in alongside meet-bot under the same parent directory. We
+# therefore set WORKDIR to `/app/meet-bot`, copy `meet-bot/*` into it, and
+# copy `packages/meet-contracts` to `/app/packages/meet-contracts` so the
+# relative `../packages/meet-contracts` reference resolves.
+#
+# Related files:
+#   - `scripts/build-meet-bot-image.sh` sets the context to `.` (repo root).
+#   - `meet-bot/Dockerfile.dockerignore` narrows the context back down. It
+#     is named `Dockerfile.dockerignore` (not `.dockerignore`) so it takes
+#     precedence over the existing repo-root `.dockerignore`, which targets
+#     different images. See:
+#     https://docs.docker.com/build/concepts/context/#dockerignore-files
 
 FROM oven/bun:1-debian
-
-WORKDIR /app
 
 # System dependencies. Keep this list grouped and sorted so future PRs can
 # add/remove packages cleanly.
@@ -34,9 +49,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app/meet-bot
+
+# Copy the sibling workspace package BEFORE meet-bot/package.json's install
+# so the `file:../packages/meet-contracts` dep in package.json resolves.
+COPY packages/meet-contracts /app/packages/meet-contracts
+
 # Install JS dependencies first so Docker can cache the layer when only
 # source files change.
-COPY package.json ./
+COPY meet-bot/package.json meet-bot/tsconfig.json ./
 RUN bun install
 
 # Pull Playwright's Chromium build. This is kept separate from apt's
@@ -44,13 +65,13 @@ RUN bun install
 # the `playwright` package version pinned in package.json.
 RUN bunx playwright install chromium
 
-COPY src ./src
+COPY meet-bot/src ./src
 
 # The PulseAudio bootstrap script is shelled out to at container start by
 # `src/media/pulse.ts`; ensure the executable bit is set in the image so the
 # runtime `bash` invocation succeeds. The script is NOT run at build time —
 # PulseAudio needs a live container environment (runtime, not image layer).
-RUN chmod +x /app/src/media/pulse-setup.sh
+RUN chmod +x /app/meet-bot/src/media/pulse-setup.sh
 
 # The placeholder probe lives at src/health.ts and exits 0; real health
 # logic lands in a later PR (see meet-phase-1 plan PR 8).

--- a/meet-bot/Dockerfile.dockerignore
+++ b/meet-bot/Dockerfile.dockerignore
@@ -1,0 +1,36 @@
+# Build context is the REPO ROOT (see `scripts/build-meet-bot-image.sh` and
+# the comment at the top of `meet-bot/Dockerfile` for why). To keep the
+# context small — tens-of-MB repos take noticeable time to send to the
+# Docker daemon — we exclude EVERYTHING and then allow-list only the paths
+# the Dockerfile actually COPYs in.
+#
+# Docker's .dockerignore supports negated patterns with a leading `!`. With
+# a leading `**` that excludes everything, we must un-ignore each directory
+# AND its descendants (`!meet-bot/**`, not just `!meet-bot/`). See:
+# https://docs.docker.com/build/concepts/context/#dockerignore-files
+**
+
+# Un-ignore the meet-bot package directory AND its contents. We list both
+# `!meet-bot` and `!meet-bot/**` because BuildKit's COPY <dir> emits a
+# spurious `CopyIgnoredFile` warning when only the descendants are
+# un-ignored — the directory itself stays matched by `**`.
+!meet-bot
+!meet-bot/**
+
+# Re-ignore local dev artifacts that are never needed in the image.
+meet-bot/node_modules
+meet-bot/dist
+meet-bot/.env*
+meet-bot/*.md
+meet-bot/__tests__
+
+# Un-ignore the sibling workspace package that meet-bot depends on via
+# `file:../packages/meet-contracts` in its package.json.
+!packages
+!packages/meet-contracts
+!packages/meet-contracts/**
+
+# Re-ignore dev artifacts in the sibling package too.
+packages/meet-contracts/node_modules
+packages/meet-contracts/dist
+packages/meet-contracts/__tests__

--- a/scripts/build-meet-bot-image.sh
+++ b/scripts/build-meet-bot-image.sh
@@ -6,6 +6,16 @@
 # tags the image as `vellum-meet-bot:dev` so local smoke tests can reference
 # a stable tag without colliding with whatever CI produces.
 #
+# The build context is the REPO ROOT (not `meet-bot/`) because meet-bot
+# depends on the workspace-relative package `packages/meet-contracts` via a
+# `file:../packages/meet-contracts` entry in package.json. Setting the
+# context to the repo root lets the Dockerfile COPY that sibling package in
+# before running `bun install`. The companion `meet-bot/Dockerfile.dockerignore`
+# keeps the effective context small by ignoring everything outside the
+# paths we actually need. It is named `Dockerfile.dockerignore` (rather
+# than `.dockerignore`) so it takes precedence over the existing repo-root
+# `.dockerignore` file, which targets other images.
+#
 # Usage:
 #   ./scripts/build-meet-bot-image.sh
 
@@ -14,4 +24,4 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-docker build -t vellum-meet-bot:dev -f meet-bot/Dockerfile meet-bot/
+docker build -t vellum-meet-bot:dev -f meet-bot/Dockerfile .


### PR DESCRIPTION
## Summary
- Moves docker build context from `meet-bot/` to repo root so `packages/meet-contracts` is reachable to `bun install`.
- Dockerfile COPY paths updated to repo-root-relative; `.dockerignore` narrowed to preserve small context.
- `scripts/build-meet-bot-image.sh` updated accordingly.

Addresses Gap F from meet-phase-1-listen.md self-review — the default `containerImage: vellum-meet-bot:dev` could not be built from the committed script.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
