### PR TITLE
fix(meet): extend knip config to cover moved meet test files

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -6,9 +6,20 @@
     "src/daemon/main.ts",
     "src/messaging/providers/*/types.ts",
     "src/messaging/providers/*/client.ts",
-    "src/memory/graph/inspect.ts"
+    "src/memory/graph/inspect.ts",
+    "../skills/meet-join/**/*.test.ts",
+    "../skills/meet-join/**/__tests__/**/*.ts",
+    "!../skills/meet-join/bot/**",
+    "!../skills/meet-join/contracts/**"
   ],
-  "project": ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts"],
+  "project": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "scripts/**/*.ts",
+    "../skills/meet-join/**/*.ts",
+    "!../skills/meet-join/bot/**",
+    "!../skills/meet-join/contracts/**"
+  ],
   "ignoreDependencies": [
     "@vellumai/ces-contracts",
     "@vellumai/credential-storage",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-1-9-skill-consolidation.md.

**Gap**: After the consolidation, meet tests moved under skills/meet-join/ are no longer visible to knip. Production exports consumed only by these tests will eventually get flagged as unused on future refactors.

**Fix**: Extend assistant/knip.json entry/project to include skills/meet-join/**/*.ts (excluding bot/ and contracts/ which are separate workspace packages).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
