### PR TITLE
chore: remove unused ElevenLabsConfigSchema and ElevenLabsConfig type

### DIFF
--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 // Default ElevenLabs voice — "Amelia" (expressive, enthusiastic, British English).
 // Used by both in-app TTS and phone calls (via Twilio ConversationRelay).
 // Mirrored in: clients/macos/.../OpenAIVoiceService.swift (defaultVoiceId)
@@ -7,60 +5,3 @@ export const DEFAULT_ELEVENLABS_VOICE_ID = "ZF6FPAbjXT4488VcRRnw";
 
 /** Valid conversation timeout values (seconds). Shared with voice-config-update tool. */
 export const VALID_CONVERSATION_TIMEOUTS = [5, 10, 15, 30, 60] as const;
-
-export const ElevenLabsConfigSchema = z
-  .object({
-    voiceId: z
-      .string({ error: "elevenlabs.voiceId must be a string" })
-      .transform((v) => v || DEFAULT_ELEVENLABS_VOICE_ID)
-      .default(DEFAULT_ELEVENLABS_VOICE_ID)
-      .describe("ElevenLabs voice ID for text-to-speech"),
-    voiceModelId: z
-      .string({ error: "elevenlabs.voiceModelId must be a string" })
-      .default("")
-      .describe(
-        "ElevenLabs model ID override (leave empty to use the default model)",
-      ),
-    speed: z
-      .number({ error: "elevenlabs.speed must be a number" })
-      .min(0.7, "elevenlabs.speed must be >= 0.7")
-      .max(1.2, "elevenlabs.speed must be <= 1.2")
-      .default(1.0)
-      .describe(
-        "Speech playback speed multiplier (0.7 = slower, 1.2 = faster)",
-      ),
-    stability: z
-      .number({ error: "elevenlabs.stability must be a number" })
-      .min(0, "elevenlabs.stability must be >= 0")
-      .max(1, "elevenlabs.stability must be <= 1")
-      .default(0.5)
-      .describe(
-        "Voice stability — higher values produce more consistent speech, lower values add expressiveness",
-      ),
-    similarityBoost: z
-      .number({ error: "elevenlabs.similarityBoost must be a number" })
-      .min(0, "elevenlabs.similarityBoost must be >= 0")
-      .max(1, "elevenlabs.similarityBoost must be <= 1")
-      .default(0.75)
-      .describe(
-        "How closely the output matches the original voice — higher values increase similarity",
-      ),
-    conversationTimeoutSeconds: z
-      .number({
-        error: "elevenlabs.conversationTimeoutSeconds must be a number",
-      })
-      .refine(
-        (v) =>
-          VALID_CONVERSATION_TIMEOUTS.includes(
-            v as (typeof VALID_CONVERSATION_TIMEOUTS)[number],
-          ),
-        {
-          message: `elevenlabs.conversationTimeoutSeconds must be one of: ${VALID_CONVERSATION_TIMEOUTS.join(", ")}`,
-        },
-      )
-      .default(30)
-      .describe("Seconds of silence before voice conversation auto-ends"),
-  })
-  .describe("ElevenLabs text-to-speech configuration");
-
-export type ElevenLabsConfig = z.infer<typeof ElevenLabsConfigSchema>;


### PR DESCRIPTION
## Summary
- Remove `ElevenLabsConfigSchema` and `ElevenLabsConfig` type from `elevenlabs.ts` — neither is imported anywhere in the codebase
- The actively-used equivalent is `TtsElevenLabsProviderConfigSchema` in `tts.ts`
- Keep `DEFAULT_ELEVENLABS_VOICE_ID` and `VALID_CONVERSATION_TIMEOUTS` which are still imported by other modules

## Original prompt
Remove dead code from `assistant/src/config/schemas/elevenlabs.ts`: delete `ElevenLabsConfigSchema` and the `ElevenLabsConfig` type export. They are never imported anywhere — the actively-used equivalent is `TtsElevenLabsProviderConfigSchema` in `tts.ts`. Keep `DEFAULT_ELEVENLABS_VOICE_ID` and `VALID_CONVERSATION_TIMEOUTS` which are still imported by other modules. Follow-up from PR #25843 review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
