### PR TITLE
fix(lint): sort imports in agent-wake.ts

### DIFF
--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -33,9 +33,9 @@
  */
 
 import type { AgentEvent, AgentLoop } from "../agent/loop.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import type { Message } from "../providers/types.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/runtime/agent-wake.ts` (line 35) by reordering imports alphabetically by path.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24482486773/job/71550017810
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
