### PR TITLE
fix(lint): use const for resultSenders in gmail-sender-digest

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -271,7 +271,7 @@ export async function run(
       .sort((a, b) => b.messageCount - a.messageCount)
       .slice(0, maxSenders);
 
-    let resultSenders = sorted.map((s) => ({
+    const resultSenders = sorted.map((s) => ({
       id: Buffer.from(s.email).toString("base64url"),
       display_name: s.displayName || s.email.split("@")[0],
       email: s.email,


### PR DESCRIPTION
## Summary
- Fix lint error on main: \`resultSenders\` is never reassigned (only mutated via \`.pop()\`), so use \`const\` instead of \`let\`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24475347999/job/71525960234
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
