### PR TITLE
daemon: init supervisor starts dockerd before assistant process

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -103,6 +103,20 @@ RUN apt-get update && apt-get install -y \
     && apt-get install -y docker-ce docker-ce-cli containerd.io \
     && rm -rf /var/lib/apt/lists/*
 
+# Configure dockerd for Docker-in-Docker execution. The init supervisor in
+# docker-entrypoint.sh starts dockerd with --storage-driver=overlay2 by
+# default, falling back to vfs if overlay2 cannot initialize (e.g. on
+# hosts whose storage driver doesn't support nested overlay mounts). The
+# storage driver is passed on the CLI rather than set here so the fallback
+# path can override it without rewriting this config. Log rotation keeps
+# sibling-container logs from filling the workspace volume.
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' \
+        '{' \
+        '  "log-driver": "json-file",' \
+        '  "log-opts": { "max-size": "10m", "max-file": "3" }' \
+        '}' > /etc/docker/daemon.json
+
 # Copy bun binary from builder instead of re-installing
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,6 +1,83 @@
 #!/usr/bin/env sh
 set -eu
 
+# ── dockerd supervisor (Docker-in-Docker) ──────────────────────────────
+# When the assistant runs inside a container (IS_CONTAINERIZED=true), we
+# need a local Docker Engine running so the Meet subsystem can spawn
+# sibling bot containers via /var/run/docker.sock. Outside a container
+# (bare-metal mode) this block is a no-op — the assistant talks to the
+# host's docker socket directly if needed.
+#
+# The canonical runtime-mode signal is IS_CONTAINERIZED (see
+# src/runtime/runtime-mode.ts / src/config/env-registry.ts). Truthy
+# values are "true" or "1".
+start_dockerd_if_containerized() {
+  case "${IS_CONTAINERIZED:-}" in
+    true|1) ;;
+    *) return 0 ;;
+  esac
+
+  DOCKERD_LOG="/var/log/dockerd.log"
+  mkdir -p /var/log
+
+  # Prefer overlay2 for performance. If overlay2 fails to come up within
+  # 30s (common when the outer storage driver doesn't support nested
+  # overlay mounts, e.g. some CI runners), fall back to vfs.
+  _try_start_dockerd() {
+    _driver="$1"
+    echo "[vellum-init] starting dockerd (--storage-driver=${_driver})" >&2
+
+    # Kill any stale dockerd from a prior attempt.
+    if [ -n "${DOCKERD_PID:-}" ] && kill -0 "${DOCKERD_PID}" 2>/dev/null; then
+      kill "${DOCKERD_PID}" 2>/dev/null || true
+      wait "${DOCKERD_PID}" 2>/dev/null || true
+    fi
+
+    # Start dockerd in the background. /etc/docker/daemon.json supplies
+    # log-driver + log-opts; the storage driver is passed on the CLI so
+    # the fallback path can override it without rewriting the config.
+    dockerd --storage-driver="${_driver}" >>"${DOCKERD_LOG}" 2>&1 &
+    DOCKERD_PID=$!
+
+    # Poll /var/run/docker.sock for up to 30s (0.5s * 60).
+    _i=0
+    while [ "${_i}" -lt 60 ]; do
+      if docker ps >/dev/null 2>&1; then
+        echo "[vellum-init] dockerd ready (storage-driver=${_driver}, pid=${DOCKERD_PID})" >&2
+        return 0
+      fi
+
+      # If dockerd already exited, bail out of this attempt immediately.
+      if ! kill -0 "${DOCKERD_PID}" 2>/dev/null; then
+        echo "[vellum-init] dockerd exited during startup (storage-driver=${_driver})" >&2
+        DOCKERD_PID=""
+        return 1
+      fi
+
+      _i=$((_i + 1))
+      sleep 0.5
+    done
+
+    echo "[vellum-init] dockerd did not become ready within 30s (storage-driver=${_driver})" >&2
+    return 1
+  }
+
+  DOCKERD_PID=""
+  if _try_start_dockerd overlay2; then
+    return 0
+  fi
+
+  echo "[vellum-init] overlay2 dockerd startup failed; falling back to vfs" >&2
+  if _try_start_dockerd vfs; then
+    return 0
+  fi
+
+  echo "[vellum-init] dockerd did not become ready within 30s; see ${DOCKERD_LOG}" >&2
+  exit 1
+}
+
+start_dockerd_if_containerized
+
 if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- New entrypoint script supervises dockerd + bun daemon in Docker mode.
- Script is a no-op in bare-metal mode (IS_CONTAINERIZED != 'true') — execs the daemon directly.
- dockerd configured with overlay2 storage driver + json-file log rotation; vfs fallback on overlay2 failure.

Part of plan: meet-phase-1-10-dind.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
