### PR TITLE
meet: TTS streaming bridge from daemon to bot /play_audio

### DIFF
--- a/assistant/src/daemon/message-types/meet.ts
+++ b/assistant/src/daemon/message-types/meet.ts
@@ -103,6 +103,33 @@ export interface MeetError {
   detail: string;
 }
 
+/**
+ * The assistant has begun speaking into the meeting via the TTS bridge. Fired
+ * once per {@link MeetSessionManager.speak} invocation immediately before the
+ * synthesis stream starts flowing to the bot's `/play_audio` endpoint. Useful
+ * for clients that want to render a "speaking …" indicator.
+ */
+export interface MeetSpeakingStarted {
+  type: "meet.speaking_started";
+  meetingId: string;
+  /** Opaque stream identifier — matches `meet.speaking_ended.streamId`. */
+  streamId: string;
+}
+
+/**
+ * The assistant has finished (or cancelled) a TTS playback stream. Fired
+ * after the bot-side playback request settles — whether normally, via an
+ * explicit cancel, or due to an upstream error.
+ */
+export interface MeetSpeakingEnded {
+  type: "meet.speaking_ended";
+  meetingId: string;
+  /** Opaque stream identifier — matches `meet.speaking_started.streamId`. */
+  streamId: string;
+  /** Why the stream ended: natural completion, caller-initiated cancel, or an upstream error. */
+  reason: "completed" | "cancelled" | "error";
+}
+
 export type _MeetServerMessages =
   | MeetJoining
   | MeetJoined
@@ -111,4 +138,6 @@ export type _MeetServerMessages =
   | MeetTranscriptChunk
   | MeetLeft
   | MeetChatSent
-  | MeetError;
+  | MeetError
+  | MeetSpeakingStarted
+  | MeetSpeakingEnded;

--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Unit tests for {@link MeetTtsBridge}.
+ *
+ * These tests exercise the bridge without touching the real TTS registry,
+ * the real ffmpeg binary, or a real bot container. Instead:
+ *
+ *   - The TTS provider is a canned implementation of {@link TtsProvider}
+ *     whose `synthesizeStream` emits a fixed PCM byte sequence synchronously
+ *     to the supplied `onChunk` callback.
+ *   - `spawn` is mocked to return an in-memory stand-in for the ffmpeg
+ *     child. The stand-in's stdout is a {@link PassThrough} — whatever the
+ *     test pushes into it is what fetch will read as the HTTP request body.
+ *     For the happy path we wire stdin → stdout as a pass-through so the
+ *     bridge's provider-chunk → stdin → stdout pipeline works end-to-end.
+ *   - A throwaway `Bun.serve` HTTP server plays the role of the bot
+ *     container's `/play_audio` endpoint. It reads the chunked request
+ *     body into memory and exposes it alongside any DELETE requests it
+ *     received so the test can assert both happy-path and cancel-path
+ *     traffic.
+ *
+ * What each test covers:
+ *
+ *   1. "bytes land at the bot unchanged" — provider emits a known PCM
+ *      payload; assert the bot HTTP server received exactly those bytes
+ *      on the POST body (with the right URL, headers, and content type).
+ *   2. "cancel mid-stream issues DELETE" — start a speak call, cancel
+ *      before the provider finishes; assert the bot saw a DELETE to
+ *      `/play_audio/<streamId>` with the bearer token.
+ *   3. "unknown stream cancel is a no-op" — `cancel("nope")` does not
+ *      throw and does not emit any HTTP traffic.
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../../../../assistant/src/tts/types.js";
+import { MeetTtsBridge } from "../tts-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Fake bot HTTP server
+// ---------------------------------------------------------------------------
+
+interface RecordedPost {
+  url: string;
+  authorization: string | null;
+  contentType: string | null;
+  body: Uint8Array;
+}
+
+interface RecordedDelete {
+  url: string;
+  authorization: string | null;
+}
+
+interface FakeBotServer {
+  url: string;
+  port: number;
+  posts: RecordedPost[];
+  deletes: RecordedDelete[];
+  stop: () => Promise<void>;
+}
+
+function startFakeBot(): FakeBotServer {
+  const posts: RecordedPost[] = [];
+  const deletes: RecordedDelete[] = [];
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      if (req.method === "POST") {
+        // Read the full chunked body into a single buffer.
+        const chunks: Uint8Array[] = [];
+        const reader = req.body?.getReader();
+        if (reader) {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) chunks.push(value);
+          }
+        }
+        const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+        const merged = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) {
+          merged.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+        posts.push({
+          url: `${url.pathname}${url.search}`,
+          authorization: req.headers.get("authorization"),
+          contentType: req.headers.get("content-type"),
+          body: merged,
+        });
+        return new Response("", { status: 200 });
+      }
+      if (req.method === "DELETE") {
+        deletes.push({
+          url: url.pathname,
+          authorization: req.headers.get("authorization"),
+        });
+        return new Response("", { status: 200 });
+      }
+      return new Response("", { status: 405 });
+    },
+  });
+  const port = server.port;
+  if (port === undefined) {
+    throw new Error("fake bot failed to bind");
+  }
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    posts,
+    deletes,
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake ffmpeg child
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an object that looks enough like a `ChildProcessWithoutNullStreams`
+ * for the bridge's purposes. `stdin` is a sink whose writes are forwarded
+ * into `stdout` so a test that doesn't care about transcode behavior just
+ * sees the provider's bytes flow through unchanged. Tests that want to
+ * observe cancel behavior can leave `stdout` open indefinitely.
+ */
+interface FakeFfmpegChild extends EventEmitter {
+  stdin: Writable;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeFakeFfmpegChild(options?: {
+  passThroughStdin?: boolean;
+}): FakeFfmpegChild {
+  const emitter = new EventEmitter() as FakeFfmpegChild;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const passThrough = options?.passThroughStdin !== false;
+  const stdin = new Writable({
+    write(chunk, _encoding, cb) {
+      if (passThrough) {
+        stdout.write(chunk, cb);
+      } else {
+        cb();
+      }
+    },
+    final(cb) {
+      if (passThrough) stdout.end();
+      cb();
+    },
+  });
+  emitter.stdin = stdin;
+  emitter.stdout = stdout;
+  emitter.stderr = stderr;
+  emitter.killed = false;
+  emitter.kill = (_signal?: string) => {
+    emitter.killed = true;
+    try {
+      stdout.end();
+    } catch {
+      /* best-effort */
+    }
+    return true;
+  };
+  return emitter;
+}
+
+function makeSpawnMock(options?: { passThroughStdin?: boolean }): {
+  spawn: ReturnType<typeof mock>;
+  lastChild: () => FakeFfmpegChild | null;
+} {
+  let child: FakeFfmpegChild | null = null;
+  const spawn = mock(() => {
+    child = makeFakeFfmpegChild(options);
+    return child as unknown as ReturnType<
+      typeof import("node:child_process").spawn
+    >;
+  });
+  return {
+    spawn,
+    lastChild: () => child,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake TTS provider
+// ---------------------------------------------------------------------------
+
+interface CannedProviderOptions {
+  chunks: Uint8Array[];
+  /** Delay (ms) between chunks — defaults to 0 for synchronous emission. */
+  gapMs?: number;
+}
+
+function makeCannedProvider(options: CannedProviderOptions): TtsProvider & {
+  calls: TtsSynthesisRequest[];
+} {
+  const calls: TtsSynthesisRequest[] = [];
+  const provider: TtsProvider & { calls: TtsSynthesisRequest[] } = {
+    id: "canned-test-provider",
+    capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+    calls,
+    async synthesize(request): Promise<TtsSynthesisResult> {
+      // Not used by the bridge but required by the contract.
+      calls.push(request);
+      const merged = Buffer.concat(options.chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+    async synthesizeStream(request, onChunk): Promise<TtsSynthesisResult> {
+      calls.push(request);
+      for (const chunk of options.chunks) {
+        if (request.signal?.aborted) {
+          throw new Error("aborted");
+        }
+        onChunk(chunk);
+        if (options.gapMs && options.gapMs > 0) {
+          await new Promise((r) => setTimeout(r, options.gapMs));
+        }
+      }
+      const merged = Buffer.concat(options.chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+  };
+  return provider;
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const TOKEN = "test-token-xyz";
+const MEETING_ID = "m-tts-bridge-test";
+
+let fakeBot: FakeBotServer;
+
+beforeEach(() => {
+  fakeBot = startFakeBot();
+});
+
+afterEach(async () => {
+  await fakeBot.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MeetTtsBridge.speak", () => {
+  test("pipes provider chunks through ffmpeg to the bot's /play_audio POST", async () => {
+    const payload = [
+      new Uint8Array([1, 2, 3, 4]),
+      new Uint8Array([5, 6, 7, 8]),
+      new Uint8Array([9, 10]),
+    ];
+    const expected = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const provider = makeCannedProvider({ chunks: payload });
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-abc",
+      },
+    );
+
+    const result = await bridge.speak({ text: "hello world", voice: "voice-1" });
+    expect(result.streamId).toBe("stream-abc");
+
+    // Wait for the POST to complete.
+    await result.completion;
+
+    // Assert: exactly one POST landed on the fake bot with the right URL,
+    // headers, and body bytes.
+    expect(fakeBot.posts).toHaveLength(1);
+    const post = fakeBot.posts[0]!;
+    expect(post.url).toBe("/play_audio?stream_id=stream-abc");
+    expect(post.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(post.contentType).toBe("application/octet-stream");
+    expect(Array.from(post.body)).toEqual(Array.from(expected));
+
+    // Assert: no DELETE was issued on the happy path.
+    expect(fakeBot.deletes).toHaveLength(0);
+
+    // Assert: provider was invoked with the expected surface + voice.
+    expect(provider.calls).toHaveLength(1);
+    expect(provider.calls[0]!.text).toBe("hello world");
+    expect(provider.calls[0]!.voiceId).toBe("voice-1");
+    expect(provider.calls[0]!.useCase).toBe("message-playback");
+
+    // No active streams linger after completion.
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+
+  test("cancel mid-stream aborts POST and issues DELETE /play_audio/<id>", async () => {
+    // Use a long gap between chunks so cancel can land before the provider
+    // finishes. The first chunk is emitted immediately so the POST has
+    // opened before we cancel.
+    const payload = [
+      new Uint8Array([0xaa, 0xbb]),
+      new Uint8Array([0xcc, 0xdd]),
+      new Uint8Array([0xee, 0xff]),
+    ];
+    const provider = makeCannedProvider({ chunks: payload, gapMs: 200 });
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-cancel",
+      },
+    );
+
+    const { streamId, completion } = await bridge.speak({
+      text: "will be cancelled",
+    });
+    expect(streamId).toBe("stream-cancel");
+
+    // Give the first chunk a chance to flow so the POST has opened.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Cancel. The bridge aborts the outbound POST and fires a DELETE.
+    await bridge.cancel(streamId);
+
+    // The completion promise should have settled by now (cancel awaits).
+    await completion.catch(() => {});
+
+    // The bot may or may not have recorded the partial POST (depending on
+    // timing — we only require that the DELETE arrived). In practice Bun
+    // records the POST when the client abort arrives; either way we assert
+    // the DELETE shape.
+    expect(fakeBot.deletes).toHaveLength(1);
+    const del = fakeBot.deletes[0]!;
+    expect(del.url).toBe("/play_audio/stream-cancel");
+    expect(del.authorization).toBe(`Bearer ${TOKEN}`);
+
+    // Active stream map is empty after cancel settles.
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+
+  test("cancel on an unknown streamId is a no-op", async () => {
+    const provider = makeCannedProvider({ chunks: [] });
+    const { spawn } = makeSpawnMock();
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+      },
+    );
+
+    await bridge.cancel("never-existed");
+    expect(fakeBot.deletes).toHaveLength(0);
+    expect(fakeBot.posts).toHaveLength(0);
+  });
+});
+
+describe("MeetTtsBridge constructor validation", () => {
+  test("throws when meetingId is empty", () => {
+    expect(
+      () =>
+        new MeetTtsBridge(
+          { meetingId: "", botBaseUrl: "http://x", botApiToken: "t" },
+          { providerFactory: () => makeCannedProvider({ chunks: [] }) },
+        ),
+    ).toThrow(/meetingId is required/);
+  });
+
+  test("throws when botBaseUrl is empty", () => {
+    expect(
+      () =>
+        new MeetTtsBridge(
+          { meetingId: "m", botBaseUrl: "", botApiToken: "t" },
+          { providerFactory: () => makeCannedProvider({ chunks: [] }) },
+        ),
+    ).toThrow(/botBaseUrl is required/);
+  });
+
+  test("throws when botApiToken is empty", () => {
+    expect(
+      () =>
+        new MeetTtsBridge(
+          { meetingId: "m", botBaseUrl: "http://x", botApiToken: "" },
+          { providerFactory: () => makeCannedProvider({ chunks: [] }) },
+        ),
+    ).toThrow(/botApiToken is required/);
+  });
+});

--- a/skills/meet-join/daemon/event-publisher.ts
+++ b/skills/meet-join/daemon/event-publisher.ts
@@ -55,7 +55,9 @@ export type MeetEventKind =
   | "meet.transcript_chunk"
   | "meet.left"
   | "meet.chat_sent"
-  | "meet.error";
+  | "meet.error"
+  | "meet.speaking_started"
+  | "meet.speaking_ended";
 
 // ---------------------------------------------------------------------------
 // publishMeetEvent

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -72,6 +72,9 @@ import type {
 import { wakeAgentForOpportunity } from "../../../assistant/src/runtime/agent-wake.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../assistant/src/runtime/assistant-scope.js";
 import { getProviderKeyAsync } from "../../../assistant/src/security/secure-keys.js";
+import { getTtsProvider } from "../../../assistant/src/tts/provider-registry.js";
+import { resolveTtsConfig } from "../../../assistant/src/tts/tts-config-resolver.js";
+import type { TtsProvider } from "../../../assistant/src/tts/types.js";
 import { getLogger } from "../../../assistant/src/util/logger.js";
 import { getWorkspaceDir } from "../../../assistant/src/util/platform.js";
 import { MeetAudioIngest } from "./audio-ingest.js";
@@ -102,6 +105,12 @@ import {
 } from "./event-publisher.js";
 import { getMeetSessionEventRouter } from "./session-event-router.js";
 import { MeetStorageWriter, type PcmSource } from "./storage-writer.js";
+import {
+  MeetTtsBridge,
+  type MeetTtsBridgeArgs,
+  type MeetTtsBridgeDeps,
+  type SpeakInput,
+} from "./tts-bridge.js";
 
 const log = getLogger("meet-session-manager");
 
@@ -278,6 +287,13 @@ interface ActiveSession extends MeetSession {
    * Disposed in `leave()` before the dispatcher is unregistered.
    */
   chatOpportunityDetector: MeetChatOpportunityDetectorLike | null;
+  /**
+   * TTS-bridge for this meeting — drives {@link MeetSessionManager.speak}
+   * and {@link MeetSessionManager.cancelSpeak}. Constructed in `join()`
+   * after the bot's base URL is known, torn down via `cancelAll()` in
+   * `leave()` so no orphan stream outlives the container.
+   */
+  ttsBridge: MeetTtsBridgeLike;
 }
 
 /**
@@ -339,6 +355,17 @@ export interface MeetStorageWriterLike {
   stop(): Promise<void>;
 }
 
+/**
+ * Thin interface for the TTS-bridge surface the session manager uses. Lets
+ * tests swap in a fake without spinning up ffmpeg or a real HTTP client.
+ */
+export interface MeetTtsBridgeLike {
+  speak(input: SpeakInput): Promise<{ streamId: string; completion: Promise<void> }>;
+  cancel(streamId: string): Promise<void>;
+  cancelAll(): Promise<void>;
+  activeStreamCount(): number;
+}
+
 /** Arguments passed to {@link MeetSessionManagerDeps.consentMonitorFactory}. */
 export interface MeetConsentMonitorFactoryArgs {
   meetingId: string;
@@ -356,6 +383,13 @@ export interface MeetConversationBridgeFactoryArgs {
 /** Arguments passed to {@link MeetSessionManagerDeps.storageWriterFactory}. */
 export interface MeetStorageWriterFactoryArgs {
   meetingId: string;
+}
+
+/** Arguments passed to {@link MeetSessionManagerDeps.ttsBridgeFactory}. */
+export interface MeetTtsBridgeFactoryArgs {
+  meetingId: string;
+  botBaseUrl: string;
+  botApiToken: string;
 }
 
 /**
@@ -451,6 +485,14 @@ export interface MeetSessionManagerDeps {
     args: MeetChatOpportunityDetectorFactoryArgs,
   ) => MeetChatOpportunityDetectorLike;
   /**
+   * Override the TTS-bridge factory. Default constructs a
+   * {@link MeetTtsBridge} that resolves the configured TTS provider via
+   * the registry on each `speak` call. Tests can inject a fake to
+   * observe speak/cancel without spinning up ffmpeg or a real HTTP
+   * client.
+   */
+  ttsBridgeFactory?: (args: MeetTtsBridgeFactoryArgs) => MeetTtsBridgeLike;
+  /**
    * Override the function the session manager calls to wake the agent
    * loop when the detector fires an opportunity. Default routes through
    * the runtime-level {@link wakeAgentForOpportunity} using the
@@ -503,6 +545,8 @@ class MeetSessionManagerImpl {
       chatOpportunityDetectorFactory:
         deps.chatOpportunityDetectorFactory ??
         defaultChatOpportunityDetectorFactory,
+      ttsBridgeFactory:
+        deps.ttsBridgeFactory ?? defaultTtsBridgeFactory,
       wakeAgent: deps.wakeAgent ?? defaultWakeAgent,
     };
 
@@ -543,6 +587,11 @@ class MeetSessionManagerImpl {
       }
       try {
         session.chatOpportunityDetector?.dispose();
+      } catch {
+        /* best-effort */
+      }
+      try {
+        void session.ttsBridge.cancelAll();
       } catch {
         /* best-effort */
       }
@@ -825,6 +874,15 @@ class MeetSessionManagerImpl {
           })
         : null;
 
+    // TTS bridge — streams synthesized speech into the bot's /play_audio
+    // endpoint. Resolved lazily per speak call so config-live provider
+    // changes propagate.
+    const ttsBridge = this.deps.ttsBridgeFactory({
+      meetingId,
+      botBaseUrl,
+      botApiToken,
+    });
+
     const startedAt = Date.now();
     const session: ActiveSession = {
       meetingId,
@@ -842,6 +900,7 @@ class MeetSessionManagerImpl {
       conversationBridge,
       storageWriter,
       chatOpportunityDetector,
+      ttsBridge,
     };
     this.sessions.set(meetingId, session);
 
@@ -973,6 +1032,19 @@ class MeetSessionManagerImpl {
       log.warn(
         { err, meetingId },
         "MeetChatOpportunityDetector.dispose threw during leave — continuing teardown",
+      );
+    }
+
+    // Cancel any in-flight TTS streams so orphan playback doesn't try to
+    // talk to a bot container that's about to be removed. `cancelAll`
+    // awaits the per-stream teardown (which includes the best-effort
+    // DELETE /play_audio/<id>) — bounded by the stream's own abort path.
+    try {
+      await session.ttsBridge.cancelAll();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetTtsBridge.cancelAll threw during leave — continuing teardown",
       );
     }
 
@@ -1167,6 +1239,87 @@ class MeetSessionManagerImpl {
   }
 
   /**
+   * Speak synthesized audio into the meeting via the bot's `/play_audio`
+   * endpoint. Thin wrapper over {@link MeetTtsBridge.speak} that looks up
+   * the active session, publishes `meet.speaking_started` before the stream
+   * begins, and publishes `meet.speaking_ended` once the bot-side playback
+   * settles. Returns the opaque streamId so callers can cancel the stream
+   * mid-playback via {@link cancelSpeak}.
+   *
+   * Throws {@link MeetSessionNotFoundError} when no active session exists.
+   */
+  async speak(
+    meetingId: string,
+    input: { text: string; voice?: string; streamId?: string },
+  ): Promise<{ streamId: string }> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      throw new MeetSessionNotFoundError(meetingId);
+    }
+
+    const result = await session.ttsBridge.speak(input);
+    const streamId = result.streamId;
+
+    void publishMeetEvent(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+      meetingId,
+      "meet.speaking_started",
+      { streamId },
+    );
+
+    // Fire-and-forget completion publisher. `result.completion` resolves
+    // when the outbound POST settles (either success, cancel, or error);
+    // errors are rethrown from the bridge so we can distinguish a natural
+    // finish from a rejected one and emit the matching reason.
+    void result.completion
+      .then(() => {
+        void publishMeetEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          meetingId,
+          "meet.speaking_ended",
+          { streamId, reason: "completed" as const },
+        );
+      })
+      .catch((err) => {
+        const reason: "cancelled" | "error" =
+          err instanceof Error && err.message === "cancel"
+            ? "cancelled"
+            : "error";
+        log.warn(
+          { err, meetingId, streamId, reason },
+          "MeetTtsBridge speak completion rejected",
+        );
+        void publishMeetEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          meetingId,
+          "meet.speaking_ended",
+          { streamId, reason },
+        );
+      });
+
+    log.info(
+      { meetingId, streamId, textLength: input.text.length },
+      "Meet TTS speak started",
+    );
+
+    return { streamId };
+  }
+
+  /**
+   * Cancel every in-flight TTS stream for the meeting. Idempotent — safe
+   * to call when no streams are active. Throws
+   * {@link MeetSessionNotFoundError} when no active session exists so
+   * callers can distinguish "unknown meeting" from "nothing to cancel".
+   */
+  async cancelSpeak(meetingId: string): Promise<void> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      throw new MeetSessionNotFoundError(meetingId);
+    }
+    await session.ttsBridge.cancelAll();
+  }
+
+  /**
    * Tear down every active meeting in parallel with a shared overall deadline.
    *
    * Invoked from the daemon's shutdown sequence so live meetings don't leak
@@ -1262,6 +1415,11 @@ class MeetSessionManagerImpl {
           }
           try {
             lingering.chatOpportunityDetector?.dispose();
+          } catch {
+            /* best-effort */
+          }
+          try {
+            await lingering.ttsBridge.cancelAll();
           } catch {
             /* best-effort */
           }
@@ -1456,6 +1614,30 @@ async function defaultCallDetectorLLM(
   } finally {
     cleanup();
   }
+}
+
+/**
+ * Default {@link MeetTtsBridge} factory — resolves the TTS provider from
+ * the registry using `services.tts.provider` on each `speak` call so
+ * config-live provider changes propagate without needing to rebuild the
+ * bridge. Tests can inject a fake via
+ * {@link MeetSessionManagerDeps.ttsBridgeFactory}.
+ */
+function defaultTtsBridgeFactory(
+  args: MeetTtsBridgeFactoryArgs,
+): MeetTtsBridgeLike {
+  const bridgeArgs: MeetTtsBridgeArgs = {
+    meetingId: args.meetingId,
+    botBaseUrl: args.botBaseUrl,
+    botApiToken: args.botApiToken,
+  };
+  const bridgeDeps: MeetTtsBridgeDeps = {
+    providerFactory: (): TtsProvider => {
+      const resolved = resolveTtsConfig(getConfig());
+      return getTtsProvider(resolved.provider);
+    },
+  };
+  return new MeetTtsBridge(bridgeArgs, bridgeDeps);
 }
 
 /**

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -1,0 +1,456 @@
+/**
+ * MeetTtsBridge — streams synthesized speech from the configured TTS
+ * provider into the Meet-bot's `/play_audio` endpoint.
+ *
+ * High-level flow per `speak()` call:
+ *
+ *   1. Allocate an opaque `streamId` (UUID v4).
+ *   2. Resolve the configured TTS provider via the injected factory and
+ *      invoke `provider.synthesizeStream({ text, voiceId, … }, onChunk)`.
+ *      The provider emits audio in its own native format (mp3, wav, pcm at
+ *      various sample rates) — the bridge does not assume 48 kHz s16le.
+ *   3. Spawn a single ffmpeg child per call that transcodes whatever the
+ *      provider emits into the bot's expected contract: raw 48 kHz / mono /
+ *      16-bit signed little-endian PCM. Provider chunks are written into
+ *      ffmpeg's stdin; ffmpeg's stdout is the body stream consumed by the
+ *      outbound HTTP POST.
+ *   4. POST `ffmpeg.stdout` to `${botUrl}/play_audio?stream_id=${streamId}`
+ *      with `Content-Type: application/octet-stream` using chunked transfer.
+ *      Because Node/undici require it for streamed upload bodies, the fetch
+ *      is called with `duplex: "half"`.
+ *   5. On abort (via `cancel(streamId)`): abort the outbound HTTP request,
+ *      kill the ffmpeg child, and best-effort hit
+ *      `DELETE /play_audio/${streamId}` so the bot can flush any buffered
+ *      audio and play silence in its place.
+ *
+ * The bridge intentionally does NOT reach into the `assistant/src/tts/`
+ * module beyond consuming the {@link TtsProvider} interface — it accepts
+ * a provider factory via constructor injection so the existing abstraction
+ * stays a black box and tests can swap in a canned provider without
+ * touching the registry.
+ */
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+} from "../../../assistant/src/tts/types.js";
+
+const log = getLogger("meet-tts-bridge");
+
+// ---------------------------------------------------------------------------
+// Tuning knobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Target audio format the bot's `/play_audio` endpoint expects on the wire.
+ * Matches the Meet audio pipeline: 48 kHz, mono, 16-bit signed little-endian
+ * PCM. See PR 1 (bot endpoint) for the contract on the other side.
+ */
+export const BOT_AUDIO_SAMPLE_RATE_HZ = 48_000;
+export const BOT_AUDIO_CHANNELS = 1;
+export const BOT_AUDIO_SAMPLE_BITS = 16;
+export const BOT_AUDIO_ENCODING = "pcm_s16le";
+
+/**
+ * ffmpeg arguments that read whatever format the TTS provider emits on
+ * stdin and write raw 48 kHz / mono / s16le PCM on stdout. The decoder is
+ * format-agnostic (no `-f` on input) so the same pipeline accepts mp3,
+ * wav, or raw provider-native PCM without branching.
+ */
+export const FFMPEG_TRANSCODE_ARGS = [
+  "-hide_banner",
+  "-loglevel",
+  "error",
+  "-i",
+  "pipe:0",
+  "-f",
+  "s16le",
+  "-acodec",
+  "pcm_s16le",
+  "-ar",
+  String(BOT_AUDIO_SAMPLE_RATE_HZ),
+  "-ac",
+  String(BOT_AUDIO_CHANNELS),
+  "pipe:1",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Input for a single `speak` call. */
+export interface SpeakInput {
+  /** Pre-sanitized text to synthesize and play. */
+  text: string;
+  /** Optional provider-specific voice identifier. */
+  voice?: string;
+  /**
+   * Optional caller-supplied stream id. Useful for tests and for callers
+   * that want to tag outbound audio with their own tracking id. When
+   * omitted, a random UUID is allocated.
+   */
+  streamId?: string;
+}
+
+/** Result returned from a successful `speak` call initiation. */
+export interface SpeakResult {
+  /** Identifier the bot uses to associate this audio stream. */
+  streamId: string;
+  /**
+   * Promise that resolves when the outbound HTTP POST to the bot settles
+   * (either on the bot's 2xx response or after a cancel/error teardown).
+   * Rejects when the bot returns a non-2xx status that isn't caused by a
+   * caller-initiated cancel. Callers can await this to know when playback
+   * has ended; most callers fire-and-forget.
+   */
+  completion: Promise<void>;
+}
+
+/**
+ * Narrow fetch-like signature the bridge actually uses. Matches the global
+ * `fetch` but keeps the dependency explicit for tests.
+ */
+export type FetchFn = (
+  input: string | URL,
+  init?: RequestInit & { duplex?: "half" },
+) => Promise<Response>;
+
+/** Spawn primitive — `node:child_process#spawn` by default. */
+export type SpawnFn = typeof nodeSpawn;
+
+export interface MeetTtsBridgeDeps {
+  /**
+   * Factory returning the configured {@link TtsProvider}. Called once per
+   * `speak` so config changes propagate on the next invocation without the
+   * bridge needing to re-subscribe.
+   */
+  providerFactory: () => TtsProvider | Promise<TtsProvider>;
+  /** Override the fetch used for outbound HTTP (tests). */
+  fetch?: FetchFn;
+  /** Override the spawn used for the ffmpeg transcode (tests). */
+  spawn?: SpawnFn;
+  /** Override the UUID generator used for streamId allocation (tests). */
+  newStreamId?: () => string;
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type MeetTtsErrorCode =
+  | "MEET_TTS_PROVIDER_UNAVAILABLE"
+  | "MEET_TTS_BOT_REJECTED"
+  | "MEET_TTS_BOT_UNREACHABLE";
+
+export class MeetTtsError extends Error {
+  readonly code: MeetTtsErrorCode;
+  readonly status?: number;
+
+  constructor(code: MeetTtsErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = "MeetTtsError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+interface ActiveStream {
+  abort: AbortController;
+  /** Resolves when the POST settles and teardown is complete. */
+  settled: Promise<void>;
+}
+
+/**
+ * Constructor input identifying which bot this bridge talks to.
+ */
+export interface MeetTtsBridgeArgs {
+  meetingId: string;
+  /** Base URL of the bot's control API, e.g. `http://127.0.0.1:49200`. */
+  botBaseUrl: string;
+  /** Per-meeting bearer token minted by the session manager. */
+  botApiToken: string;
+}
+
+export class MeetTtsBridge {
+  readonly meetingId: string;
+  readonly botBaseUrl: string;
+
+  private readonly botApiToken: string;
+  private readonly deps: Required<MeetTtsBridgeDeps>;
+  private readonly streams = new Map<string, ActiveStream>();
+
+  constructor(args: MeetTtsBridgeArgs, deps: MeetTtsBridgeDeps) {
+    if (!args.meetingId) {
+      throw new Error("MeetTtsBridge: meetingId is required");
+    }
+    if (!args.botBaseUrl) {
+      throw new Error("MeetTtsBridge: botBaseUrl is required");
+    }
+    if (!args.botApiToken) {
+      throw new Error("MeetTtsBridge: botApiToken is required");
+    }
+    if (!deps?.providerFactory) {
+      throw new Error("MeetTtsBridge: providerFactory is required");
+    }
+    this.meetingId = args.meetingId;
+    this.botBaseUrl = args.botBaseUrl.replace(/\/+$/, "");
+    this.botApiToken = args.botApiToken;
+    this.deps = {
+      providerFactory: deps.providerFactory,
+      fetch: deps.fetch ?? ((url, init) => fetch(url, init as RequestInit)),
+      spawn: deps.spawn ?? nodeSpawn,
+      newStreamId: deps.newStreamId ?? (() => randomUUID()),
+    };
+  }
+
+  /**
+   * Start streaming a synthesized utterance to the bot. Allocates (or uses
+   * the caller-supplied) `streamId`, opens the provider's streaming
+   * synthesis call, transcodes on the fly via ffmpeg, and POSTs the result
+   * to the bot. Returns the streamId immediately; the POST runs in the
+   * background and its completion can be awaited via `result.completion`.
+   */
+  async speak(input: SpeakInput): Promise<SpeakResult> {
+    const streamId = input.streamId ?? this.deps.newStreamId();
+    if (this.streams.has(streamId)) {
+      throw new Error(
+        `MeetTtsBridge: streamId ${streamId} is already active for meeting ${this.meetingId}`,
+      );
+    }
+
+    let provider: TtsProvider;
+    try {
+      provider = await this.deps.providerFactory();
+    } catch (err) {
+      throw new MeetTtsError(
+        "MEET_TTS_PROVIDER_UNAVAILABLE",
+        `TTS provider unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!provider.synthesizeStream) {
+      throw new MeetTtsError(
+        "MEET_TTS_PROVIDER_UNAVAILABLE",
+        `TTS provider "${provider.id}" does not implement synthesizeStream`,
+      );
+    }
+
+    const abort = new AbortController();
+
+    // --- ffmpeg transcode pipeline -----------------------------------------
+    //
+    // Provider output → ffmpeg stdin → ffmpeg stdout → HTTP POST body.
+    // The decoder is format-agnostic so we accept whatever the provider
+    // emits (mp3, wav, pcm of various rates) and emit the bot's expected
+    // format on stdout.
+    const ffmpeg = this.deps.spawn("ffmpeg", [...FFMPEG_TRANSCODE_ARGS], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // Surface ffmpeg errors at debug; a real spawn failure propagates as
+    // an exit with a non-zero code which we catch below.
+    ffmpeg.on("error", (err) => {
+      log.warn(
+        { err, meetingId: this.meetingId, streamId },
+        "ffmpeg transcode spawn/runtime error",
+      );
+    });
+    ffmpeg.stderr?.on("data", (chunk: Buffer) => {
+      log.debug(
+        {
+          meetingId: this.meetingId,
+          streamId,
+          stderr: chunk.toString("utf8").trim(),
+        },
+        "ffmpeg transcode stderr",
+      );
+    });
+
+    // --- Drive the provider's streaming synthesis into ffmpeg stdin --------
+    //
+    // We kick off synthesis concurrently with the HTTP POST so the bot
+    // starts receiving audio as soon as ffmpeg emits its first output
+    // bytes. Errors from the provider are handled by ending ffmpeg stdin
+    // with an explicit destroy + propagating through `completion`.
+    const synthesisRequest: TtsSynthesisRequest = {
+      text: input.text,
+      useCase: "message-playback",
+      voiceId: input.voice,
+      signal: abort.signal,
+    };
+    const synthesisPromise = provider
+      .synthesizeStream(synthesisRequest, (chunk) => {
+        if (abort.signal.aborted) return;
+        try {
+          ffmpeg.stdin.write(Buffer.from(chunk));
+        } catch (err) {
+          log.warn(
+            { err, meetingId: this.meetingId, streamId },
+            "ffmpeg stdin write threw — aborting stream",
+          );
+          abort.abort(err);
+        }
+      })
+      .catch((err) => {
+        if (!abort.signal.aborted) {
+          log.warn(
+            { err, meetingId: this.meetingId, streamId },
+            "TTS provider synthesizeStream rejected",
+          );
+          abort.abort(err);
+        }
+        return null;
+      })
+      .finally(() => {
+        // Close ffmpeg stdin so it flushes and exits naturally.
+        try {
+          ffmpeg.stdin.end();
+        } catch {
+          /* already closed */
+        }
+      });
+
+    // --- Build the HTTP POST body from ffmpeg stdout -----------------------
+    //
+    // Node's undici-backed fetch accepts a `ReadableStream` body; convert
+    // the node-stream `ffmpeg.stdout` into a web stream so we can hand it
+    // off to fetch with `duplex: "half"`.
+    const bodyStream = Readable.toWeb(
+      ffmpeg.stdout,
+    ) as unknown as ReadableStream<Uint8Array>;
+
+    const url = `${this.botBaseUrl}/play_audio?stream_id=${encodeURIComponent(streamId)}`;
+
+    const postSettled = this.runPost({
+      url,
+      body: bodyStream,
+      abort,
+      streamId,
+    });
+
+    const settled = postSettled.finally(() => {
+      // Make sure the provider synthesis task has completed before we
+      // clear the active-stream record — otherwise a late synthesis
+      // rejection could orphan state after `cancel` resolved.
+      return synthesisPromise.finally(() => {
+        // Best-effort kill in case ffmpeg is still alive (provider
+        // rejected after we aborted, stdin close raced, etc.).
+        if (!ffmpeg.killed) {
+          try {
+            ffmpeg.kill("SIGKILL");
+          } catch {
+            /* best-effort */
+          }
+        }
+        this.streams.delete(streamId);
+      });
+    });
+
+    this.streams.set(streamId, { abort, settled });
+
+    return { streamId, completion: settled };
+  }
+
+  /**
+   * Cancel an in-flight speak call. Fires the stream's abort signal which
+   * aborts the outbound HTTP request; also best-effort POSTs
+   * `DELETE /play_audio/<streamId>` so the bot flushes silence in place
+   * of any buffered audio. Safe to call with an unknown stream id
+   * (no-op).
+   */
+  async cancel(streamId: string): Promise<void> {
+    const active = this.streams.get(streamId);
+    if (!active) {
+      log.debug(
+        { meetingId: this.meetingId, streamId },
+        "cancel(): no active stream — no-op",
+      );
+      return;
+    }
+    active.abort.abort(new Error("cancel"));
+    // Best-effort DELETE — swallow failures. The outbound POST is already
+    // aborted, so the bot's stdin-side of /play_audio will observe EOF
+    // regardless; the DELETE is the explicit signal to flush.
+    try {
+      await this.deps.fetch(
+        `${this.botBaseUrl}/play_audio/${encodeURIComponent(streamId)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${this.botApiToken}` },
+        },
+      );
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId, streamId },
+        "cancel(): DELETE /play_audio failed — continuing",
+      );
+    }
+    await active.settled.catch(() => {});
+  }
+
+  /** Number of in-flight streams. Exposed for tests. */
+  activeStreamCount(): number {
+    return this.streams.size;
+  }
+
+  /**
+   * Cancel every in-flight stream. Invoked from the session manager on
+   * meeting leave so orphan streams don't outlive the container.
+   */
+  async cancelAll(): Promise<void> {
+    const ids = Array.from(this.streams.keys());
+    await Promise.allSettled(ids.map((id) => this.cancel(id)));
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async runPost(args: {
+    url: string;
+    body: ReadableStream<Uint8Array>;
+    abort: AbortController;
+    streamId: string;
+  }): Promise<void> {
+    const { url, body, abort, streamId } = args;
+    let response: Response;
+    try {
+      response = await this.deps.fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.botApiToken}`,
+          "Content-Type": "application/octet-stream",
+        },
+        body,
+        signal: abort.signal,
+        duplex: "half",
+      });
+    } catch (err) {
+      if (abort.signal.aborted) {
+        // Caller-initiated cancel: swallow.
+        return;
+      }
+      throw new MeetTtsError(
+        "MEET_TTS_BOT_UNREACHABLE",
+        `Bot /play_audio unreachable for streamId=${streamId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new MeetTtsError(
+        "MEET_TTS_BOT_REJECTED",
+        `Bot /play_audio returned ${response.status} for streamId=${streamId}: ${detail}`,
+        response.status,
+      );
+    }
+    // Drain any body the bot returned so the connection can be reused.
+    await response.arrayBuffer().catch(() => {});
+  }
+}


### PR DESCRIPTION
## Summary
- Adds MeetTtsBridge streaming PCM from the configured TTS provider into the bot's /play_audio endpoint (chunked transfer)
- Exposes MeetSessionManager.speak/cancelSpeak and publishes meet.speaking_started/ended events via assistantEventHub
- Unit tests cover happy path + cancel (DELETE) path

Part of plan: meet-phase-3-voice.md (PR 2 of 6)