### PR TITLE
meet: meet_speak tool + registration

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 14 (no-client baseline excludes host tools)", async () => {
+  test("should be exactly 16 (no-client baseline excludes host tools)", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
@@ -56,9 +56,11 @@ describe("always-loaded tool count", () => {
       "file_edit",
       "file_read",
       "file_write",
+      "meet_cancel_speak",
       "meet_join",
       "meet_leave",
       "meet_send_chat",
+      "meet_speak",
       "recall",
       "remember",
       "skill_execute",
@@ -68,6 +70,6 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(14);
+    expect(activeTools.length).toBe(16);
   });
 });

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -9,6 +9,10 @@
 import { meetJoinTool } from "../../../skills/meet-join/tools/meet-join-tool.js";
 import { meetLeaveTool } from "../../../skills/meet-join/tools/meet-leave-tool.js";
 import { meetSendChatTool } from "../../../skills/meet-join/tools/meet-send-chat-tool.js";
+import {
+  meetCancelSpeakTool,
+  meetSpeakTool,
+} from "../../../skills/meet-join/tools/meet-speak-tool.js";
 import { getConfig } from "../config/loader.js";
 import {
   isCesSecureInstallEnabled,
@@ -94,7 +98,8 @@ export const explicitTools: Tool[] = [
   recallTool,
   credentialStoreTool,
   notifyParentTool,
-  // Meet tools: `meet_join` / `meet_leave` pair with the `meet-join` skill
+  // Meet tools: `meet_join` / `meet_leave` / `meet_send_chat` /
+  // `meet_speak` / `meet_cancel_speak` pair with the `meet-join` skill
   // (see `skills/meet-join/SKILL.md`). They are registered as first-party
   // tools rather than skill scripts because they command an in-process
   // lifecycle resource (MeetSessionManager) — per the exception carve-out
@@ -105,6 +110,8 @@ export const explicitTools: Tool[] = [
   meetJoinTool,
   meetLeaveTool,
   meetSendChatTool,
+  meetSpeakTool,
+  meetCancelSpeakTool,
 ];
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────

--- a/skills/meet-join/tools/__tests__/meet-speak-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-speak-tool.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for the `meet_speak` and `meet_cancel_speak` tools.
+ *
+ * Exercises feature-flag gating, input validation (length cap, optional
+ * voice, optional meetingId), disambiguation when the caller omits
+ * `meetingId` (0 / 1 / many active sessions), explicit-id pass-through,
+ * and error propagation from the session manager. Mirrors the mocking
+ * style used in the sibling `meet-send-chat-tool.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let flagEnabled = true;
+let activeSessionsValue: Array<{
+  meetingId: string;
+  conversationId: string;
+  containerId: string;
+  botBaseUrl: string;
+  botApiToken: string;
+  startedAt: number;
+  joinTimeoutMs: number;
+}> = [];
+
+const speakMock = mock(
+  async (
+    _meetingId: string,
+    _input: { text: string; voice?: string },
+  ): Promise<{ streamId: string }> => {
+    return { streamId: "stream-default" };
+  },
+);
+const cancelSpeakMock = mock(async (_meetingId: string): Promise<void> => {});
+
+class FakeMeetSessionNotFoundError extends Error {
+  readonly name = "MeetSessionNotFoundError";
+}
+class FakeMeetSessionUnreachableError extends Error {
+  readonly name = "MeetSessionUnreachableError";
+}
+class FakeMeetBotChatError extends Error {
+  readonly name = "MeetBotChatError";
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+mock.module("../../daemon/session-manager.js", () => ({
+  MeetSessionManager: {
+    join: async () => {
+      throw new Error("join should not be invoked in speak tests");
+    },
+    leave: async () => {},
+    activeSessions: () => activeSessionsValue,
+    getSession: (meetingId: string) =>
+      activeSessionsValue.find((s) => s.meetingId === meetingId) ?? null,
+    sendChat: async () => {},
+    speak: speakMock,
+    cancelSpeak: cancelSpeakMock,
+  },
+  MeetSessionNotFoundError: FakeMeetSessionNotFoundError,
+  MeetSessionUnreachableError: FakeMeetSessionUnreachableError,
+  MeetBotChatError: FakeMeetBotChatError,
+}));
+
+mock.module(
+  "../../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
+
+mock.module("../../../../assistant/src/config/loader.js", () => ({
+  getConfig: () => ({
+    services: { meet: { consentMessage: "unused-in-speak-tests" } },
+  }),
+}));
+
+mock.module("../../../../assistant/src/util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const {
+  meetSpeakTool,
+  meetCancelSpeakTool,
+  MEET_SPEAK_MAX_TEXT_LENGTH,
+} = await import("../meet-speak-tool.js");
+
+import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+function fakeSession(meetingId: string) {
+  return {
+    meetingId,
+    conversationId: "conv-test",
+    containerId: `c-${meetingId}`,
+    botBaseUrl: "http://127.0.0.1:49000",
+    botApiToken: "token",
+    startedAt: Date.now(),
+    joinTimeoutMs: 60_000,
+  };
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  activeSessionsValue = [];
+  speakMock.mockClear();
+  speakMock.mockImplementation(async () => ({ streamId: "stream-default" }));
+  cancelSpeakMock.mockClear();
+  cancelSpeakMock.mockImplementation(async () => {});
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// meet_speak — feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_speak feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetSpeakTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_speak — input validation
+// ---------------------------------------------------------------------------
+
+describe("meet_speak input validation", () => {
+  test("rejects missing text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/^Error:/);
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSpeakTool.execute({ text: "" }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("text");
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-string text", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSpeakTool.execute(
+      { text: 123 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts text exactly at the soft length cap", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const text = "a".repeat(MEET_SPEAK_MAX_TEXT_LENGTH);
+    const result = await meetSpeakTool.execute({ text }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(speakMock.mock.calls[0][1].text.length).toBe(
+      MEET_SPEAK_MAX_TEXT_LENGTH,
+    );
+  });
+
+  test("rejects text exceeding the soft length cap", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const text = "a".repeat(MEET_SPEAK_MAX_TEXT_LENGTH + 1);
+    const result = await meetSpeakTool.execute({ text }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(`${MEET_SPEAK_MAX_TEXT_LENGTH}`);
+    expect(result.content.toLowerCase()).toContain("meet_send_chat");
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty voice when provided", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetSpeakTool.execute(
+      { text: "hi", voice: "  " },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("passes through an explicit voice id to the session manager", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    speakMock.mockImplementationOnce(async () => ({
+      streamId: "stream-voice",
+    }));
+    const result = await meetSpeakTool.execute(
+      { text: "hi there", voice: "alloy" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(speakMock.mock.calls[0][1]).toEqual({
+      text: "hi there",
+      voice: "alloy",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_speak — disambiguation
+// ---------------------------------------------------------------------------
+
+describe("meet_speak disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetSpeakTool.execute(
+      { text: "anyone there?" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    speakMock.mockImplementationOnce(async () => ({
+      streamId: "stream-1",
+    }));
+    const result = await meetSpeakTool.execute(
+      { text: "hello team" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    const [id, payload] = speakMock.mock.calls[0];
+    expect(id).toBe("solo");
+    expect(payload.text).toBe("hello team");
+    const body = JSON.parse(result.content) as {
+      streamId: string;
+      meetingId: string;
+    };
+    expect(body).toEqual({ streamId: "stream-1", meetingId: "solo" });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetSpeakTool.execute(
+      { text: "hi" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(result.content).toContain("m1");
+    expect(result.content).toContain("m2");
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    speakMock.mockImplementationOnce(async () => ({
+      streamId: "stream-m2",
+    }));
+    const result = await meetSpeakTool.execute(
+      { meetingId: "m2", text: "hi m2" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(speakMock.mock.calls[0][0]).toBe("m2");
+    expect(speakMock.mock.calls[0][1].text).toBe("hi m2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_speak — error propagation
+// ---------------------------------------------------------------------------
+
+describe("meet_speak error propagation", () => {
+  test("surfaces MeetSessionNotFoundError as a targeted tool error", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    speakMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionNotFoundError("no session");
+    });
+    const result = await meetSpeakTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no active Meet session");
+    expect(result.content).toContain("solo");
+  });
+
+  test("surfaces unknown errors verbatim", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    speakMock.mockImplementationOnce(async () => {
+      throw new Error("ffmpeg crashed");
+    });
+    const result = await meetSpeakTool.execute(
+      { text: "hello" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed to speak into Meet");
+    expect(result.content).toContain("ffmpeg crashed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_cancel_speak — feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_cancel_speak feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(cancelSpeakMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_cancel_speak — disambiguation
+// ---------------------------------------------------------------------------
+
+describe("meet_cancel_speak disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(cancelSpeakMock).not.toHaveBeenCalled();
+  });
+
+  test("cancels the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(false);
+    expect(cancelSpeakMock).toHaveBeenCalledTimes(1);
+    expect(cancelSpeakMock.mock.calls[0][0]).toBe("solo");
+    const body = JSON.parse(result.content) as {
+      cancelled: boolean;
+      meetingId: string;
+    };
+    expect(body).toEqual({ cancelled: true, meetingId: "solo" });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(cancelSpeakMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetCancelSpeakTool.execute(
+      { meetingId: "m1" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(cancelSpeakMock).toHaveBeenCalledTimes(1);
+    expect(cancelSpeakMock.mock.calls[0][0]).toBe("m1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_cancel_speak — error propagation
+// ---------------------------------------------------------------------------
+
+describe("meet_cancel_speak error propagation", () => {
+  test("surfaces MeetSessionNotFoundError as a targeted tool error", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    cancelSpeakMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionNotFoundError("no session");
+    });
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no active Meet session");
+    expect(result.content).toContain("solo");
+  });
+
+  test("surfaces unknown errors verbatim", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    cancelSpeakMock.mockImplementationOnce(async () => {
+      throw new Error("bridge cancel failed");
+    });
+    const result = await meetCancelSpeakTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed to cancel Meet speech");
+    expect(result.content).toContain("bridge cancel failed");
+  });
+});

--- a/skills/meet-join/tools/meet-speak-tool.ts
+++ b/skills/meet-join/tools/meet-speak-tool.ts
@@ -1,0 +1,300 @@
+/**
+ * meet_speak / meet_cancel_speak tools — synthesize speech into an active
+ * Meet call and (voluntarily) cut it off.
+ *
+ * Paired with {@link ./meet-join-tool.ts meet_join} and
+ * {@link ./meet-leave-tool.ts meet_leave}: all four tools are first-party
+ * because they command the in-process `MeetSessionManager` (audio bridge,
+ * per-meeting bearer tokens, container lifecycle). See the rationale comment
+ * at the top of `meet-join-tool.ts` — keeping the speech control surface
+ * in-process avoids a new HTTP API that mirrors the same session-manager
+ * state.
+ *
+ * `text` is capped at 600 characters as a *soft* upper bound: long-form
+ * answers should stay in chat where the participant can re-read them.
+ * The bot itself does not enforce a length, but pushing multi-paragraph
+ * essays through synthesis costs latency and turns the assistant into a
+ * monologue — so we refuse here and let the agent re-plan.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../../assistant/src/config/loader.js";
+import { RiskLevel } from "../../../assistant/src/permissions/types.js";
+import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../assistant/src/tools/types.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import {
+  MeetSessionManager,
+  MeetSessionNotFoundError,
+} from "../daemon/session-manager.js";
+import { MEET_FLAG_KEY } from "./meet-join-tool.js";
+
+const log = getLogger("meet-speak-tool");
+
+/**
+ * Soft cap on the synthesized text length. Anything longer should be sent
+ * as a chat message via {@link ./meet-send-chat-tool.ts meet_send_chat}
+ * instead of monopolizing the audio channel.
+ */
+export const MEET_SPEAK_MAX_TEXT_LENGTH = 600;
+
+const MeetSpeakInputSchema = z.object({
+  meetingId: z.string().trim().min(1).optional(),
+  text: z
+    .string()
+    .min(1, "text is required")
+    .max(
+      MEET_SPEAK_MAX_TEXT_LENGTH,
+      `text exceeds the ${MEET_SPEAK_MAX_TEXT_LENGTH}-character soft limit — send long replies via meet_send_chat instead`,
+    ),
+  voice: z.string().trim().min(1).optional(),
+});
+
+export type MeetSpeakInput = z.infer<typeof MeetSpeakInputSchema>;
+
+const MeetCancelSpeakInputSchema = z.object({
+  meetingId: z.string().trim().min(1).optional(),
+});
+
+export type MeetCancelSpeakInput = z.infer<typeof MeetCancelSpeakInputSchema>;
+
+/**
+ * Resolve the target meetingId from caller input + active sessions.
+ * Returns `{ ok: true, meetingId }` when a single target is determined,
+ * or `{ ok: false, content }` carrying the error string the tool should
+ * surface verbatim. Mirrors the disambiguation logic in `meet_send_chat`
+ * and `meet_leave` so the four tools behave consistently when called
+ * without an explicit meetingId.
+ */
+function resolveTargetMeetingId(
+  explicitId: string | undefined,
+):
+  | { ok: true; meetingId: string }
+  | { ok: false; content: string } {
+  if (explicitId) {
+    return { ok: true, meetingId: explicitId };
+  }
+  const active = MeetSessionManager.activeSessions();
+  if (active.length === 0) {
+    return { ok: false, content: "Error: no active Meet session." };
+  }
+  if (active.length > 1) {
+    const ids = active.map((s) => s.meetingId).join(", ");
+    return {
+      ok: false,
+      content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+    };
+  }
+  return { ok: true, meetingId: active[0].meetingId };
+}
+
+class MeetSpeakTool implements Tool {
+  name = "meet_speak";
+  description =
+    "Speak synthesized audio into an active Google Meet call. Use this to reply out loud during a meeting; for long-form answers prefer meet_send_chat. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  // Low: consent for audio output is established meeting-wide by `meet_join`
+  // (High) and the join-consent message announcing the bot. Speaking within
+  // that bounded session is within the user's expressed consent envelope,
+  // and proactive-speech wakes run on client-less conversations where a
+  // Medium-risk approval prompt would hang forever. Aligns with `meet_leave`
+  // and `meet_send_chat` (also Low).
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting to speak into, as returned by meet_join. Optional when exactly one session is active.",
+          },
+          text: {
+            type: "string",
+            description: `The text to synthesize and play. Keep it conversational and under ${MEET_SPEAK_MAX_TEXT_LENGTH} characters — longer replies should be sent via meet_send_chat.`,
+          },
+          voice: {
+            type: "string",
+            description:
+              "Optional provider-specific voice identifier. Falls back to the configured default voice when omitted.",
+          },
+        },
+        required: ["text"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate — symmetric with the other meet_* tools.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to speak in Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation.
+    const parsed = MeetSpeakInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_speak input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId, text, voice } = parsed.data;
+
+    // 3. Disambiguate target session when no id is supplied.
+    const target = resolveTargetMeetingId(explicitId);
+    if (!target.ok) {
+      return { content: target.content, isError: true };
+    }
+    const targetMeetingId = target.meetingId;
+
+    // 4. Delegate.
+    try {
+      const result = await MeetSessionManager.speak(targetMeetingId, {
+        text,
+        voice,
+      });
+      log.info(
+        {
+          meetingId: targetMeetingId,
+          streamId: result.streamId,
+          textLength: text.length,
+          voice: voice ?? "default",
+        },
+        "meet_speak tool started a TTS stream",
+      );
+      return {
+        content: JSON.stringify({
+          meetingId: targetMeetingId,
+          streamId: result.streamId,
+        }),
+        isError: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId, textLength: text.length },
+        "meet_speak tool failed",
+      );
+      if (err instanceof MeetSessionNotFoundError) {
+        return {
+          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: failed to speak into Meet — ${message}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+class MeetCancelSpeakTool implements Tool {
+  name = "meet_cancel_speak";
+  description =
+    "Cancel any in-flight synthesized speech in an active Google Meet call so the assistant can voluntarily stop talking (e.g. when interrupted by a participant). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  // Low: cancelling the assistant's own audio output is strictly less
+  // invasive than speaking — no new sound is emitted, and idempotent
+  // when nothing is currently playing.
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting whose in-flight speech should be cancelled. Optional when exactly one session is active.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation. All fields are optional so a bare `{}` is valid;
+    //    Zod still catches wrong-type submissions.
+    const parsed = MeetCancelSpeakInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_cancel_speak input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId } = parsed.data;
+
+    // 3. Disambiguate target session.
+    const target = resolveTargetMeetingId(explicitId);
+    if (!target.ok) {
+      return { content: target.content, isError: true };
+    }
+    const targetMeetingId = target.meetingId;
+
+    // 4. Delegate. `cancelSpeak` is idempotent when nothing is in flight.
+    try {
+      await MeetSessionManager.cancelSpeak(targetMeetingId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId },
+        "meet_cancel_speak tool failed",
+      );
+      if (err instanceof MeetSessionNotFoundError) {
+        return {
+          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: failed to cancel Meet speech — ${message}`,
+        isError: true,
+      };
+    }
+
+    return {
+      content: JSON.stringify({
+        cancelled: true,
+        meetingId: targetMeetingId,
+      }),
+      isError: false,
+    };
+  }
+}
+
+/** Exported singletons so the tool registry can re-register after test resets. */
+export const meetSpeakTool = new MeetSpeakTool();
+export const meetCancelSpeakTool = new MeetCancelSpeakTool();


### PR DESCRIPTION
## Summary
- Adds meet_speak tool (Zod {meetingId?, text<=600, voice?}, flag-gated on 'meet') that calls MeetSessionManager.speak
- Adds meet_cancel_speak for voluntary self-interruption
- Registered alongside meet_join/leave/send_chat in assistant/src/tools/index.ts
- Unit tests cover validation, flag gating, error paths

Part of plan: meet-phase-3-voice.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
