### PR TITLE
fix: cap gmail_sender_digest result size to prevent oversized output

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -498,7 +498,7 @@
           },
           "max_senders": {
             "type": "number",
-            "description": "Maximum senders to return (default 50)"
+            "description": "Maximum senders to return (default 50, max 75)"
           },
           "page_token": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -19,6 +19,9 @@ function isRateLimitError(e: unknown): boolean {
 const MAX_MESSAGES_CAP = 5000;
 const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
+const MAX_SENDERS_CAP = 75;
+const MAX_SUBJECT_LENGTH = 80;
+const MAX_RESULT_BYTES = 24_000;
 
 interface SenderAggregation {
   displayName: string;
@@ -60,7 +63,10 @@ export async function run(
     (input.max_messages as number) ?? 2000,
     MAX_MESSAGES_CAP,
   );
-  const maxSenders = (input.max_senders as number) ?? 50;
+  const maxSenders = Math.min(
+    (input.max_senders as number) ?? 50,
+    MAX_SENDERS_CAP,
+  );
   const inputPageToken = input.page_token as string | undefined;
 
   try {
@@ -265,7 +271,7 @@ export async function run(
       .sort((a, b) => b.messageCount - a.messageCount)
       .slice(0, maxSenders);
 
-    const resultSenders = sorted.map((s) => ({
+    let resultSenders = sorted.map((s) => ({
       id: Buffer.from(s.email).toString("base64url"),
       display_name: s.displayName || s.email.split("@")[0],
       email: s.email,
@@ -280,17 +286,38 @@ export async function run(
       newest_date: s.newestDate,
       // Preserve original query filters so follow-up searches stay scoped
       search_query: `from:${s.email} ${query}`,
-      sample_subjects: s.sampleSubjects,
+      sample_subjects: s.sampleSubjects.map((subj) =>
+        subj.length > MAX_SUBJECT_LENGTH
+          ? subj.slice(0, MAX_SUBJECT_LENGTH) + "…"
+          : subj,
+      ),
     }));
+
+    // Trim senders if the serialized result would exceed the byte budget.
+    // Senders are already sorted by message_count desc, so we drop the
+    // least-active ones first.
+    while (resultSenders.length > 1) {
+      const probe = JSON.stringify({ senders: resultSenders });
+      if (probe.length <= MAX_RESULT_BYTES) break;
+      resultSenders.pop();
+    }
+
+    // Build a set of sender IDs that survived the trim so the scan store
+    // only holds entries the LLM can reference.
+    const keptSenderIds = new Set(resultSenders.map((s) => s.id));
 
     // Store message IDs server-side to keep them out of LLM context
     const scanId = storeScanResult(
-      sorted.map((s) => ({
-        id: Buffer.from(s.email).toString("base64url"),
-        messageIds: s.messageIds,
-        newestMessageId: s.newestMessageId,
-        newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
-      })),
+      sorted
+        .filter((s) =>
+          keptSenderIds.has(Buffer.from(s.email).toString("base64url")),
+        )
+        .map((s) => ({
+          id: Buffer.from(s.email).toString("base64url"),
+          messageIds: s.messageIds,
+          newestMessageId: s.newestMessageId,
+          newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+        })),
     );
 
     return ok(


### PR DESCRIPTION
## Summary
- Hard cap `max_senders` at 75 (model was requesting 100, producing 46KB results)
- Truncate sample subject lines to 80 characters
- If the serialized result still exceeds 24KB, progressively drop least-active senders until it fits

## Context
Companion to #25880. The model called `gmail_sender_digest` with `max_senders: 100`, received a 46KB JSON response, and then produced a completely empty response. This PR reduces the tool's output size to stay well within the model's effective processing range.

The scan store still only holds entries that appear in the trimmed result, so `gmail_archive` calls using the `scan_id` will work correctly.

## Test plan
- [x] Type check clean
- [x] `messaging-skill-split.test.ts` passes (validates TOOLS.json structure)
- [ ] Manual: trigger `gmail_sender_digest` with `max_senders: 100` and verify result is under 24KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
