### PR TITLE
ci(macos): drop SPM .build cache that isn't incrementalizing

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -95,19 +95,6 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
-      - name: Compute cache week
-        id: week
-        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache SPM build artifacts
-        uses: actions/cache@v5
-        with:
-          path: clients/.build
-          key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
-          restore-keys: |
-            macos-spm-debug-week${{ steps.week.outputs.num }}-
-            macos-spm-debug-
-
       - name: Run tests
         working-directory: clients/macos
         run: ./build.sh test
@@ -201,19 +188,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.9'
-
-      - name: Compute cache week
-        id: week
-        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache SPM build artifacts
-        uses: actions/cache@v5
-        with:
-          path: clients/.build
-          key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
-          restore-keys: |
-            macos-spm-debug-week${{ steps.week.outputs.num }}-
-            macos-spm-debug-
 
       - name: Compute dev version
         id: version


### PR DESCRIPTION
## Summary

- Remove \`Compute cache week\` and \`Cache SPM build artifacts\` from both the \`test\` and \`build\` jobs in \`.github/workflows/ci-main-macos.yaml\`.
- Motivation: measured on run [24475612196](https://github.com/vellum-ai/vellum-assistant/actions/runs/24475612196/job/71526896294), the cache hit exactly (\`Cache hit for: macos-spm-debug-week16-d854e49...\`) and restored 1.8 GB over ~1 min, but the subsequent \`swift build\` still compiled **2,265 tasks from scratch**. SwiftPM's \`build.db\` tracks file timestamps/paths that don't survive transfer to a fresh runner, so the restored artifacts get invalidated during the "Planning build" phase.
- Net: the cache was costing ~1 min restore + bandwidth + storage for zero compile time saved.

## Test plan

- [ ] Next main-branch macOS CI run no longer includes \`Cache SPM build artifacts\` step
- [ ] Total job time drops by ~1 min from the cache restore removal (further savings possible from the sibling PR that drops the duplicate \`Build executable\` step)
- [ ] Cold swift build still completes within the existing 20-min \`Build macOS app\` timeout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
