### PR TITLE
fix(meet-bot): emit isSelf on bot's participant row

### DIFF
--- a/meet-bot/__tests__/main.test.ts
+++ b/meet-bot/__tests__/main.test.ts
@@ -170,6 +170,7 @@ function makeDeps(
       calls.push({
         kind: "scraper.participant.start",
         meetingId: scraperOpts.meetingId,
+        selfName: scraperOpts.selfName,
       });
       return {
         stop: () => {
@@ -395,6 +396,11 @@ describe("runBot — boot sequence", () => {
     expect(speakerCall?.meetingId).toBe("m-1");
     expect(chatCall?.meetingId).toBe("m-1");
     expect(chatCall?.selfName).toBe("Vellum Bot");
+    // The participant scraper also receives the bot's display name so it
+    // can flag the bot's own row with `isSelf: true`, letting the consent
+    // monitor identify `botParticipantId` and filter self-content from
+    // the watermark.
+    expect(participantCall?.selfName).toBe("Vellum Bot");
   });
 
   test("passes socketDir/audio.sock into audio capture", async () => {

--- a/meet-bot/__tests__/participant-scraper.test.ts
+++ b/meet-bot/__tests__/participant-scraper.test.ts
@@ -19,10 +19,15 @@ import { startParticipantScraper } from "../src/browser/participant-scraper.js";
  * Minimal participant row shape the fake page returns from `$$eval`. Mirrors
  * what the real extractor emits when it reads `data-participant-id` and the
  * participant-name subselector from each row.
+ *
+ * `isSelfByDom` mirrors the scraper's in-page detection of Meet's
+ * `data-self-name` attribute — the authoritative DOM marker for the bot's
+ * own row. Tests default it to `false`; self-row tests set it explicitly.
  */
 interface ScrapedRow {
   id: string | null;
   name: string | null;
+  isSelfByDom?: boolean;
 }
 
 /**
@@ -341,5 +346,121 @@ describe("startParticipantScraper", () => {
     const restart = events[events.length - 1]!;
     expect(restart.left).toHaveLength(0);
     expect(restart.joined.map((p) => p.id)).toEqual(["p-alice"]);
+  });
+
+  // --------------------------------------------------------------------
+  // isSelf detection — lets the consent monitor identify the bot's own
+  // participant id so bot-self transcripts and chat (e.g. the consent
+  // message) don't advance the watermark.
+  // --------------------------------------------------------------------
+
+  test("flags the bot's own row via Meet's data-self-name DOM marker", async () => {
+    // `isSelfByDom: true` simulates the real extractor finding the
+    // row's name node via `[data-self-name]` rather than
+    // `[data-participant-name]`.
+    const page = makeFakePage([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bot", name: "AI Assistant", isSelfByDom: true },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50, selfName: "AI Assistant" },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = events[0]!.joined;
+    const alice = joined.find((p) => p.id === "p-alice");
+    const bot = joined.find((p) => p.id === "p-bot");
+    expect(alice?.isSelf).toBeUndefined();
+    expect(bot?.isSelf).toBe(true);
+  });
+
+  test("flags the bot's own row by display-name match when DOM marker is absent", async () => {
+    // Simulates a Meet variant that does not expose `data-self-name`
+    // on the bot row. The scraper falls back to matching the configured
+    // `selfName`. This fallback is safe for the bot because it picks a
+    // deliberately unique display name.
+    const page = makeFakePage([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bot", name: "Velissa (Sidd's assistant)", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      {
+        meetingId: "m-1",
+        pollMs: 50,
+        selfName: "Velissa (Sidd's assistant)",
+      },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = events[0]!.joined;
+    const bot = joined.find((p) => p.name === "Velissa (Sidd's assistant)");
+    expect(bot?.isSelf).toBe(true);
+    const alice = joined.find((p) => p.id === "p-alice");
+    expect(alice?.isSelf).toBeUndefined();
+  });
+
+  test("does not flag any row when selfName is omitted and no DOM marker is present", async () => {
+    // Without a configured `selfName` and no authoritative DOM signal,
+    // the scraper plays it safe and leaves `isSelf` off every row — the
+    // consent monitor will simply never populate `botParticipantId`,
+    // which keeps its vacuous-filter behavior rather than mis-attributing
+    // a human's row as the bot.
+    const page = makeFakePage([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bob", name: "Bob", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50 },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    for (const p of events[0]!.joined) {
+      expect(p.isSelf).toBeUndefined();
+    }
+  });
+
+  test("prefers the DOM marker even when a row's name happens to equal selfName", async () => {
+    // Defense in depth: if some human participant somehow shares the
+    // bot's configured display name (unlikely but not impossible), the
+    // authoritative DOM marker still wins and the scraper also flags the
+    // name-colliding row. Both rows end up with `isSelf: true`; the
+    // consent monitor's "first isSelf join wins" rule means the earlier
+    // row determines `botParticipantId`. This test pins the scraper
+    // behavior rather than the consumer's first-wins policy.
+    const page = makeFakePage([
+      { id: "p-bot", name: "AI Assistant", isSelfByDom: true },
+      { id: "p-imposter", name: "AI Assistant", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper(
+      page as unknown as Parameters<typeof startParticipantScraper>[0],
+      (event) => events.push(event),
+      { meetingId: "m-1", pollMs: 50, selfName: "AI Assistant" },
+    );
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = events[0]!.joined;
+    expect(joined.find((p) => p.id === "p-bot")?.isSelf).toBe(true);
+    // The name-colliding row is also flagged by the name-fallback — this
+    // is a known limitation of the fallback and the reason we prefer the
+    // DOM marker when both are available.
+    expect(joined.find((p) => p.id === "p-imposter")?.isSelf).toBe(true);
   });
 });

--- a/meet-bot/src/browser/participant-scraper.ts
+++ b/meet-bot/src/browser/participant-scraper.ts
@@ -43,6 +43,20 @@ export interface ParticipantScraperOptions {
   meetingId: string;
   /** Poll interval in milliseconds. Defaults to 1000. */
   pollMs?: number;
+  /**
+   * Display name the bot joined the meeting under. When provided, the
+   * scraper flags the matching row with `isSelf: true` so downstream
+   * consumers (e.g. {@link MeetConsentMonitor}) can identify the bot's
+   * own participant id.
+   *
+   * The scraper prefers Meet's authoritative DOM signal — the name
+   * element carrying `data-self-name` rather than `data-participant-name`
+   * — and falls back to comparing the row's display name with this value
+   * when the DOM attribute is absent. The name fallback is safe for the
+   * bot (which picks a deliberately unique display name) but would be
+   * fragile for arbitrary humans.
+   */
+  selfName?: string;
 }
 
 /** Handle returned by {@link startParticipantScraper}. */
@@ -55,6 +69,13 @@ export interface ParticipantScraperHandle {
 interface ScrapedRow {
   id: string | null;
   name: string | null;
+  /**
+   * True when the row's name node was matched via `data-self-name` —
+   * Meet's own marker for the signed-in / joining user's row. Undefined
+   * when the DOM signal is absent; the caller may still flag the row by
+   * name match in that case.
+   */
+  isSelfByDom: boolean;
 }
 
 /**
@@ -74,6 +95,7 @@ export function startParticipantScraper(
 ): ParticipantScraperHandle {
   const pollMs = opts.pollMs ?? 1000;
   const meetingId = opts.meetingId;
+  const selfName = opts.selfName;
 
   /**
    * Snapshot of the previous poll keyed by participant id, so we can
@@ -109,7 +131,14 @@ export function startParticipantScraper(
             const nameEl = el.querySelector(nameSelector);
             const name =
               (nameEl?.textContent ?? "").trim() || null;
-            return { id: id ?? null, name };
+            // Meet marks the signed-in / joining user's row with
+            // `data-self-name` instead of `data-participant-name`. We
+            // use this authoritative marker to flag the bot's own row;
+            // callers may additionally match by display name.
+            const isSelfByDom =
+              nameEl instanceof HTMLElement &&
+              nameEl.hasAttribute("data-self-name");
+            return { id: id ?? null, name, isSelfByDom };
           }),
         selectors.INGAME_PARTICIPANT_NAME,
       );
@@ -129,7 +158,18 @@ export function startParticipantScraper(
       // keeps the scraper resilient to partially-rendered rows.
       const id = row.id ?? name;
       if (!id) continue;
-      current.set(id, { id, name });
+      // Flag the bot's own row so downstream consumers (consent monitor,
+      // watermark tracker) can filter out bot-self transcripts and chat.
+      // Prefer Meet's authoritative DOM signal (`data-self-name`); fall
+      // back to matching the configured bot display name when the DOM
+      // marker is absent.
+      const isSelf =
+        row.isSelfByDom ||
+        (selfName !== undefined && name !== "" && name === selfName);
+      const participant: Participant = isSelf
+        ? { id, name, isSelf: true }
+        : { id, name };
+      current.set(id, participant);
     }
 
     // First poll: everyone currently visible is a "joined" participant from

--- a/meet-bot/src/main.ts
+++ b/meet-bot/src/main.ts
@@ -134,7 +134,7 @@ export interface BotDeps {
   startParticipantScraper: (
     page: Page,
     onEvent: (event: ParticipantChangeEvent) => void,
-    opts: { meetingId: string },
+    opts: { meetingId: string; selfName: string },
   ) => ParticipantScraperHandle;
   startSpeakerScraper: (
     page: Page,
@@ -533,7 +533,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
     subsystems.participantScraper = deps.startParticipantScraper(
       subsystems.session.page,
       (event) => enqueue(event),
-      { meetingId },
+      { meetingId, selfName: joinName },
     );
     subsystems.speakerScraper = deps.startSpeakerScraper(
       subsystems.session.page,


### PR DESCRIPTION
## Summary
Participant scraper now emits `isSelf: true` on the bot's own row, driven by the configured join name. This lets `MeetConsentMonitor` correctly identify `botParticipantId` so bot-self transcripts and chat (e.g., the consent message) do not advance the watermark.

**Gap:** `botParticipantId` was never populated in production — the scraper never set `isSelf`.
**Fix:** Thread the self-name through the scraper and flag the matching row.

Fixes a gap identified during self-review for plan meet-phase-1-7-consent-monitor.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
