### PR TITLE
fix(lint): sort imports in workspace migrations registry

### DIFF
--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,3 +1,4 @@
+import { createMeetsDirMigration } from "../../../../skills/meet-join/migrations/037-create-meets-dir.js";
 import { avatarRenameMigration } from "./001-avatar-rename.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
@@ -34,7 +35,6 @@ import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-co
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
-import { createMeetsDirMigration } from "../../../../skills/meet-join/migrations/037-create-meets-dir.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 


### PR DESCRIPTION
## Summary
- Ran eslint --fix on \`assistant/src/workspace/migrations/registry.ts\` to resolve \`simple-import-sort/imports\` error blocking CI.
- The cross-directory \`createMeetsDirMigration\` import (from \`../../../../skills/meet-join/migrations/\`) is now correctly grouped before the local \`./\` imports.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24475680424/job/71527100245
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
