### PR TITLE
meet: voice loopback E2E + barge-in integration test

### DIFF
--- a/skills/meet-join/bot/__tests__/voice-loopback.test.ts
+++ b/skills/meet-join/bot/__tests__/voice-loopback.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Voice loopback E2E test for the meet-bot.
+ *
+ * Boots the real bot HTTP server with a mocked `pacat` shim that captures
+ * every byte written to its stdin into a single in-memory buffer. Then
+ * drives the full speak path end-to-end:
+ *
+ *   1. POST a deterministic, recognizable PCM stream (sine-wave-shaped
+ *      bytes) to `/play_audio` and assert the bytes that landed in the
+ *      shim are byte-for-byte identical to what we sent — proving the
+ *      pacat side of the bot/daemon contract is byte-perfect under
+ *      streaming chunked upload, with no corruption in transit.
+ *
+ *   2. Open a separate POST whose body is gated so we can fire DELETE
+ *      `/play_audio/:streamId` mid-stream. After the DELETE, assert that
+ *      the shim sees no further input bytes (growth stops) and that the
+ *      cancel path appends exactly 50ms of trailing silence (4800 zero
+ *      bytes at 48 kHz mono s16le).
+ *
+ * The `pacat` shim is the same pattern as `audio-playback.test.ts`: it
+ * exposes `SpawnedPacat` whose `stdin.write` appends into a `Uint8Array`
+ * so tests can assert ordering. The bot's `createHttpServer` is wired
+ * via `playbackSpawnOptions: { spawn: () => shim.proc }`, so no real
+ * pacat process is involved.
+ *
+ * Why a "richer" loopback test alongside the PR 1 unit test:
+ *   - The PR 1 test asserts the transport contract one assertion at a
+ *     time. This test exercises the same pipeline against a non-trivial
+ *     fixture (a recognizable byte pattern that any single-byte
+ *     corruption would surface immediately) and treats the byte-perfect
+ *     transit + cancel-with-trailing-silence invariant as the unit of
+ *     validation. It is intentionally self-contained — no shared state
+ *     with the PR 1 test, so removal of one does not regress the other.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createHttpServer,
+  type HttpServerHandle,
+} from "../src/control/http-server.js";
+import { BotState } from "../src/control/state.js";
+import {
+  DEFAULT_BYTES_PER_MS,
+  __resetForTests,
+  stopAudioPlayback,
+  type PacatWritable,
+  type SpawnedPacat,
+} from "../src/media/audio-playback.js";
+
+const API_TOKEN = "test-token-loopback";
+
+/** Trailing-silence duration the bot writes after each /play_audio POST. */
+const TRAILING_SILENCE_MS = 50;
+/** Trailing-silence byte count at 48 kHz mono s16le. */
+const TRAILING_SILENCE_BYTES = TRAILING_SILENCE_MS * DEFAULT_BYTES_PER_MS;
+
+// ---------------------------------------------------------------------------
+// Pacat shim — captures every byte ever written into a single buffer so
+// tests can assert byte-perfect ordering and trailing silence.
+// ---------------------------------------------------------------------------
+
+interface PacatShim {
+  proc: SpawnedPacat;
+  /** All bytes written to pacat's stdin, in order. */
+  readonly buffer: Uint8Array;
+  /** How many bytes are in the shim right now. */
+  size: () => number;
+}
+
+function makePacatShim(): PacatShim {
+  let buf = new Uint8Array(0);
+  let killed = false;
+  let resolveExited!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => {
+    resolveExited = resolve;
+  });
+
+  const stdin: PacatWritable = {
+    write(chunk: Uint8Array): number {
+      const next = new Uint8Array(buf.length + chunk.length);
+      next.set(buf, 0);
+      next.set(chunk, buf.length);
+      buf = next;
+      return chunk.length;
+    },
+    async end() {
+      // Tests control lifetime explicitly via kill().
+    },
+  };
+
+  const proc: SpawnedPacat = {
+    stdin,
+    exited,
+    kill() {
+      if (killed) return;
+      killed = true;
+      resolveExited(0);
+    },
+  };
+
+  return {
+    proc,
+    get buffer() {
+      return buf;
+    },
+    size: () => buf.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture — build a recognizable PCM payload so single-byte corruption
+// in transit would surface as a mismatch in the byte-by-byte comparison.
+// We synthesize a discrete sine wave at the bot's native 48 kHz mono s16le
+// format. The pattern is deterministic and non-trivial: any reorder, drop,
+// duplication, or off-by-one in the pipeline would produce a mismatch.
+// ---------------------------------------------------------------------------
+
+function buildSinePcm(
+  samples: number,
+  frequencyHz: number,
+): Uint8Array<ArrayBuffer> {
+  // The explicit `Uint8Array<ArrayBuffer>` return type (rather than the
+  // bare `Uint8Array`, which TS 5.9 widens to `Uint8Array<ArrayBufferLike>`)
+  // is what lets the result satisfy fetch's `BodyInit` constraint under
+  // strict NodeNext typing.
+  const buffer = new ArrayBuffer(samples * 2); // s16le → 2 bytes/sample
+  const view = new DataView(buffer);
+  const sampleRate = 48_000;
+  const amplitude = 0x4000; // half-scale int16 to leave headroom
+  for (let i = 0; i < samples; i++) {
+    const value = Math.round(
+      amplitude * Math.sin((2 * Math.PI * frequencyHz * i) / sampleRate),
+    );
+    view.setInt16(i * 2, value, /* littleEndian */ true);
+  }
+  return new Uint8Array(buffer);
+}
+
+/** Slice a buffer into chunks of `chunkSize` bytes for streaming. */
+function chunkBytes(payload: Uint8Array, chunkSize: number): Uint8Array[] {
+  const chunks: Uint8Array[] = [];
+  for (let off = 0; off < payload.length; off += chunkSize) {
+    chunks.push(payload.subarray(off, Math.min(off + chunkSize, payload.length)));
+  }
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("voice loopback E2E (bot HTTP → pacat shim)", () => {
+  let server: HttpServerHandle | null = null;
+  let shim: PacatShim;
+
+  beforeEach(() => {
+    __resetForTests();
+    BotState.__resetForTests();
+    shim = makePacatShim();
+  });
+
+  afterEach(async () => {
+    if (server !== null) {
+      await server.stop();
+      server = null;
+    }
+    await stopAudioPlayback();
+    __resetForTests();
+  });
+
+  function build(): HttpServerHandle {
+    return createHttpServer({
+      apiToken: API_TOKEN,
+      onLeave: () => {},
+      onSendChat: () => {},
+      onPlayAudio: () => {},
+      playbackSpawnOptions: { spawn: () => shim.proc },
+    });
+  }
+
+  test("POST /play_audio delivers a recognizable PCM stream byte-perfectly to pacat, then 50ms of silence", async () => {
+    server = build();
+    const { port } = await server.start(0);
+
+    // 480 samples = 960 bytes = 10ms of audio at 48 kHz mono s16le.
+    // A 440 Hz sine is a recognizable pattern; corruption would change
+    // the comparison at the first faulty byte.
+    const payload = buildSinePcm(480, 440);
+    expect(payload.length).toBe(960);
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/play_audio?stream_id=loopback-1`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/octet-stream",
+        },
+        body: payload,
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { streamId: string; bytes: number };
+    expect(body.streamId).toBe("loopback-1");
+    expect(body.bytes).toBe(payload.length);
+
+    // The shim must contain the original payload byte-for-byte, then
+    // exactly TRAILING_SILENCE_BYTES of zeros appended by the bot's
+    // post-stream silence flush.
+    expect(shim.size()).toBe(payload.length + TRAILING_SILENCE_BYTES);
+
+    // Byte-perfect match on the audio prefix.
+    const audioSlice = shim.buffer.subarray(0, payload.length);
+    expect(audioSlice.length).toBe(payload.length);
+    expect(Array.from(audioSlice)).toEqual(Array.from(payload));
+
+    // Trailing silence must be all zero.
+    const silenceSlice = shim.buffer.subarray(payload.length);
+    expect(silenceSlice.length).toBe(TRAILING_SILENCE_BYTES);
+    for (const byte of silenceSlice) {
+      expect(byte).toBe(0);
+    }
+  });
+
+  test("DELETE mid-stream stops buffer growth and appends exactly 50ms of trailing silence", async () => {
+    server = build();
+    const { port } = await server.start(0);
+
+    // First chunk is delivered immediately. The body's `start` then waits
+    // on a gate so the rest of the payload is only released after the
+    // test fires DELETE — guaranteeing the cancel lands while bytes are
+    // still in flight.
+    const firstChunk = buildSinePcm(240, 440); // 240 samples = 480 bytes
+    expect(firstChunk.length).toBe(480);
+    const remainingChunks: Uint8Array[] = chunkBytes(
+      buildSinePcm(2400, 880), // 2400 samples = 4800 bytes
+      512,
+    );
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const body = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(firstChunk);
+        // Park here until the test DELETEs and releases us.
+        await gate;
+        try {
+          for (const chunk of remainingChunks) {
+            controller.enqueue(chunk);
+          }
+        } catch {
+          // Reader cancelled — expected when DELETE has already aborted.
+        }
+        controller.close();
+      },
+    });
+
+    const postPromise = fetch(
+      `http://127.0.0.1:${port}/play_audio?stream_id=loopback-cancel`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/octet-stream",
+        },
+        body,
+        // @ts-expect-error — undici/fetch extension, not in lib.dom types
+        duplex: "half",
+      },
+    );
+
+    // Give the bot a beat to ingest the first chunk so the shim has
+    // recorded *some* audio bytes before we cancel. Without this the
+    // server might receive the DELETE before any bytes have been written
+    // and the partial-vs-silence assertion below would be ambiguous.
+    await new Promise((r) => setTimeout(r, 50));
+    const sizeBeforeDelete = shim.size();
+    expect(sizeBeforeDelete).toBeGreaterThan(0);
+    expect(sizeBeforeDelete).toBeLessThanOrEqual(firstChunk.length);
+
+    // Fire DELETE — the bot aborts the in-flight POST and schedules the
+    // trailing silence flush in the POST handler's `finally`.
+    const delRes = await fetch(
+      `http://127.0.0.1:${port}/play_audio/loopback-cancel`,
+      {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      },
+    );
+    expect(delRes.status).toBe(200);
+    const delBody = (await delRes.json()) as {
+      cancelled: boolean;
+      streamId: string;
+    };
+    expect(delBody.cancelled).toBe(true);
+    expect(delBody.streamId).toBe("loopback-cancel");
+
+    // Release the gate so the body's `start` coroutine completes — the
+    // server's reader has already been cancelled, so the remaining
+    // chunks are dropped on the floor (this is what we want to verify
+    // below: no further audio bytes land in the shim).
+    release();
+
+    const postRes = await postPromise;
+    expect(postRes.status).toBe(499);
+    const payload = (await postRes.json()) as {
+      streamId: string;
+      bytes: number;
+      cancelled: boolean;
+    };
+    expect(payload.streamId).toBe("loopback-cancel");
+    expect(payload.cancelled).toBe(true);
+
+    // -------- Buffer growth stops after the cancel --------
+    //
+    // The bot's POST handler must have written *only* the partial audio
+    // it already had (≤ firstChunk.length) plus exactly the trailing
+    // silence block. Anything more would mean post-cancel bytes leaked
+    // through.
+    const finalSize = shim.size();
+    const audioBytesWritten = payload.bytes;
+    expect(audioBytesWritten).toBeLessThanOrEqual(firstChunk.length);
+    expect(finalSize).toBe(audioBytesWritten + TRAILING_SILENCE_BYTES);
+
+    // The trailing TRAILING_SILENCE_BYTES bytes must all be zero.
+    const trailing = shim.buffer.subarray(
+      finalSize - TRAILING_SILENCE_BYTES,
+      finalSize,
+    );
+    expect(trailing.length).toBe(TRAILING_SILENCE_BYTES);
+    for (const byte of trailing) {
+      expect(byte).toBe(0);
+    }
+
+    // The audio prefix must match the corresponding prefix of the first
+    // chunk byte-for-byte. (No reorder / duplication / corruption.)
+    const audioPrefix = shim.buffer.subarray(0, audioBytesWritten);
+    expect(Array.from(audioPrefix)).toEqual(
+      Array.from(firstChunk.subarray(0, audioBytesWritten)),
+    );
+  });
+});

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -1,0 +1,789 @@
+/**
+ * Daemon-side voice E2E test.
+ *
+ * Wires the real {@link MeetTtsBridge} and the real {@link MeetBargeInWatcher}
+ * against a throwaway `Bun.serve` HTTP server playing the role of the
+ * meet-bot's `/play_audio` + `DELETE /play_audio/:streamId` endpoints. The
+ * watcher subscribes to the real {@link assistantEventHub} singleton (the
+ * production wiring) so `meet.speaking_*` lifecycle events flow exactly the
+ * way they would in production. The bot-event stream is supplied via an
+ * in-memory dispatcher injected through {@link MeetBargeInWatcher}'s
+ * `subscribe` hook.
+ *
+ * The bridge is given a mocked `spawn` so its ffmpeg child is replaced with
+ * a `Writable` whose writes pass straight through to a `PassThrough` that
+ * fetch consumes as the request body — this is the same pattern used by
+ * `tts-bridge.test.ts`. The TTS provider is a canned implementation that
+ * emits a recognizable byte sequence so any corruption between provider
+ * and bot would surface as a byte-by-byte mismatch.
+ *
+ * What this test exercises that the unit tests do not:
+ *
+ *   - End-to-end byte transit from the TTS provider through the bridge to
+ *     the bot HTTP endpoint, including the chunked body framing.
+ *   - The full meet.speaking_started / meet.speaking_ended lifecycle the
+ *     production session manager publishes around `bridge.speak`.
+ *   - The barge-in watcher's debounced cancel against the *real* bridge:
+ *     a triggered cancel must actually issue DELETE /play_audio to the
+ *     bot, and the cancel must be observable exactly once.
+ *   - The short-cough debounce: a non-bot speaker event followed by an
+ *     immediate return-to-bot speaker event within the 250ms debounce
+ *     window must NOT cancel the in-flight speak.
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type {
+  MeetBotEvent,
+  ParticipantChangeEvent,
+  SpeakerChangeEvent,
+} from "@vellumai/meet-contracts";
+
+import type { ServerMessage } from "../../../../assistant/src/daemon/message-protocol.js";
+import { assistantEventHub } from "../../../../assistant/src/runtime/assistant-event-hub.js";
+import { buildAssistantEvent } from "../../../../assistant/src/runtime/assistant-event.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../assistant/src/runtime/assistant-scope.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../../../../assistant/src/tts/types.js";
+import {
+  BARGE_IN_DEBOUNCE_MS,
+  MeetBargeInWatcher,
+} from "../barge-in-watcher.js";
+import type {
+  MeetEventSubscriber,
+  MeetEventUnsubscribe,
+} from "../event-publisher.js";
+import { MeetTtsBridge } from "../tts-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Fake bot HTTP server (real Bun.serve)
+// ---------------------------------------------------------------------------
+
+interface RecordedPost {
+  url: string;
+  authorization: string | null;
+  contentType: string | null;
+  body: Uint8Array;
+}
+
+interface RecordedDelete {
+  url: string;
+  authorization: string | null;
+}
+
+interface FakeBotServer {
+  url: string;
+  port: number;
+  posts: RecordedPost[];
+  deletes: RecordedDelete[];
+  /** Resolves once the next POST's body has finished streaming. */
+  awaitNextPostComplete: () => Promise<RecordedPost>;
+  stop: () => Promise<void>;
+}
+
+function startFakeBot(): FakeBotServer {
+  const posts: RecordedPost[] = [];
+  const deletes: RecordedDelete[] = [];
+  const postCompletionWaiters: Array<(p: RecordedPost) => void> = [];
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      if (req.method === "POST") {
+        const chunks: Uint8Array[] = [];
+        const reader = req.body?.getReader();
+        if (reader) {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) chunks.push(value);
+          }
+        }
+        const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+        const merged = new Uint8Array(total);
+        let offset = 0;
+        for (const c of chunks) {
+          merged.set(c, offset);
+          offset += c.byteLength;
+        }
+        const post: RecordedPost = {
+          url: `${url.pathname}${url.search}`,
+          authorization: req.headers.get("authorization"),
+          contentType: req.headers.get("content-type"),
+          body: merged,
+        };
+        posts.push(post);
+        const waiter = postCompletionWaiters.shift();
+        if (waiter) waiter(post);
+        return new Response("", { status: 200 });
+      }
+      if (req.method === "DELETE") {
+        deletes.push({
+          url: url.pathname,
+          authorization: req.headers.get("authorization"),
+        });
+        return new Response("", { status: 200 });
+      }
+      return new Response("", { status: 405 });
+    },
+  });
+  const port = server.port;
+  if (port === undefined) {
+    throw new Error("fake bot failed to bind");
+  }
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    posts,
+    deletes,
+    awaitNextPostComplete: () =>
+      new Promise<RecordedPost>((resolve) => {
+        postCompletionWaiters.push(resolve);
+      }),
+    stop: async () => {
+      await server.stop(true);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake ffmpeg child — stdin pipes straight into stdout. Same pattern as
+// `tts-bridge.test.ts`. Lets the bridge see provider chunks materialize as
+// HTTP body bytes without invoking a real ffmpeg.
+// ---------------------------------------------------------------------------
+
+interface FakeFfmpegChild extends EventEmitter {
+  stdin: Writable;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeFakeFfmpegChild(): FakeFfmpegChild {
+  const emitter = new EventEmitter() as FakeFfmpegChild;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new Writable({
+    write(chunk, _encoding, cb) {
+      stdout.write(chunk, cb);
+    },
+    final(cb) {
+      stdout.end();
+      cb();
+    },
+  });
+  emitter.stdin = stdin;
+  emitter.stdout = stdout;
+  emitter.stderr = stderr;
+  emitter.killed = false;
+  emitter.kill = (_signal?: string) => {
+    emitter.killed = true;
+    try {
+      stdout.end();
+    } catch {
+      /* best-effort */
+    }
+    return true;
+  };
+  return emitter;
+}
+
+function makeSpawnMock(): {
+  spawn: ReturnType<typeof mock>;
+} {
+  const spawn = mock(() => {
+    const child = makeFakeFfmpegChild();
+    return child as unknown as ReturnType<
+      typeof import("node:child_process").spawn
+    >;
+  });
+  return { spawn };
+}
+
+// ---------------------------------------------------------------------------
+// Canned TTS provider — emits a deterministic, recognizable byte sequence
+// so any corruption between provider and bot would surface immediately.
+// ---------------------------------------------------------------------------
+
+function buildSinePcm(samples: number, frequencyHz: number): Uint8Array {
+  const out = new Uint8Array(samples * 2);
+  const view = new DataView(out.buffer);
+  const sampleRate = 48_000;
+  const amplitude = 0x3000;
+  for (let i = 0; i < samples; i++) {
+    const value = Math.round(
+      amplitude * Math.sin((2 * Math.PI * frequencyHz * i) / sampleRate),
+    );
+    view.setInt16(i * 2, value, /* littleEndian */ true);
+  }
+  return out;
+}
+
+interface CannedProviderOptions {
+  chunks: Uint8Array[];
+  /** Delay between chunks — defaults to 0 for synchronous emission. */
+  gapMs?: number;
+}
+
+function makeCannedProvider(options: CannedProviderOptions): TtsProvider & {
+  calls: TtsSynthesisRequest[];
+} {
+  const calls: TtsSynthesisRequest[] = [];
+  return {
+    id: "canned-voice-e2e-provider",
+    capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+    calls,
+    async synthesize(request): Promise<TtsSynthesisResult> {
+      calls.push(request);
+      const merged = Buffer.concat(options.chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+    async synthesizeStream(request, onChunk): Promise<TtsSynthesisResult> {
+      calls.push(request);
+      for (const chunk of options.chunks) {
+        if (request.signal?.aborted) {
+          throw new Error("aborted");
+        }
+        onChunk(chunk);
+        if (options.gapMs && options.gapMs > 0) {
+          await new Promise((r) => setTimeout(r, options.gapMs));
+        }
+      }
+      const merged = Buffer.concat(options.chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory bot-event dispatcher — fans dispatched events to subscribers.
+// The watcher uses this in place of the production singleton so the test
+// has full control over what events the watcher observes.
+// ---------------------------------------------------------------------------
+
+function makeFakeDispatcher(): {
+  subscribe: (
+    meetingId: string,
+    cb: MeetEventSubscriber,
+  ) => MeetEventUnsubscribe;
+  dispatch: (meetingId: string, event: MeetBotEvent) => void;
+} {
+  const subs = new Map<string, Set<MeetEventSubscriber>>();
+  return {
+    subscribe(meetingId, cb) {
+      let set = subs.get(meetingId);
+      if (!set) {
+        set = new Set();
+        subs.set(meetingId, set);
+      }
+      set.add(cb);
+      return () => {
+        const existing = subs.get(meetingId);
+        if (!existing) return;
+        existing.delete(cb);
+        if (existing.size === 0) subs.delete(meetingId);
+      };
+    },
+    dispatch(meetingId, event) {
+      const set = subs.get(meetingId);
+      if (!set) return;
+      for (const cb of Array.from(set)) cb(event);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — publish meet.speaking_* through the real assistantEventHub the
+// way `MeetSessionManager.speak` does in production, and subscribe so the
+// test can collect the lifecycle events that flow back through the same
+// hub.
+// ---------------------------------------------------------------------------
+
+function publishToHub(message: ServerMessage): Promise<void> {
+  return assistantEventHub.publish(
+    buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, message),
+  );
+}
+
+/**
+ * Poll `predicate` until it returns truthy or `timeoutMs` elapses. Returns
+ * the wall-clock time (Date.now()) at which the predicate first became
+ * true so callers can measure debounce + cancel latency. Throws on
+ * timeout.
+ */
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<number> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return Date.now();
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`waitUntil: predicate did not become true in ${timeoutMs}ms`);
+}
+
+interface CapturedHub {
+  events: ServerMessage[];
+  /** Resolve when the next event matching the predicate arrives. */
+  waitFor: (
+    predicate: (m: ServerMessage) => boolean,
+    timeoutMs?: number,
+  ) => Promise<ServerMessage>;
+  dispose: () => void;
+}
+
+function captureHub(): CapturedHub {
+  const events: ServerMessage[] = [];
+  const waiters: Array<{
+    predicate: (m: ServerMessage) => boolean;
+    resolve: (m: ServerMessage) => void;
+  }> = [];
+  const sub = assistantEventHub.subscribe(
+    { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+    (event) => {
+      events.push(event.message);
+      // Snapshot so a resolver removing itself mid-iteration doesn't
+      // skip a sibling.
+      const snapshot = waiters.slice();
+      for (let i = snapshot.length - 1; i >= 0; i--) {
+        const w = snapshot[i]!;
+        if (w.predicate(event.message)) {
+          waiters.splice(waiters.indexOf(w), 1);
+          w.resolve(event.message);
+        }
+      }
+    },
+  );
+  return {
+    events,
+    waitFor: (predicate, timeoutMs = 1500) =>
+      new Promise<ServerMessage>((resolve, reject) => {
+        // Search the backlog first.
+        const existing = events.find((m) => predicate(m));
+        if (existing) {
+          resolve(existing);
+          return;
+        }
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex((w) => w.resolve === wrappedResolve);
+          if (idx >= 0) waiters.splice(idx, 1);
+          reject(new Error(`waitFor timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        const wrappedResolve = (m: ServerMessage): void => {
+          clearTimeout(timer);
+          resolve(m);
+        };
+        waiters.push({ predicate, resolve: wrappedResolve });
+      }),
+    dispose: () => sub.dispose(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight session-manager stand-in — wraps `bridge.speak` with the
+// same `meet.speaking_started` / `meet.speaking_ended` publishing the real
+// `MeetSessionManager.speak` does, and exposes a `cancelSpeak(meetingId)`
+// the watcher can call. Keeps the test focused on the bridge + watcher
+// without dragging the entire session-manager dependency graph in.
+// ---------------------------------------------------------------------------
+
+interface SessionWrapper {
+  speak: (input: { text: string; voice?: string }) => Promise<{
+    streamId: string;
+    completion: Promise<void>;
+  }>;
+  cancelSpeak: (meetingId: string) => Promise<void>;
+}
+
+function wrapSessionManager(
+  meetingId: string,
+  bridge: MeetTtsBridge,
+): SessionWrapper {
+  return {
+    async speak(input) {
+      const result = await bridge.speak(input);
+      void publishToHub({
+        type: "meet.speaking_started",
+        meetingId,
+        streamId: result.streamId,
+      });
+      void result.completion
+        .then(() =>
+          publishToHub({
+            type: "meet.speaking_ended",
+            meetingId,
+            streamId: result.streamId,
+            reason: "completed" as const,
+          }),
+        )
+        .catch((err) => {
+          const reason: "cancelled" | "error" =
+            err instanceof Error && err.message === "cancel"
+              ? "cancelled"
+              : "error";
+          void publishToHub({
+            type: "meet.speaking_ended",
+            meetingId,
+            streamId: result.streamId,
+            reason,
+          });
+        });
+      return result;
+    },
+    async cancelSpeak(_id: string) {
+      await bridge.cancelAll();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const TOKEN = "test-token-voice-e2e";
+const MEETING_ID = "m-voice-e2e";
+const BOT_PARTICIPANT_ID = "bot-self-voice-e2e";
+const HUMAN_SPEAKER_ID = "human-bob-e2e";
+
+function participantChangeWithSelf(): ParticipantChangeEvent {
+  return {
+    type: "participant.change",
+    meetingId: MEETING_ID,
+    timestamp: "2024-01-01T00:00:00.000Z",
+    joined: [{ id: BOT_PARTICIPANT_ID, name: "Velissa", isSelf: true }],
+    left: [],
+  };
+}
+
+function speakerChange(speakerId: string, speakerName = "Bob"): SpeakerChangeEvent {
+  return {
+    type: "speaker.change",
+    meetingId: MEETING_ID,
+    timestamp: "2024-01-01T00:00:00.500Z",
+    speakerId,
+    speakerName,
+  };
+}
+
+let fakeBot: FakeBotServer;
+
+beforeEach(() => {
+  fakeBot = startFakeBot();
+});
+
+afterEach(async () => {
+  await fakeBot.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
+  test("happy path: speak('hello') → bytes land at the bot byte-for-byte → meet.speaking_ended fires", async () => {
+    // Recognizable PCM so corruption surfaces immediately.
+    const payload = [
+      buildSinePcm(240, 440), // 480 bytes
+      buildSinePcm(240, 880), // 480 bytes
+      buildSinePcm(120, 660), // 240 bytes
+    ];
+    const expected = Buffer.concat(payload.map((c) => Buffer.from(c)));
+
+    const provider = makeCannedProvider({ chunks: payload });
+    const { spawn } = makeSpawnMock();
+    const dispatcher = makeFakeDispatcher();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-happy",
+      },
+    );
+
+    const session = wrapSessionManager(MEETING_ID, bridge);
+
+    const watcher = new MeetBargeInWatcher({
+      meetingId: MEETING_ID,
+      sessionManager: session,
+      subscribe: dispatcher.subscribe,
+      // assistant-event-hub stays as the real production singleton
+    });
+    watcher.start();
+
+    const captured = captureHub();
+    try {
+      // Discover the bot's self id so the watcher knows who's "self".
+      dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+      expect(watcher._getBotSpeakerId()).toBe(BOT_PARTICIPANT_ID);
+
+      // Kick off the speak — completion resolves once the bot's POST
+      // settles. The bot's `await req.body.read()` loop drains every
+      // ffmpeg chunk so the merged body is exactly the provider output.
+      const postCompletion = fakeBot.awaitNextPostComplete();
+      const result = await session.speak({ text: "hello", voice: "v1" });
+      expect(result.streamId).toBe("stream-happy");
+
+      // Wait for the assistant-event-hub to see meet.speaking_started —
+      // proves the lifecycle wiring fired through the same hub the
+      // production code uses.
+      await captured.waitFor(
+        (m) =>
+          m.type === "meet.speaking_started" &&
+          (m as { streamId: string }).streamId === "stream-happy",
+      );
+      expect(watcher._isBotSpeaking()).toBe(true);
+
+      // Wait for the bot to actually receive and finish reading the POST.
+      const post = await postCompletion;
+      expect(post.url).toBe("/play_audio?stream_id=stream-happy");
+      expect(post.authorization).toBe(`Bearer ${TOKEN}`);
+      expect(post.contentType).toBe("application/octet-stream");
+
+      // Byte-perfect: the bot's body equals the provider's emitted bytes
+      // concatenated in order. (No corruption, no reordering, no drops.)
+      expect(Array.from(post.body)).toEqual(Array.from(expected));
+
+      // Wait for the speak completion to settle and for the lifecycle
+      // event to flow back through the hub.
+      await result.completion;
+      const ended = (await captured.waitFor(
+        (m) =>
+          m.type === "meet.speaking_ended" &&
+          (m as { streamId: string }).streamId === "stream-happy",
+      )) as { reason: string; streamId: string };
+      expect(ended.reason).toBe("completed");
+
+      // Watcher's flag flips back, no DELETE was issued.
+      expect(watcher._isBotSpeaking()).toBe(false);
+      expect(fakeBot.deletes).toHaveLength(0);
+    } finally {
+      captured.dispose();
+      watcher.stop();
+    }
+  });
+
+  test("barge-in: non-bot speaker.change while speaking → cancel fires within 300ms", async () => {
+    // Use a long inter-chunk gap so the speak is still in flight when we
+    // simulate the human speaker. Short-but-not-tiny chunks (the
+    // canned provider emits one chunk every 200ms) means the POST is
+    // still actively streaming when the cancel lands.
+    const provider = makeCannedProvider({
+      chunks: [
+        buildSinePcm(240, 440),
+        buildSinePcm(240, 880),
+        buildSinePcm(240, 660),
+        buildSinePcm(240, 220),
+      ],
+      gapMs: 200,
+    });
+    const { spawn } = makeSpawnMock();
+    const dispatcher = makeFakeDispatcher();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-barge",
+      },
+    );
+
+    // Spy on cancelSpeak so we can assert "called exactly once".
+    const baseSession = wrapSessionManager(MEETING_ID, bridge);
+    const cancelSpy = mock(async (id: string) => {
+      await baseSession.cancelSpeak(id);
+    });
+    const session = {
+      speak: baseSession.speak,
+      cancelSpeak: cancelSpy,
+    };
+
+    const watcher = new MeetBargeInWatcher({
+      meetingId: MEETING_ID,
+      sessionManager: session,
+      subscribe: dispatcher.subscribe,
+    });
+    watcher.start();
+
+    const captured = captureHub();
+    try {
+      dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+      const result = await session.speak({ text: "I am about to be interrupted" });
+      expect(result.streamId).toBe("stream-barge");
+
+      await captured.waitFor((m) => m.type === "meet.speaking_started");
+
+      // Give the bridge a beat so the POST is in flight before barge-in.
+      await new Promise((r) => setTimeout(r, 60));
+
+      // Non-bot speaker takes the floor — should arm the debounced cancel.
+      const tBargeIn = Date.now();
+      dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+      expect(watcher._hasPendingCancel()).toBe(true);
+
+      // Wait for the watcher's cancelSpeak invocation. We bound this on
+      // the cancelSpy reference so we observe the cancel-fired-at moment
+      // independent of the downstream lifecycle event ordering.
+      const tCancelObserved = await waitUntil(
+        () => cancelSpy.mock.calls.length >= 1,
+        500,
+      );
+      const elapsed = tCancelObserved - tBargeIn;
+
+      // Cancel must have fired exactly once. (Idempotent debounce; no
+      // double-fire from sibling triggers.)
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+
+      // The cancel must have landed within the plan's 300ms barge-in
+      // budget (250ms debounce + slack for the timer callback + the
+      // bridge.cancelAll roundtrip). Lower bound (≥ debounce) proves
+      // we didn't fire prematurely.
+      expect(elapsed).toBeGreaterThanOrEqual(BARGE_IN_DEBOUNCE_MS);
+      expect(elapsed).toBeLessThan(300);
+
+      // The bridge issued DELETE /play_audio/<streamId> on cancel — this
+      // is the bot-side observable signal that cancel made it through
+      // the bridge, the HTTP layer, and arrived at the fake bot.
+      await waitUntil(() => fakeBot.deletes.length >= 1, 500);
+      expect(fakeBot.deletes).toHaveLength(1);
+      expect(fakeBot.deletes[0]!.url).toBe("/play_audio/stream-barge");
+      expect(fakeBot.deletes[0]!.authorization).toBe(`Bearer ${TOKEN}`);
+
+      // Lifecycle event for the cancelled stream still flows back through
+      // the real assistant-event-hub. (The reason field is determined by
+      // the session-manager's classification of the completion promise;
+      // we only assert that the event reaches the hub for this stream.)
+      await captured.waitFor(
+        (m) =>
+          m.type === "meet.speaking_ended" &&
+          (m as { streamId: string }).streamId === "stream-barge",
+        1500,
+      );
+    } finally {
+      captured.dispose();
+      watcher.stop();
+    }
+  });
+
+  test("short cough: non-bot speaker followed within 100ms by bot speaker → no cancel (debounce)", async () => {
+    // Fast emission so the speak finishes quickly — but we explicitly
+    // assert the cancel-or-not decision *before* the stream completes
+    // by holding the speak open long enough for the debounce window
+    // (250ms) to elapse fully without firing.
+    const provider = makeCannedProvider({
+      chunks: [
+        buildSinePcm(240, 440),
+        buildSinePcm(240, 880),
+        buildSinePcm(240, 660),
+        buildSinePcm(240, 220),
+      ],
+      gapMs: 100,
+    });
+    const { spawn } = makeSpawnMock();
+    const dispatcher = makeFakeDispatcher();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-cough",
+      },
+    );
+
+    const baseSession = wrapSessionManager(MEETING_ID, bridge);
+    const cancelSpy = mock(async (id: string) => {
+      await baseSession.cancelSpeak(id);
+    });
+    const session = {
+      speak: baseSession.speak,
+      cancelSpeak: cancelSpy,
+    };
+
+    const watcher = new MeetBargeInWatcher({
+      meetingId: MEETING_ID,
+      sessionManager: session,
+      subscribe: dispatcher.subscribe,
+    });
+    watcher.start();
+
+    const captured = captureHub();
+    try {
+      dispatcher.dispatch(MEETING_ID, participantChangeWithSelf());
+      const result = await session.speak({ text: "uninterrupted utterance" });
+      expect(result.streamId).toBe("stream-cough");
+
+      await captured.waitFor((m) => m.type === "meet.speaking_started");
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Brief non-bot blip — schedules a debounced cancel.
+      dispatcher.dispatch(MEETING_ID, speakerChange(HUMAN_SPEAKER_ID));
+      expect(watcher._hasPendingCancel()).toBe(true);
+
+      // Floor returns to the bot well within the 250ms debounce.
+      await new Promise((r) => setTimeout(r, 80));
+      dispatcher.dispatch(
+        MEETING_ID,
+        speakerChange(BOT_PARTICIPANT_ID, "Velissa"),
+      );
+
+      // The pending cancel must have been cleared by the return-to-bot
+      // event — no debounce timer should still be queued.
+      expect(watcher._hasPendingCancel()).toBe(false);
+
+      // Wait long enough for what *would* have been the cancel deadline
+      // to pass, then assert nothing fired.
+      await new Promise((r) => setTimeout(r, BARGE_IN_DEBOUNCE_MS + 100));
+      expect(cancelSpy).toHaveBeenCalledTimes(0);
+      expect(fakeBot.deletes).toHaveLength(0);
+
+      // Let the speak finish naturally so we leave the test in a clean
+      // state. The completion may resolve as 'completed' or, if the
+      // POST hasn't fully drained yet, may still be in flight when the
+      // afterEach tears down the bot — both are fine.
+      await result.completion.catch(() => {});
+
+      const ended = (await captured.waitFor(
+        (m) =>
+          m.type === "meet.speaking_ended" &&
+          (m as { streamId: string }).streamId === "stream-cough",
+      )) as { reason: string };
+      // Must have ended naturally (not cancelled / not error).
+      expect(ended.reason).toBe("completed");
+    } finally {
+      captured.dispose();
+      watcher.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds bot voice-loopback test: PCM in → buffer matches → DELETE cancels mid-stream → 50ms trailing silence flushed
- Adds daemon voice-e2e test integrating real MeetTtsBridge + MeetBargeInWatcher against a fake bot Bun.serve, covering happy path, barge-in within 300ms, and short-cough debounce no-op
- Asserts byte-perfect transit, observable cancel, and event lifecycle (meet.speaking_started/ended)

Part of plan: meet-phase-3-voice.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
