### PR TITLE
stt: remove unused DeepgramProviderConfigSchema

### DIFF
--- a/assistant/src/config/schemas/__tests__/stt.test.ts
+++ b/assistant/src/config/schemas/__tests__/stt.test.ts
@@ -1,50 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  DeepgramProviderConfigSchema,
   SttProvidersSchema,
   SttServiceSchema,
   VALID_STT_PROVIDERS,
 } from "../stt.js";
 
-describe("DeepgramProviderConfigSchema", () => {
-  test("empty object parses to documented defaults (diarize: false)", () => {
-    const parsed = DeepgramProviderConfigSchema.parse({});
-    expect(parsed).toEqual({ diarize: false });
-  });
-
-  test("diarize: true round-trips", () => {
-    const parsed = DeepgramProviderConfigSchema.parse({ diarize: true });
-    expect(parsed).toEqual({ diarize: true });
-  });
-
-  test("diarize: false is accepted explicitly", () => {
-    const parsed = DeepgramProviderConfigSchema.parse({ diarize: false });
-    expect(parsed).toEqual({ diarize: false });
-  });
-
-  test("rejects non-boolean diarize values", () => {
-    const stringResult = DeepgramProviderConfigSchema.safeParse({
-      diarize: "true",
-    });
-    expect(stringResult.success).toBe(false);
-
-    const numberResult = DeepgramProviderConfigSchema.safeParse({
-      diarize: 1,
-    });
-    expect(numberResult.success).toBe(false);
-
-    const nullResult = DeepgramProviderConfigSchema.safeParse({
-      diarize: null,
-    });
-    expect(nullResult.success).toBe(false);
-  });
-});
-
 describe("SttProvidersSchema", () => {
-  test("accepts a Deepgram entry with diarize set via the dedicated schema", () => {
-    const deepgramCfg = DeepgramProviderConfigSchema.parse({ diarize: true });
-    const parsed = SttProvidersSchema.parse({ deepgram: deepgramCfg });
+  test("accepts a Deepgram entry with arbitrary fields (generic record)", () => {
+    const parsed = SttProvidersSchema.parse({
+      deepgram: { diarize: true },
+    });
     expect(parsed).toEqual({ deepgram: { diarize: true } });
   });
 
@@ -62,7 +28,7 @@ describe("SttProvidersSchema", () => {
 });
 
 describe("SttServiceSchema", () => {
-  test("stt.provider=deepgram with providers.deepgram.diarize round-trips", () => {
+  test("stt.provider=deepgram with providers.deepgram round-trips", () => {
     const parsed = SttServiceSchema.parse({
       provider: "deepgram",
       providers: { deepgram: { diarize: true } },
@@ -71,7 +37,7 @@ describe("SttServiceSchema", () => {
     expect(parsed.providers.deepgram).toEqual({ diarize: true });
   });
 
-  test("VALID_STT_PROVIDERS includes deepgram so the diarize option has a home", () => {
+  test("VALID_STT_PROVIDERS includes deepgram", () => {
     expect(VALID_STT_PROVIDERS).toContain("deepgram");
   });
 });

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -11,41 +11,16 @@ export const VALID_STT_PROVIDERS = [
 ] as const;
 
 /**
- * Deepgram-specific provider options under
- * `services.stt.providers.deepgram`.
- *
- * Kept as a standalone schema (rather than inlining into the generic
- * `SttProvidersSchema` record) so known Deepgram fields carry types and
- * defaults, while still round-tripping cleanly through the forward-compatible
- * parent record.
- */
-export const DeepgramProviderConfigSchema = z
-  .object({
-    // Enables Deepgram's built-in speaker diarization. Adds no measurable
-    // latency; slight cost implications in some tiers.
-    diarize: z.boolean().default(false),
-  })
-  .describe(
-    "Deepgram-specific provider options under services.stt.providers.deepgram",
-  );
-export type DeepgramProviderConfig = z.infer<
-  typeof DeepgramProviderConfigSchema
->;
-
-/**
  * Sparse provider config map under `services.stt.providers`.
  *
  * This is a forward-compatible record that accepts any provider ID as key
  * with an object value. All provider entries — known (`openai-whisper`,
- * `deepgram`, `google-gemini`) and unknown — are accepted with generic object validation.
- * Adding a new provider ID does not require a migration to seed
+ * `deepgram`, `google-gemini`) and unknown — are accepted with generic object
+ * validation. Adding a new provider ID does not require a migration to seed
  * `services.stt.providers.<id>`.
  *
  * The map only holds entries the user has explicitly configured — it is
- * NOT required to enumerate every known provider. Typed validation for
- * known providers (e.g. {@link DeepgramProviderConfigSchema}) lives on
- * those schemas and is applied at the call site — this record is only
- * responsible for accepting the sparse shape.
+ * NOT required to enumerate every known provider.
  */
 export const SttProvidersSchema = z.record(
   z.string(),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-1-6-speaker-labels.md.

**Gap:** `DeepgramProviderConfigSchema` was added in PR 2 of the plan and tested, but never consumed at runtime. Per the plan's PR 5, `resolveStreamingTranscriber` decides diarization from caller preference + catalog capability — user config is not factored in. The schema was speculative and qualifies as dead code.

**What was expected:** Either the schema flows through to the Deepgram constructor, or it doesn't exist.
**What was found:** Schema exported + tested but no runtime reader.

Removes the dead export and its tests. The generic `SttProvidersSchema` (z.record) stays for forward-compat of unknown providers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
