### PR TITLE
meet: MeetAudioIngest requests diarization via resolver

### DIFF
--- a/assistant/src/meet/__tests__/audio-ingest.test.ts
+++ b/assistant/src/meet/__tests__/audio-ingest.test.ts
@@ -12,6 +12,30 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+// Intercept `resolveStreamingTranscriber` so we can assert the default
+// `createTranscriber` path passes the expected diarize preference through.
+// Tests that inject their own `createTranscriber` never hit this mock.
+let mockResolveCalls: Array<Record<string, unknown> | undefined> = [];
+let mockResolveResult: StreamingTranscriber | null = null;
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  resolveStreamingTranscriber: async (
+    options?: Record<string, unknown>,
+  ) => {
+    mockResolveCalls.push(options);
+    return mockResolveResult;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test — after mocks
+// ---------------------------------------------------------------------------
+
 import {
   BOT_CONNECT_TIMEOUT_MS,
   MeetAudioIngest,
@@ -202,6 +226,8 @@ function newIngestSetup(): {
 
 beforeEach(() => {
   __resetMeetSessionEventRouterForTests();
+  mockResolveCalls = [];
+  mockResolveResult = null;
 });
 
 afterEach(() => {
@@ -464,6 +490,61 @@ describe("MeetAudioIngest — audio forwarding + transcript dispatch", () => {
     await setup.ingest.stop();
   });
 
+  test("propagates speakerLabel from partial and final events into TranscriptChunkEvent", async () => {
+    const setup = newIngestSetup();
+    const captured: Array<unknown> = [];
+    getMeetSessionEventRouter().register("m-speaker", (e) => captured.push(e));
+
+    const startPromise = setup.ingest.start("m-speaker", "/tmp/speaker.sock");
+    await flushMicrotasks();
+    setup.server.connectBot();
+    await startPromise;
+
+    // Partial event with a speaker label.
+    setup.session.emit({ type: "partial", text: "hi ", speakerLabel: "1" });
+    // Final event with a different speaker label.
+    setup.session.emit({
+      type: "final",
+      text: "hi there.",
+      speakerLabel: "2",
+    });
+    // Event without a speaker label — field stays undefined.
+    setup.session.emit({ type: "partial", text: "..." });
+
+    expect(captured).toHaveLength(3);
+
+    const partial = captured[0] as {
+      type: string;
+      isFinal: boolean;
+      text: string;
+      speakerLabel?: string;
+    };
+    expect(partial.type).toBe("transcript.chunk");
+    expect(partial.isFinal).toBe(false);
+    expect(partial.text).toBe("hi ");
+    expect(partial.speakerLabel).toBe("1");
+
+    const final = captured[1] as {
+      type: string;
+      isFinal: boolean;
+      text: string;
+      speakerLabel?: string;
+    };
+    expect(final.type).toBe("transcript.chunk");
+    expect(final.isFinal).toBe(true);
+    expect(final.text).toBe("hi there.");
+    expect(final.speakerLabel).toBe("2");
+
+    const unlabeled = captured[2] as {
+      type: string;
+      speakerLabel?: string;
+    };
+    expect(unlabeled.type).toBe("transcript.chunk");
+    expect(unlabeled.speakerLabel).toBeUndefined();
+
+    await setup.ingest.stop();
+  });
+
   test("does not dispatch non-transcript events (error / closed)", async () => {
     const setup = newIngestSetup();
     const captured: Array<unknown> = [];
@@ -535,5 +616,57 @@ describe("MeetAudioIngest.stop", () => {
 
     // Stop was synchronous wrt. the connection — any late data is dropped.
     expect(setup.session.audioChunks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default transcriber factory — diarization wiring
+// ---------------------------------------------------------------------------
+
+describe("MeetAudioIngest — default transcriber factory", () => {
+  test("requests diarize: preferred from the resolver", async () => {
+    // The fake resolver returns a minimal StreamingTranscriber so the
+    // ingest has something to drive. We don't exercise the streaming path
+    // here — we just need start() to reach the resolver call.
+    const fakeSession = new FakeStreamingTranscriber();
+    mockResolveResult = fakeSession;
+
+    // No createTranscriber override — exercises the default factory path.
+    const ingest = new MeetAudioIngest({
+      listen: async () => new FakeUnixSocketServer(),
+      botConnectTimeoutMs: 1_000,
+    });
+
+    // Kick off start(); we don't need it to resolve, just to call the
+    // resolver. Attach a noop rejection handler so the bot-connect timeout
+    // doesn't surface as an unhandled rejection when the test finishes.
+    const startPromise = ingest.start("m-diarize", "/tmp/diarize.sock");
+    startPromise.catch(() => {});
+    await flushMicrotasks();
+
+    expect(mockResolveCalls).toHaveLength(1);
+    const opts = mockResolveCalls[0];
+    expect(opts).toBeDefined();
+    expect((opts as { diarize?: string }).diarize).toBe("preferred");
+    // Sanity check that the sample rate is still forwarded.
+    expect((opts as { sampleRate?: number }).sampleRate).toBeGreaterThan(0);
+
+    await ingest.stop();
+  });
+
+  test("throws MeetAudioIngestError when the resolver returns null", async () => {
+    // Unusable provider configuration — resolver returns null.
+    mockResolveResult = null;
+
+    const ingest = new MeetAudioIngest({
+      listen: async () => new FakeUnixSocketServer(),
+    });
+
+    await expect(ingest.start("m-null", "/tmp/null.sock")).rejects.toThrow(
+      MeetAudioIngestError,
+    );
+    await expect(ingest.start("m-null2", "/tmp/null2.sock")).rejects.toThrow(
+      /configured STT provider is unusable/i,
+    );
   });
 });

--- a/assistant/src/meet/audio-ingest.ts
+++ b/assistant/src/meet/audio-ingest.ts
@@ -426,14 +426,21 @@ export class MeetAudioIngest {
       return;
     }
 
-    // The existing streaming transcribers do not yet surface speaker /
-    // confidence metadata; leave those optional fields unset.
+    // `speakerLabel` is populated by provider adapters that support
+    // diarization (currently Deepgram). Non-diarizing providers leave it
+    // undefined — downstream consumers treat that as "unknown speaker".
+    // Stable `speakerId` and `confidence` remain unset; the speaker
+    // resolver (PR 7) will derive `speakerId` by cross-checking the
+    // label against Meet's DOM-sourced active-speaker signal.
     const transcript: TranscriptChunkEvent = {
       type: "transcript.chunk",
       meetingId,
       timestamp: new Date().toISOString(),
       isFinal: event.type === "final",
       text: event.text,
+      ...(event.speakerLabel !== undefined
+        ? { speakerLabel: event.speakerLabel }
+        : {}),
     };
 
     getMeetSessionEventRouter().dispatch(meetingId, transcript);
@@ -455,17 +462,27 @@ export class MeetAudioIngest {
  * defaults to 48 kHz — passing the rate explicitly keeps all three
  * producing intelligible transcripts).
  *
- * Throws {@link MeetAudioIngestError} when no streaming-capable provider
- * is configured so the session manager can surface a clear join-failure
- * message pointing at `services.stt.provider`.
+ * Requests `diarize: "preferred"` so capable providers (Deepgram) emit
+ * speaker labels that the downstream speaker resolver can cross-check
+ * against Meet's DOM-sourced active-speaker signal. Providers that
+ * don't support diarization (Gemini, Whisper) silently no-op — Meet
+ * still works, the DOM remains the only speaker source.
+ *
+ * Throws {@link MeetAudioIngestError} when the resolver returns `null`.
+ * With `"preferred"` that only happens when the configured STT provider
+ * is entirely unusable (unknown provider, no streaming support, missing
+ * credentials, or no adapter) — never due to a lack of diarization
+ * capability. The error message points the user at
+ * `services.stt.provider`.
  */
 async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
   const transcriber = await resolveStreamingTranscriber({
     sampleRate: MEET_BOT_SAMPLE_RATE_HZ,
+    diarize: "preferred",
   });
   if (!transcriber) {
     throw new MeetAudioIngestError(
-      "No streaming-capable STT provider is configured. " +
+      "The configured STT provider is unusable for Meet transcription. " +
         "Set services.stt.provider to deepgram, google-gemini, or openai-whisper " +
         "and ensure credentials are present.",
     );


### PR DESCRIPTION
## Summary
- Default `createTranscriber` now passes `diarize: "preferred"` to `resolveStreamingTranscriber`. Capable providers (Deepgram) get diarization on; others silently no-op.
- Wire `speakerLabel` from `SttStreamServerEvent` into the dispatched `TranscriptChunkEvent` so PR 7's resolver can consume it.
- Updated stale comment that referenced the now-removed dead-end.

Part of plan: meet-phase-1-6-speaker-labels.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
