### PR TITLE
fix: use Anthropic image token estimation for OpenRouter anthropic/* models

### DIFF
--- a/assistant/src/__tests__/openrouter-token-estimation.test.ts
+++ b/assistant/src/__tests__/openrouter-token-estimation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import { estimatePromptTokens } from "../context/token-estimator.js";
+import { OpenRouterProvider } from "../providers/openrouter/client.js";
+import type { Message } from "../providers/types.js";
+
+/** Build a minimal valid PNG header encoding the given dimensions. */
+function makePngBase64(width: number, height: number, paddingBytes = 0): string {
+  const header = Buffer.alloc(24);
+  header[0] = 0x89;
+  header[1] = 0x50;
+  header[2] = 0x4e;
+  header[3] = 0x47;
+  header[4] = 0x0d;
+  header[5] = 0x0a;
+  header[6] = 0x1a;
+  header[7] = 0x0a;
+  header.writeUInt32BE(13, 8);
+  header[12] = 0x49;
+  header[13] = 0x48;
+  header[14] = 0x44;
+  header[15] = 0x52;
+  header.writeUInt32BE(width, 16);
+  header.writeUInt32BE(height, 20);
+  const padding = Buffer.alloc(paddingBytes, 0x42);
+  return Buffer.concat([header, padding]).toString("base64");
+}
+
+describe("OpenRouterProvider token estimation routing", () => {
+  test("reports 'anthropic' for anthropic/* default models", () => {
+    const provider = new OpenRouterProvider(
+      "fake-key",
+      "anthropic/claude-opus-4-6",
+    );
+    expect(provider.tokenEstimationProvider).toBe("anthropic");
+  });
+
+  test("reports its own name for non-Anthropic default models", () => {
+    const provider = new OpenRouterProvider("fake-key", "x-ai/grok-4.20-beta");
+    expect(provider.tokenEstimationProvider).toBe(provider.name);
+    expect(provider.tokenEstimationProvider).toBe("openrouter");
+  });
+
+  test("estimatePromptTokens applies Anthropic image scaling when routed via OpenRouter", () => {
+    const provider = new OpenRouterProvider(
+      "fake-key",
+      "anthropic/claude-opus-4-6",
+    );
+    // 1920x1080 screenshot with ~200 KB of pixel data → base64/4 would be ~65k
+    // tokens; dimension-based Anthropic rules land around 1.6k tokens.
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: makePngBase64(1920, 1080, 200_000),
+            },
+          },
+        ],
+      },
+    ];
+
+    const estimated = estimatePromptTokens(messages, "system", {
+      providerName: provider.tokenEstimationProvider,
+    });
+
+    // Dimension-based estimate should be well under 5k; base64/4 would exceed 50k.
+    expect(estimated).toBeLessThan(5_000);
+  });
+
+  test("estimatePromptTokens falls back to base64/4 for non-Anthropic OpenRouter models", () => {
+    const provider = new OpenRouterProvider("fake-key", "x-ai/grok-4.20-beta");
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: makePngBase64(1920, 1080, 200_000),
+            },
+          },
+        ],
+      },
+    ];
+
+    const estimated = estimatePromptTokens(messages, "system", {
+      providerName: provider.tokenEstimationProvider,
+    });
+
+    // Base64/4 heuristic on ~200 KB of image data → far more than 10k tokens.
+    expect(estimated).toBeGreaterThan(50_000);
+  });
+});

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -135,6 +135,16 @@ export class ContextWindowManager {
     this.toolTokenBudget = options.toolTokenBudget ?? 0;
   }
 
+  /**
+   * Provider key for the local token estimator. Wrapper providers (e.g.
+   * OpenRouter routing to `anthropic/*`) override `tokenEstimationProvider`
+   * so image/PDF sizing uses the same rules as the upstream API instead of
+   * the generic `base64/4` fallback.
+   */
+  private get estimationProviderName(): string {
+    return this.provider.tokenEstimationProvider ?? this.provider.name;
+  }
+
   /** Lazily resolve and cache the system prompt for the duration of a compaction pass. */
   private get systemPrompt(): string {
     if (this._resolvedSystemPrompt !== undefined) {
@@ -162,7 +172,7 @@ export class ContextWindowManager {
     if (!this.config.enabled) return { needed: false, estimatedTokens: 0 };
     try {
       const estimated = estimatePromptTokens(messages, this.systemPrompt, {
-        providerName: this.provider.name,
+        providerName: this.estimationProviderName,
         toolTokenBudget: this.toolTokenBudget,
       });
       const threshold = Math.floor(
@@ -194,7 +204,7 @@ export class ContextWindowManager {
     const previousEstimatedInputTokens =
       options?.precomputedEstimate ??
       estimatePromptTokens(messages, this.systemPrompt, {
-        providerName: this.provider.name,
+        providerName: this.estimationProviderName,
         toolTokenBudget: this.toolTokenBudget,
       });
     const thresholdTokens = Math.floor(
@@ -277,7 +287,7 @@ export class ContextWindowManager {
       const didTruncate = truncatedCount > 0;
       const estimatedAfterTruncation = didTruncate
         ? estimatePromptTokens(truncatedMessages, this.systemPrompt, {
-            providerName: this.provider.name,
+            providerName: this.estimationProviderName,
             toolTokenBudget: this.toolTokenBudget,
           })
         : previousEstimatedInputTokens;
@@ -349,7 +359,7 @@ export class ContextWindowManager {
       projectedMessages,
       this.systemPrompt,
       {
-        providerName: this.provider.name,
+        providerName: this.estimationProviderName,
         toolTokenBudget: this.toolTokenBudget,
       },
     );
@@ -478,7 +488,7 @@ export class ContextWindowManager {
       compactedMessages,
       this.systemPrompt,
       {
-        providerName: this.provider.name,
+        providerName: this.estimationProviderName,
         toolTokenBudget: this.toolTokenBudget,
       },
     );
@@ -564,7 +574,7 @@ export class ContextWindowManager {
         COMPACTION_TOOL_RESULT_MAX_CHARS,
       );
       return estimatePromptTokens(projectedMessages, this.systemPrompt, {
-        providerName: this.provider.name,
+        providerName: this.estimationProviderName,
         toolTokenBudget: this.toolTokenBudget,
       });
     };
@@ -633,7 +643,7 @@ export class ContextWindowManager {
     );
 
     const estimateBlockTokens = (b: ContentBlock): number =>
-      estimateContentBlockTokens(b, { providerName: this.provider.name });
+      estimateContentBlockTokens(b, { providerName: this.estimationProviderName });
 
     let totalTokens = 0;
     for (const block of blocks) {

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -56,6 +56,15 @@ export class OpenRouterProvider extends OpenAIProvider {
     this.providerStreamTimeoutMs = options.streamTimeoutMs;
   }
 
+  // When routing to an `anthropic/*` model, actual API calls hit the Anthropic
+  // Messages endpoint, which charges for images using dimension-based pricing
+  // (~width*height/750 tokens) rather than the generic `base64/4` heuristic.
+  // Expose this so the local token estimator picks the matching rules and
+  // `shouldCompact()` doesn't over-count image tokens by ~100×.
+  get tokenEstimationProvider(): string {
+    return isAnthropicModel(this.defaultModel) ? "anthropic" : this.name;
+  }
+
   override async sendMessage(
     messages: Message[],
     tools?: ToolDefinition[],

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -144,6 +144,15 @@ export interface SendMessageOptions {
 
 export interface Provider {
   name: string;
+  /**
+   * Provider key used by the local token estimator to select model-family
+   * specific rules (e.g. Anthropic's `width * height / 750` image sizing).
+   * Wrapper providers that route to another provider's API — e.g. OpenRouter
+   * calling Anthropic's Messages endpoint for `anthropic/*` models — override
+   * this so the estimator matches what the upstream API will actually charge.
+   * Falls back to `name` when unset.
+   */
+  tokenEstimationProvider?: string;
   sendMessage(
     messages: Message[],
     tools?: ToolDefinition[],


### PR DESCRIPTION
## Summary
- When routing to `anthropic/*` via OpenRouter, the local token estimator was using the generic `base64/4` image heuristic instead of Anthropic's dimension-based rules. A typical screenshot estimated at ~325k tokens vs. ~1,600 actual, so `shouldCompact()` tripped every turn.
- Added optional `tokenEstimationProvider` to the `Provider` interface. `OpenRouterProvider` now returns `"anthropic"` for `anthropic/*` default models; `window-manager` consumes it via a private getter across its 7 call sites.
- New tests verify the getter and that image estimates for a 1920x1080 screenshot land under 5k tokens when routed to Anthropic, and above 50k when routed to a non-Anthropic OpenRouter model.

## Original prompt
OpenRouter misestimates the number of tokens images take when using Anthropic models, causing compaction to trigger constantly. Can we use the same token estimation logic we use for normal calls to Anthropic?