### PR TITLE
providers(openrouter): respect thinking.enabled config

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1182,6 +1182,106 @@ describe("effort config passthrough", () => {
     expect(config.thinking).toBeUndefined();
     expect(config.effort).toBe("high");
   });
+
+  test("thinking is preserved for openrouter provider", async () => {
+    let capturedOptions: SendMessageOptions | undefined;
+    const inner = makeProvider("openrouter", (opts) => {
+      capturedOptions = opts;
+    });
+    const retry = new RetryProvider(inner);
+
+    await retry.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: {
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    const config = capturedOptions?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({ type: "adaptive" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenRouter reasoning ↔ thinking.enabled config
+// ---------------------------------------------------------------------------
+
+describe("OpenRouterProvider reasoning", () => {
+  function userMsg(text: string): Message {
+    return { role: "user", content: [{ type: "text", text }] };
+  }
+
+  beforeEach(() => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+    lastCreateParams = null;
+    lastCreateOptions = null;
+    lastConstructorOptions = null;
+    shouldThrow = null;
+  });
+
+  test("sends reasoning.enabled=true when thinking config is present", async () => {
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "adaptive" } },
+    });
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: true });
+  });
+
+  test("sends reasoning.enabled=false when thinking config is absent", async () => {
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: {},
+    });
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+  });
+
+  test("sends reasoning.enabled=false when no options are provided", async () => {
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+  });
+
+  test("RetryProvider + OpenRouterProvider enables thinking end-to-end", async () => {
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    const retry = new RetryProvider(provider);
+
+    // thinking enabled at loop-level → config.thinking set
+    await retry.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "adaptive" } },
+    });
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: true });
+  });
+
+  test("RetryProvider + OpenRouterProvider disables thinking end-to-end", async () => {
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    const retry = new RetryProvider(provider);
+
+    // thinking disabled at loop-level → config.thinking omitted
+    await retry.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: {},
+    });
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -138,7 +138,7 @@ export class OpenAIProvider implements Provider {
           messages: openaiMessages,
           stream: true as const,
           stream_options: { include_usage: true },
-          ...this.extraCreateParams,
+          ...this.buildExtraCreateParams(options),
         };
 
       if (maxTokens) {
@@ -321,6 +321,12 @@ export class OpenAIProvider implements Provider {
         abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
+  }
+
+  protected buildExtraCreateParams(
+    _options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    return this.extraCreateParams;
   }
 
   /** Convert neutral messages + system prompt to OpenAI message format. */

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,4 +1,5 @@
 import { OpenAIProvider } from "../openai/client.js";
+import type { SendMessageOptions } from "../types.js";
 
 export interface OpenRouterProviderOptions {
   apiKey?: string;
@@ -19,7 +20,19 @@ export class OpenRouterProvider extends OpenAIProvider {
       providerName: "openrouter",
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
-      extraCreateParams: { reasoning: { enabled: true } },
     });
+  }
+
+  // OpenRouter's unified `reasoning` parameter controls extended thinking
+  // across upstream providers (e.g. it maps to Anthropic's `thinking`
+  // parameter for Claude models). Mirror the assistant's `thinking.enabled`
+  // config — loop.ts only sets `config.thinking` when enabled — so users can
+  // turn thinking off on Anthropic models served via OpenRouter.
+  protected override buildExtraCreateParams(
+    options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    const config = options?.config as Record<string, unknown> | undefined;
+    const thinkingEnabled = config?.thinking !== undefined;
+    return { reasoning: { enabled: thinkingEnabled } };
   }
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -26,6 +26,13 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "fireworks",
 ]);
 
+/**
+ * Providers that consume the `thinking` config. Anthropic uses it directly on
+ * the wire; OpenRouter translates it into its unified `reasoning` parameter so
+ * users can control extended thinking on Anthropic models served via OpenRouter.
+ */
+const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter"]);
+
 /** Patterns that indicate a transient streaming corruption from the SDK. */
 const RETRYABLE_STREAM_PATTERNS = [
   "Unexpected event order",
@@ -79,7 +86,7 @@ function normalizeSendMessageOptions(
   const hasIntent = config.modelIntent !== undefined;
 
   const needsThinkingStrip =
-    providerName !== "anthropic" && config.thinking !== undefined;
+    !THINKING_AWARE_PROVIDERS.has(providerName) && config.thinking !== undefined;
   const needsEffortStrip =
     !EFFORT_SUPPORTED_PROVIDERS.has(providerName) && config.effort !== undefined;
   const needsSpeedStrip =
@@ -98,8 +105,12 @@ function normalizeSendMessageOptions(
   const nextConfig: Record<string, unknown> = { ...config };
   delete nextConfig.modelIntent;
 
-  // thinking is Anthropic-specific; strip it for other providers
-  if (providerName !== "anthropic" && nextConfig.thinking !== undefined) {
+  // thinking is Anthropic-specific on the wire; OpenRouter reads it as a
+  // signal for its unified reasoning parameter. Strip it for other providers.
+  if (
+    !THINKING_AWARE_PROVIDERS.has(providerName) &&
+    nextConfig.thinking !== undefined
+  ) {
     delete nextConfig.thinking;
   }
 


### PR DESCRIPTION
## Summary
- OpenRouter was always sending `reasoning: { enabled: true }` regardless of the assistant's `thinking.enabled` setting; it now mirrors the config so users can actually disable extended thinking on Anthropic models routed through OpenRouter.
- Added a `buildExtraCreateParams(options)` hook to `OpenAIProvider` so OpenAI-compatible subclasses can compute per-request extras instead of freezing them at construction.
- Updated `retry.ts` to allow `thinking` through to the openrouter provider (OpenRouter uses it as a signal for its unified `reasoning` parameter, not on the wire).

## Original prompt
The OpenRouter provider should respect the "thinking.enabled" config when sending requests to anthropic