### PR TITLE
cli: publish assistant HTTP port on all interfaces for Linux bot reachability

### DIFF
--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -56,10 +56,14 @@ describe("serviceDockerRunArgs — assistant", () => {
     expect(args).toContain(`VELLUM_ASSISTANT_NAME=${instanceName}`);
   });
 
-  test("publishes the assistant HTTP port on 127.0.0.1 so sibling bot containers can reach the daemon via host.docker.internal", () => {
+  test("publishes the assistant HTTP port on all host interfaces so sibling bot containers can reach the daemon via host.docker.internal on both Docker Desktop and Linux", () => {
     const args = buildAssistantArgs();
     // The port mapping is expressed as two adjacent args: "-p" then the spec.
-    const portSpec = `127.0.0.1:${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`;
+    // Bound to all interfaces (no `127.0.0.1:` prefix) because on vanilla
+    // Linux Docker, host.docker.internal:host-gateway resolves to the Docker
+    // bridge gateway IP — packets arrive at the bridge interface, not
+    // loopback, so a 127.0.0.1 DNAT rule would not match.
+    const portSpec = `${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`;
     const portIndex = args.indexOf(portSpec);
     expect(portIndex).toBeGreaterThan(0);
     expect(args[portIndex - 1]).toBe("-p");

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -590,11 +590,25 @@ export function serviceDockerRunArgs(opts: {
         "-p",
         `${gatewayPort}:${GATEWAY_INTERNAL_PORT}`,
         // Published so the Meet subsystem's sibling bot containers can reach
-        // the daemon's internal HTTP API at host.docker.internal:<port>. Bound
-        // to 127.0.0.1 so the daemon API is not exposed beyond the host's
-        // loopback.
+        // the daemon's internal HTTP API at host.docker.internal:<port>.
+        //
+        // Published on all host interfaces (no `127.0.0.1:` prefix) because on
+        // vanilla Linux Docker, `host.docker.internal:host-gateway` resolves
+        // to the Docker bridge gateway IP (e.g. 172.17.0.1), not loopback.
+        // Packets from sibling containers arrive at the host's bridge
+        // interface, and an iptables DNAT rule keyed on dest=127.0.0.1 would
+        // not match — causing connection refused. Docker Desktop (macOS/
+        // Windows) still works because its VM proxy forwards to the same
+        // published port regardless of the binding address.
+        //
+        // Security tradeoff: the daemon HTTP API is now reachable from the
+        // host's LAN (any device that can hit the host IP on this port).
+        // This matches the gateway port's existing posture and is acceptable
+        // for single-user self-hosted Docker mode per the Phase 1.8 security
+        // note. Managed/multi-tenant deployments are out of scope and would
+        // require a different design.
         "-p",
-        `127.0.0.1:${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`,
+        `${ASSISTANT_INTERNAL_PORT}:${ASSISTANT_INTERNAL_PORT}`,
         "-v",
         `${res.workspaceVolume}:/workspace`,
         "-v",


### PR DESCRIPTION
## Summary
PR #25822 published the assistant's HTTP port on `127.0.0.1` only. That works on Docker Desktop (host.docker.internal forwards via the VM proxy to the host's loopback) but breaks on vanilla Linux Docker, where `host.docker.internal:host-gateway` resolves to the Docker bridge gateway IP — packets arrive at the host's bridge interface, NOT 127.0.0.1, so the iptables DNAT rule keyed on dest=127.0.0.1 doesn't match.

Drop the `127.0.0.1:` prefix so the port is published on all host interfaces. Sibling Meet bot containers can then reach the daemon at `host.docker.internal:3001` on both Docker Desktop and Linux. Daemon HTTP API is now reachable on the host's LAN — same security posture as the gateway port, acceptable for single-user local mode per the plan's security note.

Part of plan: meet-phase-1-8-docker-mode.md (review remediation, round 2)