### PR TITLE
fix(macos): gate thinking-anchor reset to toolRunning only

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -290,9 +290,9 @@ struct AssistantProgressView: View {
                     startDate = Date()
                 }
             }
-            // Reset thinking anchor when tools resume in a multi-wave run
-            // (tools complete → think → more tools → think → complete).
-            if newPhase == .toolRunning || newPhase == .streamingCode {
+            // Reset thinking anchor only when tools actually resume (not on streamingCode,
+            // which can fire from lingering code previews after tools complete).
+            if newPhase == .toolRunning {
                 thinkingAfterToolsStartDate = nil
                 thinkingAfterToolsEndDate = nil
             }


### PR DESCRIPTION
## Summary
- Restrict thinking-anchor reset to .toolRunning phase only (remove .streamingCode)
- Prevents late code previews from clearing valid post-tool thinking intervals
- Fixes underreported thinking duration in the progress card

Addresses feedback from #25936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
