### PR TITLE
providers(openrouter): route quality-optimized intent to Claude Opus 4.6

### DIFF
--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -38,7 +38,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   openrouter: {
     "latency-optimized": "qwen/qwen3.5-flash-02-23",
-    "quality-optimized": "x-ai/grok-4.20-beta",
+    "quality-optimized": "anthropic/claude-opus-4.6",
     "vision-optimized": "x-ai/grok-4.20-beta",
   },
 };


### PR DESCRIPTION
## Summary
- Swap OpenRouter's `quality-optimized` model intent from `x-ai/grok-4.20-beta` to `anthropic/claude-opus-4.6`. With the Anthropic Messages API routing on OpenRouter, Opus now flows through natively (extended thinking, prompt caching, cache TTL, `output_config`) without the OpenAI-compat translation layer.
- `vision-optimized` stays on Grok 4.20 Beta for now.