### PR TITLE
feat(macos): show thinking sub-activity row in progress card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -34,6 +34,12 @@ struct AssistantProgressView: View {
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
+    /// When the post-tool-completion thinking phase started (typically the last
+    /// tool's `completedAt`). Nil until all tools complete and the card remains active.
+    @State private var thinkingAfterToolsStartDate: Date?
+    /// When the thinking phase ended (card transitioned to `.complete`).
+    /// Nil while thinking is still in progress.
+    @State private var thinkingAfterToolsEndDate: Date?
 
     // MARK: - Init
 
@@ -86,12 +92,40 @@ struct AssistantProgressView: View {
         } else {
             nil
         }
+        // Seed thinking timestamps for view recycling.
+        // If we have a persisted thinking duration (from a previous render that survived
+        // through completion), reconstruct the dates. Otherwise, seed from model state.
+        let cardKeyForInit = toolCalls.first?.id
+        let persistedThinkingDuration = cardKeyForInit.flatMap {
+            progressUIState.wrappedValue.thinkingDuration(for: $0)
+        }
+        let initialThinkingStart: Date?
+        let initialThinkingEnd: Date?
+        if let duration = persistedThinkingDuration, let latestEnd = model.latestCompletedAt {
+            // Reconstruct from persisted duration
+            initialThinkingStart = latestEnd
+            initialThinkingEnd = latestEnd.addingTimeInterval(duration)
+        } else if model.allComplete && model.hasTools {
+            let phase = model.phase
+            if phase == .toolsCompleteThinking || phase == .processing {
+                initialThinkingStart = model.latestCompletedAt ?? Date()
+                initialThinkingEnd = nil
+            } else {
+                initialThinkingStart = nil
+                initialThinkingEnd = nil
+            }
+        } else {
+            initialThinkingStart = nil
+            initialThinkingEnd = nil
+        }
         // Seed from user override via ProgressCardUIState if one exists, otherwise use model's auto-expand.
         let cardKey = toolCalls.first?.id
         let resolved = progressUIState.wrappedValue.resolveCardExpanded(cardKey: cardKey, model: model)
         _isExpanded = State(initialValue: resolved)
         _startDate = State(initialValue: initialStartDate)
         _processingStartDate = State(initialValue: initialProcessingStartDate)
+        _thinkingAfterToolsStartDate = State(initialValue: initialThinkingStart)
+        _thinkingAfterToolsEndDate = State(initialValue: initialThinkingEnd)
     }
 
     /// Stable key for this progress card in `progressUIState.cardExpansionOverrides`.
@@ -254,6 +288,21 @@ struct AssistantProgressView: View {
                 processingStartDate = Date()
                 if model.earliestStartedAt == nil {
                     startDate = Date()
+                }
+            }
+            // Track thinking phase start: all tools complete, card still active.
+            if (newPhase == .toolsCompleteThinking || newPhase == .processing)
+                && model.allComplete && model.hasTools
+                && thinkingAfterToolsStartDate == nil {
+                thinkingAfterToolsStartDate = model.latestCompletedAt ?? Date()
+            }
+            // Track thinking phase end: card transitioned to complete.
+            if newPhase == .complete, let thinkingStart = thinkingAfterToolsStartDate, thinkingAfterToolsEndDate == nil {
+                thinkingAfterToolsEndDate = Date()
+                // Persist duration so it survives view recycling.
+                if let key = cardKey {
+                    let duration = Date().timeIntervalSince(thinkingStart)
+                    progressUIState.setThinkingDuration(for: key, duration: duration)
                 }
             }
             if shouldAutoExpandOnPhaseChange, !isExpanded {
@@ -509,6 +558,15 @@ struct AssistantProgressView: View {
                     )
                     .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 }
+            }
+
+            // Synthetic "Thinking" row for the post-tool-completion thinking phase.
+            if let thinkingStart = thinkingAfterToolsStartDate, model.allComplete, model.hasTools {
+                ThinkingStepRow(
+                    startDate: thinkingStart,
+                    completedAt: thinkingAfterToolsEndDate,
+                    isActive: model.isActive
+                )
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -696,7 +696,7 @@ private struct StepDetailRow: View {
                         }
 
                         if let start = toolCall.startedAt, let end = toolCall.completedAt, toolCall.isComplete {
-                            Text(formatDuration(end.timeIntervalSince(start)))
+                            Text(formatStepDuration(end.timeIntervalSince(start)))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
@@ -930,12 +930,78 @@ private struct StepDetailRow: View {
         return attributed
     }
 
-    private func formatDuration(_ seconds: TimeInterval) -> String {
-        seconds < 60
-            ? String(format: "%.1fs", seconds)
-            : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+}
+
+// MARK: - Format Duration (shared)
+
+/// Formats a time interval as a human-readable duration string.
+/// Shared between StepDetailRow and ThinkingStepRow.
+private func formatStepDuration(_ seconds: TimeInterval) -> String {
+    seconds < 60
+        ? String(format: "%.1fs", seconds)
+        : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+}
+
+// MARK: - Thinking Step Row
+
+/// Synthetic sub-activity row shown when all tool calls in a progress card have
+/// completed but the assistant is still working (thinking/processing phase).
+/// Explains the time gap between the last tool completion and the card's total
+/// elapsed time.
+private struct ThinkingStepRow: View {
+    /// When thinking started (typically `latestCompletedAt` of the tool group).
+    let startDate: Date
+    /// When thinking ended. Nil while still active.
+    let completedAt: Date?
+    /// Whether the thinking phase is still in progress.
+    let isActive: Bool
+
+    /// Minimum thinking duration (in seconds) required to show this row.
+    /// Prevents visual noise for fast completions where the model responds
+    /// almost immediately after the last tool finishes.
+    private static let minimumDisplayDuration: TimeInterval = 2.0
+
+    /// Whether the row should be rendered at all. Suppressed for very short
+    /// thinking phases that would just add clutter.
+    var shouldDisplay: Bool {
+        if isActive { return true }
+        guard let end = completedAt else { return false }
+        return end.timeIntervalSince(startDate) >= Self.minimumDisplayDuration
     }
 
+    var body: some View {
+        if shouldDisplay {
+            HStack(spacing: VSpacing.sm) {
+                if isActive {
+                    VBusyIndicator(size: 6)
+                        .frame(width: 16)
+                } else {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundStyle(VColor.primaryBase)
+                        .frame(width: 16)
+                }
+
+                Text("Thinking")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Spacer()
+
+                HStack(spacing: VSpacing.xs) {
+                    if isActive {
+                        ElapsedTimeLabel(startDate: startDate)
+                    } else if let end = completedAt {
+                        Text(formatStepDuration(end.timeIntervalSince(startDate)))
+                            .font(VFont.labelSmall)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                }
+            }
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs))
+            .padding(EdgeInsets(top: 0, leading: VSpacing.sm, bottom: 0, trailing: VSpacing.xs))
+        }
+    }
 }
 
 // MARK: - Processing Dots Label (Isolated TimelineView)

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -27,6 +27,13 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// pending-confirmation heuristics.
     var cardExpansionOverrides: [UUID: Bool] = [:]
 
+    // MARK: - Thinking Duration Persistence
+
+    /// Per-card thinking durations (in seconds) for the post-tool-completion
+    /// thinking phase. Keyed by the first tool call UUID in the group.
+    /// Persisted so the thinking row survives view recycling with correct timing.
+    var thinkingDurations: [UUID: TimeInterval] = [:]
+
     // MARK: - Rehydration Tracking
 
     /// Set of group IDs (first tool call UUID) for which rehydration has already
@@ -57,6 +64,11 @@ struct ProgressCardUIState: Equatable, Sendable {
             return override
         }
         return model.shouldAutoExpand
+    }
+
+    /// Returns the persisted thinking duration for the given card, or nil if none.
+    func thinkingDuration(for cardKey: UUID) -> TimeInterval? {
+        thinkingDurations[cardKey]
     }
 
     /// Whether rehydration has already been performed for the given group.
@@ -90,6 +102,11 @@ struct ProgressCardUIState: Equatable, Sendable {
         cardExpansionOverrides[cardKey] = expanded
     }
 
+    /// Stores the thinking duration for a completed card so it survives view recycling.
+    mutating func setThinkingDuration(for cardKey: UUID, duration: TimeInterval) {
+        thinkingDurations[cardKey] = duration
+    }
+
     /// Marks a group as having been rehydrated.
     mutating func markRehydrated(groupId: UUID) {
         rehydratedGroupIds.insert(groupId)
@@ -99,6 +116,7 @@ struct ProgressCardUIState: Equatable, Sendable {
     mutating func reset() {
         expandedStepIds.removeAll()
         cardExpansionOverrides.removeAll()
+        thinkingDurations.removeAll()
         rehydratedGroupIds.removeAll()
     }
 }


### PR DESCRIPTION
## Summary
- Wire `ThinkingStepRow` into progress card's expanded content, showing a "Thinking" row after all tools complete while the assistant is still working
- Track thinking start/end dates via `@State` in `AssistantProgressView`, seeded from model state for view recycling
- Persist thinking duration in `ProgressCardUIState` so it survives `LazyVStack` view recycling
- Suppress thinking row for short durations (< 2s) to avoid visual noise

Stacked on #25879.

## Test plan
- [x] `swift build` passes
- [x] `swift test --filter ProgressCard` — all 47 tests pass
- [ ] Manual: trigger a skill with multi-step tool execution, verify thinking row appears with live timer after tools complete
- [ ] Manual: after card completes, verify thinking row shows final duration with checkmark
- [ ] Manual: verify short thinking phases (< 2s) don't show the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
