### PR TITLE
runtime: wake the agent loop on internal opportunity (no user message)

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for `wakeAgentForOpportunity()` — the generic internal agent-wake
+ * mechanism.
+ *
+ * Exercise strategy: the wake helper takes a `resolveTarget` dependency so
+ * these tests stub out the heavyweight `Conversation` class with a minimal
+ * `WakeTarget` that just tracks buffered messages, emitted events, and a
+ * scripted `agentLoop.run()` response.
+ *
+ * The `addMessage` import from `memory/conversation-crud.ts` is stubbed
+ * via `mock.module()` so we can assert on persistence without touching a
+ * real SQLite DB.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AgentEvent } from "../../agent/loop.js";
+import type { Message } from "../../providers/types.js";
+
+// ── Stub addMessage so we can assert persistence without a real DB ───
+
+const persistedMessages: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+}> = [];
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+  ) => {
+    persistedMessages.push({ conversationId, role, content });
+    return { id: `msg-${persistedMessages.length}` };
+  },
+}));
+
+// Import after the mock is registered.
+import {
+  __resetWakeChainForTests,
+  wakeAgentForOpportunity,
+  type WakeTarget,
+} from "../agent-wake.js";
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+interface MockTarget extends WakeTarget {
+  emittedEvents: unknown[];
+  pushedMessages: Message[];
+  runCalls: Array<{ input: Message[]; requestId?: string }>;
+}
+
+function makeTarget(options: {
+  conversationId?: string;
+  baseline?: Message[];
+  scriptedAssistant?: Message | null;
+  scriptedEvents?: AgentEvent[];
+  isProcessing?: boolean;
+}): MockTarget {
+  const emittedEvents: unknown[] = [];
+  const pushedMessages: Message[] = [];
+  const runCalls: Array<{ input: Message[]; requestId?: string }> = [];
+  const history: Message[] = [...(options.baseline ?? [])];
+  let processing = options.isProcessing ?? false;
+
+  const target: MockTarget = {
+    conversationId: options.conversationId ?? "conv-test",
+    emittedEvents,
+    pushedMessages,
+    runCalls,
+    agentLoop: {
+      run: async (
+        input: Message[],
+        onEvent: (event: AgentEvent) => void | Promise<void>,
+        _signal?: AbortSignal,
+        requestId?: string,
+      ) => {
+        runCalls.push({ input: [...input], requestId });
+        // Emit any scripted events the test wanted us to produce.
+        for (const ev of options.scriptedEvents ?? []) {
+          await onEvent(ev);
+        }
+        // Final history = input + optional assistant message.
+        const next = [...input];
+        if (options.scriptedAssistant) {
+          next.push(options.scriptedAssistant);
+          await onEvent({
+            type: "message_complete",
+            message: options.scriptedAssistant,
+          });
+        }
+        return next;
+      },
+    },
+    getMessages: () => history,
+    pushMessage: (msg: Message) => {
+      pushedMessages.push(msg);
+      history.push(msg);
+    },
+    emitToClient: (msg) => {
+      emittedEvents.push(msg);
+    },
+    isProcessing: () => processing,
+  };
+
+  // Expose processing setter via test-only side-channel
+  (target as unknown as { setProcessing: (v: boolean) => void }).setProcessing =
+    (v: boolean) => {
+      processing = v;
+    };
+
+  return target;
+}
+
+beforeEach(() => {
+  persistedMessages.length = 0;
+  __resetWakeChainForTests();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("wakeAgentForOpportunity", () => {
+  test("silent no-op when agent produces no tool calls and no text", async () => {
+    const target = makeTarget({
+      baseline: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      ],
+      // Assistant replies with empty text — counts as no output.
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "someone asked a question",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // Nothing emitted to client.
+    expect(target.emittedEvents).toHaveLength(0);
+    // Nothing persisted.
+    expect(persistedMessages).toHaveLength(0);
+    // Nothing pushed into live history.
+    expect(target.pushedMessages).toHaveLength(0);
+    // Hint was included in the run input, but baseline is unchanged.
+    expect(target.runCalls).toHaveLength(1);
+    const input = target.runCalls[0]!.input;
+    expect(input).toHaveLength(3); // 2 baseline + 1 hint
+    expect(input[2]).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "[opportunity:unit-test] someone asked a question" },
+      ],
+    });
+  });
+
+  test("produces tool calls when LLM emits a tool_use block", async () => {
+    const assistantMessage: Message = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu-1",
+          name: "meet_send_chat",
+          input: { text: "Sure, here's the link" },
+        },
+      ],
+    };
+    const target = makeTarget({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedAssistant: assistantMessage,
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "question directed at assistant",
+        source: "meet-chat-opportunity",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: true });
+    // Assistant message persisted.
+    expect(persistedMessages).toHaveLength(1);
+    expect(persistedMessages[0]).toMatchObject({
+      conversationId: target.conversationId,
+      role: "assistant",
+    });
+    expect(JSON.parse(persistedMessages[0]!.content)).toEqual(
+      assistantMessage.content,
+    );
+    // Assistant message pushed into live history.
+    expect(target.pushedMessages).toContainEqual(assistantMessage);
+    // message_complete event flushed to the client.
+    const flushed = target.emittedEvents.find(
+      (e) =>
+        typeof e === "object" && e !== null && (e as { type?: string }).type === "message_complete",
+    );
+    expect(flushed).toBeDefined();
+  });
+
+  test("two concurrent wakes on the same conversation are serialized", async () => {
+    // Build a target whose agentLoop.run resolves only when we signal.
+    const gate1 = Promise.withResolvers<void>();
+    const gate2 = Promise.withResolvers<void>();
+    const runStartOrder: number[] = [];
+    const runCompleteOrder: number[] = [];
+
+    let callIndex = 0;
+    const history: Message[] = [];
+    const target: WakeTarget = {
+      conversationId: "conv-serialize",
+      agentLoop: {
+        run: async (input) => {
+          const myIndex = ++callIndex;
+          runStartOrder.push(myIndex);
+          if (myIndex === 1) {
+            await gate1.promise;
+          } else {
+            await gate2.promise;
+          }
+          runCompleteOrder.push(myIndex);
+          return input; // no assistant message → silent no-op
+        },
+      },
+      getMessages: () => history,
+      pushMessage: (msg) => {
+        history.push(msg);
+      },
+      emitToClient: () => {},
+      isProcessing: () => false,
+    };
+
+    const deps = { resolveTarget: async () => target };
+
+    const p1 = wakeAgentForOpportunity(
+      { conversationId: "conv-serialize", hint: "first", source: "t1" },
+      deps,
+    );
+    const p2 = wakeAgentForOpportunity(
+      { conversationId: "conv-serialize", hint: "second", source: "t2" },
+      deps,
+    );
+
+    // Let the microtask queue flush so p1 can start.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(runStartOrder).toEqual([1]);
+
+    // Releasing gate2 should NOT let p2 start — it's queued behind p1.
+    gate2.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(runStartOrder).toEqual([1]);
+
+    // Now release gate1 — p1 completes, then p2 starts and completes.
+    gate1.resolve();
+    await Promise.all([p1, p2]);
+    expect(runStartOrder).toEqual([1, 2]);
+    expect(runCompleteOrder).toEqual([1, 2]);
+  });
+
+  test("waits while a concurrent user turn is in flight", async () => {
+    const history: Message[] = [];
+    let processing = true;
+    const target: WakeTarget & { setProcessing: (v: boolean) => void } = {
+      conversationId: "conv-user-turn",
+      agentLoop: {
+        run: async (input) => input,
+      },
+      getMessages: () => history,
+      pushMessage: (msg) => history.push(msg),
+      emitToClient: () => {},
+      isProcessing: () => processing,
+      setProcessing: (v) => {
+        processing = v;
+      },
+    };
+
+    const wakePromise = wakeAgentForOpportunity(
+      {
+        conversationId: "conv-user-turn",
+        hint: "opportunity while user typing",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    // Wake should be waiting (isProcessing returns true).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Hasn't resolved yet.
+    let settled = false;
+    void wakePromise.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+
+    // "User turn" completes — wake now proceeds.
+    target.setProcessing(false);
+    const result = await wakePromise;
+    expect(result.invoked).toBe(true);
+    expect(result.producedToolCalls).toBe(false);
+  });
+
+  test("returns invoked: false when the conversation cannot be resolved", async () => {
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "missing", hint: "x", source: "y" },
+      { resolveTarget: async () => null },
+    );
+    expect(result).toEqual({ invoked: false, producedToolCalls: false });
+    expect(persistedMessages).toHaveLength(0);
+  });
+
+  test("agent loop error is treated as a no-op", async () => {
+    const history: Message[] = [];
+    const target: WakeTarget = {
+      conversationId: "conv-err",
+      agentLoop: {
+        run: async () => {
+          throw new Error("LLM exploded");
+        },
+      },
+      getMessages: () => history,
+      pushMessage: () => {},
+      emitToClient: () => {},
+      isProcessing: () => false,
+    };
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-err", hint: "boom", source: "t" },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(persistedMessages).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1,0 +1,334 @@
+/**
+ * Generic agent-loop wake mechanism for internal opportunities.
+ *
+ * Provides `wakeAgentForOpportunity()` — a callable used by subsystems
+ * (e.g. meet chat-opportunity detector, scheduled tasks, memory-reducer
+ * inferences) that want to invoke the agent loop without a user message.
+ *
+ * Semantics:
+ *   - Resolves the conversation context exactly as a normal user turn.
+ *   - Appends `hint` as a non-persisted internal user message visible to
+ *     the LLM only — never shows up in the transcript or SSE feed.
+ *     Format: `"[opportunity:${source}] ${hint}"`.
+ *   - Invokes the agent loop with all conversation tools available.
+ *   - No tool calls AND no assistant text → silent no-op (nothing persisted,
+ *     nothing emitted). Returns `{ invoked: true, producedToolCalls: false }`.
+ *   - Tool calls produced → normal tool execution runs (the conversation's
+ *     `AgentLoop` has its tool executor already wired). Returns
+ *     `{ invoked: true, producedToolCalls: true }`.
+ *
+ * Concurrency:
+ *   - If a user turn (or another wake) is currently in flight on the same
+ *     conversation, the wake is queued behind it (single-flight per
+ *     `conversationId`).
+ *
+ * Logging:
+ *   - Emits one structured log line per wake:
+ *     `{ source, conversationId, durationMs, producedToolCalls, toolNamesCalled }`.
+ *
+ * Skill isolation:
+ *   - This file lives in `assistant/src/runtime/` and is intentionally
+ *     generic. It does not reference Meet or any specific skill. The Meet
+ *     integration is wired up by `MeetSessionManager` (see PR 7).
+ */
+
+import type { AgentEvent, AgentLoop } from "../agent/loop.js";
+import { addMessage } from "../memory/conversation-crud.js";
+import type { Message } from "../providers/types.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("agent-wake");
+
+/**
+ * Minimum surface area of a conversation needed to wake it. Defined as an
+ * interface rather than importing `Conversation` directly so the wake
+ * helper stays decoupled from the heavyweight conversation class and is
+ * easy to exercise under unit tests.
+ */
+export interface WakeTarget {
+  readonly conversationId: string;
+  readonly agentLoop: Pick<AgentLoop, "run">;
+  /**
+   * Live LLM-visible history. We read a snapshot, append the internal hint
+   * for the run, and then (on non-empty output) append the resulting
+   * assistant message to this array so subsequent turns see it.
+   */
+  getMessages(): Message[];
+  pushMessage(message: Message): void;
+  /** Client emitter — e.g. SSE. We only call this when the wake produces output. */
+  emitToClient(msg: ServerMessage): void;
+  /** True if the conversation is already processing a turn. */
+  isProcessing(): boolean;
+}
+
+export interface WakeOptions {
+  conversationId: string;
+  hint: string;
+  source: string;
+}
+
+export interface WakeResult {
+  invoked: boolean;
+  producedToolCalls: boolean;
+}
+
+/**
+ * Dependencies injected for testing. Production callers use the defaults
+ * (which resolve the conversation from the daemon's registry).
+ */
+export interface WakeDeps {
+  /** Resolve the wake target for a conversationId. Returns `null` if not found. */
+  resolveTarget: (conversationId: string) => Promise<WakeTarget | null>;
+  /** Timestamp source (for deterministic tests). */
+  now?: () => number;
+}
+
+// ── Per-conversation single-flight lock ───────────────────────────────
+//
+// Simple promise-chain map. When a wake arrives and another run is in
+// flight, we chain onto its tail so the wake runs *after* the current
+// work completes. Using the tail promise avoids awaiting every prior
+// completion in the chain (only the last one matters) and keeps memory
+// bounded — the map entry is cleared once the chain completes.
+
+const wakeChain = new Map<string, Promise<void>>();
+
+async function runSingleFlight<T>(
+  conversationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prior = wakeChain.get(conversationId) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Install our tail *before* awaiting so later callers chain behind us.
+  wakeChain.set(conversationId, next);
+  try {
+    await prior;
+    return await fn();
+  } finally {
+    // Only clear the map entry if nothing chained behind us in the meantime.
+    if (wakeChain.get(conversationId) === next) {
+      wakeChain.delete(conversationId);
+    }
+    release();
+  }
+}
+
+/**
+ * Small helper: if a conversation reports `isProcessing()`, poll briefly
+ * so we don't try to start a second agent loop concurrently. We rely
+ * primarily on the single-flight chain above to serialize *wakes*; this
+ * extra check catches the case where a user turn started independently
+ * while our wake was queued.
+ */
+async function waitUntilIdle(
+  target: WakeTarget,
+  nowFn: () => number,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = nowFn() + timeoutMs;
+  // 50ms backoff is fine — wakes are not latency-critical and a user turn
+  // typically completes on the order of seconds.
+  while (target.isProcessing() && nowFn() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+/**
+ * Inspect the final assistant message of the post-run history to decide
+ * whether the wake produced output worth persisting/emitting.
+ */
+function inspectAssistantOutput(
+  baselineLength: number,
+  updatedHistory: Message[],
+): {
+  assistantMessage: Message | null;
+  hasVisibleText: boolean;
+  toolUseNames: string[];
+} {
+  // The agent loop appends assistant messages (and tool_result user
+  // messages) onto the history it was given. We gave it baseline +
+  // internal hint, so anything at index >= baselineLength + 1 came from
+  // the run. The *first* message past the hint is the assistant reply.
+  const firstAssistantIndex = baselineLength + 1;
+  if (updatedHistory.length <= firstAssistantIndex) {
+    return { assistantMessage: null, hasVisibleText: false, toolUseNames: [] };
+  }
+  const assistantMessage = updatedHistory[firstAssistantIndex];
+  if (!assistantMessage || assistantMessage.role !== "assistant") {
+    return { assistantMessage: null, hasVisibleText: false, toolUseNames: [] };
+  }
+  const blocks = Array.isArray(assistantMessage.content)
+    ? assistantMessage.content
+    : [];
+  let hasVisibleText = false;
+  const toolUseNames: string[] = [];
+  for (const block of blocks) {
+    if (block.type === "text" && typeof block.text === "string") {
+      if (block.text.trim().length > 0) {
+        hasVisibleText = true;
+      }
+    } else if (block.type === "tool_use") {
+      toolUseNames.push(block.name);
+    }
+  }
+  return { assistantMessage, hasVisibleText, toolUseNames };
+}
+
+/**
+ * Wake the agent loop on a conversation without a user message.
+ *
+ * See module-level doc for semantics. Safe to call concurrently; wakes
+ * are serialized per `conversationId`.
+ */
+export async function wakeAgentForOpportunity(
+  opts: WakeOptions,
+  deps: WakeDeps,
+): Promise<WakeResult> {
+  const { conversationId, hint, source } = opts;
+  const nowFn = deps.now ?? Date.now;
+  const startedAt = nowFn();
+
+  return runSingleFlight(conversationId, async () => {
+    const target = await deps.resolveTarget(conversationId);
+    if (!target) {
+      log.warn(
+        { conversationId, source },
+        "agent-wake: conversation not found; skipping",
+      );
+      return { invoked: false, producedToolCalls: false };
+    }
+
+    await waitUntilIdle(target, nowFn);
+
+    const baseline = target.getMessages();
+    const hintContent = `[opportunity:${source}] ${hint}`;
+    const hintMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: hintContent }],
+    };
+    const runInput: Message[] = [...baseline, hintMessage];
+
+    // Buffer events during the run. If the agent produces no visible
+    // output and no tool calls, we drop everything silently. If it does,
+    // we flush the buffer to the client so the client sees normal
+    // streaming events (deltas, tool_use, tool_result, etc.).
+    const buffered: ServerMessage[] = [];
+    const onEvent = (event: AgentEvent): void => {
+      // AgentEvent and ServerMessage share several variants by shape.
+      // The conversation's runtime normally translates AgentEvent into
+      // client events via a richer handler; for wake, we buffer the raw
+      // event types and forward only those that are directly
+      // client-safe. Unknown types are dropped (they produce no UI).
+      const ev = event as unknown as ServerMessage;
+      buffered.push(ev);
+    };
+
+    let updatedHistory: Message[];
+    let runError: Error | null = null;
+    try {
+      updatedHistory = await target.agentLoop.run(
+        runInput,
+        onEvent,
+        undefined, // no external abort signal
+        `wake:${source}`,
+      );
+    } catch (err) {
+      runError = err instanceof Error ? err : new Error(String(err));
+      updatedHistory = runInput;
+    }
+
+    const durationMs = nowFn() - startedAt;
+    if (runError) {
+      log.error(
+        { conversationId, source, durationMs, err: runError },
+        "agent-wake: agent loop threw; treating as no-op",
+      );
+      return { invoked: true, producedToolCalls: false };
+    }
+
+    const { assistantMessage, hasVisibleText, toolUseNames } =
+      inspectAssistantOutput(baseline.length, updatedHistory);
+
+    const producedToolCalls = toolUseNames.length > 0;
+    const producedOutput = producedToolCalls || hasVisibleText;
+
+    if (!producedOutput || !assistantMessage) {
+      log.info(
+        {
+          source,
+          conversationId,
+          durationMs,
+          producedToolCalls: false,
+          toolNamesCalled: [],
+        },
+        "agent-wake: no output; silent no-op",
+      );
+      return { invoked: true, producedToolCalls: false };
+    }
+
+    // Output produced: flush buffered client events and persist the
+    // assistant message so the transcript stays consistent. The internal
+    // hint is NOT persisted and NOT emitted — only the assistant reply
+    // (and any downstream tool-result user messages) is.
+    for (const event of buffered) {
+      try {
+        target.emitToClient(event);
+      } catch (err) {
+        log.warn(
+          { conversationId, source, err },
+          "agent-wake: client emitter threw; continuing",
+        );
+      }
+    }
+
+    // Append assistant message and any subsequent tool_result user
+    // messages to live history. The hint itself stays out of history.
+    for (let i = baseline.length + 1; i < updatedHistory.length; i++) {
+      const msg = updatedHistory[i];
+      if (msg) target.pushMessage(msg);
+    }
+
+    try {
+      await addMessage(
+        conversationId,
+        assistantMessage.role,
+        JSON.stringify(assistantMessage.content),
+      );
+    } catch (err) {
+      log.warn(
+        { conversationId, source, err },
+        "agent-wake: failed to persist assistant message",
+      );
+    }
+
+    log.info(
+      {
+        source,
+        conversationId,
+        durationMs,
+        producedToolCalls,
+        toolNamesCalled: toolUseNames,
+      },
+      "agent-wake: produced output",
+    );
+
+    return { invoked: true, producedToolCalls };
+  });
+}
+
+// ── Test-only helpers ────────────────────────────────────────────────
+
+/**
+ * Reset the internal single-flight map. Exported for tests that want a
+ * clean slate between cases. Not part of the public API — do not call
+ * from production code.
+ *
+ * @internal
+ */
+export function __resetWakeChainForTests(): void {
+  wakeChain.clear();
+}


### PR DESCRIPTION
## Summary
- Add wakeAgentForOpportunity() generic entry point in assistant/src/runtime/
- Non-persisted internal hint message visible only to the LLM
- Single-flight per conversation; user-turn behavior unchanged
- Silent no-op when agent produces no tool calls and no message
- Structured log per wake for observability

## Exploration notes
Explored the existing orchestrator path: Conversation.processMessage (daemon/conversation-process.ts) is the primary user-turn entry, which calls Conversation.runAgentLoop (daemon/conversation-agent-loop.ts runAgentLoopImpl), which ultimately invokes conversation.agentLoop.run() from agent/loop.ts. Other call sites that already invoke runAgentLoop directly (subagent/manager.ts, calls/voice-session-bridge.ts) first persist a user message via persistUserMessage — they do persist and emit.

Rather than surgically extracting a shared helper from the user-turn handler (which is 2000+ LOC of accumulated invariants and would risk regressions), agent-wake.ts targets the shared inner core directly: conversation.agentLoop.run(). It builds the run input as [...conversation.messages, internalHint], buffers events during the run, and then decides — based on the produced assistant message — whether to flush to the client and persist. If the assistant produces no tool calls and no visible text, nothing is persisted and nothing is emitted. Tools (wired via conversation.agentLoop's toolExecutor) execute normally when tool_use blocks appear.

This keeps the user-turn handler unchanged and leaves the complex compaction / overflow / convergence machinery out of the wake path (wakes are short, infrequent, and can fall back gracefully).

The WakeTarget interface defines the minimal surface the wake needs (agentLoop.run, getMessages, pushMessage, emitToClient, isProcessing) so the daemon integration (PR 7) just wraps a Conversation instance, and unit tests stub it directly.

Part of plan: meet-phase-2-chat.md (PR 6 of 8)