### PR TITLE
docs(meet-bot): use $VELLUM_WORKSPACE_DIR instead of hardcoded ~/.vellum/workspace

### DIFF
--- a/meet-bot/README.md
+++ b/meet-bot/README.md
@@ -93,7 +93,7 @@ the meet subsystem, run this manual verification loop.
   meeting-start time; the bot itself does not see STT credentials.
 - The `meet` feature flag enabled. Either:
   - **Local override** — set `meet` to `true` in
-    `~/.vellum/workspace/config.json` under the assistant feature flags
+    `$VELLUM_WORKSPACE_DIR/config.json` under the assistant feature flags
     block, OR
   - **LaunchDarkly** — flip the `meet` flag on for your platform user.
 - A throwaway Google Meet URL with at least one other human participant so
@@ -125,7 +125,7 @@ the meet subsystem, run this manual verification loop.
 5. **Inspect on-disk artifacts.** After the bot leaves, the workspace
    directory should contain the meeting's artifact tree:
    ```bash
-   ls -la ~/.vellum/workspace/meets/<meetingId>/
+   ls -la $VELLUM_WORKSPACE_DIR/meets/<meetingId>/
    ```
    Expected files:
    - `audio.opus` — Opus-encoded audio, non-empty.


### PR DESCRIPTION
## Summary
Replaces the two `~/.vellum/workspace` references in `meet-bot/README.md` with `$VELLUM_WORKSPACE_DIR` per CLAUDE.md (workspace path varies by deployment — local vs Docker vs multi-instance — and shouldn't be hardcoded in user-facing docs).

Touches the manual verification procedure for the meet-join feature; no code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
