### PR TITLE
refactor: remove scroll-to-bottom restore — inverted scroll handles it naturally

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -26,7 +26,6 @@ An `@Observable @MainActor` class with **no modes, no transitions, no recovery**
 
 - **Geometry:** `scrollContentHeight`, `scrollContainerHeight`, `lastContentOffsetY`, `viewportHeight`
 - **CTA visibility:** `showScrollToLatest` (driven by `distanceFromBottom > 400`)
-- **Send scroll:** `pendingSendScrollMessageId: UUID?` — set when user sends, cleared after scroll fires
 - **Pagination:** `wasPaginationTriggerInRange`, `lastPaginationCompletedAt` (rising-edge + 500ms cooldown)
 - **Deep-link anchor:** `anchorSetTime`, `anchorTimeoutTask`
 - **Scroll indicators:** `scrollIndicatorsHidden` (briefly hidden on conversation switch)
@@ -58,57 +57,19 @@ Both share the same `.if(row.isLatestAssistant ...)` minHeight wrapper — one c
 
 ---
 
-## The Send-Scroll Flow (Critical Path)
+## The Send Flow
 
-This is the most important interaction. When the user sends a message:
+With inverted scroll (`.flipped()`), new content naturally appears at the visual bottom. No imperative scroll-to-bottom is needed when the user sends a message.
 
 ### Step 1: Message appended
 `MessageSendCoordinator` appends the user message to `messages` and calls `flushCoalescedPublish()`. Then sets `isSending = true`.
 
-### Step 2: Detect new message
-`handleMessagesCountChanged()` fires (may fire before or after `handleSendingChanged`).
-
-**Safety net:** If `pendingSendScrollMessageId` is nil and a new user message appeared, set it:
-```swift
-if scrollState.pendingSendScrollMessageId == nil {
-    if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
-       scrollState.lastMessageId != nil,
-       lastUser.id != scrollState.lastMessageId,
-       paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
-        scrollState.pendingSendScrollMessageId = lastUser.id
-    }
-}
-```
-
-**Also:** `handleSendingChanged()` sets the ID when `isSending` becomes true (unless it's a confirmation resume).
-
-### Step 3: Scroll to bottom (deferred)
-Once the user message is in `paginatedVisibleMessages`:
-```swift
-if scrollState.pendingSendScrollMessageId != nil,
-   paginatedVisibleMessages.contains(where: { $0.id == scrollState.pendingSendScrollMessageId }) {
-    let scrollBinding = $scrollPosition
-    scrollState.pendingSendScrollMessageId = nil
-    Task { @MainActor in
-        withAnimation(VAnimation.standard) {
-            scrollBinding.wrappedValue.scrollTo(edge: .bottom)
-        }
-    }
-}
-```
-
-**Why deferred:** `Task { @MainActor in }` gives SwiftUI one run-loop tick to lay out the new cell in the LazyVStack before the scroll fires. Without this, the scroll targets the old content bottom and the user message appears off-screen.
-
-**Why `.scrollTo(edge: .bottom)`:** The imperative method animates correctly. Value replacement (`ScrollPosition(edge: .bottom)`) doesn't animate.
-
-**Why `VAnimation.standard`:** 0.25s easeInOut. Fast enough to feel responsive, slow enough to be smooth.
-
-### Step 4: MinHeight pins user message to top
-The thinking placeholder (or assistant message) has a minHeight wrapper:
+### Step 2: Content appears at bottom
+The inverted ScrollView adds new content at the visual bottom naturally. The thinking placeholder (or assistant message) has a minHeight wrapper:
 ```swift
 .frame(minHeight: turnMinHeight, alignment: .top)
 ```
-This fills the viewport below the user message, so after scroll-to-bottom the user message naturally sits at the top.
+This fills the viewport below the user message, so the user message naturally sits at the top.
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -31,7 +31,6 @@ final class MessageListScrollState {
     @ObservationIgnored var currentConversationId: UUID?
     @ObservationIgnored var lastMessageId: UUID?
     @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
-    @ObservationIgnored var pendingSendScrollMessageId: UUID?
     // MARK: - Deep-link anchor
 
     @ObservationIgnored var anchorSetTime: Date?
@@ -156,7 +155,6 @@ final class MessageListScrollState {
         ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
         currentConversationId = conversationId
         lastMessageId = nil
-        pendingSendScrollMessageId = nil
         scrollContentHeight = 0
         scrollContainerHeight = 0
         lastContentOffsetY = 0
@@ -176,8 +174,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
 
         // Briefly hide scroll indicators during switch
         hideScrollIndicatorsBriefly()
@@ -194,8 +190,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
         isPaginationInFlight = false
         lastMessageId = nil
         scrollContentHeight = 0
@@ -212,8 +206,5 @@ final class MessageListScrollState {
     @ObservationIgnored var isPaginationInFlight: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
-    /// Multi-stage scroll-to-bottom task fired on conversation switch / first mount.
-    /// Cancelled on rapid switching and when a deep-link anchor is pending.
-    @ObservationIgnored var switchRestoreTask: Task<Void, Never>?
 
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -35,9 +35,6 @@ extension MessageListView {
         // Handle pending anchor if already set.
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
-            // Deep-link anchor found — cancel any restore so it isn't overridden.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
@@ -45,10 +42,6 @@ extension MessageListView {
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
-            // Anchor pending but not yet found — cancel restore so deep-link
-            // anchors aren't overridden by the bottom-scroll restore.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
             // Start the independent timeout if not already running.
@@ -65,25 +58,6 @@ extension MessageListView {
                     scrollState.anchorTimeoutTask = nil
                 }
             }
-        } else if !isConversationSwitch {
-            // First mount (no prior conversationId, no anchor) — also needs
-            // multi-stage scroll since the first conversation load must land
-            // at the bottom, same as a switch.
-            scrollState.switchRestoreTask?.cancel()
-            let scrollBinding = $scrollPosition
-            scrollState.switchRestoreTask = Task { @MainActor in
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                try? await Task.sleep(nanoseconds: 50_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                try? await Task.sleep(nanoseconds: 150_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                scrollState.switchRestoreTask = nil
-            }
         }
     }
 
@@ -92,18 +66,7 @@ extension MessageListView {
     func handleSendingChanged() {
         // Guard against stale fires during a conversation switch.
         guard conversationId == scrollState.currentConversationId else { return }
-        if isSending {
-            // Only scroll on genuine user sends, not confirmation resumes.
-            // When the daemon resumes from awaiting_confirmation, isSending
-            // flips true but no new user message was sent — scrolling would
-            // jump the viewport to an older user message.
-            let isConfirmationResume = scrollState.lastActivityPhaseWhenIdle == "awaiting_confirmation"
-            if !isConfirmationResume {
-                if let userMessage = messages.last(where: { $0.role == .user }) {
-                    scrollState.pendingSendScrollMessageId = userMessage.id
-                }
-            }
-        } else {
+        if !isSending {
             // Capture the activity phase at the moment sending stops.
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
             // First-message detection.
@@ -147,38 +110,9 @@ extension MessageListView {
                 return
             }
         }
-        // --- Safety net: detect new user message added before isSending onChange fired ---
-        // MessageSendCoordinator appends the user message and calls flushCoalescedPublish()
-        // before setting isSending = true, so messages.count can change first.
-        // Must run before lastMessageId is updated so we can detect the change.
-        if scrollState.pendingSendScrollMessageId == nil {
-            if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
-               scrollState.lastMessageId != nil,
-               lastUser.id != scrollState.lastMessageId,
-               paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
-                scrollState.pendingSendScrollMessageId = lastUser.id
-            }
-        }
         // --- Update lastMessageId ---
         if let lastId = paginatedVisibleMessages.last?.id {
             scrollState.lastMessageId = lastId
-        }
-        // --- Scroll to bottom on send ---
-        // After the user message appears and the thinking indicator shows,
-        // scroll to bottom. The thinking indicator's minHeight wrapper
-        // naturally pins the user message to the top of the viewport.
-        // Deferred by one run-loop tick so SwiftUI lays out the new cell
-        // before the scroll fires — otherwise the scroll targets the old
-        // content bottom and the user message appears off-screen.
-        if scrollState.pendingSendScrollMessageId != nil,
-           paginatedVisibleMessages.contains(where: { $0.id == scrollState.pendingSendScrollMessageId }) {
-            let scrollBinding = $scrollPosition
-            scrollState.pendingSendScrollMessageId = nil
-            Task { @MainActor in
-                withAnimation(VAnimation.standard) {
-                    scrollBinding.wrappedValue.scrollTo(edge: .bottom)
-                }
-            }
         }
         // --- Confirmation focus handoff ---
         #if os(macOS)
@@ -218,29 +152,9 @@ extension MessageListView {
         scrollState.anchorTimeoutTask = nil
         scrollState.lastAutoFocusedRequestId = nil
         // Seed lastMessageId so scroll-to-bottom can target it.
+        // With inverted scroll, the latest messages appear at the visual
+        // bottom naturally — no imperative scroll needed.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Multi-stage scroll-to-bottom: gives LazyVStack time to materialize
-        // bottom cells across multiple layout passes. Targets "scroll-bottom-anchor"
-        // (a real Color.clear view at the absolute content bottom) instead of a
-        // message ID, avoiding height estimation errors from unmaterialized cells.
-        scrollState.switchRestoreTask?.cancel()
-        let scrollBinding = $scrollPosition
-        scrollState.switchRestoreTask = Task { @MainActor in
-            // Stage 0: immediate — catches conversations already laid out
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            // Stage 1: ~3 frames (50ms) — LazyVStack initial materialization
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            // Stage 2: slower content (150ms) — final correction
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            scrollState.switchRestoreTask = nil
-        }
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -191,7 +191,6 @@ final class MessageListScrollStateTests: XCTestCase {
         state.lastContentOffsetY = 2000
         state.lastMessageId = UUID()
         state.currentConversationId = UUID()
-        state.pendingSendScrollMessageId = UUID()
         state.wasPaginationTriggerInRange = true
         state.lastPaginationCompletedAt = Date()
         state.updateScrollToLatest()
@@ -202,7 +201,6 @@ final class MessageListScrollStateTests: XCTestCase {
 
         XCTAssertEqual(state.currentConversationId, newId)
         XCTAssertNil(state.lastMessageId)
-        XCTAssertNil(state.pendingSendScrollMessageId)
         XCTAssertEqual(state.scrollContentHeight, 0)
         XCTAssertEqual(state.scrollContainerHeight, 0)
         XCTAssertEqual(state.lastContentOffsetY, 0)


### PR DESCRIPTION
## Summary
- Remove switchRestoreTask and multi-stage scroll restore from handleConversationSwitched/handleAppear
- Remove pendingSendScrollMessageId and hasSendScrollFired — send-scroll-to-bottom no longer needed
- Simplify handleConversationSwitched to just reset state and seed lastMessageId
- Simplify handleAppear to remove first-mount restore task

Part of plan: inverted-scroll-migration.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
