### PR TITLE
Polish PreChat onboarding: layout, icons, interactions, and review fixes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/ToolSelectionView.swift
@@ -57,43 +57,46 @@ struct ToolSelectionView: View {
                 otherExpandedCard
                     .padding(.horizontal, VSpacing.xxl)
                     .padding(.top, VSpacing.sm)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .transition(.opacity)
             }
         }
     }
 
+    private var footer: some View {
+        VStack(spacing: VSpacing.sm) {
+            VButton(
+                label: selectedTools.isEmpty
+                    ? "Continue"
+                    : "Continue \u{00B7} \(selectedTools.count) selected",
+                style: .primary,
+                isFullWidth: true
+            ) {
+                onContinue()
+            }
+
+            VButton(label: "I'll set this up later", style: .ghost, tintColor: VColor.contentTertiary) {
+                onSkip()
+            }
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .opacity(showFooter ? 1 : 0)
+        .offset(y: showFooter ? 0 : 12)
+    }
+
     var body: some View {
-        VStack(spacing: 0) {
-            if otherExpanded {
-                ScrollView(.vertical, showsIndicators: false) {
+        GeometryReader { geometry in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 0) {
                     mainContent
-                }
-                .scrollBounceBehavior(.basedOnSize)
-            } else {
-                mainContent
-                Spacer()
-            }
 
-            // Footer
-            VStack(spacing: VSpacing.sm) {
-                VButton(
-                    label: selectedTools.isEmpty
-                        ? "Continue"
-                        : "Continue \u{00B7} \(selectedTools.count) selected",
-                    style: .primary,
-                    isFullWidth: true
-                ) {
-                    onContinue()
+                    footer
+                        .padding(.top, VSpacing.xl)
+                        .padding(.bottom, VSpacing.xxl)
                 }
-
-                VButton(label: "I'll set this up later", style: .ghost, tintColor: VColor.contentTertiary) {
-                    onSkip()
-                }
+                .frame(minHeight: geometry.size.height)
+                .frame(maxWidth: .infinity)
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(EdgeInsets(top: VSpacing.lg, leading: 0, bottom: VSpacing.xxl, trailing: 0))
-            .opacity(showFooter ? 1 : 0)
-            .offset(y: showFooter ? 0 : 12)
+            .scrollBounceBehavior(.basedOnSize)
         }
         .onAppear {
             // Restore otherText from selectedTools if resuming


### PR DESCRIPTION
## Summary
Continued polish of the PreChat onboarding flow following the initial PR #25602. Addresses all bot review feedback and adds layout improvements.

## Changes
- **Layout**: Replace container-swapping layout with always-on ScrollView + GeometryReader for smooth transitions when toggling "Something else" expanded card
- **Transitions**: Pure opacity fade instead of slide+opacity for cleaner card dismiss animation
- **Focus**: Wire VTextField focus via `isFocused:` init parameter instead of no-op external `.focused()` modifier
- **Deduplication**: Strip `other:` prefix before sorting/deduplicating in both `finish()` and `contextSummary`
- **Accessibility**: Add `.accessibilityLabel("Back")` to icon-only back buttons, `.accessibilityLabel("Dismiss custom tools")` to close button
- **Icons**: Move custom `other` icon to separate `custom` source in manifest (not Simple Icons)
- **Custom tools**: Split comma-separated input into discrete `other:<name>` entries; deduplicate ForEach entries
- **Retain cycle**: Use `[weak self]` in PreChat preview window closure

## Test plan
- [ ] Open PreChat preview from developer menu — verify smooth expand/collapse of "Something else"
- [ ] Type comma-separated tools — verify pills render without duplicates
- [ ] Select a built-in tool AND type the same name in Something else — verify no duplicate in context
- [ ] VoiceOver: verify back buttons and close button announce properly
- [ ] Verify "Something else" text field auto-focuses when expanded
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
