### PR TITLE
cli: publish assistant HTTP port for Meet bot reachability in Docker mode

### DIFF
--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
+  ASSISTANT_INTERNAL_PORT,
   dockerResourceNames,
   serviceDockerRunArgs,
   type ServiceName,
@@ -53,5 +54,14 @@ describe("serviceDockerRunArgs — assistant", () => {
     expect(args).toContain("IS_CONTAINERIZED=true");
     expect(args).toContain("VELLUM_WORKSPACE_DIR=/workspace");
     expect(args).toContain(`VELLUM_ASSISTANT_NAME=${instanceName}`);
+  });
+
+  test("publishes the assistant HTTP port on 127.0.0.1 so sibling bot containers can reach the daemon via host.docker.internal", () => {
+    const args = buildAssistantArgs();
+    // The port mapping is expressed as two adjacent args: "-p" then the spec.
+    const portSpec = `127.0.0.1:${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`;
+    const portIndex = args.indexOf(portSpec);
+    expect(portIndex).toBeGreaterThan(0);
+    expect(args[portIndex - 1]).toBe("-p");
   });
 });

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -589,6 +589,12 @@ export function serviceDockerRunArgs(opts: {
         `--network=${res.network}`,
         "-p",
         `${gatewayPort}:${GATEWAY_INTERNAL_PORT}`,
+        // Published so the Meet subsystem's sibling bot containers can reach
+        // the daemon's internal HTTP API at host.docker.internal:<port>. Bound
+        // to 127.0.0.1 so the daemon API is not exposed beyond the host's
+        // loopback.
+        "-p",
+        `127.0.0.1:${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`,
         "-v",
         `${res.workspaceVolume}:/workspace`,
         "-v",


### PR DESCRIPTION
## Summary
The Meet subsystem sets `DAEMON_URL=http://host.docker.internal:<port>` on the bot container, but the CLI never `-p`-mapped the assistant's internal HTTP port to the host. Result: bot→daemon HTTP calls failed silently in Docker mode (unit tests asserted the URL string but not reachability).

This PR publishes the assistant's internal port on `127.0.0.1:<port>:<port>` so `host.docker.internal:<port>` resolves correctly for sibling bot containers. Binding to loopback (not 0.0.0.0) keeps the daemon API constrained to the host machine.

Part of plan: meet-phase-1-8-docker-mode.md (review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
