### PR TITLE
fix(macos): hide daemon-seeded system:reflections group from sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -328,6 +328,10 @@ final class ConversationListStore {
         var extraForAll: [ConversationModel] = []
         for entry in raw {
             guard let group = entry.group else { continue }
+            // system:reflections renders separately via SidebarReflectionsSection;
+            // skip it here so the daemon-seeded group never shows up as a regular
+            // sidebar row (which would duplicate the dedicated section header).
+            if group.id == ReflectionsSidebarSectionId.id { continue }
             if !group.isSystemGroup && !customGroupsEnabled {
                 extraForAll.append(contentsOf: entry.conversations)
             } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -28,6 +28,10 @@ struct ConversationSwitcherDrawer: View {
         var extraForAll: [ConversationModel] = []
         for entry in raw {
             guard let group = entry.group else { continue }
+            // system:reflections renders separately as the drawer's Reflections
+            // section; skip it here so the daemon-seeded group never appears as
+            // a regular drawer row.
+            if group.id == ReflectionsSidebarSectionId.id { continue }
             let filtered = entry.conversations.filter { !$0.isAutoAnalysisConversation }
             if !group.isSystemGroup && !customGroupsEnabled {
                 extraForAll.append(contentsOf: filtered)

--- a/clients/macos/vellum-assistantTests/ConversationListStoreReflectionsGroupTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationListStoreReflectionsGroupTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+import VellumAssistantShared
+
+@Suite("ConversationListStore reflections group", .serialized)
+@MainActor
+struct ConversationListStoreReflectionsGroupTests {
+
+    private func systemGroups() -> [ConversationGroup] {
+        [
+            ConversationGroup(id: "system:pinned", name: "Pinned", sortPosition: 0, isSystemGroup: true),
+            ConversationGroup(id: "system:all", name: "Recents", sortPosition: 3, isSystemGroup: true),
+            ConversationGroup(id: ReflectionsSidebarSectionId.id, name: "Reflections", sortPosition: 100, isSystemGroup: true),
+        ]
+    }
+
+    @Test
+    func sidebarGroupEntriesExcludesReflectionsGroup_whenEmpty() {
+        let store = ConversationListStore()
+        store.groups = systemGroups()
+        store.conversations = [
+            ConversationModel(title: "Regular", conversationId: "a", groupId: "system:all")
+        ]
+
+        #expect(store.sidebarGroupEntries.allSatisfy { $0.group.id != ReflectionsSidebarSectionId.id })
+    }
+
+    @Test
+    func sidebarGroupEntriesExcludesReflectionsGroup_whenPopulated() {
+        let store = ConversationListStore()
+        store.groups = systemGroups()
+        store.conversations = [
+            ConversationModel(title: "Regular", conversationId: "a", groupId: "system:all"),
+            ConversationModel(title: "Analysis: x", conversationId: "b", groupId: ReflectionsSidebarSectionId.id, source: "auto-analysis"),
+        ]
+
+        #expect(store.sidebarGroupEntries.allSatisfy { $0.group.id != ReflectionsSidebarSectionId.id })
+    }
+}


### PR DESCRIPTION
## Summary
- Skip `system:reflections` in `ConversationListStore.recomputeSidebarGroupEntries()` and `ConversationSwitcherDrawer.drawerEntries` so the daemon-seeded group no longer shows up as a duplicate folder-icon row above the dedicated `SidebarReflectionsSection`.
- The sparkle-icon Reflections section (backed by `ReflectionsSidebarPresentation`) remains the sole Reflections UI. The backend group stays in place as the canonical on-disk home for auto-analysis conversations (`AUTO_ANALYSIS_GROUP_ID`); the server contract already documents that clients should hide it (`conversation-group-migration.ts:62-66`).
- Adds regression tests covering both empty and populated `system:reflections` groups.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
