### PR TITLE
fix(gmail): restrict archive fallback to expired scans, sanitize query

### DIFF
--- a/assistant/src/__tests__/gmail-archive-fallback.test.ts
+++ b/assistant/src/__tests__/gmail-archive-fallback.test.ts
@@ -10,18 +10,17 @@ const mockBatchModifyMessages =
       opts: Record<string, unknown>,
     ) => Promise<void>
   >();
-const mockListMessages =
-  mock<
-    (
-      conn: unknown,
-      query: string,
-      limit: number,
-      pageToken?: string,
-    ) => Promise<{
-      messages?: { id: string }[];
-      nextPageToken?: string | null;
-    }>
-  >();
+const mockListMessages = mock<
+  (
+    conn: unknown,
+    query: string,
+    limit: number,
+    pageToken?: string,
+  ) => Promise<{
+    messages?: { id: string }[];
+    nextPageToken?: string | null;
+  }>
+>();
 const mockModifyMessage =
   mock<
     (
@@ -45,13 +44,15 @@ mock.module("../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: mockResolveOAuthConnection,
 }));
 
-mock.module("../config/bundled-skills/gmail/tools/scan-result-store.js", () => ({
-  getSenderMessageIds: () => mockScanStoreReturn,
-}));
-
-const { run } = await import(
-  "../config/bundled-skills/gmail/tools/gmail-archive.js"
+mock.module(
+  "../config/bundled-skills/gmail/tools/scan-result-store.js",
+  () => ({
+    getSenderMessageIds: () => mockScanStoreReturn,
+  }),
 );
+
+const { run } =
+  await import("../config/bundled-skills/gmail/tools/gmail-archive.js");
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
@@ -93,18 +94,12 @@ describe("gmail_archive sender ID fallback", () => {
     expect(result.content).toContain("Archived 3 message(s)");
     expect(result.content).toContain("query fallback");
     expect(mockListMessages.mock.calls[0][1]).toBe(
-      "from:spam@example.com in:inbox",
+      'from:"spam@example.com" in:inbox',
     );
   });
 
-  test("falls back when scan returns empty array", async () => {
+  test("returns error when scan returns empty array (sender IDs don't match)", async () => {
     mockScanStoreReturn = []; // scan valid but no IDs resolved
-    mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
-    mockListMessages.mockResolvedValueOnce({
-      messages: [{ id: "m1" }],
-      nextPageToken: null,
-    });
-    mockBatchModifyMessages.mockResolvedValueOnce(undefined);
 
     const senderId = encodeSenderId("cold@outreach.io");
     const result = await run(
@@ -112,9 +107,8 @@ describe("gmail_archive sender ID fallback", () => {
       makeContext(),
     );
 
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Archived 1 message(s)");
-    expect(result.content).toContain("query fallback");
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("do not match the scan results");
   });
 
   test("handles multiple sender IDs in fallback", async () => {

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -193,7 +193,7 @@ The `gmail_preferences` tool persists sender preferences across cleanup sessions
 Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context. `gmail_outreach_scan` finds senders without List-Unsubscribe headers (potential cold outreach) and enriches each sender with `has_prior_reply` (whether the user has ever sent an email to that address). Use this signal to filter out legitimate correspondents before classifying cold outreach.
 
 - Pass `scan_id` + `sender_ids` to `gmail_archive` instead of `message_ids`
-- Scan results expire after **30 minutes** - if archiving fails with an expiration error, re-run the scan
+- Scan results expire after **30 minutes** — expired scans automatically fall back to query-based archiving per sender. If the fallback also fails, re-run the scan for fresh results.
 - Raw `message_ids` still work as a fallback for non-scan workflows
 
 ## Batch Operations

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -193,7 +193,7 @@ The `gmail_preferences` tool persists sender preferences across cleanup sessions
 Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context. `gmail_outreach_scan` finds senders without List-Unsubscribe headers (potential cold outreach) and enriches each sender with `has_prior_reply` (whether the user has ever sent an email to that address). Use this signal to filter out legitimate correspondents before classifying cold outreach.
 
 - Pass `scan_id` + `sender_ids` to `gmail_archive` instead of `message_ids`
-- Scan results expire after **30 minutes** — expired scans automatically fall back to query-based archiving per sender. If the fallback also fails, re-run the scan for fresh results.
+- Scan results expire after **30 minutes**. When a scan expires (`resolved === null`), archiving automatically falls back to query-based archiving per sender. If sender IDs don't match the scan results (`resolved` is empty), the tool returns an error — re-run the scan to get fresh results.
 - Raw `message_ids` still work as a fallback for non-scan workflows
 
 ## Batch Operations

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -99,9 +99,9 @@ export async function run(
     }
 
     const resolved = getSenderMessageIds(scanId, senderIds);
-    if (resolved && resolved.length > 0) {
+    if (resolved !== null && resolved.length > 0) {
       messageIds = resolved;
-    } else {
+    } else if (resolved === null) {
       // Scan expired or sender IDs unresolved — fall back to query-based archiving
       const emails: string[] = [];
       const undecodable: string[] = [];
@@ -127,7 +127,7 @@ export async function run(
         const allMessageIds: string[] = [];
 
         for (const email of emails) {
-          const fallbackQuery = `from:${email} in:inbox`;
+          const fallbackQuery = `from:"${email.replace(/"/g, "")}" in:inbox`;
           let pageToken: string | undefined;
           while (allMessageIds.length < MAX_MESSAGES) {
             const listResp = await listMessages(
@@ -168,6 +168,10 @@ export async function run(
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));
       }
+    } else {
+      return err(
+        "The provided sender IDs do not match the scan results. Please re-run the scan.",
+      );
     }
 
     // Record archived sender emails for future sessions


### PR DESCRIPTION
## Summary
- Restrict query-based fallback to resolved === null (expired scan) only
- Return error when resolved is empty (sender IDs don't match scan)
- Quote emails in fallback Gmail queries to prevent query injection
- Update SKILL.md scan expiration docs to reflect fallback behavior
- Update tests to expect quoted email format

Addresses feedback from #25950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
