### PR TITLE
fix: update SCROLL_STRATEGY.md FlippedModifier snippet to match actual code

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -28,7 +28,7 @@ The entire ScrollView and each row inside it are flipped using a `FlippedModifie
 struct FlippedModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .rotation3DEffect(.degrees(180), axis: (x: 1, y: 0, z: 0))  // rotate 180°
+            .rotationEffect(.radians(.pi))                                  // rotate 180°
             .scaleEffect(x: -1, y: 1, anchor: .center)                   // mirror horizontally
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inverted-scroll-migration.md.

**Gap:** SCROLL_STRATEGY.md code snippet uses wrong rotation API
**What was expected:** Doc snippet matches actual implementation
**What was found:** Doc shows rotation3DEffect but code uses rotationEffect + scaleEffect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
