### PR TITLE
fix(test): drain enrichment queue between commits in heartbeat test

### DIFF
--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -342,6 +342,13 @@ describe("WorkspaceHeartbeatService", () => {
       const firstResult = await heartbeat.check();
       expect(firstResult.committed).toBe(1);
 
+      // Drain fire-and-forget enrichment from the first commit before the
+      // next commit. Enrichment's writeNote() can leave a stale index.lock
+      // on some git versions (see heartbeat-service.ts:240-242), causing
+      // the subsequent commit to fail with "index.lock: File exists".
+      await getEnrichmentService().shutdown();
+      _resetEnrichmentService();
+
       // Create new changes after the commit
       writeFileSync(join(testDir, "file2.txt"), "more content");
 


### PR DESCRIPTION
## Summary
- The \`resets dirty tracking after successful commit\` test in \`workspace-heartbeat-service.test.ts\` was flaky on CI with \`fatal: Unable to create '.git/index.lock': File exists\`.
- Root cause: the first commit's fire-and-forget enrichment (\`writeNote\` via \`git notes add\`) can leave a stale \`index.lock\` that races with the subsequent commit.
- Fix follows the precedent from PR #22820: drain and reset the enrichment service between the first commit and the subsequent commits.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24445981732/job/71422339778