### PR TITLE
fix(meet): propagate cancel through MeetTtsBridge so speaking_ended reports reason=cancelled

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -39,7 +39,7 @@ import type {
   TtsSynthesisRequest,
   TtsSynthesisResult,
 } from "../../../../assistant/src/tts/types.js";
-import { MeetTtsBridge } from "../tts-bridge.js";
+import { MeetTtsBridge, MeetTtsCancelledError } from "../tts-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Fake bot HTTP server
@@ -349,7 +349,17 @@ describe("MeetTtsBridge.speak", () => {
     await bridge.cancel(streamId);
 
     // The completion promise should have settled by now (cancel awaits).
-    await completion.catch(() => {});
+    // On cancel, `completion` rejects with a typed sentinel so the session
+    // manager's classifier can publish `reason: "cancelled"` — asserting
+    // the shape here locks in the contract.
+    let caught: unknown;
+    try {
+      await completion;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MeetTtsCancelledError);
+    expect((caught as MeetTtsCancelledError).code).toBe("MEET_TTS_CANCELLED");
 
     // The bot may or may not have recorded the partial POST (depending on
     // timing — we only require that the DELETE arrived). In practice Bun

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -65,7 +65,7 @@ import type {
   MeetEventSubscriber,
   MeetEventUnsubscribe,
 } from "../event-publisher.js";
-import { MeetTtsBridge } from "../tts-bridge.js";
+import { MeetTtsBridge, MeetTtsCancelledError } from "../tts-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Fake bot HTTP server (real Bun.serve)
@@ -434,10 +434,12 @@ function wrapSessionManager(
           }),
         )
         .catch((err) => {
-          const reason: "cancelled" | "error" =
-            err instanceof Error && err.message === "cancel"
-              ? "cancelled"
-              : "error";
+          const isCancel =
+            err instanceof MeetTtsCancelledError ||
+            (err !== null &&
+              typeof err === "object" &&
+              (err as { code?: unknown }).code === "MEET_TTS_CANCELLED");
+          const reason: "cancelled" | "error" = isCancel ? "cancelled" : "error";
           void publishToHub({
             type: "meet.speaking_ended",
             meetingId,
@@ -676,16 +678,17 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
       expect(fakeBot.deletes[0]!.url).toBe("/play_audio/stream-barge");
       expect(fakeBot.deletes[0]!.authorization).toBe(`Bearer ${TOKEN}`);
 
-      // Lifecycle event for the cancelled stream still flows back through
-      // the real assistant-event-hub. (The reason field is determined by
-      // the session-manager's classification of the completion promise;
-      // we only assert that the event reaches the hub for this stream.)
-      await captured.waitFor(
+      // Lifecycle event for the cancelled stream flows back through the
+      // real assistant-event-hub with reason="cancelled" — locking in the
+      // contract that caller-initiated cancels (and barge-in cancels) are
+      // observable as such, distinct from natural "completed" finishes.
+      const ended = (await captured.waitFor(
         (m) =>
           m.type === "meet.speaking_ended" &&
           (m as { streamId: string }).streamId === "stream-barge",
         1500,
-      );
+      )) as { reason: string; streamId: string };
+      expect(ended.reason).toBe("cancelled");
     } finally {
       captured.dispose();
       watcher.stop();

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -113,6 +113,7 @@ import {
   MeetTtsBridge,
   type MeetTtsBridgeArgs,
   type MeetTtsBridgeDeps,
+  MeetTtsCancelledError,
   type SpeakInput,
 } from "./tts-bridge.js";
 
@@ -1356,14 +1357,26 @@ class MeetSessionManagerImpl {
         );
       })
       .catch((err) => {
-        const reason: "cancelled" | "error" =
-          err instanceof Error && err.message === "cancel"
-            ? "cancelled"
-            : "error";
-        log.warn(
-          { err, meetingId, streamId, reason },
-          "MeetTtsBridge speak completion rejected",
-        );
+        const isCancel =
+          err instanceof MeetTtsCancelledError ||
+          (err !== null &&
+            typeof err === "object" &&
+            (err as { code?: unknown }).code === "MEET_TTS_CANCELLED");
+        const reason: "cancelled" | "error" = isCancel ? "cancelled" : "error";
+        // Cancels are expected during barge-in / caller cancel / leave —
+        // log at debug so they don't spam warn logs; genuine errors stay
+        // at warn.
+        if (isCancel) {
+          log.debug(
+            { meetingId, streamId, reason },
+            "MeetTtsBridge speak cancelled",
+          );
+        } else {
+          log.warn(
+            { err, meetingId, streamId, reason },
+            "MeetTtsBridge speak completion rejected",
+          );
+        }
         void publishMeetEvent(
           DAEMON_INTERNAL_ASSISTANT_ID,
           meetingId,

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -159,6 +159,25 @@ export class MeetTtsError extends Error {
   }
 }
 
+/**
+ * Thrown from {@link MeetTtsBridge} when an in-flight speak is cancelled
+ * via {@link MeetTtsBridge.cancel} or {@link MeetTtsBridge.cancelAll}.
+ *
+ * The session manager's `speak()` classifier keys on this class (via
+ * `err instanceof MeetTtsCancelledError` or `err.code === "MEET_TTS_CANCELLED"`)
+ * so `meet.speaking_ended` can publish `reason: "cancelled"` for caller-
+ * initiated and barge-in cancels, distinct from `reason: "completed"` for
+ * natural finishes and `reason: "error"` for genuine upstream failures.
+ */
+export class MeetTtsCancelledError extends Error {
+  readonly code = "MEET_TTS_CANCELLED" as const;
+
+  constructor(message = "cancelled") {
+    super(message);
+    this.name = "MeetTtsCancelledError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
@@ -374,7 +393,7 @@ export class MeetTtsBridge {
       );
       return;
     }
-    active.abort.abort(new Error("cancel"));
+    active.abort.abort(new MeetTtsCancelledError());
     // Best-effort DELETE — swallow failures. The outbound POST is already
     // aborted, so the bot's stdin-side of /play_audio will observe EOF
     // regardless; the DELETE is the explicit signal to flush.
@@ -434,8 +453,11 @@ export class MeetTtsBridge {
       });
     } catch (err) {
       if (abort.signal.aborted) {
-        // Caller-initiated cancel: swallow.
-        return;
+        // Caller-initiated cancel (explicit cancel / cancelAll / barge-in).
+        // Surface via a typed sentinel so the session manager's classifier
+        // can publish `meet.speaking_ended { reason: "cancelled" }` instead
+        // of misclassifying the cancel as a natural completion.
+        throw new MeetTtsCancelledError();
       }
       throw new MeetTtsError(
         "MEET_TTS_BOT_UNREACHABLE",
@@ -452,5 +474,13 @@ export class MeetTtsBridge {
     }
     // Drain any body the bot returned so the connection can be reused.
     await response.arrayBuffer().catch(() => {});
+    // Check abort after a "successful" drain: some fetch implementations
+    // resolve the response before propagating a late abort. If the caller
+    // cancelled mid-stream, surface that as a cancel so speaking_ended
+    // reports reason=cancelled even on races where the bot saw EOF and
+    // replied 200 before the abort propagated.
+    if (abort.signal.aborted) {
+      throw new MeetTtsCancelledError();
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-3-voice.md.

**Gap:** meet.speaking_ended always reports reason: completed on caller/barge-in cancel
**What was expected:** Three distinct reasons (completed/cancelled/error) per MeetSpeakingEnded type
**What was found:** runPost swallowed the abort so the .catch() classifier in session-manager was dead code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
