### PR TITLE
test(conversation-slash-queue): stub workspace git to fix CI flake

### DIFF
--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -235,6 +235,12 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
+type ConversationWithWorkspaceDeps = Conversation & {
+  getWorkspaceGitService?: (_workspaceDir: string) => {
+    ensureInitialized: () => Promise<void>;
+  };
+};
+
 function makeConversation(): Conversation {
   const provider = {
     name: "mock",
@@ -247,7 +253,7 @@ function makeConversation(): Conversation {
       };
     },
   };
-  return new Conversation(
+  const conversation = new Conversation(
     "conv-1",
     provider,
     "system prompt",
@@ -255,6 +261,13 @@ function makeConversation(): Conversation {
     () => {},
     "/tmp",
   );
+  // Bypass real workspace git init: with "/tmp" as the workspace dir, a real
+  // ensureInitialized() walks all of /tmp and can exceed the 2s waitForPendingRun
+  // budget on CI where parallel tests churn /tmp subdirectories.
+  (conversation as ConversationWithWorkspaceDeps).getWorkspaceGitService = () => ({
+    ensureInitialized: async () => {},
+  });
+  return conversation;
 }
 
 async function waitForPendingRun(


### PR DESCRIPTION
## Summary
- First \`waitForPendingRun(1)\` in \`conversation-slash-queue.test.ts\` times out on CI because \`Conversation\` awaits \`gitService.ensureInitialized()\` before invoking \`AgentLoop.run\`, and with \`/tmp\` as the workspace dir the real init walks system dirs + races concurrent test cleanup.
- Applies the same \`getWorkspaceGitService\` stub pattern already used in \`conversation-queue.test.ts\` so the init is a no-op.
- Failing job: https://github.com/vellum-ai/vellum-assistant/actions/runs/24477667076/job/71533999465

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24477667076/job/71533999465
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
