### PR TITLE
meet: move 037-create-meets-dir migration back to core workspace registry

### DIFF
--- a/assistant/src/__tests__/skill-meet-isolation.test.ts
+++ b/assistant/src/__tests__/skill-meet-isolation.test.ts
@@ -39,9 +39,6 @@ const ALLOWLIST = new Set([
   // --- Central HTTP route mount (routes must be mounted on the server) ---
   "assistant/src/runtime/http-server.ts", // mounts meet-internal routes
 
-  // --- Central workspace migration registry (migrations must be registered) ---
-  "assistant/src/workspace/migrations/registry.ts", // registers createMeetsDirMigration
-
   // --- Daemon shutdown (session manager must be stopped on shutdown) ---
   "assistant/src/daemon/shutdown-handlers.ts", // imports MeetSessionManager
 

--- a/assistant/src/__tests__/workspace-migration-meets.test.ts
+++ b/assistant/src/__tests__/workspace-migration-meets.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createMeetsDirMigration } from "../../../skills/meet-join/migrations/037-create-meets-dir.js";
+import { createMeetsDirMigration } from "../workspace/migrations/037-create-meets-dir.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/workspace/migrations/037-create-meets-dir.ts
+++ b/assistant/src/workspace/migrations/037-create-meets-dir.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import type { WorkspaceMigration } from "../../../assistant/src/workspace/migrations/types.js";
+import type { WorkspaceMigration } from "./types.js";
 
 /**
  * `.keep` sentinel content. Keeps the directory tracked/visible even when

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,4 +1,3 @@
-import { createMeetsDirMigration } from "../../../../skills/meet-join/migrations/037-create-meets-dir.js";
 import { avatarRenameMigration } from "./001-avatar-rename.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
@@ -35,6 +34,7 @@ import { sttServiceExplicitConfigMigration } from "./033-stt-service-explicit-co
 import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-calls-voice-transcription-provider.js";
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
+import { createMeetsDirMigration } from "./037-create-meets-dir.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 

--- a/assistant/tsconfig.json
+++ b/assistant/tsconfig.json
@@ -21,7 +21,6 @@
     "../skills/meet-join/daemon/**/*.ts",
     "../skills/meet-join/tools/**/*.ts",
     "../skills/meet-join/routes/**/*.ts",
-    "../skills/meet-join/migrations/**/*.ts",
     "../skills/meet-join/config-schema.ts"
   ],
   "exclude": [

--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -1,18 +1,17 @@
 # Meet-join skill — Agent Instructions
 
 All Meet runtime code lives under this directory. The daemon module, tools,
-routes, migrations, config schema, wire-contracts, and Meet-bot container
-image are all consolidated here so the skill can evolve — or be lifted out of
-the repo entirely — without hunting down scattered references across the
-monorepo.
+routes, config schema, wire-contracts, and Meet-bot container image are all
+consolidated here so the skill can evolve — or be lifted out of the repo
+entirely — without hunting down scattered references across the monorepo.
 
 ## The isolation rule
 
 Code outside `skills/meet-join/` must not import from the skill beyond a small,
 explicit allowlist of wiring points: the central tool manifest, HTTP route
-mount, workspace migration registry, config schema, daemon shutdown handler,
-and the daemon-client SSE protocol registry. These are the places where a
-central registry has to know about Meet — everywhere else, Meet is opaque.
+mount, config schema, daemon shutdown handler, and the daemon-client SSE
+protocol registry. These are the places where a central registry has to know
+about Meet — everywhere else, Meet is opaque.
 
 The complete allowlist and enforcement live in
 `assistant/src/__tests__/skill-meet-isolation.test.ts`. A guard test scans the


### PR DESCRIPTION
## Summary
- Revert the move of workspace migration `037-create-meets-dir` out of `skills/meet-join/migrations/` and back into `assistant/src/workspace/migrations/`, restoring the local `./types.js` and `./037-create-meets-dir.js` imports.
- Fixes the CI ceiling computation in `.github/workflows/ci-register-dev-images.yaml` and `release.yml` — those workflows' regex only matches local `./` imports, so the cross-package import made the last-migration-id lookup resolve to `undefined.ts`. (Carson's attempted fix in #25901 was reverted in #25904; moving the migration back is simpler than making the workflow regex tolerant.)
- Cleans up the now-unused `skills/meet-join/migrations/` tsconfig include path, removes the `registry.ts` entry from the skill-isolation allowlist, and drops the "migrations" mention in `skills/meet-join/AGENTS.md`.
- The rest of the Meet consolidation (bot, contracts, daemon, routes, tools, config-schema) is intentional and stays put — only the migration was structurally misplaced, since workspace migrations are core daemon infrastructure, not optional skill code.

## Verification
- `bun test src/__tests__/workspace-migration-meets.test.ts` — 11/11 pass.
- Local sim of the CI ceiling computation now prints `037-create-meets-dir` (was failing on the current main).
- `skill-meet-isolation` guard test: no new violations introduced (one pre-existing violation — `assistant/scripts/test.sh`, added in #25922 — remains; unrelated to this change).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
