### PR TITLE
chore: add cutover guardrails and document OpenAI Responses transport

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2314,3 +2314,30 @@ These endpoints allow the platform (via vembda proxy) to enumerate, inspect, exp
 | `src/util/platform.ts`                     | Profiler directory path helpers                                          |
 | `src/__tests__/profiler-run-store.test.ts` | Profiler store unit tests                                                |
 | `src/__tests__/profiler-routes.test.ts`    | Profiler HTTP route tests                                                |
+
+### LLM Provider Transport — OpenAI Responses API
+
+OpenAI inference uses the **Responses API** (`client.responses.stream()`), not the Chat Completions API. OpenAI-compatible providers (OpenRouter, Fireworks, Ollama) continue to use the chat-completions transport.
+
+**Transport split:**
+
+| Provider key | Transport class           | API surface                 |
+| ------------ | ------------------------- | --------------------------- |
+| `openai`     | `OpenAIResponsesProvider` | `client.responses.stream()` |
+| `openrouter` | `OpenRouterProvider`      | `chat.completions.create()` |
+| `fireworks`  | `FireworksProvider`       | `chat.completions.create()` |
+| `ollama`     | `OllamaProvider`          | `chat.completions.create()` |
+
+The registry (`src/providers/registry.ts`) imports `OpenAIResponsesProvider` from `openai/client.ts` and wires it to the `openai` key. The chat-completions transport (`OpenAIChatCompletionsProvider`) remains available for OpenAI-compatible providers that implement the Chat Completions API.
+
+Both transports produce the same `ProviderResponse` contract so downstream code (agent loop, context management, conversation history) is transport-agnostic.
+
+**Key files:**
+
+| File                                                   | Purpose                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------- |
+| `src/providers/openai/responses-provider.ts`           | Responses API transport (streaming, tool calls, usage mapping)       |
+| `src/providers/openai/chat-completions-provider.ts`    | Chat Completions transport (OpenAI-compatible providers)             |
+| `src/providers/openai/client.ts`                       | Re-exports both transports + `validateOpenAIApiKey()`                |
+| `src/providers/registry.ts`                            | Provider initialization (wires `openai` → `OpenAIResponsesProvider`) |
+| `src/__tests__/openai-responses-cutover-guard.test.ts` | CI guard preventing chat-completions regression in OpenAI path       |

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -753,15 +753,16 @@ describe("web_search_tool_result structural guard", () => {
     // It has a separate isWebSearchToolResultBlock for the other type.
     "providers/anthropic/client.ts",
 
-    // OpenAI-compatible chat-completions transport converts Anthropic-style
-    // messages to OpenAI format. OpenAI API does not support
+    // Chat-completions transport used by OpenAI-compatible providers
+    // (OpenRouter, Fireworks, Ollama). These APIs do not support
     // web_search_tool_result natively; those blocks are handled upstream
     // before reaching the chat-completions provider.
     "providers/openai/chat-completions-provider.ts",
 
-    // OpenAI Responses API transport converts Anthropic-style messages to
-    // Responses API input format. web_search_tool_result blocks are handled
-    // upstream before reaching the responses provider.
+    // OpenAI Responses API transport (used for direct OpenAI inference).
+    // Converts Anthropic-style messages to Responses API input format.
+    // web_search_tool_result blocks are handled upstream before reaching
+    // the responses provider.
     "providers/openai/responses-provider.ts",
 
     // Renders tool_result blocks for client display. web_search_tool_result

--- a/assistant/src/__tests__/openai-responses-cutover-guard.test.ts
+++ b/assistant/src/__tests__/openai-responses-cutover-guard.test.ts
@@ -1,0 +1,184 @@
+import { execSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Guard test: prevent accidental reintroduction of OpenAI Chat Completions
+ * calls in the OpenAI provider path.
+ *
+ * OpenAI inference uses the Responses API (`client.responses.stream()`).
+ * The chat-completions transport (`chat.completions.create()`) is reserved
+ * for OpenAI-compatible providers (OpenRouter, Fireworks, Ollama).
+ *
+ * These guards fail CI if:
+ * 1. The Responses provider file contains `chat.completions.create(` calls.
+ * 2. The provider registry wires `openai` to anything other than
+ *    `OpenAIResponsesProvider`.
+ * 3. A new file appears in `providers/openai/` that introduces
+ *    `chat.completions.create(` calls.
+ *
+ * Focused test commands for the OpenAI Responses API migration surface:
+ *
+ *   # This guard test
+ *   bun test src/__tests__/openai-responses-cutover-guard.test.ts
+ *
+ *   # OpenAI provider tests (responses + chat-completions)
+ *   bun test src/__tests__/openai-provider.test.ts
+ *   bun test src/__tests__/openai-responses-provider.test.ts
+ *
+ *   # LLM context normalization (transport-agnostic message handling)
+ *   bun test src/__tests__/llm-context-normalization.test.ts
+ *
+ *   # Provider registry and managed proxy integration
+ *   bun test src/__tests__/registry.test.ts
+ *   bun test src/__tests__/provider-managed-proxy-integration.test.ts
+ *
+ *   # Web search guard (allowlist includes both provider files)
+ *   bun test src/__tests__/conversation-history-web-search.test.ts
+ */
+
+const PROVIDERS_DIR = join(import.meta.dir, "..", "providers");
+const OPENAI_PROVIDERS_DIR = join(PROVIDERS_DIR, "openai");
+
+describe("OpenAI Responses API cutover guard", () => {
+  test("responses-provider.ts does not contain chat.completions.create() calls", () => {
+    const source = readFileSync(
+      join(OPENAI_PROVIDERS_DIR, "responses-provider.ts"),
+      "utf-8",
+    );
+
+    const hasChatCompletions = source.includes("chat.completions.create(");
+
+    expect(
+      hasChatCompletions,
+      [
+        "responses-provider.ts must NOT call chat.completions.create().",
+        "OpenAI inference uses the Responses API (client.responses.stream()).",
+        "If you need chat completions, use chat-completions-provider.ts instead.",
+      ].join("\n"),
+    ).toBe(false);
+  });
+
+  test("registry.ts wires the 'openai' provider to OpenAIResponsesProvider", () => {
+    const source = readFileSync(join(PROVIDERS_DIR, "registry.ts"), "utf-8");
+
+    // The registry should import OpenAIResponsesProvider
+    expect(
+      source.includes("OpenAIResponsesProvider"),
+      "registry.ts must import OpenAIResponsesProvider for the openai provider.",
+    ).toBe(true);
+
+    // The registry should instantiate OpenAIResponsesProvider for the "openai" key.
+    // Look for `new OpenAIResponsesProvider(` near the openai registration block.
+    const hasResponsesInstantiation = source.includes(
+      "new OpenAIResponsesProvider(",
+    );
+    expect(
+      hasResponsesInstantiation,
+      [
+        "registry.ts must instantiate OpenAIResponsesProvider for the 'openai' provider.",
+        "OpenAI inference uses the Responses API, not chat completions.",
+      ].join("\n"),
+    ).toBe(true);
+
+    // The registry should NOT instantiate OpenAIChatCompletionsProvider or
+    // OpenAIProvider (the backward-compatible alias) for the "openai" key.
+    // Chat-completions classes may appear in imports but should not be
+    // instantiated in the openai registration block.
+    const chatCompletionsInstantiations = [
+      ...source.matchAll(/new\s+OpenAIChatCompletionsProvider\s*\(/g),
+      ...source.matchAll(/new\s+OpenAIProvider\s*\(/g),
+    ];
+    expect(
+      chatCompletionsInstantiations.length,
+      [
+        "registry.ts must NOT instantiate OpenAIChatCompletionsProvider or",
+        "OpenAIProvider (legacy alias). Use OpenAIResponsesProvider for openai.",
+      ].join("\n"),
+    ).toBe(0);
+  });
+
+  test("no files in providers/openai/ introduce chat.completions.create() calls", () => {
+    // The chat-completions-provider.ts is the only file allowed to use
+    // chat.completions.create() — it's the dedicated chat-completions transport.
+    const ALLOWED_FILES = new Set(["chat-completions-provider.ts"]);
+
+    const files = readdirSync(OPENAI_PROVIDERS_DIR).filter(
+      (f) =>
+        f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts"),
+    );
+
+    const violations: string[] = [];
+    for (const file of files) {
+      if (ALLOWED_FILES.has(file)) continue;
+      const source = readFileSync(join(OPENAI_PROVIDERS_DIR, file), "utf-8");
+      if (source.includes("chat.completions.create(")) {
+        violations.push(file);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Found chat.completions.create() calls in OpenAI provider files that",
+        "should not use the chat completions transport:",
+        "",
+        "Violations:",
+        ...violations.map((f) => `  - providers/openai/${f}`),
+        "",
+        "OpenAI inference uses the Responses API. Only",
+        "chat-completions-provider.ts may call chat.completions.create().",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("no production files outside providers/openai/ call chat.completions.create() for the openai provider path", () => {
+    // Broader scan: ensure no other production file accidentally calls
+    // chat.completions.create in a context that would affect the openai
+    // provider path. This catches cases where someone might add a direct
+    // OpenAI SDK call outside the provider directory.
+    let grepOutput = "";
+    try {
+      grepOutput = execSync(
+        `git grep -l "chat\\.completions\\.create(" -- 'assistant/src/**/*.ts'`,
+        { encoding: "utf-8", cwd: process.cwd() + "/.." },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    // Allowed: chat-completions-provider.ts (the dedicated transport) and test files
+    const ALLOWED_PATHS = new Set([
+      "assistant/src/providers/openai/chat-completions-provider.ts",
+    ]);
+
+    const files = grepOutput
+      .split("\n")
+      .filter((f) => f.length > 0)
+      .filter((f) => !f.includes("/__tests__/"))
+      .filter((f) => !f.endsWith(".test.ts"));
+
+    const violations = files.filter((f) => !ALLOWED_PATHS.has(f));
+
+    if (violations.length > 0) {
+      const message = [
+        "Found chat.completions.create() calls in production files outside the",
+        "allowed chat-completions transport:",
+        "",
+        "Violations:",
+        ...violations.map((f) => `  - ${f}`),
+        "",
+        "OpenAI inference uses the Responses API. Direct chat.completions.create()",
+        "calls should only exist in chat-completions-provider.ts.",
+        "If this is a different provider (OpenRouter, Fireworks, etc.), add it to",
+        "ALLOWED_PATHS in this guard test.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add regression guard test to prevent accidental chat.completions.create() reintroduction in OpenAI provider path
- Update ARCHITECTURE.md to document OpenAI Responses API transport split
- Update web-search guard allowlist for current file structure

Part of plan: responses-api-remove-completions.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
