### PR TITLE
ci(macos): install skills/meet-join deps for binary build

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -244,7 +244,9 @@ jobs:
       - name: Install nested package dependencies
         run: |
           pids=()
-          for dir in packages/*/; do
+          # The daemon bundles zod via skills/meet-join/{config-schema.ts,contracts}
+          # so those directories need their own node_modules alongside packages/.
+          for dir in packages/*/ skills/meet-join/ skills/meet-join/contracts/; do
             [ -f "${dir}/package.json" ] || continue
             echo "Installing dependencies in ${dir}"
             (cd "${dir}" && bun install) &

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -317,15 +317,22 @@ build_bun_binary() {
 }
 
 # ---------------------------------------------------------------------------
-# install_shared_packages — install node_modules for every package under
-# packages/. assistant/, cli/, gateway/, etc. reference these via file: deps
-# that point at TypeScript source, so the packages need their own node_modules
-# for transitive deps (e.g. zod) to resolve during tsc/bun build. Must run
-# before any build_bun_binary invocation, from any build mode.
+# install_shared_packages — install node_modules for every first-party package
+# that the assistant/cli/gateway binaries import from. They reference these via
+# file: deps (or direct relative imports) that point at TypeScript source, so
+# the packages need their own node_modules for transitive deps (e.g. zod) to
+# resolve during tsc/bun build. Must run before any build_bun_binary invocation,
+# from any build mode.
 # ---------------------------------------------------------------------------
 install_shared_packages() {
     command -v bun &>/dev/null || return 0
-    for pkg_dir in "$SCRIPT_DIR"/../../packages/*/; do
+    local repo_root="$SCRIPT_DIR/../.."
+    local pkg_dirs=("$repo_root"/packages/*/)
+    # The daemon imports MeetServiceSchema from skills/meet-join/config-schema.ts
+    # and @vellumai/meet-contracts (file: → skills/meet-join/contracts), so both
+    # need node_modules for `zod` to resolve during the bundle step.
+    pkg_dirs+=("$repo_root/skills/meet-join/" "$repo_root/skills/meet-join/contracts/")
+    for pkg_dir in "${pkg_dirs[@]}"; do
         [ -f "${pkg_dir}package.json" ] || continue
         (cd "$pkg_dir" && bun install --frozen-lockfile 2>/dev/null || bun install)
     done


### PR DESCRIPTION
## Summary
- Extend `install_shared_packages` in `clients/macos/build.sh` to also install deps for `skills/meet-join/` and `skills/meet-join/contracts/` — the daemon bundle pulls `zod` from both paths.
- Mirror the change in the `ci-main-macos.yaml` pre-install step so the workflow warms the same caches `build.sh` expects.
- Fixes the "Could not resolve: zod" failure in the CI Main macOS build (run 24476387253).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24476387253/job/71529597131
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
