### PR TITLE
ci: install workspace deps before openapi-check

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -175,6 +175,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install linked package dependencies
+        run: |
+          cd ../packages/ces-contracts && bun install --frozen-lockfile
+          cd ../../skills/meet-join/contracts && bun install --frozen-lockfile
+          cd .. && bun install --frozen-lockfile
+
       - name: Check OpenAPI spec is up to date
         run: bun run generate:openapi -- --check
 


### PR DESCRIPTION
## Summary
- Add the \"Install linked package dependencies\" step to the \`openapi-check\` job in \`ci-main-assistant.yaml\`, matching \`lint\`/\`typecheck\`/\`test\`.
- Without this, \`@vellumai/meet-contracts\` (now living at \`skills/meet-join/contracts\` after #25890) can't resolve from \`skills/meet-join/routes/meet-internal.ts\`, so \`generate-openapi\` silently skips every route module that transitively pulls in meet code. The resulting spec is much smaller than the committed \`openapi.yaml\`, so \`--check\` fails with \"openapi.yaml is stale\".
- Fixes the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/24478115852/job/71535575848.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24478115852/job/71535575848
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
