### PR TITLE
fix(meet): surface ffmpeg-missing as MEET_TTS_FFMPEG_UNAVAILABLE

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -39,7 +39,7 @@ import type {
   TtsSynthesisRequest,
   TtsSynthesisResult,
 } from "../../../../assistant/src/tts/types.js";
-import { MeetTtsBridge } from "../tts-bridge.js";
+import { MeetTtsBridge, MeetTtsError } from "../tts-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Fake bot HTTP server
@@ -180,17 +180,41 @@ function makeFakeFfmpegChild(options?: {
   return emitter;
 }
 
+/**
+ * Build a fake child that satisfies the `ffmpeg -version` probe — emits
+ * an `exit` event on the next tick so {@link MeetTtsBridge.ensureFfmpegAvailable}
+ * resolves `{ available: true }`.
+ */
+function makeFakeProbeChild(): FakeFfmpegChild {
+  const child = makeFakeFfmpegChild();
+  setImmediate(() => child.emit("exit", 0, null));
+  return child;
+}
+
 function makeSpawnMock(options?: { passThroughStdin?: boolean }): {
-  spawn: ReturnType<typeof mock>;
+  spawn: typeof import("node:child_process").spawn;
   lastChild: () => FakeFfmpegChild | null;
 } {
   let child: FakeFfmpegChild | null = null;
-  const spawn = mock(() => {
+  const spawn = mock((..._args: unknown[]) => {
+    // The ffmpeg -version probe is a separate spawn from the transcode
+    // pipeline. Recognize it by its single `-version` argument and
+    // respond with a synthetic "exit 0" so the probe succeeds by default.
+    const maybeArgs = _args[1];
+    const isProbe =
+      Array.isArray(maybeArgs) &&
+      maybeArgs.length === 1 &&
+      maybeArgs[0] === "-version";
+    if (isProbe) {
+      return makeFakeProbeChild() as unknown as ReturnType<
+        typeof import("node:child_process").spawn
+      >;
+    }
     child = makeFakeFfmpegChild(options);
     return child as unknown as ReturnType<
       typeof import("node:child_process").spawn
     >;
-  });
+  }) as unknown as typeof import("node:child_process").spawn;
   return {
     spawn,
     lastChild: () => child,
@@ -382,6 +406,91 @@ describe("MeetTtsBridge.speak", () => {
     await bridge.cancel("never-existed");
     expect(fakeBot.deletes).toHaveLength(0);
     expect(fakeBot.posts).toHaveLength(0);
+  });
+
+  test("rejects with MEET_TTS_FFMPEG_UNAVAILABLE when ffmpeg probe hits ENOENT", async () => {
+    // Model a machine without ffmpeg installed: the first spawn call
+    // (`ffmpeg -version`, the probe) emits an async `error` event with
+    // code `ENOENT` — the exact shape Node produces when the binary is
+    // missing from PATH. The bridge must translate that into a typed
+    // MeetTtsError with code MEET_TTS_FFMPEG_UNAVAILABLE rather than
+    // letting it cascade into an opaque downstream failure.
+    const provider = makeCannedProvider({ chunks: [new Uint8Array([1, 2])] });
+    let probeSpawnCalls = 0;
+    let transcodeSpawnCalls = 0;
+    const spawn = mock((..._args: unknown[]) => {
+      const maybeArgs = _args[1];
+      const isProbe =
+        Array.isArray(maybeArgs) &&
+        maybeArgs.length === 1 &&
+        maybeArgs[0] === "-version";
+      if (isProbe) {
+        probeSpawnCalls += 1;
+        const child = makeFakeFfmpegChild();
+        const err = new Error(
+          "spawn ffmpeg ENOENT",
+        ) as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        setImmediate(() => child.emit("error", err));
+        return child as unknown as ReturnType<
+          typeof import("node:child_process").spawn
+        >;
+      }
+      transcodeSpawnCalls += 1;
+      const child = makeFakeFfmpegChild();
+      return child as unknown as ReturnType<
+        typeof import("node:child_process").spawn
+      >;
+    }) as unknown as typeof import("node:child_process").spawn;
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-noffmpeg",
+      },
+    );
+
+    // The speak() promise should reject with a MeetTtsError carrying the
+    // MEET_TTS_FFMPEG_UNAVAILABLE code. Callers (meet_speak tool, etc.)
+    // can inspect `.code` to distinguish missing-binary from transient
+    // bot/network failures.
+    await expect(bridge.speak({ text: "hi" })).rejects.toMatchObject({
+      name: "MeetTtsError",
+      code: "MEET_TTS_FFMPEG_UNAVAILABLE",
+    });
+
+    // The bridge must not have spawned the transcode pipeline at all —
+    // the probe short-circuit catches ENOENT before any stream state is
+    // allocated.
+    expect(probeSpawnCalls).toBe(1);
+    expect(transcodeSpawnCalls).toBe(0);
+    expect(fakeBot.posts).toHaveLength(0);
+    expect(bridge.activeStreamCount()).toBe(0);
+
+    // Second speak() call reuses the cached probe result — no extra
+    // spawn, same typed error. This proves the probe is memoized.
+    await expect(bridge.speak({ text: "hi again" })).rejects.toMatchObject({
+      name: "MeetTtsError",
+      code: "MEET_TTS_FFMPEG_UNAVAILABLE",
+    });
+    expect(probeSpawnCalls).toBe(1);
+    expect(transcodeSpawnCalls).toBe(0);
+
+    // Sanity: the thrown error really is a MeetTtsError (instanceof check)
+    // so downstream error handling that branches on `err instanceof
+    // MeetTtsError` works.
+    const caught = await bridge
+      .speak({ text: "once more" })
+      .then(() => null)
+      .catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(MeetTtsError);
+    expect((caught as MeetTtsError).code).toBe("MEET_TTS_FFMPEG_UNAVAILABLE");
   });
 });
 

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -205,14 +205,29 @@ function makeFakeFfmpegChild(): FakeFfmpegChild {
 }
 
 function makeSpawnMock(): {
-  spawn: ReturnType<typeof mock>;
+  spawn: typeof import("node:child_process").spawn;
 } {
-  const spawn = mock(() => {
+  const spawn = mock((..._args: unknown[]) => {
+    // The ffmpeg -version probe is a separate spawn from the transcode
+    // pipeline. Respond with a synthetic exit so the probe cache reports
+    // "ffmpeg is available" without running the real binary.
+    const maybeArgs = _args[1];
+    const isProbe =
+      Array.isArray(maybeArgs) &&
+      maybeArgs.length === 1 &&
+      maybeArgs[0] === "-version";
+    if (isProbe) {
+      const child = makeFakeFfmpegChild();
+      setImmediate(() => child.emit("exit", 0, null));
+      return child as unknown as ReturnType<
+        typeof import("node:child_process").spawn
+      >;
+    }
     const child = makeFakeFfmpegChild();
     return child as unknown as ReturnType<
       typeof import("node:child_process").spawn
     >;
-  });
+  }) as unknown as typeof import("node:child_process").spawn;
   return { spawn };
 }
 

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -144,6 +144,7 @@ export interface MeetTtsBridgeDeps {
 
 export type MeetTtsErrorCode =
   | "MEET_TTS_PROVIDER_UNAVAILABLE"
+  | "MEET_TTS_FFMPEG_UNAVAILABLE"
   | "MEET_TTS_BOT_REJECTED"
   | "MEET_TTS_BOT_UNREACHABLE";
 
@@ -169,6 +170,11 @@ interface ActiveStream {
   settled: Promise<void>;
 }
 
+/** Cached result of the one-shot `ffmpeg -version` probe. */
+type FfmpegProbeResult =
+  | { available: true }
+  | { available: false; reason: string };
+
 /**
  * Constructor input identifying which bot this bridge talks to.
  */
@@ -187,6 +193,15 @@ export class MeetTtsBridge {
   private readonly botApiToken: string;
   private readonly deps: Required<MeetTtsBridgeDeps>;
   private readonly streams = new Map<string, ActiveStream>();
+  /**
+   * Memoized `ffmpeg -version` probe. Cached after the first `speak` call so
+   * subsequent speaks re-use the result without re-spawning ffmpeg. Resolves
+   * with `{ available: true }` when ffmpeg is on PATH and exits (regardless
+   * of exit code — even `-version` writing banner then exiting counts as
+   * "ffmpeg is runnable"), and `{ available: false, reason }` when spawn
+   * fails with ENOENT or a similar "binary missing" error.
+   */
+  private ffmpegProbe: Promise<FfmpegProbeResult> | null = null;
 
   constructor(args: MeetTtsBridgeArgs, deps: MeetTtsBridgeDeps) {
     if (!args.meetingId) {
@@ -227,6 +242,18 @@ export class MeetTtsBridge {
       );
     }
 
+    // Pre-flight: verify ffmpeg is on PATH before we allocate any streams.
+    // The probe result is memoized on the bridge instance, so this only
+    // spawns ffmpeg once per bridge lifetime on the happy path. If ffmpeg
+    // was uninstalled between bridges, each new bridge re-probes.
+    const probe = await this.ensureFfmpegAvailable();
+    if (!probe.available) {
+      throw new MeetTtsError(
+        "MEET_TTS_FFMPEG_UNAVAILABLE",
+        `ffmpeg transcoder unavailable: ${probe.reason}`,
+      );
+    }
+
     let provider: TtsProvider;
     try {
       provider = await this.deps.providerFactory();
@@ -254,13 +281,30 @@ export class MeetTtsBridge {
     const ffmpeg = this.deps.spawn("ffmpeg", [...FFMPEG_TRANSCODE_ARGS], {
       stdio: ["pipe", "pipe", "pipe"],
     });
-    // Surface ffmpeg errors at debug; a real spawn failure propagates as
-    // an exit with a non-zero code which we catch below.
+    // Spawn-time failures (e.g. ffmpeg binary missing since the probe) arrive
+    // here as an async `error` event — Node does NOT surface them as a
+    // non-zero exit code. We need to (a) abort the outbound POST so the
+    // fetch call doesn't hang forever on the broken stdout stream, and
+    // (b) stamp the probe cache as unavailable so subsequent speaks reject
+    // immediately with the correct error code.
     ffmpeg.on("error", (err) => {
-      log.warn(
-        { err, meetingId: this.meetingId, streamId },
-        "ffmpeg transcode spawn/runtime error",
-      );
+      const nodeErr = err as NodeJS.ErrnoException;
+      if (nodeErr?.code === "ENOENT") {
+        log.warn(
+          { err, meetingId: this.meetingId, streamId },
+          "ffmpeg binary missing — invalidating probe cache",
+        );
+        this.ffmpegProbe = Promise.resolve({
+          available: false,
+          reason: "ffmpeg binary not found on PATH (ENOENT)",
+        });
+      } else {
+        log.warn(
+          { err, meetingId: this.meetingId, streamId },
+          "ffmpeg transcode spawn/runtime error",
+        );
+      }
+      abort.abort(err);
     });
     ffmpeg.stderr?.on("data", (chunk: Buffer) => {
       log.debug(
@@ -452,5 +496,58 @@ export class MeetTtsBridge {
     }
     // Drain any body the bot returned so the connection can be reused.
     await response.arrayBuffer().catch(() => {});
+  }
+
+  /**
+   * One-shot, memoized `ffmpeg -version` probe. Spawns ffmpeg with
+   * `-version` and waits for either an `exit` event (any exit code means
+   * "ffmpeg ran") or an `error` event (ENOENT means the binary is missing).
+   *
+   * The probe deliberately does not treat a non-zero exit code as
+   * unavailable — a user with a corrupted ffmpeg build would still hit the
+   * downstream transcode failure with a more specific error. We only
+   * surface the pre-flight "missing binary" case here so `meet_speak`
+   * callers can distinguish a missing dependency from a transient bot
+   * failure.
+   */
+  private ensureFfmpegAvailable(): Promise<FfmpegProbeResult> {
+    if (this.ffmpegProbe) return this.ffmpegProbe;
+    this.ffmpegProbe = new Promise<FfmpegProbeResult>((resolve) => {
+      let settled = false;
+      const settle = (result: FfmpegProbeResult): void => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+
+      let child: ReturnType<SpawnFn>;
+      try {
+        child = this.deps.spawn("ffmpeg", ["-version"], {
+          stdio: ["ignore", "ignore", "ignore"],
+        });
+      } catch (err) {
+        // Synchronous spawn failure — very unusual, but treat the same as
+        // an async ENOENT.
+        settle({
+          available: false,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      child.on("error", (err) => {
+        const nodeErr = err as NodeJS.ErrnoException;
+        const reason =
+          nodeErr?.code === "ENOENT"
+            ? "ffmpeg binary not found on PATH (ENOENT)"
+            : `ffmpeg probe failed: ${err instanceof Error ? err.message : String(err)}`;
+        settle({ available: false, reason });
+      });
+      child.on("exit", () => {
+        // Any exit — zero or non-zero — means ffmpeg was runnable.
+        settle({ available: true });
+      });
+    });
+    return this.ffmpegProbe;
   }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for meet-phase-3-voice.md.

**Gap:** ffmpeg ENOENT on spawn produced an opaque error instead of a clear unavailable-dependency signal
**What was expected:** meet_speak callers can distinguish missing ffmpeg from a transient bot/network failure
**What was found:** spawn error event was logged at warn only; downstream write failure got translated to MEET_TTS_BOT_UNREACHABLE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
