### PR TITLE
meet: E2E loopback test — explicit chat send, read DOM, assert event published

### DIFF
--- a/skills/meet-join/bot/__tests__/chat-loopback.test.ts
+++ b/skills/meet-join/bot/__tests__/chat-loopback.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Explicit-send chat loopback E2E test (bot side).
+ *
+ * End-to-end exercise of the PR 1 `POST /send_chat` HTTP endpoint glued to
+ * the real `sendChat` browser helper and the real `startChatReader`. The
+ * goal is to catch regressions where:
+ *
+ *   1. The HTTP handler stops invoking the browser callback.
+ *   2. The `sendChat` helper stops driving the DOM correctly (selector
+ *      drift, lost form-submit path).
+ *   3. The `startChatReader` self-filter stops dropping the bot's own
+ *      outbound message and starts echoing it back as an inbound event,
+ *      which would create a feedback loop once PR 5's chat-opportunity
+ *      detector comes online.
+ *
+ * The test runs under normal CI: no real Playwright browser is launched,
+ * no Chromium binary is downloaded, no network egress. Instead it wires up
+ * a JSDOM-backed fake `Page` that implements the small subset of the
+ * Playwright surface that `sendChat` and `startChatReader` actually use
+ * (waitForSelector / fill / press / click / evaluate / exposeFunction /
+ * $), then presses the "submit" path so that a new message node lands in
+ * the fixture's message list. That new node simulates the way Meet
+ * echoes the bot's outgoing chat back into the in-meeting history — the
+ * very signal that would cause a feedback loop without the self-filter.
+ *
+ * Coverage:
+ *   - The `/send_chat` endpoint → `sendChat` → DOM update → `startChatReader`
+ *     chain delivers exactly the text posted to the HTTP endpoint.
+ *   - The reader filters out the bot's own message (selfName match).
+ *   - A follow-up remote message (different sender) still surfaces, so
+ *     the self-filter doesn't accidentally muzzle the whole reader after
+ *     a send.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import type { InboundChatEvent } from "@vellumai/meet-contracts";
+import type { Page } from "playwright";
+
+import { sendChat } from "../src/browser/chat-bridge.js";
+import { startChatReader, type ChatReader } from "../src/browser/chat-reader.js";
+import { chatSelectors, selectors } from "../src/browser/dom-selectors.js";
+import {
+  createHttpServer,
+  type HttpServerHandle,
+} from "../src/control/http-server.js";
+import { BotState } from "../src/control/state.js";
+
+const FIXTURE_DIR = join(import.meta.dir, "fixtures");
+const CHAT_FIXTURE = readFileSync(
+  join(FIXTURE_DIR, "meet-dom-chat.html"),
+  "utf8",
+);
+
+const API_TOKEN = "test-loopback-token";
+const SELF_NAME = "Loopback Bot";
+
+// ---------------------------------------------------------------------------
+// Fake `Page` wiring — shared with the chat-reader unit tests in spirit but
+// widened here to also cover the write path (fill / press / click) that
+// `sendChat` exercises.
+// ---------------------------------------------------------------------------
+
+type BridgeFn = (...args: unknown[]) => unknown;
+
+interface FakePage {
+  page: Page;
+  dom: JSDOM;
+  document: Document;
+  /** Append an inbound (non-self) message to the rendered list. */
+  appendRemoteMessage: (opts: {
+    id: string;
+    sender: string;
+    text: string;
+    datetime?: string;
+  }) => void;
+  /** Number of times the composer was submitted (Enter pressed or button clicked). */
+  submitCount: () => number;
+  /** Raw textarea value — exposed so the test can verify what was typed. */
+  composerValue: () => string;
+}
+
+/**
+ * Build a JSDOM-backed Playwright Page stand-in. The fake mirrors just
+ * enough of the Page surface for both code paths under test:
+ *
+ *  - `sendChat` needs `waitForSelector`, `fill`, `press`, `click`.
+ *  - `startChatReader` needs `evaluate`, `exposeFunction`, `$`.
+ *
+ * "Submitting" the composer (Enter or Send click) injects a new message
+ * node into the rendered chat list with the bot's display name attached
+ * via `data-sender-name`, exactly the way Meet renders the bot's own
+ * outgoing message back into the history panel. That is the signal the
+ * chat reader must drop.
+ */
+function createFakePage(html: string, selfName: string): FakePage {
+  const dom = new JSDOM(html, { runScripts: "outside-only" });
+  const window = dom.window;
+  const document = window.document;
+
+  // Ensure the messages container exists in the fixture — we rely on it
+  // being mounted so the submit path can append into it deterministically.
+  const messagesList = document.querySelector(
+    '[role="list"][aria-label="Chat messages"]',
+  );
+  if (!messagesList) {
+    throw new Error(
+      "Expected the chat fixture to mount [role='list'][aria-label='Chat messages'].",
+    );
+  }
+
+  // Bridges installed via `exposeFunction`, keyed by binding name.
+  const bridges = new Map<string, BridgeFn>();
+
+  // Per-submit counter, bumped by the Enter-press and Send-button paths.
+  let submitCount = 0;
+  let outgoingMessageCounter = 0;
+
+  const performSubmit = (): void => {
+    const textarea = document.querySelector(
+      chatSelectors.INPUT,
+    ) as unknown as HTMLTextAreaElement | null;
+    if (!textarea) return;
+    const text = textarea.value;
+    textarea.value = "";
+    if (!text) return;
+    submitCount += 1;
+    outgoingMessageCounter += 1;
+    // Simulate Meet echoing the bot's own outgoing message back into the
+    // in-call history. `data-sender-name` matches the reader's
+    // MESSAGE_SENDER selector so the reader sees the same "from Bot"
+    // attribution Meet produces, giving the self-filter something real to
+    // fire against. Note: we intentionally don't set `data-is-self` —
+    // this keeps the filter honest (must match by display name).
+    const node = document.createElement("div");
+    node.setAttribute("role", "listitem");
+    node.setAttribute("data-message-id", `bot-out-${outgoingMessageCounter}`);
+    const senderEl = document.createElement("span");
+    senderEl.setAttribute("data-sender-name", "");
+    senderEl.textContent = selfName;
+    const timeEl = document.createElement("time");
+    timeEl.setAttribute("datetime", new Date().toISOString());
+    timeEl.textContent = "12:00 PM";
+    const textEl = document.createElement("p");
+    textEl.setAttribute("data-message-text", "");
+    textEl.textContent = text;
+    node.appendChild(senderEl);
+    node.appendChild(timeEl);
+    node.appendChild(textEl);
+    messagesList.appendChild(node);
+  };
+
+  // -------------------------------------------------------------------------
+  // `evaluate` shim (shared with chat-reader's fake) — runs the caller's
+  // function with JSDOM's document/window/MutationObserver globals bound
+  // onto globalThis for the duration of the call. Same strategy as
+  // `chat-reader.test.ts`.
+  // -------------------------------------------------------------------------
+
+  const pageGlobals = {
+    document,
+    window,
+    MutationObserver: window.MutationObserver,
+    Date,
+    Number,
+    Array,
+    Set,
+  } as Record<string, unknown>;
+
+  const runInPage = (
+    fn: (...args: unknown[]) => unknown,
+    arg?: unknown,
+  ): unknown => {
+    const originals: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(pageGlobals)) {
+      originals[k] = (globalThis as Record<string, unknown>)[k];
+      (globalThis as Record<string, unknown>)[k] = v;
+    }
+    // Expose installed `exposeFunction` bridges on the JSDOM window so the
+    // in-page evaluator finds them when it does `(window as ...)[name]`.
+    for (const [name, fn] of bridges) {
+      (window as unknown as Record<string, BridgeFn>)[name] = fn;
+    }
+    try {
+      return arg === undefined ? fn() : fn(arg);
+    } finally {
+      for (const [k, v] of Object.entries(originals)) {
+        if (v === undefined) {
+          delete (globalThis as Record<string, unknown>)[k];
+        } else {
+          (globalThis as Record<string, unknown>)[k] = v;
+        }
+      }
+    }
+  };
+
+  // -------------------------------------------------------------------------
+  // Write-path shims — what `sendChat` drives.
+  // -------------------------------------------------------------------------
+
+  const waitForSelector: Page["waitForSelector"] = (async (
+    selector: string,
+  ) => {
+    const el = document.querySelector(selector);
+    if (!el) {
+      throw new Error(`waitForSelector: ${selector} not found`);
+    }
+    return el as unknown as Awaited<ReturnType<Page["waitForSelector"]>>;
+  }) as Page["waitForSelector"];
+
+  const fill: Page["fill"] = (async (selector: string, value: string) => {
+    const el = document.querySelector(selector) as unknown as
+      | (HTMLTextAreaElement & { value: string })
+      | null;
+    if (!el) throw new Error(`fill: ${selector} not found`);
+    el.value = value;
+  }) as Page["fill"];
+
+  const press: Page["press"] = (async (selector: string, key: string) => {
+    const el = document.querySelector(selector);
+    if (!el) throw new Error(`press: ${selector} not found`);
+    if (key === "Enter") {
+      performSubmit();
+    }
+  }) as Page["press"];
+
+  const click: Page["click"] = (async (selector: string) => {
+    const el = document.querySelector(selector);
+    if (!el) throw new Error(`click: ${selector} not found`);
+    if (selector === chatSelectors.SEND_BUTTON) {
+      performSubmit();
+    } else {
+      (el as unknown as { click: () => void }).click();
+    }
+  }) as Page["click"];
+
+  const page: Partial<Page> = {
+    waitForSelector,
+    fill,
+    press,
+    click,
+    evaluate: (async (
+      fn: (...args: unknown[]) => unknown,
+      arg?: unknown,
+    ) => {
+      return runInPage(fn, arg);
+    }) as unknown as Page["evaluate"],
+    exposeFunction: (async (name: string, cb: Function) => {
+      bridges.set(name, cb as BridgeFn);
+    }) as Page["exposeFunction"],
+    $: (async (selector: string) => {
+      const el = document.querySelector(selector);
+      if (!el) return null;
+      return {
+        click: async () => {
+          (el as unknown as { click: () => void }).click();
+        },
+      } as unknown as Awaited<ReturnType<Page["$"]>>;
+    }) as Page["$"],
+  };
+
+  const appendRemoteMessage: FakePage["appendRemoteMessage"] = ({
+    id,
+    sender,
+    text,
+    datetime,
+  }) => {
+    const node = document.createElement("div");
+    node.setAttribute("role", "listitem");
+    node.setAttribute("data-message-id", id);
+    const senderEl = document.createElement("span");
+    senderEl.setAttribute("data-sender-name", "");
+    senderEl.textContent = sender;
+    const timeEl = document.createElement("time");
+    timeEl.setAttribute("datetime", datetime ?? new Date().toISOString());
+    timeEl.textContent = "12:00 PM";
+    const textEl = document.createElement("p");
+    textEl.setAttribute("data-message-text", "");
+    textEl.textContent = text;
+    node.appendChild(senderEl);
+    node.appendChild(timeEl);
+    node.appendChild(textEl);
+    messagesList.appendChild(node);
+  };
+
+  return {
+    page: page as Page,
+    dom,
+    document,
+    appendRemoteMessage,
+    submitCount: () => submitCount,
+    composerValue: () => {
+      const textarea = document.querySelector(
+        chatSelectors.INPUT,
+      ) as unknown as HTMLTextAreaElement | null;
+      return textarea?.value ?? "";
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+async function startOnRandomPort(
+  server: HttpServerHandle,
+): Promise<string> {
+  const { port } = await server.start(0);
+  return `http://127.0.0.1:${port}`;
+}
+
+async function postSendChat(
+  base: string,
+  text: string,
+): Promise<Response> {
+  return fetch(`${base}/send_chat`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${API_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ type: "send_chat", text }),
+  });
+}
+
+/**
+ * Yield back to the event loop so JSDOM's async MutationObserver queue
+ * flushes. Same helper shape as `chat-reader.test.ts`.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("chat loopback: /send_chat → DOM → startChatReader", () => {
+  let server: HttpServerHandle | null = null;
+  let reader: ChatReader | null = null;
+
+  beforeEach(() => {
+    BotState.__resetForTests();
+  });
+
+  afterEach(async () => {
+    if (reader) {
+      await reader.stop();
+      reader = null;
+    }
+    if (server !== null) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  test(
+    "POST /send_chat drives sendChat, the chat reader observes the DOM change, and the bot's self-send is filtered out",
+    async () => {
+      const fake = createFakePage(CHAT_FIXTURE, SELF_NAME);
+
+      // 1. Stand up the chat reader first so the in-page MutationObserver
+      //    is live before we POST. This mirrors the production wiring in
+      //    `main.ts` — the reader starts during step 5 of `runBot`, well
+      //    before the HTTP control surface accepts requests.
+      const inboundEvents: InboundChatEvent[] = [];
+      reader = await startChatReader(
+        fake.page,
+        (event) => {
+          inboundEvents.push(event);
+        },
+        { meetingId: "meeting-loopback", selfName: SELF_NAME },
+      );
+
+      // Drain the fixture's pre-existing "Alice: Hello everyone..." so the
+      // assertion below only reflects post-send traffic. (That message is
+      // NOT a self-send; it's an inbound event.)
+      await flushMicrotasks();
+      expect(inboundEvents).toHaveLength(1);
+      expect(inboundEvents[0]!.fromName).toBe("Alice");
+      inboundEvents.length = 0;
+
+      // 2. Bring up the HTTP server with `onSendChat` wired to the real
+      //    `sendChat` helper, exactly like `main.ts` does.
+      server = createHttpServer({
+        apiToken: API_TOKEN,
+        onLeave: () => {},
+        onSendChat: async (text) => {
+          await sendChat(fake.page, text);
+        },
+        onPlayAudio: () => {},
+      });
+      const base = await startOnRandomPort(server);
+
+      // 3. POST the chat message.
+      const sentText = "Hello from the loopback test.";
+      const res = await postSendChat(base, sentText);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        sent: boolean;
+        timestamp: string;
+      };
+      expect(body.sent).toBe(true);
+
+      // sendChat should have filled the composer, pressed Enter, and the
+      // fake's submit handler should have cleared the field.
+      expect(fake.submitCount()).toBe(1);
+      expect(fake.composerValue()).toBe("");
+
+      // The submitted message node should now be in the DOM.
+      const messageNodes = fake.document.querySelectorAll(
+        selectors.INGAME_CHAT_MESSAGE_NODE,
+      );
+      expect(messageNodes.length).toBeGreaterThanOrEqual(2);
+      const botNode = Array.from(messageNodes).find(
+        (n) => n.getAttribute("data-message-id") === "bot-out-1",
+      );
+      expect(botNode).toBeDefined();
+      const botText = botNode
+        ?.querySelector(selectors.INGAME_CHAT_MESSAGE_TEXT)
+        ?.textContent?.trim();
+      expect(botText).toBe(sentText);
+
+      // 4. Give the MutationObserver a tick to process the newly-appended
+      //    node and invoke the bridge.
+      await flushMicrotasks();
+
+      // 5. **The critical assertion**: the bot's own outgoing message
+      //    MUST NOT appear as an InboundChatEvent. `startChatReader`'s
+      //    self-filter matches by display name (selfName === SELF_NAME
+      //    === the message's rendered sender), so the bridge call is
+      //    dropped before `onMessage` fires.
+      expect(inboundEvents).toHaveLength(0);
+
+      // 6. Sanity check: a remote (non-self) message still surfaces after
+      //    the self-send, so the filter didn't over-aggressively mute the
+      //    entire reader.
+      fake.appendRemoteMessage({
+        id: "remote-after-send",
+        sender: "Bob",
+        text: "Got it, thanks.",
+      });
+      await flushMicrotasks();
+      expect(inboundEvents).toHaveLength(1);
+      expect(inboundEvents[0]!.fromName).toBe("Bob");
+      expect(inboundEvents[0]!.text).toBe("Got it, thanks.");
+    },
+  );
+
+  test(
+    "multiple consecutive sends each round-trip through the chat reader without leaking a self-echo",
+    async () => {
+      // This guards against a subtle class of bug: if the self-filter
+      // bucketed by sender+text+timestamp only (the dedupe key), a
+      // second bot-send with the same text but a different timestamp
+      // might slip through. We send twice with different text and
+      // assert zero inbound events either way.
+      const fake = createFakePage(CHAT_FIXTURE, SELF_NAME);
+
+      const inboundEvents: InboundChatEvent[] = [];
+      reader = await startChatReader(
+        fake.page,
+        (event) => inboundEvents.push(event),
+        { meetingId: "meeting-loopback-2", selfName: SELF_NAME },
+      );
+      await flushMicrotasks();
+      inboundEvents.length = 0; // drop the fixture's "Alice: Hello..." backfill
+
+      server = createHttpServer({
+        apiToken: API_TOKEN,
+        onLeave: () => {},
+        onSendChat: async (text) => {
+          await sendChat(fake.page, text);
+        },
+        onPlayAudio: () => {},
+      });
+      const base = await startOnRandomPort(server);
+
+      // First send.
+      let res = await postSendChat(base, "first send");
+      expect(res.status).toBe(200);
+      await flushMicrotasks();
+
+      // Second send — distinct text so the bot-side dedupe key is
+      // unambiguously different from the first.
+      res = await postSendChat(base, "second send");
+      expect(res.status).toBe(200);
+      await flushMicrotasks();
+
+      expect(fake.submitCount()).toBe(2);
+      // Still zero inbound events — both self-sends dropped.
+      expect(inboundEvents).toHaveLength(0);
+    },
+  );
+});

--- a/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-send-e2e.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Daemon-side chat-send E2E test.
+ *
+ * Stands up a real `Bun.serve` HTTP endpoint on a random loopback port to
+ * play the role of the meet-bot container, drives `MeetSessionManager`
+ * through a full `join()` → `sendChat()` cycle against that fake bot, and
+ * asserts both the HTTP wire payload (body + auth header) and the
+ * `meet.chat_sent` event that lands on `assistantEventHub`.
+ *
+ * What the test exercises end-to-end:
+ *
+ *   1. `MeetSessionManager.sendChat` looks up the active session, formats
+ *      the request body as `{ type: "send_chat", text }`, and attaches
+ *      the per-meeting bearer token. The default `botSendChatFetch` is
+ *      NOT overridden, so this is a real `fetch()` call against a real
+ *      HTTP server on the loopback interface.
+ *
+ *   2. The fake bot server records the request and responds 200, so the
+ *      happy path produces no domain error.
+ *
+ *   3. `publishMeetEvent(..., "meet.chat_sent", { text })` lands on the
+ *      shared `assistantEventHub` with the expected payload. The
+ *      subscriber sees the event exactly once.
+ *
+ *   4. Domain errors surface correctly:
+ *        - Unknown meetingId → `MeetSessionNotFoundError`.
+ *        - Bot returns a non-2xx → `MeetBotChatError` whose `status`
+ *          matches the response.
+ *        - Bot unreachable (server torn down before the call) →
+ *          `MeetSessionUnreachableError`.
+ *
+ * The test does not spin up real Docker, no real Meet, and does not
+ * touch the daemon's long-running singletons directly — it uses
+ * `_createMeetSessionManagerForTests` so each test gets its own isolated
+ * manager with mock docker / audio-ingest deps. The Docker `run` result
+ * is stitched to the real bound port of the fake bot server so the
+ * session's `botBaseUrl` actually points at something we can serve a
+ * response from.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { AssistantEvent } from "../../../../assistant/src/runtime/assistant-event.js";
+import { assistantEventHub } from "../../../../assistant/src/runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
+import { meetEventDispatcher } from "../event-publisher.js";
+import { __resetMeetSessionEventRouterForTests } from "../session-event-router.js";
+import {
+  _createMeetSessionManagerForTests,
+  MEET_BOT_INTERNAL_PORT,
+  MeetBotChatError,
+  MeetSessionNotFoundError,
+  MeetSessionUnreachableError,
+  type MeetAudioIngestLike,
+} from "../session-manager.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  authorization: string | null;
+  contentType: string | null;
+  body: string;
+}
+
+interface FakeBotServer {
+  url: string;
+  port: number;
+  requests: RecordedRequest[];
+  /** Override the next response status/body — resets back to default after use. */
+  setNextResponse: (status: number, body?: unknown) => void;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Boot a throwaway `Bun.serve` on a random loopback port that records
+ * every request it receives for later assertion. Default behavior is to
+ * return `200 { sent: true, timestamp }`, mirroring the meet-bot's real
+ * `/send_chat` contract; individual tests can override the next response
+ * via `setNextResponse`.
+ */
+function startFakeBot(): FakeBotServer {
+  const requests: RecordedRequest[] = [];
+  let nextResponse: { status: number; body?: unknown } | null = null;
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: async (req) => {
+      const body = await req.text().catch(() => "");
+      requests.push({
+        method: req.method,
+        url: new URL(req.url).pathname,
+        authorization: req.headers.get("authorization"),
+        contentType: req.headers.get("content-type"),
+        body,
+      });
+      if (nextResponse) {
+        const { status, body: responseBody } = nextResponse;
+        nextResponse = null;
+        return new Response(
+          responseBody === undefined ? "" : JSON.stringify(responseBody),
+          { status, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ sent: true, timestamp: new Date().toISOString() }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+
+  const port = server.port;
+  if (port === undefined) {
+    throw new Error("fake bot server failed to bind a port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    requests,
+    setNextResponse: (status, body) => {
+      nextResponse = { status, body };
+    },
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+/**
+ * Subscribe to the event hub for `DAEMON_INTERNAL_ASSISTANT_ID` (the
+ * scope every Meet event publishes under) and collect every delivered
+ * event. Callers should call `dispose()` in a `finally` so we don't leak
+ * subscribers across tests.
+ */
+function captureHub(): {
+  received: AssistantEvent[];
+  dispose: () => void;
+} {
+  const received: AssistantEvent[] = [];
+  const sub = assistantEventHub.subscribe(
+    { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+    (event) => {
+      received.push(event);
+    },
+  );
+  return { received, dispose: () => sub.dispose() };
+}
+
+/**
+ * Minimal stand-in for the audio ingest. The session manager doesn't
+ * interact with it after `start()` resolves, so the fake is a no-op.
+ */
+function makeFakeAudioIngest(): MeetAudioIngestLike {
+  return {
+    start: async () => {},
+    stop: async () => {},
+    subscribePcm: () => () => {},
+  };
+}
+
+/**
+ * Build a mock Docker runner whose `run()` returns a container record
+ * pinned to the real fake-bot server's host port. This is how we stitch
+ * the session's `botBaseUrl` to something a real `fetch()` can hit.
+ */
+function makeMockRunnerPointingAt(fakeBot: FakeBotServer) {
+  const runResult = {
+    containerId: "container-chat-e2e",
+    boundPorts: [
+      {
+        protocol: "tcp" as const,
+        containerPort: MEET_BOT_INTERNAL_PORT,
+        hostIp: "127.0.0.1",
+        hostPort: fakeBot.port,
+      },
+    ],
+  };
+  return {
+    run: mock(async () => runResult),
+    stop: mock(async () => {}),
+    remove: mock(async () => {}),
+    inspect: mock(async () => ({ Id: runResult.containerId })),
+  };
+}
+
+let workspaceDir: string;
+let fakeBot: FakeBotServer;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "chat-send-e2e-"));
+  __resetMeetSessionEventRouterForTests();
+  meetEventDispatcher._resetForTests();
+  fakeBot = startFakeBot();
+});
+
+afterEach(async () => {
+  await fakeBot.stop();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — real HTTP, real event-hub
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager.sendChat end-to-end (real HTTP + real event hub)", () => {
+  test("forwards the message to the bot over HTTP and publishes meet.chat_sent", async () => {
+    const runner = makeMockRunnerPointingAt(fakeBot);
+    const { received, dispose } = captureHub();
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "tts-key",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: makeFakeAudioIngest,
+      });
+
+      const session = await manager.join({
+        url: "https://meet.google.com/abc-def-ghi",
+        meetingId: "m-chat-e2e",
+        conversationId: "conv-chat-e2e",
+      });
+
+      // Sanity: session is pointed at our fake bot.
+      expect(session.botBaseUrl).toBe(fakeBot.url);
+
+      const text = "hello";
+      await manager.sendChat("m-chat-e2e", text);
+
+      // ---- Assert: bot HTTP server received exactly one well-formed request.
+      expect(fakeBot.requests).toHaveLength(1);
+      const req = fakeBot.requests[0]!;
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/send_chat");
+      expect(req.authorization).toBe(`Bearer ${session.botApiToken}`);
+      expect(req.contentType).toContain("application/json");
+      const parsed = JSON.parse(req.body) as { type: string; text: string };
+      expect(parsed.type).toBe("send_chat");
+      expect(parsed.text).toBe(text);
+
+      // ---- Assert: assistantEventHub received `meet.chat_sent` with the text.
+      // publishMeetEvent is fire-and-forget inside sendChat, so give the
+      // microtask queue a tick to flush before asserting.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const chatSent = received.filter(
+        (e) => e.message.type === "meet.chat_sent",
+      );
+      expect(chatSent).toHaveLength(1);
+      const message = chatSent[0]!.message as {
+        type: "meet.chat_sent";
+        meetingId: string;
+        text: string;
+      };
+      expect(message.meetingId).toBe("m-chat-e2e");
+      expect(message.text).toBe(text);
+      expect(chatSent[0]!.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
+
+      await manager.leave("m-chat-e2e", "cleanup");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("preserves text with special characters in the JSON body", async () => {
+    // Sanity that we don't accidentally double-encode or mangle unicode
+    // on the way out. Uses a string with an emoji, non-ASCII punctuation,
+    // and embedded quotes — all legitimate chat content.
+    const runner = makeMockRunnerPointingAt(fakeBot);
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: makeFakeAudioIngest,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-chat-unicode",
+        conversationId: "c",
+      });
+
+      const text = 'Hello — "quoted" 🎉 newlines\nare\tfine';
+      await manager.sendChat("m-chat-unicode", text);
+
+      expect(fakeBot.requests).toHaveLength(1);
+      const parsed = JSON.parse(fakeBot.requests[0]!.body) as { text: string };
+      expect(parsed.text).toBe(text);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      const chatSent = received.filter(
+        (e) => e.message.type === "meet.chat_sent",
+      );
+      expect(chatSent).toHaveLength(1);
+      expect((chatSent[0]!.message as { text: string }).text).toBe(text);
+
+      await manager.leave("m-chat-unicode", "cleanup");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("throws MeetSessionNotFoundError and does NOT publish meet.chat_sent when the meeting is unknown", async () => {
+    const runner = makeMockRunnerPointingAt(fakeBot);
+    const { received, dispose } = captureHub();
+
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: makeFakeAudioIngest,
+      });
+
+      // No `join()` call — sendChat against a meetingId that was never
+      // registered is the error path the `meet_send_chat` tool relies on.
+      await expect(manager.sendChat("never-joined", "hi")).rejects.toThrow(
+        MeetSessionNotFoundError,
+      );
+
+      // Fake bot must not have seen the request.
+      expect(fakeBot.requests).toHaveLength(0);
+
+      // Nor should the event hub have published anything chat-shaped.
+      await Promise.resolve();
+      await Promise.resolve();
+      const chatSent = received.filter(
+        (e) => e.message.type === "meet.chat_sent",
+      );
+      expect(chatSent).toHaveLength(0);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("propagates MeetBotChatError when the bot responds with 502 and does NOT publish meet.chat_sent", async () => {
+    // Simulates the Playwright-failure path on the bot: PR 1's handler
+    // returns 502 when `sendChat(page, text)` throws (selector drift,
+    // panel missing, etc.). The daemon must surface this as a domain
+    // error and must NOT announce a successful send to SSE subscribers.
+    const runner = makeMockRunnerPointingAt(fakeBot);
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: makeFakeAudioIngest,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-chat-502",
+        conversationId: "c",
+      });
+
+      fakeBot.setNextResponse(502, {
+        sent: false,
+        error: "selector timeout",
+      });
+
+      let caught: unknown = null;
+      try {
+        await manager.sendChat("m-chat-502", "will fail");
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(MeetBotChatError);
+      expect((caught as MeetBotChatError).status).toBe(502);
+      // The bot's error body is preserved verbatim in the thrown message
+      // so the tool layer can show it to the user.
+      expect((caught as MeetBotChatError).message).toContain(
+        "selector timeout",
+      );
+
+      // The bot still received the request — we just responded non-OK.
+      expect(fakeBot.requests).toHaveLength(1);
+
+      // No meet.chat_sent should have been published for the failed send.
+      await Promise.resolve();
+      await Promise.resolve();
+      const chatSent = received.filter(
+        (e) => e.message.type === "meet.chat_sent",
+      );
+      expect(chatSent).toHaveLength(0);
+
+      await manager.leave("m-chat-502", "cleanup");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("maps network-level failure to MeetSessionUnreachableError", async () => {
+    // Tear the bot server down BEFORE issuing sendChat so the fetch
+    // hits a refused connection — the default `botSendChatFetch` wraps
+    // that into `MeetSessionUnreachableError`.
+    const runner = makeMockRunnerPointingAt(fakeBot);
+    const { received, dispose } = captureHub();
+    try {
+      const manager = _createMeetSessionManagerForTests({
+        dockerRunnerFactory: () => runner,
+        getProviderKey: async () => "",
+        getWorkspaceDir: () => workspaceDir,
+        botLeaveFetch: async () => {},
+        audioIngestFactory: makeFakeAudioIngest,
+      });
+
+      await manager.join({
+        url: "u",
+        meetingId: "m-chat-down",
+        conversationId: "c",
+      });
+
+      // Drop the server so the next fetch observes connection refused /
+      // dns failure / reset — whichever the kernel produces.
+      await fakeBot.stop();
+
+      let caught: unknown = null;
+      try {
+        await manager.sendChat("m-chat-down", "unreachable");
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(MeetSessionUnreachableError);
+
+      // Nothing published — the send never completed.
+      await Promise.resolve();
+      await Promise.resolve();
+      const chatSent = received.filter(
+        (e) => e.message.type === "meet.chat_sent",
+      );
+      expect(chatSent).toHaveLength(0);
+
+      // Restart the fake bot so the `afterEach` cleanup has something to
+      // `.stop()` without throwing — our server wrapper is tolerant of
+      // being stopped once, but `startFakeBot` is invoked per test and
+      // the afterEach hook expects a live handle.
+      fakeBot = startFakeBot();
+
+      await manager.leave("m-chat-down", "cleanup");
+    } finally {
+      dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bot-side loopback: POST /send_chat drives DOM via sendChat, startChatReader observes, self-message filtered
- Daemon-side E2E: mock bot HTTP server records payload, assistantEventHub assertion for meet.chat_sent
- Both tests side-effect-free (no real Docker, no real Meet)

Part of plan: meet-phase-2-chat.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
