### PR TITLE
fix(macos): reset thinking anchor on multi-wave runs, flatten padding, fix Date() consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -290,6 +290,12 @@ struct AssistantProgressView: View {
                     startDate = Date()
                 }
             }
+            // Reset thinking anchor when tools resume in a multi-wave run
+            // (tools complete → think → more tools → think → complete).
+            if newPhase == .toolRunning || newPhase == .streamingCode {
+                thinkingAfterToolsStartDate = nil
+                thinkingAfterToolsEndDate = nil
+            }
             // Track thinking phase start: all tools complete, card still active.
             if (newPhase == .toolsCompleteThinking || newPhase == .processing)
                 && model.allComplete && model.hasTools
@@ -298,10 +304,11 @@ struct AssistantProgressView: View {
             }
             // Track thinking phase end: card transitioned to complete.
             if newPhase == .complete, let thinkingStart = thinkingAfterToolsStartDate, thinkingAfterToolsEndDate == nil {
-                thinkingAfterToolsEndDate = Date()
+                let now = Date()
+                thinkingAfterToolsEndDate = now
                 // Persist duration so it survives view recycling.
                 if let key = cardKey {
-                    let duration = Date().timeIntervalSince(thinkingStart)
+                    let duration = now.timeIntervalSince(thinkingStart)
                     progressUIState.setThinkingDuration(for: key, duration: duration)
                 }
             }
@@ -1060,8 +1067,7 @@ private struct ThinkingStepRow: View {
                     }
                 }
             }
-            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs))
-            .padding(EdgeInsets(top: 0, leading: VSpacing.sm, bottom: 0, trailing: VSpacing.xs))
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm + VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs + VSpacing.xs))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reset `thinkingAfterToolsStartDate`/`EndDate` when tools resume (`.toolRunning`/`.streamingCode`) so multi-wave runs don't inflate thinking duration
- Combine consecutive `.padding()` modifiers in `ThinkingStepRow` into a single call per macOS AGENTS.md rules (perf hazard in LazyVStack)
- Capture single `let now = Date()` in `handlePhaseChange` completion path to avoid timestamp drift between displayed and persisted thinking duration

Follow-up to #25884.

## Test plan
- [ ] Verify multi-wave tool runs (tools → think → more tools → think → complete) show correct thinking duration for the final wave only
- [ ] Verify ThinkingStepRow padding appears visually identical (combined values match previous stacked paddings)
- [ ] Verify completed progress card duration matches sum of tool steps + thinking row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
