### PR TITLE
feat: normalize OpenAI Responses API request/response logs

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -446,7 +446,12 @@ function makeCtx(
 
     graphMemory: {
       onCompacted: () => {},
-      prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
+      prepareMemory: async () => ({
+        runMessages: [],
+        injectedTokens: 0,
+        latencyMs: 0,
+        mode: "none" as const,
+      }),
       reinjectCachedMemory: (messages: Message[]) => ({
         runMessages: messages,
         injectedTokens: 0,
@@ -764,6 +769,95 @@ describe("session-agent-loop", () => {
         string,
       ];
       expect(call[4]).toBe("openrouter");
+    });
+
+    test("record request log handles Responses API shaped payloads", async () => {
+      const events: ServerMessage[] = [];
+      const rawRequest = {
+        model: "gpt-5.4",
+        instructions: "Be helpful.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello" }],
+            type: "message",
+          },
+        ],
+      };
+      const rawResponse = {
+        id: "resp_test",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hi there." }],
+          },
+        ],
+        usage: {
+          input_tokens: 12,
+          output_tokens: 3,
+        },
+        status: "completed",
+      };
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Hi there." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 12,
+          outputTokens: 3,
+          model: "gpt-5.4",
+          actualProvider: "openai",
+          providerDurationMs: 45,
+          rawRequest,
+          rawResponse,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "Hi there." }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(recordRequestLogMock).toHaveBeenCalledTimes(1);
+      const call = recordRequestLogMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        undefined,
+        string,
+      ];
+      expect(call).toEqual([
+        "test-conv",
+        JSON.stringify(rawRequest),
+        JSON.stringify(rawResponse),
+        undefined,
+        "openai",
+      ]);
     });
   });
 
@@ -1940,7 +2034,6 @@ describe("session-agent-loop", () => {
 
       expect(drainReason).toBe("loop_complete");
     });
-
   });
 
   describe("stale pending surface cleanup", () => {

--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1113,4 +1113,492 @@ describe("normalizeLlmContextPayloads", () => {
     expect(malformed.requestSections).toBeUndefined();
     expect(malformed.responseSections).toBeUndefined();
   });
+
+  // ── OpenAI Responses API normalization tests ──────────────────────────
+
+  test("normalizes OpenAI Responses API request and response payloads", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_020,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "You are a helpful assistant.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello" }],
+            type: "message",
+          },
+          {
+            type: "function_call",
+            call_id: "call_abc",
+            name: "file_read",
+            arguments: JSON.stringify({ path: "/tmp" }),
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_abc",
+            output: "file contents",
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            name: "file_read",
+            description: "Read a file",
+            parameters: { type: "object" },
+            strict: null,
+          },
+        ],
+        reasoning: { effort: "high" },
+        max_output_tokens: 64000,
+        stream: true,
+        store: false,
+      },
+      responsePayload: {
+        id: "resp_abc123",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hello!" }],
+          },
+          {
+            type: "function_call",
+            call_id: "call_def",
+            name: "file_read",
+            arguments: JSON.stringify({ path: "/a" }),
+          },
+        ],
+        usage: {
+          input_tokens: 50,
+          output_tokens: 120,
+          output_tokens_details: { reasoning_tokens: 80 },
+          total_tokens: 170,
+        },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: 50,
+      outputTokens: 120,
+      stopReason: "stop",
+      requestMessageCount: 3,
+      requestToolCount: 1,
+      responseMessageCount: 1,
+      responseToolCallCount: 1,
+      responsePreview: "Hello!",
+      toolCallNames: ["file_read"],
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "You are a helpful assistant.",
+      },
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "Hello",
+      },
+      {
+        kind: "function_call",
+        label: "Request tool call (file_read)",
+        role: "assistant",
+        toolName: "file_read",
+        data: { path: "/tmp" },
+        text: '{"path":"/tmp"}',
+      },
+      {
+        kind: "tool_result",
+        label: "Tool result (call_abc)",
+        role: "tool",
+        toolName: "call_abc",
+        text: "file contents",
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        data: {
+          tools: [
+            {
+              type: "function",
+              name: "file_read",
+              description: "Read a file",
+              parameters: { type: "object" },
+              strict: null,
+            },
+          ],
+        },
+        language: "json",
+      },
+      {
+        kind: "settings",
+        label: "Request settings",
+        data: {
+          model: "gpt-5.4",
+          reasoning: { effort: "high" },
+          max_output_tokens: 64000,
+          stream: true,
+          store: false,
+        },
+        language: "json",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "Hello!",
+      },
+      {
+        kind: "function_call",
+        label: "Response tool call 1",
+        role: "assistant",
+        toolName: "file_read",
+        data: { path: "/a" },
+        text: '{"path":"/a"}',
+      },
+    ]);
+  });
+
+  test("normalizes OpenAI Responses API response with text-only output (no tool calls)", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_021,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Be concise.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "What is 2+2?" }],
+            type: "message",
+          },
+        ],
+      },
+      responsePayload: {
+        id: "resp_simple",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "4" }],
+          },
+        ],
+        usage: {
+          input_tokens: 15,
+          output_tokens: 3,
+          total_tokens: 18,
+        },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: 15,
+      outputTokens: 3,
+      stopReason: "stop",
+      requestMessageCount: 1,
+      requestToolCount: 0,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "4",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "Be concise.",
+      },
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "What is 2+2?",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "4",
+      },
+    ]);
+  });
+
+  test("normalizes OpenAI Responses API response even when the request payload is malformed", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_022,
+      requestPayload: "not-json",
+      responsePayload: {
+        id: "resp_orphan",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [
+              { type: "output_text", text: "First line\n  Second line" },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+        },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: 10,
+      outputTokens: 5,
+      stopReason: "stop",
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "First line Second line",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toBeUndefined();
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "First line\n  Second line",
+      },
+    ]);
+  });
+
+  test("normalizes OpenAI Responses API request even when the response payload is malformed", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_023,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "You are helpful.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello" }],
+            type: "message",
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            name: "search",
+            description: "Search",
+            parameters: { type: "object" },
+          },
+        ],
+      },
+      responsePayload: "not-json",
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: 1,
+      requestToolCount: 1,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "You are helpful.",
+      },
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "Hello",
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        data: {
+          tools: [
+            {
+              type: "function",
+              name: "search",
+              description: "Search",
+              parameters: { type: "object" },
+            },
+          ],
+        },
+        language: "json",
+      },
+    ]);
+    expect(normalized.responseSections).toBeUndefined();
+  });
+
+  test("maps Responses API status 'completed' to stop reason 'stop'", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_024,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Be brief.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hi" }],
+            type: "message",
+          },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hey!" }],
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 2 },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary?.stopReason).toBe("stop");
+  });
+
+  test("preserves non-completed Responses API status as stop reason", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_025,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Be brief.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hi" }],
+            type: "message",
+          },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "function_call",
+            call_id: "call_1",
+            name: "search",
+            arguments: "{}",
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 10 },
+        status: "incomplete",
+      },
+    });
+
+    expect(normalized.summary?.stopReason).toBe("incomplete");
+  });
+
+  test("legacy chat-completions payloads are still normalized correctly alongside Responses tests", () => {
+    // This test verifies backward compatibility: existing chat-completions
+    // logs stored in the database must continue to normalize correctly even
+    // after the Responses API normalizer was added.
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_026,
+      requestPayload: {
+        model: "gpt-4.1",
+        tool_choice: "auto",
+        messages: [
+          { role: "system", content: "Be helpful." },
+          { role: "user", content: "Hello" },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Lookup",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Hi there!",
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 5,
+        },
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-2026-03-01",
+      inputTokens: 20,
+      outputTokens: 5,
+      stopReason: "stop",
+      requestMessageCount: 2,
+      requestToolCount: 1,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "Hi there!",
+      toolCallNames: undefined,
+    });
+  });
+
+  test("does not mix Responses API request with Anthropic response", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_027,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "You are helpful.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello" }],
+            type: "message",
+          },
+        ],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Hello back." }],
+        stop_reason: "end_turn",
+      },
+    });
+
+    expect(normalized).toEqual({});
+  });
 });

--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -34,12 +34,9 @@ function dispatchLlmContext(messageId: string): Promise<Response> | Response {
 }
 
 function dispatchLogPayload(logId: string): Promise<Response> | Response {
-  const url = new URL(
-    `http://localhost/v1/llm-request-logs/${logId}/payload`,
-  );
+  const url = new URL(`http://localhost/v1/llm-request-logs/${logId}/payload`);
   const route = routes.find(
-    (r) =>
-      r.method === "GET" && r.endpoint === "llm-request-logs/:id/payload",
+    (r) => r.method === "GET" && r.endpoint === "llm-request-logs/:id/payload",
   );
   if (!route) {
     throw new Error("No llm-request-logs payload route found");
@@ -233,6 +230,90 @@ describe("GET /v1/messages/:id/llm-context provider preference", () => {
     expect(body.logs).toHaveLength(1);
     expect(body.logs[0]?.requestPayload).toBeNull();
     expect(body.logs[0]?.responsePayload).toBeNull();
+  });
+
+  // ── OpenAI Responses API payload tests ──────────────────────────────
+
+  const responsesApiRequestPayload = JSON.stringify({
+    model: "gpt-5.4",
+    instructions: "Be concise.",
+    input: [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "Hello there." }],
+        type: "message",
+      },
+    ],
+  });
+
+  const responsesApiResponsePayload = JSON.stringify({
+    id: "resp_test",
+    model: "gpt-5.4",
+    output: [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Hello back." }],
+      },
+    ],
+    usage: {
+      input_tokens: 11,
+      output_tokens: 4,
+    },
+    status: "completed",
+  });
+
+  test("normalizes Responses API payloads and infers OpenAI provider when no stored provider exists", async () => {
+    seedRequestLog({
+      id: "log-responses-legacy",
+      messageId: "msg-responses-legacy",
+      provider: null,
+      requestPayload: responsesApiRequestPayload,
+      responsePayload: responsesApiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-responses-legacy");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string; inputTokens?: number };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+        inputTokens: 11,
+      }),
+    );
+  });
+
+  test("prefers a stored provider over Responses API payload inference", async () => {
+    seedRequestLog({
+      id: "log-responses-openai",
+      messageId: "msg-responses-openai",
+      provider: "openai",
+      requestPayload: responsesApiRequestPayload,
+      responsePayload: responsesApiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-responses-openai");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+      }),
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -113,6 +113,168 @@ function normalizeOpenAiRequestPayload(
   requestPayload: unknown,
   allowPlainText = false,
 ): NormalizedPayloadCandidate | null {
+  // Try Responses API shape first, then fall back to chat-completions.
+  return (
+    normalizeOpenAiResponsesRequestPayload(requestPayload, allowPlainText) ??
+    normalizeOpenAiChatCompletionsRequestPayload(requestPayload, allowPlainText)
+  );
+}
+
+/**
+ * Detect and normalize OpenAI Responses API request payloads.
+ *
+ * Responses requests use `input` (array) instead of `messages`, may have a
+ * top-level `instructions` string, and tools have `type: "function"` at the
+ * top level with the function fields inlined (no nested `function` wrapper).
+ */
+function normalizeOpenAiResponsesRequestPayload(
+  requestPayload: unknown,
+  allowPlainText = false,
+): NormalizedPayloadCandidate | null {
+  const request = asRecord(requestPayload);
+  if (!request) {
+    return null;
+  }
+
+  const input = asRecordArray(request.input);
+  if (!input) {
+    return null;
+  }
+
+  // Require at least one Responses-specific signal to avoid matching generic
+  // arrays. `instructions` is the strongest signal; otherwise look for
+  // Responses-shaped input items or tool objects.
+  const hasResponsesSignal =
+    typeof request.instructions === "string" ||
+    hasOpenAiModelPrefix(asString(request.model)) ||
+    input.some(
+      (item) =>
+        asString(item.type) === "function_call" ||
+        asString(item.type) === "function_call_output",
+    ) ||
+    extractOpenAiResponsesRequestToolNames(request.tools).length > 0;
+
+  if (!allowPlainText && !hasResponsesSignal) {
+    return null;
+  }
+
+  const requestSections: LlmContextSection[] = [];
+
+  // System-level instructions
+  const instructions = asString(request.instructions);
+  if (instructions && hasMeaningfulText(instructions)) {
+    requestSections.push({
+      kind: "system",
+      label: "System prompt",
+      role: "system",
+      text: instructions,
+    });
+  }
+
+  // Input items
+  let messageIndex = 0;
+  for (const item of input) {
+    const itemType = asString(item.type);
+
+    if (itemType === "message") {
+      messageIndex++;
+      const role = asString(item.role) ?? "unknown";
+      const messageText = extractOpenAiContentText(item.content);
+      if (messageText !== undefined) {
+        requestSections.push({
+          kind: "message",
+          label: buildMessageLabel(role, messageIndex),
+          role,
+          text: messageText,
+        });
+      }
+      continue;
+    }
+
+    if (itemType === "function_call") {
+      const name = asString(item.name);
+      const args = parseJsonValue(asString(item.arguments));
+      requestSections.push({
+        kind: "function_call",
+        label: `Request tool call${name ? ` (${name})` : ""}`,
+        role: "assistant",
+        toolName: name,
+        data: args,
+        text: previewStructuredValue(args),
+      });
+      continue;
+    }
+
+    if (itemType === "function_call_output") {
+      const output = asString(item.output);
+      requestSections.push({
+        kind: "tool_result",
+        label: `Tool result${asString(item.call_id) ? ` (${asString(item.call_id)})` : ""}`,
+        role: "tool",
+        toolName: asString(item.call_id),
+        text: output,
+      });
+    }
+  }
+
+  // Tool definitions (Responses shape: top-level type/name/parameters)
+  const requestToolNames = extractOpenAiResponsesRequestToolNames(
+    request.tools,
+  );
+  if (requestToolNames.length > 0) {
+    requestSections.push({
+      kind: "tool_definitions",
+      label: "Available tools",
+      data: {
+        tools: asRecordArray(request.tools) ?? request.tools,
+      },
+      language: "json",
+    });
+  }
+
+  const requestSettings = omitRecordKeys(request, [
+    "instructions",
+    "input",
+    "tools",
+  ]);
+  if (hasMeaningfulRequestSettings(requestSettings)) {
+    requestSections.push(
+      structuredJsonSection("settings", "Request settings", requestSettings),
+    );
+  }
+
+  // Count all input items for the message count (includes messages, function
+  // calls, and function call outputs — mirrors how chat-completions counts
+  // all messages regardless of role).
+  return {
+    provider: "openai",
+    summary: {
+      provider: "openai",
+      model: asString(request.model),
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: input.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+  };
+}
+
+/**
+ * Normalize a legacy OpenAI Chat Completions request payload.
+ * Requires `messages` array in the request.
+ */
+function normalizeOpenAiChatCompletionsRequestPayload(
+  requestPayload: unknown,
+  allowPlainText = false,
+): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
   if (!request) {
     return null;
@@ -201,6 +363,130 @@ function normalizeOpenAiRequestPayload(
 }
 
 function normalizeOpenAiResponsePayload(
+  responsePayload: unknown,
+): NormalizedPayloadCandidate | null {
+  // Try Responses API shape first, then fall back to chat-completions.
+  return (
+    normalizeOpenAiResponsesResponsePayload(responsePayload) ??
+    normalizeOpenAiChatCompletionsResponsePayload(responsePayload)
+  );
+}
+
+/**
+ * Detect and normalize OpenAI Responses API response payloads.
+ *
+ * Responses responses have an `output` array of items instead of `choices`.
+ * Tool calls are top-level items with `type: "function_call"`.
+ * Usage uses `input_tokens`/`output_tokens` (not `prompt_tokens`/`completion_tokens`).
+ * `status` replaces `choices[0].finish_reason`.
+ */
+function normalizeOpenAiResponsesResponsePayload(
+  responsePayload: unknown,
+): NormalizedPayloadCandidate | null {
+  const response = asRecord(responsePayload);
+  if (!response) {
+    return null;
+  }
+
+  const output = asRecordArray(response.output);
+  if (!output) {
+    return null;
+  }
+
+  // Require at least one Responses-specific signal
+  const hasResponsesSignal =
+    typeof response.status === "string" ||
+    hasOpenAiModelPrefix(asString(response.model)) ||
+    output.some(
+      (item) =>
+        asString(item.type) === "message" ||
+        asString(item.type) === "function_call",
+    );
+  if (!hasResponsesSignal) {
+    return null;
+  }
+
+  const responseSections: LlmContextSection[] = [];
+  let responseText: string | undefined;
+  const toolCallSections: LlmContextSection[] = [];
+  let toolCallIndex = 0;
+
+  for (const item of output) {
+    const itemType = asString(item.type);
+
+    if (itemType === "message") {
+      const role = asString(item.role) ?? "assistant";
+      const content = asRecordArray(item.content);
+      const text = content ? extractOpenAiContentText(content) : undefined;
+      if (text !== undefined) {
+        responseText = text;
+        responseSections.push({
+          kind: "message",
+          label: "Assistant response",
+          role,
+          text,
+        });
+      }
+      continue;
+    }
+
+    if (itemType === "function_call") {
+      toolCallIndex++;
+      const name = asString(item.name);
+      const args = parseJsonValue(asString(item.arguments));
+      const section: LlmContextSection = {
+        kind: "function_call",
+        label: `Response tool call ${toolCallIndex}`,
+        role: "assistant",
+        toolName: name,
+        data: args,
+        text: previewStructuredValue(args),
+      };
+      toolCallSections.push(section);
+      responseSections.push(section);
+    }
+  }
+
+  const usage = asRecord(response.usage);
+  const toolCallNames = toolCallSections
+    .map((section) => section.toolName)
+    .filter((name): name is string => typeof name === "string");
+
+  // Map Responses API status to a stop reason string.
+  const status = asString(response.status);
+  const stopReason = status === "completed" ? "stop" : status;
+
+  return {
+    provider: "openai",
+    summary: {
+      provider: "openai",
+      model: asString(response.model),
+      inputTokens: asNumber(usage?.input_tokens),
+      outputTokens: asNumber(usage?.output_tokens),
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason,
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
+      responseMessageCount:
+        responseText !== undefined || toolCallSections.length > 0
+          ? 1
+          : undefined,
+      responseToolCallCount:
+        toolCallSections.length > 0 ? toolCallSections.length : undefined,
+      responsePreview: responseText ? truncateText(responseText) : undefined,
+      toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
+    },
+    responseSections:
+      responseSections.length > 0 ? responseSections : undefined,
+  };
+}
+
+/**
+ * Normalize a legacy OpenAI Chat Completions response payload.
+ * Requires `choices` array in the response.
+ */
+function normalizeOpenAiChatCompletionsResponsePayload(
   responsePayload: unknown,
 ): NormalizedPayloadCandidate | null {
   const response = asRecord(responsePayload);
@@ -736,6 +1022,23 @@ function geminiFunctionCallSections(
 function extractOpenAiRequestToolNames(tools: unknown): string[] {
   return (asRecordArray(tools) ?? [])
     .map((tool) => asString(asRecord(tool.function)?.name))
+    .filter((name): name is string => typeof name === "string");
+}
+
+/**
+ * Extract tool names from Responses API tool definitions.
+ * Responses tools have `type: "function"` at the top level with `name`
+ * directly on the tool object (no nested `function` wrapper).
+ */
+function extractOpenAiResponsesRequestToolNames(tools: unknown): string[] {
+  return (asRecordArray(tools) ?? [])
+    .map((tool) => {
+      // Responses shape: { type: "function", name: "...", ... }
+      if (asString(tool.type) === "function" && asString(tool.name)) {
+        return asString(tool.name);
+      }
+      return undefined;
+    })
     .filter((name): name is string => typeof name === "string");
 }
 


### PR DESCRIPTION
## Summary
- Extend LLM context normalization to detect and parse Responses API request/response shapes
- Preserve backward compatibility with existing chat-completions log format
- Add test fixtures for Responses API payloads alongside existing chat-completions tests

Part of plan: responses-api-remove-completions.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
