### PR TITLE
feat: apply inverted scroll to MessageListView and MessageListContentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -405,7 +405,6 @@ struct ChatView: View {
                 containerWidth: containerWidth,
                 containerHeight: containerHeight
             )
-            .id(conversationId)
             .animation(nil, value: queuedMessages.isEmpty)
 
             if let error = viewModel.errorManager.conversationError, error.isCreditsExhausted {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -221,6 +221,7 @@ struct MessageListContentView: View, Equatable {
             }
             .frame(minHeight: turnMinHeight, alignment: .top)
         }
+        .flipped()  // Flip each row back so content reads correctly in inverted scroll
     }
 
     @ViewBuilder
@@ -264,6 +265,7 @@ struct MessageListContentView: View, Equatable {
                 }
                 .padding(.vertical, VSpacing.sm)
                 .id("page-loading-indicator")
+                .flipped()
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
@@ -330,10 +332,11 @@ struct MessageListContentView: View, Equatable {
                 uniqueKeysWithValues: state.rows.map { ($0.message.id, $0) }
             )
             let displayedItems = TranscriptItems.build(from: state.rows.map(\.message))
-            ForEach(displayedItems) { item in
+            ForEach(displayedItems.reversed()) { item in
                 switch item {
                 case .queuedMarker(let count):
                     QueuedMessagesMarker(count: count)
+                        .flipped()
                 case .message(let message):
                     // Safe: every displayed message originates from `state.rows`
                     // so `rowsByMessageId[message.id]` is always present.
@@ -361,6 +364,7 @@ struct MessageListContentView: View, Equatable {
                 }
                     .id("subagent-\(subagent.id)")
                     .transition(.opacity)
+                    .flipped()
             }
 
             if state.isStreamingWithoutText && !state.canInlineProcessing {
@@ -374,13 +378,16 @@ struct MessageListContentView: View, Equatable {
                 .frame(minHeight: turnMinHeight, alignment: .top)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity)
+                .flipped()
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 VStack(spacing: 0) { compactingIndicatorRow() }
                     .frame(minHeight: turnMinHeight, alignment: .top)
+                    .flipped()
             }
 
             Color.clear.frame(height: 1)
                 .id("scroll-bottom-anchor")
+                .flipped()
         }
         .disabled(!isInteractionEnabled)
         .transaction { $0.animation = nil }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -77,9 +77,6 @@ extension MessageListView {
                 try? await Task.sleep(nanoseconds: 50_000_000)
                 guard !Task.isCancelled else { return }
                 scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-                withAnimation(VAnimation.fast) {
-                    isScrollRestored = true
-                }
 
                 try? await Task.sleep(nanoseconds: 150_000_000)
                 guard !Task.isCancelled else { return }
@@ -236,10 +233,6 @@ extension MessageListView {
             try? await Task.sleep(nanoseconds: 50_000_000)
             guard !Task.isCancelled else { return }
             scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-            // Fade in after scroll is positioned
-            withAnimation(VAnimation.fast) {
-                isScrollRestored = true
-            }
 
             // Stage 2: slower content (150ms) — final correction
             try? await Task.sleep(nanoseconds: 150_000_000)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -111,9 +111,6 @@ struct MessageListView: View {
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
     /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
     @State var scrollPosition = ScrollPosition()
-    /// Starts false on fresh mount; set to true after scroll restore settles.
-    /// Hides the scroll view during the restore window to prevent jitter.
-    @State var isScrollRestored = false
 
     // MARK: - Body
 
@@ -143,13 +140,13 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
-            .defaultScrollAnchor(.top, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .frame(width: widths.scrollSurfaceWidth)
-            .opacity(isScrollRestored ? 1 : 0)
+            .id(conversationId)
+            .flipped()  // Invert the scroll — visual bottom becomes natural top
             .overlay(alignment: .bottom) {
                 ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .bottom) })
             }


### PR DESCRIPTION
## Summary
- Apply .flipped() to ScrollView so visual bottom becomes natural top
- Flip each row back with .flipped() so content reads correctly
- Reverse row iteration so newest messages are at flipped top = visual bottom
- Flip standalone sections (orphan subagents, streaming/compacting indicators)
- Remove .defaultScrollAnchor (no longer needed)
- Remove isScrollRestored opacity fade (no jitter with inverted scroll)
- Remove .id(conversationId) from ChatView parent; keep on ScrollView itself

Part of plan: inverted-scroll-migration.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
