### PR TITLE
cli: mount /var/run/docker.sock in Docker-mode daemon with meet feature

### DIFF
--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import {
+  dockerResourceNames,
+  serviceDockerRunArgs,
+  type ServiceName,
+} from "../docker.js";
+
+const instanceName = "test-instance";
+const imageTags: Record<ServiceName, string> = {
+  assistant: "vellumai/vellum-assistant:test",
+  "credential-executor": "vellumai/vellum-credential-executor:test",
+  gateway: "vellumai/vellum-gateway:test",
+};
+
+function buildAssistantArgs(): string[] {
+  const res = dockerResourceNames(instanceName);
+  const builders = serviceDockerRunArgs({
+    gatewayPort: 7830,
+    imageTags,
+    instanceName,
+    res,
+  });
+  return builders.assistant();
+}
+
+describe("serviceDockerRunArgs — assistant", () => {
+  test("mounts the host Docker socket for Meet bot spawning", () => {
+    const args = buildAssistantArgs();
+    // The bind-mount is expressed as two adjacent args: "-v" then the spec.
+    const mountIndex = args.indexOf(
+      "/var/run/docker.sock:/var/run/docker.sock",
+    );
+    expect(mountIndex).toBeGreaterThan(0);
+    expect(args[mountIndex - 1]).toBe("-v");
+  });
+
+  test("passes VELLUM_WORKSPACE_VOLUME_NAME as a hint for the workspace-volume helper", () => {
+    const args = buildAssistantArgs();
+    const expected = `VELLUM_WORKSPACE_VOLUME_NAME=${instanceName}-workspace`;
+    const envIndex = args.indexOf(expected);
+    expect(envIndex).toBeGreaterThan(0);
+    expect(args[envIndex - 1]).toBe("-e");
+  });
+
+  test("keeps existing workspace and socket volume mounts intact", () => {
+    const args = buildAssistantArgs();
+    expect(args).toContain(`${instanceName}-workspace:/workspace`);
+    expect(args).toContain(`${instanceName}-socket:/run/ces-bootstrap`);
+  });
+
+  test("preserves existing required env vars", () => {
+    const args = buildAssistantArgs();
+    expect(args).toContain("IS_CONTAINERIZED=true");
+    expect(args).toContain("VELLUM_WORKSPACE_DIR=/workspace");
+    expect(args).toContain(`VELLUM_ASSISTANT_NAME=${instanceName}`);
+  });
+});

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -563,6 +563,23 @@ export function serviceDockerRunArgs(opts: {
   } = opts;
   return {
     assistant: () => {
+      // Mount the host Docker socket so the assistant's Meet subsystem can
+      // spawn sibling meet-bot containers on the host Docker engine. This is
+      // additive — pre-existing Docker-mode deployments continue to work and
+      // simply lack Meet support until the user restarts the daemon to pick
+      // up these new run args.
+      //
+      // Platform notes:
+      // - macOS (Docker Desktop): the socket path on the host is always
+      //   `/var/run/docker.sock`; Docker Desktop proxies it transparently.
+      // - Linux (root Docker): `/var/run/docker.sock` is the canonical path.
+      // - Linux (rootless Docker): the socket typically lives at
+      //   `$XDG_RUNTIME_DIR/docker.sock`. Rootless-Docker support is out of
+      //   scope for this phase and will require separate handling.
+      //
+      // We pass `VELLUM_WORKSPACE_VOLUME_NAME` as a hint so the workspace-
+      // volume helper inside the container can reliably find the volume name
+      // without probing Docker for it.
       const args: string[] = [
         "run",
         "--init",
@@ -576,6 +593,8 @@ export function serviceDockerRunArgs(opts: {
         `${res.workspaceVolume}:/workspace`,
         "-v",
         `${res.socketVolume}:/run/ces-bootstrap`,
+        "-v",
+        "/var/run/docker.sock:/var/run/docker.sock",
         "-e",
         "IS_CONTAINERIZED=true",
         "-e",
@@ -586,6 +605,8 @@ export function serviceDockerRunArgs(opts: {
         "RUNTIME_HTTP_HOST=0.0.0.0",
         "-e",
         "VELLUM_WORKSPACE_DIR=/workspace",
+        "-e",
+        `VELLUM_WORKSPACE_VOLUME_NAME=${res.workspaceVolume}`,
         "-e",
         "VELLUM_BACKUP_DIR=/workspace/.backups",
         "-e",


### PR DESCRIPTION
## Summary
- Adds `/var/run/docker.sock` bind-mount to the assistant daemon container so the Meet subsystem can spawn sibling bot containers.
- Sets `VELLUM_WORKSPACE_VOLUME_NAME` env var so the workspace-volume helper has a reliable hint.
- Additive change — existing Docker-mode instances continue to work; users must restart their daemon to pick up the new run args.

Part of plan: meet-phase-1-8-docker-mode.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
