### PR TITLE
meet: move workspace migration → skills/meet-join/migrations

### DIFF
--- a/assistant/src/__tests__/workspace-migration-meets.test.ts
+++ b/assistant/src/__tests__/workspace-migration-meets.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createMeetsDirMigration } from "../workspace/migrations/037-create-meets-dir.js";
+import { createMeetsDirMigration } from "../../../skills/meet-join/migrations/037-create-meets-dir.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -34,7 +34,7 @@ import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-co
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
-import { createMeetsDirMigration } from "./037-create-meets-dir.js";
+import { createMeetsDirMigration } from "../../../../skills/meet-join/migrations/037-create-meets-dir.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 

--- a/skills/meet-join/migrations/037-create-meets-dir.ts
+++ b/skills/meet-join/migrations/037-create-meets-dir.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import type { WorkspaceMigration } from "./types.js";
+import type { WorkspaceMigration } from "../../../assistant/src/workspace/migrations/types.js";
 
 /**
  * `.keep` sentinel content. Keeps the directory tracked/visible even when


### PR DESCRIPTION
## Summary
- Moves 037-create-meets-dir migration → skills/meet-join/migrations/
- Preserves sequence number 037 (append-only invariant)
- Updates one import in registry.ts and one in workspace-migration-meets.test.ts

Part of plan: meet-phase-1-9-skill-consolidation.md (PR 8 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
