### PR TITLE
fix: retry once when model returns empty response after tool results

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1708,4 +1708,127 @@ describe("AgentLoop", () => {
     // Turn 4 should NOT have the nudge (exceeded limit)
     expect(hasRetryNudge(4)).toBe(false);
   });
+
+  // Empty response retry — model returns no text and no tool_use after tool results
+  test("retries once when model returns empty response after tool results", async () => {
+    const emptyResponse: ProviderResponse = {
+      content: [],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 0 },
+      stopReason: "end_turn",
+    };
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      emptyResponse, // First response after tool result: empty
+      textResponse("Here is what I found in the file."), // Retry response: has text
+    ]);
+
+    const toolExecutor = async () => ({
+      content: "file contents here",
+      isError: false,
+    });
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // Provider should be called 3 times: initial, empty response, retry
+    expect(calls).toHaveLength(3);
+
+    // The retry call should include the nudge message
+    const retryMessages = calls[2].messages;
+    const lastMsg = retryMessages[retryMessages.length - 1];
+    expect(lastMsg.role).toBe("user");
+    expect(
+      lastMsg.content.some(
+        (b) =>
+          b.type === "text" &&
+          "text" in b &&
+          (b as { text: string }).text.includes("previous response was empty"),
+      ),
+    ).toBe(true);
+
+    // Final history should have the successful text response
+    const lastAssistant = [...history]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    expect(lastAssistant).toBeDefined();
+    expect(lastAssistant!.content).toEqual([
+      { type: "text", text: "Here is what I found in the file." },
+    ]);
+
+    // message_complete emitted for tool_use response + retry text response (not the empty one)
+    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    expect(messageCompletes).toHaveLength(2);
+  });
+
+  test("gives up after max empty response retries", async () => {
+    const emptyResponse: ProviderResponse = {
+      content: [],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 0 },
+      stopReason: "end_turn",
+    };
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/a.txt" }),
+      emptyResponse, // First response after tool result: empty
+      emptyResponse, // Retry also empty — should give up
+    ]);
+
+    const toolExecutor = async () => ({
+      content: "file contents here",
+      isError: false,
+    });
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // Provider called 3 times: initial, empty, retry (also empty)
+    expect(calls).toHaveLength(3);
+
+    // message_complete: tool_use response + final empty response (retry exhausted)
+    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    expect(messageCompletes).toHaveLength(2);
+
+    // The last assistant message in history is the empty one
+    const lastAssistant = [...history]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    expect(lastAssistant).toBeDefined();
+    expect(lastAssistant!.content).toEqual([]);
+  });
+
+  test("does not retry empty response on first turn (no prior tool use)", async () => {
+    const emptyResponse: ProviderResponse = {
+      content: [],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 0 },
+      stopReason: "end_turn",
+    };
+
+    const { provider, calls } = createMockProvider([emptyResponse]);
+
+    const loop = new AgentLoop(provider, "system");
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // Should NOT retry — this is the first turn with no tool use history
+    expect(calls).toHaveLength(1);
+    expect(history).toHaveLength(2); // user + empty assistant
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -109,6 +109,7 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 };
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
+const MAX_EMPTY_RESPONSE_RETRIES = 1;
 
 export interface ResolvedSystemPrompt {
   systemPrompt: string;
@@ -207,6 +208,7 @@ export class AgentLoop {
     const history = [...messages];
     let toolUseTurns = 0;
     let consecutiveErrorTurns = 0;
+    let emptyResponseRetries = 0;
     let lastLlmCallTime = 0;
     const rlog = requestId ? log.child({ requestId }) : log;
 
@@ -398,15 +400,53 @@ export class AgentLoop {
           role: "assistant",
           content: response.content,
         };
-        history.push(assistantMessage);
-
-        await onEvent({ type: "message_complete", message: assistantMessage });
 
         // Check for tool use
         toolUseBlocks = response.content.filter(
           (block): block is Extract<ContentBlock, { type: "tool_use" }> =>
             block.type === "tool_use",
         );
+
+        // Detect empty responses: no user-visible text and no tool calls.
+        // This can happen when the model fails to produce output after
+        // receiving a large tool result. Retry once with a nudge before
+        // the message is persisted.
+        const hasVisibleText = response.content.some(
+          (block) => block.type === "text" && block.text.trim().length > 0,
+        );
+        if (
+          !hasVisibleText &&
+          toolUseBlocks.length === 0 &&
+          toolUseTurns > 0 &&
+          emptyResponseRetries < MAX_EMPTY_RESPONSE_RETRIES
+        ) {
+          emptyResponseRetries++;
+          rlog.warn(
+            { turn: toolUseTurns, retry: emptyResponseRetries },
+            "Model returned empty response after tool results — retrying",
+          );
+          history.push({
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>",
+              },
+            ],
+          });
+          continue;
+        }
+
+        if (!hasVisibleText && toolUseBlocks.length === 0 && toolUseTurns > 0) {
+          rlog.error(
+            { turn: toolUseTurns, retries: emptyResponseRetries },
+            "Model returned empty response after tool results — retries exhausted",
+          );
+        }
+
+        history.push(assistantMessage);
+
+        await onEvent({ type: "message_complete", message: assistantMessage });
 
         if (toolUseBlocks.length === 0 || !this.toolExecutor) {
           break;


### PR DESCRIPTION
## Summary
- When the model produces no text and no tool_use blocks after receiving tool results, the agent loop now retries once with a nudge before persisting the empty message
- Previously, an empty response was silently accepted and persisted, causing "Completed 1 step" with no visible output
- The retry nudge instructs the model to respond with a text summary of what it found

## Context
Observed in production: user asked assistant to scan 30 days of inbox for archives. `gmail_sender_digest` returned a 46KB result. The model then produced a completely empty response — no text, no tool calls. The progress card showed "Completed 1 step" but the user saw nothing.

## Test plan
- [x] New tests: empty response triggers retry, retry succeeds with text
- [x] New tests: retry exhaustion persists empty message with error log
- [x] New tests: empty response on first turn (no prior tool use) is not retried
- [x] All 43 existing agent-loop tests pass
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
