### PR TITLE
fix(gmail): fall back to query-based archiving when scan store expires

### DIFF
--- a/assistant/src/__tests__/gmail-archive-fallback.test.ts
+++ b/assistant/src/__tests__/gmail-archive-fallback.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../tools/types.js";
+
+const mockBatchModifyMessages =
+  mock<
+    (
+      conn: unknown,
+      ids: string[],
+      opts: Record<string, unknown>,
+    ) => Promise<void>
+  >();
+const mockListMessages =
+  mock<
+    (
+      conn: unknown,
+      query: string,
+      limit: number,
+      pageToken?: string,
+    ) => Promise<{
+      messages?: { id: string }[];
+      nextPageToken?: string | null;
+    }>
+  >();
+const mockModifyMessage =
+  mock<
+    (
+      conn: unknown,
+      messageId: string,
+      opts: Record<string, unknown>,
+    ) => Promise<void>
+  >();
+const mockResolveOAuthConnection =
+  mock<(provider: string, opts?: unknown) => Promise<unknown>>();
+
+let mockScanStoreReturn: string[] | null = null;
+
+mock.module("../messaging/providers/gmail/client.js", () => ({
+  batchModifyMessages: mockBatchModifyMessages,
+  listMessages: mockListMessages,
+  modifyMessage: mockModifyMessage,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+mock.module("../config/bundled-skills/gmail/tools/scan-result-store.js", () => ({
+  getSenderMessageIds: () => mockScanStoreReturn,
+}));
+
+const { run } = await import(
+  "../config/bundled-skills/gmail/tools/gmail-archive.js"
+);
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    conversationId: "conv-1",
+    triggeredBySurfaceAction: true,
+    ...overrides,
+  } as ToolContext;
+}
+
+function encodeSenderId(email: string): string {
+  return Buffer.from(email).toString("base64url");
+}
+
+describe("gmail_archive sender ID fallback", () => {
+  afterEach(() => {
+    mockBatchModifyMessages.mockReset();
+    mockListMessages.mockReset();
+    mockModifyMessage.mockReset();
+    mockResolveOAuthConnection.mockReset();
+    mockScanStoreReturn = null;
+  });
+
+  test("falls back to query-based archiving when scan expires", async () => {
+    mockScanStoreReturn = null; // expired scan
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages.mockResolvedValueOnce({
+      messages: [{ id: "m1" }, { id: "m2" }, { id: "m3" }],
+      nextPageToken: null,
+    });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const senderId = encodeSenderId("spam@example.com");
+    const result = await run(
+      { scan_id: "expired-scan", sender_ids: [senderId] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Archived 3 message(s)");
+    expect(result.content).toContain("query fallback");
+    expect(mockListMessages.mock.calls[0][1]).toBe(
+      "from:spam@example.com in:inbox",
+    );
+  });
+
+  test("falls back when scan returns empty array", async () => {
+    mockScanStoreReturn = []; // scan valid but no IDs resolved
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages.mockResolvedValueOnce({
+      messages: [{ id: "m1" }],
+      nextPageToken: null,
+    });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const senderId = encodeSenderId("cold@outreach.io");
+    const result = await run(
+      { scan_id: "valid-scan", sender_ids: [senderId] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Archived 1 message(s)");
+    expect(result.content).toContain("query fallback");
+  });
+
+  test("handles multiple sender IDs in fallback", async () => {
+    mockScanStoreReturn = null;
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages
+      .mockResolvedValueOnce({
+        messages: [{ id: "m1" }, { id: "m2" }],
+        nextPageToken: null,
+      })
+      .mockResolvedValueOnce({
+        messages: [{ id: "m3" }],
+        nextPageToken: null,
+      });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const senderIds = [
+      encodeSenderId("a@example.com"),
+      encodeSenderId("b@example.com"),
+    ];
+    const result = await run(
+      { scan_id: "expired", sender_ids: senderIds },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Archived 3 message(s)");
+    expect(mockListMessages).toHaveBeenCalledTimes(2);
+  });
+
+  test("reports undecodable sender IDs", async () => {
+    mockScanStoreReturn = null;
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages.mockResolvedValueOnce({
+      messages: [{ id: "m1" }],
+      nextPageToken: null,
+    });
+    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+    const validId = encodeSenderId("ok@example.com");
+    const invalidId = "not-valid-base64-@@@";
+    const result = await run(
+      { scan_id: "expired", sender_ids: [validId, invalidId] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("1 sender ID(s) could not be decoded");
+  });
+
+  test("errors when all sender IDs are undecodable", async () => {
+    mockScanStoreReturn = null;
+
+    // base64url decodes to something without @
+    const noAtId = Buffer.from("noemail").toString("base64url");
+    const result = await run(
+      { scan_id: "expired", sender_ids: [noAtId] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("could not be decoded");
+  });
+
+  test("returns ok when fallback finds no messages", async () => {
+    mockScanStoreReturn = null;
+    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+    mockListMessages.mockResolvedValueOnce({
+      messages: [],
+      nextPageToken: null,
+    });
+
+    const senderId = encodeSenderId("gone@example.com");
+    const result = await run(
+      { scan_id: "expired", sender_ids: [senderId] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("No inbox messages found");
+  });
+});

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -14,6 +14,14 @@ import { err, ok } from "./shared.js";
 const BATCH_MODIFY_LIMIT = 1000;
 const MAX_MESSAGES = 5000;
 
+function decodeSenderEmail(senderId: string): string | null {
+  try {
+    return Buffer.from(senderId, "base64url").toString("utf-8");
+  } catch {
+    return null;
+  }
+}
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -90,12 +98,76 @@ export async function run(
     }
 
     const resolved = getSenderMessageIds(scanId, senderIds);
-    if (!resolved) {
-      return err(
-        "Scan results have expired (30-minute window). Please re-run the scan to get fresh results.",
-      );
+    if (resolved && resolved.length > 0) {
+      messageIds = resolved;
+    } else {
+      // Scan expired or sender IDs unresolved — fall back to query-based archiving
+      const emails: string[] = [];
+      const undecodable: string[] = [];
+      for (const sid of senderIds) {
+        const email = decodeSenderEmail(sid);
+        if (email && email.includes("@")) {
+          emails.push(email);
+        } else {
+          undecodable.push(sid);
+        }
+      }
+
+      if (emails.length === 0) {
+        return err(
+          "Scan results have expired and sender IDs could not be decoded. Please re-run the scan.",
+        );
+      }
+
+      try {
+        const connection = await resolveOAuthConnection("google", {
+          account,
+        });
+        const allMessageIds: string[] = [];
+
+        for (const email of emails) {
+          const fallbackQuery = `from:${email} in:inbox`;
+          let pageToken: string | undefined;
+          while (allMessageIds.length < MAX_MESSAGES) {
+            const listResp = await listMessages(
+              connection,
+              fallbackQuery,
+              Math.min(500, MAX_MESSAGES - allMessageIds.length),
+              pageToken,
+            );
+            const ids = (listResp.messages ?? []).map((m) => m.id);
+            if (ids.length === 0) break;
+            allMessageIds.push(...ids);
+            pageToken = listResp.nextPageToken ?? undefined;
+            if (!pageToken) break;
+          }
+          if (allMessageIds.length >= MAX_MESSAGES) break;
+        }
+
+        if (allMessageIds.length === 0) {
+          return ok("No inbox messages found for the selected senders.");
+        }
+
+        for (let i = 0; i < allMessageIds.length; i += BATCH_MODIFY_LIMIT) {
+          const chunk = allMessageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+          await batchModifyMessages(connection, chunk, {
+            removeLabelIds: ["INBOX"],
+          });
+        }
+
+        const parts = [
+          `Archived ${allMessageIds.length} message(s) via query fallback (scan results had expired).`,
+        ];
+        if (undecodable.length > 0) {
+          parts.push(
+            `${undecodable.length} sender ID(s) could not be decoded and were skipped.`,
+          );
+        }
+        return ok(parts.join(" "));
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
     }
-    messageIds = resolved;
   } else if (messageIds?.length) {
     // Batch message_ids path requires surface action confirmation
     if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {


### PR DESCRIPTION
## Summary
- When the in-memory scan result store expires (30-min TTL) or sender IDs don't resolve, the `gmail_archive` tool now decodes base64url sender IDs back to email addresses and falls back to `from:{email} in:inbox` query-based archiving instead of returning an error
- Reports fallback usage and any undecodable sender IDs so the user has visibility
- Adds test coverage for all fallback paths (expired scan, empty resolution, multiple senders, undecodable IDs)

## Test plan
- [x] Existing `gmail-archive-gate.test.ts` passes (15 tests)
- [x] New `gmail-archive-fallback.test.ts` passes (6 tests)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [ ] Manual: run gmail cleanup, wait >30 min for scan to expire, confirm archive still works via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
