### PR TITLE
fix(ui): remove unused actions property from ConfirmationSurfaceView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -64,7 +64,6 @@ struct SurfaceContainerView: View {
             case .confirmation(let data):
                 ConfirmationSurfaceView(
                     data: data,
-                    actions: surface.actions,
                     onAction: { actionId in
                         viewModel.onAction(actionId, nil)
                     }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -118,7 +118,7 @@ public struct InlineSurfaceRouter: View {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
         } else if case .confirmation(let data) = surface.data {
             // Confirmations manage their own card chrome — collapse to a chip after user acts
-            ConfirmationSurfaceView(data: data, actions: surface.actions, showCardChrome: true) { actionId in
+            ConfirmationSurfaceView(data: data, showCardChrome: true) { actionId in
                 onAction(surface.id, actionId, nil)
             }
             .widthCap(540)
@@ -353,7 +353,7 @@ public struct InlineSurfaceRouter: View {
             }
             .id(surface.id)
         case .confirmation(let data):
-            ConfirmationSurfaceView(data: data, actions: surface.actions) { actionId in
+            ConfirmationSurfaceView(data: data) { actionId in
                 onAction(surface.id, actionId, nil)
             }
         #if os(macOS)

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 public struct ConfirmationSurfaceView: View {
     public let data: ConfirmationSurfaceData
-    public let actions: [SurfaceActionButton]
     public let showCardChrome: Bool
     public let onAction: (String) -> Void
 
@@ -13,9 +12,8 @@ public struct ConfirmationSurfaceView: View {
 
     @State private var selectedAction: SelectedAction?
 
-    public init(data: ConfirmationSurfaceData, actions: [SurfaceActionButton], showCardChrome: Bool = false, onAction: @escaping (String) -> Void) {
+    public init(data: ConfirmationSurfaceData, showCardChrome: Bool = false, onAction: @escaping (String) -> Void) {
         self.data = data
-        self.actions = actions
         self.showCardChrome = showCardChrome
         self.onAction = onAction
     }


### PR DESCRIPTION
Follow-up to #25872. The canonical action ID change left the actions property as dead code — declared and passed but never read. Remove it from the struct, init, and all callers per AGENTS.md Dead Code Removal rule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
