### PR TITLE
meet: consent-monitor timer skips LLM when no new non-bot content

### DIFF
--- a/assistant/src/meet/__tests__/consent-monitor.test.ts
+++ b/assistant/src/meet/__tests__/consent-monitor.test.ts
@@ -141,6 +141,21 @@ function inboundChat(
   };
 }
 
+function participantChange(
+  meetingId: string,
+  timestamp: string,
+  joined: Array<{ id: string; name: string; isSelf?: boolean }>,
+  left: Array<{ id: string; name: string; isSelf?: boolean }> = [],
+): MeetBotEvent {
+  return {
+    type: "participant.change",
+    meetingId,
+    timestamp,
+    joined,
+    left,
+  };
+}
+
 async function flushPromises(): Promise<void> {
   for (let i = 0; i < 3; i++) await Promise.resolve();
 }
@@ -440,6 +455,271 @@ describe("MeetConsentMonitor timer tick", () => {
     timer.fire();
     await flushPromises();
     expect(llm).toHaveBeenCalledTimes(0);
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor content-watermark tick skip", () => {
+  test("silent meeting after one early chunk: only the first tick fires LLM", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        // Phrase that won't keyword-match — only the tick can escalate.
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // Content arrives once before any timer fires.
+    t = 1_000;
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "morning everyone, lets get started",
+        { speakerLabel: "Alice", speakerId: "alice" },
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(0);
+
+    // Tick #1: content advanced since the (null) watermark → fires.
+    t = 20_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Tick #2: silent stretch — content watermark unchanged → skipped.
+    t = 40_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Tick #3: still silent — still skipped.
+    t = 60_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+  });
+
+  test("active meeting with new content every tick: every tick fires LLM", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        // No keyword match — exercise only the tick path.
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // Three ticks, each preceded by a fresh transcript chunk ~10s in.
+    for (let tickIndex = 1; tickIndex <= 3; tickIndex++) {
+      t = (tickIndex - 1) * 20_000 + 10_000;
+      dispatcher.dispatch(
+        "m1",
+        transcriptChunk(
+          "m1",
+          new Date(t).toISOString(),
+          `something interesting ${tickIndex}`,
+          { speakerLabel: "Alice", speakerId: "alice" },
+        ),
+      );
+      await flushPromises();
+
+      t = tickIndex * 20_000;
+      timer.fire();
+      await flushPromises();
+
+      expect(llm).toHaveBeenCalledTimes(tickIndex);
+    }
+
+    monitor.stop();
+  });
+
+  test("participant join: next tick fires LLM even if joiner has not spoken", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // Seed prior content + tick so the watermark catches up.
+    t = 1_000;
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "kicking things off",
+        { speakerLabel: "Alice", speakerId: "alice" },
+      ),
+    );
+    await flushPromises();
+
+    t = 20_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Next tick with no new content would normally be skipped …
+    t = 40_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // … but a participant joining advances the watermark even though
+    // they haven't said anything yet.
+    t = 50_000;
+    dispatcher.dispatch(
+      "m1",
+      participantChange("m1", "2024-01-01T00:00:50.000Z", [
+        { id: "bob", name: "Bob" },
+      ]),
+    );
+    await flushPromises();
+
+    t = 60_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+  });
+
+  test("regression: keyword hit still fires LLM regardless of watermark", async () => {
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // First keyword hit: fires LLM (1).
+    t = 1_000;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:01.000Z",
+        "actually please leave the call",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Tick after the keyword path runs: keyword path does NOT advance the
+    // watermark, so content is "newer" than the tick watermark → tick fires
+    // a second LLM call. This is the deliberate semantic in the plan
+    // ("keyword path unchanged"); a tick still re-examines the buffer.
+    t = 20_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(2);
+
+    // Now no new content. Next tick is skipped by the watermark check.
+    t = 40_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(2);
+
+    // A second keyword hit (different text so dedupe doesn't swallow it)
+    // ALWAYS fires the LLM regardless of the watermark.
+    t = 45_000;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:45.000Z",
+        "really, please leave now",
+        "Bob",
+        "b",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(3);
 
     monitor.stop();
   });

--- a/assistant/src/meet/consent-monitor.ts
+++ b/assistant/src/meet/consent-monitor.ts
@@ -36,6 +36,7 @@
 import type {
   InboundChatEvent,
   MeetBotEvent,
+  ParticipantChangeEvent,
   TranscriptChunkEvent,
 } from "@vellumai/meet-contracts";
 
@@ -188,6 +189,37 @@ export class MeetConsentMonitor {
   /** In-flight flag so overlapping keyword hits don't fan out LLM calls. */
   private llmInFlight = false;
 
+  /**
+   * Monotonic timestamp (`this.now()`) of the most recent content-bearing
+   * event: a final transcript chunk from a non-bot speaker, an inbound
+   * chat message (the bot's own outbound chat is already stripped upstream
+   * by the chat reader's self-filter), or a `participant.change` with a
+   * non-bot joiner. Compared against {@link lastLlmCheckContentTimestamp}
+   * on every timer tick to decide whether any new objection signal has
+   * actually arrived since the last LLM check.
+   */
+  private lastContentTimestamp: number | null = null;
+
+  /**
+   * Value of {@link lastContentTimestamp} at the moment the tick-driven LLM
+   * check last fired (or `null` before the first tick-driven check). When
+   * a timer tick finds `lastContentTimestamp === lastLlmCheckContentTimestamp`
+   * it means no content-bearing event has arrived since the previous check,
+   * so the tick is skipped. Keyword-triggered LLM calls are unchanged by
+   * this watermark — only the 20s tick path both consults and advances it.
+   */
+  private lastLlmCheckContentTimestamp: number | null = null;
+
+  /**
+   * The bot's own participant id, discovered lazily from the first
+   * `participant.change` event whose `joined[].isSelf === true`. Used to
+   * drop transcript chunks whose resolved speaker id matches the bot (the
+   * bot is a silent listener, so this should never happen in practice, but
+   * cheap defense-in-depth keeps the watermark honest if an ASR pipeline
+   * mis-tags a chunk).
+   */
+  private botParticipantId: string | null = null;
+
   constructor(deps: MeetConsentMonitorDeps) {
     this.meetingId = deps.meetingId;
     this.assistantId = deps.assistantId;
@@ -264,6 +296,10 @@ export class MeetConsentMonitor {
         this.onInboundChat(event);
         return;
       }
+      if (event.type === "participant.change") {
+        this.onParticipantChange(event);
+        return;
+      }
     } catch (err) {
       log.warn(
         { err, meetingId: this.meetingId, eventType: event.type },
@@ -290,6 +326,18 @@ export class MeetConsentMonitor {
     this.transcriptBuffer.push(entry);
     this.trimTranscriptBuffer();
 
+    // Content-bearing for the tick-skip watermark iff the speaker is not
+    // the bot itself. The bot is a silent listener, so `speakerId ===
+    // botParticipantId` should be vanishingly rare — we guard it anyway so
+    // a mis-tagged ASR chunk can't falsely advance the watermark.
+    if (
+      this.botParticipantId === null ||
+      event.speakerId === undefined ||
+      event.speakerId !== this.botParticipantId
+    ) {
+      this.lastContentTimestamp = this.now();
+    }
+
     if (this.matchesKeyword(raw)) {
       void this.maybeRunLLMCheck("keyword:transcript");
     }
@@ -309,8 +357,49 @@ export class MeetConsentMonitor {
     this.chatBuffer.push(entry);
     while (this.chatBuffer.length > CHAT_BUFFER_SIZE) this.chatBuffer.shift();
 
+    // Every `InboundChatEvent` the monitor receives is already non-self —
+    // the in-page chat reader strips the bot's own outbound messages via
+    // its `selfName`/`data-is-self` filter before publishing the event.
+    // A defensive `fromId === botParticipantId` check is layered on top in
+    // case the upstream filter ever regresses.
+    if (
+      this.botParticipantId === null ||
+      event.fromId !== this.botParticipantId
+    ) {
+      this.lastContentTimestamp = this.now();
+    }
+
     if (this.matchesKeyword(raw)) {
       void this.maybeRunLLMCheck("keyword:chat");
+    }
+  }
+
+  /**
+   * New participants are exactly when a re-check is cheap insurance —
+   * someone who hasn't seen the consent disclosure may object immediately.
+   * Reset the watermark so the next 20s tick fires an LLM call regardless
+   * of whether the new participant has spoken yet. The `isSelf` joiner
+   * also gives us the bot's participant id, which is used downstream to
+   * ignore bot-tagged transcript chunks.
+   *
+   * Only `joined.length > 0` is content-bearing — leaves and speaker-tile
+   * changes are not, since "someone left" never creates a fresh objection
+   * risk the monitor hasn't already seen.
+   */
+  private onParticipantChange(event: ParticipantChangeEvent): void {
+    for (const participant of event.joined) {
+      if (participant.isSelf && this.botParticipantId === null) {
+        this.botParticipantId = participant.id;
+      }
+    }
+    // Only count *non-bot* joiners as content-bearing: a bot-self rejoin
+    // (unusual, but possible on reconnect) is not a new participant who
+    // might object.
+    const hasNonBotJoiner = event.joined.some(
+      (p) => p.isSelf !== true && p.id !== this.botParticipantId,
+    );
+    if (hasNonBotJoiner) {
+      this.lastContentTimestamp = this.now();
     }
   }
 
@@ -368,6 +457,32 @@ export class MeetConsentMonitor {
       this.chatBuffer.length === 0
     ) {
       return;
+    }
+
+    // Content-watermark skip: on a tick, if nothing content-bearing has
+    // arrived since the last tick-driven LLM check, skip the call. The
+    // keyword path is intentionally excluded — keyword hits always fire.
+    if (
+      trigger === "tick" &&
+      this.lastContentTimestamp === this.lastLlmCheckContentTimestamp
+    ) {
+      log.debug(
+        {
+          event: "consent_monitor.timer.skipped_no_new_content",
+          meetingId: this.meetingId,
+          lastContentTimestamp: this.lastContentTimestamp,
+        },
+        "MeetConsentMonitor: timer tick skipped — no new non-bot content",
+      );
+      return;
+    }
+
+    // Advance the tick-path watermark to the current content timestamp
+    // before firing. Only the tick path advances the watermark so the
+    // keyword fast-path keeps its existing semantics (PR 3 will add a
+    // separate debounce for keyword-triggered calls).
+    if (trigger === "tick") {
+      this.lastLlmCheckContentTimestamp = this.lastContentTimestamp;
     }
 
     const prompt = this.buildPrompt();


### PR DESCRIPTION
## Summary
- Track `lastContentTimestamp` (last non-bot final transcript or inbound chat) and `lastLlmCheckContentTimestamp` (content watermark at the last LLM call) on the consent monitor.
- The 20s timer tick skips the LLM call when content has not advanced since the last check; participant-join events reset the watermark so a fresh joiner always gets a re-check.
- Fast-keyword-triggered LLM calls are unchanged by this PR. Correctness invariant preserved: genuine objections still trigger leave well within the 30s budget.

Part of plan: meet-phase-1-7-consent-monitor.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
