### PR TITLE
fix(runtime): wake persists tail before drainQueue so dequeued turns see updated history

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -36,6 +36,18 @@ interface MockTarget extends WakeTarget {
   persistedTailCalls: Message[];
   /** Number of times `drainQueue` was invoked. */
   drainQueueCalls: number;
+  /**
+   * Cross-hook call sequence tag. Each push/persist/drain (and the
+   * processing toggles that bracket them) appends an entry so tests can
+   * assert end-to-end ordering, not just per-hook counts.
+   */
+  callSequence: string[];
+  /**
+   * Snapshot of `processing` at the moment `drainQueue` was invoked.
+   * Lets tests prove drain ran AFTER markProcessing(false), rather than
+   * just inferring it from the order of recorded toggles.
+   */
+  processingDuringDrain: boolean[];
 }
 
 function makeTarget(options: {
@@ -54,6 +66,8 @@ function makeTarget(options: {
   const runCalls: Array<{ input: Message[]; requestId?: string }> = [];
   const processingToggles: boolean[] = [];
   const persistedTailCalls: Message[] = [];
+  const callSequence: string[] = [];
+  const processingDuringDrain: boolean[] = [];
   const history: Message[] = [...(options.baseline ?? [])];
   let processing = options.isProcessing ?? false;
   let drainQueueCalls = 0;
@@ -65,6 +79,8 @@ function makeTarget(options: {
     runCalls,
     processingToggles,
     persistedTailCalls,
+    callSequence,
+    processingDuringDrain,
     get drainQueueCalls() {
       return drainQueueCalls;
     },
@@ -101,6 +117,7 @@ function makeTarget(options: {
     pushMessage: (msg: Message) => {
       pushedMessages.push(msg);
       history.push(msg);
+      callSequence.push("push");
     },
     emitAgentEvent: (event) => {
       emittedEvents.push(event);
@@ -109,15 +126,22 @@ function makeTarget(options: {
     markProcessing: (on: boolean) => {
       processing = on;
       processingToggles.push(on);
+      callSequence.push(on ? "processing:true" : "processing:false");
     },
     persistTailMessage: async (msg: Message) => {
       persistedTailCalls.push(msg);
+      callSequence.push("persist");
     },
     ...(options.omitDrainQueue
       ? {}
       : {
           drainQueue: async () => {
             drainQueueCalls++;
+            // Snapshot the live processing flag *inside* drain, not via
+            // the toggle log, so we directly observe the state visible
+            // to the dequeued message's enqueueMessage() gate.
+            processingDuringDrain.push(processing);
+            callSequence.push("drain");
           },
         }),
   };
@@ -533,7 +557,11 @@ describe("wakeAgentForOpportunity", () => {
     // If drain ran while processing was still true,
     // `enqueueMessage`'s `if (!ctx.processing) return ...` gate would
     // see processing=true and the drained item would itself just
-    // re-enqueue — no progress.
+    // re-enqueue — no progress. Snapshot the live flag *inside* drain
+    // (rather than inferring from toggle order) so a future regression
+    // that called drain before markProcessing(false) would fail this
+    // assertion directly.
+    expect(target.processingDuringDrain).toEqual([false]);
     expect(target.processingToggles).toEqual([true, false]);
     expect(target.isProcessing()).toBe(false);
   });
@@ -542,7 +570,7 @@ describe("wakeAgentForOpportunity", () => {
     // Verifies the drain is in the finally block, not just on success.
     // A wake that crashes mid-run must still flush queued messages —
     // otherwise a transient LLM error strands every concurrent send.
-    let drainCalls = 0;
+    const drainProcessingSnapshots: boolean[] = [];
     const toggles: boolean[] = [];
     let processing = false;
     const target: WakeTarget = {
@@ -562,13 +590,11 @@ describe("wakeAgentForOpportunity", () => {
       },
       persistTailMessage: async () => {},
       drainQueue: async () => {
-        drainCalls++;
-        // Snapshot processing inside drain to prove ordering.
-        if (processing) {
-          throw new Error(
-            "drainQueue invoked while processing=true — wrong order",
-          );
-        }
+        // Snapshot the live `processing` flag *inside* drain rather
+        // than inferring from toggle order. This directly observes the
+        // state visible to enqueueMessage's gate when a queued message
+        // is dequeued.
+        drainProcessingSnapshots.push(processing);
       },
     };
 
@@ -578,9 +604,10 @@ describe("wakeAgentForOpportunity", () => {
     );
 
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
-    expect(drainCalls).toBe(1);
     // Drain ran AFTER markProcessing(false), satisfying the
-    // enqueueMessage gate invariant.
+    // enqueueMessage gate invariant. Snapshot proves the flag was
+    // false at the moment drain ran.
+    expect(drainProcessingSnapshots).toEqual([false]);
     expect(toggles).toEqual([true, false]);
   });
 
@@ -684,4 +711,121 @@ describe("wakeAgentForOpportunity", () => {
       followup,
     ]);
   });
+
+  test(
+    "tail messages are pushed and persisted BEFORE drainQueue runs " +
+      "(so dequeued turns see updated history)",
+    async () => {
+      // Locks in the round-3 fix: a user message queued during the wake
+      // is drained against `conversation.messages`, so the wake's tail
+      // MUST be appended (push) and persisted to DB (persist) before the
+      // queue is drained. Otherwise `drainSingleMessage` reads stale
+      // history and writes a DB row that lands out of chronological
+      // order (queued user msg before the wake's just-produced
+      // assistant outputs).
+      //
+      // Mirrors the canonical user-turn pattern in
+      // conversation-agent-loop.ts:1860,2106-2126: messages updated →
+      // processing=false → drainQueue.
+      const firstAssistant: Message = {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu-1", name: "some_tool", input: {} },
+        ],
+      };
+      const toolResultUserMsg: Message = {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tu-1", content: "ok" },
+        ],
+      };
+      const followup: Message = {
+        role: "assistant",
+        content: [{ type: "text", text: "All done." }],
+      };
+      const target = makeTarget({
+        baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        scriptedAssistant: firstAssistant,
+        scriptedTail: [toolResultUserMsg, followup],
+      });
+
+      await wakeAgentForOpportunity(
+        {
+          conversationId: target.conversationId,
+          hint: "x",
+          source: "meet-chat-opportunity",
+        },
+        { resolveTarget: async () => target },
+      );
+
+      // Full call sequence: processing toggled true → 3 pushes →
+      // 3 persists → processing toggled false → drain. Specifically,
+      // every push and every persist must precede the single drain.
+      expect(target.callSequence).toEqual([
+        "processing:true",
+        "push",
+        "push",
+        "push",
+        "persist",
+        "persist",
+        "persist",
+        "processing:false",
+        "drain",
+      ]);
+
+      // Belt-and-braces: cross-check via index lookups so the failure
+      // mode (drain before push/persist) shows up clearly even if the
+      // exact sequence ever picks up additional entries.
+      const drainIdx = target.callSequence.indexOf("drain");
+      const lastPushIdx = target.callSequence.lastIndexOf("push");
+      const lastPersistIdx = target.callSequence.lastIndexOf("persist");
+      expect(drainIdx).toBeGreaterThan(lastPushIdx);
+      expect(drainIdx).toBeGreaterThan(lastPersistIdx);
+
+      // And processing was false when drain ran.
+      expect(target.processingDuringDrain).toEqual([false]);
+    },
+  );
+
+  test(
+    "silent no-op: drainQueue still runs (in finally) but nothing is " +
+      "pushed, persisted, or emitted",
+    async () => {
+      // The wake's silent-no-op semantics must be preserved by the
+      // round-3 reordering: an empty assistant reply produces no
+      // visible text and no tool calls, so no push/persist/emit should
+      // happen. drainQueue must still run in the finally block so a
+      // racy queued message is not stranded.
+      const target = makeTarget({
+        baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        scriptedAssistant: {
+          role: "assistant",
+          content: [{ type: "text", text: "" }],
+        },
+      });
+
+      await wakeAgentForOpportunity(
+        {
+          conversationId: target.conversationId,
+          hint: "x",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => target },
+      );
+
+      // No push, no persist, no emit.
+      expect(target.pushedMessages).toHaveLength(0);
+      expect(target.persistedTailCalls).toHaveLength(0);
+      expect(target.emittedEvents).toHaveLength(0);
+
+      // But drain still ran exactly once, after processing flipped to
+      // false. Sequence: toggle true → toggle false → drain.
+      expect(target.callSequence).toEqual([
+        "processing:true",
+        "processing:false",
+        "drain",
+      ]);
+      expect(target.processingDuringDrain).toEqual([false]);
+    },
+  );
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -342,18 +342,96 @@ export async function wakeAgentForOpportunity(
     // interleave writes to `conversation.messages`).
     target.markProcessing(true);
 
-    let updatedHistory: Message[];
     let runError: Error | null = null;
+    let producedToolCalls = false;
+    let toolUseNames: string[] = [];
+    let tailMessageCount = 0;
     try {
-      updatedHistory = await target.agentLoop.run(
-        runInput,
-        onEvent,
-        undefined, // no external abort signal
-        `wake:${source}`,
-      );
-    } catch (err) {
-      runError = err instanceof Error ? err : new Error(String(err));
-      updatedHistory = runInput;
+      let updatedHistory: Message[];
+      try {
+        updatedHistory = await target.agentLoop.run(
+          runInput,
+          onEvent,
+          undefined, // no external abort signal
+          `wake:${source}`,
+        );
+      } catch (err) {
+        // Capture the error for post-finally logging, then short-circuit
+        // the rest of the try body — no tail to push/persist when the
+        // run threw mid-flight. The outer finally still runs to release
+        // `processing` and drain the queue.
+        runError = err instanceof Error ? err : new Error(String(err));
+        return { invoked: true, producedToolCalls: false };
+      }
+
+      // Run completed cleanly. Inspect the tail and, if there was real
+      // output, push to in-memory history + persist + flush buffered
+      // events BEFORE the finally hands control to drainQueue. The
+      // canonical user-turn pattern (conversation-agent-loop.ts:1860,
+      // 2106-2126) updates `ctx.messages` first, then resets
+      // `ctx.processing = false`, then calls `ctx.drainQueue(...)`. We
+      // mirror that order here so a message queued during the wake is
+      // dequeued against an already-updated history — otherwise
+      // `drainSingleMessage` reads `ctx.messages` mid-tail and writes a
+      // DB row that lands out of chronological order (queued user msg
+      // before the wake's just-produced assistant outputs).
+      const { tailMessages, hasVisibleText, toolUseNames: names } =
+        inspectWakeOutput(baseline.length, updatedHistory);
+      toolUseNames = names;
+      producedToolCalls = names.length > 0;
+      const producedOutput = producedToolCalls || hasVisibleText;
+
+      if (!producedOutput || tailMessages.length === 0) {
+        // Silent no-op: drop buffered events, push nothing, persist
+        // nothing, emit nothing. The finally still runs drainQueue so a
+        // racy queued message isn't stranded.
+        return { invoked: true, producedToolCalls: false };
+      }
+
+      tailMessageCount = tailMessages.length;
+
+      // Output produced: flush buffered client events through the
+      // target's translator. The internal hint is NOT emitted.
+      for (const event of buffered) {
+        try {
+          target.emitAgentEvent(event);
+        } catch (err) {
+          log.warn(
+            { conversationId, source, err },
+            "agent-wake: client emitter threw; continuing",
+          );
+        }
+      }
+
+      // Append every tail message to live in-memory history. Without
+      // this, the next turn would rebuild from DB and lose the live
+      // references. Done BEFORE persist so a synchronous reader of
+      // `getMessages()` sees the full conversation immediately.
+      for (const msg of tailMessages) {
+        target.pushMessage(msg);
+      }
+
+      // Persist every tail message (assistant outputs + tool_result
+      // user messages from the loop's own tool execution). If we only
+      // persisted the first assistant message, a rehydration from DB
+      // would have a `tool_use` with no matching `tool_result`, which
+      // the provider would reject on the next turn. Persistence is
+      // delegated to the target so the daemon adapter can build
+      // channel/interface metadata (`provenanceFromTrustContext` + turn
+      // channel/interface contexts) and sync to the disk view, matching
+      // the canonical user-turn path.
+      for (const msg of tailMessages) {
+        try {
+          await target.persistTailMessage(msg);
+        } catch (err) {
+          log.warn(
+            { conversationId, source, err, role: msg.role },
+            "agent-wake: failed to persist wake-tail message",
+          );
+        }
+      }
+
+      return { invoked: true, producedToolCalls };
     } finally {
       // Release the processing marker regardless of success/failure so
       // the next user turn (or wake) isn't blocked waiting on a stale
@@ -370,10 +448,11 @@ export async function wakeAgentForOpportunity(
       // `enqueueMessage()` only queues when `processing === true`, so
       // late sends arriving while the wake was running landed on the
       // queue. The canonical user-turn finally calls drain after
-      // resetting `processing = false`; mirror that here so a queued
-      // message is picked up rather than stranded until the next user
-      // send. Wrapped in try/catch so a drain failure can't propagate
-      // out of the wake.
+      // resetting `processing = false` AND after `ctx.messages` has
+      // been updated with the new tail; mirror that here so a queued
+      // message is picked up against an updated history rather than
+      // stranded behind an out-of-order DB row. Wrapped in try/catch
+      // so a drain failure can't propagate out of the wake.
       if (target.drainQueue) {
         try {
           await target.drainQueue();
@@ -384,93 +463,38 @@ export async function wakeAgentForOpportunity(
           );
         }
       }
-    }
 
-    const durationMs = nowFn() - startedAt;
-    if (runError) {
-      log.error(
-        { conversationId, source, durationMs, err: runError },
-        "agent-wake: agent loop threw; treating as no-op",
-      );
-      return { invoked: true, producedToolCalls: false };
-    }
-
-    const { tailMessages, hasVisibleText, toolUseNames } = inspectWakeOutput(
-      baseline.length,
-      updatedHistory,
-    );
-
-    const producedToolCalls = toolUseNames.length > 0;
-    const producedOutput = producedToolCalls || hasVisibleText;
-
-    if (!producedOutput || tailMessages.length === 0) {
-      log.info(
-        {
-          source,
-          conversationId,
-          durationMs,
-          producedToolCalls: false,
-          toolNamesCalled: [],
-        },
-        "agent-wake: no output; silent no-op",
-      );
-      return { invoked: true, producedToolCalls: false };
-    }
-
-    // Output produced: flush buffered client events through the target's
-    // translator and persist the full tail (assistant messages + any
-    // intervening tool_result user messages) so the DB mirrors the
-    // in-memory history. The internal hint is NOT persisted and NOT
-    // emitted.
-    for (const event of buffered) {
-      try {
-        target.emitAgentEvent(event);
-      } catch (err) {
-        log.warn(
-          { conversationId, source, err },
-          "agent-wake: client emitter threw; continuing",
+      const durationMs = nowFn() - startedAt;
+      if (runError) {
+        log.error(
+          { conversationId, source, durationMs, err: runError },
+          "agent-wake: agent loop threw; treating as no-op",
+        );
+      } else if (tailMessageCount === 0) {
+        log.info(
+          {
+            source,
+            conversationId,
+            durationMs,
+            producedToolCalls: false,
+            toolNamesCalled: [],
+          },
+          "agent-wake: no output; silent no-op",
+        );
+      } else {
+        log.info(
+          {
+            source,
+            conversationId,
+            durationMs,
+            producedToolCalls,
+            toolNamesCalled: toolUseNames,
+            tailMessageCount,
+          },
+          "agent-wake: produced output",
         );
       }
     }
-
-    // Append every tail message to live in-memory history. Without this,
-    // the next turn would rebuild from DB and lose the live references.
-    for (const msg of tailMessages) {
-      target.pushMessage(msg);
-    }
-
-    // Persist every tail message (assistant outputs + tool_result user
-    // messages from the loop's own tool execution). If we only persisted
-    // the first assistant message, a rehydration from DB would have a
-    // `tool_use` with no matching `tool_result`, which the provider
-    // would reject on the next turn. Persistence is delegated to the
-    // target so the daemon adapter can build channel/interface metadata
-    // (`provenanceFromTrustContext` + turn channel/interface contexts)
-    // and sync to the disk view, matching the canonical user-turn path.
-    for (const msg of tailMessages) {
-      try {
-        await target.persistTailMessage(msg);
-      } catch (err) {
-        log.warn(
-          { conversationId, source, err, role: msg.role },
-          "agent-wake: failed to persist wake-tail message",
-        );
-      }
-    }
-
-    log.info(
-      {
-        source,
-        conversationId,
-        durationMs,
-        producedToolCalls,
-        toolNamesCalled: toolUseNames,
-        tailMessageCount: tailMessages.length,
-      },
-      "agent-wake: produced output",
-    );
-
-    return { invoked: true, producedToolCalls };
   });
 }
 


### PR DESCRIPTION
## Summary
The wake's drainQueue() previously ran in finally before the tail messages were pushed to conversation.messages or persisted. A user message queued during the wake would be drained against an outdated history snapshot, producing out-of-chronological DB rows.

Mirroring the canonical user-turn pattern (conversation-agent-loop.ts:1860,2106-2126), the wake now updates the in-memory and persistent history BEFORE drainQueue runs. drainQueue still runs in finally (so it fires even on throw) but only after the tail is in place.

Tests now capture the full call sequence (push/persist/drain) to lock in the ordering.

Part of round-3 plan review for meet-phase-2-chat.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
