### PR TITLE
fix(gmail): ensure blocklist records on single-message path and scope to scan_id

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -23,6 +23,34 @@ function decodeSenderEmail(senderId: string): string | null {
   }
 }
 
+/**
+ * Persist archived sender emails to the blocklist for future sessions.
+ * Only runs when the archive was initiated via a validated scan_id path
+ * (not bare message_ids) to prevent unverified emails from being recorded.
+ */
+function recordBlocklist(
+  scanId: string | undefined,
+  senderIds: string[] | undefined,
+): void {
+  if (!scanId || !senderIds?.length) return;
+  const archivedEmails: string[] = [];
+  for (const sid of senderIds) {
+    try {
+      const email = Buffer.from(sid, "base64url").toString("utf-8");
+      if (email.includes("@")) archivedEmails.push(email);
+    } catch {
+      // Skip undecodable sender IDs
+    }
+  }
+  if (archivedEmails.length > 0) {
+    try {
+      addToBlocklist(archivedEmails);
+    } catch {
+      // Non-fatal — preferences are best-effort
+    }
+  }
+}
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -210,6 +238,7 @@ export async function run(
       await modifyMessage(connection, messageIds[0], {
         removeLabelIds: ["INBOX"],
       });
+      recordBlocklist(scanId, senderIds);
       return ok("Message archived.");
     }
 
@@ -219,25 +248,7 @@ export async function run(
         removeLabelIds: ["INBOX"],
       });
     }
-    // Record archived sender emails for future sessions (only after success)
-    if (senderIds?.length) {
-      const archivedEmails: string[] = [];
-      for (const sid of senderIds) {
-        try {
-          const email = Buffer.from(sid, "base64url").toString("utf-8");
-          if (email.includes("@")) archivedEmails.push(email);
-        } catch {
-          // Skip undecodable sender IDs
-        }
-      }
-      if (archivedEmails.length > 0) {
-        try {
-          addToBlocklist(archivedEmails);
-        } catch {
-          // Non-fatal — preferences are best-effort
-        }
-      }
-    }
+    recordBlocklist(scanId, senderIds);
     return ok(`Archived ${messageIds.length} message(s).`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
## Summary
- Extract blocklist recording into a `recordBlocklist()` helper that requires `scanId` to be present before writing
- Call `recordBlocklist()` from both the single-message optimization path and the batch archive path
- Fixes: single-message early return (messageIds.length === 1) no longer bypasses blocklist persistence
- Fixes: blocklist writes are now scoped to scan_id-validated paths only, preventing unverified sender emails from being recorded via bare message_ids + sender_ids

Addresses review feedback from #25971.

## Test plan
- [ ] Verify single-message scan archive records sender to blocklist
- [ ] Verify batch scan archive still records senders to blocklist
- [ ] Verify bare message_ids + sender_ids (no scan_id) does NOT write to blocklist
- [ ] Verify query path and fallback path are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
