### PR TITLE
fix(gmail): abort in-flight fetches when sender digest deadline fires

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -16,6 +16,20 @@ function isRateLimitError(e: unknown): boolean {
   return /\b429\b/.test(e.message);
 }
 
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (e instanceof Error && e.message === "fetch deadline exceeded") return true;
+  // AbortSignal.reason propagated through promise chains
+  if (
+    e instanceof Error &&
+    "cause" in e &&
+    e.cause instanceof Error &&
+    e.cause.message === "fetch deadline exceeded"
+  )
+    return true;
+  return false;
+}
+
 const MAX_MESSAGES_CAP = 5000;
 const MAX_IDS_PER_SENDER = 5000;
 const MAX_SAMPLE_SUBJECTS = 3;
@@ -77,6 +91,7 @@ export async function run(
     // overlapping fetch latency with pagination latency
     const allMessageIds: string[] = [];
     const fetchPromises: Promise<GmailMessage[]>[] = [];
+    const fetchAbort = new AbortController();
     let pageToken: string | undefined = inputPageToken;
     let truncated = false;
     let timeBudgetExceeded = false;
@@ -119,6 +134,7 @@ export async function run(
           "metadata",
           metadataHeaders,
           "id,internalDate,payload/headers",
+          fetchAbort.signal,
         ),
       );
       pageToken = listResp.nextPageToken ?? undefined;
@@ -154,19 +170,15 @@ export async function run(
     }
 
     // Settle all fetch promises — collect successes and tolerate 429 failures.
-    // Race each promise against a deadline so slow retries don't exceed the
-    // executor's 120s tool timeout.
+    // Abort in-flight requests when the deadline fires so they don't continue
+    // consuming API quota in the background.
     const elapsedMs = Date.now() - startTime;
     const settleDeadlineMs = Math.max(TIME_BUDGET_MS - elapsedMs, 5_000);
-    const deadlineRejection = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error("fetch deadline exceeded")),
-        settleDeadlineMs,
-      ),
-    );
-    const settled = await Promise.allSettled(
-      fetchPromises.map((p) => Promise.race([p, deadlineRejection])),
-    );
+    const deadlineTimer = setTimeout(() => {
+      fetchAbort.abort(new Error("fetch deadline exceeded"));
+    }, settleDeadlineMs);
+    const settled = await Promise.allSettled(fetchPromises);
+    clearTimeout(deadlineTimer);
     const messages: GmailMessage[] = [];
     for (const result of settled) {
       if (result.status === "fulfilled") {
@@ -174,10 +186,7 @@ export async function run(
       } else if (isRateLimitError(result.reason)) {
         rateLimited = true;
         truncated = true;
-      } else if (
-        result.reason instanceof Error &&
-        result.reason.message === "fetch deadline exceeded"
-      ) {
+      } else if (isAbortError(result.reason)) {
         timeBudgetExceeded = true;
         truncated = true;
       } else {

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -117,11 +117,13 @@ async function request<T>(
   path: string,
   options?: GmailRequestOptions,
   query?: Record<string, string | string[]>,
+  signal?: AbortSignal,
 ): Promise<T> {
   const canRetry = options?.retryable ?? isIdempotent(options);
   const method = (options?.method ?? "GET").toUpperCase();
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    signal?.throwIfAborted();
     let resp: OAuthConnectionResponse;
     try {
       resp = await connection.request({
@@ -133,6 +135,7 @@ async function request<T>(
           ...extractNonAuthHeaders(options),
         },
         body: extractBody(options),
+        signal,
       });
     } catch (err) {
       // Retry thrown errors that indicate a retryable status (e.g. platform
@@ -213,6 +216,7 @@ export async function getMessage(
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
   fields?: string,
+  signal?: AbortSignal,
 ): Promise<GmailMessage> {
   const params = new URLSearchParams({ format });
   if (format === "metadata" && metadataHeaders) {
@@ -224,6 +228,7 @@ export async function getMessage(
     `/messages/${messageId}`,
     undefined,
     paramsToQuery(params),
+    signal,
   );
 }
 
@@ -267,6 +272,7 @@ async function executeBatchCall(
   format: GmailMessageFormat,
   metadataHeaders: string[] | undefined,
   fields?: string,
+  signal?: AbortSignal,
 ): Promise<{
   messages: Array<{ index: number; msg: GmailMessage }>;
   failedIds: Array<{ index: number; id: string }>;
@@ -292,9 +298,13 @@ async function executeBatchCall(
 
   const doBatchFetch = async (token: string) => {
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS * 2);
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : timeoutSignal;
       const resp = await fetch(GMAIL_BATCH_URL, {
         method: "POST",
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS * 2),
+        signal: combinedSignal,
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": `multipart/mixed; boundary=${boundary}`,
@@ -386,13 +396,15 @@ async function fetchMessagesIndividually(
   format: GmailMessageFormat,
   metadataHeaders?: string[],
   fields?: string,
+  signal?: AbortSignal,
 ): Promise<GmailMessage[]> {
   const results: GmailMessage[] = [];
   for (let i = 0; i < messageIds.length; i += INDIVIDUAL_CONCURRENCY) {
+    signal?.throwIfAborted();
     const wave = messageIds.slice(i, i + INDIVIDUAL_CONCURRENCY);
     const waveResults = await Promise.all(
       wave.map((id) =>
-        getMessage(connection, id, format, metadataHeaders, fields),
+        getMessage(connection, id, format, metadataHeaders, fields, signal),
       ),
     );
     results.push(...waveResults);
@@ -414,6 +426,7 @@ export async function batchGetMessages(
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
   fields?: string,
+  signal?: AbortSignal,
 ): Promise<GmailMessage[]> {
   if (messageIds.length === 0) return [];
 
@@ -426,6 +439,7 @@ export async function batchGetMessages(
         format,
         metadataHeaders,
         fields,
+        signal,
       ),
     ];
   }
@@ -447,6 +461,7 @@ export async function batchGetMessages(
       format,
       metadataHeaders,
       fields,
+      signal,
     );
   }
 
@@ -473,6 +488,7 @@ export async function batchGetMessages(
           format,
           metadataHeaders,
           fields,
+          signal,
         ),
       ),
     );
@@ -490,7 +506,7 @@ export async function batchGetMessages(
       if (failedIds.length > 0) {
         const retried = await Promise.all(
           failedIds.map(({ id }) =>
-            getMessage(connection, id, format, metadataHeaders, fields),
+            getMessage(connection, id, format, metadataHeaders, fields, signal),
           ),
         );
         for (let r = 0; r < failedIds.length; r++) {

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -82,7 +82,9 @@ export class BYOOAuthConnection implements OAuthConnection {
           method: req.method,
           headers,
           body: req.body ? JSON.stringify(req.body) : undefined,
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          signal: req.signal
+            ? AbortSignal.any([req.signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+            : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         });
 
         if (resp.status === 401) {

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -11,6 +11,8 @@ export interface OAuthConnectionRequest {
    * use the same credential but different base URLs).
    */
   baseUrl?: string;
+  /** Optional abort signal to cancel the request. */
+  signal?: AbortSignal;
 }
 
 export interface OAuthConnectionResponse {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -90,6 +90,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(body),
+        signal: req.signal,
       });
 
       if (response.status === 424) {


### PR DESCRIPTION
Follow-up to #25632. The deadline race prevented timeouts but left in-flight batchGetMessages calls running, wasting API quota and triggering 429s. Thread an AbortController/AbortSignal through the fetch path so timed-out requests are actually cancelled.

Changes:
- Add optional `signal` field to `OAuthConnectionRequest` and thread it through BYO and Platform connection implementations
- Add optional `signal` param to `batchGetMessages`, `executeBatchCall`, `fetchMessagesIndividually`, `getMessage`, and the internal `request` helper
- Replace the deadline `Promise.race` pattern in `gmail-sender-digest.ts` with an `AbortController` that actually cancels in-flight HTTP requests when the time budget expires
- Clean up the deadline timer on success to avoid leaking timers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
