### PR TITLE
test(slash-queue): mock workspace git services to fix CI flake

### DIFF
--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -209,6 +209,24 @@ mock.module("../agent/loop.js", () => ({
     }
   },
 }));
+// Avoid real workspace-git initialization on /tmp — on CI runners,
+// `git add -A` under /tmp hits permission errors on systemd-private dirs,
+// which blocks `runAgentLoopImpl` for long enough to trip the test's
+// `waitForPendingRun` 2s timeout before `AgentLoop.run` is invoked.
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../memory/app-git-service.js", () => ({
+  commitAppTurnChanges: async () => {},
+}));
+
 mock.module("../memory/canonical-guardian-store.js", () => ({
   listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
   listCanonicalGuardianRequests: () => [],


### PR DESCRIPTION
## Summary
- Mock \`workspace/git-service.js\`, \`workspace/turn-commit.js\`, and \`memory/app-git-service.js\` in \`conversation-slash-queue.test.ts\` to match the pattern already used by \`conversation-agent-loop.test.ts\`.
- CI's \`/tmp\` has \`systemd-private-*\` directories that return permission errors during \`git add -A\`, which makes \`gitService.ensureInitialized()\` slow enough that \`waitForPendingRun\` (2s timeout) fires before \`AgentLoop.run\` is invoked. See the failure at https://github.com/vellum-ai/vellum-assistant/actions/runs/24477667076/job/71533999538.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24477667076/job/71533999538
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
