### PR TITLE
fix(macos): prompt to retire conflicting local assistant on 400

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -418,6 +418,28 @@ extension AppDelegate {
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
+                // Non-Vellum users are capped at one local assistant. When the
+                // platform rejects this registration with 400, the bootstrap
+                // surfaces the existing assistant so we can prompt the user to
+                // retire it and retry.
+                if let bootstrapError = error as? LocalBootstrapError,
+                   case .existingRegistrationConflict(let existing, let organizationId) = bootstrapError {
+                    let didRetire = await self.presentExistingRegistrationConflict(
+                        existing: existing,
+                        organizationId: organizationId
+                    )
+                    if didRetire {
+                        log.info("Retired conflicting assistant — retrying local bootstrap")
+                        self.ensureLocalAssistantApiKey()
+                        return
+                    }
+                    log.info("User cancelled conflict retire; abandoning local bootstrap")
+                    self.localBootstrapDidComplete = true
+                    SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
+                    NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
+                    return
+                }
+
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
@@ -428,6 +450,44 @@ extension AppDelegate {
                     copyableDetail: error.localizedDescription
                 )
             }
+        }
+    }
+
+    /// Prompts the user to retire an existing local-assistant registration
+    /// that's blocking this device's registration, then performs the retire.
+    /// Returns true if the user confirmed and the retire succeeded — the
+    /// caller should retry the bootstrap. Returns false if the user cancelled
+    /// or the retire failed (a follow-up alert is shown on failure).
+    @MainActor
+    private func presentExistingRegistrationConflict(
+        existing: PlatformAssistant,
+        organizationId: String
+    ) async -> Bool {
+        let label = existing.name ?? existing.id
+        let alert = NSAlert()
+        alert.messageText = "Another Assistant Is Already Registered"
+        alert.informativeText = "\"\(label)\" is currently registered to your account. Retire it to register this assistant in its place."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Retire & Continue")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return false
+        }
+        do {
+            try await AuthService.shared.retireSelfHostedLocalAssistant(
+                platformAssistantId: existing.id,
+                organizationId: organizationId
+            )
+            return true
+        } catch {
+            log.error("Failed to retire conflicting assistant: \(error.localizedDescription)")
+            let failureAlert = NSAlert()
+            failureAlert.messageText = "Could Not Retire Assistant"
+            failureAlert.informativeText = error.localizedDescription
+            failureAlert.alertStyle = .warning
+            failureAlert.addButton(withTitle: "OK")
+            failureAlert.runModal()
+            return false
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -418,10 +418,6 @@ extension AppDelegate {
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
-                // Non-Vellum users are capped at one local assistant. When the
-                // platform rejects this registration with 400, the bootstrap
-                // surfaces the existing assistant so we can prompt the user to
-                // retire it and retry.
                 if let bootstrapError = error as? LocalBootstrapError,
                    case .existingRegistrationConflict(let existing, let organizationId) = bootstrapError {
                     let didRetire = await self.presentExistingRegistrationConflict(
@@ -453,11 +449,7 @@ extension AppDelegate {
         }
     }
 
-    /// Prompts the user to retire an existing local-assistant registration
-    /// that's blocking this device's registration, then performs the retire.
-    /// Returns true if the user confirmed and the retire succeeded — the
-    /// caller should retry the bootstrap. Returns false if the user cancelled
-    /// or the retire failed (a follow-up alert is shown on failure).
+    /// Returns true iff the user confirmed and the retire succeeded (caller should retry bootstrap).
     @MainActor
     private func presentExistingRegistrationConflict(
         existing: PlatformAssistant,

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -373,11 +373,7 @@ public final class AuthService {
         return try response.decode(PaginatedPlatformAssistantsResponse.self).results
     }
 
-    /// List self-hosted local assistant registrations visible to the caller.
-    ///
-    /// Used to resolve the existing registration when ensure-registration
-    /// returns 400 because the user already has another local assistant
-    /// registered (non-Vellum users are capped at one).
+    /// List self-hosted local assistant registrations for the caller.
     public func listSelfHostedLocalAssistants(organizationId: String) async throws -> [PlatformAssistant] {
         let response = try await performPlatformRequest(
             path: "v1/assistants/?hosting=local",

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -373,6 +373,20 @@ public final class AuthService {
         return try response.decode(PaginatedPlatformAssistantsResponse.self).results
     }
 
+    /// List self-hosted local assistant registrations visible to the caller.
+    ///
+    /// Used to resolve the existing registration when ensure-registration
+    /// returns 400 because the user already has another local assistant
+    /// registered (non-Vellum users are capped at one).
+    public func listSelfHostedLocalAssistants(organizationId: String) async throws -> [PlatformAssistant] {
+        let response = try await performPlatformRequest(
+            path: "v1/assistants/?hosting=local",
+            method: "GET",
+            organizationId: organizationId
+        )
+        return try response.decode(PaginatedPlatformAssistantsResponse.self).results
+    }
+
     /// Create or retrieve a managed assistant via the idempotent hatch endpoint.
     /// Returns `.reusedExisting` on 200 (assistant already exists) or `.createdNew` on 201.
     public func hatchAssistant(

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -18,6 +18,11 @@ public enum LocalBootstrapError: LocalizedError, Sendable {
     case provisioningFailed(String)
     case assistantInjectionFailed
     case multipleOrganizations
+    /// The user already has a different local assistant registered with the
+    /// platform. Carries the existing assistant so the UI can offer to retire
+    /// it and retry. Also carries the organization ID needed for the retire
+    /// call so callers don't have to re-resolve it.
+    case existingRegistrationConflict(existing: PlatformAssistant, organizationId: String)
 
     public var errorDescription: String? {
         switch self {
@@ -31,6 +36,9 @@ public enum LocalBootstrapError: LocalizedError, Sendable {
             return "Failed to inject API key into the assistant"
         case .multipleOrganizations:
             return "Multiple organizations found. Multi-org support is not yet available — please contact support."
+        case .existingRegistrationConflict(let existing, _):
+            let label = existing.name ?? existing.id
+            return "Another local assistant (\(label)) is already registered to your account."
         }
     }
 }
@@ -131,6 +139,16 @@ public final class LocalAssistantBootstrapService {
                 assistantVersion: assistantVersion
             )
         } catch let error as PlatformAPIError {
+            // Non-Vellum users are capped at one local assistant; the platform
+            // returns 400 when a different runtime tries to register. Resolve
+            // the existing registration so the UI can offer to retire it.
+            if case .serverError(400, _) = error,
+               let existing = try? await firstExistingLocalAssistant(organizationId: organizationId) {
+                throw LocalBootstrapError.existingRegistrationConflict(
+                    existing: existing,
+                    organizationId: organizationId
+                )
+            }
             throw mapPlatformError(error, context: .registration)
         } catch {
             throw LocalBootstrapError.registrationFailed(error.localizedDescription)
@@ -352,6 +370,15 @@ public final class LocalAssistantBootstrapService {
     private func resolveUserId() async throws -> String? {
         let session = try await authService.getSession()
         return session.data?.user?.id
+    }
+
+    /// Returns the first self-hosted local assistant the caller has registered
+    /// in the given organization, or nil if the list is empty / the request fails.
+    /// Used to resolve the conflicting registration after a 400 from
+    /// ensure-registration.
+    private func firstExistingLocalAssistant(organizationId: String) async throws -> PlatformAssistant? {
+        let assistants = try await authService.listSelfHostedLocalAssistants(organizationId: organizationId)
+        return assistants.first
     }
 
     private enum ErrorContext {

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -18,10 +18,7 @@ public enum LocalBootstrapError: LocalizedError, Sendable {
     case provisioningFailed(String)
     case assistantInjectionFailed
     case multipleOrganizations
-    /// The user already has a different local assistant registered with the
-    /// platform. Carries the existing assistant so the UI can offer to retire
-    /// it and retry. Also carries the organization ID needed for the retire
-    /// call so callers don't have to re-resolve it.
+    /// organizationId is carried so the retire call doesn't re-resolve it.
     case existingRegistrationConflict(existing: PlatformAssistant, organizationId: String)
 
     public var errorDescription: String? {
@@ -139,11 +136,8 @@ public final class LocalAssistantBootstrapService {
                 assistantVersion: assistantVersion
             )
         } catch let error as PlatformAPIError {
-            // Non-Vellum users are capped at one local assistant; the platform
-            // returns 400 with code=single_local_assistant_limit when a
-            // different runtime tries to register. Gate on the code (not just
-            // the 400 status) so unrelated bad-request responses fall through
-            // to the generic registration-failed path.
+            // Gate on the specific code (not just 400) so unrelated bad-request
+            // responses aren't misinterpreted as the single-assistant limit.
             if case .serverError(400, let body) = error,
                Self.isSingleLocalAssistantLimitError(body),
                let existing = try? await firstExistingLocalAssistant(organizationId: organizationId) {
@@ -375,37 +369,22 @@ public final class LocalAssistantBootstrapService {
         return session.data?.user?.id
     }
 
-    /// Stable error code returned by the platform when a non-Vellum user
-    /// already has a local assistant registered. Must stay in sync with the
-    /// backend constant on `POST /v1/assistants/self-hosted-local/ensure-registration/`.
-    private static let singleLocalAssistantLimitCode = "single_local_assistant_limit"
-
-    /// Shape of the structured 400 body the platform returns for
-    /// ensure-registration failures: `{success, code, detail}` (matches the
-    /// OAuth error pattern). All fields are optional so unrelated 400s that
-    /// don't follow this shape decode as `nil` and fall through.
+    /// Fields are optional so unrelated 400s that don't follow this shape decode as nil and fall through.
     private struct EnsureRegistrationErrorBody: Decodable {
         let success: Bool?
         let code: String?
         let detail: String?
     }
 
-    /// Returns true when the raw 400 body identifies the single-local-assistant
-    /// limit specifically. Anything else (free-form text, missing code, other
-    /// codes) returns false so the caller falls through to the generic
-    /// registration-failed path.
+    /// Code string must stay in sync with the backend on POST /v1/assistants/self-hosted-local/ensure-registration/.
     private static func isSingleLocalAssistantLimitError(_ body: String?) -> Bool {
         guard let data = body?.data(using: .utf8),
               let parsed = try? JSONDecoder().decode(EnsureRegistrationErrorBody.self, from: data) else {
             return false
         }
-        return parsed.code == singleLocalAssistantLimitCode
+        return parsed.code == "single_local_assistant_limit"
     }
 
-    /// Returns the first self-hosted local assistant the caller has registered
-    /// in the given organization, or nil if the list is empty / the request fails.
-    /// Used to resolve the conflicting registration after a 400 from
-    /// ensure-registration.
     private func firstExistingLocalAssistant(organizationId: String) async throws -> PlatformAssistant? {
         let assistants = try await authService.listSelfHostedLocalAssistants(organizationId: organizationId)
         return assistants.first

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -140,9 +140,12 @@ public final class LocalAssistantBootstrapService {
             )
         } catch let error as PlatformAPIError {
             // Non-Vellum users are capped at one local assistant; the platform
-            // returns 400 when a different runtime tries to register. Resolve
-            // the existing registration so the UI can offer to retire it.
-            if case .serverError(400, _) = error,
+            // returns 400 with code=single_local_assistant_limit when a
+            // different runtime tries to register. Gate on the code (not just
+            // the 400 status) so unrelated bad-request responses fall through
+            // to the generic registration-failed path.
+            if case .serverError(400, let body) = error,
+               Self.isSingleLocalAssistantLimitError(body),
                let existing = try? await firstExistingLocalAssistant(organizationId: organizationId) {
                 throw LocalBootstrapError.existingRegistrationConflict(
                     existing: existing,
@@ -370,6 +373,33 @@ public final class LocalAssistantBootstrapService {
     private func resolveUserId() async throws -> String? {
         let session = try await authService.getSession()
         return session.data?.user?.id
+    }
+
+    /// Stable error code returned by the platform when a non-Vellum user
+    /// already has a local assistant registered. Must stay in sync with the
+    /// backend constant on `POST /v1/assistants/self-hosted-local/ensure-registration/`.
+    private static let singleLocalAssistantLimitCode = "single_local_assistant_limit"
+
+    /// Shape of the structured 400 body the platform returns for
+    /// ensure-registration failures: `{success, code, detail}` (matches the
+    /// OAuth error pattern). All fields are optional so unrelated 400s that
+    /// don't follow this shape decode as `nil` and fall through.
+    private struct EnsureRegistrationErrorBody: Decodable {
+        let success: Bool?
+        let code: String?
+        let detail: String?
+    }
+
+    /// Returns true when the raw 400 body identifies the single-local-assistant
+    /// limit specifically. Anything else (free-form text, missing code, other
+    /// codes) returns false so the caller falls through to the generic
+    /// registration-failed path.
+    private static func isSingleLocalAssistantLimitError(_ body: String?) -> Bool {
+        guard let data = body?.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(EnsureRegistrationErrorBody.self, from: data) else {
+            return false
+        }
+        return parsed.code == singleLocalAssistantLimitCode
     }
 
     /// Returns the first self-hosted local assistant the caller has registered


### PR DESCRIPTION
## Summary

Pairs with [vellum-assistant-platform#4295](https://github.com/vellum-ai/vellum-assistant-platform/pull/4295), which limits non-Vellum users to one locally-hosted assistant by returning 400 from `POST /v1/assistants/self-hosted-local/ensure-registration/` when a different `runtime_assistant_id` is registered.

When the macOS app hits that 400 during bootstrap, it now:

1. Fetches the user's existing local registration via `GET /v1/assistants/?hosting=local` (the platform caps non-Vellum users at one, so `results.first` is the conflicting assistant).
2. Surfaces it as `LocalBootstrapError.existingRegistrationConflict(existing:organizationId:)`.
3. Shows an `NSAlert` with the existing assistant's name and a **Retire & Continue** button.
4. On confirmation, calls `DELETE /v1/assistants/{id}/retire/` (platform state only — the other device's local state is untouched and its key will be revoked on next heartbeat) and re-runs `ensureLocalAssistantApiKey()`.
5. On retire failure, shows a follow-up alert and abandons the bootstrap.
6. On user cancel, completes silently without the generic credentials-error toast.

## Files changed

- `clients/shared/App/Auth/AuthService.swift` — new `listSelfHostedLocalAssistants(organizationId:)` mirroring `listAssistants`.
- `clients/shared/App/Auth/LocalAssistantBootstrapService.swift` — new error case + 400 detection that resolves the conflict via the list endpoint.
- `clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift` — conflict-recognition branch in the existing catch + new `presentExistingRegistrationConflict(existing:organizationId:)` helper.

## Test plan

- [ ] Build (`./build.sh`) succeeds — confirmed locally.
- [ ] Manual: as a non-Vellum user with an existing local registration on another device, sign in on a fresh install → confirm the alert appears with the correct existing-assistant name → click **Retire & Continue** → confirm bootstrap completes on the second pass and the new device shows up registered.
- [ ] Manual: same flow, click **Cancel** → confirm no toast appears and the bootstrap-completed notification still fires (so dependent UI unblocks).
- [ ] Manual: simulate retire failure (e.g. revoke session mid-flow) → confirm follow-up alert and clean abandonment.
- [ ] Vellum users (`@vellum.ai`) are unaffected because the backend never returns 400 for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
