### PR TITLE
providers(openrouter): route anthropic/* models through Anthropic Messages API

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1864,3 +1864,84 @@ describe("AnthropicProvider — Haiku Model Gating", () => {
     expect(lastStreamParams!.output_config).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// OpenRouter routing Anthropic models through the Messages API
+// ---------------------------------------------------------------------------
+
+describe("OpenRouterProvider — Anthropic dispatch", () => {
+  beforeEach(() => {
+    lastStreamParams = null;
+    _lastStreamOptions = null;
+    lastConstructorArgs = null;
+  });
+
+  test("anthropic/ models are routed to Anthropic Messages API with Bearer auth", async () => {
+    const { OpenRouterProvider } = await import(
+      "../providers/openrouter/client.js"
+    );
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, "You are helpful.");
+
+    expect(lastConstructorArgs).toMatchObject({
+      apiKey: null,
+      authToken: "or-key",
+      baseURL: "https://openrouter.ai/api/v1/anthropic",
+    });
+    expect(lastStreamParams).toBeTruthy();
+    expect(lastStreamParams!.model).toBe("anthropic/claude-sonnet-4.6");
+  });
+
+  test("custom baseURL is suffixed with /anthropic for Messages API", async () => {
+    const { OpenRouterProvider } = await import(
+      "../providers/openrouter/client.js"
+    );
+    const provider = new OpenRouterProvider(
+      "ast-key",
+      "anthropic/claude-opus-4.6",
+      { baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter" },
+    );
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(lastConstructorArgs).toMatchObject({
+      baseURL:
+        "https://platform.example.com/v1/runtime-proxy/openrouter/anthropic",
+    });
+  });
+
+  test("thinking config flows through to Anthropic Messages API natively", async () => {
+    const { OpenRouterProvider } = await import(
+      "../providers/openrouter/client.js"
+    );
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "adaptive" } },
+    });
+
+    expect(lastStreamParams!.thinking).toEqual({ type: "adaptive" });
+    // The OpenAI-compat `reasoning` parameter must NOT be sent on the
+    // native Messages API path.
+    expect(lastStreamParams!.reasoning).toBeUndefined();
+  });
+
+  test("per-request model override routes based on the overridden model", async () => {
+    const { OpenRouterProvider } = await import(
+      "../providers/openrouter/client.js"
+    );
+    // Default model is non-Anthropic, but the request overrides with an
+    // Anthropic model — dispatch must honour the request-level model.
+    const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { model: "anthropic/claude-haiku-4.5" },
+    });
+
+    expect(lastStreamParams).toBeTruthy();
+    expect(lastStreamParams!.model).toBe("anthropic/claude-haiku-4.5");
+  });
+});

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1221,7 +1221,7 @@ describe("OpenRouterProvider reasoning", () => {
   test("sends reasoning.enabled=true when thinking config is present", async () => {
     const provider = new OpenRouterProvider(
       "or-key",
-      "anthropic/claude-sonnet-4.6",
+      "x-ai/grok-4",
     );
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
       config: { thinking: { type: "adaptive" } },
@@ -1234,7 +1234,7 @@ describe("OpenRouterProvider reasoning", () => {
   test("sends reasoning.enabled=false when thinking config is absent", async () => {
     const provider = new OpenRouterProvider(
       "or-key",
-      "anthropic/claude-sonnet-4.6",
+      "x-ai/grok-4",
     );
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
       config: {},
@@ -1247,7 +1247,7 @@ describe("OpenRouterProvider reasoning", () => {
   test("sends reasoning.enabled=false when no options are provided", async () => {
     const provider = new OpenRouterProvider(
       "or-key",
-      "anthropic/claude-sonnet-4.6",
+      "x-ai/grok-4",
     );
     await provider.sendMessage([userMsg("hi")]);
 
@@ -1258,7 +1258,7 @@ describe("OpenRouterProvider reasoning", () => {
   test("RetryProvider + OpenRouterProvider enables thinking end-to-end", async () => {
     const provider = new OpenRouterProvider(
       "or-key",
-      "anthropic/claude-sonnet-4.6",
+      "x-ai/grok-4",
     );
     const retry = new RetryProvider(provider);
 
@@ -1272,7 +1272,7 @@ describe("OpenRouterProvider reasoning", () => {
   test("RetryProvider + OpenRouterProvider disables thinking end-to-end", async () => {
     const provider = new OpenRouterProvider(
       "or-key",
-      "anthropic/claude-sonnet-4.6",
+      "x-ai/grok-4",
     );
     const retry = new RetryProvider(provider);
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -598,9 +598,22 @@ export class AnthropicProvider implements Provider {
       useNativeWebSearch?: boolean;
       streamTimeoutMs?: number;
       baseURL?: string;
+      /**
+       * Authenticate via `Authorization: Bearer <token>` instead of
+       * `x-api-key`. Required for proxies that front the Anthropic Messages
+       * API with their own Bearer scheme (e.g. OpenRouter). When set, the
+       * positional `apiKey` argument is ignored on the wire.
+       */
+      authToken?: string;
     } = {},
   ) {
-    this.client = new Anthropic({ apiKey, baseURL: options.baseURL });
+    this.client = options.authToken
+      ? new Anthropic({
+          apiKey: null,
+          authToken: options.authToken,
+          baseURL: options.baseURL,
+        })
+      : new Anthropic({ apiKey, baseURL: options.baseURL });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,5 +1,11 @@
+import { AnthropicProvider } from "../anthropic/client.js";
 import { OpenAIProvider } from "../openai/client.js";
-import type { SendMessageOptions } from "../types.js";
+import type {
+  Message,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../types.js";
 
 export interface OpenRouterProviderOptions {
   apiKey?: string;
@@ -9,30 +15,92 @@ export interface OpenRouterProviderOptions {
 
 const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
+// Models on OpenRouter prefixed `anthropic/` are routed through OpenRouter's
+// Anthropic-compatible Messages API (`<baseURL>/anthropic/v1/messages`) so that
+// Anthropic-native features — extended thinking, prompt caching, cache TTL,
+// output_config — work without lossy translation through the OpenAI chat
+// completions compatibility layer.
+function isAnthropicModel(model: string): boolean {
+  return model.startsWith("anthropic/");
+}
+
 export class OpenRouterProvider extends OpenAIProvider {
+  private readonly openRouterApiKey: string;
+  private readonly defaultModel: string;
+  private readonly resolvedBaseURL: string;
+  private readonly providerStreamTimeoutMs: number | undefined;
+  private anthropicInner: AnthropicProvider | undefined;
+
   constructor(
     apiKey: string,
     model: string,
     options: OpenRouterProviderOptions = {},
   ) {
+    const baseURL = options.baseURL?.trim() || DEFAULT_OPENROUTER_BASE_URL;
     super(apiKey, model, {
-      baseURL: options.baseURL?.trim() || DEFAULT_OPENROUTER_BASE_URL,
+      baseURL,
       providerName: "openrouter",
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
     });
+    this.openRouterApiKey = apiKey;
+    this.defaultModel = model;
+    this.resolvedBaseURL = baseURL;
+    this.providerStreamTimeoutMs = options.streamTimeoutMs;
   }
 
-  // OpenRouter's unified `reasoning` parameter controls extended thinking
-  // across upstream providers (e.g. it maps to Anthropic's `thinking`
-  // parameter for Claude models). Mirror the assistant's `thinking.enabled`
-  // config — loop.ts only sets `config.thinking` when enabled — so users can
-  // turn thinking off on Anthropic models served via OpenRouter.
+  override async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const effectiveModel = this.resolveEffectiveModel(options);
+    if (isAnthropicModel(effectiveModel)) {
+      return this.getAnthropicInner().sendMessage(
+        messages,
+        tools,
+        systemPrompt,
+        options,
+      );
+    }
+    return super.sendMessage(messages, tools, systemPrompt, options);
+  }
+
+  // OpenRouter's unified `reasoning` parameter controls extended thinking on
+  // its OpenAI-compatible endpoint. Mirror the assistant's `thinking.enabled`
+  // config — loop.ts only sets `config.thinking` when enabled — so non-
+  // Anthropic reasoning models (e.g. xAI Grok) can be toggled the same way.
+  // Anthropic models skip this path entirely and go through AnthropicProvider.
   protected override buildExtraCreateParams(
     options?: SendMessageOptions,
   ): Record<string, unknown> {
     const config = options?.config as Record<string, unknown> | undefined;
     const thinkingEnabled = config?.thinking !== undefined;
     return { reasoning: { enabled: thinkingEnabled } };
+  }
+
+  private resolveEffectiveModel(options?: SendMessageOptions): string {
+    const config = options?.config as Record<string, unknown> | undefined;
+    const override =
+      typeof config?.model === "string" && config.model.trim().length > 0
+        ? config.model.trim()
+        : undefined;
+    return override ?? this.defaultModel;
+  }
+
+  private getAnthropicInner(): AnthropicProvider {
+    if (!this.anthropicInner) {
+      this.anthropicInner = new AnthropicProvider(
+        this.openRouterApiKey,
+        this.defaultModel,
+        {
+          baseURL: `${this.resolvedBaseURL}/anthropic`,
+          streamTimeoutMs: this.providerStreamTimeoutMs,
+          authToken: this.openRouterApiKey,
+        },
+      );
+    }
+    return this.anthropicInner;
   }
 }


### PR DESCRIPTION
## Summary
- Anthropic models served via OpenRouter now go through OpenRouter's Anthropic-compatible Messages API (`<baseURL>/anthropic/v1/messages`) via `AnthropicProvider`, so extended thinking, prompt caching, cache TTL, and `output_config` flow natively instead of being lossily translated through the OpenAI chat-completions layer.
- Added an `authToken` option to `AnthropicProvider` so the SDK authenticates via `Authorization: Bearer` when fronted by a proxy that requires it (OpenRouter).
- `OpenRouterProvider` now dispatches per-request based on the effective model — `anthropic/*` uses the Anthropic path, everything else keeps the OpenAI-compat path with the `reasoning: { enabled: !!config.thinking }` translation.

## Original prompt
Let's switch to using this endpoint for anthropic models: https://openrouter.ai/docs/api/api-reference/anthropic-messages/create-messages

That way we can reuse much of the code from the anthropic provider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
