### PR TITLE
docs(meet): update Gemini latency/default references after Live API switch

### DIFF
--- a/assistant/src/meet/audio-ingest.ts
+++ b/assistant/src/meet/audio-ingest.ts
@@ -68,9 +68,9 @@ export const BOT_CONNECT_TIMEOUT_MS = 30_000;
  * `meet-bot/src/media/audio-capture.ts` — duplicated here rather than
  * imported because the daemon does not import from the `meet-bot` package
  * (they ship as separate artifacts). Must be kept in sync with the bot's
- * capture rate; otherwise providers whose adapter default differs
- * (e.g. Gemini defaults to 48 kHz) will decode at the wrong rate and
- * produce garbled transcripts.
+ * capture rate and passed explicitly to each STT adapter so ingest does not
+ * silently rely on any per-provider default; a mismatch would cause the
+ * provider to decode at the wrong rate and produce garbled transcripts.
  */
 const MEET_BOT_SAMPLE_RATE_HZ = 16_000;
 
@@ -450,10 +450,10 @@ export class MeetAudioIngest {
  * credentials centrally).
  *
  * Passes the meet-bot's capture sample rate through to the resolver so
- * provider adapters decode at the correct rate regardless of their
- * per-adapter defaults (Deepgram/Whisper default to 16 kHz but Gemini
- * defaults to 48 kHz — passing the rate explicitly keeps all three
- * producing intelligible transcripts).
+ * Meet's audio ingest does not depend on any adapter's per-provider default.
+ * All three streaming adapters happen to default to 16 kHz today, but being
+ * explicit insulates us from a future adapter changing its default out from
+ * under ingest.
  *
  * Throws {@link MeetAudioIngestError} when no streaming-capable provider
  * is configured so the session manager can surface a clear join-failure

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -54,4 +54,4 @@ When a single meeting is active, `meetingId` can be omitted — the tool targets
 
 ## Transcription
 
-Transcription quality and latency reflect the user's configured `services.stt.provider`. Deepgram returns sub-second partials over a WebSocket; Gemini and Whisper are chunked (roughly 1 s and 400 ms poll intervals respectively) and therefore produce finals slightly later. Speaker attribution in meeting transcripts is derived from the Meet DOM active-speaker signal — it is independent of the STT provider.
+Transcription quality and latency reflect the user's configured `services.stt.provider`. Deepgram and Gemini stream over a WebSocket and return sub-second partials; Whisper approximates streaming with ~400 ms polls and therefore produces finals slightly later. Speaker attribution in meeting transcripts is derived from the Meet DOM active-speaker signal — it is independent of the STT provider.


### PR DESCRIPTION
## Summary
- `skills/meet-join/SKILL.md`: Gemini now streams over the Live API (WebSocket, sub-second partials), not chunked polling. Update the transcription note.
- `assistant/src/meet/audio-ingest.ts`: drop the now-wrong "Gemini defaults to 48 kHz" justifications for passing `sampleRate` explicitly. Reframe as defensive hygiene — the Live API adapter defaults to 16 kHz like Deepgram and Whisper.

Fixes gaps identified during round-2 plan review for meet-phase-1-5-stt-provider.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
