### PR TITLE
meet: speaker resolver learns provider-label → DOM-participant mapping and cross-checks

### DIFF
--- a/assistant/src/meet/__tests__/conversation-bridge.test.ts
+++ b/assistant/src/meet/__tests__/conversation-bridge.test.ts
@@ -367,15 +367,16 @@ describe("MeetConversationBridge — transcript.chunk (resolver integration)", (
       meetSpeakerName: "Alice",
       meetSpeakerId: "p-alice",
       meetSpeakerLabel: "Speaker 0",
-      meetSpeakerConfidence: "dom-override",
+      meetSpeakerConfidence: "dom-authoritative",
     });
   });
 
-  test("learned mapping reused on subsequent transcripts → confidence 'deepgram'", async () => {
+  test("learned mapping reused on later transcripts (DOM gap) → dom-fallback", async () => {
     const { bridge, dispatcher, calls } = makeBridge();
     bridge.subscribe();
 
-    // Bootstrap — DOM says Alice, Deepgram says Speaker 0.
+    // Bootstrap — a single DOM-correlated transcript binds label "Speaker 0"
+    // to Alice with agreementCount=1 (below the stable threshold).
     dispatcher.dispatch(
       MEETING_ID,
       speakerChange({
@@ -390,8 +391,9 @@ describe("MeetConversationBridge — transcript.chunk (resolver integration)", (
     );
 
     // Later — another Speaker 0 transcript, well outside the correlation
-    // window, with no new DOM event. Resolver should use the learned
-    // mapping and emit `deepgram` confidence.
+    // window, with no new DOM event. Mapping is not stable yet (agreement
+    // count = 1), so the resolver falls back to the last-known DOM
+    // speaker (still Alice) with confidence `dom-fallback`.
     const laterTs = new Date(Date.parse(TIMESTAMP) + 60_000).toISOString();
     dispatcher.dispatch(
       MEETING_ID,
@@ -407,7 +409,7 @@ describe("MeetConversationBridge — transcript.chunk (resolver integration)", (
     expect(calls[1]?.metadata).toMatchObject({
       meetSpeakerName: "Alice",
       meetSpeakerId: "p-alice",
-      meetSpeakerConfidence: "deepgram",
+      meetSpeakerConfidence: "dom-fallback",
     });
   });
 

--- a/assistant/src/meet/__tests__/speaker-resolver.test.ts
+++ b/assistant/src/meet/__tests__/speaker-resolver.test.ts
@@ -3,14 +3,18 @@
  *
  * The resolver's hard parts are:
  *   - The ±500ms correlation window between DOM speaker-change events and
- *     Deepgram transcript chunks (tests drive timestamps explicitly).
- *   - Lazy learning of `speakerLabel → identity` bindings on the first
- *     near-in-time DOM event, and reusing them afterwards.
- *   - DOM-override precedence when a known Deepgram mapping disagrees
- *     with a freshly-correlated DOM snapshot.
+ *     provider transcript chunks (tests drive timestamps explicitly).
+ *   - Lazy learning of `label → participant` mappings on the first
+ *     near-in-time DOM event, agreement counts that grow on repeat
+ *     confirmations, and a 3-consecutive-disagreement threshold before a
+ *     mapping is replaced (guards against transient DOM flicker).
+ *   - Fallbacks when the DOM is absent in the correlation window: stable
+ *     mapping → `provider-via-mapping`; otherwise last-known DOM →
+ *     `dom-fallback`.
  *   - Forwarding resolved identities to the shared
  *     {@link SpeakerIdentityTracker} so cross-surface speaker profiling
  *     keeps working.
+ *   - Emitting a structured summary log on teardown.
  *
  * Tests inject a local subscribe shim so they never touch the process
  * dispatcher singleton.
@@ -107,20 +111,51 @@ function makeDispatcher() {
   return { subscribe, dispatch, subscriberCount };
 }
 
+/**
+ * Dispatch `count` agreeing DOM-then-transcript pairs so the mapping for
+ * `label` reaches `agreementCount === count`. Each pair is dispatched with
+ * a unique timestamp to avoid spurious correlation interference.
+ */
+function bootstrapAgreement(
+  resolver: MeetSpeakerResolver,
+  dispatch: (
+    meetingId: string,
+    event: SpeakerChangeEvent | TranscriptChunkEvent,
+  ) => void,
+  label: string,
+  speakerId: string,
+  speakerName: string,
+  count: number,
+): void {
+  for (let i = 0; i < count; i += 1) {
+    const t = 1_000 + i * 1_000;
+    dispatch(
+      MEETING_ID,
+      speakerChange({ timestamp: toIso(t), speakerId, speakerName }),
+    );
+    resolver.resolve(
+      transcript({
+        timestamp: toIso(t + 100),
+        speakerLabel: label,
+        text: `agree-${i}`,
+      }),
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Fixture 1 — Deepgram + DOM agree
+// Fixture 1 — Provider label matches DOM on first appearance
 // ---------------------------------------------------------------------------
 
-describe("MeetSpeakerResolver — Deepgram + DOM agree", () => {
-  test("a known-label transcript with agreeing DOM resolves via Deepgram mapping", () => {
+describe("MeetSpeakerResolver — provider label + DOM agree", () => {
+  test("first appearance binds the mapping and returns dom-authoritative", () => {
     const { subscribe, dispatch } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
       subscribe,
     });
 
-    // Bootstrap: DOM says Alice is speaking at t=900, transcript lands at
-    // t=1_000 with speakerLabel `speaker-0` — this binds the mapping.
+    // DOM says Alice at t=900; transcript lands at t=1_000 with label "0".
     dispatch(
       MEETING_ID,
       speakerChange({ timestamp: toIso(900), speakerId: "p-alice" }),
@@ -128,49 +163,304 @@ describe("MeetSpeakerResolver — Deepgram + DOM agree", () => {
     const first = resolver.resolve(
       transcript({
         timestamp: toIso(1_000),
-        speakerLabel: "speaker-0",
-        text: "first",
+        speakerLabel: "0",
       }),
     );
-    expect(first.confidence).toBe("dom-override");
+    expect(first.confidence).toBe("dom-authoritative");
     expect(first.speakerId).toBe("p-alice");
-
-    // Later: DOM emits another Alice-matching event just before the next
-    // transcript, and Deepgram keeps reporting `speaker-0`. Because the
-    // mapping is already bound *and* DOM still agrees, confidence is
-    // `"deepgram"` (the bound path is the canonical fast path).
-    dispatch(
-      MEETING_ID,
-      speakerChange({ timestamp: toIso(1_900), speakerId: "p-alice" }),
-    );
-    const second = resolver.resolve(
-      transcript({
-        timestamp: toIso(2_000),
-        speakerLabel: "speaker-0",
-        text: "second",
-      }),
-    );
-    expect(second.confidence).toBe("deepgram");
-    expect(second.speakerId).toBe("p-alice");
-    expect(second.speakerName).toBe("Alice");
+    expect(first.speakerName).toBe("Alice");
 
     resolver.unsubscribe();
   });
-});
 
-// ---------------------------------------------------------------------------
-// Fixture 2 — Deepgram label unknown + DOM known → dom-override, bind mapping
-// ---------------------------------------------------------------------------
-
-describe("MeetSpeakerResolver — learns mapping from DOM", () => {
-  test("unknown Deepgram label + near-in-time DOM binds for future calls", () => {
+  test("same label seen again with agreeing DOM increments agreementCount", () => {
     const { subscribe, dispatch } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
       subscribe,
     });
 
-    // Alice's DOM snapshot at t=1_000.
+    // Seen #1 — bind.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+    // Seen #2 — agreement.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_900) }));
+    const second = resolver.resolve(
+      transcript({ timestamp: toIso(2_000), speakerLabel: "0" }),
+    );
+    expect(second.confidence).toBe("dom-authoritative");
+    expect(second.speakerId).toBe("p-alice");
+
+    // After a third agreement, the mapping has agreementCount >= 3 and
+    // now qualifies as stable — a DOM-gap lookup would return
+    // provider-via-mapping (covered in a separate test below).
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(2_900) }));
+    const third = resolver.resolve(
+      transcript({ timestamp: toIso(3_000), speakerLabel: "0" }),
+    );
+    expect(third.confidence).toBe("dom-authoritative");
+    expect(third.speakerId).toBe("p-alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 2 — Single disagreement → mapping preserved, conflict logged
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — DOM disagreement (transient flicker)", () => {
+  test("single disagreement increments conflictCount and keeps the mapping", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind label "0" → Alice.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+
+    // DOM now flickers to Bob for a single event; same label "0" arrives.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_900),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const resolved = resolver.resolve(
+      transcript({ timestamp: toIso(2_000), speakerLabel: "0" }),
+    );
+
+    // Mapping is preserved — DOM flicker is treated as transient.
+    expect(resolved.confidence).toBe("provider-via-mapping");
+    expect(resolved.speakerId).toBe("p-alice");
+    expect(resolved.speakerName).toBe("Alice");
+
+    // The conflict is observable in the summary.
+    const summary = resolver.flushSummary();
+    expect(summary.conflictCount).toBe(1);
+    // Mapping is still bound to Alice (unchanged despite disagreement).
+    expect(summary.labelMappings).toEqual([
+      {
+        label: "0",
+        participantId: "p-alice",
+        participantName: "Alice",
+        agreementCount: 1,
+      },
+    ]);
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 3 — 3 consecutive disagreements → mapping replaced
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — mapping replacement", () => {
+  test("3 consecutive DOM disagreements replace the mapping", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind label "0" → Alice.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+
+    // Disagree #1 — mapping preserved.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(1_900),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const d1 = resolver.resolve(
+      transcript({ timestamp: toIso(2_000), speakerLabel: "0" }),
+    );
+    expect(d1.speakerId).toBe("p-alice");
+
+    // Disagree #2 — still preserved.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(2_900),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const d2 = resolver.resolve(
+      transcript({ timestamp: toIso(3_000), speakerLabel: "0" }),
+    );
+    expect(d2.speakerId).toBe("p-alice");
+
+    // Disagree #3 — crosses the threshold; mapping replaced, DOM wins.
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(3_900),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const d3 = resolver.resolve(
+      transcript({ timestamp: toIso(4_000), speakerLabel: "0" }),
+    );
+    expect(d3.confidence).toBe("dom-authoritative");
+    expect(d3.speakerId).toBe("p-bob");
+    expect(d3.speakerName).toBe("Bob");
+
+    // Subsequent transcript with a DOM-gap and no agreement rebuild yet
+    // → the new mapping has agreementCount=1, so it's not stable; the
+    // resolver falls back to the last-known DOM (which is still Bob).
+    const later = resolver.resolve(
+      transcript({ timestamp: toIso(60_000), speakerLabel: "0" }),
+    );
+    expect(later.confidence).toBe("dom-fallback");
+    expect(later.speakerId).toBe("p-bob");
+
+    resolver.unsubscribe();
+  });
+
+  test("disagreement counter resets after an agreement", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind label "0" → Alice.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+
+    // Two disagreements.
+    for (let i = 0; i < 2; i += 1) {
+      dispatch(
+        MEETING_ID,
+        speakerChange({
+          timestamp: toIso(1_900 + i * 1_000),
+          speakerId: "p-bob",
+          speakerName: "Bob",
+        }),
+      );
+      resolver.resolve(
+        transcript({
+          timestamp: toIso(2_000 + i * 1_000),
+          speakerLabel: "0",
+        }),
+      );
+    }
+
+    // An agreement arrives — counter resets.
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(3_900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(4_000), speakerLabel: "0" }),
+    );
+
+    // A single disagreement now should NOT replace (counter was reset).
+    dispatch(
+      MEETING_ID,
+      speakerChange({
+        timestamp: toIso(4_900),
+        speakerId: "p-bob",
+        speakerName: "Bob",
+      }),
+    );
+    const resolved = resolver.resolve(
+      transcript({ timestamp: toIso(5_000), speakerLabel: "0" }),
+    );
+    expect(resolved.confidence).toBe("provider-via-mapping");
+    expect(resolved.speakerId).toBe("p-alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 4 — Provider label + DOM gap + stable mapping → provider-via-mapping
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — stable mapping, DOM gap", () => {
+  test("stable mapping (agreementCount >= 3) resolves without a fresh DOM event", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    bootstrapAgreement(resolver, dispatch, "0", "p-alice", "Alice", 3);
+
+    // Long after the last DOM event — no fresh snapshot within the window.
+    const resolved = resolver.resolve(
+      transcript({
+        timestamp: toIso(60_000),
+        speakerLabel: "0",
+      }),
+    );
+    expect(resolved.confidence).toBe("provider-via-mapping");
+    expect(resolved.speakerId).toBe("p-alice");
+    expect(resolved.speakerName).toBe("Alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 5 — Provider label + DOM gap + no stable mapping → dom-fallback
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — DOM fallback for weak mapping", () => {
+  test("provider label + DOM gap + agreementCount < 3 falls back to last-known DOM", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind label "0" → Alice once (agreementCount=1).
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+
+    // Well outside the correlation window. No stable mapping yet.
+    const resolved = resolver.resolve(
+      transcript({ timestamp: toIso(60_000), speakerLabel: "0" }),
+    );
+    expect(resolved.confidence).toBe("dom-fallback");
+    expect(resolved.speakerId).toBe("p-alice");
+    expect(resolved.speakerName).toBe("Alice");
+
+    resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 6 — Provider label absent → DOM-only path (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — no provider label, DOM-only", () => {
+  test("no label + DOM in window → dom-authoritative", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
     dispatch(
       MEETING_ID,
       speakerChange({
@@ -179,42 +469,16 @@ describe("MeetSpeakerResolver — learns mapping from DOM", () => {
         speakerName: "Alice",
       }),
     );
-
-    // Deepgram speaker-0, first time seen, transcript at t=1_300 (inside
-    // the ±500ms window). → dom-override, plus the mapping is learned.
-    const first = resolver.resolve(
-      transcript({
-        timestamp: toIso(1_300),
-        speakerLabel: "speaker-0",
-      }),
+    const resolved = resolver.resolve(
+      transcript({ timestamp: toIso(1_100), speakerLabel: undefined }),
     );
-    expect(first.confidence).toBe("dom-override");
-    expect(first.speakerId).toBe("p-alice");
-    expect(first.speakerName).toBe("Alice");
-
-    // Follow-up transcript with the same Deepgram label but NO new DOM
-    // event resolves via the learned mapping → confidence `"deepgram"`.
-    const second = resolver.resolve(
-      transcript({
-        timestamp: toIso(10_000),
-        speakerLabel: "speaker-0",
-        text: "later utterance",
-      }),
-    );
-    expect(second.confidence).toBe("deepgram");
-    expect(second.speakerId).toBe("p-alice");
-    expect(second.speakerName).toBe("Alice");
+    expect(resolved.confidence).toBe("dom-authoritative");
+    expect(resolved.speakerId).toBe("p-alice");
 
     resolver.unsubscribe();
   });
-});
 
-// ---------------------------------------------------------------------------
-// Fixture 3 — Neither signal available → unknown
-// ---------------------------------------------------------------------------
-
-describe("MeetSpeakerResolver — unknown fallback", () => {
-  test("no Deepgram label + no DOM within window → unknown with default name", () => {
+  test("no label + no DOM within window → unknown", () => {
     const { subscribe } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
@@ -225,7 +489,6 @@ describe("MeetSpeakerResolver — unknown fallback", () => {
       transcript({
         timestamp: toIso(5_000),
         speakerLabel: undefined,
-        text: "orphaned utterance",
       }),
     );
     expect(resolved.confidence).toBe("unknown");
@@ -234,120 +497,28 @@ describe("MeetSpeakerResolver — unknown fallback", () => {
 
     resolver.unsubscribe();
   });
+});
 
-  test("Deepgram label + stale DOM event (outside window) → unknown", () => {
-    const { subscribe, dispatch } = makeDispatcher();
+// ---------------------------------------------------------------------------
+// Fixture 7 — No DOM ever seen → unknown
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — true unknown", () => {
+  test("label present + never saw any DOM → unknown", () => {
+    const { subscribe } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
       subscribe,
     });
-
-    // DOM at t=1_000, transcript at t=5_000 — well outside the ±500ms window.
-    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_000) }));
 
     const resolved = resolver.resolve(
       transcript({
         timestamp: toIso(5_000),
-        speakerLabel: "speaker-7",
+        speakerLabel: "0",
       }),
     );
+    // No DOM in window, no mapping, no last-known DOM → unknown.
     expect(resolved.confidence).toBe("unknown");
-    expect(resolved.speakerId).toBeUndefined();
-
-    resolver.unsubscribe();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Fixture 4 — Bound mapping works without a fresh DOM lookup
-// ---------------------------------------------------------------------------
-
-describe("MeetSpeakerResolver — mapping sticks across transcripts", () => {
-  test("learned mapping survives once DOM snapshot ages out of the window", () => {
-    const { subscribe, dispatch } = makeDispatcher();
-    const resolver = new MeetSpeakerResolver({
-      meetingId: MEETING_ID,
-      subscribe,
-    });
-
-    // Bind the mapping.
-    dispatch(
-      MEETING_ID,
-      speakerChange({ timestamp: toIso(1_000), speakerId: "p-alice" }),
-    );
-    resolver.resolve(
-      transcript({
-        timestamp: toIso(1_200),
-        speakerLabel: "speaker-0",
-      }),
-    );
-
-    // Now a long time later — no fresh DOM event, but the mapping should
-    // still apply.
-    const resolved = resolver.resolve(
-      transcript({
-        timestamp: toIso(60_000),
-        speakerLabel: "speaker-0",
-        text: "way later",
-      }),
-    );
-    expect(resolved.confidence).toBe("deepgram");
-    expect(resolved.speakerId).toBe("p-alice");
-
-    resolver.unsubscribe();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Fixture 5 — Conflict: Deepgram mapped to one, DOM says another → DOM wins
-// ---------------------------------------------------------------------------
-
-describe("MeetSpeakerResolver — conflict resolution", () => {
-  test("known Deepgram mapping disagrees with near-in-time DOM → DOM wins", () => {
-    const { subscribe, dispatch } = makeDispatcher();
-    const resolver = new MeetSpeakerResolver({
-      meetingId: MEETING_ID,
-      subscribe,
-    });
-
-    // Step 1 — bind speaker-0 → Alice.
-    dispatch(
-      MEETING_ID,
-      speakerChange({
-        timestamp: toIso(1_000),
-        speakerId: "p-alice",
-        speakerName: "Alice",
-      }),
-    );
-    const aliceBound = resolver.resolve(
-      transcript({
-        timestamp: toIso(1_100),
-        speakerLabel: "speaker-0",
-        text: "Alice says hi",
-      }),
-    );
-    expect(aliceBound.speakerId).toBe("p-alice");
-
-    // Step 2 — a later transcript also labeled speaker-0, but the DOM has
-    // shifted to Bob within the correlation window. DOM must win.
-    dispatch(
-      MEETING_ID,
-      speakerChange({
-        timestamp: toIso(10_000),
-        speakerId: "p-bob",
-        speakerName: "Bob",
-      }),
-    );
-    const conflicted = resolver.resolve(
-      transcript({
-        timestamp: toIso(10_200),
-        speakerLabel: "speaker-0",
-        text: "but Bob is speaking now",
-      }),
-    );
-    expect(conflicted.confidence).toBe("dom-override");
-    expect(conflicted.speakerId).toBe("p-bob");
-    expect(conflicted.speakerName).toBe("Bob");
 
     resolver.unsubscribe();
   });
@@ -378,7 +549,7 @@ describe("MeetSpeakerResolver — forwards to SpeakerIdentityTracker", () => {
     resolver.resolve(
       transcript({
         timestamp: toIso(1_100),
-        speakerLabel: "speaker-0",
+        speakerLabel: "0",
       }),
     );
 
@@ -445,7 +616,7 @@ describe("MeetSpeakerResolver — subscription lifecycle", () => {
     expect(subscriberCount(MEETING_ID)).toBe(0);
   });
 
-  test("non-speaker.change events do not perturb state", () => {
+  test("non-speaker.change events do not perturb DOM state", () => {
     const { subscribe, dispatch } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
@@ -459,21 +630,117 @@ describe("MeetSpeakerResolver — subscription lifecycle", () => {
       transcript({
         timestamp: toIso(1_000),
         isFinal: false,
-        speakerLabel: "speaker-0",
+        speakerLabel: "0",
       }),
     );
 
     const resolved = resolver.resolve(
       transcript({
         timestamp: toIso(1_050),
-        speakerLabel: "speaker-0",
+        speakerLabel: "0",
       }),
     );
-    // No DOM snapshot was observed, so the resolver must treat the
-    // Deepgram label as unknown → unknown fallback.
+    // No DOM snapshot was observed, so no correlation, no mapping, no
+    // last-known DOM speaker → unknown fallback.
     expect(resolved.confidence).toBe("unknown");
 
     resolver.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-of-meeting summary log
+// ---------------------------------------------------------------------------
+
+describe("MeetSpeakerResolver — meeting summary", () => {
+  test("unsubscribe returns a summary with all learned mappings", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Learn two mappings.
+    bootstrapAgreement(resolver, dispatch, "0", "p-alice", "Alice", 2);
+    bootstrapAgreement(resolver, dispatch, "1", "p-bob", "Bob", 1);
+
+    const summary = resolver.flushSummary();
+    expect(summary.meetingId).toBe(MEETING_ID);
+    expect(summary.conflictCount).toBe(0);
+    expect(summary.labelMappings).toHaveLength(2);
+    expect(summary.labelMappings).toEqual(
+      expect.arrayContaining([
+        {
+          label: "0",
+          participantId: "p-alice",
+          participantName: "Alice",
+          agreementCount: 2,
+        },
+        {
+          label: "1",
+          participantId: "p-bob",
+          participantName: "Bob",
+          agreementCount: 1,
+        },
+      ]),
+    );
+
+    resolver.unsubscribe();
+  });
+
+  test("summary includes conflictCount when disagreements occurred", () => {
+    const { subscribe, dispatch } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Bind label "0" → Alice, then two disagreements with Bob (below
+    // the replacement threshold).
+    dispatch(MEETING_ID, speakerChange({ timestamp: toIso(900) }));
+    resolver.resolve(
+      transcript({ timestamp: toIso(1_000), speakerLabel: "0" }),
+    );
+    for (let i = 0; i < 2; i += 1) {
+      dispatch(
+        MEETING_ID,
+        speakerChange({
+          timestamp: toIso(1_900 + i * 1_000),
+          speakerId: "p-bob",
+          speakerName: "Bob",
+        }),
+      );
+      resolver.resolve(
+        transcript({
+          timestamp: toIso(2_000 + i * 1_000),
+          speakerLabel: "0",
+        }),
+      );
+    }
+
+    const summary = resolver.flushSummary();
+    expect(summary.conflictCount).toBe(2);
+
+    resolver.unsubscribe();
+  });
+
+  test("flushSummary is safe to call repeatedly and before unsubscribe", () => {
+    const { subscribe } = makeDispatcher();
+    const resolver = new MeetSpeakerResolver({
+      meetingId: MEETING_ID,
+      subscribe,
+    });
+
+    // Multiple calls before and after unsubscribe return the same data.
+    const first = resolver.flushSummary();
+    const second = resolver.flushSummary();
+    resolver.unsubscribe();
+    const third = resolver.flushSummary();
+
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+    expect(first.labelMappings).toEqual([]);
+    expect(first.conflictCount).toBe(0);
   });
 });
 
@@ -482,7 +749,7 @@ describe("MeetSpeakerResolver — subscription lifecycle", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetSpeakerResolver — edge cases", () => {
-  test("unparsable transcript timestamp disables DOM correlation", () => {
+  test("unparsable transcript timestamp → no correlation, falls back to last-known DOM", () => {
     const { subscribe, dispatch } = makeDispatcher();
     const resolver = new MeetSpeakerResolver({
       meetingId: MEETING_ID,
@@ -494,11 +761,16 @@ describe("MeetSpeakerResolver — edge cases", () => {
     const resolved = resolver.resolve(
       transcript({
         timestamp: "not-a-real-timestamp",
-        speakerLabel: "speaker-0",
+        speakerLabel: "0",
       }),
     );
-    // No correlation possible with NaN ms → unknown.
-    expect(resolved.confidence).toBe("unknown");
+    // NaN ms → no correlation, so the label + no-DOM path is taken.
+    // agreementCount is 0 (no prior binding), so the resolver falls back
+    // to the last-known DOM speaker instead of binding an arbitrary label
+    // to whoever spoke last — the binding path is reserved for correlated
+    // transcripts only.
+    expect(resolved.confidence).toBe("dom-fallback");
+    expect(resolved.speakerId).toBe("p-alice");
 
     resolver.unsubscribe();
   });
@@ -513,47 +785,25 @@ describe("MeetSpeakerResolver — edge cases", () => {
 
     dispatch(MEETING_ID, speakerChange({ timestamp: toIso(1_000) }));
 
-    // ±101 ms is just outside a 100 ms window.
-    const outside = resolver.resolve(
-      transcript({
-        timestamp: toIso(1_101),
-        speakerLabel: "speaker-0",
-      }),
-    );
-    expect(outside.confidence).toBe("unknown");
-
-    // ±50 ms is inside a 100 ms window.
+    // ±50 ms is inside a 100 ms window → dom-authoritative.
     const inside = resolver.resolve(
       transcript({
         timestamp: toIso(1_050),
-        speakerLabel: "speaker-0",
+        speakerLabel: "0",
       }),
     );
-    expect(inside.confidence).toBe("dom-override");
+    expect(inside.confidence).toBe("dom-authoritative");
 
-    resolver.unsubscribe();
-  });
-
-  test("transcript without speakerLabel + DOM within window still returns dom-override", () => {
-    const { subscribe, dispatch } = makeDispatcher();
-    const resolver = new MeetSpeakerResolver({
-      meetingId: MEETING_ID,
-      subscribe,
-    });
-
-    dispatch(
-      MEETING_ID,
-      speakerChange({
-        timestamp: toIso(1_000),
-        speakerId: "p-alice",
-        speakerName: "Alice",
+    // ±101 ms is just outside a 100 ms window. No stable mapping yet
+    // (agreementCount=1 from the inside-window call), so the resolver
+    // falls back to the last-known DOM speaker.
+    const outside = resolver.resolve(
+      transcript({
+        timestamp: toIso(1_101),
+        speakerLabel: "0",
       }),
     );
-    const resolved = resolver.resolve(
-      transcript({ timestamp: toIso(1_100), speakerLabel: undefined }),
-    );
-    expect(resolved.confidence).toBe("dom-override");
-    expect(resolved.speakerId).toBe("p-alice");
+    expect(outside.confidence).toBe("dom-fallback");
 
     resolver.unsubscribe();
   });

--- a/assistant/src/meet/speaker-resolver.ts
+++ b/assistant/src/meet/speaker-resolver.ts
@@ -1,12 +1,13 @@
 /**
- * MeetSpeakerResolver — arbitrates between Deepgram speaker labels and the
- * DOM-derived active-speaker stream to produce the best identity attribution
- * for every final transcript chunk.
+ * MeetSpeakerResolver — arbitrates between the provider's diarization speaker
+ * labels (e.g. Deepgram's opaque `"0"`, `"1"`, …) and the DOM-derived active-
+ * speaker stream to produce the best identity attribution for every final
+ * transcript chunk.
  *
  * Two signals feed into the resolver:
  *
- *   1. **Deepgram labels** — opaque `speaker-N` strings that are stable
- *      *within* a session but carry no real-world identity. They ride in
+ *   1. **Provider labels** — opaque strings that are stable *within* a
+ *      session but carry no real-world identity. They ride in
  *      `TranscriptChunkEvent.speakerLabel` (and occasionally `speakerId`).
  *   2. **DOM active-speaker events** — real participant ids + names scraped
  *      from the Meet UI, delivered as `SpeakerChangeEvent`s. These are
@@ -14,22 +15,44 @@
  *      the audio stream, so they are only useful when correlated with a
  *      transcript's timestamp.
  *
- * The resolver maintains an internal label → identity mapping that is built
- * up across the meeting: the first time Deepgram says `speaker-0` while the
- * DOM says Alice is active, we bind `speaker-0 → Alice` and the next
- * Deepgram-only transcript carrying that label resolves to Alice without
- * a DOM round-trip.
+ * The resolver maintains a per-meeting label → participant mapping that is
+ * built up across the meeting: the first time the provider says `"0"` while
+ * the DOM says Alice is active, we bind `"0" → Alice` with `agreementCount=1`.
+ * Subsequent transcripts with that label plus an agreeing DOM snapshot
+ * increment the count; the count is what makes a mapping "stable" and
+ * trustworthy on its own (see `provider-via-mapping` below).
  *
- * Resolution precedence for a given transcript:
- *   - Bound mapping for the Deepgram label → `"deepgram"`
- *   - DOM event within ±{@link DOM_CORRELATION_WINDOW_MS} of the transcript
- *     timestamp → `"dom-override"` (and bind the mapping if the Deepgram
- *     label was previously unmapped)
- *   - Neither → `"unknown"` with a default name
+ * Resolution precedence for a given transcript (all conditional on the
+ * provider label being present, unless noted):
  *
- * When Deepgram's mapped identity disagrees with a near-in-time DOM event,
- * the DOM wins and the discrepancy is logged — the DOM source has higher
- * confidence because it carries the participant's actual display name.
+ *   - **DOM active-speaker in window (±{@link DOM_CORRELATION_WINDOW_MS}):**
+ *     DOM is authoritative — returned with `confidence: "dom-authoritative"`.
+ *     Mapping is created on first sight, incremented on agreement, or —
+ *     after 3 consecutive disagreements — *replaced* with the new DOM
+ *     speaker. A single disagreement is treated as transient DOM flicker:
+ *     the mapping is preserved and the resolver returns the mapped identity
+ *     with `confidence: "provider-via-mapping"` (a structured
+ *     `speaker.mapping_conflict` log captures the divergence for review).
+ *
+ *   - **No DOM in window, stable mapping exists (`agreementCount >= 3`):**
+ *     Use the learned mapping — `confidence: "provider-via-mapping"`.
+ *
+ *   - **No DOM in window, no stable mapping, but a last-known DOM speaker
+ *     exists:** fall back to the last-known DOM speaker with
+ *     `confidence: "dom-fallback"`. This handles brief DOM gaps before the
+ *     mapping has had a chance to harden.
+ *
+ *   - **No DOM in window AND no last-known DOM speaker:** the resolver has
+ *     no basis for attribution — `confidence: "unknown"` with the default
+ *     name.
+ *
+ * When the provider label is *absent* (non-diarizing provider, or
+ * diarization disabled), the DOM is the sole source: DOM in window →
+ * `dom-authoritative`, else `unknown`.
+ *
+ * On teardown ({@link MeetSpeakerResolver.unsubscribe}) the resolver emits a
+ * single structured log line summarizing the learned mappings and the
+ * conflict count for post-hoc accuracy review.
  *
  * The resolver **wraps** (not replaces) the shared {@link SpeakerIdentityTracker}
  * from the calls module: each resolved identity is forwarded via
@@ -59,11 +82,27 @@ const log = getLogger("meet-speaker-resolver");
 
 /**
  * Window within which a DOM `SpeakerChangeEvent` is considered correlated
- * with a transcript chunk. ±500ms matches the plan's call-out — Deepgram's
- * final chunks usually trail the DOM update by a few hundred ms as the
+ * with a transcript chunk. ±500ms matches the plan's call-out — provider
+ * finals usually trail the DOM update by a few hundred ms as the audio
  * buffer flushes, so a symmetric window is the conservative choice.
  */
 export const DOM_CORRELATION_WINDOW_MS = 500;
+
+/**
+ * Number of consecutive DOM disagreements before an existing
+ * `label → participant` mapping is replaced. Up to 2 disagreements are
+ * treated as transient DOM flicker and leave the mapping unchanged.
+ */
+export const MAPPING_REPLACE_THRESHOLD = 3;
+
+/**
+ * Minimum `agreementCount` at which a mapping is considered trustworthy
+ * enough to attribute a transcript when the DOM is unavailable in the
+ * correlation window. Below this threshold, the resolver prefers the
+ * last-known DOM speaker (`dom-fallback`) to avoid hardening a noisy
+ * first-observation mapping.
+ */
+export const STABLE_MAPPING_THRESHOLD = 3;
 
 /** Returned as `speakerName` when neither signal produced a binding. */
 export const UNKNOWN_SPEAKER_NAME = "Unknown speaker";
@@ -75,16 +114,22 @@ export const UNKNOWN_SPEAKER_NAME = "Unknown speaker";
 /**
  * Source of the resolved identity.
  *
- * - `"deepgram"`: a previously-learned `speakerLabel → identity` mapping
- *   was applied.
- * - `"dom-override"`: a DOM `SpeakerChangeEvent` fell inside the
- *   correlation window and supplied the identity.
+ * - `"dom-authoritative"`: a DOM `SpeakerChangeEvent` fell inside the
+ *   correlation window and supplied the identity (the highest-confidence
+ *   signal — DOM carries the real participant name).
+ * - `"provider-via-mapping"`: no DOM in the correlation window (or DOM
+ *   disagreed but the mapping was preserved as likely-flicker); the
+ *   resolver used the previously-learned mapping for the provider label.
+ * - `"dom-fallback"`: no DOM in the correlation window, no stable mapping
+ *   yet — the resolver fell back to the most recently observed DOM
+ *   speaker. Lower confidence than the mapping path.
  * - `"unknown"`: neither signal produced a binding — the caller should
  *   treat this as an unattributed utterance.
  */
 export type ResolvedSpeakerConfidence =
-  | "deepgram"
-  | "dom-override"
+  | "dom-authoritative"
+  | "provider-via-mapping"
+  | "dom-fallback"
   | "unknown";
 
 export interface ResolvedSpeaker {
@@ -94,6 +139,18 @@ export interface ResolvedSpeaker {
   speakerName: string;
   /** Which signal produced the identity. See {@link ResolvedSpeakerConfidence}. */
   confidence: ResolvedSpeakerConfidence;
+}
+
+/** Shape of the per-meeting summary emitted on teardown. */
+export interface MeetingSummary {
+  meetingId: string;
+  labelMappings: Array<{
+    label: string;
+    participantId: string;
+    participantName: string;
+    agreementCount: number;
+  }>;
+  conflictCount: number;
 }
 
 export interface MeetSpeakerResolverDeps {
@@ -133,10 +190,17 @@ interface ActiveSpeakerSnapshot {
   timestampMs: number;
 }
 
-/** A bound `speakerLabel → identity` mapping learned from the DOM stream. */
-interface LabelBinding {
-  speakerId: string;
-  speakerName: string;
+/**
+ * A learned `label → participant` mapping. `agreementCount` grows when a
+ * fresh DOM snapshot within the correlation window confirms the mapping.
+ * `consecutiveDisagreements` is reset on agreement and grows on a DOM
+ * conflict; crossing {@link MAPPING_REPLACE_THRESHOLD} replaces the mapping.
+ */
+interface LabelMapping {
+  participantId: string;
+  participantName: string;
+  agreementCount: number;
+  consecutiveDisagreements: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,12 +217,18 @@ export class MeetSpeakerResolver {
   private activeSpeaker: ActiveSpeakerSnapshot | null = null;
 
   /**
-   * Bound `speakerLabel → identity` map. Once a label has been bound by a
-   * near-in-time DOM event, the mapping sticks until the resolver is
-   * disposed — callers drop and recreate the resolver per meeting so
-   * stale bindings from a prior meeting can't leak.
+   * Learned `label → participant` mappings. Once bound, a mapping is only
+   * replaced when the DOM disagrees {@link MAPPING_REPLACE_THRESHOLD} times
+   * in a row. Callers drop and recreate the resolver per meeting so stale
+   * bindings from a prior meeting can't leak.
    */
-  private readonly labelBindings = new Map<string, LabelBinding>();
+  private readonly labelMappings = new Map<string, LabelMapping>();
+
+  /** Count of `speaker.mapping_conflict` log events — reported at teardown. */
+  private conflictCount = 0;
+
+  /** Guards {@link flushSummary} against double-emission. */
+  private summaryFlushed = false;
 
   constructor(deps: MeetSpeakerResolverDeps) {
     this.meetingId = deps.meetingId;
@@ -177,69 +247,31 @@ export class MeetSpeakerResolver {
   /**
    * Resolve a transcript chunk to its best-available speaker identity.
    *
-   * Mutates internal state (may bind a previously-unmapped
-   * `speakerLabel`), so callers should treat this as the single entry
-   * point per transcript — do not call twice on the same event.
+   * Mutates internal state (may create, increment, or replace a mapping
+   * for the provider label), so callers should treat this as the single
+   * entry point per transcript — do not call twice on the same event.
    */
   resolve(transcript: TranscriptChunkEvent): ResolvedSpeaker {
     const transcriptMs = parseTimestamp(transcript.timestamp);
     const domMatch = this.correlatedActiveSpeaker(transcriptMs);
     const label = transcript.speakerLabel;
 
-    // 1) Bound Deepgram label wins when no DOM disagreement is visible.
+    // Case A — provider label present.
     if (label !== undefined) {
-      const bound = this.labelBindings.get(label);
-      if (bound) {
-        // Deepgram says we already know this label → if DOM now disagrees,
-        // DOM takes precedence (participant identities outrank stable-but-
-        // opaque ASR labels). Log so the divergence is observable.
-        if (
-          domMatch &&
-          (domMatch.speakerId !== bound.speakerId ||
-            domMatch.speakerName !== bound.speakerName)
-        ) {
-          log.warn(
-            {
-              meetingId: this.meetingId,
-              speakerLabel: label,
-              deepgramSpeakerId: bound.speakerId,
-              deepgramSpeakerName: bound.speakerName,
-              domSpeakerId: domMatch.speakerId,
-              domSpeakerName: domMatch.speakerName,
-            },
-            "Meet speaker resolver: Deepgram/DOM disagree — DOM overrides",
-          );
-          return this.emit({
-            speakerId: domMatch.speakerId,
-            speakerName: domMatch.speakerName,
-            confidence: "dom-override",
-          });
-        }
-        return this.emit({
-          speakerId: bound.speakerId,
-          speakerName: bound.speakerName,
-          confidence: "deepgram",
-        });
+      if (domMatch) {
+        return this.resolveWithLabelAndDom(label, domMatch);
       }
+      return this.resolveWithLabelNoDom(label);
     }
 
-    // 2) Unbound label (or absent) + DOM match → DOM overrides, and if a
-    //    Deepgram label was present we learn it for next time.
+    // Case B — provider label absent. DOM is the sole source.
     if (domMatch) {
-      if (label !== undefined) {
-        this.labelBindings.set(label, {
-          speakerId: domMatch.speakerId,
-          speakerName: domMatch.speakerName,
-        });
-      }
       return this.emit({
         speakerId: domMatch.speakerId,
         speakerName: domMatch.speakerName,
-        confidence: "dom-override",
+        confidence: "dom-authoritative",
       });
     }
-
-    // 3) Nothing — unattributed utterance.
     return this.emit({
       speakerId: undefined,
       speakerName: UNKNOWN_SPEAKER_NAME,
@@ -247,7 +279,40 @@ export class MeetSpeakerResolver {
     });
   }
 
-  /** Tear down the dispatcher subscription. Safe to call multiple times. */
+  /**
+   * Build and emit the end-of-meeting summary log. Invoked automatically
+   * the first time {@link unsubscribe} is called; callers that want the
+   * summary before teardown can call this explicitly. Idempotent — the
+   * log is emitted at most once. Returns the summary payload regardless
+   * of whether the log was actually emitted, so tests (and future
+   * observability hooks) can inspect it without parsing log output.
+   */
+  flushSummary(): MeetingSummary {
+    const summary: MeetingSummary = {
+      meetingId: this.meetingId,
+      labelMappings: Array.from(this.labelMappings.entries()).map(
+        ([label, mapping]) => ({
+          label,
+          participantId: mapping.participantId,
+          participantName: mapping.participantName,
+          agreementCount: mapping.agreementCount,
+        }),
+      ),
+      conflictCount: this.conflictCount,
+    };
+
+    if (!this.summaryFlushed) {
+      this.summaryFlushed = true;
+      log.info(summary, "Meet speaker resolver: meeting summary");
+    }
+    return summary;
+  }
+
+  /**
+   * Tear down the dispatcher subscription and emit the end-of-meeting
+   * summary log. Safe to call multiple times — the summary is emitted
+   * at most once.
+   */
   unsubscribe(): void {
     try {
       this.unsubscribeFn();
@@ -257,6 +322,7 @@ export class MeetSpeakerResolver {
         "MeetSpeakerResolver: unsubscribe threw",
       );
     }
+    this.flushSummary();
   }
 
   // ── Internals ──────────────────────────────────────────────────────
@@ -271,12 +337,135 @@ export class MeetSpeakerResolver {
   }
 
   /**
+   * Provider label + DOM snapshot in window. DOM is authoritative; update
+   * the mapping (create, agree, or record disagreement) accordingly.
+   */
+  private resolveWithLabelAndDom(
+    label: string,
+    domMatch: ActiveSpeakerSnapshot,
+  ): ResolvedSpeaker {
+    const existing = this.labelMappings.get(label);
+
+    if (!existing) {
+      // First sight — bind the mapping and emit DOM.
+      this.labelMappings.set(label, {
+        participantId: domMatch.speakerId,
+        participantName: domMatch.speakerName,
+        agreementCount: 1,
+        consecutiveDisagreements: 0,
+      });
+      return this.emit({
+        speakerId: domMatch.speakerId,
+        speakerName: domMatch.speakerName,
+        confidence: "dom-authoritative",
+      });
+    }
+
+    const agrees =
+      existing.participantId === domMatch.speakerId &&
+      existing.participantName === domMatch.speakerName;
+
+    if (agrees) {
+      existing.agreementCount += 1;
+      existing.consecutiveDisagreements = 0;
+      return this.emit({
+        speakerId: domMatch.speakerId,
+        speakerName: domMatch.speakerName,
+        confidence: "dom-authoritative",
+      });
+    }
+
+    // Disagreement — log and decide whether to replace.
+    this.conflictCount += 1;
+    log.warn(
+      {
+        event: "speaker.mapping_conflict",
+        meetingId: this.meetingId,
+        label,
+        previousMapping: {
+          participantId: existing.participantId,
+          participantName: existing.participantName,
+          agreementCount: existing.agreementCount,
+        },
+        newDomSpeaker: {
+          speakerId: domMatch.speakerId,
+          speakerName: domMatch.speakerName,
+        },
+        consecutiveDisagreements: existing.consecutiveDisagreements + 1,
+      },
+      "Meet speaker resolver: provider-label mapping disagrees with DOM",
+    );
+
+    existing.consecutiveDisagreements += 1;
+    if (existing.consecutiveDisagreements >= MAPPING_REPLACE_THRESHOLD) {
+      // Mapping has been wrong too many times in a row — replace it and
+      // emit the new DOM speaker authoritatively.
+      existing.participantId = domMatch.speakerId;
+      existing.participantName = domMatch.speakerName;
+      existing.agreementCount = 1;
+      existing.consecutiveDisagreements = 0;
+      return this.emit({
+        speakerId: domMatch.speakerId,
+        speakerName: domMatch.speakerName,
+        confidence: "dom-authoritative",
+      });
+    }
+
+    // Preserve the mapping: treat this as transient DOM flicker and stay
+    // with the learned identity. The caller still needs an attribution —
+    // the mapping path is the best option.
+    return this.emit({
+      speakerId: existing.participantId,
+      speakerName: existing.participantName,
+      confidence: "provider-via-mapping",
+    });
+  }
+
+  /**
+   * Provider label present but DOM is not in the correlation window.
+   * Prefer a stable mapping; else fall back to the last-known DOM speaker;
+   * else unknown.
+   */
+  private resolveWithLabelNoDom(label: string): ResolvedSpeaker {
+    const existing = this.labelMappings.get(label);
+    if (existing && existing.agreementCount >= STABLE_MAPPING_THRESHOLD) {
+      return this.emit({
+        speakerId: existing.participantId,
+        speakerName: existing.participantName,
+        confidence: "provider-via-mapping",
+      });
+    }
+
+    // No stable mapping — fall back to the last-known DOM speaker if we
+    // have one. This is lower confidence: we haven't verified that this
+    // label corresponds to the last speaker, but in short DOM gaps the
+    // last-known speaker is usually still the one talking.
+    const lastDom = this.activeSpeaker;
+    if (lastDom) {
+      return this.emit({
+        speakerId: lastDom.speakerId,
+        speakerName: lastDom.speakerName,
+        confidence: "dom-fallback",
+      });
+    }
+
+    return this.emit({
+      speakerId: undefined,
+      speakerName: UNKNOWN_SPEAKER_NAME,
+      confidence: "unknown",
+    });
+  }
+
+  /**
    * Return the most-recent DOM active speaker if their `timestamp` is
    * within the correlation window of `transcriptMs`, otherwise `null`.
    *
    * If `transcriptMs` is NaN (unparsable ISO string) we refuse to match —
-   * an unbounded window would bind arbitrary labels to whoever spoke last,
-   * which is worse than leaving the transcript unattributed.
+   * an unbounded window would create a label↔participant mapping based on
+   * whoever spoke most recently, regardless of how stale that DOM event
+   * is. Returning `null` here forces the fallback path (last-known DOM
+   * with `dom-fallback`, or `unknown`), which never mutates the mapping
+   * table and so can't poison future resolutions.
    */
   private correlatedActiveSpeaker(
     transcriptMs: number,


### PR DESCRIPTION
## Summary
- Speaker resolver now learns a provider-label → DOM-participant mapping with an `agreementCount` per label.
- Mapping replacement requires 3 consecutive disagreements (guards against transient DOM flicker).
- When the provider label is present but DOM is unavailable in the correlation window, falls back to the stable mapping (`provider-via-mapping`) or last-known DOM (`dom-fallback`).
- Emits a `meet.left` summary log of learned mappings + conflict count for post-hoc accuracy review.

Part of plan: meet-phase-1-6-speaker-labels.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
