### PR TITLE
ci: regenerate stale openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2750,7 +2750,9 @@ paths:
     post:
       operationId: conversations_by_id_archive_post
       summary: Archive a conversation
-      description: Move a conversation to the archived state. Archived conversations are hidden from the default sidebar but preserved for search and recall.
+      description:
+        Move a conversation to the archived state. Archived conversations are hidden from the default sidebar but
+        preserved for search and recall.
       tags:
         - conversations
       responses:
@@ -2891,6 +2893,22 @@ paths:
           required: true
           schema:
             type: string
+  /v1/conversations/{id}/unarchive:
+    post:
+      operationId: conversations_by_id_unarchive_post
+      summary: Unarchive a conversation
+      description: Restore an archived conversation back to the default sidebar.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}/undo:
     post:
       operationId: conversations_by_id_undo_post
@@ -2916,22 +2934,6 @@ paths:
                   - removedCount
                   - conversationId
                 additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-  /v1/conversations/{id}/unarchive:
-    post:
-      operationId: conversations_by_id_unarchive_post
-      summary: Unarchive a conversation
-      description: Restore an archived conversation back to the default sidebar.
-      tags:
-        - conversations
-      responses:
-        "200":
-          description: Successful response
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
## Summary
- Regenerates \`assistant/openapi.yaml\` to match \`bun run generate:openapi\` output.
- Fixes the OpenAPI Spec Check CI failure on main (run 24478577254, job 71537165233).
- Drift was cosmetic: archive description line wrapping + unarchive/undo path ordering.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24478577254/job/71537165233
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
