### PR TITLE
fix(ci): allowlist assistant/scripts/test.sh in meet-join isolation guard

### DIFF
--- a/assistant/src/__tests__/skill-meet-isolation.test.ts
+++ b/assistant/src/__tests__/skill-meet-isolation.test.ts
@@ -65,6 +65,9 @@ const ALLOWLIST = new Set([
   "clients/macos/build.sh", // packages skill deps into daemon bundle
   "scripts/build-meet-bot-image.sh", // builds the meet-bot Docker image
 
+  // --- Test runner (discovers tests inside skills/meet-join/ subpackages) ---
+  "assistant/scripts/test.sh", // runs bun test across meet-join workspace packages
+
   // --- Documentation (top-level architecture references) ---
   "AGENTS.md", // architecture and invariant documentation
   "ARCHITECTURE.md", // architecture documentation


### PR DESCRIPTION
## Summary
- \`assistant/scripts/test.sh\` was extended in #25922 to discover tests under \`skills/meet-join/\`, introducing a reference to \`skills/meet-join/\` outside the allowlist.
- The \`skill-meet-isolation\` guard test flagged it as a violation, breaking CI on main.
- Add the file to the ALLOWLIST with a comment explaining its role (test discovery across the meet-join workspace packages).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24478577254/job/71537165245
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
