### PR TITLE
feat(gmail): cold outreach workflow with LLM classification + scan enrichment

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -135,12 +135,44 @@ When a user asks to declutter, clean up, or organize their email - start scannin
    - If yes, call `gmail_filters` with `action: "create"` for each sender with `from` set to the sender's email and `remove_label_ids: ["INBOX"]`.
    - Then offer a recurring declutter schedule: "Want me to scan for new clutter monthly?" If yes, use `schedule_create` to set up a monthly declutter check.
 
+### Cold Outreach Cleanup
+
+After the newsletter/promotions pass, offer to clean up cold outreach — unsolicited emails from senders without unsubscribe links. This catches sales pitches, recruiting spam, and mass outreach that newsletter filters miss.
+
+1. **Scan**: Call `gmail_outreach_scan` (default: last 90 days, senders without `List-Unsubscribe` headers). The scan includes a `has_prior_reply` flag per sender — true means the user has previously replied to that sender.
+2. **Filter out known contacts**: Exclude senders where `has_prior_reply: true` — these are conversations, not cold outreach. If the `contacts` skill is loaded, also cross-reference against Google Contacts and exclude matches.
+3. **Classify senders** using sample subjects, email domains, and message patterns. Categorize into:
+   - **Clear junk** (pre-select for archive): loan/LOC offers, generic SaaS pitches, mass marketing from unknown domains, senders with random/concatenated domain names
+   - **Sales outreach** (pre-select for archive): targeted product pitches with personalised subject lines ("Hi [name]", "for [company]"), outreach tool domains (apollo.io, outreach.io, lemlist.com, instantly.ai, etc.)
+   - **Potentially useful** (deselect / keep by default): recruiting, investor outreach, partnership proposals, vendor introductions that reference the user's specific product or role
+   - **Ambiguous** (deselect / keep by default): anything you're not confident about
+4. **Present as a table** following the same `ui_show` pattern as the newsletter workflow. Use two visual sections:
+   - Pre-selected rows: clear junk + sales outreach
+   - Deselected rows: potentially useful + ambiguous senders (user reviews these)
+   - **Caption**: "Cold outreach from the last 90 days (senders without unsubscribe links). Pre-selected senders look like spam or sales pitches. Deselected senders may be useful — review before archiving."
+5. **Archive on user action**: Same flow as newsletter cleanup — wait for surface action button click, then batch archive.
+
+**Key principle**: Not all cold outreach is unwanted. Recruiting, investor, and partnership emails can be valuable. When uncertain, default to keeping the sender (deselected) and let the user decide.
+
+### Large Inbox Handling
+
+When a scan returns `truncated: true` or `time_budget_exceeded: true`, the inbox has more messages than a single scan pass can cover. Split subsequent scans by date range to ensure full coverage:
+
+```
+Pass 1: in:inbox older_than:90d                     (oldest backlog)
+Pass 2: in:inbox newer_than:90d older_than:30d      (recent months)
+Pass 3: in:inbox newer_than:30d older_than:7d       (recent weeks)
+Pass 4: in:inbox newer_than:7d                      (this week)
+```
+
+Merge results from all passes before presenting the final table. Each pass covers a smaller window, reducing per-scan message count and avoiding timeouts. Only split when a scan actually reports truncation — most inboxes are handled fine in a single pass.
+
 ### Edge Cases
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured - don't offer to scan more. Tell the user: "Scanned [N] messages - here are your top senders."
-- **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Do not retry or continue - the partial results are useful as-is.
+- **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured. Offer to run additional date-range passes to cover the remaining messages (see Large Inbox Handling above).
+- **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Offer to run additional date-range passes for uncovered periods.
 
 ## Cleanup Preferences (Blocklist & Safelist)
 
@@ -158,7 +190,7 @@ The `gmail_preferences` tool persists sender preferences across cleanup sessions
 
 ## Scan ID
 
-Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context. `gmail_outreach_scan` is a pure data aggregation tool - it finds senders without List-Unsubscribe headers (potential cold outreach) and does not use LLM classification.
+Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context. `gmail_outreach_scan` finds senders without List-Unsubscribe headers (potential cold outreach) and enriches each sender with `has_prior_reply` (whether the user has ever sent an email to that address). Use this signal to filter out legitimate correspondents before classifying cold outreach.
 
 - Pass `scan_id` + `sender_ids` to `gmail_archive` instead of `message_ids`
 - Scan results expire after **30 minutes** - if archiving fails with an expiration error, re-run the scan

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -238,11 +238,30 @@ export async function run(
       .sort((a, b) => b.messageCount - a.messageCount)
       .slice(0, maxSenders);
 
+    // Enrich with prior-reply signal: check if user has ever sent to each sender.
+    // Fire all checks in parallel (each is a lightweight maxResults:1 list call).
+    const priorReplyMap = new Map<string, boolean>();
+    const replyChecks = sorted.map(async (s) => {
+      try {
+        const resp = await listMessages(
+          connection,
+          `from:me to:${s.email}`,
+          1,
+        );
+        priorReplyMap.set(s.email, (resp.messages?.length ?? 0) > 0);
+      } catch {
+        // Non-fatal — default to unknown (false)
+        priorReplyMap.set(s.email, false);
+      }
+    });
+    await Promise.all(replyChecks);
+
     const senders = sorted.map((s) => ({
       id: Buffer.from(s.email).toString("base64url"),
       display_name: s.displayName || s.email.split("@")[0],
       email: s.email,
       message_count: s.messageCount,
+      has_prior_reply: priorReplyMap.get(s.email) ?? false,
       newest_message_id: s.newestMessageId,
       oldest_date: s.oldestDate,
       newest_date: s.newestDate,


### PR DESCRIPTION
## Summary
- Adds `has_prior_reply` enrichment to `gmail_outreach_scan` — parallel `from:me to:{email}` checks (1 lightweight API call per sender) so the assistant can filter out legitimate correspondents before classifying cold outreach
- SKILL.md: new cold outreach cleanup workflow guiding the assistant to classify senders using LLM judgment into categories (clear junk, sales, recruiting/partnership, ambiguous) rather than hardcoded heuristics
- SKILL.md: large inbox date-range splitting strategy for when scans report truncation
- Key design choice: not all cold outreach is bad — recruiting, investor, and partnership emails default to kept (deselected), only clear junk is pre-selected for archive

## Test plan
- [x] `gmail-archive-gate.test.ts` — 9 tests pass (no regressions)
- [x] Type-check clean (`bunx tsc --noEmit`)
- [ ] Manual: run outreach scan, verify `has_prior_reply` is populated per sender
- [ ] Manual: run full cold outreach cleanup workflow, verify classification categories and table presentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
