### PR TITLE
daemon: install Docker Engine packages in daemon image

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -87,6 +87,22 @@ RUN apt-get update && apt-get install -y \
     xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Docker Engine (docker-ce, docker-ce-cli, containerd.io).
+# The dockerd daemon remains dormant in this image; a later PR wires up an
+# init supervisor to start it when Docker-in-Docker is needed (e.g. for Meet
+# bot sibling containers). Adds ~200-300 MB to the image.
+RUN apt-get update && apt-get install -y \
+        ca-certificates \
+        curl \
+        gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian trixie stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy bun binary from builder instead of re-installing
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx


### PR DESCRIPTION
## Summary
- Install docker-ce, docker-ce-cli, containerd.io in the daemon Dockerfile.
- dockerd remains dormant — PR 2 of the Phase 1.10 plan adds the init supervisor.
- Image size grows by ~200–300 MB.

Part of plan: meet-phase-1-10-dind.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
