### PR TITLE
refactor(macos): extract formatDuration and add ThinkingStepRow scaffold

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -696,7 +696,7 @@ private struct StepDetailRow: View {
                         }
 
                         if let start = toolCall.startedAt, let end = toolCall.completedAt, toolCall.isComplete {
-                            Text(formatDuration(end.timeIntervalSince(start)))
+                            Text(formatStepDuration(end.timeIntervalSince(start)))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
@@ -930,12 +930,78 @@ private struct StepDetailRow: View {
         return attributed
     }
 
-    private func formatDuration(_ seconds: TimeInterval) -> String {
-        seconds < 60
-            ? String(format: "%.1fs", seconds)
-            : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+}
+
+// MARK: - Format Duration (shared)
+
+/// Formats a time interval as a human-readable duration string.
+/// Shared between StepDetailRow and ThinkingStepRow.
+private func formatStepDuration(_ seconds: TimeInterval) -> String {
+    seconds < 60
+        ? String(format: "%.1fs", seconds)
+        : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+}
+
+// MARK: - Thinking Step Row
+
+/// Synthetic sub-activity row shown when all tool calls in a progress card have
+/// completed but the assistant is still working (thinking/processing phase).
+/// Explains the time gap between the last tool completion and the card's total
+/// elapsed time.
+private struct ThinkingStepRow: View {
+    /// When thinking started (typically `latestCompletedAt` of the tool group).
+    let startDate: Date
+    /// When thinking ended. Nil while still active.
+    let completedAt: Date?
+    /// Whether the thinking phase is still in progress.
+    let isActive: Bool
+
+    /// Minimum thinking duration (in seconds) required to show this row.
+    /// Prevents visual noise for fast completions where the model responds
+    /// almost immediately after the last tool finishes.
+    private static let minimumDisplayDuration: TimeInterval = 2.0
+
+    /// Whether the row should be rendered at all. Suppressed for very short
+    /// thinking phases that would just add clutter.
+    var shouldDisplay: Bool {
+        if isActive { return true }
+        guard let end = completedAt else { return false }
+        return end.timeIntervalSince(startDate) >= Self.minimumDisplayDuration
     }
 
+    var body: some View {
+        if shouldDisplay {
+            HStack(spacing: VSpacing.sm) {
+                if isActive {
+                    VBusyIndicator(size: 6)
+                        .frame(width: 16)
+                } else {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundStyle(VColor.primaryBase)
+                        .frame(width: 16)
+                }
+
+                Text("Thinking")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Spacer()
+
+                HStack(spacing: VSpacing.xs) {
+                    if isActive {
+                        ElapsedTimeLabel(startDate: startDate)
+                    } else if let end = completedAt {
+                        Text(formatStepDuration(end.timeIntervalSince(startDate)))
+                            .font(VFont.labelSmall)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                }
+            }
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs))
+            .padding(EdgeInsets(top: 0, leading: VSpacing.sm, bottom: 0, trailing: VSpacing.xs))
+        }
+    }
 }
 
 // MARK: - Processing Dots Label (Isolated TimelineView)


### PR DESCRIPTION
## Summary
- Extract `formatDuration` from `StepDetailRow` to a file-level `formatStepDuration` function so it can be shared across step row types
- Add `ThinkingStepRow` view struct that renders a synthetic "Thinking" sub-activity row (not yet wired into the progress card)
- Part 1 of 3: progress card improvements to show thinking time between tool calls

## Test plan
- [x] `swift build` passes
- [x] `swift test --filter ProgressCard` — all 47 tests pass
- [ ] No behavioral change — `ThinkingStepRow` is defined but not rendered yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
