### PR TITLE
refactor: evaluate and simplify minHeight wrapper for inverted scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -163,7 +163,7 @@ struct ChatView: View {
         // children (808pt fallback) or when rapid drag updates are batched.
         GeometryReader { proxy in
             ZStack {
-                mainContentStack(containerWidth: proxy.size.width, containerHeight: proxy.size.height)
+                mainContentStack(containerWidth: proxy.size.width)
                     .background(alignment: .bottom) {
                         chatBackground
                     }
@@ -257,7 +257,7 @@ struct ChatView: View {
     // MARK: - Body Subviews (extracted to help the Swift type checker)
 
     @ViewBuilder
-    private func mainContentStack(containerWidth: CGFloat, containerHeight: CGFloat) -> some View {
+    private func mainContentStack(containerWidth: CGFloat) -> some View {
         VStack(spacing: 0) {
             if showSkeleton {
                 ChatLoadingSkeleton()
@@ -325,7 +325,7 @@ struct ChatView: View {
                     .id(conversationId)
                 }
             } else {
-                activeConversationContent(containerWidth: containerWidth, containerHeight: containerHeight)
+                activeConversationContent(containerWidth: containerWidth)
             }
         }
     }
@@ -345,7 +345,7 @@ struct ChatView: View {
     /// individually; it feeds them into the projector and renders the resulting
     /// `TranscriptRenderModel` via `MessageListContentView`.
     @ViewBuilder
-    private func activeConversationContent(containerWidth: CGFloat, containerHeight: CGFloat = 0) -> some View {
+    private func activeConversationContent(containerWidth: CGFloat) -> some View {
         let layoutMetrics = MessageListLayoutMetrics(containerWidth: containerWidth)
         let queuedMessages = viewModel.queuedMessages
         VStack(spacing: 0) {
@@ -402,8 +402,7 @@ struct ChatView: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 isInteractionEnabled: isInteractionEnabled,
-                containerWidth: containerWidth,
-                containerHeight: containerHeight
+                containerWidth: containerWidth
             )
             .animation(nil, value: queuedMessages.isEmpty)
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -45,7 +45,6 @@ struct MessageListContentView: View, Equatable {
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.subagentDetailStore === rhs.subagentDetailStore
             && lhs.assistantStatusText == rhs.assistantStatusText
-            && lhs.containerHeight == rhs.containerHeight
     }
 
     // MARK: - Data properties (compared in ==)
@@ -69,9 +68,6 @@ struct MessageListContentView: View, Equatable {
     let configuredProviders: Set<String>
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
-    /// Stable height of the full chat pane. Used for minHeight instead of
-    /// scroll viewport height which fluctuates with composer resizing.
-    let containerHeight: CGFloat
 
     // MARK: - @Observable references (not compared in ==; reads occur in closures or child views)
 
@@ -134,16 +130,12 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Transcript row rendering
 
     /// Renders a single transcript row (either a real message cell or the
-    /// synthetic thinking placeholder) with the `active turn` minHeight
-    /// wrapper applied when the row is the latest assistant and also the
-    /// tail of `state.rows` (so the user's last message sits at the top
-    /// of the viewport while the assistant streams).
+    /// synthetic thinking placeholder).
     @ViewBuilder
     private func transcriptRow(
         row: TranscriptRowModel,
         isUnanchoredThinking: Bool,
-        thinkingLabel: String,
-        turnMinHeight: CGFloat
+        thinkingLabel: String
     ) -> some View {
         Group {
             if row.isThinkingPlaceholder {
@@ -209,18 +201,6 @@ struct MessageListContentView: View, Equatable {
                 .equatable()
             }
         }
-        // Latest assistant message (or thinking placeholder): wrap in
-        // VStack with minHeight so user message sits at top. The same
-        // wrapper applies to both the placeholder and the real assistant
-        // message, eliminating layout jump on transition.
-        .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
-            VStack(spacing: 0) {
-                view
-                Color.clear.frame(height: 1)
-                    .id("active-turn-content-bottom")
-            }
-            .frame(minHeight: turnMinHeight, alignment: .top)
-        }
         .flipped()  // Flip each row back so content reads correctly in inverted scroll
     }
 
@@ -269,55 +249,6 @@ struct MessageListContentView: View, Equatable {
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
-            // Estimate user message cell height for precise minHeight offset.
-            // Queued user messages are collapsed into QueuedMessagesMarker and
-            // don't render as full bubbles, so they must be excluded — using a
-            // queued follow-up's height would over-estimate and under-size the
-            // turn minHeight, breaking the "sent message pinned at top"
-            // invariant during an active turn.
-            let estimatedUserHeight: CGFloat = {
-                let hasQueuedMessages = state.rows.contains(where: { row in
-                    guard row.message.role == .user else { return false }
-                    if case .queued = row.message.status { return true }
-                    return false
-                })
-                // ~40pt: QueuedMessagesMarker = single-line labelDefault text
-                // with VSpacing.sm top+bottom padding.
-                let markerHeight: CGFloat = hasQueuedMessages ? 40 : 0
-                guard let lastUser = state.rows.last(where: { row in
-                    guard row.message.role == .user else { return false }
-                    if case .queued = row.message.status { return false }
-                    return true
-                }) else {
-                    return 80 + markerHeight
-                }
-                // Messages with attachments are always collapsed — use max height
-                if !lastUser.message.attachments.isEmpty {
-                    return 260 + markerHeight
-                }
-                let text = lastUser.message.text as NSString
-                let contentWidth = max(layoutMetrics.bubbleMaxWidth - 2 * VSpacing.lg, 0)
-                let font = NSFont.systemFont(ofSize: 14, weight: .regular)
-                let textRect = text.boundingRect(
-                    with: NSSize(width: contentWidth, height: .greatestFiniteMagnitude),
-                    options: [.usesLineFragmentOrigin, .usesFontLeading],
-                    attributes: [.font: font]
-                )
-                let textHeight = ceil(textRect.height)
-                // Bubble padding (24) + timestamp (24) + spacing (12) + show more button (30) + gradient (10)
-                let cellOverhead: CGFloat = 100
-                // Cap at collapsed bubble height (150pt content + overhead)
-                return min(textHeight + cellOverhead, 260) + markerHeight
-            }()
-            // Precise minHeight: fill the space between user message and composer.
-            // containerHeight = full chat pane (stable, from GeometryReader)
-            // composerHeight = 80pt static (empty after send — when minHeight matters)
-            // layoutPadding = LazyVStack top/bottom padding + inter-item spacing + anchor
-            let composerHeight: CGFloat = 80
-            let layoutPadding: CGFloat = VSpacing.md * 3 + 1
-            let turnMinHeight: CGFloat = containerHeight > 0
-                ? max(0, containerHeight - composerHeight - estimatedUserHeight - layoutPadding)
-                : 0
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."
@@ -344,8 +275,7 @@ struct MessageListContentView: View, Equatable {
                         transcriptRow(
                             row: row,
                             isUnanchoredThinking: isUnanchoredThinking,
-                            thinkingLabel: thinkingLabel,
-                            turnMinHeight: turnMinHeight
+                            thinkingLabel: thinkingLabel
                         )
                     }
                 }
@@ -368,20 +298,16 @@ struct MessageListContentView: View, Equatable {
             }
 
             if state.isStreamingWithoutText && !state.canInlineProcessing {
-                VStack(spacing: 0) {
-                    HStack {
-                        TypingIndicatorView()
-                        Spacer()
-                    }
-                    .frame(width: effectiveBubbleMaxWidth)
+                HStack {
+                    TypingIndicatorView()
+                    Spacer()
                 }
-                .frame(minHeight: turnMinHeight, alignment: .top)
+                .frame(width: effectiveBubbleMaxWidth)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity)
                 .flipped()
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
-                VStack(spacing: 0) { compactingIndicatorRow() }
-                    .frame(minHeight: turnMinHeight, alignment: .top)
+                compactingIndicatorRow()
                     .flipped()
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -169,7 +169,6 @@ extension MessageListView {
             configuredProviders: configuredProviders,
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
-            containerHeight: containerHeight,
             scrollState: scrollState,
             onConfirmationAllow: onConfirmationAllow,
             onConfirmationDeny: onConfirmationDeny,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -77,9 +77,6 @@ struct MessageListView: View {
     /// Measured width of the full chat pane. `layoutMetrics` derives the
     /// centered transcript column width from this value.
     var containerWidth: CGFloat = 0
-    /// Stable height of the full chat pane (from GeometryReader). Unlike
-    /// scroll viewport height, this doesn't fluctuate when the composer resizes.
-    var containerHeight: CGFloat = 0
     var layoutMetrics: MessageListLayoutMetrics {
         MessageListLayoutMetrics(containerWidth: containerWidth)
     }

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,7 +49,6 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
-            containerHeight: 0,
             scrollState: MessageListScrollState()
         )
     }


### PR DESCRIPTION
## Summary
- Remove turnMinHeight calculation and minHeight wrapper from latest assistant/thinking rows
- Remove containerHeight property (was only used for minHeight)
- Inverted scroll naturally anchors to visual bottom, keeping user message visible

Part of plan: inverted-scroll-migration.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
