### PR TITLE
meet: move runtime/routes/meet-internal.ts → skills/meet-join/routes

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -66,7 +66,6 @@ describe("route policy coverage", () => {
       "browser-extension-pair-routes.ts",
       "guardian-bootstrap-routes.ts",
       "guardian-refresh-routes.ts",
-      "meet-internal.ts",
     ]);
     const allSources = [httpServerSrc];
     try {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -18,6 +18,10 @@ import { dirname, resolve } from "node:path";
 import type { ServerWebSocket } from "bun";
 
 import {
+  handleMeetInternalEvents,
+  MEET_INTERNAL_EVENTS_PATH_RE,
+} from "../../../skills/meet-join/routes/meet-internal.js";
+import {
   startGuardianActionSweep,
   stopGuardianActionSweep,
 } from "../calls/guardian-action-sweep.js";
@@ -194,10 +198,6 @@ import { twilioRouteDefinitions } from "./routes/integrations/twilio.js";
 import { vercelRouteDefinitions } from "./routes/integrations/vercel.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { logExportRouteDefinitions } from "./routes/log-export-routes.js";
-import {
-  handleMeetInternalEvents,
-  MEET_INTERNAL_EVENTS_PATH_RE,
-} from "./routes/meet-internal.js";
 import { memoryItemRouteDefinitions } from "./routes/memory-item-routes.js";
 import { migrationRollbackRouteDefinitions } from "./routes/migration-rollback-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
@@ -1068,10 +1068,10 @@ export class RuntimeHttpServer {
     // auth because the bot presents a per-meeting bearer token minted by
     // the session manager, not a daemon-minted JWT. The route handler
     // validates the token against `MeetSessionEventRouter.resolveBotApiToken`
-    // — see the comment block in `routes/meet-internal.ts` explaining why
-    // this endpoint does not violate CLAUDE.md's "No New Daemon HTTP Port
-    // Consumers" rule (the bot is an assistant-spawned subprocess, not an
-    // out-of-process CLI tool or sibling service).
+    // — see the comment block in `skills/meet-join/routes/meet-internal.ts`
+    // explaining why this endpoint does not violate CLAUDE.md's "No New
+    // Daemon HTTP Port Consumers" rule (the bot is an assistant-spawned
+    // subprocess, not an out-of-process CLI tool or sibling service).
     const meetInternalMatch = path.match(MEET_INTERNAL_EVENTS_PATH_RE);
     if (meetInternalMatch && req.method === "POST") {
       let meetingId: string;

--- a/skills/meet-join/routes/__tests__/meet-internal.test.ts
+++ b/skills/meet-join/routes/__tests__/meet-internal.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { MeetBotEvent } from "@vellumai/meet-contracts";
 
-import { MeetSessionEventRouter } from "../../../../../skills/meet-join/daemon/session-event-router.js";
+import { MeetSessionEventRouter } from "../../daemon/session-event-router.js";
 import { handleMeetInternalEvents } from "../meet-internal.js";
 
 // ---------------------------------------------------------------------------

--- a/skills/meet-join/routes/meet-internal.ts
+++ b/skills/meet-join/routes/meet-internal.ts
@@ -44,9 +44,9 @@ import { z } from "zod";
 import {
   getMeetSessionEventRouter,
   type MeetSessionEventRouter,
-} from "../../../../skills/meet-join/daemon/session-event-router.js";
-import { getLogger } from "../../util/logger.js";
-import { httpError } from "../http-errors.js";
+} from "../daemon/session-event-router.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import { httpError } from "../../../assistant/src/runtime/http-errors.js";
 
 const log = getLogger("meet-internal-routes");
 


### PR DESCRIPTION
## Summary
- Moves assistant/src/runtime/routes/meet-internal.ts → skills/meet-join/routes/
- Moves its tests similarly
- Updates single import in the central route registry

Part of plan: meet-phase-1-9-skill-consolidation.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
