### PR TITLE
fix: auto-register and inject platform credentials after teleport to local/docker

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -58,9 +58,12 @@ const leaseGuardianTokenMock = mock(async () => ({
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 }));
 
+const computeDeviceIdMock = mock(() => "device-id-123");
+
 mock.module("../lib/guardian-token.js", () => ({
   loadGuardianToken: loadGuardianTokenMock,
   leaseGuardianToken: leaseGuardianTokenMock,
+  computeDeviceId: computeDeviceIdMock,
 }));
 
 const readPlatformTokenMock = mock((): string | null => "platform-token");
@@ -145,6 +148,23 @@ const checkExistingPlatformAssistantMock = mock(
   async (): Promise<{ id: string; name: string; status: string } | null> =>
     null,
 );
+const ensureSelfHostedLocalRegistrationMock = mock(async () => ({
+  assistant: { id: "platform-assistant-1", name: "my-assistant" },
+  registration: {
+    client_installation_id: "device-id-123",
+    runtime_assistant_id: "target-local",
+    client_platform: "cli",
+  },
+  assistant_api_key: "api-key-123",
+  webhook_secret: "webhook-secret-123",
+}));
+const injectCredentialsIntoAssistantMock = mock(async () => true);
+const fetchCurrentUserMock = mock(async () => ({
+  id: "user-1",
+  email: "test@example.com",
+  display: "Test",
+}));
+const fetchOrganizationIdMock = mock(async () => "org-1");
 
 mock.module("../lib/platform-client.js", () => ({
   readPlatformToken: readPlatformTokenMock,
@@ -160,6 +180,10 @@ mock.module("../lib/platform-client.js", () => ({
   platformUploadToSignedUrl: platformUploadToSignedUrlMock,
   platformImportPreflightFromGcs: platformImportPreflightFromGcsMock,
   platformImportBundleFromGcs: platformImportBundleFromGcsMock,
+  ensureSelfHostedLocalRegistration: ensureSelfHostedLocalRegistrationMock,
+  injectCredentialsIntoAssistant: injectCredentialsIntoAssistantMock,
+  fetchCurrentUser: fetchCurrentUserMock,
+  fetchOrganizationId: fetchOrganizationIdMock,
 }));
 
 const hatchLocalMock = mock(async () => {});
@@ -347,6 +371,29 @@ beforeEach(() => {
   });
   checkExistingPlatformAssistantMock.mockReset();
   checkExistingPlatformAssistantMock.mockResolvedValue(null);
+  ensureSelfHostedLocalRegistrationMock.mockReset();
+  ensureSelfHostedLocalRegistrationMock.mockResolvedValue({
+    assistant: { id: "platform-assistant-1", name: "my-assistant" },
+    registration: {
+      client_installation_id: "device-id-123",
+      runtime_assistant_id: "target-local",
+      client_platform: "cli",
+    },
+    assistant_api_key: "api-key-123",
+    webhook_secret: "webhook-secret-123",
+  });
+  injectCredentialsIntoAssistantMock.mockReset();
+  injectCredentialsIntoAssistantMock.mockResolvedValue(true);
+  fetchCurrentUserMock.mockReset();
+  fetchCurrentUserMock.mockResolvedValue({
+    id: "user-1",
+    email: "test@example.com",
+    display: "Test",
+  });
+  fetchOrganizationIdMock.mockReset();
+  fetchOrganizationIdMock.mockResolvedValue("org-1");
+  computeDeviceIdMock.mockReset();
+  computeDeviceIdMock.mockReturnValue("device-id-123");
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -2148,6 +2195,169 @@ describe("credential import display", () => {
       expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/8");
       expect(consoleLogSpy).toHaveBeenCalledWith(
         "  Platform credentials skipped: 3",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Platform credential injection after teleport
+// ---------------------------------------------------------------------------
+
+describe("teleport platform credential injection", () => {
+  test("platform→local teleport calls ensureSelfHostedLocalRegistration and injectCredentialsIntoAssistant", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", {
+      cloud: "local",
+      bearerToken: "local-bearer",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalledWith(
+        "platform-token",
+        "org-1",
+        "device-id-123",
+        "my-local",
+        "cli",
+      );
+      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalledWith({
+        gatewayUrl: "http://localhost:7821",
+        bearerToken: "local-bearer",
+        assistantApiKey: "api-key-123",
+        platformAssistantId: "platform-assistant-1",
+        platformBaseUrl: "https://platform.vellum.ai",
+        organizationId: "org-1",
+        userId: "user-1",
+        webhookSecret: "webhook-secret-123",
+      });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Platform credentials injected.",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("platform→docker teleport also calls credential injection", async () => {
+    setArgv("--from", "my-platform", "--docker", "my-docker");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:8821",
+      bearerToken: "docker-bearer",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-docker") return dockerEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Platform credentials injected.",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("local→local teleport does NOT call credential injection", async () => {
+    setArgv("--from", "my-local", "--docker", "my-docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:8821",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "my-docker") return dockerEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("if user is not logged in (readPlatformToken returns null), injection is skipped gracefully", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // The readPlatformToken mock is called twice during teleport:
+    // once during the platform export flow and once during credential injection.
+    // We need the first call to return a token (for the export to work)
+    // and the second call to return null (to test the skip path).
+    let callCount = 0;
+    readPlatformTokenMock.mockImplementation(() => {
+      callCount++;
+      // The platform export path calls readPlatformToken first;
+      // the credential injection helper calls it after import.
+      // Return null only on the last call (the injection helper).
+      if (callCount <= 1) return "platform-token";
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Skipped platform credential injection (not logged in).",
+      );
+      // Teleport still succeeds
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -9,6 +9,7 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 import {
   loadGuardianToken,
   leaseGuardianToken,
+  computeDeviceId,
 } from "../lib/guardian-token.js";
 import {
   readPlatformToken,
@@ -25,6 +26,10 @@ import {
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
   platformPollImportStatus,
+  ensureSelfHostedLocalRegistration,
+  injectCredentialsIntoAssistant,
+  fetchCurrentUser,
+  fetchOrganizationId,
 } from "../lib/platform-client.js";
 import {
   hatchDocker,
@@ -1104,6 +1109,54 @@ function printImportSummary(result: ImportResponse): void {
   }
 }
 
+/**
+ * After teleporting to a local/docker target, register the assistant with
+ * the platform and inject fresh platform credentials — mirroring the
+ * login flow. Non-fatal: failures are logged as warnings.
+ */
+async function tryInjectPlatformCredentials(
+  entry: AssistantEntry,
+): Promise<void> {
+  const token = readPlatformToken();
+  if (!token) {
+    console.log("  Skipped platform credential injection (not logged in).");
+    return;
+  }
+
+  try {
+    const user = await fetchCurrentUser(token);
+    const orgId = await fetchOrganizationId(token);
+    const clientInstallationId = computeDeviceId();
+    const registration = await ensureSelfHostedLocalRegistration(
+      token,
+      orgId,
+      clientInstallationId,
+      entry.assistantId,
+      "cli",
+    );
+
+    const allInjected = await injectCredentialsIntoAssistant({
+      gatewayUrl: entry.runtimeUrl,
+      bearerToken: entry.bearerToken,
+      assistantApiKey: registration.assistant_api_key,
+      platformAssistantId: registration.assistant.id,
+      platformBaseUrl: getPlatformUrl(),
+      organizationId: orgId,
+      userId: user.id,
+      webhookSecret: registration.webhook_secret,
+    });
+
+    if (allInjected) {
+      console.log("  Platform credentials injected.");
+    } else {
+      console.warn("  Some platform credentials could not be injected.");
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  Platform credential injection skipped: ${msg}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -1436,6 +1489,13 @@ export async function teleport(): Promise<void> {
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
   await importToAssistant(toEntry, toCloud, bundleData, false);
+
+  // After successful import, inject fresh platform credentials if the
+  // user is logged in — replaces the source's stale vellum:* credentials
+  // that were filtered during import.
+  if (fromCloud === "vellum") {
+    await tryInjectPlatformCredentials(toEntry);
+  }
 
   // Retire source after successful import
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {


### PR DESCRIPTION
## Summary
- Add `tryInjectPlatformCredentials` helper that registers the local/docker assistant with the platform and injects fresh `vellum:*` credentials
- Call this helper after successful import when teleporting from platform to local/docker
- Non-fatal: failures are logged as warnings and don't block the teleport
- Add tests verifying credential injection for platform→local, platform→docker, and skip behavior

Part of plan: teleport-credential-fixes.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
