### PR TITLE
fix: correct credentialsImported semantics and add missing type declarations

### DIFF
--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -207,6 +207,7 @@ export interface ImportCommitSuccessResponse {
     succeeded: number;
     failed: number;
     failedAccounts: string[];
+    skippedPlatform?: number;
   };
 }
 

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -98,6 +98,7 @@ export interface MigrationWizardState {
     succeeded: number;
     failed: number;
     failedAccounts: string[];
+    skippedPlatform?: number;
   };
 
   /** Timestamp of last state change (ISO 8601). */

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -524,7 +524,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
           );
           const succeeded = userCredentials.length - failedResults.length;
           credentialsImported = {
-            total: bundleCredentials.length,
+            total: userCredentials.length,
             succeeded,
             failed: failedResults.length,
             failedAccounts: failedResults.map((f) => f.account),
@@ -540,12 +540,19 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
           result.report.warnings.push(
             `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
           );
+          credentialsImported = {
+            total: userCredentials.length,
+            succeeded: 0,
+            failed: userCredentials.length,
+            failedAccounts: userCredentials.map((c) => c.account),
+            skippedPlatform,
+          };
         }
       } else if (skippedPlatform > 0) {
         // All credentials in the bundle were platform credentials — report
         // the skip count even though nothing was sent to CES.
         credentialsImported = {
-          total: bundleCredentials.length,
+          total: userCredentials.length,
           succeeded: 0,
           failed: 0,
           failedAccounts: [],


### PR DESCRIPTION
## Summary
- Fix `total` semantics in `credentialsImported` to mean 'credentials attempted for import' (not including skipped platform creds)
- Add `skippedPlatform?` to type declarations in migration-wizard.ts and migration-transport.ts
- Set `credentialsImported` in the error catch path so CLI gets structured info on import failure

Fixes gaps identified during plan review for teleport-credential-fixes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
