### PR TITLE
meet: DockerRunner uses inner dockerd in Docker mode + host-gateway networking

### DIFF
--- a/skills/meet-join/daemon/__tests__/docker-mode-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-mode-e2e.test.ts
@@ -1,23 +1,20 @@
 /**
  * End-to-end Docker-mode spawn-arg regression test for the Meet pipeline.
  *
- * What this test covers:
+ * What this test covers (Phase 1.10 — DinD):
  *   - Bare-metal mode: `DockerRunner.resolveMounts` emits host-path `Binds`
- *     instead of named-volume `Mounts`, and does not reference the workspace
- *     volume name.
- *   - Docker mode: `DockerRunner.resolveMounts` emits `HostConfig.Mounts`
- *     with `VolumeOptions.Subpath` referencing the injected workspace volume
- *     name, the `ExtraHosts` entry for `host.docker.internal:host-gateway`
- *     is always present, the daemon URL uses `host.docker.internal`, the
- *     internal bot port is published on `127.0.0.1:<ephemeral>`, and the env
- *     vars the bot requires (`DAEMON_URL`, `MEETING_ID`, `MEET_URL`,
- *     `JOIN_NAME`, `BOT_API_TOKEN`, `CONSENT_MESSAGE`) are present.
- *   - Docker mode with no workspace volume: `join()` surfaces the
- *     prerequisite-missing error before any `/containers/create` is issued
- *     (only the memoized `/_ping` round-trip happens).
- *   - Docker mode with unreachable socket: `join()` surfaces the
- *     socket-unreachable prerequisite-missing error from the ping probe
- *     before any create/start is issued.
+ *     rooted at the workspace directory.
+ *   - Docker mode: `DockerRunner.resolveMounts` emits host-path `Binds`
+ *     rooted at the daemon container's internal workspace dir (inner
+ *     `dockerd` sees that as a regular path). The `ExtraHosts` entry for
+ *     `host.docker.internal:host-gateway` is always present, the daemon
+ *     URL uses `host.docker.internal`, the internal bot port is published
+ *     on `127.0.0.1:<ephemeral>`, and the env vars the bot requires
+ *     (`DAEMON_URL`, `MEETING_ID`, `MEET_URL`, `JOIN_NAME`,
+ *     `BOT_API_TOKEN`, `CONSENT_MESSAGE`) are present.
+ *   - Docker mode with unreachable socket: `join()` surfaces the Phase
+ *     1.10 inner-dockerd-not-running error from the ping probe before any
+ *     create/start is issued.
  *
  * Nothing here touches a real Docker daemon or a real Meet URL. The
  * DockerRunner talks to an in-process HTTP server bound to a tempdir unix
@@ -43,7 +40,6 @@ import {
 } from "bun:test";
 
 import {
-  DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE,
   DockerRunner,
   dockerSocketUnreachableMessage,
   HOST_GATEWAY_ALIAS,
@@ -270,7 +266,7 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe("Meet Docker-mode spawn-arg E2E", () => {
-  test("docker mode: uses named-volume subpath mounts, host-gateway alias, host.docker.internal DAEMON_URL, and ephemeral 127.0.0.1 port binding", async () => {
+  test("docker mode (DinD): uses host-path Binds to daemon-internal workspace paths, host-gateway alias, host.docker.internal DAEMON_URL, and ephemeral 127.0.0.1 port binding", async () => {
     engine = await startDockerEngineMock();
     // /_ping → /containers/create → /containers/<id>/start → /containers/<id>/json
     engine.queueResponse({ status: 200, body: "OK" });
@@ -293,7 +289,9 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
     const runner = new DockerRunner({
       socketPath: engine.socketPath,
       resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => "test-workspace-vol",
+      // In Docker (DinD) mode the runner uses the daemon container's own
+      // workspace dir as the bind source — inner dockerd sees it as a
+      // regular path. The tempdir stands in for that.
       workspaceDir,
     });
 
@@ -326,24 +324,15 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
 
       const body = JSON.parse(createReq!.body) as DockerCreateBody;
 
-      // ── Subpath volume mounts referencing the injected volume name ──
-      expect(body.HostConfig.Binds).toEqual([]);
-      expect(body.HostConfig.Mounts).toEqual([
-        {
-          Type: "volume",
-          Source: "test-workspace-vol",
-          Target: "/sockets",
-          ReadOnly: false,
-          VolumeOptions: { Subpath: "meets/m-docker-1/sockets" },
-        },
-        {
-          Type: "volume",
-          Source: "test-workspace-vol",
-          Target: "/out",
-          ReadOnly: false,
-          VolumeOptions: { Subpath: "meets/m-docker-1/out" },
-        },
+      // ── Host-path binds rooted at the daemon container's workspace dir ──
+      // No named-volume Mounts payload — that's a Phase 1.8 relic, replaced
+      // by direct host-path binds now that inner dockerd has direct
+      // visibility into /workspace.
+      expect(body.HostConfig.Binds).toEqual([
+        `${workspaceDir}/meets/m-docker-1/sockets:/sockets`,
+        `${workspaceDir}/meets/m-docker-1/out:/out`,
       ]);
+      expect(body.HostConfig.Mounts).toBeUndefined();
 
       // ── host-gateway alias is always emitted ──
       expect(body.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
@@ -384,7 +373,7 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
     }
   });
 
-  test("bare-metal mode: uses host-path Binds, no named-volume Mounts, and does not reference the volume name", async () => {
+  test("bare-metal mode: uses host-path Binds and no named-volume Mounts", async () => {
     engine = await startDockerEngineMock();
     // Bare-metal skips /_ping. create → start → inspect.
     engine.queueResponse({ status: 201, body: { Id: "bm-1" } });
@@ -403,18 +392,9 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
       },
     });
 
-    // Resolver should never be consulted in bare-metal mode — surface a
-    // clear failure if that invariant ever regresses.
-    const resolveWorkspaceVolumeNameSpy = mock(async () => {
-      throw new Error(
-        "resolveWorkspaceVolumeName must not be called in bare-metal mode",
-      );
-    });
-
     const runner = new DockerRunner({
       socketPath: engine.socketPath,
       resolveMode: () => "bare-metal",
-      resolveWorkspaceVolumeName: resolveWorkspaceVolumeNameSpy,
       workspaceDir,
     });
 
@@ -452,15 +432,8 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
       // ── No Mounts payload at all — purely bind-mount path ──
       expect(body.HostConfig.Mounts).toBeUndefined();
 
-      // ── And no reference to the Docker-mode volume name ──
-      const serialized = JSON.stringify(body);
-      expect(serialized).not.toContain("test-workspace-vol");
-
       // ── host-gateway alias is still emitted unconditionally ──
       expect(body.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
-
-      // ── Resolver must not be consulted in bare-metal mode ──
-      expect(resolveWorkspaceVolumeNameSpy).toHaveBeenCalledTimes(0);
 
       // ── /_ping is skipped in bare-metal mode — only create + start + inspect ──
       expect(engine.captured).toHaveLength(3);
@@ -472,68 +445,16 @@ describe("Meet Docker-mode spawn-arg E2E", () => {
     }
   });
 
-  test("docker mode: missing workspace volume surfaces the prerequisite-missing error before any create is issued", async () => {
-    engine = await startDockerEngineMock();
-    // Only /_ping should be consumed — the runner bails on the volume lookup
-    // before reaching /containers/create.
-    engine.queueResponse({ status: 200, body: "OK" });
-
-    const runner = new DockerRunner({
-      socketPath: engine.socketPath,
-      resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => null,
-      workspaceDir,
-    });
-
-    const manager = _createMeetSessionManagerForTests({
-      dockerRunnerFactory: () => runner,
-      getProviderKey: async () => "tts-k",
-      getWorkspaceDir: () => workspaceDir,
-      botLeaveFetch: async () => {},
-      audioIngestFactory: makeFakeAudioIngest,
-      consentMonitorFactory: makeFakeConsentMonitor,
-      conversationBridgeFactory: makeFakeConversationBridge,
-      storageWriterFactory: makeFakeStorageWriter,
-      resolveAssistantDisplayName: () => "Atlas",
-    });
-
-    await expect(
-      manager.join({
-        url: "https://meet.google.com/xxx-yyyy-zzz",
-        meetingId: "m-no-vol",
-        conversationId: "conv-no-vol",
-      }),
-    ).rejects.toThrow(DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE);
-
-    // Only the memoized /_ping round-trip happened — no create/start.
-    expect(engine.captured).toHaveLength(1);
-    expect(engine.captured[0].url).toContain("/_ping");
-    expect(
-      engine.captured.find((c) => c.url.includes("/containers/create")),
-    ).toBeUndefined();
-    expect(
-      engine.captured.find((c) => c.url.includes("/start")),
-    ).toBeUndefined();
-
-    // No session lingers on the error path.
-    expect(manager.activeSessions()).toHaveLength(0);
-  });
-
-  test("docker mode: unreachable docker socket surfaces the prerequisite-missing error before any create is issued", async () => {
+  test("docker mode: unreachable inner dockerd surfaces the Phase 1.10 prerequisite-missing error before any create is issued", async () => {
     // No mock server — point at a socket path that nobody is listening on so
     // the /_ping probe fails fast. This parallels the DockerRunner unit test
-    // but covers the full session-manager → docker-runner pipe.
+    // but covers the full session-manager → docker-runner pipe and stands
+    // in for the init supervisor failing to bring up dockerd.
     const bogusSocketPath = join(tempDir, "nonexistent.sock");
 
     const runner = new DockerRunner({
       socketPath: bogusSocketPath,
       resolveMode: () => "docker",
-      // Volume name resolver should never be consulted — we bail at ping.
-      resolveWorkspaceVolumeName: async () => {
-        throw new Error(
-          "resolveWorkspaceVolumeName must not be called when the socket is unreachable",
-        );
-      },
       workspaceDir,
     });
 

--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -14,7 +14,6 @@ import {
 
 import {
   buildCreateBody,
-  DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE,
   DockerApiError,
   DockerRunner,
   dockerSocketUnreachableMessage,
@@ -374,7 +373,7 @@ describe("buildCreateBody", () => {
     expect(hc.Mounts).toBeUndefined();
   });
 
-  test("serializes extraBinds from resolved workspace mounts (bare-metal mode)", () => {
+  test("serializes extraBinds from resolved workspace mounts (both modes)", () => {
     const body = buildCreateBody(
       { image: "x:y" },
       {
@@ -389,7 +388,6 @@ describe("buildCreateBody", () => {
             readOnly: true,
           },
         ],
-        mounts: [],
       },
     );
     const hc = body.HostConfig as Record<string, unknown>;
@@ -397,51 +395,9 @@ describe("buildCreateBody", () => {
       "/ws/meets/abc/sockets:/sockets",
       "/ws/meets/abc/out:/out:ro",
     ]);
-    // No Mounts field emitted in the bare-metal branch.
+    // Mounts is never emitted under the DinD model — Binds alone is the
+    // workspace-mount vocabulary.
     expect(hc.Mounts).toBeUndefined();
-  });
-
-  test("serializes named-volume mounts via HostConfig.Mounts (Docker mode)", () => {
-    const body = buildCreateBody(
-      { image: "x:y" },
-      {
-        extraBinds: [],
-        mounts: [
-          {
-            Type: "volume",
-            Source: "vellum-work",
-            Target: "/sockets",
-            ReadOnly: false,
-            VolumeOptions: { Subpath: "meets/abc/sockets" },
-          },
-          {
-            Type: "volume",
-            Source: "vellum-work",
-            Target: "/out",
-            ReadOnly: true,
-            VolumeOptions: { Subpath: "meets/abc/out" },
-          },
-        ],
-      },
-    );
-    const hc = body.HostConfig as Record<string, unknown>;
-    expect(hc.Binds).toEqual([]);
-    expect(hc.Mounts).toEqual([
-      {
-        Type: "volume",
-        Source: "vellum-work",
-        Target: "/sockets",
-        ReadOnly: false,
-        VolumeOptions: { Subpath: "meets/abc/sockets" },
-      },
-      {
-        Type: "volume",
-        Source: "vellum-work",
-        Target: "/out",
-        ReadOnly: true,
-        VolumeOptions: { Subpath: "meets/abc/out" },
-      },
-    ]);
   });
 });
 
@@ -491,7 +447,7 @@ describe("extractBoundPorts", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Mode-aware workspace mounts + host-gateway flag (Phase 1.8)
+// Mode-aware workspace mounts + host-gateway flag (Phase 1.10 — DinD)
 // ---------------------------------------------------------------------------
 
 describe("DockerRunner workspace-mount mode branching", () => {
@@ -518,15 +474,9 @@ describe("DockerRunner workspace-mount mode branching", () => {
       body: { Id: "bm-1", NetworkSettings: { Ports: {} } },
     });
 
-    const resolveWorkspaceVolumeName = async () => {
-      throw new Error(
-        "resolveWorkspaceVolumeName must not be called in bare-metal mode",
-      );
-    };
     const runner = new DockerRunner({
       socketPath: mock.socketPath,
       resolveMode: () => "bare-metal",
-      resolveWorkspaceVolumeName,
       workspaceDir: "/ws",
     });
 
@@ -550,7 +500,7 @@ describe("DockerRunner workspace-mount mode branching", () => {
     expect(createBody.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
   });
 
-  test("Docker mode probes the socket, translates workspaceMounts to named-volume subpath mounts, and sets host-gateway", async () => {
+  test("Docker (DinD) mode probes the inner dockerd socket, translates workspaceMounts to daemon-internal host-path binds, and sets host-gateway", async () => {
     mock = await startMockDocker();
     // /_ping → create → start → inspect
     mock.queueResponse({ status: 200, body: "OK" });
@@ -571,9 +521,9 @@ describe("DockerRunner workspace-mount mode branching", () => {
     const runner = new DockerRunner({
       socketPath: mock.socketPath,
       resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => "vellum-inst-workspace",
-      // workspaceDir unused in Docker mode.
-      workspaceDir: "/irrelevant",
+      // In Docker mode workspaceDir points at the daemon container's
+      // internal /workspace — inner dockerd sees that as a regular path.
+      workspaceDir: "/workspace",
     });
 
     const result = await runner.run({
@@ -601,59 +551,31 @@ describe("DockerRunner workspace-mount mode branching", () => {
     expect(mock.captured[0].url).toContain("/_ping");
 
     const createBody = JSON.parse(mock.captured[1].body);
-    expect(createBody.HostConfig.Binds).toEqual([]);
-    expect(createBody.HostConfig.Mounts).toEqual([
-      {
-        Type: "volume",
-        Source: "vellum-inst-workspace",
-        Target: "/sockets",
-        ReadOnly: false,
-        VolumeOptions: { Subpath: "meets/m1/sockets" },
-      },
-      {
-        Type: "volume",
-        Source: "vellum-inst-workspace",
-        Target: "/out",
-        ReadOnly: true,
-        VolumeOptions: { Subpath: "meets/m1/out" },
-      },
+    // Simple host-path binds — daemon-internal /workspace paths that inner
+    // dockerd can resolve. No named-volume Mounts payload.
+    expect(createBody.HostConfig.Binds).toEqual([
+      "/workspace/meets/m1/sockets:/sockets",
+      "/workspace/meets/m1/out:/out:ro",
     ]);
+    expect(createBody.HostConfig.Mounts).toBeUndefined();
     expect(createBody.HostConfig.ExtraHosts).toEqual([HOST_GATEWAY_ALIAS]);
   });
 
-  test("Docker mode throws when workspace volume name is null — and never attempts create", async () => {
-    mock = await startMockDocker();
-    // Only /_ping should be consumed before we bail on the volume lookup.
-    mock.queueResponse({ status: 200, body: "OK" });
-
-    const runner = new DockerRunner({
-      socketPath: mock.socketPath,
-      resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => null,
-    });
-
-    await expect(
-      runner.run({
-        image: "vellum-meet-bot:dev",
-        workspaceMounts: [
-          { target: "/sockets", subpath: "meets/m1/sockets" },
-        ],
-      }),
-    ).rejects.toThrow(DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE);
-
-    // Only the ping round-trip happened; no create was issued.
-    expect(mock.captured).toHaveLength(1);
-    expect(mock.captured[0].url).toContain("/_ping");
-  });
-
-  test("Docker mode surfaces the prerequisite-missing error when the socket is unreachable", async () => {
-    // Use a bogus socket path — no server listening there.
+  test("Docker mode surfaces the Phase 1.10 prerequisite-missing error when inner dockerd is unreachable", async () => {
+    // Use a bogus socket path — no server listening there. Stands in for
+    // the init supervisor failing to bring up dockerd.
     const socketPath = join(tempDir, "nonexistent.sock");
     const runner = new DockerRunner({
       socketPath,
       resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => "vellum-inst-workspace",
+      workspaceDir: "/workspace",
     });
+
+    const expected = dockerSocketUnreachableMessage(socketPath);
+    // Guard the exact Phase 1.10 wording so regressions to the old
+    // Phase 1.8 "host docker socket" message surface loudly.
+    expect(expected).toContain("Inner dockerd is not running");
+    expect(expected).toContain("Phase 1.10 PR 2");
 
     await expect(
       runner.run({
@@ -662,7 +584,7 @@ describe("DockerRunner workspace-mount mode branching", () => {
           { target: "/sockets", subpath: "meets/m1/sockets" },
         ],
       }),
-    ).rejects.toThrow(dockerSocketUnreachableMessage(socketPath));
+    ).rejects.toThrow(expected);
   });
 
   test("Docker-mode ping success is memoized across run() calls", async () => {
@@ -686,7 +608,7 @@ describe("DockerRunner workspace-mount mode branching", () => {
     const runner = new DockerRunner({
       socketPath: mock.socketPath,
       resolveMode: () => "docker",
-      resolveWorkspaceVolumeName: async () => "vol",
+      workspaceDir: "/workspace",
     });
 
     await runner.run({

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -11,22 +11,27 @@
  * structured JSON, and avoids the PATH/CLI surface entirely. See
  * `cli/src/lib/docker.ts` for the broader service container lifecycle.
  *
- * Mode-awareness (Phase 1.8):
+ * Mode-awareness (Phase 1.10 — Docker-in-Docker):
  *   - In bare-metal mode the daemon writes workspace artifacts to host paths
- *     it can share with bot containers via standard Docker bind mounts.
- *   - In Docker mode the daemon itself lives in a container whose
- *     `/workspace` path is not visible to the host Docker engine. Workspace-
- *     rooted mounts have to be expressed as named-volume mounts against the
- *     same workspace volume the daemon is using (discovered via
- *     {@link getWorkspaceVolumeName}). We use Docker's volume `Mounts` API
- *     with `VolumeOptions.Subpath` so each bot only sees its own meeting
- *     directory — that requires Docker Engine 25+.
+ *     it can share with sibling bot containers via standard Docker bind
+ *     mounts on the host's Docker engine.
+ *   - In Docker mode the daemon container ships its own `dockerd` (started
+ *     by the init supervisor). The socket at `/var/run/docker.sock` now
+ *     points at that inner `dockerd` rather than the host engine. Because
+ *     the daemon's `/workspace` is a regular directory from inner
+ *     `dockerd`'s point of view, workspace-rooted mounts collapse to simple
+ *     host-path binds — same shape as bare-metal, just rooted at the
+ *     daemon-internal workspace path (typically `/workspace`). No volume-
+ *     name discovery, no subpath Mounts.
  *
  * Networking:
  *   - We always attach `host.docker.internal:host-gateway` via
- *     `HostConfig.ExtraHosts` so the bot can reach the daemon HTTP port on
- *     the host in either mode. On Docker Desktop it's already mapped; on
- *     Linux the explicit gateway alias is required.
+ *     `HostConfig.ExtraHosts` so the bot can reach the daemon HTTP port in
+ *     either mode. On Docker Desktop it's already mapped; on Linux (and in
+ *     inner `dockerd` on the managed platform) the explicit gateway alias
+ *     is required. In Docker mode the alias resolves to the inner bridge
+ *     gateway, which routes back to the daemon process in the same
+ *     container.
  */
 
 import { request as httpRequest } from "node:http";
@@ -35,7 +40,6 @@ import { posix as posixPath } from "node:path";
 import type { DaemonRuntimeMode } from "../../../assistant/src/runtime/runtime-mode.js";
 import { getDaemonRuntimeMode } from "../../../assistant/src/runtime/runtime-mode.js";
 import { getLogger } from "../../../assistant/src/util/logger.js";
-import { getWorkspaceVolumeName } from "./workspace-volume.js";
 
 const log = getLogger("meet-docker-runner");
 
@@ -89,10 +93,11 @@ export interface BindMount {
 }
 
 /**
- * A workspace-rooted mount request. The runner translates these to either a
- * host-path bind (bare-metal mode) or a named-volume `Mounts` entry with
- * `VolumeOptions.Subpath` (Docker mode). The same logical spec works in
- * both deployment modes.
+ * A workspace-rooted mount request. The runner translates these to host-path
+ * binds against the daemon's workspace directory — in bare-metal mode that
+ * resolves to a host-visible path, in Docker mode (DinD) it resolves to the
+ * daemon container's internal `/workspace` which is visible to inner
+ * `dockerd`. Same logical spec works in both deployment modes.
  *
  * `subpath` is interpreted relative to the workspace root on disk — e.g.
  * `"meets/<id>/sockets"`. `target` is the absolute path inside the bot
@@ -110,9 +115,11 @@ export interface DockerRunOptions {
   image: string;
   env?: Record<string, string>;
   /**
-   * Workspace-rooted mounts resolved according to the current runtime
-   * mode. In bare-metal mode these become host-path binds; in Docker mode
-   * they become named-volume `Mounts` against the workspace volume.
+   * Workspace-rooted mounts resolved against the daemon's workspace dir.
+   * In both bare-metal and Docker (DinD) modes these become host-path
+   * `Binds` — the difference is only the absolute prefix: a host-visible
+   * path in bare-metal, the daemon container's internal `/workspace` in
+   * Docker mode.
    */
   workspaceMounts?: WorkspaceMount[];
   ports?: PortMapping[];
@@ -157,19 +164,13 @@ export interface DockerRunnerOptions {
    */
   resolveMode?: () => DaemonRuntimeMode;
   /**
-   * Override the workspace-volume-name resolver. Defaults to
-   * {@link getWorkspaceVolumeName} with no options (production cache
-   * path). Tests inject a fake so they can steer the Docker branch
-   * between "volume found" and "volume null" outcomes without touching
-   * `/proc/self/mountinfo`.
-   */
-  resolveWorkspaceVolumeName?: () => Promise<string | null>;
-  /**
-   * Workspace directory on disk. Required when running in bare-metal mode
-   * with `workspaceMounts` — the runner resolves each `subpath` under this
-   * directory to produce the host-path bind. Defaults to `process.cwd()`
-   * if unset; callers should inject the real workspace dir
-   * (`getWorkspaceDir()` from `util/platform.ts`).
+   * Workspace directory on disk. Used by the runner to resolve each
+   * `workspaceMounts[i].subpath` under this directory to produce the
+   * host-path bind. In bare-metal mode this is a host-visible path; in
+   * Docker mode it's the daemon container's internal `/workspace`
+   * (visible to inner `dockerd`). Defaults to `process.cwd()` if unset;
+   * callers should inject the real workspace dir (`getWorkspaceDir()`
+   * from `util/platform.ts`).
    */
   workspaceDir?: string;
 }
@@ -192,23 +193,21 @@ export class DockerApiError extends Error {
 }
 
 /**
- * Message surfaced when the Docker Engine socket is unreachable from the
- * daemon in Docker mode. Exported as a function so the session-manager
- * error path and unit tests share the exact string while still letting the
- * configured socket path flow through (useful when tests run against a
- * tempdir socket, or if an operator overrides the default socket path).
+ * Message surfaced when the inner `dockerd` socket is unreachable from the
+ * daemon in Docker mode. In Phase 1.10 the socket at
+ * `/var/run/docker.sock` is the daemon container's OWN Docker Engine
+ * (Docker-in-Docker), started by the init supervisor shipped in Phase 1.10
+ * PR 2. If this probe fails, the init supervisor likely failed to bring
+ * `dockerd` up — check the daemon container logs.
+ *
+ * Exported as a function so the session-manager error path and unit tests
+ * share the exact string while still letting the configured socket path
+ * flow through (useful when tests run against a tempdir socket, or if an
+ * operator overrides the default socket path).
  */
 export function dockerSocketUnreachableMessage(socketPath: string): string {
-  return `The daemon cannot reach the Docker Engine at ${socketPath}. In Docker mode the daemon container must have the socket bind-mounted. Upgrade your vellum CLI to a version that supports Meet in Docker mode (see Phase 1.8 docs).`;
+  return `Inner dockerd is not running (socket ${socketPath}). The daemon container's init supervisor (Phase 1.10 PR 2) failed to start dockerd. Check daemon container logs.`;
 }
-
-/**
- * Message surfaced when Docker mode is active but no named workspace
- * volume was discoverable. Exported so the session-manager error path and
- * unit tests can share the exact string.
- */
-export const DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE =
-  "Meet in Docker mode requires the workspace to be on a named Docker volume. Ensure the vellum CLI launched the daemon with a named volume at /workspace, or set VELLUM_WORKSPACE_VOLUME_NAME.";
 
 /**
  * Module-level cache of in-flight or resolved `/_ping` reachability probes,
@@ -317,14 +316,11 @@ function requestRaw(
 export class DockerRunner {
   readonly socketPath: string;
   private readonly resolveMode: () => DaemonRuntimeMode;
-  private readonly resolveWorkspaceVolumeName: () => Promise<string | null>;
   private readonly workspaceDir: string;
 
   constructor(options: DockerRunnerOptions = {}) {
     this.socketPath = options.socketPath ?? DEFAULT_DOCKER_SOCKET_PATH;
     this.resolveMode = options.resolveMode ?? getDaemonRuntimeMode;
-    this.resolveWorkspaceVolumeName =
-      options.resolveWorkspaceVolumeName ?? (() => getWorkspaceVolumeName());
     this.workspaceDir = options.workspaceDir ?? process.cwd();
   }
 
@@ -332,26 +328,32 @@ export class DockerRunner {
    * Create + start a container. Returns the containerId and any host-side
    * ports Docker bound after start.
    *
-   * In Docker mode we first confirm the engine socket is reachable (a
-   * missing bind-mount of `/var/run/docker.sock` is the most common
-   * prerequisite miss) and discover the workspace volume name before
-   * translating `workspaceMounts` into named-volume `Mounts` with
-   * subpaths. In bare-metal mode we skip those steps and bind host paths
-   * directly.
+   * In Docker mode we first confirm the inner `dockerd` socket is
+   * reachable — a `dockerd` that failed to start in the init supervisor
+   * is the most common prerequisite miss on the managed platform. In
+   * bare-metal mode we skip the probe (a missing local Docker surfaces
+   * clearly enough on the create-path failure).
+   *
+   * Workspace mount resolution is the same in both modes: each
+   * `workspaceMounts[i]` becomes a host-path `Bind` rooted at
+   * {@link workspaceDir}. In bare-metal that's the host's workspace path;
+   * in Docker mode that's the daemon container's internal `/workspace`,
+   * which inner `dockerd` sees as a regular path.
    */
   async run(opts: DockerRunOptions): Promise<DockerRunResult> {
     const mode = this.resolveMode();
 
     // One-time socket reachability probe. In bare-metal mode the daemon
     // on a developer machine may not have Docker running; the existing
-    // create-path failure already covers that case with a clear error,
-    // so we only hard-gate in Docker mode where a missing bind-mount is
-    // a deployment bug the caller cannot work around.
+    // create-path failure already covers that case with a clear error.
+    // In Docker mode the socket points at the daemon container's own
+    // `dockerd` — if that's not responding, the init supervisor failed
+    // to bring it up and no meeting can proceed.
     if (mode === "docker") {
       await ensureSocketReachable(this.socketPath);
     }
 
-    const resolvedMounts = await this.resolveMounts(mode, opts.workspaceMounts);
+    const resolvedMounts = this.resolveMounts(opts.workspaceMounts);
 
     const createBody = buildCreateBody(opts, resolvedMounts);
     const createPath = opts.name
@@ -426,49 +428,33 @@ export class DockerRunner {
   // -------------------------------------------------------------------------
 
   /**
-   * Translate `workspaceMounts` into either host-path binds or
-   * named-volume `Mounts` entries according to the runtime mode.
+   * Translate `workspaceMounts` into host-path `Binds` rooted at the
+   * daemon's workspace dir. Works the same in both modes:
    *
-   * Bare-metal: each mount becomes a `BindMount` with
-   * `<workspaceDir>/<subpath>` as the host path. Docker: each mount
-   * becomes a volume mount against the discovered workspace volume with
-   * `VolumeOptions.Subpath = <subpath>`. Subpath requires Docker Engine
-   * 25+. If Engine <25 is observed in the field, the fallback is to
-   * mount the whole workspace volume at `/workspace` inside the bot and
-   * have the bot itself resolve paths under `/workspace/meets/<id>/…`;
-   * that's left as a follow-up because Docker Desktop ships Engine 25+
-   * and the CLI requires it as a prerequisite in `cli/src/lib/docker.ts`.
+   * - Bare-metal: `<hostWorkspaceDir>/<subpath>` → a host path the host's
+   *   Docker engine mounts into the sibling bot container.
+   * - Docker (DinD): `<daemonInternalWorkspaceDir>/<subpath>` (typically
+   *   `/workspace/<subpath>`) → a path inside the daemon container that
+   *   inner `dockerd` sees as regular filesystem and mounts into the
+   *   nested bot container.
+   *
+   * No named-volume `Mounts` payload is emitted — the Phase 1.8 subpath
+   * volume dance is gone now that the daemon's own dockerd has direct
+   * visibility into `/workspace`.
    */
-  private async resolveMounts(
-    mode: DaemonRuntimeMode,
+  private resolveMounts(
     workspaceMounts: WorkspaceMount[] | undefined,
-  ): Promise<ResolvedMounts> {
+  ): ResolvedMounts {
     if (!workspaceMounts || workspaceMounts.length === 0) {
-      return { extraBinds: [], mounts: [] };
+      return { extraBinds: [] };
     }
 
-    if (mode === "bare-metal") {
-      const extraBinds = workspaceMounts.map<BindMount>((m) => ({
-        hostPath: resolveWorkspaceSubpath(this.workspaceDir, m.subpath),
-        containerPath: m.target,
-        readOnly: m.readOnly,
-      }));
-      return { extraBinds, mounts: [] };
-    }
-
-    // Docker mode — named-volume subpath mounts.
-    const volumeName = await this.resolveWorkspaceVolumeName();
-    if (volumeName === null) {
-      throw new Error(DOCKER_WORKSPACE_VOLUME_MISSING_MESSAGE);
-    }
-    const mounts = workspaceMounts.map((m) => ({
-      Type: "volume" as const,
-      Source: volumeName,
-      Target: m.target,
-      ReadOnly: m.readOnly === true,
-      VolumeOptions: { Subpath: m.subpath },
+    const extraBinds = workspaceMounts.map<BindMount>((m) => ({
+      hostPath: resolveWorkspaceSubpath(this.workspaceDir, m.subpath),
+      containerPath: m.target,
+      readOnly: m.readOnly,
     }));
-    return { extraBinds: [], mounts };
+    return { extraBinds };
   }
 
   /** Issue a unix-socket HTTP request and decode the JSON body, if any. */
@@ -536,19 +522,13 @@ export class DockerRunner {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolved mount spec produced by {@link DockerRunner.resolveMounts} — either
- * extra bind mounts to append to `HostConfig.Binds` (bare-metal) or named
- * volume mounts to pass via `HostConfig.Mounts` (Docker mode).
+ * Resolved mount spec produced by {@link DockerRunner.resolveMounts} — a flat
+ * list of host-path bind mounts to serialize into `HostConfig.Binds`. Works
+ * the same in bare-metal and Docker (DinD) modes; the only difference is the
+ * absolute path prefix injected via {@link DockerRunnerOptions.workspaceDir}.
  */
 export interface ResolvedMounts {
   extraBinds: BindMount[];
-  mounts: Array<{
-    Type: "volume";
-    Source: string;
-    Target: string;
-    ReadOnly: boolean;
-    VolumeOptions: { Subpath: string };
-  }>;
 }
 
 /** Always-on hostname alias that lets the bot reach the daemon HTTP port. */
@@ -577,15 +557,14 @@ export function resolveWorkspaceSubpath(
  */
 export function buildCreateBody(
   opts: DockerRunOptions,
-  resolved: ResolvedMounts = { extraBinds: [], mounts: [] },
+  resolved: ResolvedMounts = { extraBinds: [] },
 ): Record<string, unknown> {
   const env = opts.env
     ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`)
     : [];
-  // In bare-metal mode the resolver produces host-path binds from
-  // `workspaceMounts`; in Docker mode it produces named-volume `Mounts`
-  // instead and `extraBinds` is empty. Either way, `Binds` is what the
-  // engine expects for the host-path style so we serialize it here.
+  // In both bare-metal and Docker (DinD) modes the resolver produces
+  // host-path binds from `workspaceMounts` — the Phase 1.8 named-volume
+  // subpath `Mounts` payload is no longer emitted.
   const binds = resolved.extraBinds.map((b) =>
     b.readOnly
       ? `${b.hostPath}:${b.containerPath}:ro`
@@ -622,7 +601,6 @@ export function buildCreateBody(
     // `host-gateway` value is required. Applied unconditionally because
     // the resolution is identical either way on modern engines.
     ExtraHosts: [HOST_GATEWAY_ALIAS],
-    ...(resolved.mounts.length > 0 ? { Mounts: resolved.mounts } : {}),
     ...(opts.network ? { NetworkMode: opts.network } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Docker-mode DockerRunner now talks to the daemon container's own dockerd (inner socket), not the host's.
- Replace Phase 1.8 subpath-volume Mounts with simple HostConfig.Binds (daemon-internal paths like /workspace/meets/<id>/sockets:/sockets).
- Pre-flight ping on inner dockerd surfaces a Phase 1.10-specific error if the init supervisor failed.
- Bare-metal path unchanged.

Part of plan: meet-phase-1-10-dind.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
