### PR TITLE
fix(watcher): separate credential health skip from circuit breaker errors

### DIFF
--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -19,6 +19,7 @@ import {
   insertWatcherEvent,
   resetStuckWatchers,
   setWatcherConversationId,
+  skipWatcherPoll,
   updateEventDisposition,
 } from "./watcher-store.js";
 
@@ -80,9 +81,8 @@ export async function runWatchersOnce(
     // Prevents wasting API calls and burning through circuit breaker
     // attempts on credentials that need manual reauthorization.
     try {
-      const { checkCredentialForProvider } = await import(
-        "../credential-health/credential-health-service.js"
-      );
+      const { checkCredentialForProvider } =
+        await import("../credential-health/credential-health-service.js");
       const health = await checkCredentialForProvider(
         watcher.credentialService,
       );
@@ -92,10 +92,7 @@ export async function runWatchersOnce(
           health.status === "missing_token" ||
           (health.status === "expired" && !health.canAutoRecover))
       ) {
-        failWatcherPoll(
-          watcher.id,
-          `Credential unhealthy: ${health.details}`,
-        );
+        skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);
         continue;
       }
     } catch {

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -222,6 +222,37 @@ export function completeWatcherPoll(
 }
 
 /**
+ * Skip a watcher poll: apply backoff to nextPollAt without incrementing
+ * consecutiveErrors. Used when a poll is skipped for a recoverable reason
+ * (e.g. credential health gate) that should NOT count toward the circuit
+ * breaker threshold.
+ */
+export function skipWatcherPoll(id: string, reason: string): void {
+  const db = getDb();
+  const watcher = db.select().from(watchers).where(eq(watchers.id, id)).get();
+  if (!watcher) return;
+
+  const now = Date.now();
+  // Use the same backoff formula but based on existing consecutiveErrors
+  // (which stays unchanged). Minimum backoff of 30s.
+  const backoff = Math.min(
+    30_000 * Math.pow(2, watcher.consecutiveErrors),
+    60 * 60 * 1000,
+  );
+
+  db.update(watchers)
+    .set({
+      status: "idle",
+      lastError: truncate(reason, 2000, ""),
+      lastPollAt: now,
+      nextPollAt: now + backoff,
+      updatedAt: now,
+    })
+    .where(eq(watchers.id, id))
+    .run();
+}
+
+/**
  * Record a poll error: increment consecutive errors, apply backoff.
  */
 export function failWatcherPoll(id: string, error: string): void {


### PR DESCRIPTION
Address review feedback from #25959. The credential health gate was using failWatcherPoll() which increments consecutiveErrors toward the circuit breaker. This caused premature breaker trips after credential recovery. Introduces skipWatcherPoll() to apply backoff without inflating the error counter.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
