### PR TITLE
Migrate chat to inverted scroll architecture

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -293,29 +293,29 @@ References:
 
 ## Scroll and Layout Stability
 
-> The old mode-based scroll state machine (ScrollCoordinator, ScrollMode enum with initialLoad/followingBottom/freeBrowsing/programmaticScroll/stabilizing, recovery windows, stabilization, auto-follow) has been completely removed. The current system is a flat coordinator with no modal state.
+> The old mode-based scroll state machine (ScrollCoordinator, ScrollMode enum with initialLoad/followingBottom/freeBrowsing/programmaticScroll/stabilizing, recovery windows, stabilization, auto-follow) has been completely removed. The current system uses inverted scroll via a `FlippedModifier` — a flat coordinator with no modal state.
 
-### Architecture: Flat Scroll Coordinator
+### Architecture: Inverted Scroll via FlippedModifier
 
 > **Canonical reference:** See [`clients/macos/SCROLL_STRATEGY.md`](macos/SCROLL_STRATEGY.md) for the full scroll behavior specification, design decisions, and restoration guide. If scroll behavior breaks, use that document as the source of truth.
 
-The scroll system has no mode-based state machine. `MessageListScrollState` (`Features/Chat/MessageListScrollState.swift`) is a lightweight `@Observable @MainActor` class owned by `MessageListView` via `@State`. It tracks CTA visibility and distance-from-bottom — not scroll modes.
+The scroll system uses an inverted ScrollView (rotate 180 degrees + mirror horizontally via `FlippedModifier`). The ScrollView gets `.flipped()`, and each row inside also gets `.flipped()` — the double-flip means content appears right-side-up, but the scroll coordinate system is inverted: offset 0 = visual bottom (latest messages).
 
-**Threads open at top.** `.defaultScrollAnchor(.top, for: .initialOffset)` on the ScrollView positions new and switched conversations at the top. No explicit scroll-to-bottom on conversation switch — SwiftUI handles it via `.id(conversationId)` recreation.
+`MessageListScrollState` (`Features/Chat/MessageListScrollState.swift`) is a lightweight `@Observable @MainActor` class owned by `MessageListView` via `@State`. It tracks CTA visibility and inverted distance metrics — not scroll modes.
 
-**Scroll-to-bottom on send.** When the user sends a message, `handleMessagesCountChanged` detects the new user message (via `pendingSendScrollMessageId`), defers one run-loop tick for LazyVStack materialization, then calls `scrollPosition.scrollTo(edge: .bottom)` with `VAnimation.standard`. The minHeight wrapper on the thinking indicator / assistant message fills the viewport so the user message is pinned to the top of the visible area.
+**Threads open at bottom naturally.** The inverted ScrollView starts at coordinate top (visual bottom = latest messages) without any `.defaultScrollAnchor`. On conversation switch, `.id(conversationId)` recreates the ScrollView and it naturally opens at visual bottom.
+
+**No scroll-to-bottom on send.** In the inverted ScrollView, new content appears at coordinate top (visual bottom) where the viewport already sits. No imperative scroll calls needed — the viewport stays put naturally.
 
 **No auto-follow during streaming.** The viewport does NOT track new content as the assistant generates tokens. The user message stays visible at the top; assistant content grows below it off-screen.
 
-**"Scroll to latest" CTA.** Appears when `distanceFromBottom > 400` (distance-based, not mode-based). Tapping calls `scrollState.dismissScrollToLatest()` + `scrollPosition = ScrollPosition(edge: .bottom)` inside `withAnimation(VAnimation.spring)`.
+**"Scroll to latest" CTA.** Appears when `distanceFromBottom > 400`. In inverted scroll, `distanceFromBottom = lastContentOffsetY` (offset 0 = visual bottom). Tapping calls `scrollState.dismissScrollToLatest()` + `scrollPosition = ScrollPosition(edge: .top)` inside `withAnimation(VAnimation.spring)`. Note: `.top` = visual bottom in inverted scroll.
 
-**Thinking placeholder row.** `TranscriptProjector` appends a synthetic placeholder assistant row when `shouldShowThinkingIndicator` is true. This renders the thinking indicator inside the ForEach's minHeight wrapper — the same container that later holds the real assistant message. Eliminates layout jump on transition. Uses a stable deterministic UUID.
+**Thinking placeholder row.** `TranscriptProjector` appends a synthetic placeholder assistant row when `shouldShowThinkingIndicator` is true. This renders the thinking indicator inside the same ForEach row that later holds the real assistant message. Eliminates layout jump on transition. Uses a stable deterministic UUID.
 
-**MinHeight calculation.** `containerHeight - composerHeight(80) - estimatedUserHeight - layoutPadding`. Uses stable container height from GeometryReader (not scroll viewport which fluctuates with composer resize). User message height estimated via `NSString.boundingRect`.
+**Pagination.** Rising-edge sentinel detection with 500ms cooldown using `distanceFromTop` (distance to oldest messages = `scrollContentHeight - lastContentOffsetY - scrollContainerHeight`). The `isPaginationInFlight` flag gates the pagination sentinel to prevent stacking concurrent pagination loads.
 
-**Pagination.** Rising-edge sentinel detection with 500ms cooldown. Independent of scroll mode. The `isPaginationInFlight` flag gates the pagination sentinel to prevent stacking concurrent pagination loads.
-
-**Deep-link anchor.** One-shot scroll-to-ID via `ScrollPosition` value replacement. Independent of scroll mode.
+**Deep-link anchor.** One-shot scroll-to-ID via `ScrollPosition` value replacement. Uses `.center` anchor which is view-relative and works unchanged in inverted scroll.
 
 ### Scroll Event Detection
 

--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -26,7 +26,6 @@ An `@Observable @MainActor` class with **no modes, no transitions, no recovery**
 
 - **Geometry:** `scrollContentHeight`, `scrollContainerHeight`, `lastContentOffsetY`, `viewportHeight`
 - **CTA visibility:** `showScrollToLatest` (driven by `distanceFromBottom > 400`)
-- **Send scroll:** `pendingSendScrollMessageId: UUID?` — set when user sends, cleared after scroll fires
 - **Pagination:** `wasPaginationTriggerInRange`, `lastPaginationCompletedAt` (rising-edge + 500ms cooldown)
 - **Deep-link anchor:** `anchorSetTime`, `anchorTimeoutTask`
 - **Scroll indicators:** `scrollIndicatorsHidden` (briefly hidden on conversation switch)
@@ -58,57 +57,19 @@ Both share the same `.if(row.isLatestAssistant ...)` minHeight wrapper — one c
 
 ---
 
-## The Send-Scroll Flow (Critical Path)
+## The Send Flow
 
-This is the most important interaction. When the user sends a message:
+With inverted scroll (`.flipped()`), new content naturally appears at the visual bottom. No imperative scroll-to-bottom is needed when the user sends a message.
 
 ### Step 1: Message appended
 `MessageSendCoordinator` appends the user message to `messages` and calls `flushCoalescedPublish()`. Then sets `isSending = true`.
 
-### Step 2: Detect new message
-`handleMessagesCountChanged()` fires (may fire before or after `handleSendingChanged`).
-
-**Safety net:** If `pendingSendScrollMessageId` is nil and a new user message appeared, set it:
-```swift
-if scrollState.pendingSendScrollMessageId == nil {
-    if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
-       scrollState.lastMessageId != nil,
-       lastUser.id != scrollState.lastMessageId,
-       paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
-        scrollState.pendingSendScrollMessageId = lastUser.id
-    }
-}
-```
-
-**Also:** `handleSendingChanged()` sets the ID when `isSending` becomes true (unless it's a confirmation resume).
-
-### Step 3: Scroll to bottom (deferred)
-Once the user message is in `paginatedVisibleMessages`:
-```swift
-if scrollState.pendingSendScrollMessageId != nil,
-   paginatedVisibleMessages.contains(where: { $0.id == scrollState.pendingSendScrollMessageId }) {
-    let scrollBinding = $scrollPosition
-    scrollState.pendingSendScrollMessageId = nil
-    Task { @MainActor in
-        withAnimation(VAnimation.standard) {
-            scrollBinding.wrappedValue.scrollTo(edge: .bottom)
-        }
-    }
-}
-```
-
-**Why deferred:** `Task { @MainActor in }` gives SwiftUI one run-loop tick to lay out the new cell in the LazyVStack before the scroll fires. Without this, the scroll targets the old content bottom and the user message appears off-screen.
-
-**Why `.scrollTo(edge: .bottom)`:** The imperative method animates correctly. Value replacement (`ScrollPosition(edge: .bottom)`) doesn't animate.
-
-**Why `VAnimation.standard`:** 0.25s easeInOut. Fast enough to feel responsive, slow enough to be smooth.
-
-### Step 4: MinHeight pins user message to top
-The thinking placeholder (or assistant message) has a minHeight wrapper:
+### Step 2: Content appears at bottom
+The inverted ScrollView adds new content at the visual bottom naturally. The thinking placeholder (or assistant message) has a minHeight wrapper:
 ```swift
 .frame(minHeight: turnMinHeight, alignment: .top)
 ```
-This fills the viewport below the user message, so after scroll-to-bottom the user message naturally sits at the top.
+This fills the viewport below the user message, so the user message naturally sits at the top.
 
 ---
 

--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -1,7 +1,7 @@
 # Vellum Chat Scroll Strategy
 
-> **Reference commit:** `2dcb606af` (merged 2026-04-13)
-> **PR:** #25206 — "refactor: remove scroll state machine — replace with flat coordinator"
+> **Architecture:** Inverted scroll via `FlippedModifier`
+> **Reference PRs:** #25828 through #25834 (inverted scroll migration, PRs 1-7)
 >
 > This document captures the exact scroll behavior and architecture that feels right.
 > If scroll behavior breaks due to future changes, use this as the source of truth to restore it.
@@ -11,10 +11,38 @@
 ## Design Philosophy
 
 1. **No auto-follow.** The viewport does NOT track streaming content. The user message stays pinned at the top while the assistant response grows below it.
-2. **Scroll to bottom on send.** When the user sends a message, we smoothly scroll to the bottom. The assistant's minHeight container fills the viewport, naturally pinning the user message to the top.
+2. **Inverted scroll eliminates scroll-to-bottom management.** The ScrollView is flipped 180 degrees — new content naturally appears at the visual bottom without any imperative `scrollTo` calls.
 3. **Simple distance-based CTA.** "Scroll to latest" appears when >400pt from bottom. No modes, no hysteresis, no state machine.
-4. **Threads open at bottom.** `.defaultScrollAnchor(.bottom, for: .initialOffset)` — conversations start at the latest messages.
+4. **Threads open at bottom.** The inverted ScrollView starts at the visual bottom (latest messages) naturally. No `.defaultScrollAnchor` needed.
 5. **One container for thinking + assistant.** A synthetic placeholder row in the ForEach holds the thinking indicator. When the real assistant message arrives, it replaces the placeholder in the same container — no layout jump.
+
+---
+
+## The Inverted Scroll Technique
+
+### FlippedModifier
+
+The entire ScrollView and each row inside it are flipped using a `FlippedModifier`:
+
+```swift
+struct FlippedModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .rotation3DEffect(.degrees(180), axis: (x: 1, y: 0, z: 0))  // rotate 180°
+            .scaleEffect(x: -1, y: 1, anchor: .center)                   // mirror horizontally
+    }
+}
+```
+
+The ScrollView gets `.flipped()`, and each row inside also gets `.flipped()`. The double-flip means the content appears right-side-up to the user, but the scroll coordinate system is inverted: the ScrollView's natural "top" (offset 0) is the visual bottom (latest messages).
+
+### Why This Works
+
+1. **No scroll-to-bottom management.** In a normal ScrollView, new content added at the bottom pushes the viewport up — you need imperative `scrollTo(.bottom)` to follow. In an inverted ScrollView, new content is added at the coordinate "top" (visual bottom), which is where the viewport already sits. The viewport stays put naturally.
+
+2. **No LazyVStack materialization hang.** With a normal bottom-anchored ScrollView, SwiftUI had to materialize all items to compute content height before it could position at the bottom. With inverted scroll, the "top" (visual bottom) is the natural starting position — SwiftUI only materializes visible items.
+
+3. **No multi-stage scroll restore.** The old architecture needed `switchRestoreTask`, `isScrollRestored` opacity fade, and deferred scroll calls to restore position on conversation switch. With inverted scroll, `.id(conversationId)` recreates the ScrollView and it naturally opens at visual bottom (coordinate top).
 
 ---
 
@@ -25,12 +53,15 @@
 An `@Observable @MainActor` class with **no modes, no transitions, no recovery**. Just tracks:
 
 - **Geometry:** `scrollContentHeight`, `scrollContainerHeight`, `lastContentOffsetY`, `viewportHeight`
+- **Distance metrics (inverted):**
+  - `distanceFromBottom = lastContentOffsetY` (in inverted scroll, offset 0 = visual bottom, so raw offset IS distance from bottom)
+  - `distanceFromTop = scrollContentHeight - lastContentOffsetY - scrollContainerHeight` (for pagination — distance from visual top = oldest messages)
 - **CTA visibility:** `showScrollToLatest` (driven by `distanceFromBottom > 400`)
-- **Pagination:** `wasPaginationTriggerInRange`, `lastPaginationCompletedAt` (rising-edge + 500ms cooldown)
+- **Pagination:** `wasPaginationTriggerInRange`, `lastPaginationCompletedAt` (rising-edge + 500ms cooldown), uses `distanceFromTop` threshold
 - **Deep-link anchor:** `anchorSetTime`, `anchorTimeoutTask`
 - **Scroll indicators:** `scrollIndicatorsHidden` (briefly hidden on conversation switch)
 
-**What does NOT exist:** ScrollMode enum, mode transitions, auto-follow, recovery windows, stabilization, deferred bottom pins, circuit breaker, scroll closures (scrollTo/scrollToEdge/cancelScrollAnimation), configureScrollCallbacks, restoreScrollToBottom, ScrollCoordinator.
+**What does NOT exist:** ScrollMode enum, mode transitions, auto-follow, recovery windows, stabilization, deferred bottom pins, circuit breaker, scroll closures (scrollTo/scrollToEdge/cancelScrollAnimation), configureScrollCallbacks, restoreScrollToBottom, ScrollCoordinator, switchRestoreTask, pendingSendScrollMessageId, hasSendScrollFired, isScrollRestored, minHeight wrapper, turnMinHeight, containerHeight.
 
 ### View: `MessageListView`
 
@@ -38,55 +69,32 @@ An `@Observable @MainActor` class with **no modes, no transitions, no recovery**
 ScrollView {
     HStack { Spacer + scrollViewContent + Spacer }
 }
-.defaultScrollAnchor(.top, for: .initialOffset)
+.flipped()                                              // Inverted scroll
 .scrollPosition($scrollPosition)
 .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
-.id(conversationId)
+.id(conversationId)                                     // On ScrollView itself
 .overlay(alignment: .bottom) { ScrollToLatestOverlayView }
 ```
 
-No `.onScrollPhaseChange`. No `.environment(\.suppressAutoScroll)`. No ScrollCoordinator.
+No `.defaultScrollAnchor`. No `.onScrollPhaseChange`. No `.environment(\.suppressAutoScroll)`. No ScrollCoordinator.
 
 ### Content: `MessageListContentView`
 
-ForEach renders both:
-- **Normal message cells** via `MessageCellView`
-- **Thinking placeholder** via `row.isThinkingPlaceholder` (synthetic row from TranscriptProjector)
+ForEach iterates `displayedItems.reversed()` (oldest-first becomes newest-first in the data, which maps to coordinate-top in the inverted ScrollView = visual bottom). Each row and standalone section gets `.flipped()` to undo the ScrollView flip.
 
-Both share the same `.if(row.isLatestAssistant ...)` minHeight wrapper — one container, no swap.
+Both normal message cells and the thinking placeholder share the same ForEach — one container, no swap.
 
 ---
 
 ## The Send Flow
 
-With inverted scroll (`.flipped()`), new content naturally appears at the visual bottom. No imperative scroll-to-bottom is needed when the user sends a message.
+With inverted scroll, new content naturally appears at the visual bottom. No imperative scroll-to-bottom is needed.
 
 ### Step 1: Message appended
 `MessageSendCoordinator` appends the user message to `messages` and calls `flushCoalescedPublish()`. Then sets `isSending = true`.
 
 ### Step 2: Content appears at bottom
-The inverted ScrollView adds new content at the visual bottom naturally. The thinking placeholder (or assistant message) has a minHeight wrapper:
-```swift
-.frame(minHeight: turnMinHeight, alignment: .top)
-```
-This fills the viewport below the user message, so the user message naturally sits at the top.
-
----
-
-## MinHeight Calculation (Critical)
-
-```swift
-let estimatedUserHeight = min(NSString.boundingRect(text) + 100, 260)
-let composerHeight: CGFloat = 80        // static — composer is empty after send
-let layoutPadding = VSpacing.md * 3 + 1 // top + bottom + inter-item + anchor
-let turnMinHeight = containerHeight - composerHeight - estimatedUserHeight - layoutPadding
-```
-
-### Key decisions:
-- **Uses `containerHeight`** (full chat pane from GeometryReader), NOT `scrollState.viewportHeight`. The viewport height fluctuates when the composer resizes — the container height is stable.
-- **Composer is static 80pt.** We only care about the composer height when it's empty (after the user hits send). It grows when typing, but by then minHeight doesn't matter.
-- **User message estimated via `NSString.boundingRect`** for word-wrap accuracy. Cell overhead is 100pt (bubble padding 24 + timestamp 24 + spacing 12 + show more button 30 + gradient 10). Capped at 260pt (collapse threshold + overhead).
-- **MinHeight applies when `row.isLatestAssistant && row.message.id == state.rows.last?.message.id`.** No `isActiveTurn` gate — the minHeight persists after streaming ends so the viewport doesn't jump.
+The inverted ScrollView adds new content at coordinate top (visual bottom) naturally. The viewport stays put — no scroll management required.
 
 ---
 
@@ -112,6 +120,8 @@ if shouldShowThinkingIndicator {
 
 ## Scroll-to-Latest CTA
 
+In inverted scroll, `distanceFromBottom` is simply `lastContentOffsetY` (offset 0 = visual bottom).
+
 ```swift
 // In MessageListScrollState:
 func updateScrollToLatest() {
@@ -130,30 +140,46 @@ Button tap:
 ```swift
 withAnimation(VAnimation.spring) {
     scrollState.dismissScrollToLatest()
-    onScrollToBottom()  // → scrollPosition = ScrollPosition(edge: .bottom)
+    onScrollToBottom()  // -> scrollPosition = ScrollPosition(edge: .top)  // .top = visual bottom in inverted scroll
 }
 ```
 
-**Why `dismissScrollToLatest()` inside the animation block:** So the exit transition (`.move(edge: .bottom).combined(with: .opacity)`) animates in sync with the scroll.
+**Why `ScrollPosition(edge: .top)` for visual bottom:** In the inverted ScrollView, coordinate top IS visual bottom. So scrolling to `.top` takes you to the latest messages.
 
-**Why value replacement for CTA but imperative for send-scroll:** The CTA doesn't need animation (spring handles it). Send-scroll needs `VAnimation.standard` which works with the imperative `.scrollTo(edge:)` method.
+---
+
+## Pagination
+
+Pagination triggers when the user scrolls toward older messages (visual top = coordinate bottom in inverted scroll).
+
+```swift
+// distanceFromTop = scrollContentHeight - lastContentOffsetY - scrollContainerHeight
+let isNearTop = distanceFromTop < paginationThreshold
+```
+
+Uses the same rising-edge detection with 500ms cooldown as before — just the distance metric changed from `distanceFromBottom` (old) to `distanceFromTop` (inverted).
+
+---
+
+## Deep-Link Anchors
+
+Deep-link scroll uses `.center` anchor for scroll-to-ID via `ScrollPosition` value replacement. The `.center` anchor is view-relative and works unchanged in inverted scroll — no special handling needed.
 
 ---
 
 ## Conversation Switching
 
 ```swift
-.id(conversationId)                                    // Destroys + recreates ScrollView
-.defaultScrollAnchor(.top, for: .initialOffset)        // New view starts at top
+.id(conversationId)    // Destroys + recreates ScrollView — on the ScrollView itself
 ```
 
 `handleAppear()` detects the switch via `scrollState.currentConversationId` comparison, calls `handleConversationSwitched()` which:
 1. Cancels queued geometry callbacks (`ScrollGeometryUpdateDispatcher.shared.cancel`)
 2. Resets all scroll state (`scrollState.reset(for:)`)
 3. Seeds `lastMessageId`
-4. Does NOT write to `scrollPosition` — `.defaultScrollAnchor(.top)` handles positioning
+4. Does NOT write to `scrollPosition` — inverted scroll naturally opens at visual bottom
 
-**No explicit scroll on switch.** The `.id()` recreation + `.defaultScrollAnchor` is sufficient.
+**No explicit scroll on switch.** The `.id()` recreation is sufficient. Inverted scroll starts at coordinate top = visual bottom naturally.
 
 ---
 
@@ -168,7 +194,7 @@ let isCollapsible = userMessageIntrinsicHeight > 0
 ```
 
 Collapsed messages have:
-- Gradient fade overlay (transparent → `VColor.surfaceLift`)
+- Gradient fade overlay (transparent -> `VColor.surfaceLift`)
 - "Show more" button using `VButton(style: .ghost, size: .compact, tintColor: .contentTertiary)`, left-aligned
 - Button is inside the bubble container (rounded corners, surfaceLift background)
 
@@ -189,6 +215,13 @@ These were removed for a reason. Do not re-introduce:
 | Recovery windows / deadlines | Complex timer-based scroll correction; the flat model doesn't need it |
 | Stabilization / circuit breaker | Protected against layout storms from mode transitions; no modes = no storms |
 | `isAtBottom` hysteresis | Asymmetric thresholds to prevent oscillation; distance CTA is simpler |
+| `switchRestoreTask` | Multi-stage scroll restore on conversation switch; inverted scroll opens at bottom naturally |
+| `pendingSendScrollMessageId` | Tracked which message to scroll to after send; inverted scroll needs no scroll-to-bottom |
+| `hasSendScrollFired` | Gated the send-scroll-to-bottom call; no send-scroll exists in inverted model |
+| `isScrollRestored` / opacity fade | Hid content until scroll position was restored; inverted scroll positions instantly |
+| `.defaultScrollAnchor(.bottom)` | Was needed to start at bottom in normal scroll; inverted scroll starts at visual bottom naturally |
+| `turnMinHeight` / minHeight wrapper | Filled viewport below user message on send; inverted scroll keeps user message visible without it |
+| `containerHeight` property | Drove the minHeight calculation; removed along with minHeight wrapper |
 
 ---
 
@@ -196,11 +229,12 @@ These were removed for a reason. Do not re-introduce:
 
 | File | Responsibility |
 |------|---------------|
-| `MessageListScrollState.swift` | Flat coordinator — geometry, CTA, pagination, anchor state |
-| `MessageListView.swift` | ScrollView setup — position binding, anchor, indicators, overlay |
-| `MessageListView+ScrollHandling.swift` | Geometry handler — updates state, triggers pagination |
-| `MessageListView+Lifecycle.swift` | Send detection, scroll-to-bottom, conversation switch, anchor resolution |
-| `MessageListContentView.swift` | ForEach rendering, minHeight wrapper, thinking placeholder |
+| `MessageListTypes.swift` | `FlippedModifier` — the rotation + mirror transform for inverted scroll |
+| `MessageListScrollState.swift` | Flat coordinator — geometry, CTA, pagination, anchor state, inverted distance metrics |
+| `MessageListView.swift` | ScrollView setup — `.flipped()`, position binding, indicators, overlay |
+| `MessageListView+ScrollHandling.swift` | Geometry handler — updates state, triggers pagination using `distanceFromTop` |
+| `MessageListView+Lifecycle.swift` | Send detection, conversation switch, anchor resolution |
+| `MessageListContentView.swift` | ForEach rendering with `.reversed()` + per-row `.flipped()`, thinking placeholder |
 | `MessageListHelperViews.swift` | ScrollToLatestOverlayView — CTA button |
 | `TranscriptProjector.swift` | Thinking placeholder row injection |
 | `TranscriptRenderModel.swift` | `isThinkingPlaceholder` flag on row model |

--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -28,7 +28,7 @@ The entire ScrollView and each row inside it are flipped using a `FlippedModifie
 struct FlippedModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .rotation3DEffect(.degrees(180), axis: (x: 1, y: 0, z: 0))  // rotate 180°
+            .rotationEffect(.radians(.pi))                                  // rotate 180°
             .scaleEffect(x: -1, y: 1, anchor: .center)                   // mirror horizontally
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -163,7 +163,7 @@ struct ChatView: View {
         // children (808pt fallback) or when rapid drag updates are batched.
         GeometryReader { proxy in
             ZStack {
-                mainContentStack(containerWidth: proxy.size.width, containerHeight: proxy.size.height)
+                mainContentStack(containerWidth: proxy.size.width)
                     .background(alignment: .bottom) {
                         chatBackground
                     }
@@ -257,7 +257,7 @@ struct ChatView: View {
     // MARK: - Body Subviews (extracted to help the Swift type checker)
 
     @ViewBuilder
-    private func mainContentStack(containerWidth: CGFloat, containerHeight: CGFloat) -> some View {
+    private func mainContentStack(containerWidth: CGFloat) -> some View {
         VStack(spacing: 0) {
             if showSkeleton {
                 ChatLoadingSkeleton()
@@ -325,7 +325,7 @@ struct ChatView: View {
                     .id(conversationId)
                 }
             } else {
-                activeConversationContent(containerWidth: containerWidth, containerHeight: containerHeight)
+                activeConversationContent(containerWidth: containerWidth)
             }
         }
     }
@@ -345,7 +345,7 @@ struct ChatView: View {
     /// individually; it feeds them into the projector and renders the resulting
     /// `TranscriptRenderModel` via `MessageListContentView`.
     @ViewBuilder
-    private func activeConversationContent(containerWidth: CGFloat, containerHeight: CGFloat = 0) -> some View {
+    private func activeConversationContent(containerWidth: CGFloat) -> some View {
         let layoutMetrics = MessageListLayoutMetrics(containerWidth: containerWidth)
         let queuedMessages = viewModel.queuedMessages
         VStack(spacing: 0) {
@@ -402,8 +402,7 @@ struct ChatView: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 isInteractionEnabled: isInteractionEnabled,
-                containerWidth: containerWidth,
-                containerHeight: containerHeight
+                containerWidth: containerWidth
             )
             .animation(nil, value: queuedMessages.isEmpty)
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -405,7 +405,6 @@ struct ChatView: View {
                 containerWidth: containerWidth,
                 containerHeight: containerHeight
             )
-            .id(conversationId)
             .animation(nil, value: queuedMessages.isEmpty)
 
             if let error = viewModel.errorManager.conversationError, error.isCreditsExhausted {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -221,6 +221,7 @@ struct MessageListContentView: View, Equatable {
             }
             .frame(minHeight: turnMinHeight, alignment: .top)
         }
+        .flipped()  // Flip each row back so content reads correctly in inverted scroll
     }
 
     @ViewBuilder
@@ -264,6 +265,7 @@ struct MessageListContentView: View, Equatable {
                 }
                 .padding(.vertical, VSpacing.sm)
                 .id("page-loading-indicator")
+                .flipped()
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
@@ -330,10 +332,11 @@ struct MessageListContentView: View, Equatable {
                 uniqueKeysWithValues: state.rows.map { ($0.message.id, $0) }
             )
             let displayedItems = TranscriptItems.build(from: state.rows.map(\.message))
-            ForEach(displayedItems) { item in
+            ForEach(displayedItems.reversed()) { item in
                 switch item {
                 case .queuedMarker(let count):
                     QueuedMessagesMarker(count: count)
+                        .flipped()
                 case .message(let message):
                     // Safe: every displayed message originates from `state.rows`
                     // so `rowsByMessageId[message.id]` is always present.
@@ -361,6 +364,7 @@ struct MessageListContentView: View, Equatable {
                 }
                     .id("subagent-\(subagent.id)")
                     .transition(.opacity)
+                    .flipped()
             }
 
             if state.isStreamingWithoutText && !state.canInlineProcessing {
@@ -374,13 +378,16 @@ struct MessageListContentView: View, Equatable {
                 .frame(minHeight: turnMinHeight, alignment: .top)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity)
+                .flipped()
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 VStack(spacing: 0) { compactingIndicatorRow() }
                     .frame(minHeight: turnMinHeight, alignment: .top)
+                    .flipped()
             }
 
             Color.clear.frame(height: 1)
                 .id("scroll-bottom-anchor")
+                .flipped()
         }
         .disabled(!isInteractionEnabled)
         .transaction { $0.animation = nil }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -45,7 +45,6 @@ struct MessageListContentView: View, Equatable {
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.subagentDetailStore === rhs.subagentDetailStore
             && lhs.assistantStatusText == rhs.assistantStatusText
-            && lhs.containerHeight == rhs.containerHeight
     }
 
     // MARK: - Data properties (compared in ==)
@@ -69,9 +68,6 @@ struct MessageListContentView: View, Equatable {
     let configuredProviders: Set<String>
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
-    /// Stable height of the full chat pane. Used for minHeight instead of
-    /// scroll viewport height which fluctuates with composer resizing.
-    let containerHeight: CGFloat
 
     // MARK: - @Observable references (not compared in ==; reads occur in closures or child views)
 
@@ -134,16 +130,12 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Transcript row rendering
 
     /// Renders a single transcript row (either a real message cell or the
-    /// synthetic thinking placeholder) with the `active turn` minHeight
-    /// wrapper applied when the row is the latest assistant and also the
-    /// tail of `state.rows` (so the user's last message sits at the top
-    /// of the viewport while the assistant streams).
+    /// synthetic thinking placeholder).
     @ViewBuilder
     private func transcriptRow(
         row: TranscriptRowModel,
         isUnanchoredThinking: Bool,
-        thinkingLabel: String,
-        turnMinHeight: CGFloat
+        thinkingLabel: String
     ) -> some View {
         Group {
             if row.isThinkingPlaceholder {
@@ -209,18 +201,6 @@ struct MessageListContentView: View, Equatable {
                 .equatable()
             }
         }
-        // Latest assistant message (or thinking placeholder): wrap in
-        // VStack with minHeight so user message sits at top. The same
-        // wrapper applies to both the placeholder and the real assistant
-        // message, eliminating layout jump on transition.
-        .if(row.isLatestAssistant && row.message.id == state.rows.last?.message.id) { view in
-            VStack(spacing: 0) {
-                view
-                Color.clear.frame(height: 1)
-                    .id("active-turn-content-bottom")
-            }
-            .frame(minHeight: turnMinHeight, alignment: .top)
-        }
         .flipped()  // Flip each row back so content reads correctly in inverted scroll
     }
 
@@ -269,55 +249,6 @@ struct MessageListContentView: View, Equatable {
             }
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
-            // Estimate user message cell height for precise minHeight offset.
-            // Queued user messages are collapsed into QueuedMessagesMarker and
-            // don't render as full bubbles, so they must be excluded — using a
-            // queued follow-up's height would over-estimate and under-size the
-            // turn minHeight, breaking the "sent message pinned at top"
-            // invariant during an active turn.
-            let estimatedUserHeight: CGFloat = {
-                let hasQueuedMessages = state.rows.contains(where: { row in
-                    guard row.message.role == .user else { return false }
-                    if case .queued = row.message.status { return true }
-                    return false
-                })
-                // ~40pt: QueuedMessagesMarker = single-line labelDefault text
-                // with VSpacing.sm top+bottom padding.
-                let markerHeight: CGFloat = hasQueuedMessages ? 40 : 0
-                guard let lastUser = state.rows.last(where: { row in
-                    guard row.message.role == .user else { return false }
-                    if case .queued = row.message.status { return false }
-                    return true
-                }) else {
-                    return 80 + markerHeight
-                }
-                // Messages with attachments are always collapsed — use max height
-                if !lastUser.message.attachments.isEmpty {
-                    return 260 + markerHeight
-                }
-                let text = lastUser.message.text as NSString
-                let contentWidth = max(layoutMetrics.bubbleMaxWidth - 2 * VSpacing.lg, 0)
-                let font = NSFont.systemFont(ofSize: 14, weight: .regular)
-                let textRect = text.boundingRect(
-                    with: NSSize(width: contentWidth, height: .greatestFiniteMagnitude),
-                    options: [.usesLineFragmentOrigin, .usesFontLeading],
-                    attributes: [.font: font]
-                )
-                let textHeight = ceil(textRect.height)
-                // Bubble padding (24) + timestamp (24) + spacing (12) + show more button (30) + gradient (10)
-                let cellOverhead: CGFloat = 100
-                // Cap at collapsed bubble height (150pt content + overhead)
-                return min(textHeight + cellOverhead, 260) + markerHeight
-            }()
-            // Precise minHeight: fill the space between user message and composer.
-            // containerHeight = full chat pane (stable, from GeometryReader)
-            // composerHeight = 80pt static (empty after send — when minHeight matters)
-            // layoutPadding = LazyVStack top/bottom padding + inter-item spacing + anchor
-            let composerHeight: CGFloat = 80
-            let layoutPadding: CGFloat = VSpacing.md * 3 + 1
-            let turnMinHeight: CGFloat = containerHeight > 0
-                ? max(0, containerHeight - composerHeight - estimatedUserHeight - layoutPadding)
-                : 0
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
             let thinkingLabel = !hasEverSentMessage && state.hasUserMessage
                 ? "Waking up..."
@@ -344,8 +275,7 @@ struct MessageListContentView: View, Equatable {
                         transcriptRow(
                             row: row,
                             isUnanchoredThinking: isUnanchoredThinking,
-                            thinkingLabel: thinkingLabel,
-                            turnMinHeight: turnMinHeight
+                            thinkingLabel: thinkingLabel
                         )
                     }
                 }
@@ -368,20 +298,16 @@ struct MessageListContentView: View, Equatable {
             }
 
             if state.isStreamingWithoutText && !state.canInlineProcessing {
-                VStack(spacing: 0) {
-                    HStack {
-                        TypingIndicatorView()
-                        Spacer()
-                    }
-                    .frame(width: effectiveBubbleMaxWidth)
+                HStack {
+                    TypingIndicatorView()
+                    Spacer()
                 }
-                .frame(minHeight: turnMinHeight, alignment: .top)
+                .frame(width: effectiveBubbleMaxWidth)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity)
                 .flipped()
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
-                VStack(spacing: 0) { compactingIndicatorRow() }
-                    .frame(minHeight: turnMinHeight, alignment: .top)
+                compactingIndicatorRow()
                     .flipped()
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -236,17 +236,45 @@ struct MessageListContentView: View, Equatable {
         // causing multi-minute hangs on long conversations. Do NOT remove the
         // .transaction modifier or wrap content changes in withAnimation.
         LazyVStack(alignment: .leading, spacing: VSpacing.md) {
-            if isLoadingMoreMessages {
+            // ── Coordinate TOP = Visual BOTTOM (near latest messages) ──
+            // In the inverted scroll, the first items in the LazyVStack appear
+            // at the visual bottom. Place current-activity indicators here.
+
+            Color.clear.frame(height: 1)
+                .id("scroll-bottom-anchor")
+                .flipped()
+
+            if state.isStreamingWithoutText && !state.canInlineProcessing {
                 HStack {
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.small)
+                    TypingIndicatorView()
                     Spacer()
                 }
-                .padding(.vertical, VSpacing.sm)
-                .id("page-loading-indicator")
+                .frame(width: effectiveBubbleMaxWidth)
+                .id("streaming-without-text-indicator")
+                .transition(.opacity)
                 .flipped()
+            } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
+                compactingIndicatorRow()
+                    .flipped()
             }
+
+            ForEach(state.orphanSubagents) { subagent in
+                // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
+                HStack(spacing: 0) {
+                    SubagentEventsReader(
+                        store: subagentDetailStore,
+                        subagent: subagent,
+                        onAbort: { onAbortSubagent?(subagent.id) },
+                        onTap: { onSubagentTap?(subagent.id) }
+                    )
+                    Spacer(minLength: 0)
+                }
+                    .id("subagent-\(subagent.id)")
+                    .transition(.opacity)
+                    .flipped()
+            }
+
+            // ── Messages ──
 
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)
@@ -281,39 +309,21 @@ struct MessageListContentView: View, Equatable {
                 }
             }
 
-            ForEach(state.orphanSubagents) { subagent in
-                // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
-                HStack(spacing: 0) {
-                    SubagentEventsReader(
-                        store: subagentDetailStore,
-                        subagent: subagent,
-                        onAbort: { onAbortSubagent?(subagent.id) },
-                        onTap: { onSubagentTap?(subagent.id) }
-                    )
-                    Spacer(minLength: 0)
-                }
-                    .id("subagent-\(subagent.id)")
-                    .transition(.opacity)
-                    .flipped()
-            }
+            // ── Coordinate BOTTOM = Visual TOP (near oldest messages) ──
+            // In the inverted scroll, the last items in the LazyVStack appear
+            // at the visual top. Place the page-loading indicator here.
 
-            if state.isStreamingWithoutText && !state.canInlineProcessing {
+            if isLoadingMoreMessages {
                 HStack {
-                    TypingIndicatorView()
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
                     Spacer()
                 }
-                .frame(width: effectiveBubbleMaxWidth)
-                .id("streaming-without-text-indicator")
-                .transition(.opacity)
+                .padding(.vertical, VSpacing.sm)
+                .id("page-loading-indicator")
                 .flipped()
-            } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
-                compactingIndicatorRow()
-                    .flipped()
             }
-
-            Color.clear.frame(height: 1)
-                .id("scroll-bottom-anchor")
-                .flipped()
         }
         .disabled(!isInteractionEnabled)
         .transaction { $0.animation = nil }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -80,7 +80,17 @@ final class MessageListScrollState {
 
     // MARK: - Computed
 
+    /// With inverted scroll (180° rotation), contentOffsetY is 0 at the visual
+    /// bottom (latest messages) and increases as you scroll toward older messages.
+    /// So contentOffsetY itself IS the distance from the latest messages.
     var distanceFromBottom: CGFloat {
+        lastContentOffsetY
+    }
+
+    /// Distance from the visual top (oldest messages) in inverted scroll.
+    /// Approaches 0 when the user scrolls to the oldest messages — used by
+    /// the pagination sentinel to trigger loading older history.
+    var distanceFromTop: CGFloat {
         scrollContentHeight - lastContentOffsetY - scrollContainerHeight
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -31,7 +31,6 @@ final class MessageListScrollState {
     @ObservationIgnored var currentConversationId: UUID?
     @ObservationIgnored var lastMessageId: UUID?
     @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
-    @ObservationIgnored var pendingSendScrollMessageId: UUID?
     // MARK: - Deep-link anchor
 
     @ObservationIgnored var anchorSetTime: Date?
@@ -156,7 +155,6 @@ final class MessageListScrollState {
         ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
         currentConversationId = conversationId
         lastMessageId = nil
-        pendingSendScrollMessageId = nil
         scrollContentHeight = 0
         scrollContainerHeight = 0
         lastContentOffsetY = 0
@@ -176,8 +174,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
 
         // Briefly hide scroll indicators during switch
         hideScrollIndicatorsBriefly()
@@ -194,8 +190,6 @@ final class MessageListScrollState {
         paginationTask = nil
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
-        switchRestoreTask?.cancel()
-        switchRestoreTask = nil
         isPaginationInFlight = false
         lastMessageId = nil
         scrollContentHeight = 0
@@ -212,8 +206,5 @@ final class MessageListScrollState {
     @ObservationIgnored var isPaginationInFlight: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
-    /// Multi-stage scroll-to-bottom task fired on conversation switch / first mount.
-    /// Cancelled on rapid switching and when a deep-link anchor is pending.
-    @ObservationIgnored var switchRestoreTask: Task<Void, Never>?
 
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -116,6 +116,9 @@ final class MessageListScrollState {
 
     /// Handles rising-edge detection for the pagination sentinel with a 500ms cooldown.
     /// Returns `true` when pagination should fire.
+    ///
+    /// With inverted scroll, callers pass `-distanceFromBottom` so values near
+    /// zero mean the user is close to the visual top (oldest messages).
     func handlePaginationSentinel(sentinelMinY: CGFloat) -> Bool {
         let triggerBand: CGFloat = 200
         let isInRange = sentinelMinY > -triggerBand

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -156,3 +156,22 @@ final class ProjectionCache {
         isThrottled = false
     }
 }
+
+// MARK: - Flipped Modifier
+
+/// Rotates 180° and mirrors horizontally — the "inverted scroll" technique.
+/// Apply to both the ScrollView and each row to get a bottom-anchored list
+/// where new content appears at the bottom without any scroll management.
+struct FlippedModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(.radians(.pi))
+            .scaleEffect(x: -1, y: 1, anchor: .center)
+    }
+}
+
+extension View {
+    func flipped() -> some View {
+        modifier(FlippedModifier())
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -169,7 +169,6 @@ extension MessageListView {
             configuredProviders: configuredProviders,
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
-            containerHeight: containerHeight,
             scrollState: scrollState,
             onConfirmationAllow: onConfirmationAllow,
             onConfirmationDeny: onConfirmationDeny,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -37,6 +37,7 @@ extension MessageListView {
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
             flashHighlight(messageId: displayId)
             anchorMessageId = nil
@@ -85,6 +86,7 @@ extension MessageListView {
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             withAnimation {
                 $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }
@@ -169,6 +171,7 @@ extension MessageListView {
         if let displayId = TranscriptItems.displayId(for: id, in: messages) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
+            // .center anchor is view-relative and works correctly with inverted scroll.
             withAnimation {
                 $scrollPosition.wrappedValue = ScrollPosition(id: displayId, anchor: .center)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -77,9 +77,6 @@ extension MessageListView {
                 try? await Task.sleep(nanoseconds: 50_000_000)
                 guard !Task.isCancelled else { return }
                 scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-                withAnimation(VAnimation.fast) {
-                    isScrollRestored = true
-                }
 
                 try? await Task.sleep(nanoseconds: 150_000_000)
                 guard !Task.isCancelled else { return }
@@ -236,10 +233,6 @@ extension MessageListView {
             try? await Task.sleep(nanoseconds: 50_000_000)
             guard !Task.isCancelled else { return }
             scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-            // Fade in after scroll is positioned
-            withAnimation(VAnimation.fast) {
-                isScrollRestored = true
-            }
 
             // Stage 2: slower content (150ms) — final correction
             try? await Task.sleep(nanoseconds: 150_000_000)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -35,9 +35,6 @@ extension MessageListView {
         // Handle pending anchor if already set.
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
-            // Deep-link anchor found — cancel any restore so it isn't overridden.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
             $scrollPosition.wrappedValue.scrollTo(id: displayId, anchor: .center)
@@ -45,10 +42,6 @@ extension MessageListView {
             anchorMessageId = nil
             scrollState.anchorSetTime = nil
         } else if anchorMessageId != nil {
-            // Anchor pending but not yet found — cancel restore so deep-link
-            // anchors aren't overridden by the bottom-scroll restore.
-            scrollState.switchRestoreTask?.cancel()
-            scrollState.switchRestoreTask = nil
             os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
             if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
             // Start the independent timeout if not already running.
@@ -65,25 +58,6 @@ extension MessageListView {
                     scrollState.anchorTimeoutTask = nil
                 }
             }
-        } else if !isConversationSwitch {
-            // First mount (no prior conversationId, no anchor) — also needs
-            // multi-stage scroll since the first conversation load must land
-            // at the bottom, same as a switch.
-            scrollState.switchRestoreTask?.cancel()
-            let scrollBinding = $scrollPosition
-            scrollState.switchRestoreTask = Task { @MainActor in
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                try? await Task.sleep(nanoseconds: 50_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                try? await Task.sleep(nanoseconds: 150_000_000)
-                guard !Task.isCancelled else { return }
-                scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-                scrollState.switchRestoreTask = nil
-            }
         }
     }
 
@@ -92,18 +66,7 @@ extension MessageListView {
     func handleSendingChanged() {
         // Guard against stale fires during a conversation switch.
         guard conversationId == scrollState.currentConversationId else { return }
-        if isSending {
-            // Only scroll on genuine user sends, not confirmation resumes.
-            // When the daemon resumes from awaiting_confirmation, isSending
-            // flips true but no new user message was sent — scrolling would
-            // jump the viewport to an older user message.
-            let isConfirmationResume = scrollState.lastActivityPhaseWhenIdle == "awaiting_confirmation"
-            if !isConfirmationResume {
-                if let userMessage = messages.last(where: { $0.role == .user }) {
-                    scrollState.pendingSendScrollMessageId = userMessage.id
-                }
-            }
-        } else {
+        if !isSending {
             // Capture the activity phase at the moment sending stops.
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
             // First-message detection.
@@ -147,38 +110,9 @@ extension MessageListView {
                 return
             }
         }
-        // --- Safety net: detect new user message added before isSending onChange fired ---
-        // MessageSendCoordinator appends the user message and calls flushCoalescedPublish()
-        // before setting isSending = true, so messages.count can change first.
-        // Must run before lastMessageId is updated so we can detect the change.
-        if scrollState.pendingSendScrollMessageId == nil {
-            if let lastUser = paginatedVisibleMessages.last(where: { $0.role == .user }),
-               scrollState.lastMessageId != nil,
-               lastUser.id != scrollState.lastMessageId,
-               paginatedVisibleMessages.last?.id != scrollState.lastMessageId {
-                scrollState.pendingSendScrollMessageId = lastUser.id
-            }
-        }
         // --- Update lastMessageId ---
         if let lastId = paginatedVisibleMessages.last?.id {
             scrollState.lastMessageId = lastId
-        }
-        // --- Scroll to bottom on send ---
-        // After the user message appears and the thinking indicator shows,
-        // scroll to bottom. The thinking indicator's minHeight wrapper
-        // naturally pins the user message to the top of the viewport.
-        // Deferred by one run-loop tick so SwiftUI lays out the new cell
-        // before the scroll fires — otherwise the scroll targets the old
-        // content bottom and the user message appears off-screen.
-        if scrollState.pendingSendScrollMessageId != nil,
-           paginatedVisibleMessages.contains(where: { $0.id == scrollState.pendingSendScrollMessageId }) {
-            let scrollBinding = $scrollPosition
-            scrollState.pendingSendScrollMessageId = nil
-            Task { @MainActor in
-                withAnimation(VAnimation.standard) {
-                    scrollBinding.wrappedValue.scrollTo(edge: .bottom)
-                }
-            }
         }
         // --- Confirmation focus handoff ---
         #if os(macOS)
@@ -218,29 +152,9 @@ extension MessageListView {
         scrollState.anchorTimeoutTask = nil
         scrollState.lastAutoFocusedRequestId = nil
         // Seed lastMessageId so scroll-to-bottom can target it.
+        // With inverted scroll, the latest messages appear at the visual
+        // bottom naturally — no imperative scroll needed.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Multi-stage scroll-to-bottom: gives LazyVStack time to materialize
-        // bottom cells across multiple layout passes. Targets "scroll-bottom-anchor"
-        // (a real Color.clear view at the absolute content bottom) instead of a
-        // message ID, avoiding height estimation errors from unmaterialized cells.
-        scrollState.switchRestoreTask?.cancel()
-        let scrollBinding = $scrollPosition
-        scrollState.switchRestoreTask = Task { @MainActor in
-            // Stage 0: immediate — catches conversations already laid out
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            // Stage 1: ~3 frames (50ms) — LazyVStack initial materialization
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            // Stage 2: slower content (150ms) — final correction
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
-            scrollBinding.wrappedValue.scrollTo(id: "scroll-bottom-anchor", anchor: .bottom)
-
-            scrollState.switchRestoreTask = nil
-        }
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -85,7 +85,8 @@ extension MessageListView {
                     try? await Task.sleep(nanoseconds: 100_000_000)
                     guard !Task.isCancelled else { return }
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
-                    scrollBinding.wrappedValue = ScrollPosition(id: id, anchor: .top)
+                    // .bottom in scroll coordinates = visual top in inverted scroll
+                    scrollBinding.wrappedValue = ScrollPosition(id: id, anchor: .bottom)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -40,7 +40,10 @@ extension MessageListView {
         scrollState.updateScrollToLatest()
 
         // --- Pagination ---
-        handlePaginationSentinel(sentinelMinY: -newState.contentOffsetY)
+        // With inverted scroll the visual top (oldest messages) maps to the
+        // geometric bottom of the scroll content. Use distanceFromBottom so
+        // the sentinel fires when the user scrolls toward older messages.
+        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromBottom)
     }
 
     // MARK: - Pagination sentinel

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -40,10 +40,10 @@ extension MessageListView {
         scrollState.updateScrollToLatest()
 
         // --- Pagination ---
-        // With inverted scroll the visual top (oldest messages) maps to the
-        // geometric bottom of the scroll content. Use distanceFromBottom so
-        // the sentinel fires when the user scrolls toward older messages.
-        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromBottom)
+        // With inverted scroll the visual top (oldest messages) is where
+        // distanceFromTop approaches 0. Negate so the sentinel's
+        // `sentinelMinY > -triggerBand` fires near the visual top.
+        handlePaginationSentinel(sentinelMinY: -scrollState.distanceFromTop)
     }
 
     // MARK: - Pagination sentinel

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -111,9 +111,6 @@ struct MessageListView: View {
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
     /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
     @State var scrollPosition = ScrollPosition()
-    /// Starts false on fresh mount; set to true after scroll restore settles.
-    /// Hides the scroll view during the restore window to prevent jitter.
-    @State var isScrollRestored = false
 
     // MARK: - Body
 
@@ -143,13 +140,13 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .scrollDisabled(messages.isEmpty && !isSending)
-            .defaultScrollAnchor(.top, for: .initialOffset)
             .scrollPosition($scrollPosition)
             .environment(\.thinkingBlockExpansionStore, thinkingBlockExpansionStore)
             .environment(\.filePreviewExpansionStore, filePreviewExpansionStore)
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .frame(width: widths.scrollSurfaceWidth)
-            .opacity(isScrollRestored ? 1 : 0)
+            .id(conversationId)
+            .flipped()  // Invert the scroll — visual bottom becomes natural top
             .overlay(alignment: .bottom) {
                 ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .bottom) })
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -148,7 +148,9 @@ struct MessageListView: View {
             .id(conversationId)
             .flipped()  // Invert the scroll — visual bottom becomes natural top
             .overlay(alignment: .bottom) {
-                ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .bottom) })
+                // Inverted scroll: SwiftUI's .top edge maps to the visual bottom
+                // (latest messages), so we scroll to .top to reach them.
+                ScrollToLatestOverlayView(scrollState: scrollState, onScrollToBottom: { scrollPosition = ScrollPosition(edge: .top) })
             }
             .onAppear {
                 handleAppear()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -77,9 +77,6 @@ struct MessageListView: View {
     /// Measured width of the full chat pane. `layoutMetrics` derives the
     /// centered transcript column width from this value.
     var containerWidth: CGFloat = 0
-    /// Stable height of the full chat pane (from GeometryReader). Unlike
-    /// scroll viewport height, this doesn't fluctuate when the composer resizes.
-    var containerHeight: CGFloat = 0
     var layoutMetrics: MessageListLayoutMetrics {
         MessageListLayoutMetrics(containerWidth: containerWidth)
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -34,9 +34,8 @@ final class MessageListScrollStateTests: XCTestCase {
     // MARK: - updateScrollToLatest: Distance Threshold
 
     func testUpdateScrollToLatestShowsWhenFarFromBottom() {
-        state.scrollContentHeight = 5000
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 2000  // distanceFromBottom = 5000 - 2000 - 800 = 2200
+        // Inverted scroll: lastContentOffsetY IS distanceFromBottom
+        state.lastContentOffsetY = 2200  // distanceFromBottom = 2200
 
         state.updateScrollToLatest()
 
@@ -45,9 +44,8 @@ final class MessageListScrollStateTests: XCTestCase {
     }
 
     func testUpdateScrollToLatestHidesWhenNearBottom() {
-        state.scrollContentHeight = 1000
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 100  // distanceFromBottom = 1000 - 100 - 800 = 100
+        // Inverted scroll: lastContentOffsetY IS distanceFromBottom
+        state.lastContentOffsetY = 100  // distanceFromBottom = 100
 
         state.updateScrollToLatest()
 
@@ -56,9 +54,8 @@ final class MessageListScrollStateTests: XCTestCase {
     }
 
     func testUpdateScrollToLatestExactThreshold() {
-        state.scrollContentHeight = 1600
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 400  // distanceFromBottom = 1600 - 400 - 800 = 400
+        // Inverted scroll: lastContentOffsetY IS distanceFromBottom
+        state.lastContentOffsetY = 400  // distanceFromBottom = 400
 
         state.updateScrollToLatest()
 
@@ -67,9 +64,8 @@ final class MessageListScrollStateTests: XCTestCase {
     }
 
     func testUpdateScrollToLatestJustAboveThreshold() {
-        state.scrollContentHeight = 1602
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 401  // distanceFromBottom = 1602 - 401 - 800 = 401
+        // Inverted scroll: lastContentOffsetY IS distanceFromBottom
+        state.lastContentOffsetY = 401  // distanceFromBottom = 401
 
         state.updateScrollToLatest()
 
@@ -78,8 +74,7 @@ final class MessageListScrollStateTests: XCTestCase {
     }
 
     func testUpdateScrollToLatestAtBottom() {
-        state.scrollContentHeight = 800
-        state.scrollContainerHeight = 800
+        // Inverted scroll: 0 = at visual bottom (latest messages)
         state.lastContentOffsetY = 0  // distanceFromBottom = 0
 
         state.updateScrollToLatest()
@@ -89,15 +84,13 @@ final class MessageListScrollStateTests: XCTestCase {
     }
 
     func testUpdateScrollToLatestTogglesCorrectly() {
-        // Start far from bottom
-        state.scrollContentHeight = 5000
-        state.scrollContainerHeight = 800
+        // Start far from bottom (inverted scroll: offset = distance)
         state.lastContentOffsetY = 2000
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest)
 
-        // Scroll to bottom
-        state.lastContentOffsetY = 4200  // distanceFromBottom = 0
+        // Scroll to bottom (offset 0 = at latest messages)
+        state.lastContentOffsetY = 0  // distanceFromBottom = 0
         state.updateScrollToLatest()
         XCTAssertFalse(state.showScrollToLatest,
                        "Should toggle off when scrolled back to bottom")
@@ -106,33 +99,26 @@ final class MessageListScrollStateTests: XCTestCase {
     // MARK: - updateScrollToLatest: Hysteresis Band
 
     func testUpdateScrollToLatestStaysVisibleInsideHysteresisBand() {
-        // Show the CTA first.
-        state.scrollContentHeight = 5000
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 2000  // distanceFromBottom = 2200
+        // Show the CTA first (inverted scroll: offset = distance).
+        state.lastContentOffsetY = 2200  // distanceFromBottom = 2200
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest)
 
         // Drop distance into the 200..400 band — should stay visible.
-        state.scrollContentHeight = 1100
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 0  // distanceFromBottom = 300
+        state.lastContentOffsetY = 300  // distanceFromBottom = 300
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest,
                       "Once visible, CTA should stay visible inside the 200..400 hysteresis band")
     }
 
     func testUpdateScrollToLatestHidesBelowLowThreshold() {
-        state.scrollContentHeight = 5000
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 2000  // distanceFromBottom = 2200
+        // Inverted scroll: offset = distance from bottom.
+        state.lastContentOffsetY = 2200  // distanceFromBottom = 2200
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest)
 
         // Drop below the 200pt hide threshold — should hide.
-        state.scrollContentHeight = 999
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 0  // distanceFromBottom = 199
+        state.lastContentOffsetY = 199  // distanceFromBottom = 199
         state.updateScrollToLatest()
         XCTAssertFalse(state.showScrollToLatest,
                        "Should hide once distanceFromBottom drops below 200")
@@ -144,14 +130,13 @@ final class MessageListScrollStateTests: XCTestCase {
 
         // Put distance inside the 200..400 band — should remain hidden
         // because the show threshold (>400) was never crossed.
-        state.scrollContentHeight = 1199
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 0  // distanceFromBottom = 399
+        // Inverted scroll: offset = distance from bottom.
+        state.lastContentOffsetY = 399  // distanceFromBottom = 399
         state.updateScrollToLatest()
         XCTAssertFalse(state.showScrollToLatest,
                        "Hidden CTA should not appear until distanceFromBottom exceeds 400")
 
-        state.scrollContentHeight = 1000  // distanceFromBottom = 200
+        state.lastContentOffsetY = 200  // distanceFromBottom = 200
         state.updateScrollToLatest()
         XCTAssertFalse(state.showScrollToLatest,
                        "Hidden CTA should not appear at the low threshold either")
@@ -162,20 +147,19 @@ final class MessageListScrollStateTests: XCTestCase {
         // oscillates across the 400pt show threshold should not toggle
         // visibility repeatedly once the CTA is hidden — the low threshold
         // must be crossed first for it to appear.
-        state.scrollContentHeight = 1201
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 0  // distanceFromBottom = 401
+        // Inverted scroll: lastContentOffsetY = distanceFromBottom.
+        state.lastContentOffsetY = 401  // distanceFromBottom = 401
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest, "Crosses show threshold → visible")
 
         // Bounce to 399 (noise): must stay visible (inside the band).
-        state.scrollContentHeight = 1199  // distanceFromBottom = 399
+        state.lastContentOffsetY = 399  // distanceFromBottom = 399
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest,
                       "Noise in the hysteresis band must not toggle visibility")
 
         // Bounce back to 410: still visible, no flicker.
-        state.scrollContentHeight = 1210  // distanceFromBottom = 410
+        state.lastContentOffsetY = 410  // distanceFromBottom = 410
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest)
     }
@@ -185,10 +169,10 @@ final class MessageListScrollStateTests: XCTestCase {
     func testResetClearsAllState() {
         let newId = UUID()
 
-        // Set up non-default state
+        // Set up non-default state (inverted scroll: offset = distance from bottom)
         state.scrollContentHeight = 5000
         state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 2000
+        state.lastContentOffsetY = 2000  // distanceFromBottom = 2000
         state.lastMessageId = UUID()
         state.currentConversationId = UUID()
         state.wasPaginationTriggerInRange = true
@@ -365,29 +349,29 @@ final class MessageListScrollStateTests: XCTestCase {
     // MARK: - distanceFromBottom
 
     func testDistanceFromBottomCalculation() {
-        state.scrollContentHeight = 2000
-        state.scrollContainerHeight = 800
+        // Inverted scroll: distanceFromBottom = lastContentOffsetY directly.
+        // 0 = at visual bottom (latest messages), increases toward older messages.
         state.lastContentOffsetY = 500
 
-        XCTAssertEqual(state.distanceFromBottom, 700,
-                       "distanceFromBottom = contentHeight - offsetY - containerHeight")
+        XCTAssertEqual(state.distanceFromBottom, 500,
+                       "distanceFromBottom = lastContentOffsetY (inverted scroll)")
     }
 
     func testDistanceFromBottomAtBottom() {
-        state.scrollContentHeight = 2000
-        state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 1200
+        // Inverted scroll: 0 offset = at visual bottom (latest messages).
+        state.lastContentOffsetY = 0
 
         XCTAssertEqual(state.distanceFromBottom, 0,
-                       "Should be 0 when scrolled to bottom")
+                       "Should be 0 when scrolled to bottom (offset = 0)")
     }
 
     // MARK: - cancelAll
 
     func testCancelAllResetsState() {
+        // Inverted scroll: offset = distance from bottom
         state.scrollContentHeight = 5000
         state.scrollContainerHeight = 800
-        state.lastContentOffsetY = 2000
+        state.lastContentOffsetY = 2000  // distanceFromBottom = 2000
         state.updateScrollToLatest()
         XCTAssertTrue(state.showScrollToLatest)
 

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -191,7 +191,6 @@ final class MessageListScrollStateTests: XCTestCase {
         state.lastContentOffsetY = 2000
         state.lastMessageId = UUID()
         state.currentConversationId = UUID()
-        state.pendingSendScrollMessageId = UUID()
         state.wasPaginationTriggerInRange = true
         state.lastPaginationCompletedAt = Date()
         state.updateScrollToLatest()
@@ -202,7 +201,6 @@ final class MessageListScrollStateTests: XCTestCase {
 
         XCTAssertEqual(state.currentConversationId, newId)
         XCTAssertNil(state.lastMessageId)
-        XCTAssertNil(state.pendingSendScrollMessageId)
         XCTAssertEqual(state.scrollContentHeight, 0)
         XCTAssertEqual(state.scrollContainerHeight, 0)
         XCTAssertEqual(state.lastContentOffsetY, 0)

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,7 +49,6 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
-            containerHeight: 0,
             scrollState: MessageListScrollState()
         )
     }


### PR DESCRIPTION
## Summary
Replace scroll-to-bottom management (multi-stage restore, switchRestoreTask, opacity fade, ScrollPosition edge targeting) with the inverted scroll technique. The ScrollView is flipped 180° so new content naturally appears at the visual bottom — eliminating the LazyVStack materialization hang, stale @State persistence, and all scroll-to-bottom timing problems.

## Self-review result
GAPS FOUND — 4 gaps fixed across 4 fix PRs (unit tests, pagination anchor, LazyVStack ordering, doc snippet)

## PRs merged into feature branch
- #25828: feat: add FlippedModifier for inverted scroll technique
- #25829: feat: apply inverted scroll to MessageListView and MessageListContentView
- #25831: refactor: remove scroll-to-bottom restore — inverted scroll handles it naturally
- #25830: fix: adjust pagination sentinel for inverted scroll coordinates
- #25833: fix: verify and adjust CTA and deep-link anchors for inverted scroll
- #25832: refactor: remove minHeight wrapper — inverted scroll keeps user message visible naturally
- #25834: docs: update SCROLL_STRATEGY.md for inverted scroll architecture

### Fix PRs
- #25836: fix: flip pagination anchor from .top to .bottom for inverted scroll
- #25837: fix: update SCROLL_STRATEGY.md FlippedModifier snippet to match actual code
- #25838: fix: reorder LazyVStack items for correct visual positions in inverted scroll
- #25839: fix: update unit tests for inverted distanceFromBottom formula

Part of plan: inverted-scroll-migration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
