### PR TITLE
feat: add shell-output-compression feature flag and command detector

### DIFF
--- a/assistant/src/__tests__/shell-compression-detect.test.ts
+++ b/assistant/src/__tests__/shell-compression-detect.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectCommand } from "../tools/shared/shell-compression/detect-command.js";
+
+describe("detectCommand", () => {
+  // ── Test runners ──────────────────────────────────────────────
+
+  test("pytest -v -> test-runner", () => {
+    expect(detectCommand("pytest -v").category).toBe("test-runner");
+  });
+
+  test("python -m pytest -> test-runner", () => {
+    expect(detectCommand("python -m pytest tests/").category).toBe(
+      "test-runner",
+    );
+  });
+
+  test("cargo test -> test-runner", () => {
+    expect(detectCommand("cargo test --release").category).toBe("test-runner");
+  });
+
+  test("jest -> test-runner", () => {
+    expect(detectCommand("jest --coverage").category).toBe("test-runner");
+  });
+
+  test("vitest -> test-runner", () => {
+    expect(detectCommand("vitest run").category).toBe("test-runner");
+  });
+
+  test("npx jest -> test-runner", () => {
+    expect(detectCommand("npx jest src/").category).toBe("test-runner");
+  });
+
+  test("npx vitest -> test-runner", () => {
+    expect(detectCommand("npx vitest").category).toBe("test-runner");
+  });
+
+  test("go test -> test-runner", () => {
+    expect(detectCommand("go test ./...").category).toBe("test-runner");
+  });
+
+  test("bun test -> test-runner", () => {
+    expect(detectCommand("bun test src/foo.test.ts").category).toBe(
+      "test-runner",
+    );
+  });
+
+  test("rspec -> test-runner", () => {
+    expect(detectCommand("rspec spec/models/").category).toBe("test-runner");
+  });
+
+  test("playwright -> test-runner", () => {
+    expect(detectCommand("playwright test").category).toBe("test-runner");
+  });
+
+  // ── git diff / git show ───────────────────────────────────────
+
+  test("git diff HEAD~1 -> git-diff", () => {
+    expect(detectCommand("git diff HEAD~1").category).toBe("git-diff");
+  });
+
+  test("git diff --staged -> git-diff", () => {
+    expect(detectCommand("git diff --staged").category).toBe("git-diff");
+  });
+
+  test("git show abc123 -> git-diff", () => {
+    expect(detectCommand("git show abc123").category).toBe("git-diff");
+  });
+
+  // ── git status ────────────────────────────────────────────────
+
+  test("git status -> git-status", () => {
+    expect(detectCommand("git status").category).toBe("git-status");
+  });
+
+  test("git status --short -> git-status", () => {
+    expect(detectCommand("git status --short").category).toBe("git-status");
+  });
+
+  // ── Directory listing ─────────────────────────────────────────
+
+  test("ls -la src/ -> directory-listing", () => {
+    expect(detectCommand("ls -la src/").category).toBe("directory-listing");
+  });
+
+  test("find . -name '*.ts' -> directory-listing", () => {
+    expect(detectCommand("find . -name '*.ts'").category).toBe(
+      "directory-listing",
+    );
+  });
+
+  test("tree src/ -> directory-listing", () => {
+    expect(detectCommand("tree src/").category).toBe("directory-listing");
+  });
+
+  test("ls after pipe should NOT be directory-listing", () => {
+    expect(detectCommand("cat file.txt | ls").category).not.toBe(
+      "directory-listing",
+    );
+  });
+
+  // ── Search results ────────────────────────────────────────────
+
+  test("grep -r 'foo' -> search-results", () => {
+    expect(detectCommand("grep -r 'foo' src/").category).toBe("search-results");
+  });
+
+  test("rg pattern -> search-results", () => {
+    expect(detectCommand("rg 'TODO' --type ts").category).toBe(
+      "search-results",
+    );
+  });
+
+  test("ag pattern -> search-results", () => {
+    expect(detectCommand("ag 'fixme'").category).toBe("search-results");
+  });
+
+  // ── Build / lint ──────────────────────────────────────────────
+
+  test("tsc --noEmit -> build-lint", () => {
+    expect(detectCommand("tsc --noEmit").category).toBe("build-lint");
+  });
+
+  test("eslint src/ -> build-lint", () => {
+    expect(detectCommand("eslint src/").category).toBe("build-lint");
+  });
+
+  test("cargo build -> build-lint", () => {
+    expect(detectCommand("cargo build").category).toBe("build-lint");
+  });
+
+  test("cargo check -> build-lint", () => {
+    expect(detectCommand("cargo check").category).toBe("build-lint");
+  });
+
+  test("cargo clippy -> build-lint", () => {
+    expect(detectCommand("cargo clippy").category).toBe("build-lint");
+  });
+
+  test("npm run build -> build-lint", () => {
+    expect(detectCommand("npm run build").category).toBe("build-lint");
+  });
+
+  test("npm run lint -> build-lint", () => {
+    expect(detectCommand("npm run lint").category).toBe("build-lint");
+  });
+
+  test("ruff check . -> build-lint", () => {
+    expect(detectCommand("ruff check .").category).toBe("build-lint");
+  });
+
+  // ── Command chains (cd foo &&) ────────────────────────────────
+
+  test("cd /app && cargo test -> test-runner", () => {
+    expect(detectCommand("cd /app && cargo test").category).toBe("test-runner");
+  });
+
+  test("cd src && cd lib && jest -> test-runner", () => {
+    expect(detectCommand("cd src && cd lib && jest").category).toBe(
+      "test-runner",
+    );
+  });
+
+  // ── Env var prefixes ──────────────────────────────────────────
+
+  test("CI=1 jest --coverage -> test-runner", () => {
+    expect(detectCommand("CI=1 jest --coverage").category).toBe("test-runner");
+  });
+
+  test("NODE_ENV=test npx vitest -> test-runner", () => {
+    expect(detectCommand("NODE_ENV=test npx vitest").category).toBe(
+      "test-runner",
+    );
+  });
+
+  // ── sudo ──────────────────────────────────────────────────────
+
+  test("sudo cargo test -> test-runner", () => {
+    expect(detectCommand("sudo cargo test").category).toBe("test-runner");
+  });
+
+  // ── Pipes ─────────────────────────────────────────────────────
+
+  test("git diff | head -50 -> git-diff", () => {
+    expect(detectCommand("git diff | head -50").category).toBe("git-diff");
+  });
+
+  test("pytest | tee output.log -> test-runner", () => {
+    expect(detectCommand("pytest | tee output.log").category).toBe(
+      "test-runner",
+    );
+  });
+
+  // ── Unknown commands ──────────────────────────────────────────
+
+  test("docker ps -> unknown", () => {
+    expect(detectCommand("docker ps").category).toBe("unknown");
+  });
+
+  test("curl https://example.com -> unknown", () => {
+    expect(detectCommand("curl https://example.com").category).toBe("unknown");
+  });
+
+  test("echo hello -> unknown", () => {
+    expect(detectCommand("echo hello").category).toBe("unknown");
+  });
+
+  // ── Empty / whitespace ────────────────────────────────────────
+
+  test("empty string -> unknown", () => {
+    const result = detectCommand("");
+    expect(result.category).toBe("unknown");
+    expect(result.commandName).toBe("");
+  });
+
+  test("whitespace only -> unknown", () => {
+    const result = detectCommand("   ");
+    expect(result.category).toBe("unknown");
+    expect(result.commandName).toBe("");
+  });
+
+  // ── ANSI escape codes ─────────────────────────────────────────
+
+  test("command with ANSI codes -> correctly classified", () => {
+    expect(detectCommand("\x1B[32mpytest\x1B[0m -v").category).toBe(
+      "test-runner",
+    );
+  });
+
+  // ── commandName field ─────────────────────────────────────────
+
+  test("returns commandName for matched commands", () => {
+    expect(detectCommand("cargo test --release").commandName).toBe(
+      "cargo test",
+    );
+  });
+
+  test("returns empty commandName for unknown", () => {
+    expect(detectCommand("docker ps").commandName).toBe("");
+  });
+});

--- a/assistant/src/__tests__/shell-compression-detect.test.ts
+++ b/assistant/src/__tests__/shell-compression-detect.test.ts
@@ -94,9 +94,7 @@ describe("detectCommand", () => {
   });
 
   test("ls after pipe should NOT be directory-listing", () => {
-    expect(detectCommand("cat file.txt | ls").category).not.toBe(
-      "directory-listing",
-    );
+    expect(detectCommand("cat file.txt | ls").category).toBe("unknown");
   });
 
   // ── Search results ────────────────────────────────────────────
@@ -189,6 +187,20 @@ describe("detectCommand", () => {
     expect(detectCommand("pytest | tee output.log").category).toBe(
       "test-runner",
     );
+  });
+
+  // ── Pipeline head restriction ──────────────────────────────────
+
+  test("echo 'pytest' -> unknown (pytest is in argument, not command)", () => {
+    expect(detectCommand('echo "pytest"').category).toBe("unknown");
+  });
+
+  test("echo hi | pytest -> unknown (echo produces output)", () => {
+    expect(detectCommand("echo hi | pytest").category).toBe("unknown");
+  });
+
+  test("cat file | grep pattern -> unknown (cat produces output)", () => {
+    expect(detectCommand("cat file | grep pattern").category).toBe("unknown");
   });
 
   // ── Unknown commands ──────────────────────────────────────────

--- a/assistant/src/tools/shared/shell-compression/detect-command.ts
+++ b/assistant/src/tools/shared/shell-compression/detect-command.ts
@@ -54,10 +54,10 @@ const CATEGORIES: Array<{ category: CommandCategory; pattern: RegExp }> = [
     category: "git-status",
     pattern: /\bgit\s+status\b/,
   },
-  // Directory listing — only when NOT after a pipe
+  // Directory listing
   {
     category: "directory-listing",
-    pattern: /(?<!\|[^|]*)\b(ls|find|tree)\b/,
+    pattern: /\b(ls|find|tree)\b/,
   },
   // Search tools
   {
@@ -76,8 +76,8 @@ const CATEGORIES: Array<{ category: CommandCategory; pattern: RegExp }> = [
  * Detect the primary command category from a shell command string.
  *
  * Handles ANSI codes, `cd && ...` chains, env-var prefixes, `sudo`,
- * and pipes (the first command in a pipeline determines the category,
- * except for directory-listing which must not follow a pipe).
+ * and pipes. Only the head segment of a pipeline (before the first `|`)
+ * is classified, since that command produces the output we compress.
  */
 export function detectCommand(command: string): DetectResult {
   if (!command || !command.trim()) {
@@ -85,7 +85,11 @@ export function detectCommand(command: string): DetectResult {
   }
 
   const cleaned = stripAnsi(command);
-  const stripped = stripPrefixes(cleaned);
+  // Extract the head segment of a pipeline — only the first command before
+  // any `|` produces the output we'll compress.
+  const pipeIndex = cleaned.indexOf("|");
+  const headSegment = pipeIndex >= 0 ? cleaned.slice(0, pipeIndex) : cleaned;
+  const stripped = stripPrefixes(headSegment);
 
   for (const { category, pattern } of CATEGORIES) {
     const match = stripped.match(pattern);

--- a/assistant/src/tools/shared/shell-compression/detect-command.ts
+++ b/assistant/src/tools/shared/shell-compression/detect-command.ts
@@ -1,0 +1,98 @@
+import type { CommandCategory } from "./types.js";
+
+/**
+ * Strip ANSI escape codes from a string.
+ */
+function stripAnsi(str: string): string {
+  return str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+/**
+ * Strip common command prefixes that don't affect classification:
+ * - `cd <path> &&` chains
+ * - environment variable assignments (`FOO=bar`)
+ * - `sudo`
+ */
+function stripPrefixes(cmd: string): string {
+  let result = cmd.trim();
+
+  // Strip leading `cd <path> &&` (possibly repeated)
+  while (/^cd\s+\S+\s*&&\s*/.test(result)) {
+    result = result.replace(/^cd\s+\S+\s*&&\s*/, "");
+  }
+
+  // Strip leading env var assignments (KEY=value, KEY="value", KEY='value')
+  while (/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/.test(result)) {
+    result = result.replace(/^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/, "");
+  }
+
+  // Strip leading `sudo`
+  result = result.replace(/^sudo\s+/, "");
+
+  return result.trim();
+}
+
+interface DetectResult {
+  category: CommandCategory;
+  commandName: string;
+}
+
+const CATEGORIES: Array<{ category: CommandCategory; pattern: RegExp }> = [
+  // Test runners — highest priority
+  {
+    category: "test-runner",
+    pattern:
+      /\b(cargo\s+test|pytest|python\s+-m\s+pytest|jest|vitest|npx\s+(jest|vitest)|go\s+test|bun\s+test|rspec|playwright)\b/,
+  },
+  // git diff / git show
+  {
+    category: "git-diff",
+    pattern: /\bgit\s+(diff|show)\b/,
+  },
+  // git status
+  {
+    category: "git-status",
+    pattern: /\bgit\s+status\b/,
+  },
+  // Directory listing — only when NOT after a pipe
+  {
+    category: "directory-listing",
+    pattern: /(?<!\|[^|]*)\b(ls|find|tree)\b/,
+  },
+  // Search tools
+  {
+    category: "search-results",
+    pattern: /\b(grep|rg|ripgrep|ag)\b/,
+  },
+  // Build / lint tools
+  {
+    category: "build-lint",
+    pattern:
+      /\b(tsc|eslint|cargo\s+(build|check|clippy)|npm\s+run\s+(build|lint)|ruff)\b/,
+  },
+];
+
+/**
+ * Detect the primary command category from a shell command string.
+ *
+ * Handles ANSI codes, `cd && ...` chains, env-var prefixes, `sudo`,
+ * and pipes (the first command in a pipeline determines the category,
+ * except for directory-listing which must not follow a pipe).
+ */
+export function detectCommand(command: string): DetectResult {
+  if (!command || !command.trim()) {
+    return { category: "unknown", commandName: "" };
+  }
+
+  const cleaned = stripAnsi(command);
+  const stripped = stripPrefixes(cleaned);
+
+  for (const { category, pattern } of CATEGORIES) {
+    const match = stripped.match(pattern);
+    if (match) {
+      return { category, commandName: match[0].trim() };
+    }
+  }
+
+  return { category: "unknown", commandName: "" };
+}

--- a/assistant/src/tools/shared/shell-compression/types.ts
+++ b/assistant/src/tools/shared/shell-compression/types.ts
@@ -1,0 +1,20 @@
+export type CommandCategory =
+  | "test-runner"
+  | "git-diff"
+  | "git-status"
+  | "directory-listing"
+  | "search-results"
+  | "build-lint"
+  | "unknown";
+
+export interface CompressionResult {
+  compressed: string;
+  originalLength: number;
+  compressedLength: number;
+  category: CommandCategory;
+  wasCompressed: boolean;
+}
+
+export interface Compressor {
+  compress(stdout: string, stderr: string, exitCode: number | null): string;
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -360,6 +360,14 @@
       "label": "Google Meet",
       "description": "Enables the Google Meet joining bot and the meet-join skill.",
       "defaultEnabled": false
+    },
+    {
+      "id": "shell-output-compression",
+      "scope": "assistant",
+      "key": "shell-output-compression",
+      "label": "Shell Output Compression",
+      "description": "Command-aware smart compression of shell tool results before context injection",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register shell-output-compression feature flag (defaultEnabled: false)
- Add CommandCategory, CompressionResult, and Compressor type definitions
- Implement regex-based command classifier with support for 6 categories and 30+ test cases

Part of plan: shell-output-compression.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
