### PR TITLE
feat: add git-diff output compressor for shell compression

### DIFF
--- a/assistant/src/__tests__/shell-compression-git-diff.test.ts
+++ b/assistant/src/__tests__/shell-compression-git-diff.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "bun:test";
+
+import { compressGitDiff } from "../tools/shared/shell-compression/compressors/git-diff.js";
+
+describe("compressGitDiff", () => {
+  // ── Context line reduction ────────────────────────────────────
+
+  test("reduces context lines from 3 to 1 around changes", () => {
+    const diff = [
+      "diff --git a/src/app.ts b/src/app.ts",
+      "index abc1234..def5678 100644",
+      "--- a/src/app.ts",
+      "+++ b/src/app.ts",
+      "@@ -10,11 +10,11 @@",
+      " context line 1",
+      " context line 2",
+      " context line 3",
+      "-old line",
+      "+new line",
+      " context line 4",
+      " context line 5",
+      " context line 6",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    const lines = result.split("\n");
+
+    // Header lines preserved
+    expect(lines[0]).toBe("diff --git a/src/app.ts b/src/app.ts");
+    expect(lines[1]).toBe("index abc1234..def5678 100644");
+    expect(lines[2]).toBe("--- a/src/app.ts");
+    expect(lines[3]).toBe("+++ b/src/app.ts");
+    expect(lines[4]).toBe("@@ -10,11 +10,11 @@");
+
+    // Only 1 context line before and 1 after the change
+    expect(result).toContain(" context line 3");
+    expect(result).toContain("-old line");
+    expect(result).toContain("+new line");
+    expect(result).toContain(" context line 4");
+
+    // Context lines 1, 2, 5, 6 should be removed
+    expect(result).not.toContain(" context line 1");
+    expect(result).not.toContain(" context line 2");
+    expect(result).not.toContain(" context line 5");
+    expect(result).not.toContain(" context line 6");
+  });
+
+  test("preserves all +/- lines exactly in multi-file diff", () => {
+    const diff = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -1,7 +1,7 @@",
+      " ctx before",
+      " ctx before 2",
+      " ctx before 3",
+      "-removed from foo",
+      "+added to foo",
+      " ctx after",
+      " ctx after 2",
+      " ctx after 3",
+      "diff --git a/src/bar.ts b/src/bar.ts",
+      "--- a/src/bar.ts",
+      "+++ b/src/bar.ts",
+      "@@ -5,6 +5,8 @@",
+      " ctx",
+      " ctx",
+      " ctx",
+      "+new line 1 in bar",
+      "+new line 2 in bar",
+      " ctx",
+      " ctx",
+      " ctx",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+
+    // All changed lines must be present
+    expect(result).toContain("-removed from foo");
+    expect(result).toContain("+added to foo");
+    expect(result).toContain("+new line 1 in bar");
+    expect(result).toContain("+new line 2 in bar");
+
+    // Both file headers present
+    expect(result).toContain("diff --git a/src/foo.ts b/src/foo.ts");
+    expect(result).toContain("diff --git a/src/bar.ts b/src/bar.ts");
+  });
+
+  // ── Lock file detection ───────────────────────────────────────
+
+  test("collapses lock file diff to summary line", () => {
+    const diff = [
+      "diff --git a/package-lock.json b/package-lock.json",
+      "--- a/package-lock.json",
+      "+++ b/package-lock.json",
+      "@@ -100,5 +100,10 @@",
+      '-    "version": "1.0.0"',
+      '+    "version": "1.1.0"',
+      "+    some new dep line 1",
+      "+    some new dep line 2",
+      "+    some new dep line 3",
+      "+    some new dep line 4",
+      "+    some new dep line 5",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toBe(
+      "package-lock.json: +6 -1 lines (lock file, details omitted)",
+    );
+  });
+
+  test("collapses yarn.lock diff to summary line", () => {
+    const diff = [
+      "diff --git a/yarn.lock b/yarn.lock",
+      "--- a/yarn.lock",
+      "+++ b/yarn.lock",
+      "@@ -1,3 +1,5 @@",
+      "+added 1",
+      "+added 2",
+      "-removed 1",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toBe("yarn.lock: +2 -1 lines (lock file, details omitted)");
+  });
+
+  test("collapses Cargo.lock diff to summary line", () => {
+    const diff = [
+      "diff --git a/Cargo.lock b/Cargo.lock",
+      "--- a/Cargo.lock",
+      "+++ b/Cargo.lock",
+      "@@ -1,2 +1,3 @@",
+      "+new dep",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toBe("Cargo.lock: +1 -0 lines (lock file, details omitted)");
+  });
+
+  test("collapses pnpm-lock.yaml diff to summary line", () => {
+    const diff = [
+      "diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml",
+      "--- a/pnpm-lock.yaml",
+      "+++ b/pnpm-lock.yaml",
+      "@@ -1,2 +1,3 @@",
+      "+new line",
+      "-old line",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toBe(
+      "pnpm-lock.yaml: +1 -1 lines (lock file, details omitted)",
+    );
+  });
+
+  test("collapses Gemfile.lock diff to summary line", () => {
+    const diff = [
+      "diff --git a/Gemfile.lock b/Gemfile.lock",
+      "--- a/Gemfile.lock",
+      "+++ b/Gemfile.lock",
+      "@@ -1,2 +1,3 @@",
+      "+new gem",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toBe(
+      "Gemfile.lock: +1 -0 lines (lock file, details omitted)",
+    );
+  });
+
+  // ── Binary files ──────────────────────────────────────────────
+
+  test("preserves binary file diff as-is", () => {
+    const diff = [
+      "diff --git a/icon.png b/icon.png",
+      "Binary files a/icon.png and b/icon.png differ",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toContain("Binary files a/icon.png and b/icon.png differ");
+  });
+
+  test("preserves new binary file diff", () => {
+    const diff = [
+      "diff --git a/logo.png b/logo.png",
+      "new file mode 100644",
+      "Binary files /dev/null and b/logo.png differ",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toContain("Binary files /dev/null and b/logo.png differ");
+  });
+
+  // ── Error output ──────────────────────────────────────────────
+
+  test("passes through error output with non-zero exit code", () => {
+    const stderr = "fatal: bad revision 'nonexistent'";
+    const result = compressGitDiff("", stderr, 128);
+    expect(result).toBe(stderr);
+  });
+
+  test("passes through stderr even with exit code 0", () => {
+    // git diff can write warnings to stderr with exit code 0
+    const stderr = "warning: some git warning";
+    const stdout = "diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n";
+    const result = compressGitDiff(stdout, stderr, 0);
+    expect(result).toContain(stderr);
+    expect(result).toContain(stdout);
+  });
+
+  test("passes through stderr with null exit code", () => {
+    const stderr = "error: something went wrong";
+    const result = compressGitDiff("some output", stderr, null);
+    expect(result).toContain(stderr);
+    expect(result).toContain("some output");
+  });
+
+  test("passes through stdout with non-zero exit code and no stderr", () => {
+    const stdout = "some partial output before failure";
+    const result = compressGitDiff(stdout, "", 1);
+    expect(result).toBe(stdout);
+  });
+
+  // ── Large hunk truncation ─────────────────────────────────────
+
+  test("truncates file diff exceeding 5000 chars", () => {
+    const longLine = "+".padEnd(100, "x");
+    const lines = [
+      "diff --git a/big.ts b/big.ts",
+      "--- a/big.ts",
+      "+++ b/big.ts",
+      "@@ -1,2 +1,100 @@",
+    ];
+    // Add enough lines to exceed 5000 chars
+    for (let i = 0; i < 60; i++) {
+      lines.push(longLine);
+    }
+    const diff = lines.join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+    expect(result).toContain("... (");
+    expect(result).toContain("more lines)");
+    expect(result.length).toBeLessThan(diff.length);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────
+
+  test("returns empty string for empty input", () => {
+    expect(compressGitDiff("", "", 0)).toBe("");
+  });
+
+  test("returns whitespace input as-is", () => {
+    expect(compressGitDiff("  \n  ", "", 0)).toBe("  \n  ");
+  });
+
+  test("handles git show preamble before diff", () => {
+    const output = [
+      "commit abc1234567890",
+      "Author: Test User <test@example.com>",
+      "Date:   Mon Jan 1 00:00:00 2024 +0000",
+      "",
+      "    Fix the thing",
+      "",
+      "diff --git a/src/thing.ts b/src/thing.ts",
+      "--- a/src/thing.ts",
+      "+++ b/src/thing.ts",
+      "@@ -1,5 +1,5 @@",
+      " context",
+      "-old",
+      "+new",
+      " context",
+    ].join("\n");
+
+    const result = compressGitDiff(output, "", 0);
+    expect(result).toContain("commit abc1234567890");
+    expect(result).toContain("Fix the thing");
+    expect(result).toContain("-old");
+    expect(result).toContain("+new");
+  });
+
+  test("handles multiple changed blocks in a single hunk", () => {
+    const diff = [
+      "diff --git a/multi.ts b/multi.ts",
+      "--- a/multi.ts",
+      "+++ b/multi.ts",
+      "@@ -1,15 +1,15 @@",
+      " ctx 1",
+      " ctx 2",
+      " ctx 3",
+      "-change A old",
+      "+change A new",
+      " between 1",
+      " between 2",
+      " between 3",
+      " between 4",
+      " between 5",
+      "-change B old",
+      "+change B new",
+      " ctx 4",
+      " ctx 5",
+      " ctx 6",
+    ].join("\n");
+
+    const result = compressGitDiff(diff, "", 0);
+
+    // All changes preserved
+    expect(result).toContain("-change A old");
+    expect(result).toContain("+change A new");
+    expect(result).toContain("-change B old");
+    expect(result).toContain("+change B new");
+
+    // Only 1 context line before/after each change block
+    expect(result).toContain(" ctx 3");
+    expect(result).toContain(" between 1");
+    expect(result).toContain(" between 5");
+    expect(result).toContain(" ctx 4");
+
+    // Extra context removed
+    expect(result).not.toContain(" ctx 1");
+    expect(result).not.toContain(" ctx 2");
+    expect(result).not.toContain(" between 2");
+    expect(result).not.toContain(" between 3");
+    expect(result).not.toContain(" between 4");
+    expect(result).not.toContain(" ctx 5");
+    expect(result).not.toContain(" ctx 6");
+  });
+});

--- a/assistant/src/tools/shared/shell-compression/compressors/git-diff.ts
+++ b/assistant/src/tools/shared/shell-compression/compressors/git-diff.ts
@@ -1,0 +1,183 @@
+const LOCK_FILE_PATTERNS = [
+  /lock\b/i,
+  /-lock\./,
+  /^package-lock\.json$/,
+  /^yarn\.lock$/,
+  /^Cargo\.lock$/,
+  /^Gemfile\.lock$/,
+  /^pnpm-lock\.yaml$/,
+];
+
+const MAX_FILE_DIFF_CHARS = 5000;
+
+/**
+ * Check whether a file path looks like a lock file.
+ */
+function isLockFile(filePath: string): boolean {
+  const basename = filePath.split("/").pop() ?? filePath;
+  return LOCK_FILE_PATTERNS.some((p) => p.test(basename));
+}
+
+/**
+ * Count added and removed lines in a raw diff section.
+ */
+function countChanges(diffText: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) added++;
+    if (line.startsWith("-") && !line.startsWith("---")) removed++;
+  }
+  return { added, removed };
+}
+
+/**
+ * Extract the file path from a `diff --git a/... b/...` header line.
+ */
+function extractFilePath(header: string): string {
+  const match = header.match(/^diff --git a\/(.+?) b\/(.+)/);
+  return match ? match[2] : "";
+}
+
+/**
+ * Reduce context lines around changed blocks from the default 3 to 1.
+ *
+ * Walks the hunk body line-by-line, keeping all changed lines (`+`/`-`)
+ * and only 1 context line (lines starting with space) immediately before
+ * and after each contiguous block of changes.
+ */
+function reduceContext(hunkBody: string[]): string[] {
+  // Tag each line as "change" or "context"
+  const isChange = hunkBody.map(
+    (line) =>
+      line.startsWith("+") ||
+      line.startsWith("-") ||
+      // "\ No newline at end of file" lines belong with the change
+      line.startsWith("\\"),
+  );
+
+  const keep = new Array<boolean>(hunkBody.length).fill(false);
+
+  for (let i = 0; i < hunkBody.length; i++) {
+    if (isChange[i]) {
+      keep[i] = true;
+      // Keep 1 context line before
+      if (i > 0 && !isChange[i - 1]) keep[i - 1] = true;
+      // Keep 1 context line after
+      if (i < hunkBody.length - 1 && !isChange[i + 1]) keep[i + 1] = true;
+    }
+  }
+
+  return hunkBody.filter((_, i) => keep[i]);
+}
+
+/**
+ * Compress a single file's diff section. Returns the compressed text.
+ */
+function compressFileDiff(section: string): string {
+  const lines = section.split("\n");
+  const headerLine = lines[0]; // diff --git ...
+  const filePath = extractFilePath(headerLine);
+
+  // Lock file: collapse to summary
+  if (isLockFile(filePath)) {
+    const { added, removed } = countChanges(section);
+    return `${filePath}: +${added} -${removed} lines (lock file, details omitted)`;
+  }
+
+  // Binary file: keep as-is
+  if (section.includes("Binary files") && section.includes("differ")) {
+    return section.trimEnd();
+  }
+
+  const result: string[] = [];
+  let i = 0;
+
+  // Keep header lines (diff --git, index, ---, +++)
+  while (i < lines.length && !lines[i].startsWith("@@")) {
+    result.push(lines[i]);
+    i++;
+  }
+
+  // Process hunks
+  while (i < lines.length) {
+    if (lines[i].startsWith("@@")) {
+      result.push(lines[i]); // Keep @@ header
+      i++;
+
+      // Collect hunk body until next @@ or end
+      const body: string[] = [];
+      while (i < lines.length && !lines[i].startsWith("@@")) {
+        body.push(lines[i]);
+        i++;
+      }
+
+      // Reduce context and append
+      const reduced = reduceContext(body);
+      result.push(...reduced);
+    } else {
+      result.push(lines[i]);
+      i++;
+    }
+  }
+
+  let compressed = result.join("\n").trimEnd();
+
+  // Large hunk truncation
+  if (compressed.length > MAX_FILE_DIFF_CHARS) {
+    const truncated = compressed.slice(0, MAX_FILE_DIFF_CHARS);
+    // Count remaining lines
+    const fullLines = compressed.split("\n").length;
+    const truncatedLines = truncated.split("\n").length;
+    const remaining = fullLines - truncatedLines;
+    compressed = truncated + `\n... (${remaining} more lines)`;
+  }
+
+  return compressed;
+}
+
+/**
+ * Compress `git diff` / `git show` output.
+ *
+ * - Reduces context lines from default 3 to 1 around changed blocks
+ * - Collapses lock file diffs to a one-line summary
+ * - Preserves binary file notices as-is
+ * - Truncates large per-file diffs with a summary
+ * - Passes through error output unchanged
+ */
+export function compressGitDiff(
+  stdout: string,
+  stderr: string,
+  exitCode: number | null,
+): string {
+  // Error case: prepend stderr and return as-is
+  if (stderr || exitCode !== 0) {
+    const parts: string[] = [];
+    if (stderr) parts.push(stderr);
+    if (stdout) parts.push(stdout);
+    return parts.join("\n");
+  }
+
+  if (!stdout.trim()) return stdout;
+
+  // Split on `diff --git` boundaries, keeping the delimiter
+  const sections = stdout.split(/^(?=diff --git )/m).filter(Boolean);
+
+  // If no diff sections found, return as-is (e.g. commit message from git show)
+  if (sections.length === 0) return stdout;
+
+  // Check if there's preamble text before the first diff (e.g. git show commit info)
+  const firstDiffIndex = stdout.indexOf("diff --git ");
+  const preamble =
+    firstDiffIndex > 0 ? stdout.slice(0, firstDiffIndex).trimEnd() : "";
+
+  const compressed = sections
+    .map((section) => compressFileDiff(section.trimEnd()))
+    .join("\n");
+
+  if (preamble) {
+    return preamble + "\n" + compressed;
+  }
+
+  return compressed;
+}


### PR DESCRIPTION
## Summary
- Implement compressGitDiff() with unified diff parsing
- Reduce context lines from 3 to 1, collapse lock file diffs, handle binary files
- Preserve all changed lines (+/-) exactly, pass through errors unchanged

Part of plan: shell-output-compression.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
