### PR TITLE
fix: adjust pagination sentinel for inverted scroll coordinates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -117,6 +117,9 @@ final class MessageListScrollState {
 
     /// Handles rising-edge detection for the pagination sentinel with a 500ms cooldown.
     /// Returns `true` when pagination should fire.
+    ///
+    /// With inverted scroll, callers pass `-distanceFromBottom` so values near
+    /// zero mean the user is close to the visual top (oldest messages).
     func handlePaginationSentinel(sentinelMinY: CGFloat) -> Bool {
         let triggerBand: CGFloat = 200
         let isInRange = sentinelMinY > -triggerBand

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -40,7 +40,10 @@ extension MessageListView {
         scrollState.updateScrollToLatest()
 
         // --- Pagination ---
-        handlePaginationSentinel(sentinelMinY: -newState.contentOffsetY)
+        // With inverted scroll the visual top (oldest messages) maps to the
+        // geometric bottom of the scroll content. Use distanceFromBottom so
+        // the sentinel fires when the user scrolls toward older messages.
+        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromBottom)
     }
 
     // MARK: - Pagination sentinel


### PR DESCRIPTION
## Summary
- Adjust pagination sentinel coordinate checks for inverted scroll geometry
- Ensure scrolling up (toward older messages) still triggers pagination correctly
- Pagination cooldown and loading indicator behavior preserved

Part of plan: inverted-scroll-migration.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
