### PR TITLE
fix(ci): add missing afterEach import in send-endpoint-busy test

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -6,7 +6,7 @@
  * - Messages are queued (202, queued: true) when the conversation is busy, not 409.
  * - SSE subscribers receive events from messages sent via this endpoint.
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 


### PR DESCRIPTION
## Summary
- Add `afterEach` to the `bun:test` import in `send-endpoint-busy.test.ts` — it was used but not imported, causing both the test and type-check CI jobs to fail.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/24485588391

🤖 Generated with [Claude Code](https://claude.com/claude-code)