### PR TITLE
meet: discover workspace volume name when daemon runs in Docker mode

### DIFF
--- a/assistant/src/meet/__tests__/workspace-volume.test.ts
+++ b/assistant/src/meet/__tests__/workspace-volume.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for the workspace-volume discovery helper.
+ *
+ * Mountinfo fixtures are written to a tempdir so we can exercise the real
+ * readFile path without touching `/proc`. The env-var fallback is tested by
+ * passing an explicit `env` override so tests don't mutate `process.env`.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  getWorkspaceVolumeName,
+  parseWorkspaceVolumeFromMountinfo,
+  resetWorkspaceVolumeNameCacheForTests,
+} from "../workspace-volume.js";
+
+let tempDir: string;
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "workspace-volume-test-"));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+/**
+ * Representative mountinfo line for a Docker named volume mounted at
+ * `/workspace`. Taken (anonymized) from a real Docker container running
+ * under the overlay2 storage driver.
+ */
+const WORKSPACE_VOLUME_LINE =
+  "2345 2100 0:123 / /workspace rw,relatime shared:456 - ext4 /var/lib/docker/volumes/myassistant-workspace/_data rw,seclabel";
+
+/** A mountinfo line for an unrelated mount — used to verify we skip it. */
+const ROOT_MOUNT_LINE =
+  "100 99 8:1 / / rw,relatime - ext4 /dev/sda1 rw,seclabel";
+
+/** A mountinfo line for `/proc` — also unrelated, here as noise. */
+const PROC_MOUNT_LINE =
+  "200 100 0:4 / /proc rw,relatime - proc proc rw";
+
+function writeFixture(name: string, contents: string): string {
+  const path = join(tempDir, name);
+  writeFileSync(path, contents, "utf8");
+  return path;
+}
+
+describe("parseWorkspaceVolumeFromMountinfo", () => {
+  test("extracts the volume name when /workspace is backed by a Docker volume", () => {
+    const raw = [ROOT_MOUNT_LINE, WORKSPACE_VOLUME_LINE, PROC_MOUNT_LINE].join(
+      "\n",
+    );
+    expect(parseWorkspaceVolumeFromMountinfo(raw)).toBe(
+      "myassistant-workspace",
+    );
+  });
+
+  test("returns null when there is no /workspace entry", () => {
+    const raw = [ROOT_MOUNT_LINE, PROC_MOUNT_LINE].join("\n");
+    expect(parseWorkspaceVolumeFromMountinfo(raw)).toBeNull();
+  });
+
+  test("returns null when /workspace is a host bind mount (not a Docker volume)", () => {
+    // Host bind mounts show up with a non-Docker source path.
+    const bindMountLine =
+      "2345 2100 0:123 / /workspace rw,relatime shared:456 - ext4 /home/user/workspace rw,seclabel";
+    expect(parseWorkspaceVolumeFromMountinfo(bindMountLine)).toBeNull();
+  });
+
+  test("handles volume names with dashes, underscores, and dots", () => {
+    const line =
+      "2345 2100 0:123 / /workspace rw,relatime shared:456 - ext4 /var/lib/docker/volumes/my_assistant-v1.2/_data rw,seclabel";
+    expect(parseWorkspaceVolumeFromMountinfo(line)).toBe(
+      "my_assistant-v1.2",
+    );
+  });
+
+  test("handles mountinfo lines with multiple optional fields before the separator", () => {
+    // Some configurations include several optional fields (`shared:N`,
+    // `master:N`, `propagate_from:N`). The parser must still find the
+    // `-` separator and not confuse optional fields with the mount_point.
+    const line =
+      "2345 2100 0:123 / /workspace rw,relatime shared:456 master:789 - ext4 /var/lib/docker/volumes/multi-opt/_data rw,seclabel";
+    expect(parseWorkspaceVolumeFromMountinfo(line)).toBe("multi-opt");
+  });
+
+  test("returns null for an empty blob", () => {
+    expect(parseWorkspaceVolumeFromMountinfo("")).toBeNull();
+  });
+});
+
+describe("getWorkspaceVolumeName", () => {
+  test("returns the Docker volume name when mountinfo has a /workspace entry", async () => {
+    const path = writeFixture(
+      "mountinfo-happy",
+      [ROOT_MOUNT_LINE, WORKSPACE_VOLUME_LINE, PROC_MOUNT_LINE].join("\n"),
+    );
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: path,
+      env: {},
+    });
+    expect(result).toBe("myassistant-workspace");
+  });
+
+  test("returns null when mountinfo has no /workspace entry and no env fallback", async () => {
+    const path = writeFixture(
+      "mountinfo-no-workspace",
+      [ROOT_MOUNT_LINE, PROC_MOUNT_LINE].join("\n"),
+    );
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: path,
+      env: {},
+    });
+    expect(result).toBeNull();
+  });
+
+  test("falls back to VELLUM_WORKSPACE_VOLUME_NAME when mountinfo yields nothing", async () => {
+    const path = writeFixture(
+      "mountinfo-no-workspace-env-hint",
+      [ROOT_MOUNT_LINE].join("\n"),
+    );
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: path,
+      env: { VELLUM_WORKSPACE_VOLUME_NAME: "env-provided-volume" },
+    });
+    expect(result).toBe("env-provided-volume");
+  });
+
+  test("prefers the mountinfo value over the env-var fallback when both are present", async () => {
+    const path = writeFixture(
+      "mountinfo-both",
+      [WORKSPACE_VOLUME_LINE].join("\n"),
+    );
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: path,
+      env: { VELLUM_WORKSPACE_VOLUME_NAME: "env-provided-volume" },
+    });
+    expect(result).toBe("myassistant-workspace");
+  });
+
+  test("ignores an empty-string env-var value", async () => {
+    const path = writeFixture(
+      "mountinfo-empty-env",
+      [ROOT_MOUNT_LINE].join("\n"),
+    );
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: path,
+      env: { VELLUM_WORKSPACE_VOLUME_NAME: "" },
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null cleanly when mountinfo cannot be read (macOS case)", async () => {
+    // Simulate `/proc/self/mountinfo` not existing by pointing at a file
+    // under tempDir that we never created.
+    const missingPath = join(tempDir, "does-not-exist-mountinfo");
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: missingPath,
+      env: {},
+    });
+    expect(result).toBeNull();
+  });
+
+  test("uses the env-var fallback even when mountinfo cannot be read", async () => {
+    const missingPath = join(tempDir, "also-missing-mountinfo");
+    const result = await getWorkspaceVolumeName({
+      mountinfoPath: missingPath,
+      env: { VELLUM_WORKSPACE_VOLUME_NAME: "hinted-volume" },
+    });
+    expect(result).toBe("hinted-volume");
+  });
+
+  test("caches the result across calls when no overrides are supplied", async () => {
+    resetWorkspaceVolumeNameCacheForTests();
+    // First default-options call resolves (and caches) a lookup. On
+    // macOS/dev machines this is almost always null; that's fine — the
+    // contract we're verifying is that the same promise reference is
+    // returned on subsequent calls, not the specific value.
+    const first = getWorkspaceVolumeName();
+    const second = getWorkspaceVolumeName();
+    expect(second).toBe(first);
+    await first;
+    resetWorkspaceVolumeNameCacheForTests();
+  });
+
+  test("override calls bypass the module-level cache", async () => {
+    resetWorkspaceVolumeNameCacheForTests();
+    const pathA = writeFixture(
+      "mountinfo-cache-a",
+      [WORKSPACE_VOLUME_LINE].join("\n"),
+    );
+    const pathB = writeFixture(
+      "mountinfo-cache-b",
+      [
+        "2345 2100 0:123 / /workspace rw,relatime shared:456 - ext4 /var/lib/docker/volumes/volume-b/_data rw,seclabel",
+      ].join("\n"),
+    );
+    const resultA = await getWorkspaceVolumeName({
+      mountinfoPath: pathA,
+      env: {},
+    });
+    const resultB = await getWorkspaceVolumeName({
+      mountinfoPath: pathB,
+      env: {},
+    });
+    expect(resultA).toBe("myassistant-workspace");
+    expect(resultB).toBe("volume-b");
+    resetWorkspaceVolumeNameCacheForTests();
+  });
+});

--- a/assistant/src/meet/workspace-volume.ts
+++ b/assistant/src/meet/workspace-volume.ts
@@ -1,0 +1,196 @@
+/**
+ * Workspace volume discovery — figures out which Docker named volume backs
+ * the assistant's `/workspace` mount when the daemon runs inside a container.
+ *
+ * Meet-bot containers need to mount the same workspace volume as the
+ * assistant so transcripts, audio, and other meeting artifacts land on the
+ * shared per-instance volume (see `docs` under Docker Volume Architecture).
+ * To launch a sibling container with a matching bind/volume spec, we first
+ * have to know the volume's name — which the running process can only
+ * discover by inspecting its own mount table.
+ *
+ * The Linux kernel exposes mount information at `/proc/self/mountinfo`.
+ * Each line is space-separated:
+ *
+ *   mount_id parent_id major:minor root mount_point mount_options ... - fs_type mount_source super_options
+ *
+ * Docker binds named volumes under
+ * `/var/lib/docker/volumes/<volname>/_data` on the host, so when a container
+ * mounts one at `/workspace` the `mount_source` field (first field after the
+ * `-` separator) carries that path. Parsing it gives us the volume name
+ * without needing to shell out to `docker inspect` or touch the Docker API.
+ *
+ * On non-Linux hosts (macOS/Windows developer machines running the daemon
+ * bare-metal) `/proc/self/mountinfo` does not exist — we return `null`
+ * cleanly. Callers should treat `null` as "daemon not in a Docker
+ * workspace mount"; Meet's Docker runner will use this result to either
+ * reuse the discovered volume or fall back to a host bind mount for
+ * local-mode launches.
+ *
+ * This helper is unused by default; PR 3 in the Meet Docker-mode plan wires
+ * it into the session-manager's container launch path.
+ */
+
+import { readFile } from "node:fs/promises";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("meet-workspace-volume");
+
+/** Default path to the Linux mount-info virtual file. */
+const DEFAULT_MOUNTINFO_PATH = "/proc/self/mountinfo";
+
+/** Container-internal path the workspace volume is mounted at. */
+const WORKSPACE_MOUNT_POINT = "/workspace";
+
+/**
+ * Env-var fallback. The CLI can set this when spawning the daemon container
+ * as a belt-and-suspenders hint — useful if mountinfo parsing breaks on
+ * some future Docker layout, or when the runtime uses a less common
+ * storage driver.
+ */
+const VOLUME_NAME_ENV_VAR = "VELLUM_WORKSPACE_VOLUME_NAME";
+
+/**
+ * Regex that extracts `<volname>` from a Docker volume source path like
+ * `/var/lib/docker/volumes/<volname>/_data`. The volume name may contain
+ * letters, digits, dashes, underscores, and dots per Docker's allowed
+ * charset.
+ */
+const DOCKER_VOLUME_SOURCE_RE =
+  /^\/var\/lib\/docker\/volumes\/([A-Za-z0-9][A-Za-z0-9_.-]*)\/_data$/;
+
+/**
+ * Options for {@link getWorkspaceVolumeName}. Primarily for test injection.
+ */
+export interface GetWorkspaceVolumeNameOptions {
+  /** Override the mountinfo path. Defaults to `/proc/self/mountinfo`. */
+  mountinfoPath?: string;
+  /**
+   * Override the environment object used for the fallback lookup. Defaults
+   * to `process.env`. Tests pass a fresh object so the real environment
+   * doesn't leak in.
+   */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Module-level cache. Holds the in-flight or resolved promise from the
+ * first successful (or failed) lookup with default options so concurrent
+ * callers share a single parse pass. Tests that pass overrides bypass the
+ * cache — this keeps fixtures from poisoning production reads and vice
+ * versa.
+ */
+let cachedPromise: Promise<string | null> | null = null;
+
+/**
+ * Resolve the name of the Docker named volume backing `/workspace`, or
+ * `null` if we can't determine one (daemon is bare-metal, workspace is a
+ * host bind mount, or the file couldn't be read).
+ *
+ * Result is cached on the first call that uses default options; subsequent
+ * calls without overrides return the cached value immediately. The value
+ * doesn't change for the lifetime of the process — the mount table is
+ * established at container start.
+ */
+export function getWorkspaceVolumeName(
+  options: GetWorkspaceVolumeNameOptions = {},
+): Promise<string | null> {
+  const hasOverrides =
+    options.mountinfoPath !== undefined || options.env !== undefined;
+  if (hasOverrides) {
+    // Bypass cache for test injection so fixtures can't contaminate real
+    // lookups and vice versa.
+    return resolveWorkspaceVolumeName(options);
+  }
+  if (cachedPromise === null) {
+    cachedPromise = resolveWorkspaceVolumeName(options);
+  }
+  return cachedPromise;
+}
+
+/**
+ * Reset the memoized lookup. Only for tests that want to re-exercise the
+ * cache path; production code should never call this.
+ */
+export function resetWorkspaceVolumeNameCacheForTests(): void {
+  cachedPromise = null;
+}
+
+async function resolveWorkspaceVolumeName(
+  options: GetWorkspaceVolumeNameOptions,
+): Promise<string | null> {
+  const mountinfoPath = options.mountinfoPath ?? DEFAULT_MOUNTINFO_PATH;
+  const env = options.env ?? process.env;
+
+  const fromMountinfo = await readMountinfoVolumeName(mountinfoPath);
+  if (fromMountinfo !== null) {
+    return fromMountinfo;
+  }
+
+  const fromEnv = env[VOLUME_NAME_ENV_VAR];
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    return fromEnv;
+  }
+
+  return null;
+}
+
+async function readMountinfoVolumeName(
+  mountinfoPath: string,
+): Promise<string | null> {
+  let raw: string;
+  try {
+    raw = await readFile(mountinfoPath, "utf8");
+  } catch (err) {
+    // Expected on macOS/Windows — `/proc` doesn't exist. Log at debug so
+    // we don't spam warnings on every developer machine.
+    log.debug(
+      { err, mountinfoPath },
+      "Failed to read mountinfo; workspace volume discovery will fall back",
+    );
+    return null;
+  }
+
+  return parseWorkspaceVolumeFromMountinfo(raw);
+}
+
+/**
+ * Parse a raw mountinfo blob and return the Docker volume name backing
+ * `/workspace`, or `null` if no matching entry is present.
+ *
+ * Exported for direct unit testing with synthetic fixtures.
+ */
+export function parseWorkspaceVolumeFromMountinfo(
+  raw: string,
+): string | null {
+  for (const line of raw.split("\n")) {
+    if (line.length === 0) continue;
+    const volumeName = extractVolumeNameFromLine(line);
+    if (volumeName !== null) return volumeName;
+  }
+  return null;
+}
+
+function extractVolumeNameFromLine(line: string): string | null {
+  // mountinfo format:
+  //   mount_id parent_id major:minor root mount_point mount_options (optional_fields)* - fs_type mount_source super_options
+  // The `-` separator terminates the optional fields list. Fields 1..5 are
+  // always in fixed positions; everything after the `-` is the post-split
+  // half (fs_type, mount_source, super_options).
+  const parts = line.split(" ");
+  if (parts.length < 10) return null;
+
+  const mountPoint = parts[4];
+  if (mountPoint !== WORKSPACE_MOUNT_POINT) return null;
+
+  const separatorIdx = parts.indexOf("-", 6);
+  if (separatorIdx < 0 || separatorIdx + 2 >= parts.length) return null;
+
+  const mountSource = parts[separatorIdx + 2];
+  if (mountSource === undefined) return null;
+
+  const match = DOCKER_VOLUME_SOURCE_RE.exec(mountSource);
+  if (match === null) return null;
+  return match[1] ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds `getWorkspaceVolumeName()` helper that parses `/proc/self/mountinfo` to find the Docker volume backing `/workspace`, with `VELLUM_WORKSPACE_VOLUME_NAME` env-var fallback.
- Caches the result; returns null on macOS (bare-metal daemon).
- Unused by default — PR 3 wires it in.

Part of plan: meet-phase-1-8-docker-mode.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
