### PR TITLE
ci(assistant): install skills/meet-join deps so zod resolves

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -82,6 +83,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -120,6 +122,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -48,6 +48,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -89,6 +90,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
@@ -127,6 +129,7 @@ jobs:
         run: |
           cd ../packages/ces-contracts && bun install --frozen-lockfile
           cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts


### PR DESCRIPTION
## Summary
- After the meet-skill restructure, \`skills/meet-join/config-schema.ts\` imports \`zod\` and is loaded by the assistant test/lint/typecheck jobs via \`assistant/src/config/schemas/services.ts\`.
- CI only installs deps for \`skills/meet-join/contracts\`, not the parent \`skills/meet-join\`, so bun's module resolution walks up from the file's location and fails to find \`zod\` — causing mass test failures like \`Cannot find package 'zod' from '.../skills/meet-join/config-schema.ts'\`.
- Add \`cd .. && bun install --frozen-lockfile\` (from the contracts dir, i.e. \`skills/meet-join\`) to all three \`Install linked package dependencies\` steps in both \`ci-main-assistant.yaml\` and \`pr-assistant.yaml\`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24476648935/job/71530473731
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
