### PR TITLE
fix(meet): meet_send_chat risk level aligns with bounded meeting consent

### DIFF
--- a/skills/meet-join/tools/meet-send-chat-tool.ts
+++ b/skills/meet-join/tools/meet-send-chat-tool.ts
@@ -43,7 +43,12 @@ class MeetSendChatTool implements Tool {
   description =
     "Post a message into the chat of an active Google Meet call. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
   category = "meet";
-  defaultRiskLevel = RiskLevel.Medium;
+  // Low: consent is established meeting-wide by `meet_join` (High) and the
+  // Phase 1 join-consent message announcing the bot. Chat posts within that
+  // bounded session are within the user's expressed consent envelope, and
+  // proactive-chat wakes run on client-less conversations where a Medium-risk
+  // approval prompt would hang forever. Aligns with `meet_leave` (also Low).
+  defaultRiskLevel = RiskLevel.Low;
 
   getDefinition(): ToolDefinition {
     return {


### PR DESCRIPTION
## Summary
Proactive-chat wakes (PR 7/PR 8) call meet_send_chat on a conversation with no connected client. Medium-risk approval prompts never resolve in that state, hanging the wake indefinitely.

Meeting consent is already established by the Phase 1 join-consent message, so the chat-send is already within the user's expressed consent envelope. Aligning risk level with the bounded nature of the in-meeting action.

Part of plan review for meet-phase-2-chat.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
