### PR TITLE
meet/stt: update Swift tests to expect realtime-ws for google-gemini

### DIFF
--- a/clients/shared/Tests/STTStreamingClientTests.swift
+++ b/clients/shared/Tests/STTStreamingClientTests.swift
@@ -210,7 +210,7 @@ final class STTStreamingClientTests: XCTestCase {
     func testGoogleGeminiSupportsConversationStreaming() {
         let registry = buildTestRegistry()
         XCTAssertTrue(registry.supportsConversationStreaming(provider: "google-gemini"))
-        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "google-gemini"), .incrementalBatch)
+        XCTAssertEqual(registry.conversationStreamingMode(forProvider: "google-gemini"), .realtimeWs)
     }
 
     func testOpenAIWhisperSupportsConversationStreaming() {
@@ -332,7 +332,7 @@ final class STTStreamingClientTests: XCTestCase {
                     setupMode: .apiKey,
                     setupHint: "test",
                     apiKeyProviderName: "gemini",
-                    conversationStreamingMode: .incrementalBatch,
+                    conversationStreamingMode: .realtimeWs,
                     credentialsGuide: nil
                 ),
             ]


### PR DESCRIPTION
## Summary
- Updates `STTStreamingClientTests.swift` to assert `.realtimeWs` for `google-gemini`, matching the Swift fallback registry and daemon catalog (both flipped in #25786).
- Fixes `buildTestRegistry()` helper's stale `conversationStreamingMode: .incrementalBatch` for google-gemini.

Follow-up for plan: gemini-live-stt.md (self-review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
