### PR TITLE
fix(ci): flaky send-endpoint-busy test + stale OpenAPI spec

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1335,6 +1335,562 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/btw:
+    post:
+      operationId: btw_post
+      summary: Run ephemeral LLM side-chain
+      description:
+        Stream an ephemeral LLM call reusing the conversation's provider and message history. Response is SSE
+        (btw_text_delta, btw_complete, btw_error).
+      tags:
+        - btw
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Conversation key to scope the call
+                content:
+                  type: string
+                  description: User prompt content
+              required:
+                - conversationKey
+                - content
+              additionalProperties: false
+  /v1/calls/{id}:
+    get:
+      operationId: calls_by_id_get
+      summary: Get call status
+      description: Return the current status and details of a call session.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  conversationId:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  provider:
+                    type: string
+                  providerCallSid:
+                    type: string
+                  task:
+                    type: string
+                  startedAt:
+                    type: string
+                  endedAt:
+                    type: string
+                  lastError:
+                    type: string
+                  pendingQuestion:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - callSessionId
+                  - conversationId
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - provider
+                  - providerCallSid
+                  - task
+                  - startedAt
+                  - endedAt
+                  - lastError
+                  - pendingQuestion
+                  - createdAt
+                  - updatedAt
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/calls/{id}/answer:
+    post:
+      operationId: calls_by_id_answer_post
+      summary: Answer a pending call question
+      description: Provide an answer to a pending question during an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  questionId:
+                    type: string
+                required:
+                  - ok
+                  - questionId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                answer:
+                  type: string
+                  description: Answer text
+                pendingQuestionId:
+                  type: string
+                  description: ID of the pending question
+              required:
+                - answer
+                - pendingQuestionId
+              additionalProperties: false
+  /v1/calls/{id}/cancel:
+    post:
+      operationId: calls_by_id_cancel_post
+      summary: Cancel a call
+      description: Cancel an active or pending call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  status:
+                    type: string
+                required:
+                  - callSessionId
+                  - status
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Cancellation reason
+              required:
+                - reason
+              additionalProperties: false
+  /v1/calls/{id}/instruction:
+    post:
+      operationId: calls_by_id_instruction_post
+      summary: Relay instruction to active call
+      description: Send a real-time instruction to an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+                  description: Instruction text to relay
+              required:
+                - instruction
+              additionalProperties: false
+  /v1/calls/start:
+    post:
+      operationId: calls_start_post
+      summary: Start a call
+      description: Initiate a new outbound phone call. Supports idempotency keys to prevent duplicate calls.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  callSid:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  callerIdentityMode:
+                    type: string
+                required:
+                  - callSessionId
+                  - callSid
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - callerIdentityMode
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phoneNumber:
+                  type: string
+                  description: Phone number to call
+                task:
+                  type: string
+                  description: Task description for the call
+                context:
+                  type: string
+                  description: Additional context for the call
+                conversationId:
+                  type: string
+                  description: Conversation to associate with
+                callerIdentityMode:
+                  type: string
+                  description: "Caller identity: 'assistant_number' or 'user_number'"
+                idempotencyKey:
+                  type: string
+                  description: Idempotency key to prevent duplicate calls
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/channel-verification-sessions:
+    delete:
+      operationId: channelverificationsessions_delete
+      summary: Cancel verification sessions
+      description: Cancel all active inbound and outbound verification sessions.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  channel:
+                    type: string
+                required:
+                  - success
+                  - channel
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+    post:
+      operationId: channelverificationsessions_post
+      summary: Create verification session
+      description: Create a channel verification session (inbound challenge, outbound, or trusted contact).
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Channel ID
+                destination:
+                  type: string
+                  description: Outbound destination
+                rebind:
+                  type: boolean
+                conversationId:
+                  type: string
+                originConversationId:
+                  type: string
+                purpose:
+                  type: string
+                  description: guardian or trusted_contact
+                contactChannelId:
+                  type: string
+              required:
+                - channel
+                - destination
+                - rebind
+                - conversationId
+                - originConversationId
+                - purpose
+                - contactChannelId
+              additionalProperties: false
+  /v1/channel-verification-sessions/resend:
+    post:
+      operationId: channelverificationsessions_resend_post
+      summary: Resend verification code
+      description: Resend the outbound verification code.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                originConversationId:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/revoke:
+    post:
+      operationId: channelverificationsessions_revoke_post
+      summary: Revoke verification binding
+      description: Cancel all sessions and revoke the guardian binding.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/status:
+    get:
+      operationId: channelverificationsessions_status_get
+      summary: Get verification status
+      description: Check guardian binding and verification session status.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
+  /v1/channels/conversation:
+    delete:
+      operationId: channels_conversation_delete
+      summary: Delete channel conversation
+      description: Delete a conversation by channel source.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/dead-letters:
+    get:
+      operationId: channels_deadletters_get
+      summary: List dead letters
+      description: Return undeliverable channel messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/delivery-ack:
+    post:
+      operationId: channels_deliveryack_post
+      summary: Acknowledge channel delivery
+      description: Acknowledge delivery of a channel message.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/inbound:
+    post:
+      operationId: channels_inbound_post
+      summary: Process inbound channel message
+      description: Receive an inbound message from a channel integration.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/readiness:
+    get:
+      operationId: channels_readiness_get
+      summary: Get channel readiness
+      description: Return readiness snapshots for one or all channels.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Channel readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
+        - name: includeRemote
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Include remote checks (default true)
+  /v1/channels/readiness/refresh:
+    post:
+      operationId: channels_readiness_refresh_post
+      summary: Refresh channel readiness
+      description: Invalidate cache and re-evaluate channel readiness.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Refreshed readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Optional channel ID to refresh
+                includeRemote:
+                  type: boolean
+                  description: Include remote checks (default true)
+              required:
+                - channel
+                - includeRemote
+              additionalProperties: false
+  /v1/channels/replay:
+    post:
+      operationId: channels_replay_post
+      summary: Replay dead letters
+      description: Retry delivery of dead-letter messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
   /v1/computer-use/watch:
     post:
       operationId: computeruse_watch_post
@@ -1401,6 +1957,58 @@ paths:
                 - captureIndex
                 - totalExpected
               additionalProperties: false
+  /v1/config:
+    get:
+      operationId: config_get
+      summary: Get full config
+      description: Return the raw settings.json configuration object.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    patch:
+      operationId: config_patch
+      summary: Patch config
+      description: Deep-merge a partial JSON object into the settings.json configuration.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/config/embeddings:
+    get:
+      operationId: config_embeddings_get
+      summary: Get embedding config
+      description: Return the active embedding provider, model, and available options.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    put:
+      operationId: config_embeddings_put
+      summary: Set embedding config
+      description: Change the embedding provider and optionally model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                model:
+                  type: string
+              required:
+                - provider
+              additionalProperties: false
   /v1/config/platform:
     get:
       operationId: config_platform_get
@@ -1444,6 +2052,49 @@ paths:
                   type: string
               required:
                 - baseUrl
+              additionalProperties: false
+  /v1/confirm:
+    post:
+      operationId: confirm_post
+      summary: Resolve a pending confirmation
+      description: Approve or deny a pending tool confirmation by requestId.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                decision:
+                  type: string
+                  description: "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny, always_allow_high_risk"
+                selectedPattern:
+                  type: string
+                  description: Allowlist pattern for persistent decisions
+                selectedScope:
+                  type: string
+                  description: Scope for persistent decisions
+              required:
+                - requestId
+                - decision
               additionalProperties: false
   /v1/contact-channels/{contactChannelId}:
     patch:
@@ -1679,6 +2330,223 @@ paths:
                 - address
                 - externalUserId
               additionalProperties: false
+  /v1/contacts/invites:
+    get:
+      operationId: contacts_invites_get
+      summary: List invites
+      description: Return all invites, optionally filtered by sourceChannel or status.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invites:
+                    type: array
+                    items: {}
+                    description: Invite objects
+                required:
+                  - ok
+                  - invites
+                additionalProperties: false
+      parameters:
+        - name: sourceChannel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by source channel
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by invite status
+    post:
+      operationId: contacts_invites_post
+      summary: Create an invite
+      description: Create a new invite. Supports voice invites when sourceChannel is "phone".
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Created invite
+                required:
+                  - ok
+                  - invite
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contactId:
+                  type: string
+                  description: Contact to invite
+                sourceChannel:
+                  type: string
+                  description: Source channel (e.g. phone)
+                note:
+                  type: string
+                  description: Optional note
+                maxUses:
+                  type: number
+                  description: Max redemptions
+                expiresInMs:
+                  type: number
+                  description: Expiry duration in ms
+                contactName:
+                  type: string
+                  description: Contact display name
+                expectedExternalUserId:
+                  type: string
+                  description: Expected user ID (E.164 for phone)
+                friendName:
+                  type: string
+                  description: Friend name for the invite
+                guardianName:
+                  type: string
+                  description: Guardian name
+              required:
+                - contactId
+              additionalProperties: false
+  /v1/contacts/invites/{id}:
+    delete:
+      operationId: contacts_invites_by_id_delete
+      summary: Revoke an invite
+      description: Revoke an invite by ID.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/{id}/call:
+    post:
+      operationId: contacts_invites_by_id_call_post
+      summary: Trigger invite call
+      description: Trigger an outbound call for a phone invite.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  callSid:
+                    type: string
+                    description: Call SID from the provider
+                required:
+                  - ok
+                  - callSid
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/redeem:
+    post:
+      operationId: contacts_invites_redeem_post
+      summary: Redeem an invite
+      description: Redeem an invite by token or voice code.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Redeemed invite (token path)
+                  type:
+                    type: string
+                    description: Redemption type (voice path)
+                  memberId:
+                    type: string
+                    description: Member ID (voice path)
+                required:
+                  - ok
+                  - invite
+                  - type
+                  - memberId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  description: Invite token (token-based redemption)
+                code:
+                  type: string
+                  description: Voice code (voice-code redemption)
+                callerExternalUserId:
+                  type: string
+                  description: Caller E.164 phone (voice-code)
+                externalUserId:
+                  type: string
+                  description: External user ID (token-based)
+                externalChatId:
+                  type: string
+                  description: External chat ID (token-based)
+                sourceChannel:
+                  type: string
+                  description: Source channel (token-based)
+                assistantId:
+                  type: string
+                  description: Assistant ID (voice-code)
+              required:
+                - token
+                - code
+                - callerExternalUserId
+                - externalUserId
+                - externalChatId
+                - sourceChannel
+                - assistantId
+              additionalProperties: false
   /v1/contacts/merge:
     post:
       operationId: contacts_merge_post
@@ -1779,17 +2647,334 @@ paths:
             type: string
           description: Scope ID (default "default")
   /v1/conversations:
+    delete:
+      operationId: conversations_delete
+      summary: Clear all conversations
+      description: Permanently delete ALL conversations, messages, and memory. Requires X-Confirm-Destructive header.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
     get:
       operationId: conversations_get
       responses:
         "200":
           description: Successful response
+    post:
+      operationId: conversations_post
+      summary: Create a conversation
+      description: Create or get an existing conversation by key.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  conversationKey:
+                    type: string
+                  conversationType:
+                    type: string
+                required:
+                  - id
+                  - conversationKey
+                  - conversationType
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Idempotency key for the conversation
+                conversationType:
+                  type: string
+                  description: "'standard' (default) or 'private'"
+              required:
+                - conversationKey
+                - conversationType
+              additionalProperties: false
   /v1/conversations/{id}:
+    delete:
+      operationId: conversations_by_id_delete
+      summary: Delete a conversation
+      description: Permanently delete a single conversation and its messages.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
     get:
       operationId: conversations_by_id_get
       responses:
         "200":
           description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/analyze:
+    post:
+      operationId: conversations_by_id_analyze_post
+      summary: Analyze a conversation
+      description: Create a new conversation with a structured self-assessment of an existing conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/archive:
+    post:
+      operationId: conversations_by_id_archive_post
+      summary: Archive a conversation
+      description:
+        Move a conversation to the archived state. Archived conversations are hidden from the default sidebar but
+        preserved for search and recall.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/cancel:
+    post:
+      operationId: conversations_by_id_cancel_post
+      summary: Cancel generation
+      description: Abort the in-progress assistant response for a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/host-access:
+    get:
+      operationId: conversations_by_id_hostaccess_get
+      summary: Get conversation host access
+      description: Return whether the conversation can use host tools.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - hostAccess
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: conversations_by_id_hostaccess_patch
+      summary: Update conversation host access
+      description: Enable or disable host access for a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - hostAccess
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hostAccess:
+                  type: boolean
+              required:
+                - hostAccess
+              additionalProperties: false
+  /v1/conversations/{id}/name:
+    patch:
+      operationId: conversations_by_id_name_patch
+      summary: Rename a conversation
+      description: Update the display name of a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+              additionalProperties: false
+  /v1/conversations/{id}/regenerate:
+    post:
+      operationId: conversations_by_id_regenerate_post
+      summary: Regenerate response
+      description: Re-run the assistant for the last user message in a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/unarchive:
+    post:
+      operationId: conversations_by_id_unarchive_post
+      summary: Unarchive a conversation
+      description: Restore an archived conversation back to the default sidebar.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/undo:
+    post:
+      operationId: conversations_by_id_undo_post
+      summary: Undo last message
+      description: Remove the most recent user+assistant message pair from the conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removedCount:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  conversationId:
+                    type: string
+                required:
+                  - removedCount
+                  - conversationId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/wipe:
+    post:
+      operationId: conversations_by_id_wipe_post
+      summary: Wipe a conversation
+      description: Delete all messages in a conversation and revert associated memory changes.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  wiped:
+                    type: boolean
+                  unsupersededItems:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  deletedSummaries:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  cancelledJobs:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - wiped
+                  - unsupersededItems
+                  - deletedSummaries
+                  - cancelledJobs
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -1852,12 +3037,129 @@ paths:
           schema:
             type: number
           description: Cursor for pagination (timestamp)
+  /v1/conversations/fork:
+    post:
+      operationId: conversations_fork_post
+      summary: Fork a conversation
+      description: Create a copy of a conversation, optionally truncated at a specific message.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                throughMessageId:
+                  type: string
+                  description: Truncate the fork at this message
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/conversations/reorder:
+    post:
+      operationId: conversations_reorder_post
+      summary: Reorder conversations
+      description: Batch-update display order and pin state for conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updates:
+                  type: array
+                  items: {}
+                  description: Array of { conversationId, displayOrder?, isPinned? } objects
+              required:
+                - updates
+              additionalProperties: false
+  /v1/conversations/search:
+    get:
+      operationId: conversations_search_get
+      summary: Search conversations
+      description: Full-text search across conversation titles and message content.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
   /v1/conversations/seen:
     post:
       operationId: conversations_seen_post
       responses:
         "200":
           description: Successful response
+  /v1/conversations/switch:
+    post:
+      operationId: conversations_switch_post
+      summary: Switch active conversation
+      description: Set the active conversation for the current session.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  title:
+                    type: string
+                  conversationType:
+                    type: string
+                  hostAccess:
+                    type: boolean
+                required:
+                  - conversationId
+                  - title
+                  - conversationType
+                  - hostAccess
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                conversationKey:
+                  type: string
+                  description: Optional key to register for this conversation
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/unread:
     post:
       operationId: conversations_unread_post
@@ -2111,6 +3413,23 @@ paths:
           required: true
           schema:
             type: string
+  /v1/events:
+    get:
+      operationId: events_get
+      summary: Subscribe to assistant events
+      description: Stream assistant events as Server-Sent Events (SSE).
+      tags:
+        - events
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: conversationKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Scope to a single conversation
   /v1/export:
     post:
       operationId: export_post
@@ -2327,6 +3646,87 @@ paths:
               required:
                 - updates
               additionalProperties: false
+  /v1/guardian-actions/decision:
+    post:
+      operationId: guardianactions_decision_post
+      summary: Submit guardian decision
+      description: Submit a guardian action decision (approve/reject).
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  applied:
+                    type: boolean
+                  requestId:
+                    type: string
+                  reason:
+                    description: Decline reason (present only when applied is false)
+                    type: string
+                  replyText:
+                    description: Resolver reply text for the guardian (e.g. verification code)
+                    type: string
+                required:
+                  - applied
+                  - requestId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Guardian request ID
+                action:
+                  type: string
+                  description: Decision action
+                conversationId:
+                  type: string
+                  description: Conversation ID
+              required:
+                - requestId
+                - action
+              additionalProperties: false
+  /v1/guardian-actions/pending:
+    get:
+      operationId: guardianactions_pending_get
+      summary: List pending guardian actions
+      description: Return pending guardian decision prompts for a conversation.
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  prompts:
+                    type: array
+                    items: {}
+                    description: Guardian decision prompt objects
+                required:
+                  - conversationId
+                  - prompts
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID (required)
   /v1/guardian/init:
     post:
       operationId: guardian_init_post
@@ -3663,6 +5063,36 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/llm-request-logs/{id}/payload:
+    get:
+      operationId: llmrequestlogs_by_id_payload_get
+      summary: Get raw payload for a single LLM request log
+      description: Return the full request and response payloads for a specific log entry.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  requestPayload: {}
+                  responsePayload: {}
+                required:
+                  - id
+                  - requestPayload
+                  - responsePayload
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/logs/export:
     post:
       operationId: logs_export_post
@@ -3913,6 +5343,120 @@ paths:
                 importance:
                   type: number
               additionalProperties: false
+  /v1/messages:
+    get:
+      operationId: messages_get
+      summary: List messages
+      description: Return messages for a conversation, including attachments and interface file metadata.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items: {}
+                    description: Array of message objects
+                  hasMore:
+                    description: Whether older messages exist beyond this page
+                    type: boolean
+                  oldestTimestamp:
+                    description: Timestamp of the oldest message in this page (ms since epoch)
+                    type: number
+                  oldestMessageId:
+                    description: ID of the oldest message in this page
+                    type: string
+                required:
+                  - messages
+                additionalProperties: false
+    post:
+      operationId: messages_post
+      summary: Send a message
+      description: Send a user message to a conversation and trigger the assistant response.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                content:
+                  type: string
+                  description: Message text content
+                attachments:
+                  type: array
+                  items: {}
+                  description: Optional file attachments
+                conversationType:
+                  type: string
+                slashCommand:
+                  type: string
+              required:
+                - content
+              additionalProperties: false
+  /v1/messages/{id}/content:
+    get:
+      operationId: messages_by_id_content_get
+      summary: Get message content
+      description: Return the full content of a single message by ID.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/messages/{id}/llm-context:
+    get:
+      operationId: messages_by_id_llmcontext_get
+      summary: Get LLM context for a message
+      description: Return request/response logs and memory recall data for a specific message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                  logs:
+                    type: array
+                    items: {}
+                  memoryRecall:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - messageId
+                  - logs
+                  - memoryRecall
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/messages/{id}/tts:
     post:
       operationId: messages_by_id_tts_post
@@ -3935,6 +5479,22 @@ paths:
           schema:
             type: string
           description: Conversation that contains the message
+  /v1/messages/queued/{id}:
+    delete:
+      operationId: messages_queued_by_id_delete
+      summary: Delete a queued message
+      description: Remove a pending message from the conversation queue before it is processed.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/migrations/export:
     post:
       operationId: migrations_export_post
@@ -4063,6 +5623,62 @@ paths:
                   - errors
                   - manifest
                 additionalProperties: false
+  /v1/model:
+    get:
+      operationId: model_get
+      summary: Get current model config
+      description: Return the active LLM model ID, provider, and available models.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    put:
+      operationId: model_put
+      summary: Set LLM model
+      description: Change the active LLM model and optionally its provider.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+                provider:
+                  type: string
+                  description: Optional provider override
+              required:
+                - modelId
+              additionalProperties: false
+  /v1/model/image-gen:
+    put:
+      operationId: model_imagegen_put
+      summary: Set image generation model
+      description: Change the active image generation model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+              required:
+                - modelId
+              additionalProperties: false
   /v1/notification-intent-result:
     post:
       operationId: notificationintentresult_post
@@ -4276,6 +5892,48 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/pending-interactions:
+    get:
+      operationId: pendinginteractions_get
+      summary: List pending interactions
+      description: Return pending confirmations and secrets for a conversation.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pendingConfirmation:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending confirmation details or null
+                  pendingSecret:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending secret request or null
+                required:
+                  - pendingConfirmation
+                  - pendingSecret
+                additionalProperties: false
+      parameters:
+        - name: conversationKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation key
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID
   /v1/profiler/runs:
     get:
       operationId: profiler_runs_get
@@ -4660,6 +6318,239 @@ paths:
               required:
                 - conversationId
               additionalProperties: false
+  /v1/schedules:
+    get:
+      operationId: schedules_get
+      summary: List schedules
+      description: Return all scheduled jobs.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Schedule objects
+                required:
+                  - schedules
+                additionalProperties: false
+  /v1/schedules/{id}:
+    delete:
+      operationId: schedules_by_id_delete
+      summary: Delete schedule
+      description: Remove a schedule by ID.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: schedules_by_id_patch
+      summary: Update schedule
+      description: Partially update fields on a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                expression:
+                  type: string
+                timezone:
+                  type: string
+                message:
+                  type: string
+                mode:
+                  type: string
+                  description: notify or execute
+                routingIntent:
+                  type: string
+                  description: single_channel, multi_channel, or all_channels
+                quiet:
+                  type: boolean
+                reuseConversation:
+                  type: boolean
+              required:
+                - name
+                - expression
+                - timezone
+                - message
+                - mode
+                - routingIntent
+                - quiet
+                - reuseConversation
+              additionalProperties: false
+  /v1/schedules/{id}/cancel:
+    post:
+      operationId: schedules_by_id_cancel_post
+      summary: Cancel schedule
+      description: Cancel a pending schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/run:
+    post:
+      operationId: schedules_by_id_run_post
+      summary: Run schedule now
+      description: Trigger an immediate execution of a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/toggle:
+    post:
+      operationId: schedules_by_id_toggle_post
+      summary: Toggle schedule
+      description: Enable or disable a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: New enabled state
+              required:
+                - enabled
+              additionalProperties: false
+  /v1/search:
+    get:
+      operationId: search_get
+      summary: Search conversations
+      description: Full-text search across all conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
   /v1/search/global:
     get:
       operationId: search_global_get
@@ -4711,6 +6602,45 @@ paths:
           schema:
             type: string
           description: Enable semantic search for memories (true/false)
+  /v1/secret:
+    post:
+      operationId: secret_post
+      summary: Resolve a pending secret request
+      description: Provide a secret value for a pending secret request.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                value:
+                  type: string
+                  description: Secret value
+                delivery:
+                  type: string
+                  description: "Delivery mode: store or transient_send"
+              required:
+                - requestId
+              additionalProperties: false
   /v1/secrets:
     delete:
       operationId: secrets_delete
@@ -4946,6 +6876,1110 @@ paths:
               required:
                 - activationKey
               additionalProperties: false
+  /v1/skills:
+    get:
+      operationId: skills_get
+      summary: List all skills
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports
+        optional filter params: origin, kind, q, category."
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects
+                  categoryCounts:
+                    description: Count of skills per category (before category filter is applied)
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total number of skills matching non-category filters
+                    type: number
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - catalog
+          description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
+        - name: origin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind."
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text search across skill name, description, id, and origin label.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by inferred category (e.g. 'communication', 'productivity').
+    post:
+      operationId: skills_post
+      summary: Create skill
+      description: Create a new skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                skillId:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                bodyMarkdown:
+                  type: string
+              required:
+                - skillId
+                - name
+                - description
+                - bodyMarkdown
+              additionalProperties: false
+  /v1/skills/{id}:
+    delete:
+      operationId: skills_by_id_delete
+      summary: Uninstall skill
+      description: Remove an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: skills_by_id_get
+      summary: Get skill
+      description: Return a single skill by ID with enriched detail fields.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skill:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: vellum
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: clawhub
+                          slug:
+                            type: string
+                          author:
+                            type: string
+                          stars:
+                            type: number
+                          installs:
+                            type: number
+                          reports:
+                            type: number
+                          publishedAt:
+                            type: string
+                          version:
+                            type: string
+                          owner:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  handle:
+                                    type: string
+                                  displayName:
+                                    type: string
+                                  image:
+                                    type: string
+                                required:
+                                  - handle
+                                  - displayName
+                                additionalProperties: false
+                              - type: "null"
+                          stats:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  stars:
+                                    type: number
+                                  installs:
+                                    type: number
+                                  downloads:
+                                    type: number
+                                  versions:
+                                    type: number
+                                required:
+                                  - stars
+                                  - installs
+                                  - downloads
+                                  - versions
+                                additionalProperties: false
+                              - type: "null"
+                          latestVersion:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  version:
+                                    type: string
+                                  changelog:
+                                    type: string
+                                required:
+                                  - version
+                                additionalProperties: false
+                              - type: "null"
+                          createdAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          updatedAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - author
+                          - stars
+                          - installs
+                          - reports
+                          - version
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: skillssh
+                          slug:
+                            type: string
+                          sourceRepo:
+                            type: string
+                          installs:
+                            type: number
+                          audit:
+                            type: object
+                            propertyNames:
+                              type: string
+                            additionalProperties:
+                              type: object
+                              properties:
+                                risk:
+                                  type: string
+                                  enum:
+                                    - safe
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                    - unknown
+                                alerts:
+                                  type: number
+                                score:
+                                  type: number
+                                analyzedAt:
+                                  type: string
+                              required:
+                                - risk
+                                - analyzedAt
+                              additionalProperties: false
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - sourceRepo
+                          - installs
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                    description: Skill detail object
+                required:
+                  - skill
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/config:
+    patch:
+      operationId: skills_by_id_config_patch
+      summary: Configure skill
+      description: Update skill configuration (env, apiKey, config).
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                env:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Environment variables
+                apiKey:
+                  type: string
+                config:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Arbitrary config
+              required:
+                - env
+                - apiKey
+                - config
+              additionalProperties: false
+  /v1/skills/{id}/disable:
+    post:
+      operationId: skills_by_id_disable_post
+      summary: Disable skill
+      description: Disable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/enable:
+    post:
+      operationId: skills_by_id_enable_post
+      summary: Enable skill
+      description: Enable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files:
+    get:
+      operationId: skills_by_id_files_get
+      summary: Get skill files
+      description: Return skill metadata and directory contents.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files/content:
+    get:
+      operationId: skills_by_id_files_content_get
+      summary: Get skill file content
+      description: Return the content of a single file belonging to an installed or catalog skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  name:
+                    type: string
+                  size:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  mimeType:
+                    type: string
+                  isBinary:
+                    type: boolean
+                  content:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - path
+                  - name
+                  - size
+                  - mimeType
+                  - isBinary
+                  - content
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Relative path of the file within the skill directory
+  /v1/skills/{id}/inspect:
+    get:
+      operationId: skills_by_id_inspect_get
+      summary: Inspect skill
+      description: Return detailed skill information.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/update:
+    post:
+      operationId: skills_by_id_update_post
+      summary: Update skill
+      description: Update an installed skill to the latest version.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/check-updates:
+    post:
+      operationId: skills_checkupdates_post
+      summary: Check skill updates
+      description: Check for available updates to installed skills.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Update availability info
+                required:
+                  - data
+                additionalProperties: false
+  /v1/skills/draft:
+    post:
+      operationId: skills_draft_post
+      summary: Draft a skill
+      description: Generate a skill draft from source text.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sourceText:
+                  type: string
+                  description: Source text for drafting
+              required:
+                - sourceText
+              additionalProperties: false
+  /v1/skills/install:
+    post:
+      operationId: skills_install_post
+      summary: Install skill
+      description: Install a skill by slug, URL, or spec.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  skillId:
+                    type: string
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slug:
+                  type: string
+                  description: Skill slug
+                url:
+                  type: string
+                  description: Skill URL
+                spec:
+                  type: string
+                  description: Skill spec
+                version:
+                  type: string
+                origin:
+                  description: Which registry to install from. When omitted, the install flow auto-detects based on slug format.
+                  type: string
+                  enum:
+                    - clawhub
+                    - skillssh
+              required:
+                - slug
+                - url
+                - spec
+                - version
+              additionalProperties: false
+  /v1/skills/search:
+    get:
+      operationId: skills_search_get
+      summary: Search skill catalog
+      description: Search the skill catalog by query string.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects matching the search query
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query (required)
   /v1/slack/channels:
     get:
       operationId: slack_channels_get
@@ -4994,6 +8028,157 @@ paths:
                 - audioBase64
                 - mimeType
               additionalProperties: false
+  /v1/subagents/{id}:
+    get:
+      operationId: subagents_by_id_get
+      summary: Get subagent detail
+      description: Return subagent objective and event history.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  objective:
+                    type: string
+                  events:
+                    type: array
+                    items: {}
+                    description: Subagent event objects
+                required:
+                  - subagentId
+                  - objective
+                  - events
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent conversation ID (required)
+  /v1/subagents/{id}/abort:
+    post:
+      operationId: subagents_by_id_abort_post
+      summary: Abort subagent
+      description: Abort a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  aborted:
+                    type: boolean
+                required:
+                  - subagentId
+                  - aborted
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/subagents/{id}/message:
+    post:
+      operationId: subagents_by_id_message_post
+      summary: Send message to subagent
+      description: Send a text message to a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  sent:
+                    type: boolean
+                required:
+                  - subagentId
+                  - sent
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                content:
+                  type: string
+              required:
+                - conversationId
+                - content
+              additionalProperties: false
+  /v1/suggestion:
+    get:
+      operationId: suggestion_get
+      summary: Get reply suggestion
+      description: Return an LLM-generated follow-up suggestion for the most recent assistant message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestion:
+                    type: string
+                  messageId:
+                    type: string
+                  source:
+                    type: string
+                required:
+                  - suggestion
+                  - messageId
+                  - source
+                additionalProperties: false
   /v1/surface-actions:
     post:
       operationId: surfaceactions_post
@@ -5261,6 +8446,54 @@ paths:
           schema:
             type: integer
           description: Return events after this sequence number
+  /v1/trust-rules:
+    post:
+      operationId: trustrules_post
+      summary: Add a trust rule for a pending confirmation
+      description: Add a trust rule bound to a pending confirmation without resolving it.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending confirmation request ID
+                pattern:
+                  type: string
+                  description: Allowlist pattern
+                scope:
+                  type: string
+                  description: Scope for the rule
+                decision:
+                  type: string
+                  description: allow or deny
+                allowHighRisk:
+                  type: boolean
+                  description: Allow high-risk invocations
+              required:
+                - requestId
+                - pattern
+                - scope
+                - decision
+              additionalProperties: false
   /v1/trust-rules/manage:
     get:
       operationId: trustrules_manage_get
@@ -5565,6 +8798,247 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+  /v1/work-items:
+    get:
+      operationId: workitems_get
+      summary: List work items
+      description: Return work items, optionally filtered by status.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: {}
+                required:
+                  - items
+                additionalProperties: false
+  /v1/work-items/{id}:
+    delete:
+      operationId: workitems_by_id_delete
+      summary: Delete a work item
+      description: Permanently remove a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: workitems_by_id_get
+      summary: Get a work item
+      description: Return a single work item by ID.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: workitems_by_id_patch
+      summary: Update a work item
+      description: Partially update a work item's title, notes, status, or priority.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                notes:
+                  type: string
+                status:
+                  type: string
+                priorityTier:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+                sortIndex:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+              required:
+                - title
+                - notes
+                - status
+                - priorityTier
+                - sortIndex
+              additionalProperties: false
+  /v1/work-items/{id}/approve-permissions:
+    post:
+      operationId: workitems_by_id_approvepermissions_post
+      summary: Approve tool permissions
+      description: Pre-approve a set of tools for a work item before it runs.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approvedTools:
+                  type: array
+                  items: {}
+                  description: Array of tool names to approve
+              required:
+                - approvedTools
+              additionalProperties: false
+  /v1/work-items/{id}/cancel:
+    post:
+      operationId: workitems_by_id_cancel_post
+      summary: Cancel a running work item
+      description: Abort a running work item and set its status to cancelled.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/complete:
+    post:
+      operationId: workitems_by_id_complete_post
+      summary: Complete a work item
+      description: Transition a work item from awaiting_review to done.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/output:
+    get:
+      operationId: workitems_by_id_output_get
+      summary: Get work item output
+      description: Return the final output of a completed work item run.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  output:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - output
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/preflight:
+    post:
+      operationId: workitems_by_id_preflight_post
+      summary: Preflight check
+      description: Check tool permissions needed before running a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  permissions:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - permissions
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/run:
+    post:
+      operationId: workitems_by_id_run_post
+      summary: Run a work item
+      description: Execute the task associated with a work item. Returns immediately; execution happens in the background.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/workspace-files:
     get:
       operationId: workspacefiles_get

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -322,6 +322,10 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     eventHub = new AssistantEventHub();
   });
 
+  afterEach(async () => {
+    await server?.stop();
+  });
+
   async function startServer(
     conversationFactory: () => Conversation,
     options?: { approvalConversationGenerator?: ApprovalConversationGenerator },


### PR DESCRIPTION
## Summary
- Add `afterEach` cleanup to `send-endpoint-busy.test.ts` to ensure the HTTP server is stopped between tests, preventing EADDRINUSE port collisions on test failure
- Regenerate `openapi.yaml` with meet-join routes properly resolved (was stale since meet routes were added)

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24485360015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
