### PR TITLE
fix: verify and adjust CTA and deep-link anchors for inverted scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -87,6 +87,13 @@ final class MessageListScrollState {
         lastContentOffsetY
     }
 
+    /// Distance from the visual top (oldest messages) in inverted scroll.
+    /// Approaches 0 when the user scrolls to the oldest messages — used by
+    /// the pagination sentinel to trigger loading older history.
+    var distanceFromTop: CGFloat {
+        scrollContentHeight - lastContentOffsetY - scrollContainerHeight
+    }
+
     // MARK: - Scroll-to-latest
 
     // Hysteresis band: show at >400pt, hide only below 200pt. Prevents the CTA

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -80,8 +80,11 @@ final class MessageListScrollState {
 
     // MARK: - Computed
 
+    /// With inverted scroll (180° rotation), contentOffsetY is 0 at the visual
+    /// bottom (latest messages) and increases as you scroll toward older messages.
+    /// So contentOffsetY itself IS the distance from the latest messages.
     var distanceFromBottom: CGFloat {
-        scrollContentHeight - lastContentOffsetY - scrollContainerHeight
+        lastContentOffsetY
     }
 
     // MARK: - Scroll-to-latest

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -37,6 +37,7 @@ extension MessageListView {
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
             flashHighlight(messageId: displayId)
             anchorMessageId = nil
@@ -85,6 +86,7 @@ extension MessageListView {
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             withAnimation {
                 $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }
@@ -169,6 +171,7 @@ extension MessageListView {
         if let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             withAnimation {
                 $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -40,10 +40,10 @@ extension MessageListView {
         scrollState.updateScrollToLatest()
 
         // --- Pagination ---
-        // With inverted scroll the visual top (oldest messages) maps to the
-        // geometric bottom of the scroll content. Use distanceFromBottom so
-        // the sentinel fires when the user scrolls toward older messages.
-        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromBottom)
+        // With inverted scroll the visual top (oldest messages) is where
+        // distanceFromTop approaches 0. Negate so the sentinel's
+        // `sentinelMinY > -triggerBand` fires near the visual top.
+        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromTop)
     }
 
     // MARK: - Pagination sentinel

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -148,7 +148,9 @@ struct MessageListView: View {
             .id(conversationId)
             .flipped()  // Invert the scroll — visual bottom becomes natural top
             .overlay(alignment: .bottom) {
-                ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .bottom) })
+                // Inverted scroll: SwiftUI's .top edge maps to the visual bottom
+                // (latest messages), so we scroll to .top to reach them.
+                ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .top) })
             }
             .onAppear {
                 handleAppear()


### PR DESCRIPTION
## Summary
- Change CTA scroll target from .bottom to .top (visual bottom in inverted scroll)
- Adjust distanceFromBottom to use contentOffsetY directly (inverted coordinate system)
- Verify deep-link anchors work correctly with inverted scroll
- Add comments documenting inverted scroll coordinate conventions

Part of plan: inverted-scroll-migration.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
