### PR TITLE
providers(openrouter): route latency/vision intents to Anthropic

### DIFF
--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -37,9 +37,9 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "vision-optimized": "accounts/fireworks/models/kimi-k2p5",
   },
   openrouter: {
-    "latency-optimized": "qwen/qwen3.5-flash-02-23",
+    "latency-optimized": "anthropic/claude-haiku-4.5",
     "quality-optimized": "anthropic/claude-opus-4.6",
-    "vision-optimized": "x-ai/grok-4.20-beta",
+    "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };
 


### PR DESCRIPTION
## Summary
- `latency-optimized`: `qwen/qwen3.5-flash-02-23` → `anthropic/claude-haiku-4.5`
- `vision-optimized`: `x-ai/grok-4.20-beta` → `anthropic/claude-opus-4.6`
- All three OpenRouter intents now route Anthropic models through the native Messages API path (extended thinking, prompt caching, cache TTL, `output_config`) instead of the OpenAI chat-completions compatibility layer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
