### PR TITLE
meet: move assistant/src/tools/meet → skills/meet-join/tools

### DIFF
--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,6 +6,8 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
+import { meetJoinTool } from "../../../skills/meet-join/tools/meet-join-tool.js";
+import { meetLeaveTool } from "../../../skills/meet-join/tools/meet-leave-tool.js";
 import { getConfig } from "../config/loader.js";
 import {
   isCesSecureInstallEnabled,
@@ -19,8 +21,6 @@ import { fileEditTool } from "./filesystem/edit.js";
 import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
 import { fileWriteTool } from "./filesystem/write.js";
-import { meetJoinTool } from "./meet/meet-join-tool.js";
-import { meetLeaveTool } from "./meet/meet-leave-tool.js";
 import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -113,7 +113,7 @@ const DEFAULT_DAEMON_PORT = 7821;
  * bot's `needsFullWiring` predicate requires a non-empty `JOIN_NAME`, so
  * this fallback keeps the full-join path reachable even on first boot
  * before `IDENTITY.md` has been written. Matches the tool-side fallback
- * in `assistant/src/tools/meet/meet-join-tool.ts`.
+ * in `skills/meet-join/tools/meet-join-tool.ts`.
  */
 export const MEET_JOIN_NAME_FALLBACK = "AI Assistant";
 
@@ -804,10 +804,7 @@ class MeetSessionManagerImpl {
     try {
       await session.storageWriter.stop();
     } catch (err) {
-      log.warn(
-        { err, meetingId },
-        "MeetStorageWriter.stop threw during leave",
-      );
+      log.warn({ err, meetingId }, "MeetStorageWriter.stop threw during leave");
     }
 
     // Tear down dispatcher subscribers BEFORE unregistering the router so no

--- a/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
@@ -41,7 +41,7 @@ const joinMock = mock(
   }),
 );
 
-mock.module("../../../../../skills/meet-join/daemon/session-manager.js", () => ({
+mock.module("../../daemon/session-manager.js", () => ({
   MeetSessionManager: {
     join: joinMock,
     leave: async () => {},
@@ -50,14 +50,17 @@ mock.module("../../../../../skills/meet-join/daemon/session-manager.js", () => (
   },
 }));
 
-mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) => {
-    if (key === "meet") return flagEnabled;
-    return true;
-  },
-}));
+mock.module(
+  "../../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
 
-mock.module("../../../config/loader.js", () => ({
+mock.module("../../../../assistant/src/config/loader.js", () => ({
   getConfig: () => ({
     services: {
       meet: {
@@ -67,11 +70,11 @@ mock.module("../../../config/loader.js", () => ({
   }),
 }));
 
-mock.module("../../../daemon/identity-helpers.js", () => ({
+mock.module("../../../../assistant/src/daemon/identity-helpers.js", () => ({
   getAssistantName: () => assistantNameValue,
 }));
 
-mock.module("../../../util/logger.js", () => ({
+mock.module("../../../../assistant/src/util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -86,7 +89,7 @@ const {
   DEFAULT_ASSISTANT_NAME,
 } = await import("../meet-join-tool.js");
 
-import type { ToolContext } from "../../types.js";
+import type { ToolContext } from "../../../../assistant/src/tools/types.js";
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {

--- a/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
@@ -27,7 +27,7 @@ const getSessionMock = mock((meetingId: string) => {
   return found ?? null;
 });
 
-mock.module("../../../../../skills/meet-join/daemon/session-manager.js", () => ({
+mock.module("../../daemon/session-manager.js", () => ({
   MeetSessionManager: {
     join: async () => {
       throw new Error("join should not be invoked in leave tests");
@@ -38,31 +38,33 @@ mock.module("../../../../../skills/meet-join/daemon/session-manager.js", () => (
   },
 }));
 
-mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) => {
-    if (key === "meet") return flagEnabled;
-    return true;
-  },
-}));
+mock.module(
+  "../../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
 
-mock.module("../../../config/loader.js", () => ({
+mock.module("../../../../assistant/src/config/loader.js", () => ({
   getConfig: () => ({
     services: { meet: { consentMessage: "unused-in-leave-tests" } },
   }),
 }));
 
-mock.module("../../../util/logger.js", () => ({
+mock.module("../../../../assistant/src/util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
 }));
 
-const { meetLeaveTool, DEFAULT_LEAVE_REASON } = await import(
-  "../meet-leave-tool.js"
-);
+const { meetLeaveTool, DEFAULT_LEAVE_REASON } =
+  await import("../meet-leave-tool.js");
 
-import type { ToolContext } from "../../types.js";
+import type { ToolContext } from "../../../../assistant/src/tools/types.js";
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {

--- a/skills/meet-join/tools/meet-join-tool.ts
+++ b/skills/meet-join/tools/meet-join-tool.ts
@@ -23,14 +23,18 @@ import { randomUUID } from "node:crypto";
 
 import { z } from "zod";
 
-import { MeetSessionManager } from "../../../../skills/meet-join/daemon/session-manager.js";
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
-import { getAssistantName } from "../../daemon/identity-helpers.js";
-import { RiskLevel } from "../../permissions/types.js";
-import type { ToolDefinition } from "../../providers/types.js";
-import { getLogger } from "../../util/logger.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../../assistant/src/config/loader.js";
+import { getAssistantName } from "../../../assistant/src/daemon/identity-helpers.js";
+import { RiskLevel } from "../../../assistant/src/permissions/types.js";
+import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../assistant/src/tools/types.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import { MeetSessionManager } from "../daemon/session-manager.js";
 
 const log = getLogger("meet-join-tool");
 
@@ -51,14 +55,10 @@ export const MEET_URL_REGEX =
   /^https:\/\/meet\.google\.com\/[a-z]{3,4}-?[a-z]{4}-?[a-z]{3,4}(?:\?.*)?$/i;
 
 const MeetJoinInputSchema = z.object({
-  url: z
-    .string()
-    .trim()
-    .min(1, "url is required")
-    .regex(MEET_URL_REGEX, {
-      message:
-        "url must be a Google Meet link (https://meet.google.com/xxx-yyyy-zzz)",
-    }),
+  url: z.string().trim().min(1, "url is required").regex(MEET_URL_REGEX, {
+    message:
+      "url must be a Google Meet link (https://meet.google.com/xxx-yyyy-zzz)",
+  }),
   note: z.string().optional(),
 });
 

--- a/skills/meet-join/tools/meet-leave-tool.ts
+++ b/skills/meet-join/tools/meet-leave-tool.ts
@@ -12,13 +12,17 @@
 
 import { z } from "zod";
 
-import { MeetSessionManager } from "../../../../skills/meet-join/daemon/session-manager.js";
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
-import { RiskLevel } from "../../permissions/types.js";
-import type { ToolDefinition } from "../../providers/types.js";
-import { getLogger } from "../../util/logger.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../../assistant/src/config/loader.js";
+import { RiskLevel } from "../../../assistant/src/permissions/types.js";
+import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../assistant/src/tools/types.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import { MeetSessionManager } from "../daemon/session-manager.js";
 import { MEET_FLAG_KEY } from "./meet-join-tool.js";
 
 const log = getLogger("meet-leave-tool");


### PR DESCRIPTION
## Summary
- Moves assistant/src/tools/meet/ → skills/meet-join/tools/
- Updates imports in the central tool registry
- Imports from daemon now use sibling path (../daemon/) from the new location

Part of plan: meet-phase-1-9-skill-consolidation.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
