### PR TITLE
fix: flip pagination anchor from .top to .bottom for inverted scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -85,7 +85,8 @@ extension MessageListView {
                     try? await Task.sleep(nanoseconds: 100_000_000)
                     guard !Task.isCancelled else { return }
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
-                    scrollBinding.wrappedValue = ScrollPosition(id: id, anchor: .top)
+                    // .bottom in scroll coordinates = visual top in inverted scroll
+                    scrollBinding.wrappedValue = ScrollPosition(id: id, anchor: .bottom)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inverted-scroll-migration.md.

**Gap:** Pagination anchor uses .top which maps to visual bottom in inverted scroll
**What was expected:** Anchor message stays at visual top after loading older pages
**What was found:** anchor: .top jumps message to visual bottom in inverted coordinates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
