### PR TITLE
fix(providers/openrouter): correct Anthropic Messages API base URL

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1889,26 +1889,27 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
     expect(lastConstructorArgs).toMatchObject({
       apiKey: null,
       authToken: "or-key",
-      baseURL: "https://openrouter.ai/api/v1/anthropic",
+      baseURL: "https://openrouter.ai/api",
     });
     expect(lastStreamParams).toBeTruthy();
     expect(lastStreamParams!.model).toBe("anthropic/claude-sonnet-4.6");
   });
 
-  test("custom baseURL is suffixed with /anthropic for Messages API", async () => {
+  test("custom baseURL has trailing /v1 stripped for Messages API", async () => {
     const { OpenRouterProvider } = await import(
       "../providers/openrouter/client.js"
     );
     const provider = new OpenRouterProvider(
       "ast-key",
       "anthropic/claude-opus-4.6",
-      { baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter" },
+      {
+        baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter/v1",
+      },
     );
     await provider.sendMessage([userMsg("hi")]);
 
     expect(lastConstructorArgs).toMatchObject({
-      baseURL:
-        "https://platform.example.com/v1/runtime-proxy/openrouter/anthropic",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
     });
   });
 

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -16,12 +16,19 @@ export interface OpenRouterProviderOptions {
 const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 // Models on OpenRouter prefixed `anthropic/` are routed through OpenRouter's
-// Anthropic-compatible Messages API (`<baseURL>/anthropic/v1/messages`) so that
+// Anthropic-compatible Messages API at `<root>/v1/messages` (where `<root>` is
+// the OpenRouter API root, e.g. `https://openrouter.ai/api`) so that
 // Anthropic-native features — extended thinking, prompt caching, cache TTL,
 // output_config — work without lossy translation through the OpenAI chat
-// completions compatibility layer.
+// completions compatibility layer. The Anthropic SDK appends `/v1/messages` to
+// its configured baseURL, so we strip the trailing `/v1` segment from the
+// OpenAI-compat base before handing it to the SDK.
 function isAnthropicModel(model: string): boolean {
   return model.startsWith("anthropic/");
+}
+
+function toAnthropicMessagesBaseURL(openRouterBaseURL: string): string {
+  return openRouterBaseURL.replace(/\/v1\/?$/, "");
 }
 
 export class OpenRouterProvider extends OpenAIProvider {
@@ -95,7 +102,7 @@ export class OpenRouterProvider extends OpenAIProvider {
         this.openRouterApiKey,
         this.defaultModel,
         {
-          baseURL: `${this.resolvedBaseURL}/anthropic`,
+          baseURL: toAnthropicMessagesBaseURL(this.resolvedBaseURL),
           streamTimeoutMs: this.providerStreamTimeoutMs,
           authToken: this.openRouterApiKey,
         },


### PR DESCRIPTION
## Summary
- OpenRouter's Anthropic Messages endpoint is `https://openrouter.ai/api/v1/messages`, not `/api/v1/anthropic/v1/messages`. The old URL 404'd to OpenRouter's Next.js frontend, surfacing in the desktop app as `ProviderError: Anthropic API error (404): <!DOCTYPE html…>` whenever an `anthropic/*` model was selected.
- Strip trailing `/v1` from the OpenRouter base before passing to the Anthropic SDK; SDK appends its own `/v1/messages` to reach the correct path.
- Update the two tests that codified the bad URL. Verified by curl: wrong URL returns 404 + HTML; correct URL returns 401 + JSON (auth error, as expected with a dummy key).