### PR TITLE
ci(macos): remove duplicate Build executable step

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -230,10 +230,6 @@ jobs:
         if: needs.changes.outputs.clients == 'true' || github.event_name == 'workflow_dispatch'
         run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
-      - name: Build executable
-        working-directory: clients
-        run: swift build --product vellum-assistant
-
       - name: Configure GitHub auth for SPM binary downloads
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Delete the \`Build executable\` step from \`.github/workflows/ci-main-macos.yaml\`. It ran \`swift build --product vellum-assistant\` with \`working-directory: clients\`, but the next step (\`Build macOS app\`) runs \`./build.sh\` from \`clients/macos/\` which re-runs the exact same swift build from scratch into a separate \`.build\` directory (\`clients/macos/.build\`, not \`clients/.build\`).
- Both invocations compiled ~2,250 Swift sources from scratch. Measured on run [24475612196](https://github.com/vellum-ai/vellum-assistant/actions/runs/24475612196/job/71526896294): \`Build executable\` took 411.72s; \`Build macOS app\`'s inner swift build took 403.54s. Expected savings: ~7 minutes per main-branch macOS CI run.
- The pre-check provided no value — if compilation fails, \`Build macOS app\` fails on the same error ~18 seconds later.

## Historical context

The step was originally added in #11459 (2026-03-02) as a pre-test compile-check in the combined \`test\` job — where it was useful because \`Run tests\` shared its \`.build\`. #18687 (2026-03-17) split test and build into separate jobs and carried this step into the new \`build\` job, where its \`.build\` is no longer reused. This PR undoes that inadvertent duplication.

## Test plan

- [ ] Next main-branch CI macOS run completes in ~9-10 min instead of ~16 min
- [ ] App and DMG artifacts are still produced by \`Build macOS app\` and upload steps
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
