### PR TITLE
test(always-loaded-tools-guard): add meet_send_chat to expected set

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 13 (no-client baseline excludes host tools)", async () => {
+  test("should be exactly 14 (no-client baseline excludes host tools)", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
@@ -58,6 +58,7 @@ describe("always-loaded tool count", () => {
       "file_write",
       "meet_join",
       "meet_leave",
+      "meet_send_chat",
       "recall",
       "remember",
       "skill_execute",
@@ -67,6 +68,6 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(13);
+    expect(activeTools.length).toBe(14);
   });
 });


### PR DESCRIPTION
## Summary
- Update the always-loaded tools guard to include \`meet_send_chat\`, added in #25942. The baseline now has 14 tools instead of 13.
- Restores green CI on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24482287729/job/71549391552
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
