### PR TITLE
test(cli/teleport): add dockerdDataVolume to mocked dockerResourceNames

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -200,6 +200,7 @@ const dockerResourceNamesMock = mock((name: string) => ({
   assistantContainer: `${name}-assistant`,
   cesContainer: `${name}-credential-executor`,
   cesSecurityVolume: `${name}-ces-sec`,
+  dockerdDataVolume: `${name}-dockerd-data`,
   gatewayContainer: `${name}-gateway`,
   gatewaySecurityVolume: `${name}-gateway-sec`,
   network: `${name}-net`,


### PR DESCRIPTION
## Summary
- The teleport test's `mock.module("../lib/docker.js", ...)` globally replaces `dockerResourceNames` for the whole `bun test` run. Since PR #25908 added `dockerdDataVolume` to the real resource names, the stale mock caused `docker.test.ts`'s "mounts a dedicated named volume at /var/lib/docker" assertion to receive `undefined:/var/lib/docker` instead of `test-instance-dockerd-data:/var/lib/docker`.
- Fix: add `dockerdDataVolume: \`${name}-dockerd-data\`` to the mock. Full suite now shows 214 pass / 0 fail (was 213 pass / 1 fail).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24477909688/job/71534855006
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
