### PR TITLE
feat(gmail): persistent cleanup preferences (blocklist + safelist)

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mutable state for mocks ──────────────────────────────────────────
+
+const secureKeyValues = new Map<string, string>();
+
+let mockProviders: Array<{
+  provider: string;
+  defaultScopes: string;
+  pingUrl: string | null;
+  pingMethod: string | null;
+  pingHeaders: string | null;
+  pingBody: string | null;
+}> = [];
+
+let mockConnections: Map<
+  string,
+  Array<{
+    id: string;
+    provider: string;
+    accountInfo: string | null;
+    grantedScopes: string;
+    expiresAt: number | null;
+    hasRefreshToken: number;
+    status: string;
+  }>
+> = new Map();
+
+let mockFetchResponse: { ok: boolean; status: number } = {
+  ok: true,
+  status: 200,
+};
+let mockFetchThrows = false;
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => "deleted",
+  listSecureKeysAsync: async () => [],
+  getProviderKeyAsync: async () => undefined,
+  getMaskedProviderKey: () => undefined,
+}));
+
+mock.module("../oauth/oauth-store.js", () => ({
+  listProviders: () => mockProviders,
+  listActiveConnectionsByProvider: (provider: string) =>
+    mockConnections.get(provider) ?? [],
+  getProvider: (provider: string) =>
+    mockProviders.find((p) => p.provider === provider),
+  isProviderConnected: () => false,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+const {
+  checkAllCredentials,
+  checkCredentialForProvider,
+  _setFetchFn,
+} = await import("../credential-health/credential-health-service.js");
+
+// Inject mock fetch via the test helper (Bun's global fetch can't be
+// overridden via globalThis assignment).
+_setFetchFn((async () => {
+  if (mockFetchThrows) {
+    throw new Error("Network error");
+  }
+  return {
+    ok: mockFetchResponse.ok,
+    status: mockFetchResponse.status,
+  } as Response;
+}) as unknown as typeof fetch);
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function addProvider(
+  provider: string,
+  opts?: {
+    defaultScopes?: string[];
+    pingUrl?: string | null;
+    pingMethod?: string | null;
+  },
+) {
+  mockProviders.push({
+    provider,
+    defaultScopes: JSON.stringify(opts?.defaultScopes ?? []),
+    pingUrl: opts?.pingUrl ?? null,
+    pingMethod: opts?.pingMethod ?? null,
+    pingHeaders: null,
+    pingBody: null,
+  });
+}
+
+function addConnection(
+  provider: string,
+  id: string,
+  opts?: {
+    expiresAt?: number | null;
+    hasRefreshToken?: boolean;
+    grantedScopes?: string[];
+    accountInfo?: string | null;
+  },
+) {
+  const conns = mockConnections.get(provider) ?? [];
+  conns.push({
+    id,
+    provider,
+    accountInfo: opts?.accountInfo ?? `user@${provider}.com`,
+    grantedScopes: JSON.stringify(opts?.grantedScopes ?? []),
+    expiresAt: opts?.expiresAt ?? null,
+    hasRefreshToken: opts?.hasRefreshToken ? 1 : 0,
+    status: "active",
+  });
+  mockConnections.set(provider, conns);
+}
+
+function setToken(connectionId: string, token = "mock-token") {
+  secureKeyValues.set(
+    `oauth_connection/${connectionId}/access_token`,
+    token,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("credential-health-service", () => {
+  beforeEach(() => {
+    secureKeyValues.clear();
+    mockProviders = [];
+    mockConnections = new Map();
+    mockFetchResponse = { ok: true, status: 200 };
+    mockFetchThrows = false;
+  });
+
+  test("returns empty report when no providers exist", async () => {
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(0);
+    expect(report.unhealthy).toHaveLength(0);
+    expect(report.checkedAt).toBeGreaterThan(0);
+  });
+
+  test("returns empty report when provider has no connections", async () => {
+    addProvider("google");
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(0);
+    expect(report.unhealthy).toHaveLength(0);
+  });
+
+  test("returns healthy for connection with valid token and future expiry", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("healthy");
+    expect(report.unhealthy).toHaveLength(0);
+  });
+
+  test("returns missing_token when no access token in secure storage", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1");
+    // Don't set token
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("missing_token");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+    expect(report.unhealthy).toHaveLength(1);
+  });
+
+  test("returns expired when token is past expiresAt without refresh token", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() - 60_000, // 1 minute ago
+      hasRefreshToken: false,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("expired");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("returns expiring when token is past expiresAt with refresh token", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() - 60_000, // 1 minute ago
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("expiring");
+    expect(report.results[0]!.canAutoRecover).toBe(true);
+  });
+
+  test("returns expiring when token expires within 7 days without refresh token", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 3 * 24 * 60 * 60 * 1000, // 3 days from now
+      hasRefreshToken: false,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("expiring");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("returns healthy when token expires within 7 days but has refresh token", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 3 * 24 * 60 * 60 * 1000, // 3 days from now
+      hasRefreshToken: true,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("healthy");
+  });
+
+  test("returns missing_scopes when grantedScopes is subset of defaultScopes", async () => {
+    addProvider("slack", {
+      defaultScopes: ["chat:write", "channels:read", "im:write"],
+    });
+    addConnection("slack", "conn-1", {
+      grantedScopes: ["chat:write"],
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("missing_scopes");
+    expect(report.results[0]!.missingScopes).toEqual([
+      "channels:read",
+      "im:write",
+    ]);
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("returns revoked when ping returns 401", async () => {
+    mockFetchResponse = { ok: false, status: 401 };
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("revoked");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("returns ping_failed on non-auth ping error", async () => {
+    mockFetchResponse = { ok: false, status: 500 };
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("ping_failed");
+  });
+
+  test("returns ping_failed on network error (does not throw)", async () => {
+    mockFetchThrows = true;
+    addProvider("google", {
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    });
+    addConnection("google", "conn-1", {
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    // Network error -> ping_failed (non-auth), not an exception
+    expect(report.results[0]!.status).toBe("ping_failed");
+  });
+
+  test("checks multiple providers and connections", async () => {
+    addProvider("google");
+    addProvider("slack", {
+      defaultScopes: ["chat:write", "channels:read"],
+    });
+
+    addConnection("google", "conn-g1");
+    setToken("conn-g1");
+    addConnection("slack", "conn-s1", {
+      grantedScopes: ["chat:write", "channels:read"],
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-s1");
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(2);
+
+    const google = report.results.find((r) => r.provider === "google");
+    const slack = report.results.find((r) => r.provider === "slack");
+
+    // Google: token set, no expiry -> healthy
+    expect(google!.status).toBe("healthy");
+    // Slack: all scopes present, valid token -> healthy
+    expect(slack!.status).toBe("healthy");
+  });
+
+  describe("checkCredentialForProvider", () => {
+    test("returns null when no connections exist", async () => {
+      const result = await checkCredentialForProvider("google");
+      expect(result).toBeNull();
+    });
+
+    test("returns health result for the most recent connection", async () => {
+      addProvider("google");
+      addConnection("google", "conn-1", {
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      });
+      setToken("conn-1");
+
+      const result = await checkCredentialForProvider("google");
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe("healthy");
+      expect(result!.connectionId).toBe("conn-1");
+    });
+
+    test("returns unhealthy for missing token", async () => {
+      addProvider("google");
+      addConnection("google", "conn-1");
+
+      const result = await checkCredentialForProvider("google");
+      expect(result!.status).toBe("missing_token");
+    });
+  });
+});

--- a/assistant/src/__tests__/gmail-preferences.test.ts
+++ b/assistant/src/__tests__/gmail-preferences.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Create a temp workspace dir for each test
+const testWorkspace = join(tmpdir(), `gmail-prefs-test-${Date.now()}`);
+mkdirSync(join(testWorkspace, "data"), { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => testWorkspace,
+}));
+
+const {
+  loadPreferences,
+  addToBlocklist,
+  addToSafelist,
+  removeFromBlocklist,
+  removeFromSafelist,
+} = await import(
+  "../config/bundled-skills/gmail/tools/gmail-preferences.js"
+);
+
+describe("gmail preferences", () => {
+  afterEach(() => {
+    // Clean up the prefs file between tests
+    try {
+      rmSync(join(testWorkspace, "data", "gmail-preferences.json"));
+    } catch {
+      // OK if doesn't exist
+    }
+  });
+
+  test("returns empty lists when no prefs file exists", () => {
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toEqual([]);
+    expect(prefs.safelist).toEqual([]);
+  });
+
+  test("addToBlocklist persists and deduplicates emails", () => {
+    addToBlocklist(["spam@example.com", "junk@test.com"]);
+    addToBlocklist(["spam@example.com", "more@test.com"]);
+
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toContain("spam@example.com");
+    expect(prefs.blocklist).toContain("junk@test.com");
+    expect(prefs.blocklist).toContain("more@test.com");
+    expect(prefs.blocklist.filter((e) => e === "spam@example.com")).toHaveLength(
+      1,
+    );
+  });
+
+  test("addToSafelist persists and deduplicates emails", () => {
+    addToSafelist(["keep@example.com"]);
+    addToSafelist(["keep@example.com", "also@keep.com"]);
+
+    const prefs = loadPreferences();
+    expect(prefs.safelist).toContain("keep@example.com");
+    expect(prefs.safelist).toContain("also@keep.com");
+    expect(prefs.safelist.filter((e) => e === "keep@example.com")).toHaveLength(
+      1,
+    );
+  });
+
+  test("blocklisting removes from safelist", () => {
+    addToSafelist(["sender@example.com"]);
+    expect(loadPreferences().safelist).toContain("sender@example.com");
+
+    addToBlocklist(["sender@example.com"]);
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toContain("sender@example.com");
+    expect(prefs.safelist).not.toContain("sender@example.com");
+  });
+
+  test("safelisting removes from blocklist", () => {
+    addToBlocklist(["sender@example.com"]);
+    expect(loadPreferences().blocklist).toContain("sender@example.com");
+
+    addToSafelist(["sender@example.com"]);
+    const prefs = loadPreferences();
+    expect(prefs.safelist).toContain("sender@example.com");
+    expect(prefs.blocklist).not.toContain("sender@example.com");
+  });
+
+  test("removeFromBlocklist works", () => {
+    addToBlocklist(["a@test.com", "b@test.com", "c@test.com"]);
+    removeFromBlocklist(["b@test.com"]);
+
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toContain("a@test.com");
+    expect(prefs.blocklist).not.toContain("b@test.com");
+    expect(prefs.blocklist).toContain("c@test.com");
+  });
+
+  test("removeFromSafelist works", () => {
+    addToSafelist(["a@test.com", "b@test.com"]);
+    removeFromSafelist(["a@test.com"]);
+
+    const prefs = loadPreferences();
+    expect(prefs.safelist).not.toContain("a@test.com");
+    expect(prefs.safelist).toContain("b@test.com");
+  });
+
+  test("normalizes emails to lowercase", () => {
+    addToBlocklist(["SPAM@Example.COM"]);
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toContain("spam@example.com");
+  });
+
+  test("handles corrupted prefs file gracefully", () => {
+    writeFileSync(
+      join(testWorkspace, "data", "gmail-preferences.json"),
+      "not json",
+    );
+    const prefs = loadPreferences();
+    expect(prefs.blocklist).toEqual([]);
+    expect(prefs.safelist).toEqual([]);
+  });
+});

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -106,7 +106,7 @@ When searching Gmail, the query uses Gmail's search operators:
 
 When a user asks to declutter, clean up, or organize their email - start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Go straight to scanning - but once results are ready, always show them via `ui_show` and let the user choose actions before archiving or unsubscribing.
 
-**CRITICAL**: Never call `gmail_archive`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table - NOT auto-archive. Previous batch approvals do not carry forward, but **deselections DO carry forward**: when the user deselects senders from a cleanup table, the system records those deselections as user preferences. Before building the next cleanup table, check `<dynamic-user-profile>` for previously deselected senders and exclude them from future cleanup tables - the user already indicated they want to keep those.
+**CRITICAL**: Never call `gmail_archive`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table - NOT auto-archive. Previous batch approvals do not carry forward, but **deselections DO carry forward**: when the user deselects senders from a cleanup table, call `gmail_preferences` with `action: "add_safelist"` to persist those senders. Before building the next cleanup table, call `gmail_preferences` with `action: "list"` and exclude safelisted senders from the table — the user already indicated they want to keep those.
 
 ### Workflow
 
@@ -141,6 +141,20 @@ When a user asks to declutter, clean up, or organize their email - start scannin
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
 - **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured - don't offer to scan more. Tell the user: "Scanned [N] messages - here are your top senders."
 - **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Do not retry or continue - the partial results are useful as-is.
+
+## Cleanup Preferences (Blocklist & Safelist)
+
+The `gmail_preferences` tool persists sender preferences across cleanup sessions:
+
+- **Blocklist**: Sender emails archived in previous sessions. On future cleanups, pre-pass archive all blocklisted senders before scanning (use `gmail_archive` with `query: "from:email1 OR from:email2 ... in:inbox"`).
+- **Safelist**: Sender emails the user explicitly deselected (chose to keep). Exclude these senders from future cleanup tables entirely.
+
+### Workflow integration
+
+1. **Before scanning**: Call `gmail_preferences` with `action: "list"`. If blocklisted senders exist, offer to auto-archive them first ("I have N previously archived senders — want me to clean those up first?"). Remove safelisted senders from scan results before presenting the table.
+2. **After archiving**: The blocklist is updated automatically when `gmail_archive` runs with `scan_id` + `sender_ids`.
+3. **After user deselects**: When the user deselects senders from a cleanup table, call `gmail_preferences` with `action: "add_safelist"` and the deselected sender emails.
+4. **User overrides**: If the user asks to stop blocking or stop keeping a sender, use `remove_blocklist` or `remove_safelist` accordingly.
 
 ## Scan ID
 

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -553,6 +553,36 @@
       },
       "executor": "tools/gmail-outreach-scan.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "gmail_preferences",
+      "description": "Manage Gmail cleanup preferences (blocklist and safelist). The blocklist contains senders to auto-archive in future cleanups. The safelist contains senders the user wants to keep (excluded from cleanup tables).",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "add_blocklist", "add_safelist", "remove_blocklist", "remove_safelist"],
+            "description": "Preference action: list all preferences, or add/remove emails from blocklist or safelist"
+          },
+          "emails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Email addresses to add or remove (required for add/remove actions)"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/gmail-preferences-tool.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -8,6 +8,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { addToBlocklist } from "./gmail-preferences.js";
 import { getSenderMessageIds } from "./scan-result-store.js";
 import { err, ok } from "./shared.js";
 
@@ -166,6 +167,24 @@ export async function run(
         return ok(parts.join(" "));
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
+      }
+    }
+
+    // Record archived sender emails for future sessions
+    const archivedEmails: string[] = [];
+    for (const sid of senderIds) {
+      try {
+        const email = Buffer.from(sid, "base64url").toString("utf-8");
+        if (email.includes("@")) archivedEmails.push(email);
+      } catch {
+        // Skip undecodable sender IDs
+      }
+    }
+    if (archivedEmails.length > 0) {
+      try {
+        addToBlocklist(archivedEmails);
+      } catch {
+        // Non-fatal — preferences are best-effort
       }
     }
   } else if (messageIds?.length) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-preferences-tool.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-preferences-tool.ts
@@ -1,0 +1,59 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import {
+  addToBlocklist,
+  addToSafelist,
+  loadPreferences,
+  removeFromBlocklist,
+  removeFromSafelist,
+} from "./gmail-preferences.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+  const emails = input.emails as string[] | undefined;
+
+  switch (action) {
+    case "list": {
+      const prefs = loadPreferences();
+      return ok(
+        JSON.stringify({
+          blocklist_count: prefs.blocklist.length,
+          safelist_count: prefs.safelist.length,
+          blocklist: prefs.blocklist,
+          safelist: prefs.safelist,
+        }),
+      );
+    }
+    case "add_blocklist": {
+      if (!emails?.length) return err("emails is required for add_blocklist");
+      addToBlocklist(emails);
+      return ok(`Added ${emails.length} sender(s) to blocklist.`);
+    }
+    case "add_safelist": {
+      if (!emails?.length) return err("emails is required for add_safelist");
+      addToSafelist(emails);
+      return ok(`Added ${emails.length} sender(s) to safelist.`);
+    }
+    case "remove_blocklist": {
+      if (!emails?.length)
+        return err("emails is required for remove_blocklist");
+      removeFromBlocklist(emails);
+      return ok(`Removed ${emails.length} sender(s) from blocklist.`);
+    }
+    case "remove_safelist": {
+      if (!emails?.length) return err("emails is required for remove_safelist");
+      removeFromSafelist(emails);
+      return ok(`Removed ${emails.length} sender(s) from safelist.`);
+    }
+    default:
+      return err(
+        `Unknown action "${action}". Use list, add_blocklist, add_safelist, remove_blocklist, or remove_safelist.`,
+      );
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-preferences.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-preferences.ts
@@ -1,0 +1,81 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { getWorkspaceDir } from "../../../../util/platform.js";
+
+interface GmailPreferences {
+  /** Sender emails archived in previous sessions — auto-archive candidates. */
+  blocklist: string[];
+  /** Sender emails the user explicitly kept (deselected) — exclude from future tables. */
+  safelist: string[];
+}
+
+const PREFS_FILENAME = "gmail-preferences.json";
+
+function getPrefsPath(): string {
+  return join(getWorkspaceDir(), "data", PREFS_FILENAME);
+}
+
+export function loadPreferences(): GmailPreferences {
+  try {
+    const raw = readFileSync(getPrefsPath(), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<GmailPreferences>;
+    return {
+      blocklist: Array.isArray(parsed.blocklist) ? parsed.blocklist : [],
+      safelist: Array.isArray(parsed.safelist) ? parsed.safelist : [],
+    };
+  } catch {
+    return { blocklist: [], safelist: [] };
+  }
+}
+
+function savePreferences(prefs: GmailPreferences): void {
+  const path = getPrefsPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(prefs, null, 2));
+}
+
+/** Add sender emails to the blocklist (deduplicated). */
+export function addToBlocklist(emails: string[]): void {
+  const prefs = loadPreferences();
+  const existing = new Set(prefs.blocklist);
+  for (const email of emails) {
+    const normalized = email.toLowerCase();
+    existing.add(normalized);
+    // If a sender is blocklisted, remove them from safelist
+    const safeIdx = prefs.safelist.indexOf(normalized);
+    if (safeIdx !== -1) prefs.safelist.splice(safeIdx, 1);
+  }
+  prefs.blocklist = [...existing];
+  savePreferences(prefs);
+}
+
+/** Add sender emails to the safelist (deduplicated). */
+export function addToSafelist(emails: string[]): void {
+  const prefs = loadPreferences();
+  const existing = new Set(prefs.safelist);
+  for (const email of emails) {
+    const normalized = email.toLowerCase();
+    existing.add(normalized);
+    // If a sender is safelisted, remove them from blocklist
+    const blockIdx = prefs.blocklist.indexOf(normalized);
+    if (blockIdx !== -1) prefs.blocklist.splice(blockIdx, 1);
+  }
+  prefs.safelist = [...existing];
+  savePreferences(prefs);
+}
+
+/** Remove sender emails from the blocklist. */
+export function removeFromBlocklist(emails: string[]): void {
+  const prefs = loadPreferences();
+  const toRemove = new Set(emails.map((e) => e.toLowerCase()));
+  prefs.blocklist = prefs.blocklist.filter((e) => !toRemove.has(e));
+  savePreferences(prefs);
+}
+
+/** Remove sender emails from the safelist. */
+export function removeFromSafelist(emails: string[]): void {
+  const prefs = loadPreferences();
+  const toRemove = new Set(emails.map((e) => e.toLowerCase()));
+  prefs.safelist = prefs.safelist.filter((e) => !toRemove.has(e));
+  savePreferences(prefs);
+}

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -1,0 +1,366 @@
+/**
+ * Proactive credential health monitoring.
+ *
+ * Enumerates all active OAuth connections and validates each one for:
+ * - Token presence in secure storage
+ * - Token expiry (expired or expiring within the warning window)
+ * - Scope coverage (grantedScopes vs provider defaultScopes)
+ * - Liveness ping (for providers with a pingUrl)
+ *
+ * Designed to run during the heartbeat cycle. All checks are diagnostic —
+ * no token refresh or recovery is attempted.
+ */
+
+import {
+  isTokenExpired,
+  oauthConnectionAccessTokenPath,
+} from "@vellumai/credential-storage";
+
+import {
+  getProvider,
+  listActiveConnectionsByProvider,
+  listProviders,
+} from "../oauth/oauth-store.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("credential-health");
+
+/** 7 days in milliseconds — warn if token expires within this window. */
+const EXPIRY_WARNING_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Timeout for liveness pings. */
+const PING_TIMEOUT_MS = 5_000;
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type CredentialHealthStatus =
+  | "healthy"
+  | "expiring"
+  | "expired"
+  | "missing_token"
+  | "missing_scopes"
+  | "revoked"
+  | "ping_failed";
+
+export interface CredentialHealthResult {
+  connectionId: string;
+  provider: string;
+  accountInfo: string | null;
+  status: CredentialHealthStatus;
+  details: string;
+  missingScopes: string[];
+  canAutoRecover: boolean;
+}
+
+export interface CredentialHealthReport {
+  checkedAt: number;
+  results: CredentialHealthResult[];
+  unhealthy: CredentialHealthResult[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function scopeDifference(required: string[], granted: string[]): string[] {
+  const grantedSet = new Set(granted);
+  return required.filter((s) => !grantedSet.has(s));
+}
+
+// ── Liveness ping ─────────────────────────────────────────────────────
+
+/** @internal Exposed for test injection. */
+export let _fetchFn: typeof fetch = fetch;
+
+/** @internal Test-only: override the fetch function used for pings. */
+export function _setFetchFn(fn: typeof fetch): void {
+  _fetchFn = fn;
+}
+
+async function pingProvider(
+  token: string,
+  pingUrl: string,
+  pingMethod: string | null,
+  pingHeaders: string | null,
+  pingBody: string | null,
+): Promise<{ ok: boolean; authError: boolean }> {
+  const method = pingMethod ?? "GET";
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    ...safeJsonParse<Record<string, string>>(pingHeaders, {}),
+  };
+
+  const body =
+    method !== "GET" && pingBody
+      ? (typeof pingBody === "string" ? pingBody : JSON.stringify(pingBody))
+      : undefined;
+
+  try {
+    const response = await _fetchFn(pingUrl, {
+      method,
+      headers,
+      body,
+      signal: AbortSignal.timeout(PING_TIMEOUT_MS),
+    });
+
+    if (response.ok) return { ok: true, authError: false };
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, authError: true };
+    }
+    return { ok: false, authError: false };
+  } catch {
+    // Network error or timeout — treat as non-auth failure
+    return { ok: false, authError: false };
+  }
+}
+
+// ── Core check ────────────────────────────────────────────────────────
+
+interface CheckConnectionOpts {
+  connectionId: string;
+  provider: string;
+  accountInfo: string | null;
+  expiresAt: number | null;
+  hasRefreshToken: boolean;
+  grantedScopesRaw: string;
+  defaultScopesRaw: string;
+  pingUrl: string | null;
+  pingMethod: string | null;
+  pingHeaders: string | null;
+  pingBody: string | null;
+}
+
+async function checkConnection(
+  opts: CheckConnectionOpts,
+): Promise<CredentialHealthResult> {
+  const {
+    connectionId,
+    provider,
+    accountInfo,
+    expiresAt,
+    hasRefreshToken,
+    grantedScopesRaw,
+    defaultScopesRaw,
+    pingUrl,
+    pingMethod,
+    pingHeaders,
+    pingBody,
+  } = opts;
+
+  const base = { connectionId, provider, accountInfo, missingScopes: [] as string[] };
+
+  // 1. Check token presence
+  const token = await getSecureKeyAsync(
+    oauthConnectionAccessTokenPath(connectionId),
+  );
+  if (!token) {
+    return {
+      ...base,
+      status: "missing_token",
+      details: `No access token found for ${provider}. Re-authorization required.`,
+      canAutoRecover: false,
+    };
+  }
+
+  // 2. Check token expiry
+  if (isTokenExpired(expiresAt)) {
+    return {
+      ...base,
+      status: hasRefreshToken ? "expiring" : "expired",
+      details: hasRefreshToken
+        ? `Token for ${provider} is expired but has a refresh token — auto-recovery may work.`
+        : `Token for ${provider} is expired with no refresh token. Re-authorization required.`,
+      canAutoRecover: hasRefreshToken,
+    };
+  }
+
+  // Check if expiring within warning window (but not yet expired by the 5-min buffer)
+  if (expiresAt && Date.now() >= expiresAt - EXPIRY_WARNING_MS) {
+    // Token works now but will expire soon
+    if (!hasRefreshToken) {
+      return {
+        ...base,
+        status: "expiring",
+        details: `Token for ${provider} expires within 7 days and has no refresh token. Re-authorization will be needed soon.`,
+        canAutoRecover: false,
+      };
+    }
+    // Has refresh token — not an issue, auto-refresh will handle it
+  }
+
+  // 3. Check scope coverage
+  const grantedScopes = safeJsonParse<string[]>(grantedScopesRaw, []);
+  const defaultScopes = safeJsonParse<string[]>(defaultScopesRaw, []);
+  if (defaultScopes.length > 0 && grantedScopes.length > 0) {
+    const missing = scopeDifference(defaultScopes, grantedScopes);
+    if (missing.length > 0) {
+      return {
+        ...base,
+        status: "missing_scopes",
+        details: `${provider} is missing required scopes: ${missing.join(", ")}. Features may not work correctly.`,
+        missingScopes: missing,
+        canAutoRecover: false,
+      };
+    }
+  }
+
+  // 4. Liveness ping
+  if (pingUrl) {
+    const pingResult = await pingProvider(
+      token,
+      pingUrl,
+      pingMethod,
+      pingHeaders,
+      pingBody,
+    );
+    if (!pingResult.ok) {
+      if (pingResult.authError) {
+        return {
+          ...base,
+          status: "revoked",
+          details: `${provider} token was rejected (401/403). The token may have been revoked. Re-authorization required.`,
+          canAutoRecover: false,
+        };
+      }
+      // Non-auth ping failure — log but don't mark as critical.
+      // Could be a transient API issue.
+      log.debug(
+        { provider, connectionId },
+        "Credential ping failed with non-auth error",
+      );
+      return {
+        ...base,
+        status: "ping_failed",
+        details: `${provider} liveness check failed (non-auth error). This may be transient.`,
+        canAutoRecover: false,
+      };
+    }
+  }
+
+  return {
+    ...base,
+    status: "healthy",
+    details: `${provider} credential is healthy.`,
+    canAutoRecover: hasRefreshToken,
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Check the health of all active OAuth connections.
+ *
+ * Iterates every registered provider, looks up active connections, and
+ * validates each one. Returns a structured report with overall results
+ * and a filtered list of unhealthy credentials.
+ */
+export async function checkAllCredentials(): Promise<CredentialHealthReport> {
+  const checkedAt = Date.now();
+  const results: CredentialHealthResult[] = [];
+
+  let providers;
+  try {
+    providers = listProviders();
+  } catch (err) {
+    log.warn({ err }, "Failed to list OAuth providers");
+    return { checkedAt, results, unhealthy: [] };
+  }
+
+  for (const providerRow of providers) {
+    let connections;
+    try {
+      connections = listActiveConnectionsByProvider(providerRow.provider);
+    } catch (err) {
+      log.warn(
+        { err, provider: providerRow.provider },
+        "Failed to list connections for provider",
+      );
+      continue;
+    }
+
+    for (const conn of connections) {
+      try {
+        const result = await checkConnection({
+          connectionId: conn.id,
+          provider: conn.provider,
+          accountInfo: conn.accountInfo,
+          expiresAt: conn.expiresAt,
+          hasRefreshToken: !!conn.hasRefreshToken,
+          grantedScopesRaw: conn.grantedScopes,
+          defaultScopesRaw: providerRow.defaultScopes,
+          pingUrl: providerRow.pingUrl,
+          pingMethod: providerRow.pingMethod,
+          pingHeaders: providerRow.pingHeaders,
+          pingBody: providerRow.pingBody,
+        });
+        results.push(result);
+      } catch (err) {
+        log.warn(
+          { err, provider: conn.provider, connectionId: conn.id },
+          "Failed to check credential health",
+        );
+      }
+    }
+  }
+
+  const unhealthy = results.filter((r) => r.status !== "healthy");
+  if (unhealthy.length > 0) {
+    log.info(
+      {
+        total: results.length,
+        unhealthy: unhealthy.length,
+        providers: [...new Set(unhealthy.map((r) => r.provider))],
+      },
+      "Credential health check found issues",
+    );
+  } else {
+    log.debug({ total: results.length }, "All credentials healthy");
+  }
+
+  return { checkedAt, results, unhealthy };
+}
+
+/**
+ * Check credential health for a single provider. Returns the health
+ * result for the most recent active connection, or null if no connection
+ * exists.
+ *
+ * Used by the watcher engine for pre-poll gating.
+ */
+export async function checkCredentialForProvider(
+  provider: string,
+): Promise<CredentialHealthResult | null> {
+  let connections;
+  try {
+    connections = listActiveConnectionsByProvider(provider);
+  } catch {
+    return null;
+  }
+  if (connections.length === 0) return null;
+
+  const conn = connections[0]!;
+  const providerRow = getProvider(conn.provider);
+  if (!providerRow) return null;
+
+  return checkConnection({
+    connectionId: conn.id,
+    provider: conn.provider,
+    accountInfo: conn.accountInfo,
+    expiresAt: conn.expiresAt,
+    hasRefreshToken: !!conn.hasRefreshToken,
+    grantedScopesRaw: conn.grantedScopes,
+    defaultScopesRaw: providerRow.defaultScopes,
+    pingUrl: providerRow.pingUrl,
+    pingMethod: providerRow.pingMethod,
+    pingHeaders: providerRow.pingHeaders,
+    pingBody: providerRow.pingBody,
+  });
+}

--- a/assistant/src/credential-health/index.ts
+++ b/assistant/src/credential-health/index.ts
@@ -1,0 +1,7 @@
+export {
+  checkAllCredentials,
+  checkCredentialForProvider,
+  type CredentialHealthReport,
+  type CredentialHealthResult,
+  type CredentialHealthStatus,
+} from "./credential-health-service.js";


### PR DESCRIPTION
## Summary
- Adds a workspace-backed `gmail-preferences.json` file that persists sender preferences across cleanup sessions
- **Blocklist**: senders archived in previous sessions — the assistant can auto-archive these on future cleanups
- **Safelist**: senders the user explicitly deselected — excluded from future cleanup tables
- `gmail_archive` automatically appends archived sender emails to the blocklist after successful batch archiving
- New `gmail_preferences` tool (low risk, read/write) for the assistant to list, add, and remove entries
- SKILL.md updated: replaces the unimplemented `<dynamic-user-profile>` reference with concrete preference read/write workflows

## Test plan
- [x] `gmail-preferences.test.ts` — 9 tests covering all CRUD operations, deduplication, cross-list removal, normalization, and corruption handling
- [x] `gmail-archive-gate.test.ts` — existing 9 tests pass (no regressions)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [ ] Manual: run cleanup session, verify `~/.vellum/workspace/data/gmail-preferences.json` is created with archived senders, verify safelisted senders are excluded from subsequent cleanup tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
