### PR TITLE
cli: complete docker mock in teleport tests to unblock main CI

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -174,9 +174,13 @@ const retireDockerMock = mock(async () => {});
 const sleepContainersMock = mock(async () => {});
 const dockerResourceNamesMock = mock((name: string) => ({
   assistantContainer: `${name}-assistant`,
+  cesContainer: `${name}-credential-executor`,
+  cesSecurityVolume: `${name}-ces-sec`,
   gatewayContainer: `${name}-gateway`,
-  cesContainer: `${name}-ces`,
+  gatewaySecurityVolume: `${name}-gateway-sec`,
   network: `${name}-net`,
+  socketVolume: `${name}-socket`,
+  workspaceVolume: `${name}-workspace`,
 }));
 
 mock.module("../lib/docker.js", () => ({


### PR DESCRIPTION
## Summary
- `cli/src/__tests__/teleport.test.ts` mocks `../lib/docker.js` with a partial `dockerResourceNames` stub. Bun's `mock.module` persists for the rest of the test run, so the `docker.test.ts` suite added in #25816 inherits the stub under `bun test --coverage` and sees `undefined` for `workspaceVolume` / `socketVolume`.
- Fill in the missing fields (`workspaceVolume`, `socketVolume`, `cesSecurityVolume`, `gatewaySecurityVolume`) and align `cesContainer` with the real suffix (`-credential-executor`) so the mock matches `dockerResourceNames` exactly.
- Verified with `bun test --coverage` in `cli/`: 203 pass / 0 fail (previously 2 fails in `serviceDockerRunArgs — assistant`).

Fixes the failing `CI Main CLI Checks` run on main: https://github.com/vellum-ai/vellum-assistant/actions/runs/24448460083/job/71430943497

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24448460083/job/71430943497
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
