### PR TITLE
meet: meet_send_chat tool + session-manager chat-send API

### DIFF
--- a/assistant/src/daemon/message-types/meet.ts
+++ b/assistant/src/daemon/message-types/meet.ts
@@ -82,6 +82,19 @@ export interface MeetLeft {
   reason: string;
 }
 
+/**
+ * The assistant successfully posted a chat message into the meeting via
+ * the bot's `/send_chat` endpoint. Emitted once per successful send so
+ * SSE-subscribed clients can render the outbound chat without waiting for
+ * the bot to echo it back through the transcript/chat stream.
+ */
+export interface MeetChatSent {
+  type: "meet.chat_sent";
+  meetingId: string;
+  /** The text that was posted into the meeting's chat. */
+  text: string;
+}
+
 /** The bot hit a non-recoverable error (container crash, join failure, etc.). */
 export interface MeetError {
   type: "meet.error";
@@ -97,4 +110,5 @@ export type _MeetServerMessages =
   | MeetSpeakerChanged
   | MeetTranscriptChunk
   | MeetLeft
+  | MeetChatSent
   | MeetError;

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -8,6 +8,7 @@
 
 import { meetJoinTool } from "../../../skills/meet-join/tools/meet-join-tool.js";
 import { meetLeaveTool } from "../../../skills/meet-join/tools/meet-leave-tool.js";
+import { meetSendChatTool } from "../../../skills/meet-join/tools/meet-send-chat-tool.js";
 import { getConfig } from "../config/loader.js";
 import {
   isCesSecureInstallEnabled,
@@ -103,6 +104,7 @@ export const explicitTools: Tool[] = [
   // silent when `meet` is disabled.
   meetJoinTool,
   meetLeaveTool,
+  meetSendChatTool,
 ];
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────

--- a/skills/meet-join/daemon/event-publisher.ts
+++ b/skills/meet-join/daemon/event-publisher.ts
@@ -54,6 +54,7 @@ export type MeetEventKind =
   | "meet.speaker_changed"
   | "meet.transcript_chunk"
   | "meet.left"
+  | "meet.chat_sent"
   | "meet.error";
 
 // ---------------------------------------------------------------------------

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -96,6 +96,9 @@ export const MEET_BOT_HOST_IP = "127.0.0.1";
 /** Timeout for the best-effort bot `/leave` HTTP call before falling back to stop. */
 export const BOT_LEAVE_HTTP_TIMEOUT_MS = 10_000;
 
+/** Timeout for the bot `/send_chat` HTTP call before giving up. */
+export const BOT_SEND_CHAT_HTTP_TIMEOUT_MS = 10_000;
+
 /**
  * Shared deadline for tearing down every active Meet session during daemon
  * shutdown. Past this budget any remaining containers are force-stopped
@@ -116,6 +119,56 @@ const DEFAULT_DAEMON_PORT = 7821;
  * in `skills/meet-join/tools/meet-join-tool.ts`.
  */
 export const MEET_JOIN_NAME_FALLBACK = "AI Assistant";
+
+// ---------------------------------------------------------------------------
+// Domain errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by {@link MeetSessionManager.sendChat} when no active session exists
+ * for the given meeting id. Callers (e.g. the `meet_send_chat` tool) match
+ * on this class to surface a targeted error rather than a generic failure.
+ */
+export class MeetSessionNotFoundError extends Error {
+  readonly name = "MeetSessionNotFoundError";
+
+  constructor(meetingId: string) {
+    super(`No active Meet session for meetingId=${meetingId}`);
+  }
+}
+
+/**
+ * Thrown by {@link MeetSessionManager.sendChat} when the bot's control API
+ * could not be reached (network error, timeout, container gone). Distinct
+ * from {@link MeetBotChatError} which represents a well-formed bot response
+ * whose body indicates failure.
+ */
+export class MeetSessionUnreachableError extends Error {
+  readonly name = "MeetSessionUnreachableError";
+
+  constructor(meetingId: string, cause: string) {
+    super(
+      `Meet bot unreachable for meetingId=${meetingId}: ${cause}`,
+    );
+  }
+}
+
+/**
+ * Thrown by {@link MeetSessionManager.sendChat} when the bot responded with
+ * a non-2xx status code — e.g. a 502 from an upstream Meet chat failure.
+ * Preserves the status so tool-layer callers can relay a helpful message.
+ */
+export class MeetBotChatError extends Error {
+  readonly name = "MeetBotChatError";
+  readonly status: number;
+
+  constructor(meetingId: string, status: number, detail: string) {
+    super(
+      `Meet bot /send_chat returned ${status} for meetingId=${meetingId}: ${detail}`,
+    );
+    this.status = status;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -268,6 +321,18 @@ export interface MeetSessionManagerDeps {
   getProviderKey?: (provider: string) => Promise<string | undefined>;
   /** Override the function that hits the bot's `/leave` endpoint. */
   botLeaveFetch?: (url: string, token: string) => Promise<void>;
+  /**
+   * Override the function that hits the bot's `/send_chat` endpoint.
+   * Resolves on 2xx, throws {@link MeetBotChatError} on non-2xx, and throws
+   * {@link MeetSessionUnreachableError} when the fetch itself fails (DNS,
+   * connect refused, timeout, etc.).
+   */
+  botSendChatFetch?: (
+    url: string,
+    token: string,
+    text: string,
+    meetingId: string,
+  ) => Promise<void>;
   /** Override the daemon-URL resolver (used for `DAEMON_URL` env var). */
   resolveDaemonUrl?: () => string;
   /** Override workspace directory resolution (tests). */
@@ -328,6 +393,7 @@ class MeetSessionManagerImpl {
         (() => new DockerRunner({ workspaceDir: resolveWorkspaceDir() })),
       getProviderKey: deps.getProviderKey ?? getProviderKeyAsync,
       botLeaveFetch: deps.botLeaveFetch ?? defaultBotLeaveFetch,
+      botSendChatFetch: deps.botSendChatFetch ?? defaultBotSendChatFetch,
       resolveDaemonUrl: deps.resolveDaemonUrl ?? defaultResolveDaemonUrl,
       getWorkspaceDir: deps.getWorkspaceDir ?? getWorkspaceDir,
       audioIngestFactory:
@@ -895,6 +961,45 @@ class MeetSessionManagerImpl {
   }
 
   /**
+   * Post a chat message into the meeting via the bot's `/send_chat`
+   * endpoint. Looks up the per-meeting bearer token so the bot can
+   * authenticate the inbound request, forwards the text as
+   * `{ type: "send_chat", text }`, and emits a `meet.chat_sent` event on
+   * success.
+   *
+   * Throws:
+   *   - {@link MeetSessionNotFoundError} when no active session exists for
+   *     the id.
+   *   - {@link MeetSessionUnreachableError} on network-level failures
+   *     (connection refused, DNS, timeout) — the bot container is likely
+   *     gone.
+   *   - {@link MeetBotChatError} when the bot responded with a non-2xx
+   *     status (e.g. 502 when the upstream Meet chat call failed).
+   */
+  async sendChat(meetingId: string, text: string): Promise<void> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      throw new MeetSessionNotFoundError(meetingId);
+    }
+
+    await this.deps.botSendChatFetch(
+      `${session.botBaseUrl}/send_chat`,
+      session.botApiToken,
+      text,
+      meetingId,
+    );
+
+    void publishMeetEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      meetingId,
+      "meet.chat_sent",
+      { text },
+    );
+
+    log.info({ meetingId, textLength: text.length }, "Meet chat message sent");
+  }
+
+  /**
    * Tear down every active meeting in parallel with a shared overall deadline.
    *
    * Invoked from the daemon's shutdown sequence so live meetings don't leak
@@ -1140,6 +1245,39 @@ async function defaultBotLeaveFetch(url: string, token: string): Promise<void> {
     throw new Error(
       `Bot /leave returned ${response.status}: ${await response.text().catch(() => "")}`,
     );
+  }
+}
+
+/**
+ * Default bot `/send_chat` hitter. Honors
+ * {@link BOT_SEND_CHAT_HTTP_TIMEOUT_MS}. On network-level failure throws
+ * {@link MeetSessionUnreachableError}; on non-2xx throws
+ * {@link MeetBotChatError} so the tool layer can distinguish the two.
+ */
+async function defaultBotSendChatFetch(
+  url: string,
+  token: string,
+  text: string,
+  meetingId: string,
+): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ type: "send_chat", text }),
+      signal: AbortSignal.timeout(BOT_SEND_CHAT_HTTP_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new MeetSessionUnreachableError(meetingId, detail);
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new MeetBotChatError(meetingId, response.status, body);
   }
 }
 

--- a/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
@@ -47,6 +47,17 @@ mock.module("../../daemon/session-manager.js", () => ({
     leave: async () => {},
     activeSessions: () => [],
     getSession: () => null,
+    sendChat: async () => {},
+  },
+  MeetSessionNotFoundError: class extends Error {
+    readonly name = "MeetSessionNotFoundError";
+  },
+  MeetSessionUnreachableError: class extends Error {
+    readonly name = "MeetSessionUnreachableError";
+  },
+  MeetBotChatError: class extends Error {
+    readonly name = "MeetBotChatError";
+    readonly status: number = 0;
   },
 }));
 

--- a/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-leave-tool.test.ts
@@ -35,6 +35,17 @@ mock.module("../../daemon/session-manager.js", () => ({
     leave: leaveMock,
     activeSessions: () => activeSessionsValue,
     getSession: getSessionMock,
+    sendChat: async () => {},
+  },
+  MeetSessionNotFoundError: class extends Error {
+    readonly name = "MeetSessionNotFoundError";
+  },
+  MeetSessionUnreachableError: class extends Error {
+    readonly name = "MeetSessionUnreachableError";
+  },
+  MeetBotChatError: class extends Error {
+    readonly name = "MeetBotChatError";
+    readonly status: number = 0;
   },
 }));
 

--- a/skills/meet-join/tools/__tests__/meet-send-chat-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-send-chat-tool.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for the `meet_send_chat` tool.
+ *
+ * Exercises feature-flag gating, input validation, disambiguation when the
+ * caller omits `meetingId` (0 / 1 / many active sessions), explicit-id
+ * pass-through, and error propagation from the session manager. Mirrors
+ * the mocking style used in the sibling `meet-leave-tool.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let flagEnabled = true;
+let activeSessionsValue: Array<{
+  meetingId: string;
+  conversationId: string;
+  containerId: string;
+  botBaseUrl: string;
+  botApiToken: string;
+  startedAt: number;
+  joinTimeoutMs: number;
+}> = [];
+
+const sendChatMock = mock(async (_meetingId: string, _text: string) => {});
+
+class FakeMeetSessionNotFoundError extends Error {
+  readonly name = "MeetSessionNotFoundError";
+}
+class FakeMeetSessionUnreachableError extends Error {
+  readonly name = "MeetSessionUnreachableError";
+}
+class FakeMeetBotChatError extends Error {
+  readonly name = "MeetBotChatError";
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+mock.module("../../daemon/session-manager.js", () => ({
+  MeetSessionManager: {
+    join: async () => {
+      throw new Error("join should not be invoked in send-chat tests");
+    },
+    leave: async () => {},
+    activeSessions: () => activeSessionsValue,
+    getSession: (meetingId: string) =>
+      activeSessionsValue.find((s) => s.meetingId === meetingId) ?? null,
+    sendChat: sendChatMock,
+  },
+  MeetSessionNotFoundError: FakeMeetSessionNotFoundError,
+  MeetSessionUnreachableError: FakeMeetSessionUnreachableError,
+  MeetBotChatError: FakeMeetBotChatError,
+}));
+
+mock.module(
+  "../../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
+
+mock.module("../../../../assistant/src/config/loader.js", () => ({
+  getConfig: () => ({
+    services: { meet: { consentMessage: "unused-in-send-chat-tests" } },
+  }),
+}));
+
+mock.module("../../../../assistant/src/util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const { meetSendChatTool } = await import("../meet-send-chat-tool.js");
+
+import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+function fakeSession(meetingId: string) {
+  return {
+    meetingId,
+    conversationId: "conv-test",
+    containerId: `c-${meetingId}`,
+    botBaseUrl: "http://127.0.0.1:49000",
+    botApiToken: "token",
+    startedAt: Date.now(),
+    joinTimeoutMs: 60_000,
+  };
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  activeSessionsValue = [];
+  sendChatMock.mockClear();
+  sendChatMock.mockImplementation(async () => {});
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_send_chat feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetSendChatTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("meet_send_chat input validation", () => {
+  test("rejects missing text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSendChatTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/^Error:/);
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSendChatTool.execute(
+      { text: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("text");
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-string text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSendChatTool.execute(
+      { text: 123 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disambiguation when meetingId is omitted
+// ---------------------------------------------------------------------------
+
+describe("meet_send_chat disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetSendChatTool.execute(
+      { text: "hi there" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSendChatTool.execute(
+      { text: "hello team" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(sendChatMock).toHaveBeenCalledTimes(1);
+    const [id, text] = sendChatMock.mock.calls[0];
+    expect(id).toBe("solo");
+    expect(text).toBe("hello team");
+    const payload = JSON.parse(result.content) as {
+      sent: boolean;
+      meetingId: string;
+    };
+    expect(payload).toEqual({ sent: true, meetingId: "solo" });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetSendChatTool.execute(
+      { text: "hi" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(result.content).toContain("m1");
+    expect(result.content).toContain("m2");
+    expect(sendChatMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetSendChatTool.execute(
+      { meetingId: "m2", text: "hi m2" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(sendChatMock).toHaveBeenCalledTimes(1);
+    expect(sendChatMock.mock.calls[0][0]).toBe("m2");
+    expect(sendChatMock.mock.calls[0][1]).toBe("hi m2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error propagation
+// ---------------------------------------------------------------------------
+
+describe("meet_send_chat error propagation", () => {
+  test("surfaces MeetSessionNotFoundError as a targeted tool error", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    sendChatMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionNotFoundError("no session");
+    });
+    const result = await meetSendChatTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no active Meet session");
+    expect(result.content).toContain("solo");
+  });
+
+  test("surfaces MeetSessionUnreachableError with a bot-unreachable message", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    sendChatMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionUnreachableError("connect ECONNREFUSED");
+    });
+    const result = await meetSendChatTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet bot unreachable");
+    expect(result.content).toContain("ECONNREFUSED");
+  });
+
+  test("surfaces MeetBotChatError with the upstream status code", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    sendChatMock.mockImplementationOnce(async () => {
+      throw new FakeMeetBotChatError("upstream meet chat failed", 502);
+    });
+    const result = await meetSendChatTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("status 502");
+    expect(result.content).toContain("upstream meet chat failed");
+  });
+
+  test("surfaces unknown errors verbatim", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    sendChatMock.mockImplementationOnce(async () => {
+      throw new Error("something exploded");
+    });
+    const result = await meetSendChatTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed to send Meet chat");
+    expect(result.content).toContain("something exploded");
+  });
+});

--- a/skills/meet-join/tools/meet-send-chat-tool.ts
+++ b/skills/meet-join/tools/meet-send-chat-tool.ts
@@ -1,0 +1,159 @@
+/**
+ * meet_send_chat tool — post a chat message into an active Meet call.
+ *
+ * Paired with {@link ./meet-join-tool.ts meet_join} and
+ * {@link ./meet-leave-tool.ts meet_leave}: all three are first-party tools
+ * because they command the in-process `MeetSessionManager`. See the
+ * rationale comment at the top of `meet-join-tool.ts` — keeping the chat
+ * control surface in-process avoids a new HTTP API that mirrors the same
+ * session-manager state.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../../assistant/src/config/loader.js";
+import { RiskLevel } from "../../../assistant/src/permissions/types.js";
+import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../assistant/src/tools/types.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import {
+  MeetBotChatError,
+  MeetSessionManager,
+  MeetSessionNotFoundError,
+  MeetSessionUnreachableError,
+} from "../daemon/session-manager.js";
+import { MEET_FLAG_KEY } from "./meet-join-tool.js";
+
+const log = getLogger("meet-send-chat-tool");
+
+const MeetSendChatInputSchema = z.object({
+  meetingId: z.string().trim().min(1).optional(),
+  text: z.string().min(1, "text is required"),
+});
+
+export type MeetSendChatInput = z.infer<typeof MeetSendChatInputSchema>;
+
+class MeetSendChatTool implements Tool {
+  name = "meet_send_chat";
+  description =
+    "Post a message into the chat of an active Google Meet call. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting to send chat to, as returned by meet_join. Optional when exactly one session is active.",
+          },
+          text: {
+            type: "string",
+            description:
+              "The message text to post into the meeting chat. Keep it concise and conversational.",
+          },
+        },
+        required: ["text"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate — symmetric with meet_join / meet_leave.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to send chat in Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation.
+    const parsed = MeetSendChatInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_send_chat input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId, text } = parsed.data;
+
+    // 3. Disambiguate target session when no id is supplied. Zero or >1
+    //    active sessions is a caller error — refuse rather than guess.
+    let targetMeetingId: string;
+    if (explicitId) {
+      targetMeetingId = explicitId;
+    } else {
+      const active = MeetSessionManager.activeSessions();
+      if (active.length === 0) {
+        return {
+          content:
+            "Error: no active Meet session to send chat to.",
+          isError: true,
+        };
+      }
+      if (active.length > 1) {
+        const ids = active.map((s) => s.meetingId).join(", ");
+        return {
+          content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+          isError: true,
+        };
+      }
+      targetMeetingId = active[0].meetingId;
+    }
+
+    // 4. Delegate.
+    try {
+      await MeetSessionManager.sendChat(targetMeetingId, text);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId, textLength: text.length },
+        "meet_send_chat tool failed",
+      );
+      if (err instanceof MeetSessionNotFoundError) {
+        return {
+          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetSessionUnreachableError) {
+        return {
+          content: `Error: meet bot unreachable — ${message}`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetBotChatError) {
+        return {
+          content: `Error: meet bot rejected the chat (status ${err.status}) — ${message}`,
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: failed to send Meet chat — ${message}`,
+        isError: true,
+      };
+    }
+
+    return {
+      content: JSON.stringify({ sent: true, meetingId: targetMeetingId }),
+      isError: false,
+    };
+  }
+}
+
+/** Exported singleton so the tool registry can re-register it after test resets. */
+export const meetSendChatTool = new MeetSendChatTool();


### PR DESCRIPTION
## Summary
- Add MeetSessionManager.sendChat that POSTs to the bot's /send_chat endpoint
- Add meet_send_chat daemon tool (feature-flag gated on 'meet')
- Emit meet.chat_sent event on success
- Unit tests for validation, disambiguation, flag gating, error paths

Part of plan: meet-phase-2-chat.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
