### PR TITLE
docs(meet): correct barge-in-watcher comment about speaker attribution

### DIFF
--- a/skills/meet-join/daemon/barge-in-watcher.ts
+++ b/skills/meet-join/daemon/barge-in-watcher.ts
@@ -341,10 +341,10 @@ export class MeetBargeInWatcher {
     if (event.confidence === undefined) return;
     if (event.confidence <= this.interimConfidenceThreshold) return;
 
-    // Drop chunks attributed to the bot itself. Both `speakerId` (preferred)
-    // and `speakerLabel` are checked — the bot is a silent listener so this
-    // should be vanishingly rare, but cheap defense-in-depth keeps us from
-    // firing on a mis-tagged echo of the bot's own audio.
+    // Drop chunks attributed to the bot itself via `speakerId`. The bot is a
+    // silent listener so this should be vanishingly rare, but cheap
+    // defense-in-depth keeps us from firing on a mis-tagged echo of the
+    // bot's own audio.
     if (
       this.botSpeakerId !== null &&
       event.speakerId !== undefined &&


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-3-voice.md.

**Gap:** barge-in-watcher comment claimed speakerLabel check that doesn't exist
**What was expected:** Comments match code behavior
**What was found:** Comment mentioned speakerLabel fallback but only speakerId is actually compared
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
