### PR TITLE
Degrade gracefully when inner dockerd fails to start

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -72,8 +72,12 @@ start_dockerd_if_containerized() {
     return 0
   fi
 
-  echo "[vellum-init] dockerd did not become ready within 30s; see ${DOCKERD_LOG}" >&2
-  exit 1
+  # Keep the assistant booting even when the inner Docker Engine is
+  # unavailable. Features that require nested containers (for example,
+  # Meet bot spawning) already fail lazily with a clear runtime error when
+  # they probe /var/run/docker.sock.
+  echo "[vellum-init] dockerd did not become ready within 30s; continuing without nested container support; see ${DOCKERD_LOG}" >&2
+  return 0
 }
 
 start_dockerd_if_containerized

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -72,6 +72,12 @@ start_dockerd_if_containerized() {
     return 0
   fi
 
+  # Kill the stale dockerd from the last failed attempt before continuing.
+  if [ -n "${DOCKERD_PID:-}" ] && kill -0 "${DOCKERD_PID}" 2>/dev/null; then
+    kill "${DOCKERD_PID}" 2>/dev/null || true
+    wait "${DOCKERD_PID}" 2>/dev/null || true
+  fi
+
   # Keep the assistant booting even when the inner Docker Engine is
   # unavailable. Features that require nested containers (for example,
   # Meet bot spawning) already fail lazily with a clear runtime error when


### PR DESCRIPTION
## Summary
- keep the assistant container booting when both overlay2 and vfs inner-dockerd startup attempts fail
- log an explicit degraded-mode warning so operators can see nested container support is unavailable
- rely on the existing lazy runtime error path for meet features that require /var/run/docker.sock

## Original prompt
assistant in minkube is doing this │ assistant-container [vellum-init] starting dockerd (--storage-driver=overlay2)
│ assistant-container [vellum-init] dockerd exited during startup (storage-driver=overlay2)
│ assistant-container [vellum-init] overlay2 dockerd startup failed; falling back to vfs
│ assistant-container [vellum-init] starting dockerd (--storage-driver=vfs)
│ assistant-container [vellum-init] dockerd exited during startup (storage-driver=vfs)
│ gateway-sidecar       "thinking",
│ assistant-container [vellum-init] dockerd did not become ready within 30s; see /var/log/dockerd.log

and its causing a crash loop startup can you make sure the assistant can still start dispite a problem with docker daemon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
