### PR TITLE
feat: integrate shell output compression into formatShellOutput

### DIFF
--- a/assistant/src/__tests__/shell-compression-integration.test.ts
+++ b/assistant/src/__tests__/shell-compression-integration.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../config/assistant-feature-flags.js";
+import { formatShellOutput } from "../tools/shared/shell-output.js";
+
+// A large pytest-style output fixture (>2000 chars) to test compression.
+const LARGE_PYTEST_OUTPUT = [
+  "============================= test session starts ==============================",
+  "platform linux -- Python 3.11.0, pytest-7.4.0",
+  "collected 50 items",
+  "",
+  ...Array.from(
+    { length: 50 },
+    (_, i) => `tests/test_module.py::test_case_${i} PASSED`,
+  ),
+  "",
+  "============================== 50 passed in 2.34s ==============================",
+].join("\n");
+
+describe("shell compression integration", () => {
+  beforeEach(() => {
+    clearFeatureFlagOverridesCache();
+  });
+
+  afterEach(() => {
+    clearFeatureFlagOverridesCache();
+  });
+
+  test("flag off: large pytest output unchanged", () => {
+    _setOverridesForTesting({ "shell-output-compression": false });
+    const result = formatShellOutput(LARGE_PYTEST_OUTPUT, "", 0, false, 120, {
+      command: "pytest -v",
+    });
+    // Output should contain all PASSED lines since compression is off
+    expect(result.content).toContain("test_case_25 PASSED");
+  });
+
+  test("flag on: large pytest output compressed", () => {
+    _setOverridesForTesting({ "shell-output-compression": true });
+    const result = formatShellOutput(LARGE_PYTEST_OUTPUT, "", 0, false, 120, {
+      command: "pytest -v",
+    });
+    // Compressed output should be shorter — PASSED lines collapsed
+    expect(result.content.length).toBeLessThan(LARGE_PYTEST_OUTPUT.length);
+    expect(result.content).toContain("50 passed");
+  });
+
+  test("flag on, unknown command: output unchanged", () => {
+    _setOverridesForTesting({ "shell-output-compression": true });
+    const stdout = "some output\n".repeat(200);
+    const result = formatShellOutput(stdout, "", 0, false, 120, {
+      command: "docker ps",
+    });
+    expect(result.content).toBe(stdout);
+  });
+
+  test("flag on, short output: output unchanged", () => {
+    _setOverridesForTesting({ "shell-output-compression": true });
+    const stdout = "tests/test.py::test_one PASSED\n1 passed in 0.01s";
+    const result = formatShellOutput(stdout, "", 0, false, 120, {
+      command: "pytest",
+    });
+    // Short output (<2000 chars) should not be compressed
+    expect(result.content).toBe(stdout);
+  });
+
+  test("backward compat: call without options param works", () => {
+    _setOverridesForTesting({ "shell-output-compression": true });
+    const result = formatShellOutput("hello world", "", 0, false, 120);
+    expect(result.content).toBe("hello world");
+    expect(result.isError).toBe(false);
+  });
+});

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -14,6 +14,7 @@ interface PendingRequest {
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
   timeoutSec: number;
+  command: string;
   /** Detach the abort listener from the caller's signal. No-op when no signal was passed. */
   detachAbort: () => void;
 }
@@ -115,6 +116,7 @@ export class HostBashProxy {
         reject,
         timer,
         timeoutSec,
+        command: input.command,
         detachAbort,
       });
 
@@ -170,6 +172,7 @@ export class HostBashProxy {
       response.exitCode,
       response.timedOut,
       entry.timeoutSec,
+      { command: entry.command },
     );
     entry.resolve(result);
   }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -263,6 +263,7 @@ class HostShellTool implements Tool {
           code,
           timedOut,
           timeoutSec,
+          { command },
         );
 
         resolve({

--- a/assistant/src/tools/shared/shell-compression/index.ts
+++ b/assistant/src/tools/shared/shell-compression/index.ts
@@ -1,0 +1,106 @@
+import { getLogger } from "../../../util/logger.js";
+import { compressBuildOutput } from "./compressors/build-lint.js";
+import { compressDirectoryListing } from "./compressors/directory-listing.js";
+import { compressGitDiff } from "./compressors/git-diff.js";
+import { compressGitStatus } from "./compressors/git-status.js";
+import { compressSearchResults } from "./compressors/search-results.js";
+import { compressTestOutput } from "./compressors/test-runner.js";
+import { detectCommand } from "./detect-command.js";
+import type { CompressionResult } from "./types.js";
+
+const log = getLogger("shell-compression");
+
+/** Minimum output length before compression is attempted. */
+const MIN_LENGTH = 2000;
+
+/**
+ * Compress shell command output using command-aware compression.
+ *
+ * Detects the command type and routes to the appropriate compressor.
+ * Returns a passthrough result for short output, unknown commands,
+ * or when no compression is beneficial.
+ */
+export function compressShellOutput(
+  command: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number | null,
+): CompressionResult {
+  const originalLength = stdout.length + stderr.length;
+
+  if (originalLength < MIN_LENGTH) {
+    return {
+      compressed: "",
+      originalLength,
+      compressedLength: originalLength,
+      category: "unknown",
+      wasCompressed: false,
+    };
+  }
+
+  const { category } = detectCommand(command);
+
+  if (category === "unknown") {
+    return {
+      compressed: "",
+      originalLength,
+      compressedLength: originalLength,
+      category,
+      wasCompressed: false,
+    };
+  }
+
+  let compressed: string;
+
+  switch (category) {
+    case "test-runner":
+      compressed = compressTestOutput(stdout, stderr, exitCode);
+      break;
+    case "git-diff":
+      compressed = compressGitDiff(stdout, stderr, exitCode);
+      break;
+    case "git-status":
+      compressed = compressGitStatus(stdout, stderr, exitCode);
+      break;
+    case "directory-listing":
+      compressed = compressDirectoryListing(stdout, stderr, exitCode);
+      break;
+    case "search-results":
+      compressed = compressSearchResults(stdout, stderr, exitCode);
+      break;
+    case "build-lint":
+      compressed = compressBuildOutput(stdout, stderr, exitCode);
+      break;
+  }
+
+  const compressedLength = compressed.length;
+
+  // Only use compressed version if it's actually shorter
+  if (compressedLength >= originalLength) {
+    return {
+      compressed: "",
+      originalLength,
+      compressedLength: originalLength,
+      category,
+      wasCompressed: false,
+    };
+  }
+
+  log.debug(
+    {
+      category,
+      originalLength,
+      compressedLength,
+      savings: `${((1 - compressedLength / originalLength) * 100).toFixed(1)}%`,
+    },
+    "Shell output compressed",
+  );
+
+  return {
+    compressed,
+    originalLength,
+    compressedLength,
+    category,
+    wasCompressed: true,
+  };
+}

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -3,7 +3,13 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
 import { safeStringSlice } from "../../util/unicode.js";
+import { compressShellOutput } from "./shell-compression/index.js";
+
+const log = getLogger("shell-output");
 
 export const MAX_OUTPUT_LENGTH = 20_000;
 
@@ -40,10 +46,32 @@ export function formatShellOutput(
   code: number | null,
   timedOut: boolean,
   timeoutSec: number,
+  options?: { command?: string },
 ): ShellOutputResult {
   let output = stdout;
   if (stderr) {
     output += (output ? "\n" : "") + stderr;
+  }
+
+  // Command-aware compression: reduce output before the hard truncation
+  // limit so that information is preserved rather than chopped.
+  if (
+    options?.command &&
+    isAssistantFeatureFlagEnabled("shell-output-compression", getConfig())
+  ) {
+    const result = compressShellOutput(options.command, stdout, stderr, code);
+    if (result.wasCompressed) {
+      output = result.compressed;
+      log.debug(
+        {
+          category: result.category,
+          originalLength: result.originalLength,
+          compressedLength: result.compressedLength,
+          savings: `${((1 - result.compressedLength / result.originalLength) * 100).toFixed(1)}%`,
+        },
+        "Shell output compressed",
+      );
+    }
   }
 
   const statusParts: string[] = [];
@@ -57,7 +85,10 @@ export function formatShellOutput(
   if (output.length > MAX_OUTPUT_LENGTH) {
     let fullOutputPath: string | undefined;
     try {
-      fullOutputPath = join(tmpdir(), `vellum-shell-output-${randomUUID()}.txt`);
+      fullOutputPath = join(
+        tmpdir(),
+        `vellum-shell-output-${randomUUID()}.txt`,
+      );
       writeFileSync(fullOutputPath, output, { encoding: "utf-8", mode: 0o600 });
       trackedTempFiles.add(fullOutputPath);
     } catch {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -383,6 +383,7 @@ class ShellTool implements Tool {
           code,
           timedOut,
           timeoutSec,
+          { command },
         );
 
         resolve({


### PR DESCRIPTION
## Summary
- Create compressShellOutput orchestrator routing commands to per-category compressors
- Add optional { command } param to formatShellOutput, apply compression when flag is enabled
- Thread command string through shell.ts, host-shell.ts, and host-bash-proxy.ts callers
- Add integration tests verifying flag on/off, unknown commands, and backward compat

Part of plan: shell-output-compression.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
