### PR TITLE
fix: remove duplicate logging, preserve stderr in compressors, remove dead interface

### DIFF
--- a/assistant/src/tools/shared/shell-compression/compressors/directory-listing.ts
+++ b/assistant/src/tools/shared/shell-compression/compressors/directory-listing.ts
@@ -24,24 +24,33 @@ export function compressDirectoryListing(
     (l) => /^[dlcbps-][rwxsStT-]{9}/.test(l) || /^total\s+\d+/.test(l),
   );
 
+  let result: string;
+
   if (isLsLa) {
-    return compressLsOutput(lines);
+    result = compressLsOutput(lines);
+  } else {
+    // Check for find-style output: lines that look like file paths.
+    // Covers ./path, /path, and relative paths like src/file.ts.
+    const isFind = lines.every(
+      (l) =>
+        l.startsWith("./") ||
+        l.startsWith("/") ||
+        (/\//.test(l) && !/^\s/.test(l)),
+    );
+    if (isFind) {
+      result = compressFindOutput(lines);
+    } else {
+      // Plain ls (just filenames) — group by extension
+      result = compressPlainLs(lines);
+    }
   }
 
-  // Check for find-style output: lines that look like file paths.
-  // Covers ./path, /path, and relative paths like src/file.ts.
-  const isFind = lines.every(
-    (l) =>
-      l.startsWith("./") ||
-      l.startsWith("/") ||
-      (/\//.test(l) && !/^\s/.test(l)),
-  );
-  if (isFind) {
-    return compressFindOutput(lines);
+  // Preserve stderr (e.g., "Permission denied" warnings) even on success
+  if (stderr.trim()) {
+    result += "\n\n--- stderr ---\n" + stderr.trim();
   }
 
-  // Plain ls (just filenames) — group by extension
-  return compressPlainLs(lines);
+  return result;
 }
 
 function compressLsOutput(lines: string[]): string {

--- a/assistant/src/tools/shared/shell-compression/compressors/git-status.ts
+++ b/assistant/src/tools/shared/shell-compression/compressors/git-status.ts
@@ -58,5 +58,10 @@ export function compressGitStatus(
     }
   }
 
+  // Preserve stderr (e.g., warnings) even on success
+  if (stderr.trim()) {
+    result.push("", "--- stderr ---", stderr.trim());
+  }
+
   return result.join("\n");
 }

--- a/assistant/src/tools/shared/shell-compression/compressors/search-results.ts
+++ b/assistant/src/tools/shared/shell-compression/compressors/search-results.ts
@@ -53,5 +53,11 @@ export function compressSearchResults(
   result.push(
     `(${byFile.size} files, ${lines.length - nonMatchLines.length} matches total)`,
   );
+
+  // Preserve stderr (e.g., "binary file matches" warnings) even on success
+  if (stderr.trim()) {
+    result.push("", "--- stderr ---", stderr.trim());
+  }
+
   return result.join("\n");
 }

--- a/assistant/src/tools/shared/shell-compression/index.ts
+++ b/assistant/src/tools/shared/shell-compression/index.ts
@@ -1,4 +1,3 @@
-import { getLogger } from "../../../util/logger.js";
 import { compressBuildOutput } from "./compressors/build-lint.js";
 import { compressDirectoryListing } from "./compressors/directory-listing.js";
 import { compressGitDiff } from "./compressors/git-diff.js";
@@ -7,8 +6,6 @@ import { compressSearchResults } from "./compressors/search-results.js";
 import { compressTestOutput } from "./compressors/test-runner.js";
 import { detectCommand } from "./detect-command.js";
 import type { CompressionResult } from "./types.js";
-
-const log = getLogger("shell-compression");
 
 /** Minimum output length before compression is attempted. */
 const MIN_LENGTH = 2000;
@@ -85,16 +82,6 @@ export function compressShellOutput(
       wasCompressed: false,
     };
   }
-
-  log.debug(
-    {
-      category,
-      originalLength,
-      compressedLength,
-      savings: `${((1 - compressedLength / originalLength) * 100).toFixed(1)}%`,
-    },
-    "Shell output compressed",
-  );
 
   return {
     compressed,

--- a/assistant/src/tools/shared/shell-compression/types.ts
+++ b/assistant/src/tools/shared/shell-compression/types.ts
@@ -14,7 +14,3 @@ export interface CompressionResult {
   category: CommandCategory;
   wasCompressed: boolean;
 }
-
-export interface Compressor {
-  compress(stdout: string, stderr: string, exitCode: number | null): string;
-}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for shell-output-compression.md.

**Gap:** Duplicate debug logging + compressors drop stderr on success
**What was expected:** Single log site, stderr preserved
**What was found:** Both index.ts and shell-output.ts logged; git-status/directory-listing/search-results ignored stderr on exitCode=0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
