### PR TITLE
feat: add FlippedModifier for inverted scroll technique

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -156,3 +156,22 @@ final class ProjectionCache {
         isThrottled = false
     }
 }
+
+// MARK: - Flipped Modifier
+
+/// Rotates 180° and mirrors horizontally — the "inverted scroll" technique.
+/// Apply to both the ScrollView and each row to get a bottom-anchored list
+/// where new content appears at the bottom without any scroll management.
+struct FlippedModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(.radians(.pi))
+            .scaleEffect(x: -1, y: 1, anchor: .center)
+    }
+}
+
+extension View {
+    func flipped() -> some View {
+        modifier(FlippedModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- Add FlippedModifier ViewModifier that rotates 180° and mirrors horizontally
- Add .flipped() View extension for convenient usage
- Utility for the inverted scroll technique (applied in later PRs)

Part of plan: inverted-scroll-migration.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
