### PR TITLE
providers: add Anthropic models to OpenRouter catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -76,6 +76,10 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "openrouter",
     displayName: "OpenRouter",
     models: [
+      // Anthropic
+      { id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6" },
+      { id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6" },
+      { id: "anthropic/claude-haiku-4.5", displayName: "Claude Haiku 4.5" },
       // xAI
       { id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta" },
       { id: "x-ai/grok-4", displayName: "Grok 4" },


### PR DESCRIPTION
## Summary
- Adds Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 to the \`openrouter\` entry in \`PROVIDER_CATALOG\` so they appear in the model picker and pass \`isModelInCatalog()\` validation in \`setModel()\`.
- Uses OpenRouter's conventional \`anthropic/claude-*\` slugs. Default model and model-intent mappings (Grok/Qwen) are intentionally left unchanged — Claude-via-OpenRouter is only used when explicitly selected.
- No provider-layer changes: the existing \`OpenRouterProvider\` (extends \`OpenAIProvider\` with \`reasoning: { enabled: true }\`) already handles tool use, streaming, vision, prompt caching, and extended thinking for Claude models through OpenRouter's OpenAI-compatible API.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
