### PR TITLE
meet: debounce consent-monitor LLM checks to 8s minimum interval

### DIFF
--- a/assistant/src/meet/__tests__/consent-monitor.test.ts
+++ b/assistant/src/meet/__tests__/consent-monitor.test.ts
@@ -13,6 +13,7 @@ import type { MeetBotEvent } from "@vellumai/meet-contracts";
 
 import {
   DEDUPE_WINDOW_MS,
+  LLM_CHECK_DEBOUNCE_MS,
   LLM_TICK_INTERVAL_MS,
   MeetConsentMonitor,
   type MeetSessionLeaver,
@@ -355,8 +356,10 @@ describe("MeetConsentMonitor dedupe", () => {
     // One transcript entry recorded (the others were deduped).
     expect(monitor._bufferedTranscriptCount()).toBe(1);
 
-    // Past the dedupe window, the same text re-enters the keyword path.
-    t = DEDUPE_WINDOW_MS + 1;
+    // Past both the dedupe and debounce windows, the same text re-enters
+    // the keyword path. We use `LLM_CHECK_DEBOUNCE_MS + 1` (which is also
+    // > DEDUPE_WINDOW_MS) so neither guard short-circuits the second call.
+    t = LLM_CHECK_DEBOUNCE_MS + 1;
     dispatcher.dispatch(
       "m1",
       transcriptChunk("m1", new Date(t).toISOString(), "please leave the meeting"),
@@ -956,6 +959,214 @@ describe("MeetConsentMonitor resilience", () => {
 
     resolveFirst({ objected: false, reason: "" });
     await flushPromises();
+
+    monitor.stop();
+  });
+});
+
+describe("MeetConsentMonitor LLM check debounce", () => {
+  test("three fast-check hits in rapid succession collapse to a single LLM call", async () => {
+    // Models the worst-case fast-keyword spam scenario: a participant
+    // (or several) saying "please leave" three times in a few seconds. The
+    // debounce should reduce those three keyword hits to one LLM call.
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // First keyword hit at t=0 — fires LLM.
+    t = 0;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "please leave first"),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Second keyword hit at t=3s — within 8s debounce window, skipped.
+    t = 3_000;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:03.000Z",
+        "please leave second",
+        "Bob",
+        "b",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // Third keyword hit at t=9s — past 8s debounce window, fires LLM.
+    t = 9_000;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:09.000Z",
+        "please leave third",
+        "Carol",
+        "c",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+  });
+
+  test("timer tick + fast-check hit within 100ms collapse to a single LLM call", async () => {
+    // Either trigger can win the debounce race depending on event order;
+    // whichever lands first locks out the other for the debounce window.
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: false,
+        reason: "",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // Seed a non-keyword chunk so the tick has buffer content to work with
+    // (otherwise the empty-buffer guard would short-circuit the tick).
+    t = 19_900;
+    dispatcher.dispatch(
+      "m1",
+      transcriptChunk(
+        "m1",
+        "2024-01-01T00:00:19.900Z",
+        "we're discussing the roadmap",
+        { speakerLabel: "Alice", speakerId: "alice" },
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(0);
+
+    // Tick fires first at t=20s (LLM call #1).
+    t = 20_000;
+    timer.fire();
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    // 50ms later a keyword-matching chat arrives — within 8s debounce, skipped.
+    t = 20_050;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:20.050Z",
+        "please leave the meeting",
+        "Bob",
+        "b",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+  });
+
+  test("regression: after objection-decided + leave, additional fast-checks produce no LLM activity", async () => {
+    // The "already decided to leave" guard short-circuits before the
+    // debounce, so a second keyword hit after leave was triggered must
+    // not produce any additional LLM call regardless of how much time
+    // has elapsed.
+    const dispatcher = makeFakeDispatcher();
+    const session = makeFakeSessionManager();
+    const timer = makeTimerControl();
+    let t = 0;
+    const llm = mock(
+      async (_prompt: string): Promise<ObjectionDecision> => ({
+        objected: true,
+        reason: "explicit ask to leave",
+      }),
+    );
+
+    const monitor = new MeetConsentMonitor({
+      meetingId: "m1",
+      assistantId: "self",
+      sessionManager: session,
+      config: {
+        autoLeaveOnObjection: true,
+        objectionKeywords: ["please leave"],
+      },
+      llmAsk: llm,
+      subscribe: dispatcher.subscribe,
+      setIntervalFn: timer.setIntervalFn,
+      clearIntervalFn: timer.clearIntervalFn,
+      now: () => t,
+    });
+    monitor.start();
+
+    // First keyword hit at t=0 — fires LLM, decision is objected=true,
+    // session.leave invoked.
+    t = 0;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat("m1", "2024-01-01T00:00:00.000Z", "please leave now"),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(1);
+    expect(monitor._isDecided()).toBe(true);
+
+    // Second keyword hit well past the debounce window — must NOT fire
+    // an additional LLM call because `decided` short-circuits first.
+    t = LLM_CHECK_DEBOUNCE_MS + 5_000;
+    dispatcher.dispatch(
+      "m1",
+      inboundChat(
+        "m1",
+        "2024-01-01T00:00:13.000Z",
+        "please leave again",
+        "Bob",
+        "b",
+      ),
+    );
+    await flushPromises();
+    expect(llm).toHaveBeenCalledTimes(1);
+    expect(session.leave).toHaveBeenCalledTimes(1);
 
     monitor.stop();
   });

--- a/assistant/src/meet/consent-monitor.ts
+++ b/assistant/src/meet/consent-monitor.ts
@@ -72,6 +72,19 @@ export const LLM_TICK_INTERVAL_MS = 20_000;
 /** Window used to dedupe identical chunks. */
 export const DEDUPE_WINDOW_MS = 5_000;
 
+/**
+ * Minimum wall-clock interval between consecutive LLM checks regardless of
+ * trigger source (timer tick or fast-keyword hit). Acts as a coarse rate
+ * limiter so e.g. three keyword-matching utterances in quick succession
+ * collapse to a single LLM call. Intentionally not exposed via config —
+ * making this tunable is premature until production data justifies it.
+ *
+ * Worst-case objection latency with this debounce in place:
+ *   8s (debounce window) + 20s (next timer tick) = 28s, comfortably under
+ *   the 30s correctness invariant.
+ */
+export const LLM_CHECK_DEBOUNCE_MS = 8_000;
+
 /** LLM call timeout — keeps the consent path bounded. */
 export const CONSENT_LLM_TIMEOUT_MS = 5_000;
 
@@ -219,6 +232,17 @@ export class MeetConsentMonitor {
    * mis-tags a chunk).
    */
   private botParticipantId: string | null = null;
+
+  /**
+   * Wall-clock timestamp (`this.now()`) of the most recent LLM check
+   * regardless of trigger source. Set on entry to {@link maybeRunLLMCheck}
+   * before the async LLM call begins so concurrent triggers within the
+   * debounce window collapse to a single call. Compared against
+   * {@link LLM_CHECK_DEBOUNCE_MS} on every potential LLM-firing path
+   * (tick AND keyword) — both guards (this debounce and the content
+   * watermark) apply independently and either can short-circuit a call.
+   */
+  private lastLlmCheckAt: number | null = null;
 
   constructor(deps: MeetConsentMonitorDeps) {
     this.meetingId = deps.meetingId;
@@ -447,6 +471,21 @@ export class MeetConsentMonitor {
    * Run one LLM check over the current buffer if one isn't already in
    * flight and the monitor hasn't already decided. Overlapping calls are
    * collapsed — the buffer the in-flight call saw is sufficient context.
+   *
+   * Two independent skip guards apply here:
+   *   1. **Debounce** ({@link LLM_CHECK_DEBOUNCE_MS}) — applies to ALL
+   *      triggers. If less than the debounce window has elapsed since the
+   *      last LLM call, skip. The watermark below cannot save the keyword
+   *      path on its own, so this guard gives keyword-triggered calls a
+   *      coarse rate limit too.
+   *   2. **Content watermark** — applies only to tick-driven calls. If
+   *      no content-bearing event has arrived since the last tick-driven
+   *      check, skip even if the debounce window has elapsed.
+   *
+   * The "already decided to leave" guard short-circuits before either,
+   * and intentionally does NOT touch {@link lastLlmCheckAt} — we don't
+   * want a stop-and-leave flow to reset debounce state for any future
+   * checks (there shouldn't be any, but defense-in-depth).
    */
   private async maybeRunLLMCheck(trigger: string): Promise<void> {
     if (this.decided || this.llmInFlight) return;
@@ -459,9 +498,31 @@ export class MeetConsentMonitor {
       return;
     }
 
+    // Debounce guard: applies to every trigger (tick AND keyword). A
+    // string of "please leave" utterances within an 8s window collapses
+    // to a single LLM call. Independent of the content watermark below —
+    // both guards can skip a call for different reasons.
+    const now = this.now();
+    if (
+      this.lastLlmCheckAt !== null &&
+      now - this.lastLlmCheckAt < LLM_CHECK_DEBOUNCE_MS
+    ) {
+      log.debug(
+        {
+          event: "consent_monitor.check.debounced",
+          meetingId: this.meetingId,
+          trigger,
+          msSinceLastCheck: now - this.lastLlmCheckAt,
+        },
+        "MeetConsentMonitor: LLM check debounced",
+      );
+      return;
+    }
+
     // Content-watermark skip: on a tick, if nothing content-bearing has
     // arrived since the last tick-driven LLM check, skip the call. The
-    // keyword path is intentionally excluded — keyword hits always fire.
+    // keyword path is intentionally excluded — keyword hits always fire
+    // (subject to the debounce above).
     if (
       trigger === "tick" &&
       this.lastContentTimestamp === this.lastLlmCheckContentTimestamp
@@ -479,11 +540,16 @@ export class MeetConsentMonitor {
 
     // Advance the tick-path watermark to the current content timestamp
     // before firing. Only the tick path advances the watermark so the
-    // keyword fast-path keeps its existing semantics (PR 3 will add a
-    // separate debounce for keyword-triggered calls).
+    // keyword fast-path keeps its existing semantics; the debounce above
+    // is what rate-limits keyword-triggered calls.
     if (trigger === "tick") {
       this.lastLlmCheckContentTimestamp = this.lastContentTimestamp;
     }
+
+    // Stamp the debounce clock BEFORE the async LLM call begins so a
+    // second trigger arriving while this call is in flight is debounced
+    // (in addition to being collapsed by the in-flight flag below).
+    this.lastLlmCheckAt = now;
 
     const prompt = this.buildPrompt();
     this.llmInFlight = true;


### PR DESCRIPTION
## Summary
- Add `LLM_CHECK_DEBOUNCE_MS = 8_000` and `lastLlmCheckAt` state to `MeetConsentMonitor`.
- Every path that fires an LLM check (tick and keyword) is wrapped in a debounce guard; skips log `consent_monitor.check.debounced`. Watermark (PR 2) and debounce are independent guards that both apply to tick-driven calls.
- Worst-case objection latency after all three PRs: 28s, under the 30s invariant.

Part of plan: meet-phase-1-7-consent-monitor.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
