### PR TITLE
fix(meet): remove unused DEDUPE_WINDOW_MS import breaking lint

### DIFF
--- a/assistant/src/meet/__tests__/consent-monitor.test.ts
+++ b/assistant/src/meet/__tests__/consent-monitor.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, mock, test } from "bun:test";
 import type { MeetBotEvent } from "@vellumai/meet-contracts";
 
 import {
-  DEDUPE_WINDOW_MS,
   LLM_CHECK_DEBOUNCE_MS,
   LLM_TICK_INTERVAL_MS,
   MeetConsentMonitor,


### PR DESCRIPTION
## Summary
- Remove unused `DEDUPE_WINDOW_MS` import from `consent-monitor.test.ts` — only referenced in a code comment, not actual code, which tripped `@typescript-eslint/no-unused-vars` and broke the Lint CI job on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24446840506/job/71425302009
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
