### PR TITLE
fix: extend test.sh to cover skills/meet-join/ tests

### DIFF
--- a/.github/workflows/pr-skills.yaml
+++ b/.github/workflows/pr-skills.yaml
@@ -124,6 +124,26 @@ jobs:
       - name: Run tests
         run: |
           SKILL_DIR="skills/${{ matrix.skill }}"
+          SKILL_NAME="${{ matrix.skill }}"
+
+          # Skills tested elsewhere (to avoid duplicate / broken coverage):
+          # - meet-join: daemon tests use `mock.module()` which is process-global
+          #   in Bun. A flat `bun test` across all files causes cross-file
+          #   pollution and SyntaxError failures. These tests are covered by
+          #   pr-assistant.yaml's test.sh, which runs each file in its own
+          #   process. Subpackages with their own package.json `test` script
+          #   (bot/, contracts/) still run below.
+          if [ "$SKILL_NAME" = "meet-join" ]; then
+            echo "Skipping flat test run for meet-join — covered by pr-assistant.yaml (per-file isolation)."
+            for sub in bot contracts; do
+              if [ -f "$SKILL_DIR/$sub/package.json" ]; then
+                echo "Running tests for skills/$SKILL_NAME/$sub ..."
+                (cd "$SKILL_DIR/$sub" && bun install && bun test)
+              fi
+            done
+            exit 0
+          fi
+
           # Only run tests if the skill has test files
           if find "$SKILL_DIR" -name '*.test.ts' -o -name '*.test.js' | grep -q .; then
             cd "$SKILL_DIR"

--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -97,7 +97,23 @@ while IFS= read -r test_file; do
   fi
 
   test_files+=("${test_file}")
-done < <(find src -type f -name '*.test.ts' | sort)
+done < <(
+  {
+    find src -type f -name '*.test.ts'
+    # Also scan skills that have been consolidated from assistant/src/ but whose
+    # tests still exercise daemon internals and must keep running under the
+    # assistant's CI job. Exclude subpackages that have their own package.json
+    # + test runner (bot/, contracts/) — they are covered by pr-skills.yaml or
+    # their own workspace commands.
+    if [[ -d ../skills/meet-join ]]; then
+      find ../skills/meet-join \
+        -path ../skills/meet-join/bot -prune -o \
+        -path ../skills/meet-join/contracts -prune -o \
+        -path ../skills/meet-join/node_modules -prune -o \
+        -type f -name '*.test.ts' -print
+    fi
+  } | sort
+)
 
 if [[ ${#test_files[@]} -eq 0 ]]; then
   echo "No test files found under src"


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-1-9-skill-consolidation.md.

**Gap:** After the Phase 1.9 consolidation, 16 meet tests moved under skills/meet-join/ are no longer picked up by assistant/scripts/test.sh's 'find src' discovery. CI on main branch no longer runs those tests.

**Fix:** Extend test.sh to also scan skills/meet-join/ (excluding bot/ and contracts/ which have their own test runners). Per-file-process isolation via the existing loop preserves mock.module correctness.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
