### PR TITLE
fix(macos): recover from retired managed assistant + restore LUM-755

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -100,7 +100,12 @@ async function retireVellum(
     headers: await authHeaders(token, runtimeUrl),
   });
 
-  if (!response.ok) {
+  // Treat 404 as success: the assistant is already gone from the platform
+  // (previously retired, deleted from the web UI, or retired from another
+  // device) so the caller's job is done. Falling through to the lockfile
+  // cleanup avoids leaving a stale entry that would otherwise wedge the
+  // macOS app in a permanent health-check loop.
+  if (!response.ok && response.status !== 404) {
     const body = await response.text();
     console.error(
       `Error: Platform retire failed (${response.status}): ${body}`,
@@ -108,7 +113,13 @@ async function retireVellum(
     process.exit(1);
   }
 
-  console.log("\u2705 Platform-hosted instance retired.");
+  if (response.status === 404) {
+    console.log(
+      "\u2705 Platform-hosted instance already retired (404) — cleaning up local state.",
+    );
+  } else {
+    console.log("\u2705 Platform-hosted instance retired.");
+  }
 }
 
 function parseSource(): string | undefined {

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -663,9 +663,17 @@ extension AppDelegate {
             replacement = await client.forceRemoveActiveAssistant()
         }
 
+        finalizePostRetire(replacement: replacement)
+        return true
+    }
+
+    /// Post-retire orchestration shared between the explicit retire flow and
+    /// the remote-retire-detected flow: either switch to the replacement
+    /// assistant or tear down the app and show onboarding.
+    func finalizePostRetire(replacement: LockfileAssistant?) {
         if let replacement {
             performSwitchAssistant(to: replacement)
-            return true
+            return
         }
 
         // No assistants left — tear down fully and show onboarding
@@ -745,7 +753,23 @@ extension AppDelegate {
         }
 
         showOnboarding()
-        return true
+    }
+
+    /// Respond to `.managedAssistantRetiredRemotely`: the platform has no
+    /// record of our active managed assistant. Force-remove its lockfile
+    /// entry (platform deregistration is best-effort and will no-op on 404)
+    /// and run the shared post-retire flow.
+    func handleManagedAssistantRetiredRemotely() {
+        guard let activeId = LockfileAssistant.loadActiveAssistantId() else {
+            log.info("managedAssistantRetiredRemotely: no active assistant — ignoring")
+            return
+        }
+        log.warning("Managed assistant '\(activeId, privacy: .public)' no longer exists on platform — cleaning up local state")
+        Task { @MainActor in
+            let client = AssistantManagementClient.create()
+            let replacement = await client.forceRemoveActiveAssistant()
+            finalizePostRetire(replacement: replacement)
+        }
     }
 
     // MARK: - Uninstall

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -138,6 +138,23 @@ extension AppDelegate {
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()
 
+        // Observe the managed-assistant-gone signal (health check 404) once
+        // per setup so a retired/deleted platform assistant no longer leaves
+        // the app in a permanent loading state.
+        if let prev = managedAssistantRetiredObserver {
+            NotificationCenter.default.removeObserver(prev)
+        }
+        managedAssistantRetiredObserver = NotificationCenter.default.addObserver(
+            forName: .managedAssistantRetiredRemotely,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.handleManagedAssistantRetiredRemotely()
+            }
+        }
+
         // Subscribe to SSE event stream for UI event routing.
         startEventSubscription()
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -126,6 +126,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the assistant-instance-changed observer. Stored so we can properly remove
     /// the closure-based observer before registering a new one.
     var instanceChangeObserver: NSObjectProtocol?
+    /// Opaque token for the observer that cleans up local state when the
+    /// platform reports the active managed assistant no longer exists.
+    var managedAssistantRetiredObserver: NSObjectProtocol?
     /// Tracks file paths of .vellum bundles awaiting assistant responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.

--- a/clients/macos/vellum-assistant/App/AssistantManagementClient.swift
+++ b/clients/macos/vellum-assistant/App/AssistantManagementClient.swift
@@ -173,6 +173,33 @@ class AssistantManagementClient {
         return nil
     }
 
+    /// How a backend should react when its underlying retire operation
+    /// throws. See ``retireFailurePolicy(for:)``.
+    enum RetireFailurePolicy {
+        /// Swallow the error and auto-clean local state. Used for managed
+        /// (cloud-hosted) assistants whose cloud instance may have been
+        /// torn down even when the CLI reports failure — reconnecting to a
+        /// dead platform assistant strands the user on an unreachable /
+        /// permanently-loading screen (LUM-755).
+        case autoCleanAndFindReplacement
+        /// Re-throw the error so the caller can prompt the user with a
+        /// Force Remove / Cancel alert. Used for local assistants whose
+        /// daemon may still be running after a CLI failure.
+        case rethrow
+    }
+
+    /// Decide how to recover from a retire failure for the given assistant.
+    ///
+    /// - Important: This encodes the LUM-755 invariant: a managed retire
+    ///   failure must NOT show the Force Remove / Cancel alert and must
+    ///   NOT reconnect to the (possibly dead) platform assistant. A prior
+    ///   refactor (#24927 / #24959) collapsed this branch and regressed the
+    ///   fix — the name and unit test are the forcing function that keeps
+    ///   it from happening again. Don't inline this logic.
+    static func retireFailurePolicy(for assistant: LockfileAssistant?) -> RetireFailurePolicy {
+        return (assistant?.isManaged == true) ? .autoCleanAndFindReplacement : .rethrow
+    }
+
     /// Force-removes the active assistant's lockfile entry, clears the
     /// active ID, and returns the best remaining assistant to switch to.
     /// Used by the "Force Remove" UI path when `retire()` fails.

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -307,7 +307,19 @@ final class VellumCli: AssistantManagementClient {
             log.error("CLI retire failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
             log.warning("[audit] CLI done: retire exit=\(status) duration=\(retireMs)ms")
 
-            throw CLIError.executionFailed(stderr)
+            // LUM-755: for managed assistants, swallow the CLI failure and
+            // auto-clean local state. The cloud instance may already be
+            // torn down, and reconnecting strands the user on a loading /
+            // unreachable screen. Local assistants fall through to the
+            // Force Remove / Cancel alert in AppDelegate+AuthLifecycle.
+            let retired = LockfileAssistant.loadByName(resolvedName)
+            switch AssistantManagementClient.retireFailurePolicy(for: retired) {
+            case .autoCleanAndFindReplacement:
+                log.warning("Managed retire failed — auto-cleaning local state (LUM-755)")
+                return await forceRemoveActiveAssistant()
+            case .rethrow:
+                throw CLIError.executionFailed(stderr)
+            }
         }
 
         log.info("CLI retire completed successfully")

--- a/clients/macos/vellum-assistantTests/RetireFailurePolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/RetireFailurePolicyTests.swift
@@ -1,0 +1,109 @@
+import VellumAssistantShared
+import XCTest
+@testable import VellumAssistantLib
+
+/// Regression tests for LUM-755.
+///
+/// Original issue: when the CLI retire of a managed (cloud-hosted) assistant
+/// fails, showing the Force Remove / Cancel alert and reconnecting on Cancel
+/// strands the user on an unreachable / permanently-loading screen because
+/// the cloud instance may already be partially torn down.
+///
+/// Fix (PR #24317, April 2026): managed retire failures auto-clean local
+/// state and find a replacement — no alert, no reconnect.
+///
+/// Regression (PRs #24927 + #24959, April 2026): a refactor collapsed the
+/// managed-specific branch; #24927's own checklist flagged the risk but the
+/// PR merged without the behavior preserved and without a test to catch it.
+///
+/// These tests lock the invariant in place. Any future refactor that
+/// collapses or removes ``AssistantManagementClient.retireFailurePolicy(for:)``
+/// will trip these tests rather than silently ship the regression a third
+/// time.
+@MainActor
+final class RetireFailurePolicyTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - LUM-755 invariant
+
+    func testLUM755_managedRetireFailureAutoCleansWithoutAlert() {
+        let managed = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+
+        let policy = AssistantManagementClient.retireFailurePolicy(for: managed)
+
+        XCTAssertEqual(
+            policy,
+            .autoCleanAndFindReplacement,
+            "LUM-755: managed retire failures must auto-clean local state. Showing the Force Remove / Cancel alert reconnects to a possibly dead cloud instance and strands the user on an unreachable / permanently-loading screen."
+        )
+    }
+
+    func testLocalRetireFailurePromptsForceRemoveOrCancel() {
+        let local = makeAssistant(id: "local-a", runtimeUrl: "", isLocal: true)
+
+        let policy = AssistantManagementClient.retireFailurePolicy(for: local)
+
+        XCTAssertEqual(
+            policy,
+            .rethrow,
+            "Local retire failures must re-throw so the caller can show the Force Remove / Cancel alert — the daemon may still be running and the user must decide."
+        )
+    }
+
+    func testNilAssistantRetireFailureFallsThroughToAlert() {
+        // Defensive: an unknown/missing assistant should not silently
+        // auto-clean (there's nothing safe to clean) — re-throw and let
+        // the caller surface the error.
+        let policy = AssistantManagementClient.retireFailurePolicy(for: nil)
+
+        XCTAssertEqual(policy, .rethrow)
+    }
+
+    // MARK: - Helpers
+
+    /// Construct a minimal `LockfileAssistant` for testing. Mirrors the
+    /// helper in `AssistantSwitcherViewModelTests`.
+    private func makeAssistant(
+        id: String,
+        runtimeUrl: String,
+        isLocal: Bool = false
+    ) -> LockfileAssistant {
+        let dir = tempDir.appendingPathComponent(UUID().uuidString, isDirectory: true).path
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = (dir as NSString).appendingPathComponent(".vellum.lock.json")
+        if isLocal {
+            let json: [String: Any] = [
+                "activeAssistant": id,
+                "assistants": [
+                    id: [
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "instanceDir": dir,
+                    ]
+                ]
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            try! data.write(to: URL(fileURLWithPath: path))
+        } else {
+            LockfileAssistant.ensureManagedEntry(
+                assistantId: id,
+                runtimeUrl: runtimeUrl,
+                hatchedAt: "2024-01-01T00:00:00Z",
+                lockfilePath: path
+            )
+        }
+        return LockfileAssistant.loadByName(id, lockfilePath: path)!
+    }
+}

--- a/clients/shared/Network/DaemonNotifications.swift
+++ b/clients/shared/Network/DaemonNotifications.swift
@@ -7,4 +7,11 @@ extension Notification.Name {
     /// Posted when the daemon's signing key fingerprint changes, indicating an instance switch.
     /// Observers should trigger credential re-bootstrap.
     public static let daemonInstanceChanged = Notification.Name("daemonInstanceChanged")
+
+    /// Posted by `GatewayConnectionManager` when the platform reports the
+    /// currently connected managed assistant no longer exists (404 on the
+    /// `assistants/{id}/health` endpoint). Observers should tear down local
+    /// state for the missing assistant and switch to a replacement or show
+    /// onboarding.
+    public static let managedAssistantRetiredRemotely = Notification.Name("managedAssistantRetiredRemotely")
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -322,6 +322,9 @@ public final class GatewayConnectionManager: ObservableObject {
             guard response.isSuccess else {
                 if response.statusCode == 401 {
                     handleAuthenticationFailure()
+                } else if response.statusCode == 404, isManaged {
+                    handleManagedAssistantGoneFromPlatform()
+                    throw ConnectionError.healthCheckFailed
                 }
                 throw ConnectionError.healthCheckFailed
             }
@@ -507,6 +510,19 @@ public final class GatewayConnectionManager: ObservableObject {
         default:
             break
         }
+    }
+
+    // MARK: - 404 Recovery (managed assistant gone from platform)
+
+    /// Called when the managed-assistant health endpoint returns 404. The
+    /// assistant was retired on the platform (here, from the web UI, or from
+    /// another device) but local state still references it, so the health
+    /// check loop is hitting a dead endpoint forever. Stop reconnecting and
+    /// post a notification so the platform-layer observer can clean up.
+    private func handleManagedAssistantGoneFromPlatform() {
+        log.warning("Managed assistant returned 404 from health endpoint — disconnecting and notifying observer for cleanup")
+        disconnect()
+        NotificationCenter.default.post(name: .managedAssistantRetiredRemotely, object: self)
     }
 
     // MARK: - 401 Recovery


### PR DESCRIPTION
## Summary

Fixes the macOS app getting stuck in a permanent loading state after a managed assistant is retired, while hammering the platform with 404s against `/v1/assistants/{id}/health/`. Two independent regressions converged:

1. **LUM-755 was silently reverted.** PR #24317 added a managed-specific auto-clean on CLI retire failure. The refactor stack #24927 + #24959 collapsed that branch. #24927's own checklist flagged the regression risk but the PR merged without preserving the behavior and without a test to catch it.

2. **Nothing reacted to a 404 on the managed health endpoint.** `performHealthCheck` only special-cased 401, so a retired assistant (from here, the web UI, or another device) left the health-check loop pinging forever while the UI sat on `DaemonLoadingChatSkeleton`.

## Changes

**Restored LUM-755**
- `AssistantManagementClient.retireFailurePolicy(for:)` — new static helper with explicit doc comment naming LUM-755 and the refactor PRs that unwound it. The doc comment warns against inlining the logic; the test name is the forcing function.
- `VellumCli.retire()` — consults the policy on CLI failure. Managed → `forceRemoveActiveAssistant()` returns the replacement; no alert, no reconnect. Local → re-throws so the existing Force Remove / Cancel alert still runs.

**Regression test**
- `RetireFailurePolicyTests.swift` — three tests, one prefixed `testLUM755_` with a doc-comment narrative of the original bug, the fix, and the regression. Deleting or weakening it will now require an explicit review conversation.

**Reactive 404 handler (safety net)**
- `DaemonNotifications.swift` — new `.managedAssistantRetiredRemotely` notification.
- `GatewayConnectionManager.performHealthCheck` — on 404 against a managed assistant, disconnects and posts the notification.
- `AppDelegate+ConnectionSetup` — registers observer once per connection setup, rebinds on reconfigure.
- `AppDelegate+AuthLifecycle` — extracted `finalizePostRetire(replacement:)` from `performRetireAsync` so both the explicit retire flow and the new `handleManagedAssistantRetiredRemotely()` share one teardown path.

**CLI atomicity**
- `cli/src/commands/retire.ts` — treats 404 from `DELETE /v1/assistants/{id}/retire/` as success so an already-gone platform assistant doesn't leave a stale lockfile entry.

## Test plan

- [ ] `RetireFailurePolicyTests` passes (macOS test target).
- [ ] Manual: retire a managed assistant with the platform reachable → switches to another assistant or onboarding, no 404 loop.
- [ ] Manual: retire a managed assistant with the CLI failing (e.g. revoke token first) → no Force Remove / Cancel alert; local state cleans automatically; lands on replacement or onboarding.
- [ ] Manual: retire the managed assistant from another device / web UI, then reopen the macOS app → 404 handler kicks in within ~15s and lands on replacement or onboarding.
- [ ] Manual: retire a local assistant with the CLI failing → Force Remove / Cancel alert still appears (regression check on the local path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
