### PR TITLE
meet: DockerRunner produces Docker-mode volume + networking specs

### DIFF
--- a/assistant/src/meet/__tests__/docker-runner.test.ts
+++ b/assistant/src/meet/__tests__/docker-runner.test.ts
@@ -13,9 +13,13 @@ import {
 
 import {
   buildCreateBody,
+  DOCKER_SOCKET_UNREACHABLE_MESSAGE,
+  DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE,
   DockerApiError,
   DockerRunner,
   extractBoundPorts,
+  HOST_GATEWAY_ALIAS,
+  resolveWorkspaceSubpath,
 } from "../docker-runner.js";
 
 // ---------------------------------------------------------------------------
@@ -332,7 +336,7 @@ describe("DockerRunner.inspect", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildCreateBody", () => {
-  test("serializes env + binds + ports + network", () => {
+  test("serializes env + binds + ports + network and always sets host-gateway", () => {
     const body = buildCreateBody({
       image: "foo:bar",
       env: { A: "1", B: "two" },
@@ -364,6 +368,96 @@ describe("buildCreateBody", () => {
       "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
       "9000/udp": [{ HostIp: "0.0.0.0", HostPort: "9000" }],
     });
+    // host-gateway is always appended so Linux bots can reach the daemon.
+    expect(hc.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
+    // Mounts is omitted entirely when no named-volume mounts resolved.
+    expect(hc.Mounts).toBeUndefined();
+  });
+
+  test("appends extraBinds from resolved workspace mounts (bare-metal mode)", () => {
+    const body = buildCreateBody(
+      {
+        image: "x:y",
+        binds: [{ hostPath: "/explicit", containerPath: "/mnt" }],
+      },
+      {
+        extraBinds: [
+          {
+            hostPath: "/ws/meets/abc/sockets",
+            containerPath: "/sockets",
+          },
+          {
+            hostPath: "/ws/meets/abc/out",
+            containerPath: "/out",
+            readOnly: true,
+          },
+        ],
+        mounts: [],
+      },
+    );
+    const hc = body.HostConfig as Record<string, unknown>;
+    expect(hc.Binds).toEqual([
+      "/explicit:/mnt",
+      "/ws/meets/abc/sockets:/sockets",
+      "/ws/meets/abc/out:/out:ro",
+    ]);
+    // No Mounts field emitted in the bare-metal branch.
+    expect(hc.Mounts).toBeUndefined();
+  });
+
+  test("serializes named-volume mounts via HostConfig.Mounts (Docker mode)", () => {
+    const body = buildCreateBody(
+      { image: "x:y" },
+      {
+        extraBinds: [],
+        mounts: [
+          {
+            Type: "volume",
+            Source: "vellum-work",
+            Target: "/sockets",
+            ReadOnly: false,
+            VolumeOptions: { Subpath: "meets/abc/sockets" },
+          },
+          {
+            Type: "volume",
+            Source: "vellum-work",
+            Target: "/out",
+            ReadOnly: true,
+            VolumeOptions: { Subpath: "meets/abc/out" },
+          },
+        ],
+      },
+    );
+    const hc = body.HostConfig as Record<string, unknown>;
+    expect(hc.Binds).toEqual([]);
+    expect(hc.Mounts).toEqual([
+      {
+        Type: "volume",
+        Source: "vellum-work",
+        Target: "/sockets",
+        ReadOnly: false,
+        VolumeOptions: { Subpath: "meets/abc/sockets" },
+      },
+      {
+        Type: "volume",
+        Source: "vellum-work",
+        Target: "/out",
+        ReadOnly: true,
+        VolumeOptions: { Subpath: "meets/abc/out" },
+      },
+    ]);
+  });
+});
+
+describe("resolveWorkspaceSubpath", () => {
+  test("joins a relative subpath under the workspace dir", () => {
+    expect(resolveWorkspaceSubpath("/ws", "meets/abc/sockets")).toBe(
+      "/ws/meets/abc/sockets",
+    );
+  });
+
+  test("tolerates leading slashes in the subpath", () => {
+    expect(resolveWorkspaceSubpath("/ws", "/meets/abc")).toBe("/ws/meets/abc");
   });
 });
 
@@ -397,5 +491,211 @@ describe("extractBoundPorts", () => {
 
   test("returns empty list when NetworkSettings is absent", () => {
     expect(extractBoundPorts({ Id: "x" })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode-aware workspace mounts + host-gateway flag (Phase 1.8)
+// ---------------------------------------------------------------------------
+
+describe("DockerRunner workspace-mount mode branching", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("bare-metal mode translates workspaceMounts to host-path binds and always sets host-gateway", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 201, body: { Id: "bm-1" } });
+    mock.queueResponse({ status: 204, body: null });
+    mock.queueResponse({
+      status: 200,
+      body: { Id: "bm-1", NetworkSettings: { Ports: {} } },
+    });
+
+    const resolveWorkspaceVolumeName = async () => {
+      throw new Error(
+        "resolveWorkspaceVolumeName must not be called in bare-metal mode",
+      );
+    };
+    const runner = new DockerRunner({
+      socketPath: mock.socketPath,
+      resolveMode: () => "bare-metal",
+      resolveWorkspaceVolumeName,
+      workspaceDir: "/ws",
+    });
+
+    await runner.run({
+      image: "vellum-meet-bot:dev",
+      workspaceMounts: [
+        { target: "/sockets", subpath: "meets/m1/sockets" },
+        { target: "/out", subpath: "meets/m1/out" },
+      ],
+    });
+
+    // Bare-metal mode skips the /_ping probe; only create + start + inspect.
+    expect(mock.captured).toHaveLength(3);
+
+    const createBody = JSON.parse(mock.captured[0].body);
+    expect(createBody.HostConfig.Binds).toEqual([
+      "/ws/meets/m1/sockets:/sockets",
+      "/ws/meets/m1/out:/out",
+    ]);
+    expect(createBody.HostConfig.Mounts).toBeUndefined();
+    expect(createBody.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
+  });
+
+  test("Docker mode probes the socket, translates workspaceMounts to named-volume subpath mounts, and sets host-gateway", async () => {
+    mock = await startMockDocker();
+    // /_ping → create → start → inspect
+    mock.queueResponse({ status: 200, body: "OK" });
+    mock.queueResponse({ status: 201, body: { Id: "dk-1" } });
+    mock.queueResponse({ status: 204, body: null });
+    mock.queueResponse({
+      status: 200,
+      body: {
+        Id: "dk-1",
+        NetworkSettings: {
+          Ports: {
+            "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "49200" }],
+          },
+        },
+      },
+    });
+
+    const runner = new DockerRunner({
+      socketPath: mock.socketPath,
+      resolveMode: () => "docker",
+      resolveWorkspaceVolumeName: async () => "vellum-inst-workspace",
+      // workspaceDir unused in Docker mode.
+      workspaceDir: "/irrelevant",
+    });
+
+    const result = await runner.run({
+      image: "vellum-meet-bot:dev",
+      workspaceMounts: [
+        { target: "/sockets", subpath: "meets/m1/sockets" },
+        { target: "/out", subpath: "meets/m1/out", readOnly: true },
+      ],
+      ports: [
+        {
+          hostIp: "127.0.0.1",
+          hostPort: 0,
+          containerPort: 3000,
+          protocol: "tcp",
+        },
+      ],
+      name: "vellum-meet-m1",
+    });
+
+    expect(result.containerId).toBe("dk-1");
+
+    // /_ping first, then create/start/inspect.
+    expect(mock.captured).toHaveLength(4);
+    expect(mock.captured[0].method).toBe("GET");
+    expect(mock.captured[0].url).toContain("/_ping");
+
+    const createBody = JSON.parse(mock.captured[1].body);
+    expect(createBody.HostConfig.Binds).toEqual([]);
+    expect(createBody.HostConfig.Mounts).toEqual([
+      {
+        Type: "volume",
+        Source: "vellum-inst-workspace",
+        Target: "/sockets",
+        ReadOnly: false,
+        VolumeOptions: { Subpath: "meets/m1/sockets" },
+      },
+      {
+        Type: "volume",
+        Source: "vellum-inst-workspace",
+        Target: "/out",
+        ReadOnly: true,
+        VolumeOptions: { Subpath: "meets/m1/out" },
+      },
+    ]);
+    expect(createBody.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
+  });
+
+  test("Docker mode throws when workspace volume name is null — and never attempts create", async () => {
+    mock = await startMockDocker();
+    // Only /_ping should be consumed before we bail on the volume lookup.
+    mock.queueResponse({ status: 200, body: "OK" });
+
+    const runner = new DockerRunner({
+      socketPath: mock.socketPath,
+      resolveMode: () => "docker",
+      resolveWorkspaceVolumeName: async () => null,
+    });
+
+    await expect(
+      runner.run({
+        image: "vellum-meet-bot:dev",
+        workspaceMounts: [
+          { target: "/sockets", subpath: "meets/m1/sockets" },
+        ],
+      }),
+    ).rejects.toThrow(DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE);
+
+    // Only the ping round-trip happened; no create was issued.
+    expect(mock.captured).toHaveLength(1);
+    expect(mock.captured[0].url).toContain("/_ping");
+  });
+
+  test("Docker mode surfaces the prerequisite-missing error when the socket is unreachable", async () => {
+    // Use a bogus socket path — no server listening there.
+    const runner = new DockerRunner({
+      socketPath: join(tempDir, "nonexistent.sock"),
+      resolveMode: () => "docker",
+      resolveWorkspaceVolumeName: async () => "vellum-inst-workspace",
+    });
+
+    await expect(
+      runner.run({
+        image: "vellum-meet-bot:dev",
+        workspaceMounts: [
+          { target: "/sockets", subpath: "meets/m1/sockets" },
+        ],
+      }),
+    ).rejects.toThrow(DOCKER_SOCKET_UNREACHABLE_MESSAGE);
+  });
+
+  test("Docker-mode ping success is memoized across run() calls", async () => {
+    mock = await startMockDocker();
+    // First run: /_ping + create + start + inspect (4).
+    mock.queueResponse({ status: 200, body: "OK" });
+    mock.queueResponse({ status: 201, body: { Id: "m-1" } });
+    mock.queueResponse({ status: 204, body: null });
+    mock.queueResponse({
+      status: 200,
+      body: { Id: "m-1", NetworkSettings: { Ports: {} } },
+    });
+    // Second run skips /_ping — create + start + inspect (3).
+    mock.queueResponse({ status: 201, body: { Id: "m-2" } });
+    mock.queueResponse({ status: 204, body: null });
+    mock.queueResponse({
+      status: 200,
+      body: { Id: "m-2", NetworkSettings: { Ports: {} } },
+    });
+
+    const runner = new DockerRunner({
+      socketPath: mock.socketPath,
+      resolveMode: () => "docker",
+      resolveWorkspaceVolumeName: async () => "vol",
+    });
+
+    await runner.run({
+      image: "x:y",
+      workspaceMounts: [{ target: "/sockets", subpath: "meets/m-1/sockets" }],
+    });
+    await runner.run({
+      image: "x:y",
+      workspaceMounts: [{ target: "/sockets", subpath: "meets/m-2/sockets" }],
+    });
+
+    // 4 + 3 = 7. If the ping were not memoized we'd see 8.
+    expect(mock.captured).toHaveLength(7);
+    const pingCalls = mock.captured.filter((c) => c.url.includes("/_ping"));
+    expect(pingCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/meet/__tests__/session-manager.test.ts
+++ b/assistant/src/meet/__tests__/session-manager.test.ts
@@ -172,12 +172,19 @@ describe("MeetSessionManager.join", () => {
     expect(getProviderKey).toHaveBeenCalledWith("tts");
     expect(getProviderKey).not.toHaveBeenCalledWith("deepgram");
 
-    // Runner invoked with the expected env/binds/ports/name/network.
+    // Runner invoked with the expected env/workspaceMounts/ports/name/network.
+    // Session-manager passes mode-agnostic workspaceMounts — the runner is
+    // responsible for translating them to binds (bare-metal) or named-volume
+    // Mounts (Docker). See `docker-runner.test.ts` for that resolution.
     expect(runner.run).toHaveBeenCalledTimes(1);
     const runOpts = runner.run.mock.calls[0][0] as {
       image: string;
       env: Record<string, string>;
-      binds: Array<{ hostPath: string; containerPath: string }>;
+      workspaceMounts: Array<{
+        target: string;
+        subpath: string;
+        readOnly?: boolean;
+      }>;
       ports: Array<{
         hostIp: string;
         hostPort: number;
@@ -205,15 +212,9 @@ describe("MeetSessionManager.join", () => {
     expect(runOpts.env.TTS_API_KEY).toBe("tts-secret");
     expect(runOpts.env.SKIP_PULSE).toBe("0");
 
-    expect(runOpts.binds).toEqual([
-      {
-        hostPath: join(workspaceDir, "meets", "m1", "sockets"),
-        containerPath: "/sockets",
-      },
-      {
-        hostPath: join(workspaceDir, "meets", "m1", "out"),
-        containerPath: "/out",
-      },
+    expect(runOpts.workspaceMounts).toEqual([
+      { target: "/sockets", subpath: "meets/m1/sockets" },
+      { target: "/out", subpath: "meets/m1/out" },
     ]);
 
     expect(runOpts.ports).toEqual([

--- a/assistant/src/meet/__tests__/workspace-volume.test.ts
+++ b/assistant/src/meet/__tests__/workspace-volume.test.ts
@@ -9,7 +9,6 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 import {

--- a/assistant/src/meet/docker-runner.ts
+++ b/assistant/src/meet/docker-runner.ts
@@ -10,11 +10,32 @@
  * on stdio. The HTTP-socket API keeps everything in-process, returns
  * structured JSON, and avoids the PATH/CLI surface entirely. See
  * `cli/src/lib/docker.ts` for the broader service container lifecycle.
+ *
+ * Mode-awareness (Phase 1.8):
+ *   - In bare-metal mode the daemon writes workspace artifacts to host paths
+ *     it can share with bot containers via standard Docker bind mounts.
+ *   - In Docker mode the daemon itself lives in a container whose
+ *     `/workspace` path is not visible to the host Docker engine. Workspace-
+ *     rooted mounts have to be expressed as named-volume mounts against the
+ *     same workspace volume the daemon is using (discovered via
+ *     {@link getWorkspaceVolumeName}). We use Docker's volume `Mounts` API
+ *     with `VolumeOptions.Subpath` so each bot only sees its own meeting
+ *     directory — that requires Docker Engine 25+.
+ *
+ * Networking:
+ *   - We always attach `host.docker.internal:host-gateway` via
+ *     `HostConfig.ExtraHosts` so the bot can reach the daemon HTTP port on
+ *     the host in either mode. On Docker Desktop it's already mapped; on
+ *     Linux the explicit gateway alias is required.
  */
 
 import { request as httpRequest } from "node:http";
+import { posix as posixPath } from "node:path";
 
+import type { DaemonRuntimeMode } from "../runtime/runtime-mode.js";
+import { getDaemonRuntimeMode } from "../runtime/runtime-mode.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceVolumeName } from "./workspace-volume.js";
 
 const log = getLogger("meet-docker-runner");
 
@@ -63,11 +84,36 @@ export interface BindMount {
   readOnly?: boolean;
 }
 
+/**
+ * A workspace-rooted mount request. The runner translates these to either a
+ * host-path bind (bare-metal mode) or a named-volume `Mounts` entry with
+ * `VolumeOptions.Subpath` (Docker mode). Callers should prefer this over
+ * raw `binds` for anything that lives inside the daemon's workspace — the
+ * same logical spec then works in both deployment modes.
+ *
+ * `subpath` is interpreted relative to the workspace root on disk — e.g.
+ * `"meets/<id>/sockets"`. `target` is the absolute path inside the bot
+ * container — e.g. `"/sockets"`.
+ */
+export interface WorkspaceMount {
+  target: string;
+  subpath: string;
+  /** Whether the mount is read-only. Defaults to `false`. */
+  readOnly?: boolean;
+}
+
 /** Options for creating + starting a container. */
 export interface DockerRunOptions {
   image: string;
   env?: Record<string, string>;
+  /** Raw host-path bind mounts. Prefer `workspaceMounts` for workspace-rooted paths. */
   binds?: BindMount[];
+  /**
+   * Workspace-rooted mounts resolved according to the current runtime
+   * mode. In bare-metal mode these become host-path binds; in Docker mode
+   * they become named-volume `Mounts` against the workspace volume.
+   */
+  workspaceMounts?: WorkspaceMount[];
   ports?: PortMapping[];
   name?: string;
   network?: string;
@@ -105,6 +151,28 @@ export interface DockerRunResult {
 export interface DockerRunnerOptions {
   /** Override the unix socket path. Primarily used in tests. */
   socketPath?: string;
+  /**
+   * Override the runtime-mode resolver. Defaults to
+   * {@link getDaemonRuntimeMode}. Tests inject a fixed value to exercise
+   * both bare-metal and Docker branches without touching env vars.
+   */
+  resolveMode?: () => DaemonRuntimeMode;
+  /**
+   * Override the workspace-volume-name resolver. Defaults to
+   * {@link getWorkspaceVolumeName} with no options (production cache
+   * path). Tests inject a fake so they can steer the Docker branch
+   * between "volume found" and "volume null" outcomes without touching
+   * `/proc/self/mountinfo`.
+   */
+  resolveWorkspaceVolumeName?: () => Promise<string | null>;
+  /**
+   * Workspace directory on disk. Required when running in bare-metal mode
+   * with `workspaceMounts` — the runner resolves each `subpath` under this
+   * directory to produce the host-path bind. Defaults to `process.cwd()`
+   * if unset; callers should inject the real workspace dir
+   * (`getWorkspaceDir()` from `util/platform.ts`).
+   */
+  workspaceDir?: string;
 }
 
 /**
@@ -124,19 +192,69 @@ export class DockerApiError extends Error {
   }
 }
 
+/**
+ * Message surfaced when the Docker Engine socket is unreachable from the
+ * daemon in Docker mode. Exported so the session-manager error path and
+ * unit tests can share the exact string.
+ */
+export const DOCKER_SOCKET_UNREACHABLE_MESSAGE =
+  "The daemon cannot reach the Docker Engine at /var/run/docker.sock. In Docker mode the daemon container must have the socket bind-mounted. Upgrade your vellum CLI to a version that supports Meet in Docker mode (see Phase 1.8 docs).";
+
+/**
+ * Message surfaced when Docker mode is active but no named workspace
+ * volume was discoverable. Exported so the session-manager error path and
+ * unit tests can share the exact string.
+ */
+export const DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE =
+  "Meet in Docker mode requires the workspace to be on a named Docker volume. Ensure the vellum CLI launched the daemon with a named volume at /workspace, or set VELLUM_WORKSPACE_VOLUME_NAME.";
+
 export class DockerRunner {
   readonly socketPath: string;
+  private readonly resolveMode: () => DaemonRuntimeMode;
+  private readonly resolveWorkspaceVolumeName: () => Promise<string | null>;
+  private readonly workspaceDir: string;
+  /**
+   * Memoized result of the one-time `/_ping` reachability probe. Resolves
+   * to `true` on success, rejects with a clear prerequisite-missing error
+   * on failure. Shared across concurrent callers so we don't hammer the
+   * socket on the first-spawn path.
+   */
+  private pingPromise: Promise<true> | null = null;
 
   constructor(options: DockerRunnerOptions = {}) {
     this.socketPath = options.socketPath ?? DEFAULT_DOCKER_SOCKET_PATH;
+    this.resolveMode = options.resolveMode ?? getDaemonRuntimeMode;
+    this.resolveWorkspaceVolumeName =
+      options.resolveWorkspaceVolumeName ?? (() => getWorkspaceVolumeName());
+    this.workspaceDir = options.workspaceDir ?? process.cwd();
   }
 
   /**
    * Create + start a container. Returns the containerId and any host-side
    * ports Docker bound after start.
+   *
+   * In Docker mode we first confirm the engine socket is reachable (a
+   * missing bind-mount of `/var/run/docker.sock` is the most common
+   * prerequisite miss) and discover the workspace volume name before
+   * translating `workspaceMounts` into named-volume `Mounts` with
+   * subpaths. In bare-metal mode we skip those steps and bind host paths
+   * directly.
    */
   async run(opts: DockerRunOptions): Promise<DockerRunResult> {
-    const createBody = buildCreateBody(opts);
+    const mode = this.resolveMode();
+
+    // One-time socket reachability probe. In bare-metal mode the daemon
+    // on a developer machine may not have Docker running; the existing
+    // create-path failure already covers that case with a clear error,
+    // so we only hard-gate in Docker mode where a missing bind-mount is
+    // a deployment bug the caller cannot work around.
+    if (mode === "docker") {
+      await this.ensureSocketReachable();
+    }
+
+    const resolvedMounts = await this.resolveMounts(mode, opts.workspaceMounts);
+
+    const createBody = buildCreateBody(opts, resolvedMounts);
     const createPath = opts.name
       ? `/${DOCKER_API_VERSION}/containers/create?name=${encodeURIComponent(opts.name)}`
       : `/${DOCKER_API_VERSION}/containers/create`;
@@ -208,6 +326,134 @@ export class DockerRunner {
   // Internals
   // -------------------------------------------------------------------------
 
+  /**
+   * One-time `GET /_ping` reachability probe. Memoizes the success so the
+   * second and later spawns skip the extra round-trip; memoizes failures
+   * for the same promise too so concurrent first spawns all surface the
+   * same clear prerequisite-missing error.
+   */
+  private ensureSocketReachable(): Promise<true> {
+    if (this.pingPromise === null) {
+      this.pingPromise = this.probePing().catch((err) => {
+        // Clear the cache on failure so subsequent spawns can retry if
+        // the operator bind-mounts the socket and restarts the daemon.
+        // We still reject the current call so fail-fast semantics hold.
+        this.pingPromise = null;
+        throw err;
+      });
+    }
+    return this.pingPromise;
+  }
+
+  private async probePing(): Promise<true> {
+    // `/_ping` returns the literal text `"OK"` (not JSON), so we go
+    // straight to the raw-response helper rather than `request<T>`
+    // which would choke on the non-JSON body.
+    try {
+      await this.requestRaw(
+        "GET",
+        `/${DOCKER_API_VERSION}/_ping`,
+        null,
+      );
+      return true;
+    } catch (err) {
+      log.warn(
+        { err, socketPath: this.socketPath },
+        "Docker Engine socket reachability probe failed",
+      );
+      throw new Error(DOCKER_SOCKET_UNREACHABLE_MESSAGE);
+    }
+  }
+
+  /**
+   * Lower-level request helper used for endpoints that return non-JSON
+   * bodies (e.g. `/_ping` → `"OK"`). Resolves with the raw body string
+   * on 2xx; rejects with {@link DockerApiError} otherwise.
+   */
+  private requestRaw(
+    method: string,
+    path: string,
+    body: unknown,
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const payload =
+        body === null || body === undefined ? null : JSON.stringify(body);
+      const headers: Record<string, string | number> = {
+        Host: UNIX_SOCKET_HOST,
+        Accept: "*/*",
+      };
+      if (payload !== null) {
+        headers["Content-Type"] = "application/json";
+        headers["Content-Length"] = Buffer.byteLength(payload);
+      }
+      const req = httpRequest(
+        { socketPath: this.socketPath, method, path, headers },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk: Buffer) => chunks.push(chunk));
+          res.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            const status = res.statusCode ?? 0;
+            if (status < 200 || status >= 300) {
+              reject(new DockerApiError(method, path, status, raw));
+              return;
+            }
+            resolve(raw);
+          });
+        },
+      );
+      req.on("error", (err) => reject(err));
+      if (payload !== null) req.write(payload);
+      req.end();
+    });
+  }
+
+  /**
+   * Translate `workspaceMounts` into either host-path binds or
+   * named-volume `Mounts` entries according to the runtime mode.
+   *
+   * Bare-metal: each mount becomes a `BindMount` with
+   * `<workspaceDir>/<subpath>` as the host path. Docker: each mount
+   * becomes a volume mount against the discovered workspace volume with
+   * `VolumeOptions.Subpath = <subpath>`. Subpath requires Docker Engine
+   * 25+. If Engine <25 is observed in the field, the fallback is to
+   * mount the whole workspace volume at `/workspace` inside the bot and
+   * have the bot itself resolve paths under `/workspace/meets/<id>/…`;
+   * that's left as a follow-up because Docker Desktop ships Engine 25+
+   * and the CLI requires it as a prerequisite in `cli/src/lib/docker.ts`.
+   */
+  private async resolveMounts(
+    mode: DaemonRuntimeMode,
+    workspaceMounts: WorkspaceMount[] | undefined,
+  ): Promise<ResolvedMounts> {
+    if (!workspaceMounts || workspaceMounts.length === 0) {
+      return { extraBinds: [], mounts: [] };
+    }
+
+    if (mode === "bare-metal") {
+      const extraBinds = workspaceMounts.map<BindMount>((m) => ({
+        hostPath: resolveWorkspaceSubpath(this.workspaceDir, m.subpath),
+        containerPath: m.target,
+        readOnly: m.readOnly,
+      }));
+      return { extraBinds, mounts: [] };
+    }
+
+    // Docker mode — named-volume subpath mounts.
+    const volumeName = await this.resolveWorkspaceVolumeName();
+    if (volumeName === null) {
+      throw new Error(DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE);
+    }
+    const mounts = workspaceMounts.map((m) => ({
+      Type: "volume" as const,
+      Source: volumeName,
+      Target: m.target,
+      ReadOnly: m.readOnly === true,
+      VolumeOptions: { Subpath: m.subpath },
+    }));
+    return { extraBinds: [], mounts };
+  }
+
   /** Issue a unix-socket HTTP request and decode the JSON body, if any. */
   private request<T>(
     method: string,
@@ -273,16 +519,54 @@ export class DockerRunner {
 // ---------------------------------------------------------------------------
 
 /**
- * Translate the high-level `DockerRunOptions` into the JSON body the Docker
- * Engine's `/containers/create` endpoint expects.
+ * Resolved mount spec produced by {@link DockerRunner.resolveMounts} — either
+ * extra bind mounts to append to `HostConfig.Binds` (bare-metal) or named
+ * volume mounts to pass via `HostConfig.Mounts` (Docker mode).
+ */
+export interface ResolvedMounts {
+  extraBinds: BindMount[];
+  mounts: Array<{
+    Type: "volume";
+    Source: string;
+    Target: string;
+    ReadOnly: boolean;
+    VolumeOptions: { Subpath: string };
+  }>;
+}
+
+/** Always-on hostname alias that lets the bot reach the daemon HTTP port. */
+export const HOST_GATEWAY_ALIAS = "host.docker.internal:host-gateway";
+
+/**
+ * Resolve a workspace-relative `subpath` against the absolute `workspaceDir`
+ * using POSIX join semantics. Leading slashes in `subpath` are tolerated;
+ * POSIX rules are used so the result is portable across test platforms.
+ */
+export function resolveWorkspaceSubpath(
+  workspaceDir: string,
+  subpath: string,
+): string {
+  const trimmed = subpath.replace(/^\/+/, "");
+  return posixPath.join(workspaceDir, trimmed);
+}
+
+/**
+ * Translate the high-level `DockerRunOptions` plus any pre-resolved workspace
+ * mounts into the JSON body the Docker Engine's `/containers/create`
+ * endpoint expects.
+ *
+ * `resolved` is optional so tests (and callers that don't use workspace
+ * mounts) can keep passing just the options bag.
  */
 export function buildCreateBody(
   opts: DockerRunOptions,
+  resolved: ResolvedMounts = { extraBinds: [], mounts: [] },
 ): Record<string, unknown> {
   const env = opts.env
     ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`)
     : [];
-  const binds = (opts.binds ?? []).map((b) =>
+  const allBinds = [...(opts.binds ?? []), ...resolved.extraBinds];
+  const binds = allBinds.map((b) =>
     b.readOnly
       ? `${b.hostPath}:${b.containerPath}:ro`
       : `${b.hostPath}:${b.containerPath}`,
@@ -312,6 +596,13 @@ export function buildCreateBody(
   const hostConfig: Record<string, unknown> = {
     Binds: binds,
     PortBindings: portBindings,
+    // Always expose `host.docker.internal` so the bot can reach the
+    // daemon's HTTP port on the host in both modes. Docker Desktop
+    // already maps this alias; on Linux hosts the explicit
+    // `host-gateway` value is required. Applied unconditionally because
+    // the resolution is identical either way on modern engines.
+    ExtraHosts: [HOST_GATEWAY_ALIAS],
+    ...(resolved.mounts.length > 0 ? { Mounts: resolved.mounts } : {}),
     ...(opts.network ? { NetworkMode: opts.network } : {}),
     ...(opts.hostConfigExtras ?? {}),
   };

--- a/assistant/src/meet/session-manager.ts
+++ b/assistant/src/meet/session-manager.ts
@@ -321,9 +321,11 @@ class MeetSessionManagerImpl {
 
   constructor(deps: MeetSessionManagerDeps = {}) {
     const insertMessage = deps.insertMessage ?? addMessage;
+    const resolveWorkspaceDir = deps.getWorkspaceDir ?? getWorkspaceDir;
     this.deps = {
       dockerRunnerFactory:
-        deps.dockerRunnerFactory ?? (() => new DockerRunner()),
+        deps.dockerRunnerFactory ??
+        (() => new DockerRunner({ workspaceDir: resolveWorkspaceDir() })),
       getProviderKey: deps.getProviderKey ?? getProviderKeyAsync,
       botLeaveFetch: deps.botLeaveFetch ?? defaultBotLeaveFetch,
       resolveDaemonUrl: deps.resolveDaemonUrl ?? defaultResolveDaemonUrl,
@@ -503,9 +505,16 @@ class MeetSessionManagerImpl {
       runResult = await runner.run({
         image: meet.containerImage,
         env,
-        binds: [
-          { hostPath: socketsDir, containerPath: "/sockets" },
-          { hostPath: outDir, containerPath: "/out" },
+        // Logical workspace-rooted mounts. DockerRunner resolves each one
+        // to either a host-path bind (bare-metal mode) or a named-volume
+        // subpath mount (Docker mode) based on the daemon's runtime mode.
+        // Session-manager stays mode-agnostic — the only thing we rely on
+        // is that the directories exist under the daemon's view of the
+        // workspace so the audio-ingest socket path lines up with what the
+        // bot sees inside its container.
+        workspaceMounts: [
+          { target: "/sockets", subpath: `meets/${meetingId}/sockets` },
+          { target: "/out", subpath: `meets/${meetingId}/out` },
         ],
         ports: [
           {


### PR DESCRIPTION
## Summary
- DockerRunner branches on `getDaemonRuntimeMode()`: bare-metal uses host-path binds; Docker mode uses named-volume subpath mounts (`Mounts` API) against the workspace volume discovered via `getWorkspaceVolumeName()`.
- Always passes `HostConfig.ExtraHosts: ["host.docker.internal:host-gateway"]` so Linux hosts can reach the daemon (no-op on Docker Desktop).
- Adds a `/_ping` reachability check that surfaces a clear prerequisite-missing error when the daemon container lacks the socket bind-mount.
- Absorbs PR 4's scope — PR 4 will be closed unmerged.

Design: Option B (encapsulation). Session-manager passes mode-agnostic `workspaceMounts: [{ target, subpath }]`; DockerRunner internally resolves them to either `HostConfig.Binds` (bare-metal) or `HostConfig.Mounts` with `VolumeOptions.Subpath` (Docker). Runner mode/volume/workspaceDir resolvers are injectable for tests.

Part of plan: meet-phase-1-8-docker-mode.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
