### PR TITLE
Fix teleport credential handling

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -135,6 +135,42 @@ describe("extractCredentialsFromBundle", () => {
       value: "value with spaces & special=chars!",
     });
   });
+
+  test("extracts vellum:-prefixed credentials (filtering happens in migration-routes)", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set(
+      "credentials/vellum:assistant_api_key",
+      makeTarEntry("key-123"),
+    );
+    entries.set(
+      "credentials/vellum:platform_assistant_id",
+      makeTarEntry("asst-456"),
+    );
+    entries.set("credentials/openai-key", makeTarEntry("sk-user-789"));
+
+    const manifest = makeManifest([
+      "credentials/vellum:assistant_api_key",
+      "credentials/vellum:platform_assistant_id",
+      "credentials/openai-key",
+    ]);
+    const credentials = extractCredentialsFromBundle(entries, manifest);
+
+    // extractCredentialsFromBundle does NOT filter — it returns all credentials.
+    // Filtering of vellum:* platform credentials is done in migration-routes.ts.
+    expect(credentials).toHaveLength(3);
+    expect(credentials).toContainEqual({
+      account: "vellum:assistant_api_key",
+      value: "key-123",
+    });
+    expect(credentials).toContainEqual({
+      account: "vellum:platform_assistant_id",
+      value: "asst-456",
+    });
+    expect(credentials).toContainEqual({
+      account: "openai-key",
+      value: "sk-user-789",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -207,6 +207,7 @@ export interface ImportCommitSuccessResponse {
     succeeded: number;
     failed: number;
     failedAccounts: string[];
+    skippedPlatform?: number;
   };
 }
 

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -98,6 +98,7 @@ export interface MigrationWizardState {
     succeeded: number;
     failed: number;
     failedAccounts: string[];
+    skippedPlatform?: number;
   };
 
   /** Timestamp of last state change (ISO 8601). */

--- a/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for platform credential filtering during bundle import.
+ *
+ * The filtering logic in migration-routes.ts uses the PLATFORM_CREDENTIAL_PREFIX
+ * constant ("vellum:") to exclude platform-identity credentials from being
+ * written to the credential store during import. Since the filtering is a simple
+ * array filter, we test the logic directly using the same prefix constant and
+ * extractCredentialsFromBundle function — without needing to drive the full
+ * HTTP handler (which has heavy transitive dependencies).
+ *
+ * Covers:
+ * - vellum:* credentials are excluded when filtering with the prefix
+ * - User credentials (without vellum: prefix) pass through unchanged
+ * - Mixed bundles correctly split platform vs user credentials
+ * - skippedPlatform count is accurate
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { extractCredentialsFromBundle } from "../../migrations/vbundle-importer.js";
+import type {
+  ManifestType,
+  VBundleTarEntry,
+} from "../../migrations/vbundle-validator.js";
+
+// ---------------------------------------------------------------------------
+// The same constant used by migration-routes.ts
+// ---------------------------------------------------------------------------
+
+const PLATFORM_CREDENTIAL_PREFIX = "vellum:";
+
+// ---------------------------------------------------------------------------
+// Helpers (same pattern as vbundle-import-credentials.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeTarEntry(data: string): VBundleTarEntry {
+  const encoded = new TextEncoder().encode(data);
+  return { name: "", data: encoded, size: encoded.length };
+}
+
+function makeManifest(paths: string[]): ManifestType {
+  return {
+    schema_version: "1.0.0",
+    created_at: new Date().toISOString(),
+    source: "test",
+    manifest_sha256: "test",
+    files: paths.map((path) => ({
+      path,
+      size: 0,
+      sha256: "test",
+    })),
+  } as ManifestType;
+}
+
+/**
+ * Simulate the filtering logic from migration-routes.ts:
+ *
+ *   const userCredentials = bundleCredentials.filter(
+ *     (c) => !c.account.startsWith(PLATFORM_CREDENTIAL_PREFIX),
+ *   );
+ */
+function filterCredentials(
+  bundleCredentials: Array<{ account: string; value: string }>,
+) {
+  const userCredentials = bundleCredentials.filter(
+    (c) => !c.account.startsWith(PLATFORM_CREDENTIAL_PREFIX),
+  );
+  const skippedPlatform = bundleCredentials.length - userCredentials.length;
+  return { userCredentials, skippedPlatform };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("migration import credential filtering", () => {
+  test("vellum:-prefixed credentials are excluded", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/vellum:assistant_api_key", makeTarEntry("key-1"));
+    entries.set(
+      "credentials/vellum:platform_assistant_id",
+      makeTarEntry("asst-2"),
+    );
+    entries.set(
+      "credentials/vellum:platform_base_url",
+      makeTarEntry("https://example.com"),
+    );
+    entries.set(
+      "credentials/vellum:platform_organization_id",
+      makeTarEntry("org-3"),
+    );
+    entries.set("credentials/vellum:platform_user_id", makeTarEntry("user-4"));
+    entries.set("credentials/vellum:webhook_secret", makeTarEntry("whsec-5"));
+
+    const manifest = makeManifest([
+      "credentials/vellum:assistant_api_key",
+      "credentials/vellum:platform_assistant_id",
+      "credentials/vellum:platform_base_url",
+      "credentials/vellum:platform_organization_id",
+      "credentials/vellum:platform_user_id",
+      "credentials/vellum:webhook_secret",
+    ]);
+
+    const bundleCredentials = extractCredentialsFromBundle(entries, manifest);
+    const { userCredentials, skippedPlatform } =
+      filterCredentials(bundleCredentials);
+
+    expect(userCredentials).toHaveLength(0);
+    expect(skippedPlatform).toBe(6);
+  });
+
+  test("user credentials without vellum: prefix pass through unchanged", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/openai-key", makeTarEntry("sk-user-123"));
+    entries.set("credentials/anthropic-key", makeTarEntry("sk-ant-456"));
+
+    const manifest = makeManifest([
+      "credentials/openai-key",
+      "credentials/anthropic-key",
+    ]);
+
+    const bundleCredentials = extractCredentialsFromBundle(entries, manifest);
+    const { userCredentials, skippedPlatform } =
+      filterCredentials(bundleCredentials);
+
+    expect(userCredentials).toHaveLength(2);
+    expect(userCredentials).toContainEqual({
+      account: "openai-key",
+      value: "sk-user-123",
+    });
+    expect(userCredentials).toContainEqual({
+      account: "anthropic-key",
+      value: "sk-ant-456",
+    });
+    expect(skippedPlatform).toBe(0);
+  });
+
+  test("mixed bundle with both vellum:* and user credentials correctly splits", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set(
+      "credentials/vellum:assistant_api_key",
+      makeTarEntry("platform-key"),
+    );
+    entries.set(
+      "credentials/vellum:platform_user_id",
+      makeTarEntry("platform-user"),
+    );
+    entries.set("credentials/openai-key", makeTarEntry("sk-user-123"));
+    entries.set("credentials/anthropic-key", makeTarEntry("sk-ant-456"));
+    entries.set("credentials/github-token", makeTarEntry("ghp-789"));
+
+    const manifest = makeManifest([
+      "credentials/vellum:assistant_api_key",
+      "credentials/vellum:platform_user_id",
+      "credentials/openai-key",
+      "credentials/anthropic-key",
+      "credentials/github-token",
+    ]);
+
+    const bundleCredentials = extractCredentialsFromBundle(entries, manifest);
+    const { userCredentials, skippedPlatform } =
+      filterCredentials(bundleCredentials);
+
+    // Only user credentials should pass through
+    expect(userCredentials).toHaveLength(3);
+    const accounts = userCredentials.map((c) => c.account).sort();
+    expect(accounts).toEqual(["anthropic-key", "github-token", "openai-key"]);
+
+    // No vellum: credentials in the filtered output
+    const vellumCreds = userCredentials.filter((c) =>
+      c.account.startsWith("vellum:"),
+    );
+    expect(vellumCreds).toHaveLength(0);
+
+    expect(skippedPlatform).toBe(2);
+  });
+
+  test("skippedPlatform count is accurate with mixed credentials", () => {
+    const entries = new Map<string, VBundleTarEntry>();
+    entries.set("credentials/vellum:assistant_api_key", makeTarEntry("v1"));
+    entries.set("credentials/vellum:platform_base_url", makeTarEntry("v2"));
+    entries.set("credentials/vellum:webhook_secret", makeTarEntry("v3"));
+    entries.set("credentials/user-key", makeTarEntry("user-val"));
+
+    const manifest = makeManifest([
+      "credentials/vellum:assistant_api_key",
+      "credentials/vellum:platform_base_url",
+      "credentials/vellum:webhook_secret",
+      "credentials/user-key",
+    ]);
+
+    const bundleCredentials = extractCredentialsFromBundle(entries, manifest);
+    const { userCredentials, skippedPlatform } =
+      filterCredentials(bundleCredentials);
+
+    expect(skippedPlatform).toBe(3);
+    expect(userCredentials).toHaveLength(1);
+    expect(userCredentials[0]).toEqual({
+      account: "user-key",
+      value: "user-val",
+    });
+
+    // Verify total = user + skipped
+    expect(bundleCredentials.length).toBe(
+      userCredentials.length + skippedPlatform,
+    );
+  });
+});

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -524,7 +524,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
           );
           const succeeded = userCredentials.length - failedResults.length;
           credentialsImported = {
-            total: bundleCredentials.length,
+            total: userCredentials.length,
             succeeded,
             failed: failedResults.length,
             failedAccounts: failedResults.map((f) => f.account),
@@ -540,12 +540,19 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
           result.report.warnings.push(
             `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
           );
+          credentialsImported = {
+            total: userCredentials.length,
+            succeeded: 0,
+            failed: userCredentials.length,
+            failedAccounts: userCredentials.map((c) => c.account),
+            skippedPlatform,
+          };
         }
       } else if (skippedPlatform > 0) {
         // All credentials in the bundle were platform credentials — report
         // the skip count even though nothing was sent to CES.
         credentialsImported = {
-          total: bundleCredentials.length,
+          total: userCredentials.length,
           succeeded: 0,
           failed: 0,
           failedAccounts: [],

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -45,6 +45,9 @@ import {
 } from "../migrations/vbundle-importer.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 
+/** Credentials with this prefix are platform-identity keys and must not be imported. */
+const PLATFORM_CREDENTIAL_PREFIX = "vellum:";
+
 const log = getLogger("migration-routes");
 
 /**
@@ -483,6 +486,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
           succeeded: number;
           failed: number;
           failedAccounts: string[];
+          skippedPlatform: number;
         }
       | undefined;
 
@@ -491,9 +495,22 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
         validation.entries,
         validation.manifest!,
       );
-      if (bundleCredentials.length > 0) {
+
+      // Filter out platform-identity credentials (vellum:*) — these are
+      // environment-specific and must not overwrite the target's own identity.
+      const userCredentials = bundleCredentials.filter(
+        (c) => !c.account.startsWith(PLATFORM_CREDENTIAL_PREFIX),
+      );
+      const skippedPlatform = bundleCredentials.length - userCredentials.length;
+      if (skippedPlatform > 0) {
+        log.info(
+          `Skipped ${skippedPlatform} platform credential(s) from import`,
+        );
+      }
+
+      if (userCredentials.length > 0) {
         try {
-          const credResults = await bulkSetSecureKeysAsync(bundleCredentials);
+          const credResults = await bulkSetSecureKeysAsync(userCredentials);
           const failedResults = credResults.filter((r) => !r.ok);
           if (failedResults.length > 0) {
             log.warn(
@@ -502,15 +519,16 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
             );
           }
           log.info(
-            { total: bundleCredentials.length, failed: failedResults.length },
+            { total: userCredentials.length, failed: failedResults.length },
             "Credential import complete",
           );
-          const succeeded = bundleCredentials.length - failedResults.length;
+          const succeeded = userCredentials.length - failedResults.length;
           credentialsImported = {
             total: bundleCredentials.length,
             succeeded,
             failed: failedResults.length,
             failedAccounts: failedResults.map((f) => f.account),
+            skippedPlatform,
           };
           if (failedResults.length > 0) {
             result.report.warnings.push(
@@ -523,6 +541,16 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
             `Credential import failed: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
+      } else if (skippedPlatform > 0) {
+        // All credentials in the bundle were platform credentials — report
+        // the skip count even though nothing was sent to CES.
+        credentialsImported = {
+          total: bundleCredentials.length,
+          succeeded: 0,
+          failed: 0,
+          failedAccounts: [],
+          skippedPlatform,
+        };
       }
     }
 

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -2178,7 +2178,7 @@ describe("credential import display", () => {
           backups_created: 1,
         },
         credentialsImported: {
-          total: 8,
+          total: 5,
           succeeded: 5,
           failed: 0,
           failedAccounts: [],
@@ -2192,7 +2192,7 @@ describe("credential import display", () => {
 
     try {
       await teleport();
-      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/8");
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
       expect(consoleLogSpy).toHaveBeenCalledWith(
         "  Platform credentials skipped: 3",
       );

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1973,3 +1973,184 @@ describe("version guard: block platform→non-platform when target is behind", (
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Credential import display tests
+// ---------------------------------------------------------------------------
+
+describe("credential import display", () => {
+  test("prints credential counts when credentialsImported is present", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformImportBundleFromGcsMock.mockResolvedValue({
+      statusCode: 200,
+      body: {
+        success: true,
+        summary: {
+          total_files: 3,
+          files_created: 2,
+          files_overwritten: 1,
+          files_skipped: 0,
+          backups_created: 1,
+        },
+        credentialsImported: {
+          total: 5,
+          succeeded: 5,
+          failed: 0,
+          failedAccounts: [],
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/5");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not print credential line when credentialsImported is absent (old server)", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Mock the GCS import path (used by default since platformRequestUploadUrl
+    // succeeds) with a response that has no credentialsImported field, simulating
+    // an older server.
+    platformImportBundleFromGcsMock.mockResolvedValue({
+      statusCode: 200,
+      body: {
+        success: true,
+        summary: {
+          total_files: 3,
+          files_created: 2,
+          files_overwritten: 1,
+          files_skipped: 0,
+          backups_created: 1,
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      const allLogCalls = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]);
+      const credentialLines = allLogCalls.filter(
+        (msg: string) =>
+          typeof msg === "string" && msg.includes("Credentials imported"),
+      );
+      expect(credentialLines).toHaveLength(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("lists failed credential accounts individually", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformImportBundleFromGcsMock.mockResolvedValue({
+      statusCode: 200,
+      body: {
+        success: true,
+        summary: {
+          total_files: 3,
+          files_created: 2,
+          files_overwritten: 1,
+          files_skipped: 0,
+          backups_created: 1,
+        },
+        credentialsImported: {
+          total: 5,
+          succeeded: 3,
+          failed: 2,
+          failedAccounts: ["google:user@example.com", "github:octocat"],
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 3/5");
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials failed:  2");
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "    - google:user@example.com",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith("    - github:octocat");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("shows platform credentials skipped count", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformImportBundleFromGcsMock.mockResolvedValue({
+      statusCode: 200,
+      body: {
+        success: true,
+        summary: {
+          total_files: 3,
+          files_created: 2,
+          files_overwritten: 1,
+          files_skipped: 0,
+          backups_created: 1,
+        },
+        credentialsImported: {
+          total: 8,
+          succeeded: 5,
+          failed: 0,
+          failedAccounts: [],
+          skippedPlatform: 3,
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/8");
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Platform credentials skipped: 3",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -58,9 +58,12 @@ const leaseGuardianTokenMock = mock(async () => ({
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 }));
 
+const computeDeviceIdMock = mock(() => "device-id-123");
+
 mock.module("../lib/guardian-token.js", () => ({
   loadGuardianToken: loadGuardianTokenMock,
   leaseGuardianToken: leaseGuardianTokenMock,
+  computeDeviceId: computeDeviceIdMock,
 }));
 
 const readPlatformTokenMock = mock((): string | null => "platform-token");
@@ -145,6 +148,23 @@ const checkExistingPlatformAssistantMock = mock(
   async (): Promise<{ id: string; name: string; status: string } | null> =>
     null,
 );
+const ensureSelfHostedLocalRegistrationMock = mock(async () => ({
+  assistant: { id: "platform-assistant-1", name: "my-assistant" },
+  registration: {
+    client_installation_id: "device-id-123",
+    runtime_assistant_id: "target-local",
+    client_platform: "cli",
+  },
+  assistant_api_key: "api-key-123",
+  webhook_secret: "webhook-secret-123",
+}));
+const injectCredentialsIntoAssistantMock = mock(async () => true);
+const fetchCurrentUserMock = mock(async () => ({
+  id: "user-1",
+  email: "test@example.com",
+  display: "Test",
+}));
+const fetchOrganizationIdMock = mock(async () => "org-1");
 
 mock.module("../lib/platform-client.js", () => ({
   readPlatformToken: readPlatformTokenMock,
@@ -160,6 +180,10 @@ mock.module("../lib/platform-client.js", () => ({
   platformUploadToSignedUrl: platformUploadToSignedUrlMock,
   platformImportPreflightFromGcs: platformImportPreflightFromGcsMock,
   platformImportBundleFromGcs: platformImportBundleFromGcsMock,
+  ensureSelfHostedLocalRegistration: ensureSelfHostedLocalRegistrationMock,
+  injectCredentialsIntoAssistant: injectCredentialsIntoAssistantMock,
+  fetchCurrentUser: fetchCurrentUserMock,
+  fetchOrganizationId: fetchOrganizationIdMock,
 }));
 
 const hatchLocalMock = mock(async () => {});
@@ -347,6 +371,29 @@ beforeEach(() => {
   });
   checkExistingPlatformAssistantMock.mockReset();
   checkExistingPlatformAssistantMock.mockResolvedValue(null);
+  ensureSelfHostedLocalRegistrationMock.mockReset();
+  ensureSelfHostedLocalRegistrationMock.mockResolvedValue({
+    assistant: { id: "platform-assistant-1", name: "my-assistant" },
+    registration: {
+      client_installation_id: "device-id-123",
+      runtime_assistant_id: "target-local",
+      client_platform: "cli",
+    },
+    assistant_api_key: "api-key-123",
+    webhook_secret: "webhook-secret-123",
+  });
+  injectCredentialsIntoAssistantMock.mockReset();
+  injectCredentialsIntoAssistantMock.mockResolvedValue(true);
+  fetchCurrentUserMock.mockReset();
+  fetchCurrentUserMock.mockResolvedValue({
+    id: "user-1",
+    email: "test@example.com",
+    display: "Test",
+  });
+  fetchOrganizationIdMock.mockReset();
+  fetchOrganizationIdMock.mockResolvedValue("org-1");
+  computeDeviceIdMock.mockReset();
+  computeDeviceIdMock.mockReturnValue("device-id-123");
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -2148,6 +2195,169 @@ describe("credential import display", () => {
       expect(consoleLogSpy).toHaveBeenCalledWith("  Credentials imported: 5/8");
       expect(consoleLogSpy).toHaveBeenCalledWith(
         "  Platform credentials skipped: 3",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Platform credential injection after teleport
+// ---------------------------------------------------------------------------
+
+describe("teleport platform credential injection", () => {
+  test("platform→local teleport calls ensureSelfHostedLocalRegistration and injectCredentialsIntoAssistant", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", {
+      cloud: "local",
+      bearerToken: "local-bearer",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalledWith(
+        "platform-token",
+        "org-1",
+        "device-id-123",
+        "my-local",
+        "cli",
+      );
+      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalledWith({
+        gatewayUrl: "http://localhost:7821",
+        bearerToken: "local-bearer",
+        assistantApiKey: "api-key-123",
+        platformAssistantId: "platform-assistant-1",
+        platformBaseUrl: "https://platform.vellum.ai",
+        organizationId: "org-1",
+        userId: "user-1",
+        webhookSecret: "webhook-secret-123",
+      });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Platform credentials injected.",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("platform→docker teleport also calls credential injection", async () => {
+    setArgv("--from", "my-platform", "--docker", "my-docker");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:8821",
+      bearerToken: "docker-bearer",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-docker") return dockerEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Platform credentials injected.",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("local→local teleport does NOT call credential injection", async () => {
+    setArgv("--from", "my-local", "--docker", "my-docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("my-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:8821",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "my-docker") return dockerEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("if user is not logged in (readPlatformToken returns null), injection is skipped gracefully", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // The readPlatformToken mock is called twice during teleport:
+    // once during the platform export flow and once during credential injection.
+    // We need the first call to return a token (for the export to work)
+    // and the second call to return null (to test the skip path).
+    let callCount = 0;
+    readPlatformTokenMock.mockImplementation(() => {
+      callCount++;
+      // The platform export path calls readPlatformToken first;
+      // the credential injection helper calls it after import.
+      // Return null only on the last call (the injection helper).
+      if (callCount <= 1) return "platform-token";
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+      expect(ensureSelfHostedLocalRegistrationMock).not.toHaveBeenCalled();
+      expect(injectCredentialsIntoAssistantMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "  Skipped platform credential injection (not logged in).",
+      );
+      // Teleport still succeeds
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -9,6 +9,7 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 import {
   loadGuardianToken,
   leaseGuardianToken,
+  computeDeviceId,
 } from "../lib/guardian-token.js";
 import {
   readPlatformToken,
@@ -25,6 +26,10 @@ import {
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
   platformPollImportStatus,
+  ensureSelfHostedLocalRegistration,
+  injectCredentialsIntoAssistant,
+  fetchCurrentUser,
+  fetchOrganizationId,
 } from "../lib/platform-client.js";
 import {
   hatchDocker,
@@ -1104,6 +1109,54 @@ function printImportSummary(result: ImportResponse): void {
   }
 }
 
+/**
+ * After teleporting to a local/docker target, register the assistant with
+ * the platform and inject fresh platform credentials — mirroring the
+ * login flow. Non-fatal: failures are logged as warnings.
+ */
+async function tryInjectPlatformCredentials(
+  entry: AssistantEntry,
+): Promise<void> {
+  const token = readPlatformToken();
+  if (!token) {
+    console.log("  Skipped platform credential injection (not logged in).");
+    return;
+  }
+
+  try {
+    const user = await fetchCurrentUser(token);
+    const orgId = await fetchOrganizationId(token);
+    const clientInstallationId = computeDeviceId();
+    const registration = await ensureSelfHostedLocalRegistration(
+      token,
+      orgId,
+      clientInstallationId,
+      entry.assistantId,
+      "cli",
+    );
+
+    const allInjected = await injectCredentialsIntoAssistant({
+      gatewayUrl: entry.runtimeUrl,
+      bearerToken: entry.bearerToken,
+      assistantApiKey: registration.assistant_api_key,
+      platformAssistantId: registration.assistant.id,
+      platformBaseUrl: getPlatformUrl(),
+      organizationId: orgId,
+      userId: user.id,
+      webhookSecret: registration.webhook_secret,
+    });
+
+    if (allInjected) {
+      console.log("  Platform credentials injected.");
+    } else {
+      console.warn("  Some platform credentials could not be injected.");
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  Platform credential injection skipped: ${msg}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -1436,6 +1489,13 @@ export async function teleport(): Promise<void> {
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
   await importToAssistant(toEntry, toCloud, bundleData, false);
+
+  // After successful import, inject fresh platform credentials if the
+  // user is logged in — replaces the source's stale vellum:* credentials
+  // that were filtered during import.
+  if (fromCloud === "vellum") {
+    await tryInjectPlatformCredentials(toEntry);
+  }
 
   // Retire source after successful import
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -609,6 +609,13 @@ interface ImportResponse {
     files_skipped: number;
     backups_created: number;
   };
+  credentialsImported?: {
+    total: number;
+    succeeded: number;
+    failed: number;
+    failedAccounts: string[];
+    skippedPlatform?: number;
+  };
 }
 
 async function importToAssistant(
@@ -1072,6 +1079,20 @@ function printImportSummary(result: ImportResponse): void {
   console.log(`  Files overwritten: ${summary.files_overwritten}`);
   console.log(`  Files skipped:     ${summary.files_skipped}`);
   console.log(`  Backups created:   ${summary.backups_created}`);
+
+  const creds = result.credentialsImported;
+  if (creds) {
+    console.log(`  Credentials imported: ${creds.succeeded}/${creds.total}`);
+    if (creds.skippedPlatform) {
+      console.log(`  Platform credentials skipped: ${creds.skippedPlatform}`);
+    }
+    if (creds.failed > 0) {
+      console.log(`  Credentials failed:  ${creds.failed}`);
+      for (const account of creds.failedAccounts) {
+        console.log(`    - ${account}`);
+      }
+    }
+  }
 
   const warnings = result.warnings ?? [];
   if (warnings.length > 0) {


### PR DESCRIPTION
## Summary
Fix three issues with how teleport transfers credentials between environments:

1. **Filter `vellum:*` platform-identity credentials during import** — prevents the source's stale platform credentials from overwriting the target's own platform identity
2. **Auto-register and inject fresh platform credentials** — after teleporting from platform to local/docker, automatically registers the target with the platform and injects fresh `vellum:*` credentials (mirroring the login flow)
3. **Surface credential import results in CLI** — displays credential import counts, skipped platform creds, and failed accounts in teleport output

## Self-review result
PASS — 3 gaps found and fixed across 2 fix PRs

## PRs merged into feature branch
- #25867: fix: filter `vellum:*` platform-identity credentials during bundle import
- #25866: feat: display credential import results in teleport CLI output
- #25871: fix: auto-register and inject platform credentials after teleport to local/docker

### Fix PRs
- #25873: fix: correct credentialsImported total semantics, add type declarations, handle error path
- #25874: fix: align test mock data with corrected total semantics

Part of plan: teleport-credential-fixes.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
