### PR TITLE
fix(meet): clean up guard allowlist and document message-types/meet.ts as stays-put

### DIFF
--- a/assistant/src/__tests__/skill-meet-isolation.test.ts
+++ b/assistant/src/__tests__/skill-meet-isolation.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, test } from "bun:test";
  * import from it beyond the narrow allowlist below, which captures the
  * unavoidable wiring points where central registries must know about Meet
  * (tool manifest, route mount, migration registry, shutdown handler, config
- * schema, feature flag registry).
+ * schema, daemon-client SSE protocol registry).
  *
  * This guard keeps the Meet surface area consolidated so the skill can evolve
  * (or be lifted out of the repo entirely) without hunting down scattered
@@ -29,9 +29,6 @@ import { describe, expect, test } from "bun:test";
  * move into the skill directory itself).
  */
 const ALLOWLIST = new Set([
-  // --- Feature flag registration (central declaration, one entry per flag) ---
-  "meta/feature-flags/feature-flag-registry.json", // `meet` flag declaration
-
   // --- Config schema wiring (central schema must know about MeetService) ---
   "assistant/src/config/schema.ts", // re-exports MeetService type from skill
   "assistant/src/config/schemas/services.ts", // composes MeetServiceSchema into services schema
@@ -47,6 +44,9 @@ const ALLOWLIST = new Set([
 
   // --- Daemon shutdown (session manager must be stopped on shutdown) ---
   "assistant/src/daemon/shutdown-handlers.ts", // imports MeetSessionManager
+
+  // --- Daemon-client SSE protocol registry (one file per domain; stays put) ---
+  "assistant/src/daemon/message-types/meet.ts", // Meet entry in the per-domain wire-protocol index (apps.ts, browser.ts, etc.); re-exported from message-protocol.ts
 
   // --- Container build / packaging ---
   ".dockerignore", // include/exclude rules for the skill directory

--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -11,7 +11,7 @@ monorepo.
 Code outside `skills/meet-join/` must not import from the skill beyond a small,
 explicit allowlist of wiring points: the central tool manifest, HTTP route
 mount, workspace migration registry, config schema, daemon shutdown handler,
-and the `meet` feature-flag registration. These are the places where a
+and the daemon-client SSE protocol registry. These are the places where a
 central registry has to know about Meet — everywhere else, Meet is opaque.
 
 The complete allowlist and enforcement live in
@@ -32,3 +32,34 @@ If you do need a new external reference (e.g. a new central registry has to
 learn about Meet), add the file path to the `ALLOWLIST` in
 `skill-meet-isolation.test.ts` with a comment explaining *why* the reference
 is necessary and why it cannot live inside the skill.
+
+## Central registries that stay put
+
+A handful of central files reference Meet by design — they are per-domain
+entries in a repo-wide registry, and splitting one entry out into the skill
+would break the "one file per domain" pattern the registry relies on. These
+are **not** candidates for relocation into `skills/meet-join/`:
+
+- **`assistant/src/daemon/message-types/meet.ts`** — the Meet entry in the
+  daemon-client SSE wire-protocol index. Each domain has one file here
+  (`apps.ts`, `browser.ts`, `contacts.ts`, etc.), all re-exported from
+  `assistant/src/daemon/message-protocol.ts`. Meet's server→client push
+  message shapes (e.g. `MeetJoined`, `MeetTranscriptChunk`) live in this
+  file alongside every other domain's wire types. This is protocol-level
+  surface, not runtime code.
+
+- **`meta/feature-flags/feature-flag-registry.json`** — the central
+  declaration of every assistant feature flag, including `meet`. This is
+  the canonical flag registry; per-flag entries are not relocated to
+  owning skills.
+
+- **`assistant/src/config/schema.ts` /
+  `assistant/src/config/schemas/services.ts`** — the central config
+  schema composes the per-service schemas, including `MeetService`.
+
+Among these, only files that actually import from `skills/meet-join/` or
+`@vellumai/meet-contracts` trip the guard test. `config/schema.ts` and
+`config/schemas/services.ts` do, so they're in the allowlist. The
+message-types file currently does not, but is allowlisted pre-emptively in
+case a future change introduces such an import. The feature-flag registry
+JSON contains neither substring and is not in the allowlist.


### PR DESCRIPTION
## Summary
Addresses gaps identified during plan review for meet-phase-1-9-skill-consolidation.md:
- **Gap C**: Explicitly document that assistant/src/daemon/message-types/meet.ts stays put (it's part of the central daemon-client SSE protocol registry, one file per domain). Updated skills/meet-join/AGENTS.md and added the path to the guard test allowlist.
- **Gap D**: Removed the dead allowlist entry for meta/feature-flags/feature-flag-registry.json — the JSON doesn't contain 'skills/meet-join' or '@vellumai/meet-contracts' so the entry never matched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
