### PR TITLE
fix: align test mock data with corrected total semantics

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -2178,7 +2178,7 @@ describe("credential import display", () => {
           backups_created: 1,
         },
         credentialsImported: {
-          total: 8,
+          total: 5,
           succeeded: 5,
           failed: 0,
           failedAccounts: [],
@@ -2192,7 +2192,7 @@ describe("credential import display", () => {
 
     try {
       await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/8");
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
       expect(consoleLogSpy).toHaveBeenCalledWith(
         "  Platform credentials skipped: 3",
       );


### PR DESCRIPTION
## Summary
- Fix test mock data in the 'shows platform credentials skipped count' test to use total=5 (matching server behavior where total = user credentials only)
- Update assertion from 'Credentials imported: 5/8' to 'Credentials imported: 5/5'

Fixes test data inconsistency found during plan review for teleport-credential-fixes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
