### PR TITLE
docs: Docker Volume Architecture updated for Meet socket mount

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,14 +159,15 @@ Use `QDRANT_HTTP_PORT` (not `QDRANT_URL`) when allocating per-instance Qdrant po
 
 ## Docker Volume Architecture
 
-Docker instances use four dedicated volumes with strict per-service access boundaries. Each volume is mounted only by the services that need it, enforcing least-privilege at the container level.
+Docker instances use four dedicated volumes with strict per-service access boundaries, plus one host bind-mount for the Meet subsystem. Each volume is mounted only by the services that need it, enforcing least-privilege at the container level.
 
-| Volume | Mount path | Access | Contents |
+| Volume / bind | Mount path | Access | Contents |
 |---|---|---|---|
 | **Workspace** (`<name>-workspace`) | `/workspace` | Assistant: read-write, Gateway: read-write, CES: read-only | `config.json`, conversations, apps, skills, db, logs, `.backups/`, `.backup.key` |
 | **Gateway security** (`<name>-gateway-sec`) | `/gateway-security` | Gateway only | Files private to the gateway container |
 | **CES security** (`<name>-ces-sec`) | `/ces-security` | CES only | `keys.enc`, `store.key` |
 | **Socket** (`<name>-socket`) | `/run/ces-bootstrap` | Assistant + CES | CES bootstrap socket for initial handshake |
+| **Docker socket** (host bind-mount, not a named volume) | `/var/run/docker.sock` | Assistant: read-write | Host Docker Engine API — used by the Meet subsystem to spawn sibling bot containers. |
 
 The assistant's container root (`/`) stores per-container ephemeral and persistent state: package installs (`~/.bun`), `device.json`, and embed-worker PID files. This replaces the former shared data volume which previously held all state.
 
@@ -174,7 +175,10 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 
 - **Trust rules** are owned by the gateway. In Docker mode (`IS_CONTAINERIZED=true`), the assistant reads and writes trust rules via the gateway's HTTP trust API — it has no direct filesystem access to `trust.json`. The gateway reads `trust.json` from `/gateway-security/trust.json`.
 - **Credentials** are owned by the CES. In Docker mode, the assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`). Neither service has direct filesystem access to `keys.enc` or `store.key`.
+- **Meet bots are sibling containers, not nested.** The daemon uses `/var/run/docker.sock` to instruct the host's Docker engine to spawn them. This grants the daemon effective root on the host — acceptable for single-user local deployments, not for managed/multi-tenant mode. Managed/hosted mode is explicitly out of scope for this Docker-socket approach; future managed Meet support needs a different spawn model (see [`vellum-assistant-platform`](../vellum-assistant-platform)).
 - The legacy shared data volume (`<name>-data`) is no longer created for new instances. Existing instances are migrated: gateway security files and CES security files are copied from the data volume to their respective security volumes on startup (see `migrateGatewaySecurityFiles()` and `migrateCesSecurityFiles()` in `cli/src/lib/docker.ts`).
+
+**Meet workspace-volume discovery**: Meet-bot sibling containers need to mount the same workspace volume as the assistant so transcripts, audio, and other meeting artifacts land on the shared per-instance volume. The assistant discovers the volume name at runtime by parsing `/proc/self/mountinfo` (see `assistant/src/meet/workspace-volume.ts`). The CLI also passes `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as a belt-and-suspenders hint so the workspace-volume helper can skip the mountinfo probe and fall back cleanly on storage drivers with non-standard layouts.
 
 **Backup paths in Docker mode**: The backup system stores local snapshots at `VELLUM_BACKUP_DIR` (default: `/workspace/.backups/`) and the encryption key at `VELLUM_BACKUP_KEY_PATH` (default: `/workspace/.backup.key`) on the workspace volume. This means workspace volume destruction loses both data and backups. For stronger isolation, a dedicated backup volume could be added in a future iteration.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ The lockfile can contain both local and remote entries. Remote entries (cloud pr
 
 ## Docker Volume Architecture
 
-Docker instances use dedicated volumes with per-service access boundaries instead of a single shared data volume. This enforces least-privilege: each service only has filesystem access to the data it owns.
+Docker instances use dedicated volumes with per-service access boundaries instead of a single shared data volume. This enforces least-privilege: each service only has filesystem access to the data it owns. A single host bind-mount (`/var/run/docker.sock`) is also attached to the assistant container so the Meet subsystem can spawn sibling bot containers — see [Meet Sibling-Container Model](#meet-sibling-container-model) below.
 
 ### Volume Layout
 
@@ -146,12 +146,33 @@ Docker instances use dedicated volumes with per-service access boundaries instea
 <instance-name>-gateway-sec     →  /gateway-security    (gateway only)
 <instance-name>-ces-sec         →  /ces-security        (CES only)
 <instance-name>-socket          →  /run/ces-bootstrap   (assistant + CES)
+/var/run/docker.sock            →  /var/run/docker.sock (assistant: rw — host bind, not a named volume)
 ```
 
 - **Workspace volume** (`/workspace`): Shared state — config, conversations, apps, skills, database, logs. Set via `VELLUM_WORKSPACE_DIR=/workspace`. The assistant and gateway have read-write access; the CES mounts it read-only (for config reading).
 - **Gateway security volume** (`/gateway-security`): Files private to the gateway container. Only the gateway container mounts this volume. Set via `GATEWAY_SECURITY_DIR=/gateway-security`.
 - **CES security volume** (`/ces-security`): Credential encryption keys (`keys.enc`, `store.key`). Only the CES container mounts this volume. Set via `CREDENTIAL_SECURITY_DIR=/ces-security`.
 - **Socket volume** (`/run/ces-bootstrap`): CES bootstrap socket for initial service handshake between the assistant and CES containers.
+- **Docker socket bind-mount** (`/var/run/docker.sock`): Host Docker Engine API, used by the assistant's Meet subsystem to spawn sibling Meet-bot containers. Mounted read-write on the assistant container only. The CLI also passes `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as an env-var hint so the workspace-volume helper can find the volume reliably without probing Docker (see `assistant/src/meet/workspace-volume.ts`).
+
+### Meet Sibling-Container Model
+
+Meet bots are **sibling** containers to the assistant, not nested (Docker-in-Docker). The assistant instructs the host's Docker engine via the mounted socket to spawn each bot; bots therefore run next to the assistant on the same engine and share the workspace volume.
+
+```
+                host Docker Engine (/var/run/docker.sock)
+                         |
+           +-------------+--------------+--------------------+
+           |             |              |                    |
+    assistant ct.   gateway ct.     CES ct.          meet-bot ct. (per meeting)
+           |                                                 |
+           +-------- /workspace (<name>-workspace) ----------+
+                     (mounted on both, for artifact exchange)
+```
+
+The assistant creates each bot with a bind of the discovered workspace volume at `/workspace` so the bot can drop transcripts, audio, and metadata into `/workspace/meets/<meetingId>/` where the assistant can read them back. Bots have no access to the gateway-security or CES-security volumes.
+
+**Security boundary — single-user local only.** Mounting `/var/run/docker.sock` grants the assistant effective root on the host (any container mount, any image run). This is acceptable for single-user local deployments where the assistant is already running with the user's privileges. It is **not** acceptable for managed/multi-tenant mode. Managed Meet support is explicitly out of scope for this Docker-socket approach — the platform deployment (`vellum-assistant-platform`) needs a different spawn model (e.g. a Kubernetes job runner or a dedicated bot-scheduler service) before Meet can ship to managed instances.
 
 ### Cross-Service Access Patterns
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -58,3 +58,7 @@ The CLI creates and manages Docker volumes for containerized instances. See the 
 **Volume cleanup** (`retire`): All volumes (including the legacy data volume if it exists) are removed when an instance is retired.
 
 **Volume mount rules**: Each service container receives only the volumes it needs. The assistant never mounts `gateway-security` or `ces-security`. The gateway never mounts `ces-security`. The CES mounts the workspace volume as read-only.
+
+**Meet sibling-container support** (assistant container only): In addition to the named volumes above, the assistant container receives a host bind-mount of `/var/run/docker.sock:/var/run/docker.sock` so the Meet subsystem can spawn sibling Meet-bot containers on the host's Docker engine. The CLI also injects `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as a hint so the assistant's workspace-volume helper can look up the volume by name without probing `/proc/self/mountinfo`. Both are wired in `serviceDockerRunArgs()` in `lib/docker.ts`.
+
+Mounting the Docker socket grants the daemon effective root on the host — acceptable for single-user local deployments, not for managed/multi-tenant mode. Managed Meet support requires a different spawn model and is out of scope for this CLI.


### PR DESCRIPTION
## Summary
- Documents the `/var/run/docker.sock` bind-mount on the assistant container and the `VELLUM_WORKSPACE_VOLUME_NAME` env var.
- Adds a sibling-container invariant note clarifying that Meet bots are not nested.
- Flags the security boundary: socket mount is acceptable for single-user local deployments, not for managed/multi-tenant mode.

Part of plan: meet-phase-1-8-docker-mode.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
