### PR TITLE
docs: Docker Volume Architecture updated for DinD model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,15 +170,15 @@ Use `QDRANT_HTTP_PORT` (not `QDRANT_URL`) when allocating per-instance Qdrant po
 
 ## Docker Volume Architecture
 
-Docker instances use four dedicated volumes with strict per-service access boundaries, plus one host bind-mount for the Meet subsystem. Each volume is mounted only by the services that need it, enforcing least-privilege at the container level.
+Docker instances use five dedicated volumes with strict per-service access boundaries. Each volume is mounted only by the services that need it, enforcing least-privilege at the container level.
 
-| Volume / bind | Mount path | Access | Contents |
+| Volume | Mount path | Access | Contents |
 |---|---|---|---|
 | **Workspace** (`<name>-workspace`) | `/workspace` | Assistant: read-write, Gateway: read-write, CES: read-only | `config.json`, conversations, apps, skills, db, logs, `.backups/`, `.backup.key` |
 | **Gateway security** (`<name>-gateway-sec`) | `/gateway-security` | Gateway only | Files private to the gateway container |
 | **CES security** (`<name>-ces-sec`) | `/ces-security` | CES only | `keys.enc`, `store.key` |
 | **Socket** (`<name>-socket`) | `/run/ces-bootstrap` | Assistant + CES | CES bootstrap socket for initial handshake |
-| **Docker socket** (host bind-mount, not a named volume) | `/var/run/docker.sock` | Assistant: read-write | Host Docker Engine API — used by the Meet subsystem to spawn sibling bot containers. |
+| **Inner dockerd data** (`<name>-dockerd-data`) | `/var/lib/docker` | Assistant only | Docker image cache and container state for the inner `dockerd` running inside the assistant container (Docker-in-Docker model for Meet). Persists the pulled meet-bot image across assistant restarts. |
 
 The assistant's container root (`/`) stores per-container ephemeral and persistent state: package installs (`~/.bun`), `device.json`, and embed-worker PID files. This replaces the former shared data volume which previously held all state.
 
@@ -186,10 +186,17 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 
 - **Trust rules** are owned by the gateway. In Docker mode (`IS_CONTAINERIZED=true`), the assistant reads and writes trust rules via the gateway's HTTP trust API — it has no direct filesystem access to `trust.json`. The gateway reads `trust.json` from `/gateway-security/trust.json`.
 - **Credentials** are owned by the CES. In Docker mode, the assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`). Neither service has direct filesystem access to `keys.enc` or `store.key`.
-- **Meet bots are sibling containers, not nested.** The daemon uses `/var/run/docker.sock` to instruct the host's Docker engine to spawn them. This grants the daemon effective root on the host — acceptable for single-user local deployments, not for managed/multi-tenant mode. Managed/hosted mode is explicitly out of scope for this Docker-socket approach; future managed Meet support needs a different spawn model (see [`vellum-assistant-platform`](../vellum-assistant-platform)).
+- **Meet bots are nested (Docker-in-Docker) in Docker mode.** The assistant container runs its own `dockerd` instance under an init supervisor and spawns meet-bot containers against that inner engine. The assistant container itself runs `--privileged` (or with `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`) so the inner dockerd can create network namespaces and mount overlay filesystems. In **bare-metal mode** (assistant running directly on the host), Meet bots are **sibling** containers on the host's Docker engine — the daemon connects to the host's Docker API directly. The assistant auto-detects which mode it is in and picks the correct engine.
 - The legacy shared data volume (`<name>-data`) is no longer created for new instances. Existing instances are migrated: gateway security files and CES security files are copied from the data volume to their respective security volumes on startup (see `migrateGatewaySecurityFiles()` and `migrateCesSecurityFiles()` in `cli/src/lib/docker.ts`).
 
-**Meet workspace-volume discovery**: Meet-bot sibling containers need to mount the same workspace volume as the assistant so transcripts, audio, and other meeting artifacts land on the shared per-instance volume. The assistant discovers the volume name at runtime by parsing `/proc/self/mountinfo` (see `skills/meet-join/daemon/workspace-volume.ts`). The CLI also passes `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as a belt-and-suspenders hint so the workspace-volume helper can fall back when mountinfo yields nothing (e.g. on storage drivers with non-standard layouts).
+**Bare-metal vs Docker-mode bot spawning:**
+
+- **Bare-metal mode** (assistant process runs directly on the user's machine): Meet bots are **sibling containers** launched against the host's Docker Engine. The host's `docker ps` lists every active bot alongside any other containers the user runs. If the assistant process crashes or is killed, orphan bot containers can linger on the host — the meet-bot image's built-in max-meeting-minutes timeout is the safety net that eventually terminates them, and the assistant also cleans up on graceful shutdown.
+- **Docker mode (Docker-in-Docker)**: Meet bots are **nested containers** inside the assistant container's own `dockerd`. The *host's* `docker ps` shows only the assistant/gateway/CES containers — meet-bots are invisible at that level and only appear to `docker ps` run inside the assistant container. Bot lifecycle is tied to the assistant: if the assistant container (or the pod it lives in) dies, the inner `dockerd` dies with it and every bot container is torn down automatically, so orphans are impossible.
+
+**Security tradeoff for Docker mode:** The Docker-in-Docker model requires the assistant container to run with `--privileged`, or at minimum `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`, so the inner `dockerd` can configure cgroups, overlay mounts, and container networking. This is acceptable for single-user local deployments. Managed/hosted deployments that run on Kubernetes must configure Pod Security Admission (or an equivalent admission controller) to allow this privilege level on the assistant pod, or swap in a different bot spawn model (e.g. a Kubernetes job runner). Managed Meet support is out of scope for the Docker-in-Docker approach — see [`vellum-assistant-platform`](../vellum-assistant-platform).
+
+**Meet workspace-volume discovery**: Meet-bot containers still need to mount the same workspace volume as the assistant so transcripts, audio, and other meeting artifacts land on the shared per-instance volume. In Docker mode the workspace volume is re-bound into each bot container by the inner `dockerd` using the assistant container's own `/workspace` bind as the source. In bare-metal mode the assistant resolves the host-side workspace path and passes it directly to the sibling bot. Either way, bots see the workspace mounted at `/workspace`.
 
 **Backup paths in Docker mode**: The backup system stores local snapshots at `VELLUM_BACKUP_DIR` (default: `/workspace/.backups/`) and the encryption key at `VELLUM_BACKUP_KEY_PATH` (default: `/workspace/.backup.key`) on the workspace volume. This means workspace volume destruction loses both data and backups. For stronger isolation, a dedicated backup volume could be added in a future iteration.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ The lockfile can contain both local and remote entries. Remote entries (cloud pr
 
 ## Docker Volume Architecture
 
-Docker instances use dedicated volumes with per-service access boundaries instead of a single shared data volume. This enforces least-privilege: each service only has filesystem access to the data it owns. A single host bind-mount (`/var/run/docker.sock`) is also attached to the assistant container so the Meet subsystem can spawn sibling bot containers — see [Meet Sibling-Container Model](#meet-sibling-container-model) below.
+Docker instances use dedicated volumes with per-service access boundaries instead of a single shared data volume. This enforces least-privilege: each service only has filesystem access to the data it owns. The assistant container also owns a dedicated `dockerd-data` volume that backs the inner Docker engine used by the Meet subsystem — see [Meet Docker-in-Docker Model](#meet-docker-in-docker-model) below.
 
 ### Volume Layout
 
@@ -146,33 +146,42 @@ Docker instances use dedicated volumes with per-service access boundaries instea
 <instance-name>-gateway-sec     →  /gateway-security    (gateway only)
 <instance-name>-ces-sec         →  /ces-security        (CES only)
 <instance-name>-socket          →  /run/ces-bootstrap   (assistant + CES)
-/var/run/docker.sock            →  /var/run/docker.sock (assistant: rw — host bind, not a named volume)
+<instance-name>-dockerd-data    →  /var/lib/docker      (assistant only — inner dockerd state)
 ```
 
 - **Workspace volume** (`/workspace`): Shared state — config, conversations, apps, skills, database, logs. Set via `VELLUM_WORKSPACE_DIR=/workspace`. The assistant and gateway have read-write access; the CES mounts it read-only (for config reading).
 - **Gateway security volume** (`/gateway-security`): Files private to the gateway container. Only the gateway container mounts this volume. Set via `GATEWAY_SECURITY_DIR=/gateway-security`.
 - **CES security volume** (`/ces-security`): Credential encryption keys (`keys.enc`, `store.key`). Only the CES container mounts this volume. Set via `CREDENTIAL_SECURITY_DIR=/ces-security`.
 - **Socket volume** (`/run/ces-bootstrap`): CES bootstrap socket for initial service handshake between the assistant and CES containers.
-- **Docker socket bind-mount** (`/var/run/docker.sock`): Host Docker Engine API, used by the assistant's Meet subsystem to spawn sibling Meet-bot containers. Mounted read-write on the assistant container only. The CLI also passes `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as an env-var hint so the workspace-volume helper can find the volume reliably without probing Docker (see `skills/meet-join/daemon/workspace-volume.ts`).
+- **Inner dockerd data volume** (`/var/lib/docker`): Persistent storage for the `dockerd` that runs *inside* the assistant container. Holds the pulled meet-bot image and any in-flight bot container state so image pulls don't repeat on every assistant restart. Only the assistant container mounts this volume.
 
-### Meet Sibling-Container Model
+### Meet Docker-in-Docker Model
 
-Meet bots are **sibling** containers to the assistant, not nested (Docker-in-Docker). The assistant instructs the host's Docker engine via the mounted socket to spawn each bot; bots therefore run next to the assistant on the same engine and share the workspace volume.
+In Docker mode, Meet bots are **nested** containers spawned by a `dockerd` running *inside* the assistant container. The assistant container runs an init supervisor that starts both the daemon and a local `dockerd`; the Meet subsystem connects to that inner engine and spawns bot containers as children of the assistant container.
 
 ```
-                host Docker Engine (/var/run/docker.sock)
-                         |
-           +-------------+--------------+--------------------+
-           |             |              |                    |
-    assistant ct.   gateway ct.     CES ct.          meet-bot ct. (per meeting)
-           |                                                 |
-           +-------- /workspace (<name>-workspace) ----------+
-                     (mounted on both, for artifact exchange)
+  host Docker Engine
+        |
+        +--- assistant ct. (privileged)
+        |       |
+        |       +--- (inner) dockerd
+        |       |        |
+        |       |        +--- meet-bot ct. (per meeting)
+        |       |        +--- meet-bot ct. (per meeting)
+        |       |
+        |       +--- /workspace (<name>-workspace)
+        |
+        +--- gateway ct.
+        +--- CES ct.
 ```
 
-The assistant creates each bot with a bind of the discovered workspace volume at `/workspace` so the bot can drop transcripts, audio, and metadata into `/workspace/meets/<meetingId>/` where the assistant can read them back. Bots have no access to the gateway-security or CES-security volumes.
+Each bot container receives a bind of `/workspace` sourced from the assistant's own `/workspace` mount, so the bot can drop transcripts, audio, and metadata into `/workspace/meets/<meetingId>/` where the assistant can read them back. Bots have no access to the gateway-security or CES-security volumes.
 
-**Security boundary — single-user local only.** Mounting `/var/run/docker.sock` grants the assistant effective root on the host (any container mount, any image run). This is acceptable for single-user local deployments where the assistant is already running with the user's privileges. It is **not** acceptable for managed/multi-tenant mode. Managed Meet support is explicitly out of scope for this Docker-socket approach — the platform deployment (`vellum-assistant-platform`) needs a different spawn model (e.g. a Kubernetes job runner or a dedicated bot-scheduler service) before Meet can ship to managed instances.
+**Bot lifecycle is coupled to the assistant container.** Because the inner `dockerd` process runs inside the assistant container, if that container dies the inner engine dies with it and every bot container is torn down automatically. There are no orphan bot containers on the host — `docker ps` on the host only ever lists the assistant/gateway/CES containers.
+
+**Bare-metal fallback.** When the assistant runs directly on the host (bare-metal / local-dev mode) there is no inner `dockerd`; the daemon connects to the host's Docker engine and spawns bot containers as *siblings* of the assistant process. In that configuration host-level `docker ps` does see each bot, and an ungraceful assistant exit can leave orphan bot containers — the meet-bot image's built-in max-meeting-minutes timeout caps their lifetime.
+
+**Security boundary — single-user local only.** The Docker-in-Docker model requires the assistant container to run with `--privileged`, or at minimum `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`, so the inner `dockerd` can set up cgroups, overlay mounts, and container networks. This is acceptable for single-user local deployments where the assistant already runs with the user's privileges. It is **not** acceptable as-is for managed/multi-tenant mode: Kubernetes deployments must configure Pod Security Admission to allow this privilege level on the assistant pod, or swap in a different bot-spawn model (e.g. a Kubernetes job runner or a dedicated bot-scheduler service) before Meet can ship to managed instances. Managed Meet support is explicitly out of scope for this Docker-in-Docker approach — see [`vellum-assistant-platform`](../vellum-assistant-platform).
 
 ### Cross-Service Access Patterns
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -51,14 +51,20 @@ For example, the signing key used for JWT auth between the daemon and gateway is
 
 The CLI creates and manages Docker volumes for containerized instances. See the root `AGENTS.md` § Docker Volume Architecture for the full volume layout.
 
-**Volume creation** (`hatch`): Creates four volumes per instance — workspace, gateway-security, ces-security, and socket. The legacy data volume is no longer created.
+**Volume creation** (`hatch`): Creates five volumes per instance — workspace, gateway-security, ces-security, socket, and dockerd-data (the last backs the inner Docker engine used for Meet; see below). The legacy data volume is no longer created.
 
 **Volume migration** (`wake`/`hatch`): On startup, existing instances that still have a legacy data volume are migrated. `migrateGatewaySecurityFiles()` and `migrateCesSecurityFiles()` in `lib/docker.ts` copy security files from the data volume to their respective security volumes. Migrations are idempotent and non-fatal.
 
 **Volume cleanup** (`retire`): All volumes (including the legacy data volume if it exists) are removed when an instance is retired.
 
-**Volume mount rules**: Each service container receives only the volumes it needs. The assistant never mounts `gateway-security` or `ces-security`. The gateway never mounts `ces-security`. The CES mounts the workspace volume as read-only.
+**Volume mount rules**: Each service container receives only the volumes it needs. The assistant never mounts `gateway-security` or `ces-security`. The gateway never mounts `ces-security`. The CES mounts the workspace volume as read-only. The `dockerd-data` volume is mounted only on the assistant container.
 
-**Meet sibling-container support** (assistant container only): In addition to the named volumes above, the assistant container receives a host bind-mount of `/var/run/docker.sock:/var/run/docker.sock` so the Meet subsystem can spawn sibling Meet-bot containers on the host's Docker engine. The CLI also injects `VELLUM_WORKSPACE_VOLUME_NAME=<name>-workspace` as a hint so the assistant's workspace-volume helper can look up the volume by name without probing `/proc/self/mountinfo`. Both are wired in `serviceDockerRunArgs()` in `lib/docker.ts`.
+**Meet Docker-in-Docker support** (assistant container only): The assistant container runs an inner `dockerd` that hosts the Meet-bot containers as nested children. The CLI supports this by:
 
-Mounting the Docker socket grants the daemon effective root on the host — acceptable for single-user local deployments, not for managed/multi-tenant mode. Managed Meet support requires a different spawn model and is out of scope for this CLI.
+- Creating a dedicated `<name>-dockerd-data` volume mounted at `/var/lib/docker` so pulled images and container state persist across assistant restarts.
+- Running the assistant container with `--privileged` (or `CAP_SYS_ADMIN` + `CAP_NET_ADMIN`) so the inner dockerd can configure cgroups, overlay mounts, and container networking.
+- No longer bind-mounting the host's `/var/run/docker.sock`; Meet-bot spawning happens entirely inside the assistant container.
+
+Both are wired in `serviceDockerRunArgs()` in `lib/docker.ts`.
+
+The privileged assistant container is acceptable for single-user local deployments. Managed/multi-tenant mode needs a different spawn model (e.g. a Kubernetes job runner) and is out of scope for this CLI.


### PR DESCRIPTION
## Summary
- Update AGENTS.md Docker Volume Architecture section to describe the DinD model for Docker-mode daemons (the project's CLAUDE.md equivalent lives at AGENTS.md).
- Drop references to the Phase 1.8 host docker socket bind-mount in Docker mode; document the new `<name>-dockerd-data` volume backing the inner dockerd.
- Add 'Bare-metal vs Docker-mode bot spawning' subsection explaining the two isolation models and the `--privileged` security tradeoff (incl. Pod Security Admission note for managed mode).
- Rework ARCHITECTURE.md's Meet section from 'Sibling-Container Model' to 'Docker-in-Docker Model' with an updated diagram and a bare-metal fallback note.
- Update cli/AGENTS.md to describe the new five-volume layout (adds dockerd-data), drop the socket bind-mount, and note the `--privileged` requirement.

Note: implementation PRs (1–5, 8) land after this doc PR in the plan. This describes the target state.

Part of plan: meet-phase-1-10-dind.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
