### PR TITLE
feat: wire credential health checks into heartbeat and watcher engine

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -217,6 +217,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup
       "meet/session-manager.ts", // Meet bot container provisioning (provider API key lookup for Deepgram/TTS)
+      "credential-health/credential-health-service.ts", // credential health check reads access tokens for liveness pings
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -255,8 +255,82 @@ export class HeartbeatService {
     this._nextRunAt = Date.now() + intervalMs;
   }
 
+  private async runCredentialHealthCheck(): Promise<void> {
+    try {
+      const { checkAllCredentials } = await import(
+        "../credential-health/credential-health-service.js"
+      );
+      const report = await checkAllCredentials();
+      if (report.unhealthy.length > 0) {
+        await this.notifyUnhealthyCredentials(report.unhealthy);
+      }
+    } catch (err) {
+      log.warn({ err }, "Credential health check failed (non-fatal)");
+    }
+  }
+
+  private async notifyUnhealthyCredentials(
+    results: Array<{
+      connectionId: string;
+      provider: string;
+      accountInfo: string | null;
+      status: string;
+      details: string;
+      missingScopes: string[];
+    }>,
+  ): Promise<void> {
+    let emitNotificationSignal: typeof import("../notifications/emit-signal.js").emitNotificationSignal;
+    try {
+      ({ emitNotificationSignal } = await import(
+        "../notifications/emit-signal.js"
+      ));
+    } catch {
+      log.warn("Failed to import notification signal emitter");
+      return;
+    }
+
+    for (const result of results) {
+      const urgency =
+        result.status === "revoked" || result.status === "expired"
+          ? ("high" as const)
+          : ("medium" as const);
+
+      try {
+        await emitNotificationSignal({
+          sourceEventName: "credential.health_alert",
+          sourceChannel: "watcher",
+          sourceContextId: result.connectionId,
+          dedupeKey: `credential-health:${result.connectionId}:${result.status}`,
+          attentionHints: {
+            requiresAction: true,
+            urgency,
+            isAsyncBackground: true,
+            visibleInSourceNow: false,
+          },
+          contextPayload: {
+            provider: result.provider,
+            accountInfo: result.accountInfo,
+            status: result.status,
+            details: result.details,
+            missingScopes: result.missingScopes,
+          },
+          routingIntent: "single_channel",
+        });
+      } catch (err) {
+        log.warn(
+          { err, provider: result.provider, connectionId: result.connectionId },
+          "Failed to emit credential health notification",
+        );
+      }
+    }
+  }
+
   private async executeRun(): Promise<void> {
     log.info("Running heartbeat");
+
+    // Credential health check — surface broken credentials proactively
+    // before the LLM heartbeat prompt runs.
+    await this.runCredentialHealthCheck();
 
     try {
       const config = getConfig().heartbeat;

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -97,6 +97,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     id: "voice.response_ready",
     description: "Voice response ready for playback",
   },
+  {
+    id: "credential.health_alert",
+    description:
+      "OAuth credential health issue detected (expired, revoked, missing scopes)",
+  },
 ] as const;
 
 export type NotificationSourceEventName =

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -76,6 +76,32 @@ export async function runWatchersOnce(
       continue;
     }
 
+    // Pre-poll credential gate: skip if token is irrecoverably broken.
+    // Prevents wasting API calls and burning through circuit breaker
+    // attempts on credentials that need manual reauthorization.
+    try {
+      const { checkCredentialForProvider } = await import(
+        "../credential-health/credential-health-service.js"
+      );
+      const health = await checkCredentialForProvider(
+        watcher.credentialService,
+      );
+      if (
+        health &&
+        (health.status === "revoked" ||
+          health.status === "missing_token" ||
+          (health.status === "expired" && !health.canAutoRecover))
+      ) {
+        failWatcherPoll(
+          watcher.id,
+          `Credential unhealthy: ${health.details}`,
+        );
+        continue;
+      }
+    } catch {
+      // Non-fatal: proceed with normal poll if health check fails
+    }
+
     try {
       const config = watcher.configJson ? JSON.parse(watcher.configJson) : {};
 


### PR DESCRIPTION
## Summary
- Integrates the credential health service into the heartbeat cycle, running proactive health checks before each LLM prompt and sending notifications for unhealthy credentials (expired, revoked, missing scopes, missing tokens)
- Adds a pre-poll credential gate to the watcher engine that skips polls for irrecoverably broken credentials, avoiding wasted API calls and circuit breaker trips
- Registers `credential.health_alert` as a notification source event with deduplication to prevent alert fatigue

## Test plan
- [x] 16 unit tests pass for credential-health-service (`bun test src/__tests__/credential-health-service.test.ts`)
- [x] TypeScript compiles cleanly (`bunx tsc --noEmit`)
- [ ] Manual: verify heartbeat runs credential check and surfaces notification when an OAuth token is revoked
- [ ] Manual: verify watcher skips poll when credential is missing and logs appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
