### PR TITLE
fix(ui): confirmation surface buttons always send canonical action IDs

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1272,7 +1272,13 @@ export function buildCompletionSummary(
           : undefined;
       return cancelLabel ? `User chose: "${cancelLabel}"` : "Cancelled";
     }
-    if (actionId === "confirm") return "Confirmed";
+    if (actionId === "confirm") {
+      const confirmLabel =
+        typeof surfaceData?.confirmLabel === "string"
+          ? surfaceData.confirmLabel
+          : undefined;
+      return confirmLabel ? `User chose: "${confirmLabel}"` : "Confirmed";
+    }
     // Preserve the actual action ID so the LLM knows the user's exact choice
     // (e.g. "deny", "no", "reject") rather than misreporting it as confirmed.
     return `User selected: ${actionId}`;
@@ -1319,7 +1325,13 @@ export function buildUserFacingLabel(
           : undefined;
       return cancelLabel ?? "Cancelled";
     }
-    if (actionId === "confirm") return "Confirmed";
+    if (actionId === "confirm") {
+      const confirmLabel =
+        typeof surfaceData?.confirmLabel === "string"
+          ? surfaceData.confirmLabel
+          : undefined;
+      return confirmLabel ?? "Confirmed";
+    }
     return `Selected: ${actionId}`;
   }
   if (surfaceType === "form") return "Submitted";

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -21,22 +21,12 @@ public struct ConfirmationSurfaceView: View {
     }
 
     /// The action ID to emit when the user cancels.
-    /// Uses the first server-provided action ID if exactly 2 actions are defined, otherwise defaults to "cancel".
-    private var cancelActionId: String {
-        if actions.count == 2 {
-            return actions[0].id
-        }
-        return "cancel"
-    }
+    /// Always "cancel" — the visible label is controlled by `data.cancelLabel`.
+    private var cancelActionId: String { "cancel" }
 
     /// The action ID to emit when the user confirms.
-    /// Uses the second server-provided action ID if exactly 2 actions are defined, otherwise defaults to "confirm".
-    private var confirmActionId: String {
-        if actions.count == 2 {
-            return actions[1].id
-        }
-        return "confirm"
-    }
+    /// Always "confirm" — the visible label is controlled by `data.confirmLabel`.
+    private var confirmActionId: String { "confirm" }
 
     public var body: some View {
         Group {


### PR DESCRIPTION
## Summary
- **Client**: `ConfirmationSurfaceView` now always sends `"cancel"` / `"confirm"` as action IDs instead of reading from the `actions` array by position. Labels are already controlled by `data.cancelLabel` / `data.confirmLabel`.
- **Server**: `buildCompletionSummary` and `buildUserFacingLabel` now include the custom `confirmLabel` when the user confirms (e.g. `User chose: "Archive"` instead of generic `Confirmed`).
- **Root cause**: When the LLM generated the `actions` array with entries in non-standard order, clicking "Archive" could send `"cancel"` as the actionId, making the assistant think the user cancelled.

## Test plan
- [ ] Create a confirmation surface with `confirmLabel: "Archive"` and verify clicking Archive sends `"confirm"` (not the action array entry)
- [ ] Verify the LLM receives `User chose: "Archive"` in the completion summary
- [ ] Verify confirmation surfaces without custom labels still show "Confirmed" / "Cancelled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
