### PR TITLE
fix(meet): cleanup — lint + test mock isolation + dead code

### DIFF
--- a/assistant/src/meet/__tests__/audio-ingest.test.ts
+++ b/assistant/src/meet/__tests__/audio-ingest.test.ts
@@ -6,34 +6,28 @@
  * network or filesystem socket is opened.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
+// `resolveStreamingTranscriber` is imported at file scope (before any mock
+// is installed) so the "default transcriber factory" describe below can
+// restore the real export in its `afterAll`. Bun's `mock.module` is
+// process-global and persists until re-mocked; installing it at file
+// scope bleeds into sibling test files that share a Bun process (e.g.
+// `providers/speech-to-text/__tests__/resolve.test.ts`).
+import { resolveStreamingTranscriber as realResolveStreamingTranscriberImport } from "../../providers/speech-to-text/resolve.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
-
-// ---------------------------------------------------------------------------
-// Module mocks — must appear before any imports of the modules under test
-// ---------------------------------------------------------------------------
-
-// Intercept `resolveStreamingTranscriber` so we can assert the default
-// `createTranscriber` path passes the expected diarize preference through.
-// Tests that inject their own `createTranscriber` never hit this mock.
-let mockResolveCalls: Array<Record<string, unknown> | undefined> = [];
-let mockResolveResult: StreamingTranscriber | null = null;
-
-mock.module("../../providers/speech-to-text/resolve.js", () => ({
-  resolveStreamingTranscriber: async (options?: Record<string, unknown>) => {
-    mockResolveCalls.push(options);
-    return mockResolveResult;
-  },
-}));
-
-// ---------------------------------------------------------------------------
-// Imports under test — after mocks
-// ---------------------------------------------------------------------------
-
 import {
   BOT_CONNECT_TIMEOUT_MS,
   MeetAudioIngest,
@@ -45,6 +39,20 @@ import {
   __resetMeetSessionEventRouterForTests,
   getMeetSessionEventRouter,
 } from "../session-event-router.js";
+
+// Copy the imported function reference out of its live binding so it can
+// be used as the restoration target in `afterAll`. ES module named imports
+// are live bindings that `mock.module` rebinds in place, so passing
+// `realResolveStreamingTranscriberImport` directly into the `afterAll`
+// re-mock factory would just hand back the stub. Saving the current
+// callable value breaks that live link.
+const realResolveStreamingTranscriberFn = realResolveStreamingTranscriberImport;
+
+// Shared state for the default-transcriber-factory describe below. Declared
+// here so both the `mock.module` factory (installed in that describe's
+// `beforeAll`) and the tests themselves have access.
+let mockResolveCalls: Array<Record<string, unknown> | undefined> = [];
+let mockResolveResult: StreamingTranscriber | null = null;
 
 // ---------------------------------------------------------------------------
 // In-memory fakes
@@ -734,6 +742,29 @@ describe("MeetAudioIngest.stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("MeetAudioIngest — default transcriber factory", () => {
+  // Install the module mock only for this describe so it doesn't leak
+  // into sibling test files that share a Bun process (Bun's `mock.module`
+  // is process-global). Restore in `afterAll` by re-mocking with the real
+  // function reference captured at file load time — Bun's `mock.restore()`
+  // doesn't undo `mock.module`, so we have to re-point it at the original
+  // export ourselves.
+  beforeAll(() => {
+    mock.module("../../providers/speech-to-text/resolve.js", () => ({
+      resolveStreamingTranscriber: async (
+        options?: Record<string, unknown>,
+      ) => {
+        mockResolveCalls.push(options);
+        return mockResolveResult;
+      },
+    }));
+  });
+
+  afterAll(() => {
+    mock.module("../../providers/speech-to-text/resolve.js", () => ({
+      resolveStreamingTranscriber: realResolveStreamingTranscriberFn,
+    }));
+  });
+
   test("requests diarize: preferred from the resolver", async () => {
     // The fake resolver returns a minimal StreamingTranscriber so the
     // ingest has something to drive. We don't exercise the streaming path

--- a/assistant/src/meet/__tests__/consent-monitor.test.ts
+++ b/assistant/src/meet/__tests__/consent-monitor.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, mock, test } from "bun:test";
 import type { MeetBotEvent } from "@vellumai/meet-contracts";
 
 import {
-  DEDUPE_WINDOW_MS,
   LLM_CHECK_DEBOUNCE_MS,
   LLM_TICK_INTERVAL_MS,
   MeetConsentMonitor,
@@ -357,8 +356,9 @@ describe("MeetConsentMonitor dedupe", () => {
     expect(monitor._bufferedTranscriptCount()).toBe(1);
 
     // Past both the dedupe and debounce windows, the same text re-enters
-    // the keyword path. We use `LLM_CHECK_DEBOUNCE_MS + 1` (which is also
-    // > DEDUPE_WINDOW_MS) so neither guard short-circuits the second call.
+    // the keyword path. We use `LLM_CHECK_DEBOUNCE_MS + 1` — since
+    // `LLM_CHECK_DEBOUNCE_MS` is defined to exceed the dedupe window,
+    // neither guard short-circuits the second call.
     t = LLM_CHECK_DEBOUNCE_MS + 1;
     dispatcher.dispatch(
       "m1",

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -357,36 +357,6 @@ class MeetSessionManagerImpl {
     });
   }
 
-  /** Swap dependencies at runtime. Tests only. */
-  _replaceDeps(deps: MeetSessionManagerDeps): void {
-    const insertMessage = deps.insertMessage ?? this.deps.insertMessage;
-    this.deps = {
-      dockerRunnerFactory:
-        deps.dockerRunnerFactory ?? this.deps.dockerRunnerFactory,
-      getProviderKey: deps.getProviderKey ?? this.deps.getProviderKey,
-      botLeaveFetch: deps.botLeaveFetch ?? this.deps.botLeaveFetch,
-      resolveDaemonUrl: deps.resolveDaemonUrl ?? this.deps.resolveDaemonUrl,
-      getWorkspaceDir: deps.getWorkspaceDir ?? this.deps.getWorkspaceDir,
-      audioIngestFactory:
-        deps.audioIngestFactory ?? this.deps.audioIngestFactory,
-      consentMonitorFactory:
-        deps.consentMonitorFactory ?? this.deps.consentMonitorFactory,
-      conversationBridgeFactory:
-        deps.conversationBridgeFactory ?? this.deps.conversationBridgeFactory,
-      storageWriterFactory:
-        deps.storageWriterFactory ?? this.deps.storageWriterFactory,
-      resolveAssistantDisplayName:
-        deps.resolveAssistantDisplayName ??
-        this.deps.resolveAssistantDisplayName,
-      insertMessage,
-    };
-    // Re-install the token resolver in case `_resetForTests` cleared it.
-    getMeetSessionEventRouter().setBotApiTokenResolver((meetingId) => {
-      const session = this.sessions.get(meetingId);
-      return session ? session.botApiToken : null;
-    });
-  }
-
   /** Reset internal state. Tests only. */
   _resetForTests(): void {
     for (const session of this.sessions.values()) {


### PR DESCRIPTION
## Summary
Three small cleanups identified during round-2 self-review of meet-phase-1-listen.md:

- **Lint**: removed unused `DEDUPE_WINDOW_MS` import in `consent-monitor.test.ts` (stranded by PR #25803). Updated the in-test comment that referenced the symbol by name.
- **Test isolation**: audio-ingest.test.ts's `mock.module(...resolve.js...)` at file scope leaked into resolve.test.ts when both ran in the same Bun process, causing 7 failures in the 'diarize preference' describe block. Moved the mock install into `beforeAll` of the one describe that needs it and restore it in `afterAll` by re-mocking with a captured function reference (ES named imports are live bindings that `mock.module` rebinds in place, so copying the current callable value is required to hold onto the pre-mock function).
- **Dead code**: removed unused `_replaceDeps` test hook on `MeetSessionManagerImpl` per CLAUDE.md.

Round-2 remediation after meet-phase-1-listen.md self-review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
