### PR TITLE
fix: handle non-local import paths in workspace migration ceiling computation

### DIFF
--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -206,15 +206,16 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const registry = fs.readFileSync('assistant/src/workspace/migrations/registry.ts', 'utf-8');
+            const registryDir = 'assistant/src/workspace/migrations';
             const importMap = {};
-            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]\.\/([^'\x22]+)['\x22];/g)) {
+            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]([^'\x22]+)['\x22];/g)) {
               importMap[m[1]] = m[2];
             }
             const arrayMatch = registry.match(/WORKSPACE_MIGRATIONS[^=]*=\s*\[([\s\S]*?)\]/);
             const entries = arrayMatch[1].match(/\w+/g);
             const lastVar = entries[entries.length - 1];
             const relPath = importMap[lastVar];
-            const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
+            const filePath = path.resolve(registryDir, relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
             const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
             console.log(idMatch[1]);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1141,15 +1141,16 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const registry = fs.readFileSync('assistant/src/workspace/migrations/registry.ts', 'utf-8');
+            const registryDir = 'assistant/src/workspace/migrations';
             const importMap = {};
-            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]\.\/([^'\x22]+)['\x22];/g)) {
+            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]([^'\x22]+)['\x22];/g)) {
               importMap[m[1]] = m[2];
             }
             const arrayMatch = registry.match(/WORKSPACE_MIGRATIONS[^=]*=\s*\[([\s\S]*?)\]/);
             const entries = arrayMatch[1].match(/\w+/g);
             const lastVar = entries[entries.length - 1];
             const relPath = importMap[lastVar];
-            const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
+            const filePath = path.resolve(registryDir, relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
             const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
             console.log(idMatch[1]);


### PR DESCRIPTION
## Summary
- Fix regex in migration ceiling scripts to match any import path, not just `./` relative paths
- Use `path.resolve()` instead of `path.join()` to correctly resolve paths like `../../../../skills/meet-join/migrations/...`
- Applied to both `ci-register-dev-images.yaml` and `release.yml` (same duplicated logic)
- Fixes CI failure where `createMeetsDirMigration` imported from outside the migrations directory caused `relPath` to be undefined
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
