### PR TITLE
fix(oauth): add gmail.settings.basic scope to Google OAuth defaults

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -86,6 +86,7 @@ export const PROVIDER_SEED_DATA: Record<
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/gmail.modify",
       "https://www.googleapis.com/auth/gmail.send",
+      "https://www.googleapis.com/auth/gmail.settings.basic",
       "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/calendar.events",
       "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
## Summary
- Add `gmail.settings.basic` to Google OAuth default scopes so filter creation, label management, and other settings-level Gmail operations work
- Existing connections will be flagged as `missing_scopes` by the credential health service, prompting re-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)