### PR TITLE
meet/stt: fix stop/close race and related correctness gaps in Gemini Live adapter

### DIFF
--- a/assistant/src/providers/speech-to-text/google-gemini-live-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-live-stream.test.ts
@@ -548,7 +548,9 @@ describe("GoogleGeminiLiveStreamingTranscriber", () => {
 
     // Partial-style messages after stop() should not produce additional
     // partial events (they are dropped because `stopping` is true) and
-    // never interleave between final and closed.
+    // never interleave between final and closed. The text is still
+    // accumulated so the flushed final reflects all audio that arrived
+    // during the grace period.
     session.simulateMessage({
       serverContent: { inputTranscription: { text: " late" } },
     });
@@ -559,10 +561,17 @@ describe("GoogleGeminiLiveStreamingTranscriber", () => {
     const lastTwo = types.slice(-2);
     expect(lastTwo).toEqual(["final", "closed"]);
 
-    // No partials after the final.
-    const finalIdx = types.indexOf("final");
-    const afterFinal = types.slice(finalIdx + 1);
-    expect(afterFinal).toEqual(["closed"]);
+    // No partials emitted after stop() — only the initial pre-stop
+    // partial, then the final and closed.
+    const partialsAfterStop = events
+      .slice(1)
+      .filter((e) => e.type === "partial");
+    expect(partialsAfterStop).toHaveLength(0);
+
+    // But the final should include text that arrived during the grace
+    // period, since we kept accumulating.
+    const finals = events.filter((e) => e.type === "final");
+    expect(finals).toEqual([{ type: "final", text: "abc late" }]);
   });
 
   test("no events emitted after closed on unexpected close", async () => {
@@ -579,6 +588,148 @@ describe("GoogleGeminiLiveStreamingTranscriber", () => {
 
     expect(events.length).toBe(count);
   });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: double-final on stop → turnComplete → close race
+  // ─────────────────────────────────────────────────────────────────
+
+  test(
+    "does not emit a second empty final when provider closes normally after a completion signal",
+    async () => {
+      const { transcriber: t, session, events } = await startSession();
+
+      session.simulateMessage({
+        serverContent: { inputTranscription: { text: "hello" } },
+      });
+      t.stop();
+
+      // Server flushes turnComplete in response to audioStreamEnd, then
+      // closes normally. Both events used to produce a final event, with
+      // the second being an empty string — storage-writer in Meet would
+      // write an empty transcript line.
+      session.simulateMessage({
+        serverContent: { turnComplete: true },
+      });
+      session.simulateClose(1000, "normal");
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toEqual([{ type: "final", text: "hello" }]);
+      expect(events.filter((e) => e.type === "closed")).toHaveLength(1);
+    },
+  );
+
+  test(
+    "still emits a final on normal close when no completion signal arrived during the grace period",
+    async () => {
+      const { transcriber: t, session, events } = await startSession();
+
+      session.simulateMessage({
+        serverContent: { inputTranscription: { text: "midstream" } },
+      });
+      t.stop();
+      // No turnComplete/generationComplete before close — the flush is
+      // the only source of the final.
+      session.simulateClose(1000, "normal");
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toEqual([{ type: "final", text: "midstream" }]);
+    },
+  );
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: session leak on connect timeout
+  // ─────────────────────────────────────────────────────────────────
+
+  test(
+    "closes the underlying session when start() times out after the SDK resolved a session handle",
+    async () => {
+      const t = new GoogleGeminiLiveStreamingTranscriber(TEST_API_KEY, {
+        connectTimeoutMs: 20,
+      });
+      // autoOpen=false so `onopen` never fires; connectPromise still
+      // resolves synchronously with the session — this is the leak path.
+      const { capturedCalls } = installMockClient(t, { autoOpen: false });
+
+      const { onEvent } = createEventCollector();
+      await expect(t.start(onEvent)).rejects.toThrow(
+        "Gemini Live connect timeout",
+      );
+
+      const session = capturedCalls[0]?.session;
+      expect(session).toBeDefined();
+      // The session handle must have been closed by start()'s catch
+      // block via forceCloseSession() — otherwise the WebSocket leaks.
+      expect(session!.closeCalled).toBe(true);
+    },
+  );
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: honor inputTranscription.finished
+  // ─────────────────────────────────────────────────────────────────
+
+  test(
+    "emits final on inputTranscription.finished=true (SDK says it's independent of model turns)",
+    async () => {
+      const { session, events } = await startSession();
+
+      session.simulateMessage({
+        serverContent: { inputTranscription: { text: "quick brown fox" } },
+      });
+      session.simulateMessage({
+        serverContent: { inputTranscription: { finished: true } },
+      });
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toEqual([{ type: "final", text: "quick brown fox" }]);
+    },
+  );
+
+  test(
+    "finished=true also suppresses the trailing empty final on subsequent normal close",
+    async () => {
+      const { transcriber: t, session, events } = await startSession();
+
+      session.simulateMessage({
+        serverContent: { inputTranscription: { text: "done" } },
+      });
+      session.simulateMessage({
+        serverContent: { inputTranscription: { finished: true } },
+      });
+
+      t.stop();
+      session.simulateClose(1000, "normal");
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toEqual([{ type: "final", text: "done" }]);
+    },
+  );
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: MIME normalization preserves non-rate parameters
+  // ─────────────────────────────────────────────────────────────────
+
+  test(
+    "normalizePcmMimeType appends rate= without dropping other PCM parameters",
+    async () => {
+      const { transcriber: t, session } = await startSession({
+        transcriberOptions: {
+          pcmSampleRate: 16_000,
+          inactivityTimeoutMs: 60_000,
+        },
+      });
+
+      t.sendAudio(Buffer.from([1, 2, 3]), "audio/pcm;encoding=linear16");
+
+      const input = session.sentInputs[0] as {
+        audio?: { data: string; mimeType: string };
+      };
+      // The original `encoding=linear16` parameter must be preserved;
+      // only the missing `rate=` is appended.
+      expect(input.audio?.mimeType).toBe(
+        "audio/pcm;encoding=linear16;rate=16000",
+      );
+    },
+  );
 
   // ─────────────────────────────────────────────────────────────────
   // Provider identity

--- a/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
@@ -139,6 +139,16 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
   /** Accumulated input transcription for the current turn. */
   private currentTurnText = "";
 
+  /**
+   * Whether we've already emitted a `final` event for the current turn
+   * via a completion signal (`turnComplete` / `generationComplete` /
+   * `inputTranscription.finished`). Reset when a new turn's text begins
+   * accumulating. Used by `flushFinalAndClose` to avoid emitting a
+   * trailing empty final when the provider closes normally after stop()
+   * has already flushed a final for the turn.
+   */
+  private finalEmittedForCurrentTurn = false;
+
   constructor(apiKey: string, options: GoogleGeminiLiveStreamOptions = {}) {
     this.model = options.model ?? DEFAULT_MODEL;
     this.pcmSampleRate = options.pcmSampleRate ?? 16_000;
@@ -168,6 +178,7 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
     this.stopping = false;
     this.lastEmittedPartial = "";
     this.currentTurnText = "";
+    this.finalEmittedForCurrentTurn = false;
 
     log.info({ model: this.model }, "Opening Gemini Live session");
 
@@ -279,7 +290,11 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
       ]);
     } catch (err) {
       this.onEvent = null;
-      this.session = null;
+      // The connectPromise may have already resolved with a session
+      // handle before the timeout fired — if so, the `.then()` above
+      // captured it on `this.session`. Close any such orphaned session
+      // here to prevent leaking a live WebSocket to the provider.
+      this.forceCloseSession();
       throw err;
     }
 
@@ -362,13 +377,23 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
     if (!serverContent) return;
 
     // Append any new input transcription text to the current turn buffer.
+    // A new turn begins when we see text while the buffer is empty —
+    // reset the "final already emitted" flag so the next completion
+    // signal can emit again.
     const transcriptionText = serverContent.inputTranscription?.text;
     if (typeof transcriptionText === "string" && transcriptionText.length > 0) {
+      if (this.currentTurnText.length === 0) {
+        this.finalEmittedForCurrentTurn = false;
+      }
       this.currentTurnText += transcriptionText;
     }
 
-    // Detect turn completion.
+    // Detect turn completion. Per the `@google/genai` SDK docs,
+    // `inputTranscription` is independent of the model's response turn,
+    // so we honor `Transcription.finished` as an additional completion
+    // signal alongside `turnComplete` / `generationComplete`.
     const isComplete =
+      serverContent.inputTranscription?.finished === true ||
       serverContent.generationComplete === true ||
       serverContent.turnComplete === true;
 
@@ -376,9 +401,16 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
       const finalText = this.currentTurnText;
       this.currentTurnText = "";
       this.lastEmittedPartial = "";
+      this.finalEmittedForCurrentTurn = true;
       this.emitEvent({ type: "final", text: finalText });
       return;
     }
+
+    // During the stop() grace period we still accumulate text (above)
+    // so any flushed final is complete, but we suppress partials — the
+    // session orchestrator does not want interleaved partials between
+    // stop() and the final emission.
+    if (this.stopping) return;
 
     // Otherwise emit a partial only if text has changed.
     if (
@@ -462,13 +494,24 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
    * Flush any pending transcription as a final event, then close. Used
    * when the provider closes normally after stop() or when the close
    * grace timer fires.
+   *
+   * Avoids emitting a spurious empty-string final when the server
+   * already emitted a completion signal (`turnComplete` / `finished` /
+   * `generationComplete`) for the current turn before closing — that
+   * path already emitted the final and drained the accumulator. The
+   * stream contract callers (e.g. Meet's storage-writer) would write
+   * an empty transcript line on the extra final, so we suppress it.
    */
   private flushFinalAndClose(): void {
     if (this.closed) return;
     const pending = this.currentTurnText;
+    const alreadyEmitted = this.finalEmittedForCurrentTurn;
     this.currentTurnText = "";
     this.lastEmittedPartial = "";
-    this.emitEvent({ type: "final", text: pending });
+    this.finalEmittedForCurrentTurn = false;
+    if (!(alreadyEmitted && pending.length === 0)) {
+      this.emitEvent({ type: "final", text: pending });
+    }
     this.emitClosedAndCleanup();
   }
 
@@ -547,13 +590,18 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
   /**
    * Normalize generic PCM MIME types to include the sample-rate hint that
    * Gemini Live requires. Passes non-PCM MIME types through unchanged.
+   *
+   * When the input lacks a `rate=` parameter, we append `;rate=<N>` to
+   * the original string rather than rebuilding from scratch, so
+   * auxiliary parameters (e.g. `encoding=linear16`) and the caller's
+   * original casing are preserved.
    */
   private normalizePcmMimeType(mimeType: string): string {
     const base = mimeType.split(";")[0].trim().toLowerCase();
     if (base !== "audio/pcm") return mimeType;
     // Preserve an explicit rate= parameter if the caller supplied one.
     if (/rate\s*=\s*\d+/i.test(mimeType)) return mimeType;
-    return `audio/pcm;rate=${this.pcmSampleRate}`;
+    return `${mimeType};rate=${this.pcmSampleRate}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes 5 gaps caught by self-review of the Gemini Live STT adapter (from plan gemini-live-stt.md):

1. Double `final` emission on stop → turnComplete → close race (would write empty transcript lines to Meet storage-writer)
2. Session leak when start() times out after SDK returned session early
3. Adapter now honors `Transcription.finished` as a final completion signal (SDK docs state `inputTranscription` is independent of model turns)
4. `handleServerMessage` now respects `stopping` (accumulates text but does not emit partials during the stop grace period, matching the test comment contract)
5. PCM MIME normalization preserves non-rate parameters when appending `rate=<N>`

## Risk
Adapter-local changes only; no interface or catalog changes. All existing tests still pass plus new regression tests for each fix.

Follow-up for plan: gemini-live-stt.md (self-review round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
