### PR TITLE
fix(gmail): persist blocklist only after archive succeeds

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -173,24 +173,6 @@ export async function run(
         "The provided sender IDs do not match the scan results. Please re-run the scan.",
       );
     }
-
-    // Record archived sender emails for future sessions
-    const archivedEmails: string[] = [];
-    for (const sid of senderIds) {
-      try {
-        const email = Buffer.from(sid, "base64url").toString("utf-8");
-        if (email.includes("@")) archivedEmails.push(email);
-      } catch {
-        // Skip undecodable sender IDs
-      }
-    }
-    if (archivedEmails.length > 0) {
-      try {
-        addToBlocklist(archivedEmails);
-      } catch {
-        // Non-fatal — preferences are best-effort
-      }
-    }
   } else if (messageIds?.length) {
     // Batch message_ids path requires surface action confirmation
     if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
@@ -236,6 +218,25 @@ export async function run(
       await batchModifyMessages(connection, chunk, {
         removeLabelIds: ["INBOX"],
       });
+    }
+    // Record archived sender emails for future sessions (only after success)
+    if (senderIds?.length) {
+      const archivedEmails: string[] = [];
+      for (const sid of senderIds) {
+        try {
+          const email = Buffer.from(sid, "base64url").toString("utf-8");
+          if (email.includes("@")) archivedEmails.push(email);
+        } catch {
+          // Skip undecodable sender IDs
+        }
+      }
+      if (archivedEmails.length > 0) {
+        try {
+          addToBlocklist(archivedEmails);
+        } catch {
+          // Non-fatal — preferences are best-effort
+        }
+      }
     }
     return ok(`Archived ${messageIds.length} message(s).`);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Move blocklist recording to after batch archive completes successfully
- Prevents senders from being blocklisted when the archive operation fails
- The bundled-tool-registry entry was already addressed in #25961

Addresses feedback from #25953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
