### PR TITLE
meet: barge-in cancellation of in-flight TTS

### DIFF
--- a/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
+++ b/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
@@ -1,0 +1,629 @@
+/**
+ * Unit tests for {@link MeetBargeInWatcher}.
+ *
+ * These tests inject a fake meeting-event dispatcher, a fake assistant-
+ * event-hub subscriber, manual timer hooks, and a stub session manager so
+ * each scenario is deterministic. Real provider/dispatcher singletons are
+ * never touched.
+ *
+ * Coverage:
+ *   - Bot-self identification from `participant.change` with `isSelf: true`.
+ *   - Cancel fires only after the debounce window has elapsed AND the bot
+ *     is still speaking AND a non-bot speaker took the floor.
+ *   - Brief (< 250ms) non-bot speaker events do not trigger cancel — the
+ *     pending cancel is cleared when the bot regains the floor or when
+ *     speaking ends.
+ *   - Bot-attributed events (speaker.change to the bot, transcript.chunk
+ *     attributed to the bot, low-confidence chunks) never schedule a cancel.
+ *   - High-confidence interim transcript chunks attributed to a non-bot
+ *     speaker DO schedule a cancel.
+ *   - Watcher does nothing while the bot is not speaking.
+ *   - `stop()` clears the pending cancel and unsubscribes.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { MeetBotEvent } from "@vellumai/meet-contracts";
+
+import type {
+  AssistantEventCallback,
+  AssistantEventSubscription,
+} from "../../../../assistant/src/runtime/assistant-event-hub.js";
+import type { ServerMessage } from "../../../../assistant/src/daemon/message-protocol.js";
+import {
+  buildAssistantEvent,
+  type AssistantEvent,
+} from "../../../../assistant/src/runtime/assistant-event.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
+import {
+  BARGE_IN_DEBOUNCE_MS,
+  type BargeInCanceller,
+  MeetBargeInWatcher,
+} from "../barge-in-watcher.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeFakeDispatcher(): {
+  subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  dispatch: (meetingId: string, event: MeetBotEvent) => void;
+  subscriberCount: (meetingId: string) => number;
+} {
+  const subs = new Map<string, Set<MeetEventSubscriber>>();
+  return {
+    subscribe(meetingId, cb) {
+      let set = subs.get(meetingId);
+      if (!set) {
+        set = new Set();
+        subs.set(meetingId, set);
+      }
+      set.add(cb);
+      return () => {
+        const existing = subs.get(meetingId);
+        if (!existing) return;
+        existing.delete(cb);
+        if (existing.size === 0) subs.delete(meetingId);
+      };
+    },
+    dispatch(meetingId, event) {
+      const set = subs.get(meetingId);
+      if (!set) return;
+      for (const cb of Array.from(set)) cb(event);
+    },
+    subscriberCount(meetingId) {
+      return subs.get(meetingId)?.size ?? 0;
+    },
+  };
+}
+
+function makeFakeAssistantEventHub(): {
+  subscribe: (cb: AssistantEventCallback) => AssistantEventSubscription;
+  publish: (message: ServerMessage) => void;
+  subscriberCount: () => number;
+} {
+  const subs = new Set<AssistantEventCallback>();
+  return {
+    subscribe(cb) {
+      subs.add(cb);
+      let active = true;
+      return {
+        dispose: () => {
+          if (!active) return;
+          active = false;
+          subs.delete(cb);
+        },
+        get active() {
+          return active;
+        },
+      };
+    },
+    publish(message) {
+      const event: AssistantEvent = buildAssistantEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        message,
+      );
+      for (const cb of Array.from(subs)) {
+        void cb(event);
+      }
+    },
+    subscriberCount: () => subs.size,
+  };
+}
+
+function makeFakeSession(): BargeInCanceller & {
+  cancelSpeak: ReturnType<typeof mock>;
+} {
+  return {
+    cancelSpeak: mock(async (_id: string) => {}),
+  };
+}
+
+interface TimerControl {
+  setTimeoutFn: (cb: () => void, ms: number) => unknown;
+  clearTimeoutFn: (handle: unknown) => void;
+  fire: (handle: unknown) => void;
+  fireAll: () => void;
+  /** Map of pending handle → callback. */
+  pending: Map<symbol, { cb: () => void; ms: number }>;
+}
+
+function makeTimerControl(): TimerControl {
+  const pending = new Map<symbol, { cb: () => void; ms: number }>();
+  return {
+    pending,
+    setTimeoutFn(cb, ms) {
+      const handle = Symbol("barge-in-test-timer");
+      pending.set(handle, { cb, ms });
+      return handle;
+    },
+    clearTimeoutFn(handle) {
+      pending.delete(handle as symbol);
+    },
+    fire(handle) {
+      const entry = pending.get(handle as symbol);
+      if (!entry) return;
+      pending.delete(handle as symbol);
+      entry.cb();
+    },
+    fireAll() {
+      const handles = Array.from(pending.keys());
+      for (const handle of handles) {
+        const entry = pending.get(handle);
+        if (!entry) continue;
+        pending.delete(handle);
+        entry.cb();
+      }
+    },
+  };
+}
+
+const MEETING_ID = "m-barge-in";
+const BOT_PARTICIPANT_ID = "bot-self-id";
+const HUMAN_SPEAKER_ID = "human-alice";
+
+function participantChangeWithSelf(): MeetBotEvent {
+  return {
+    type: "participant.change",
+    meetingId: MEETING_ID,
+    timestamp: "2024-01-01T00:00:00.000Z",
+    joined: [{ id: BOT_PARTICIPANT_ID, name: "Velissa", isSelf: true }],
+    left: [],
+  };
+}
+
+function speakerChange(speakerId: string, speakerName = "Alice"): MeetBotEvent {
+  return {
+    type: "speaker.change",
+    meetingId: MEETING_ID,
+    timestamp: "2024-01-01T00:00:01.000Z",
+    speakerId,
+    speakerName,
+  };
+}
+
+function interimTranscript(
+  options: {
+    confidence?: number;
+    speakerId?: string;
+    text?: string;
+  } = {},
+): MeetBotEvent {
+  return {
+    type: "transcript.chunk",
+    meetingId: MEETING_ID,
+    timestamp: "2024-01-01T00:00:01.500Z",
+    isFinal: false,
+    text: options.text ?? "interrupting…",
+    confidence: options.confidence ?? 0.9,
+    speakerId: options.speakerId,
+  };
+}
+
+function speakingStarted(streamId = "stream-1"): ServerMessage {
+  return {
+    type: "meet.speaking_started",
+    meetingId: MEETING_ID,
+    streamId,
+  };
+}
+
+function speakingEnded(
+  streamId = "stream-1",
+  reason: "completed" | "cancelled" | "error" = "completed",
+): ServerMessage {
+  return {
+    type: "meet.speaking_ended",
+    meetingId: MEETING_ID,
+    streamId,
+    reason,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 3; i++) await Promise.resolve();
+}
+
+interface Harness {
+  watcher: MeetBargeInWatcher;
+  dispatcher: ReturnType<typeof makeFakeDispatcher>;
+  hub: ReturnType<typeof makeFakeAssistantEventHub>;
+  timer: TimerControl;
+  session: BargeInCanceller & { cancelSpeak: ReturnType<typeof mock> };
+}
+
+function makeHarness(): Harness {
+  const dispatcher = makeFakeDispatcher();
+  const hub = makeFakeAssistantEventHub();
+  const timer = makeTimerControl();
+  const session = makeFakeSession();
+  const watcher = new MeetBargeInWatcher({
+    meetingId: MEETING_ID,
+    sessionManager: session,
+    subscribe: dispatcher.subscribe,
+    subscribeAssistantEvents: hub.subscribe,
+    setTimeoutFn: timer.setTimeoutFn,
+    clearTimeoutFn: timer.clearTimeoutFn,
+  });
+  watcher.start();
+  return { watcher, dispatcher, hub, timer, session };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MeetBargeInWatcher — bot-self identification", () => {
+  test("captures botSpeakerId from the first participant.change with isSelf", () => {
+    const { watcher, dispatcher } = makeHarness();
+    expect(watcher._getBotSpeakerId()).toBeNull();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    expect(watcher._getBotSpeakerId()).toBe(BOT_PARTICIPANT_ID);
+    watcher.stop();
+  });
+
+  test("ignores subsequent isSelf joiners — first wins", () => {
+    const { watcher, dispatcher } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    expect(watcher._getBotSpeakerId()).toBe(BOT_PARTICIPANT_ID);
+    dispatcher.dispatch(MEETING_ID, {
+      type: "participant.change",
+      meetingId: MEETING_ID,
+      timestamp: "2024-01-01T00:00:05.000Z",
+      joined: [{ id: "different-self", name: "Other", isSelf: true }],
+      left: [],
+    });
+    expect(watcher._getBotSpeakerId()).toBe(BOT_PARTICIPANT_ID);
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — speaking lifecycle", () => {
+  test("does not arm cancel until meet.speaking_started", () => {
+    const { watcher, dispatcher, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+
+    // Bot is not yet speaking — a non-bot speaker change must not schedule
+    // a cancel.
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    expect(timer.pending.size).toBe(0);
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("flips isBotSpeaking on speaking_started/ended events", async () => {
+    const { watcher, hub } = makeHarness();
+    expect(watcher._isBotSpeaking()).toBe(false);
+
+    hub.publish(speakingStarted());
+    await flushPromises();
+    expect(watcher._isBotSpeaking()).toBe(true);
+
+    hub.publish(speakingEnded());
+    await flushPromises();
+    expect(watcher._isBotSpeaking()).toBe(false);
+
+    watcher.stop();
+  });
+
+  test("ignores meet.speaking_* events for a different meetingId", async () => {
+    const { watcher, hub } = makeHarness();
+    hub.publish({
+      type: "meet.speaking_started",
+      meetingId: "different-meeting",
+      streamId: "x",
+    });
+    await flushPromises();
+    expect(watcher._isBotSpeaking()).toBe(false);
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — speaker.change cancel path", () => {
+  test("non-bot speaker.change while bot is speaking schedules a cancel that fires after the debounce", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    // Cancel is queued but not yet fired.
+    expect(watcher._hasPendingCancel()).toBe(true);
+    expect(timer.pending.size).toBe(1);
+    const [{ ms }] = Array.from(timer.pending.values());
+    expect(ms).toBe(BARGE_IN_DEBOUNCE_MS);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    // Fire the timer — cancel runs.
+    timer.fireAll();
+    await flushPromises();
+
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(1);
+    const [calledMeetingId] = session.cancelSpeak.mock.calls[0] as unknown as [
+      string,
+    ];
+    expect(calledMeetingId).toBe(MEETING_ID);
+    expect(watcher._hasPendingCancel()).toBe(false);
+
+    watcher.stop();
+  });
+
+  test("brief non-bot speaker (returns to bot within debounce) does NOT cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    // Brief blip from a human speaker.
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    expect(watcher._hasPendingCancel()).toBe(true);
+
+    // Floor returns to the bot before the debounce expires.
+    dispatcher.dispatch(MEETING_ID, speakerChange(BOT_PARTICIPANT_ID, "Velissa"));
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(timer.pending.size).toBe(0);
+
+    // Even firing any leftover timers should not produce a cancel.
+    timer.fireAll();
+    await flushPromises();
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("speaker.change to the bot while bot is speaking is a no-op", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, speakerChange(BOT_PARTICIPANT_ID, "Velissa"));
+    expect(timer.pending.size).toBe(0);
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("speaking_ended within debounce window cancels the pending cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    expect(watcher._hasPendingCancel()).toBe(true);
+
+    // Stream finishes naturally before the debounce expires.
+    hub.publish(speakingEnded());
+    await flushPromises();
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(timer.pending.size).toBe(0);
+
+    timer.fireAll();
+    await flushPromises();
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("scheduling is idempotent — repeated triggers within the debounce window do not stack timers", async () => {
+    const { watcher, dispatcher, hub, timer } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    dispatcher.dispatch(MEETING_ID, speakerChange("another-human"));
+    dispatcher.dispatch(MEETING_ID, speakerChange("third-human"));
+    expect(timer.pending.size).toBe(1);
+    expect(watcher._hasPendingCancel()).toBe(true);
+
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — transcript.chunk cancel path", () => {
+  test("interim non-bot chunk above confidence threshold schedules a cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(
+      MEETING_ID,
+      interimTranscript({ confidence: 0.85, speakerId: HUMAN_SPEAKER_ID }),
+    );
+    expect(watcher._hasPendingCancel()).toBe(true);
+
+    timer.fireAll();
+    await flushPromises();
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(1);
+
+    watcher.stop();
+  });
+
+  test("interim chunk attributed to the bot does NOT schedule a cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(
+      MEETING_ID,
+      interimTranscript({ confidence: 0.95, speakerId: BOT_PARTICIPANT_ID }),
+    );
+    expect(timer.pending.size).toBe(0);
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("low-confidence interim chunk does NOT schedule a cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(
+      MEETING_ID,
+      interimTranscript({ confidence: 0.3, speakerId: HUMAN_SPEAKER_ID }),
+    );
+    expect(timer.pending.size).toBe(0);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("final transcript chunks (isFinal:true) are ignored — only interim chunks count", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, {
+      type: "transcript.chunk",
+      meetingId: MEETING_ID,
+      timestamp: "2024-01-01T00:00:01.500Z",
+      isFinal: true,
+      text: "I am interrupting",
+      confidence: 0.95,
+      speakerId: HUMAN_SPEAKER_ID,
+    });
+    expect(timer.pending.size).toBe(0);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+
+  test("interim chunk without confidence is ignored — threshold cannot be evaluated", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    const noConfidenceChunk: MeetBotEvent = {
+      type: "transcript.chunk",
+      meetingId: MEETING_ID,
+      timestamp: "2024-01-01T00:00:02.500Z",
+      isFinal: false,
+      text: "background noise",
+      speakerId: HUMAN_SPEAKER_ID,
+    };
+    dispatcher.dispatch(MEETING_ID, noConfidenceChunk);
+
+    expect(timer.pending.size).toBe(0);
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — bot speaking to itself", () => {
+  test("bot speaks with no other speaker activity — no cancel ever fires", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    // No speaker.change, no transcript.chunk — long bot utterance.
+    expect(timer.pending.size).toBe(0);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    hub.publish(speakingEnded());
+    await flushPromises();
+    expect(timer.pending.size).toBe(0);
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — fire-time guard", () => {
+  test("debounced cancel does not call cancelSpeak when bot stopped speaking between schedule and fire", async () => {
+    // Defense-in-depth: even though `meet.speaking_ended` already clears
+    // the pending cancel today, the timer's own callback re-checks
+    // `isBotSpeaking` at fire time. We exercise that guard by capturing
+    // the queued callback, manually flipping the flag without touching
+    // the watcher's clear path, and firing the captured callback.
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    expect(timer.pending.size).toBe(1);
+    const [{ cb }] = Array.from(timer.pending.values());
+
+    // Flip `isBotSpeaking` to false via the production path, but capture
+    // the queued cb BEFORE calling that path so the cb's closure is the
+    // one we'll invoke directly. The production path will also call
+    // clearPendingCancel which removes the timer from `timer.pending`,
+    // but the closure we captured above is still valid.
+    hub.publish(speakingEnded());
+    await flushPromises();
+
+    // Manually invoke the captured callback to simulate a regression in
+    // which the clear path didn't run before the timer fired.
+    cb();
+    await flushPromises();
+
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+    watcher.stop();
+  });
+});
+
+describe("MeetBargeInWatcher — start/stop idempotency", () => {
+  test("double start does not double-subscribe", () => {
+    const { watcher, dispatcher, hub } = makeHarness();
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(1);
+    expect(hub.subscriberCount()).toBe(1);
+    watcher.start();
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(1);
+    expect(hub.subscriberCount()).toBe(1);
+    watcher.stop();
+  });
+
+  test("stop unsubscribes from both the dispatcher and the hub", () => {
+    const { watcher, dispatcher, hub } = makeHarness();
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(1);
+    expect(hub.subscriberCount()).toBe(1);
+    watcher.stop();
+    expect(dispatcher.subscriberCount(MEETING_ID)).toBe(0);
+    expect(hub.subscriberCount()).toBe(0);
+  });
+
+  test("stop clears any pending cancel", async () => {
+    const { watcher, dispatcher, hub, timer, session } = makeHarness();
+    dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+    hub.publish(speakingStarted());
+    await flushPromises();
+    dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+    expect(watcher._hasPendingCancel()).toBe(true);
+
+    watcher.stop();
+    expect(watcher._hasPendingCancel()).toBe(false);
+    expect(timer.pending.size).toBe(0);
+
+    timer.fireAll();
+    await flushPromises();
+    expect(session.cancelSpeak).toHaveBeenCalledTimes(0);
+  });
+
+  test("double stop is safe", () => {
+    const { watcher } = makeHarness();
+    watcher.stop();
+    expect(() => watcher.stop()).not.toThrow();
+  });
+});

--- a/skills/meet-join/daemon/barge-in-watcher.ts
+++ b/skills/meet-join/daemon/barge-in-watcher.ts
@@ -1,0 +1,405 @@
+/**
+ * MeetBargeInWatcher — auto-cancels in-flight TTS playback when a non-bot
+ * speaker takes the floor while the bot is mid-utterance.
+ *
+ * High-level flow:
+ *
+ *   1. Track the bot's own DOM participant id by snooping
+ *      {@link ParticipantChangeEvent}s on the dispatcher and remembering
+ *      the joiner whose `isSelf === true`. Mirrors the same self-detection
+ *      pattern used by {@link MeetSpeakerResolver} and
+ *      {@link MeetConsentMonitor} — the bot's container always emits a
+ *      participant.change with `isSelf: true` shortly after joining.
+ *
+ *   2. Subscribe to `meet.speaking_started` / `meet.speaking_ended` events
+ *      on {@link assistantEventHub} (these are the lifecycle events fired
+ *      by {@link MeetSessionManager.speak}). The watcher only arms its
+ *      barge-in logic while a bot stream is active.
+ *
+ *   3. While the bot is speaking, watch for two trigger signals on the
+ *      meeting's bot-event stream:
+ *        - `SpeakerChangeEvent` with `speakerId !== botSpeakerId` —
+ *          authoritative DOM signal that someone else has the floor.
+ *        - `TranscriptChunkEvent` (interim, confidence > 0.6) attributed
+ *          to a non-bot speaker — ASR-side signal that a non-bot voice
+ *          is producing audio (catches cases where DOM lags).
+ *
+ *   4. When a trigger fires, schedule a cancel via
+ *      {@link MeetSessionManager.cancelSpeak} after a {@link BARGE_IN_DEBOUNCE_MS}
+ *      delay. If the bot stops speaking, the speaker switches back to the
+ *      bot, or speaking ends within that window, the pending cancel is
+ *      cleared. This prevents a brief cough or transient ASR mis-attribution
+ *      from killing legitimate playback.
+ *
+ * Dependency injection keeps the watcher fully testable: subscribe + clock
+ * + timer hooks all default to production wiring but can be swapped for
+ * in-memory shims in unit tests.
+ */
+
+import type {
+  MeetBotEvent,
+  ParticipantChangeEvent,
+  SpeakerChangeEvent,
+  TranscriptChunkEvent,
+} from "@vellumai/meet-contracts";
+
+import {
+  type AssistantEventCallback,
+  type AssistantEventSubscription,
+  assistantEventHub,
+} from "../../../assistant/src/runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../assistant/src/runtime/assistant-scope.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import {
+  type MeetEventSubscriber,
+  type MeetEventUnsubscribe,
+  subscribeToMeetingEvents,
+} from "./event-publisher.js";
+
+const log = getLogger("meet-barge-in-watcher");
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Delay between detecting a non-bot speaker trigger and actually invoking
+ * cancel. Lets brief non-bot blips (a cough, a single mis-attributed ASR
+ * chunk, the bot's own DOM tile flickering for one frame) pass without
+ * killing legitimate playback. The plan calls out 250ms explicitly:
+ * comfortably above typical DOM jitter, well below human perception of
+ * conversational latency.
+ */
+export const BARGE_IN_DEBOUNCE_MS = 250;
+
+/**
+ * Minimum ASR confidence for an interim transcript chunk to count as a
+ * non-bot voice signal. Lower-confidence chunks tend to be background
+ * noise or speculative partials that don't yet justify cancelling
+ * legitimate bot audio.
+ */
+export const BARGE_IN_INTERIM_CONFIDENCE_THRESHOLD = 0.6;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimal session-manager surface the watcher depends on. The real
+ * {@link MeetSessionManager} satisfies this naturally.
+ */
+export interface BargeInCanceller {
+  cancelSpeak(meetingId: string): Promise<void>;
+}
+
+export interface MeetBargeInWatcherDeps {
+  meetingId: string;
+  /** Drives the actual cancel — typically the active session manager. */
+  sessionManager: BargeInCanceller;
+  /**
+   * Override the dispatcher subscribe (tests). Defaults to the production
+   * {@link subscribeToMeetingEvents} helper.
+   */
+  subscribe?: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  /**
+   * Override the assistant-event-hub subscribe (tests). Defaults to the
+   * process-level {@link assistantEventHub} singleton.
+   */
+  subscribeAssistantEvents?: (
+    cb: AssistantEventCallback,
+  ) => AssistantEventSubscription;
+  /** Override `setTimeout` for tests that capture the timer handle. */
+  setTimeoutFn?: (cb: () => void, ms: number) => unknown;
+  /** Override `clearTimeout` paired with {@link setTimeoutFn}. */
+  clearTimeoutFn?: (handle: unknown) => void;
+  /**
+   * Optional override for the debounce window (ms). Defaults to
+   * {@link BARGE_IN_DEBOUNCE_MS}. Tests use this to make the window
+   * deterministic without juggling the timer hook.
+   */
+  debounceMs?: number;
+  /**
+   * Optional override for the interim-chunk confidence floor. Defaults
+   * to {@link BARGE_IN_INTERIM_CONFIDENCE_THRESHOLD}. Tests use this to
+   * exercise the threshold without having to construct boundary-precision
+   * floats.
+   */
+  interimConfidenceThreshold?: number;
+}
+
+// ---------------------------------------------------------------------------
+// MeetBargeInWatcher
+// ---------------------------------------------------------------------------
+
+export class MeetBargeInWatcher {
+  private readonly meetingId: string;
+  private readonly sessionManager: BargeInCanceller;
+  private readonly subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  private readonly subscribeAssistantEvents: (
+    cb: AssistantEventCallback,
+  ) => AssistantEventSubscription;
+  private readonly setTimeoutFn: (cb: () => void, ms: number) => unknown;
+  private readonly clearTimeoutFn: (handle: unknown) => void;
+  private readonly debounceMs: number;
+  private readonly interimConfidenceThreshold: number;
+
+  /** Bot's DOM participant id, captured from the first `isSelf` joiner. */
+  private botSpeakerId: string | null = null;
+
+  /** True between `meet.speaking_started` and `meet.speaking_ended`. */
+  private isBotSpeaking = false;
+
+  /** Debounce timer for a pending cancel. `null` when no cancel is queued. */
+  private pendingCancelHandle: unknown = null;
+
+  private dispatcherUnsubscribe: MeetEventUnsubscribe | null = null;
+  private hubSubscription: AssistantEventSubscription | null = null;
+
+  constructor(deps: MeetBargeInWatcherDeps) {
+    this.meetingId = deps.meetingId;
+    this.sessionManager = deps.sessionManager;
+    this.subscribe = deps.subscribe ?? subscribeToMeetingEvents;
+    this.subscribeAssistantEvents =
+      deps.subscribeAssistantEvents ??
+      ((cb) =>
+        assistantEventHub.subscribe(
+          { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+          cb,
+        ));
+    this.setTimeoutFn =
+      deps.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimeoutFn =
+      deps.clearTimeoutFn ??
+      ((handle) =>
+        clearTimeout(handle as ReturnType<typeof setTimeout>));
+    this.debounceMs = deps.debounceMs ?? BARGE_IN_DEBOUNCE_MS;
+    this.interimConfidenceThreshold =
+      deps.interimConfidenceThreshold ??
+      BARGE_IN_INTERIM_CONFIDENCE_THRESHOLD;
+  }
+
+  /**
+   * Begin observing the meeting. Idempotent — calling `start` twice is a
+   * no-op so the session manager doesn't have to track lifecycle state.
+   */
+  start(): void {
+    if (this.dispatcherUnsubscribe || this.hubSubscription) return;
+
+    this.dispatcherUnsubscribe = this.subscribe(this.meetingId, (event) =>
+      this.onMeetingEvent(event),
+    );
+    this.hubSubscription = this.subscribeAssistantEvents((event) =>
+      this.onAssistantEvent(event),
+    );
+  }
+
+  /**
+   * Tear down the dispatcher + hub subscriptions and clear any pending
+   * cancel timer. Idempotent.
+   */
+  stop(): void {
+    this.clearPendingCancel();
+
+    if (this.dispatcherUnsubscribe) {
+      try {
+        this.dispatcherUnsubscribe();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetBargeInWatcher: dispatcher unsubscribe threw",
+        );
+      }
+      this.dispatcherUnsubscribe = null;
+    }
+
+    if (this.hubSubscription) {
+      try {
+        this.hubSubscription.dispose();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "MeetBargeInWatcher: assistant-event-hub dispose threw",
+        );
+      }
+      this.hubSubscription = null;
+    }
+
+    // Reset speaking state so a re-start (e.g. test) doesn't inherit the
+    // last meeting's flag.
+    this.isBotSpeaking = false;
+  }
+
+  /** Test-only: read the bot's discovered speaker id. */
+  _getBotSpeakerId(): string | null {
+    return this.botSpeakerId;
+  }
+
+  /** Test-only: read the bot-speaking flag. */
+  _isBotSpeaking(): boolean {
+    return this.isBotSpeaking;
+  }
+
+  /** Test-only: true while a debounced cancel is queued. */
+  _hasPendingCancel(): boolean {
+    return this.pendingCancelHandle !== null;
+  }
+
+  // ── Event handling ────────────────────────────────────────────────────────
+
+  private onMeetingEvent(event: MeetBotEvent): void {
+    try {
+      switch (event.type) {
+        case "participant.change":
+          this.onParticipantChange(event);
+          return;
+        case "speaker.change":
+          this.onSpeakerChange(event);
+          return;
+        case "transcript.chunk":
+          this.onTranscriptChunk(event);
+          return;
+        default:
+          return;
+      }
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId, eventType: event.type },
+        "MeetBargeInWatcher: meeting-event handler threw",
+      );
+    }
+  }
+
+  private onAssistantEvent(event: { message: { type: string; meetingId?: string } }): void {
+    const message = event.message;
+    // Filter to our own meeting only — the assistant event hub fans every
+    // assistant event to every subscriber, so we have to gate on meetingId
+    // ourselves. `meetingId` is part of the `meet.speaking_*` payload shape.
+    if (message.meetingId !== this.meetingId) return;
+
+    if (message.type === "meet.speaking_started") {
+      this.isBotSpeaking = true;
+      // Speaking_started arrives *before* any audio has hit the wire, so
+      // there's no in-flight cancel state to clear here. We still drop a
+      // potentially-stale pending cancel just in case the previous
+      // utterance ended in a barge-in that we never fired (defensive).
+      this.clearPendingCancel();
+      return;
+    }
+
+    if (message.type === "meet.speaking_ended") {
+      this.isBotSpeaking = false;
+      // Stream is over — any pending cancel for this stream is moot.
+      this.clearPendingCancel();
+      return;
+    }
+  }
+
+  private onParticipantChange(event: ParticipantChangeEvent): void {
+    // Snapshot the bot's DOM participant id from the first `isSelf` joiner
+    // we see. The bot's `isSelf` participant arrives shortly after the
+    // container joins; once captured, we don't overwrite it (a re-join
+    // would mint a new id, but in practice the watcher is dropped and
+    // recreated alongside the session).
+    if (this.botSpeakerId !== null) return;
+    for (const participant of event.joined) {
+      if (participant.isSelf === true) {
+        this.botSpeakerId = participant.id;
+        return;
+      }
+    }
+  }
+
+  private onSpeakerChange(event: SpeakerChangeEvent): void {
+    if (!this.isBotSpeaking) return;
+
+    if (this.botSpeakerId !== null && event.speakerId === this.botSpeakerId) {
+      // Floor returned to the bot — cancel any debounced cancel that was
+      // triggered by a transient non-bot blip.
+      this.clearPendingCancel();
+      return;
+    }
+
+    // Non-bot speaker took the floor (or we don't yet know the bot's id —
+    // be conservative and treat unknown as non-bot, since the watcher only
+    // fires while bot audio is mid-flight).
+    this.scheduleCancel("speaker.change");
+  }
+
+  private onTranscriptChunk(event: TranscriptChunkEvent): void {
+    if (!this.isBotSpeaking) return;
+    // Only interim chunks count for barge-in: finals are too late to be
+    // a useful real-time signal, and the speaker.change path covers the
+    // authoritative DOM-derived signal.
+    if (event.isFinal) return;
+
+    if (event.confidence === undefined) return;
+    if (event.confidence <= this.interimConfidenceThreshold) return;
+
+    // Drop chunks attributed to the bot itself. Both `speakerId` (preferred)
+    // and `speakerLabel` are checked — the bot is a silent listener so this
+    // should be vanishingly rare, but cheap defense-in-depth keeps us from
+    // firing on a mis-tagged echo of the bot's own audio.
+    if (
+      this.botSpeakerId !== null &&
+      event.speakerId !== undefined &&
+      event.speakerId === this.botSpeakerId
+    ) {
+      return;
+    }
+
+    // ASR can produce interim chunks with no speaker attribution at all.
+    // Those still count as a non-bot voice signal: the bot is a silent
+    // listener, so any audible voice in the room is by definition not the
+    // bot.
+    this.scheduleCancel("transcript.chunk");
+  }
+
+  // ── Debounced cancel ──────────────────────────────────────────────────────
+
+  private scheduleCancel(trigger: string): void {
+    // If a cancel is already queued, leave it alone — the existing timer
+    // will fire at its original deadline. Re-arming on every trigger would
+    // *delay* the cancel, which is the opposite of what we want: we want
+    // the first non-bot signal to start the clock and the cancel to fire
+    // 250ms after that signal (subject to the bot resuming the floor).
+    if (this.pendingCancelHandle !== null) return;
+
+    this.pendingCancelHandle = this.setTimeoutFn(() => {
+      this.pendingCancelHandle = null;
+      // Re-check at fire time — `isBotSpeaking` may have been flipped
+      // off by `meet.speaking_ended` between scheduling and firing, in
+      // which case there's nothing left to cancel.
+      if (!this.isBotSpeaking) return;
+
+      log.info(
+        { meetingId: this.meetingId, trigger },
+        "Meet barge-in: cancelling in-flight TTS",
+      );
+      void this.sessionManager.cancelSpeak(this.meetingId).catch((err) => {
+        log.warn(
+          { err, meetingId: this.meetingId, trigger },
+          "MeetBargeInWatcher: cancelSpeak rejected",
+        );
+      });
+    }, this.debounceMs);
+  }
+
+  private clearPendingCancel(): void {
+    if (this.pendingCancelHandle === null) return;
+    try {
+      this.clearTimeoutFn(this.pendingCancelHandle);
+    } catch (err) {
+      log.warn(
+        { err, meetingId: this.meetingId },
+        "MeetBargeInWatcher: clearTimeout threw",
+      );
+    }
+    this.pendingCancelHandle = null;
+  }
+}

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -79,6 +79,10 @@ import { getLogger } from "../../../assistant/src/util/logger.js";
 import { getWorkspaceDir } from "../../../assistant/src/util/platform.js";
 import { MeetAudioIngest } from "./audio-ingest.js";
 import {
+  type BargeInCanceller,
+  MeetBargeInWatcher,
+} from "./barge-in-watcher.js";
+import {
   type ChatOpportunityDecision,
   type ChatOpportunityDetectorStats,
   type ChatOpportunityLLMAsk,
@@ -294,6 +298,13 @@ interface ActiveSession extends MeetSession {
    * `leave()` so no orphan stream outlives the container.
    */
   ttsBridge: MeetTtsBridgeLike;
+  /**
+   * Barge-in watcher for this meeting — auto-cancels in-flight TTS when
+   * a non-bot speaker takes the floor while the bot is mid-utterance.
+   * Started in `join()` immediately after the session record is in place
+   * and torn down in `leave()` before the dispatcher is unregistered.
+   */
+  bargeInWatcher: MeetBargeInWatcherLike;
 }
 
 /**
@@ -366,6 +377,17 @@ export interface MeetTtsBridgeLike {
   activeStreamCount(): number;
 }
 
+/**
+ * Thin interface for the barge-in watcher surface the session manager
+ * uses. Lets tests swap in a fake to observe `start`/`stop` without
+ * spinning up the dispatcher + assistant-event-hub subscriptions. The
+ * real {@link MeetBargeInWatcher} satisfies this naturally.
+ */
+export interface MeetBargeInWatcherLike {
+  start(): void;
+  stop(): void;
+}
+
 /** Arguments passed to {@link MeetSessionManagerDeps.consentMonitorFactory}. */
 export interface MeetConsentMonitorFactoryArgs {
   meetingId: string;
@@ -390,6 +412,12 @@ export interface MeetTtsBridgeFactoryArgs {
   meetingId: string;
   botBaseUrl: string;
   botApiToken: string;
+}
+
+/** Arguments passed to {@link MeetSessionManagerDeps.bargeInWatcherFactory}. */
+export interface MeetBargeInWatcherFactoryArgs {
+  meetingId: string;
+  sessionManager: BargeInCanceller;
 }
 
 /**
@@ -493,6 +521,16 @@ export interface MeetSessionManagerDeps {
    */
   ttsBridgeFactory?: (args: MeetTtsBridgeFactoryArgs) => MeetTtsBridgeLike;
   /**
+   * Override the barge-in watcher factory. Default constructs a
+   * {@link MeetBargeInWatcher} that subscribes to the meeting's
+   * dispatcher and the {@link assistantEventHub} for `meet.speaking_*`
+   * events. Tests can inject a fake to observe `start`/`stop` without
+   * spinning up the subscription stack.
+   */
+  bargeInWatcherFactory?: (
+    args: MeetBargeInWatcherFactoryArgs,
+  ) => MeetBargeInWatcherLike;
+  /**
    * Override the function the session manager calls to wake the agent
    * loop when the detector fires an opportunity. Default routes through
    * the runtime-level {@link wakeAgentForOpportunity} using the
@@ -547,6 +585,8 @@ class MeetSessionManagerImpl {
         defaultChatOpportunityDetectorFactory,
       ttsBridgeFactory:
         deps.ttsBridgeFactory ?? defaultTtsBridgeFactory,
+      bargeInWatcherFactory:
+        deps.bargeInWatcherFactory ?? defaultBargeInWatcherFactory,
       wakeAgent: deps.wakeAgent ?? defaultWakeAgent,
     };
 
@@ -592,6 +632,11 @@ class MeetSessionManagerImpl {
       }
       try {
         void session.ttsBridge.cancelAll();
+      } catch {
+        /* best-effort */
+      }
+      try {
+        session.bargeInWatcher.stop();
       } catch {
         /* best-effort */
       }
@@ -883,6 +928,16 @@ class MeetSessionManagerImpl {
       botApiToken,
     });
 
+    // Barge-in watcher — auto-cancels in-flight TTS when a non-bot speaker
+    // takes the floor mid-utterance. Subscribes to the dispatcher and the
+    // assistant-event-hub for `meet.speaking_*` lifecycle. Constructed
+    // before the session record is in place so the field is non-null on
+    // first read; `start()` runs below alongside the other subscribers.
+    const bargeInWatcher = this.deps.bargeInWatcherFactory({
+      meetingId,
+      sessionManager: this,
+    });
+
     const startedAt = Date.now();
     const session: ActiveSession = {
       meetingId,
@@ -901,6 +956,7 @@ class MeetSessionManagerImpl {
       storageWriter,
       chatOpportunityDetector,
       ttsBridge,
+      bargeInWatcher,
     };
     this.sessions.set(meetingId, session);
 
@@ -965,6 +1021,12 @@ class MeetSessionManagerImpl {
     // Chat-opportunity detector subscribes to the same dispatcher. Skipped
     // entirely when `proactiveChat.enabled === false` (detector is null).
     chatOpportunityDetector?.start();
+
+    // Barge-in watcher subscribes to the dispatcher (for speaker.change /
+    // transcript.chunk / participant.change) and the assistant-event-hub
+    // (for `meet.speaking_*` lifecycle). Auto-cancels in-flight TTS when
+    // a non-bot speaker takes the floor.
+    bargeInWatcher.start();
 
     // Max-meeting-minutes hard cap. Using setTimeout keeps this compatible
     // with Bun's fake-timer harness for tests.
@@ -1032,6 +1094,19 @@ class MeetSessionManagerImpl {
       log.warn(
         { err, meetingId },
         "MeetChatOpportunityDetector.dispose threw during leave — continuing teardown",
+      );
+    }
+
+    // Stop the barge-in watcher before we cancel any in-flight TTS so the
+    // synthetic `meet.speaking_ended` events emitted by `cancelAll` below
+    // don't trigger any dispatcher work in the watcher. Also clears any
+    // pending debounced cancel that hasn't fired yet.
+    try {
+      session.bargeInWatcher.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "MeetBargeInWatcher.stop threw during leave — continuing teardown",
       );
     }
 
@@ -1419,6 +1494,11 @@ class MeetSessionManagerImpl {
             /* best-effort */
           }
           try {
+            lingering.bargeInWatcher.stop();
+          } catch {
+            /* best-effort */
+          }
+          try {
             await lingering.ttsBridge.cancelAll();
           } catch {
             /* best-effort */
@@ -1638,6 +1718,20 @@ function defaultTtsBridgeFactory(
     },
   };
   return new MeetTtsBridge(bridgeArgs, bridgeDeps);
+}
+
+/**
+ * Default {@link MeetBargeInWatcher} factory — wires the watcher to the
+ * production dispatcher + assistant-event-hub. Tests can inject a fake
+ * via {@link MeetSessionManagerDeps.bargeInWatcherFactory}.
+ */
+function defaultBargeInWatcherFactory(
+  args: MeetBargeInWatcherFactoryArgs,
+): MeetBargeInWatcherLike {
+  return new MeetBargeInWatcher({
+    meetingId: args.meetingId,
+    sessionManager: args.sessionManager,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds MeetBargeInWatcher that subscribes to SpeakerChangeEvent + interim TranscriptChunkEvent and meet.speaking_* events
- Cancels in-flight TTS via MeetSessionManager.cancelSpeak when a non-bot speaker takes the floor while the bot is speaking
- 250ms debounce prevents brief non-bot blips from triggering cancel; watcher is hooked into MeetSessionManager.join

Part of plan: meet-phase-3-voice.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
