### PR TITLE
fix: silently fall back to default for empty config string fields

### DIFF
--- a/assistant/src/config/schemas/__tests__/meet.test.ts
+++ b/assistant/src/config/schemas/__tests__/meet.test.ts
@@ -94,14 +94,14 @@ describe("MeetServiceSchema", () => {
     expect(parsed.joinName).toBe("Notes Bot");
   });
 
-  test("rejects empty containerImage", () => {
-    const result = MeetServiceSchema.safeParse({ containerImage: "" });
-    expect(result.success).toBe(false);
+  test("empty containerImage falls back to default", () => {
+    const parsed = MeetServiceSchema.parse({ containerImage: "" });
+    expect(parsed.containerImage).toBe("vellum-meet-bot:dev");
   });
 
-  test("rejects empty dockerNetwork", () => {
-    const result = MeetServiceSchema.safeParse({ dockerNetwork: "" });
-    expect(result.success).toBe(false);
+  test("empty dockerNetwork falls back to default", () => {
+    const parsed = MeetServiceSchema.parse({ dockerNetwork: "" });
+    expect(parsed.dockerNetwork).toBe("bridge");
   });
 
   test("rejects non-string entries in objectionKeywords", () => {

--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -12,7 +12,7 @@ export const ElevenLabsConfigSchema = z
   .object({
     voiceId: z
       .string({ error: "elevenlabs.voiceId must be a string" })
-      .min(1, "elevenlabs.voiceId must not be empty")
+      .transform((v) => v || DEFAULT_ELEVENLABS_VOICE_ID)
       .default(DEFAULT_ELEVENLABS_VOICE_ID)
       .describe("ElevenLabs voice ID for text-to-speech"),
     voiceModelId: z

--- a/assistant/src/config/schemas/host-browser.ts
+++ b/assistant/src/config/schemas/host-browser.ts
@@ -59,7 +59,7 @@ export const HostBrowserCdpInspectConfigSchema = z
       ),
     host: z
       .string({ error: "hostBrowser.cdpInspect.host must be a string" })
-      .min(1, "hostBrowser.cdpInspect.host must not be empty")
+      .transform((v) => v || "localhost")
       .default("localhost")
       .describe(
         "Host name or IP address where the host Chrome instance exposes its remote debugging endpoint.",

--- a/assistant/src/config/schemas/meet.ts
+++ b/assistant/src/config/schemas/meet.ts
@@ -58,7 +58,7 @@ export const MeetServiceSchema = z
       ),
     containerImage: z
       .string({ error: "services.meet.containerImage must be a string" })
-      .min(1, "services.meet.containerImage must not be empty")
+      .transform((v) => v || "vellum-meet-bot:dev")
       .default("vellum-meet-bot:dev")
       .describe(
         "Docker image tag used to spawn the Meet bot container for each joined meeting",
@@ -99,7 +99,7 @@ export const MeetServiceSchema = z
       ),
     dockerNetwork: z
       .string({ error: "services.meet.dockerNetwork must be a string" })
-      .min(1, "services.meet.dockerNetwork must not be empty")
+      .transform((v) => v || "bridge")
       .default("bridge")
       .describe("Docker network the Meet bot container attaches to"),
     maxMeetingMinutes: z

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -30,7 +30,7 @@ export const TtsElevenLabsProviderConfigSchema = z
       .string({
         error: "services.tts.providers.elevenlabs.voiceId must be a string",
       })
-      .min(1, "services.tts.providers.elevenlabs.voiceId must not be empty")
+      .transform((v) => v || DEFAULT_ELEVENLABS_VOICE_ID)
       .default(DEFAULT_ELEVENLABS_VOICE_ID)
       .describe("ElevenLabs voice ID for text-to-speech"),
     voiceModelId: z
@@ -150,7 +150,7 @@ export const TtsDeepgramProviderConfigSchema = z
       .string({
         error: "services.tts.providers.deepgram.model must be a string",
       })
-      .min(1, "services.tts.providers.deepgram.model must not be empty")
+      .transform((v) => v || "aura-asteria-en")
       .default("aura-asteria-en")
       .describe("Deepgram TTS model identifier"),
     format: z


### PR DESCRIPTION
## Summary
- Replace `.min(1)` Zod checks with `.transform(v => v || default)` on six config fields that already have sensible defaults
- Empty strings now silently resolve to the default value instead of logging a validation warning and then falling back anyway
- Affects: ElevenLabs voiceId, Deepgram model, CDP inspect host, Meet container image, Meet docker network
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
