### PR TITLE
stt: use module-top logger in resolve.ts to match sibling files

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -103,14 +103,19 @@ mock.module("../openai-whisper-stream.js", () => ({
 
 // ---------------------------------------------------------------------------
 // Subject import (after mocks)
+//
+// Use a dynamic `await import(...)` so the module-top `const log = getLogger(...)`
+// in `resolve.ts` is captured by the mocked logger above. Static ESM imports
+// are hoisted above all module-top statements, which would cause `resolve.ts`
+// to evaluate — and call the real `getLogger` — before `mock.module(...)` runs.
 // ---------------------------------------------------------------------------
 
-import {
+const {
   resolveBatchTranscriber,
   resolveConversationStreamingSttCapability,
   resolveStreamingTranscriber,
   resolveTelephonySttCapability,
-} from "../resolve.js";
+} = await import("../resolve.js");
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -14,6 +14,8 @@ import {
   supportsDiarization,
 } from "./provider-catalog.js";
 
+const log = getLogger("stt-resolver");
+
 // ---------------------------------------------------------------------------
 // Batch transcriber resolver (existing public API — unchanged contract)
 // ---------------------------------------------------------------------------
@@ -303,7 +305,7 @@ export async function resolveStreamingTranscriber(
     provider as SttProviderId,
   );
   if (diarizePreference === "required" && !providerSupportsDiarization) {
-    getLogger("stt-resolver").warn(
+    log.warn(
       { providerId: provider },
       "diarization is required but configured STT provider does not support it",
     );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-1-6-speaker-labels.md.

**Gap:** `resolve.ts` used an inline `getLogger(...).warn(...)` call while the three sibling adapter files in the same directory (`deepgram-realtime.ts`, `google-gemini-live-stream.ts`, `openai-whisper-stream.ts`) all use the conventional `const log = getLogger(...);` at module top.

**Why the inline pattern shipped originally:** The PR 5 agent observed that switching to a module-top `log` broke the existing `resolve.test.ts` assertion on captured warnings — and they were right about the mechanism. Static ESM `import { ... } from "../resolve.js"` is hoisted above all module-top statements in the test file, so `resolve.ts` evaluated (and invoked the real `getLogger`) before `mock.module("../../../util/logger.js", ...)` executed. The inline `getLogger(...).warn(...)` pattern worked around this by re-resolving `getLogger` at call time, after the mock was installed. What the earlier review missed is that the fix is to change the subject import, not to keep using the inline call pattern.

**Fix:**
1. Added `const log = getLogger("stt-resolver");` at module top in `resolve.ts` and replaced the inline call with `log.warn(...)`, matching the sibling files.
2. Converted `resolve.test.ts`'s subject import from static `import { ... } from "../resolve.js"` to dynamic `const { ... } = await import("../resolve.js")` so the mock is installed before the subject evaluates. This is the same pattern used in `assistant/src/tools/meet/__tests__/meet-join-tool.test.ts`.

## Test plan
- [x] `bun test src/providers/speech-to-text/__tests__/resolve.test.ts` — 51/51 pass
- [x] `bunx tsc --noEmit` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
