### PR TITLE
fix(meet): classify runPost aborts by reason so internal errors surface as reason=error

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -508,6 +508,187 @@ describe("MeetTtsBridge.speak", () => {
   });
 });
 
+describe("MeetTtsBridge abort reason classification", () => {
+  test("ffmpeg error mid-stream surfaces as MeetTtsError, not MeetTtsCancelledError", async () => {
+    // Regression: after #25989, runPost threw MeetTtsCancelledError whenever
+    // abort.signal.aborted was true — including when the ffmpeg child's
+    // `error` event handler called abort.abort(err) with a raw ErrnoException.
+    // The session manager's classifier then misclassified the failure as
+    // reason=cancelled instead of reason=error.
+    //
+    // This test simulates an ffmpeg crash mid-stream: the provider starts
+    // emitting chunks, the ffmpeg child emits an `error` event (which the
+    // bridge catches and calls abort.abort(err)), and the completion promise
+    // must reject with something that is NOT a MeetTtsCancelledError so the
+    // session manager can emit reason=error.
+    const payload = [
+      new Uint8Array([1, 2, 3, 4]),
+      new Uint8Array([5, 6, 7, 8]),
+    ];
+    const provider = makeCannedProvider({ chunks: payload, gapMs: 100 });
+
+    let transcodeChild: FakeFfmpegChild | null = null;
+    const spawn = mock((..._args: unknown[]) => {
+      const maybeArgs = _args[1];
+      const isProbe =
+        Array.isArray(maybeArgs) &&
+        maybeArgs.length === 1 &&
+        maybeArgs[0] === "-version";
+      if (isProbe) {
+        return makeFakeProbeChild() as unknown as ReturnType<
+          typeof import("node:child_process").spawn
+        >;
+      }
+      transcodeChild = makeFakeFfmpegChild();
+      return transcodeChild as unknown as ReturnType<
+        typeof import("node:child_process").spawn
+      >;
+    }) as unknown as typeof import("node:child_process").spawn;
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-ffmpeg-crash",
+      },
+    );
+
+    const { completion } = await bridge.speak({ text: "will crash" });
+
+    // Give the first chunk time to flow before crashing ffmpeg.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Simulate an ffmpeg runtime error (e.g. SIGKILL, I/O error).
+    const ffmpegErr = new Error("ffmpeg process exited unexpectedly") as NodeJS.ErrnoException;
+    ffmpegErr.code = "EPIPE";
+    transcodeChild!.emit("error", ffmpegErr);
+
+    // The completion must reject, but NOT with MeetTtsCancelledError.
+    let caught: unknown;
+    try {
+      await completion;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(MeetTtsCancelledError);
+    // The original ffmpeg error should propagate through.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("ffmpeg process exited unexpectedly");
+
+    // Active stream map is clean after settlement.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+
+  test("provider synthesizeStream rejection mid-stream surfaces as Error, not MeetTtsCancelledError", async () => {
+    // Regression: the provider's synthesizeStream .catch handler calls
+    // abort.abort(err) with the provider's rejection. After #25989, runPost
+    // treated any aborted signal as a cancel, losing the real error.
+    //
+    // This test uses a provider that rejects after its first chunk.
+
+    const rejectingProvider: TtsProvider = {
+      id: "rejecting-test-provider",
+      capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+      async synthesize(): Promise<{ audio: Buffer; contentType: string }> {
+        throw new Error("not implemented");
+      },
+      async synthesizeStream(_request, onChunk) {
+        // Emit one chunk successfully, then reject.
+        onChunk(new Uint8Array([0xaa, 0xbb]));
+        await new Promise((r) => setTimeout(r, 20));
+        throw new Error("provider upstream 503: service unavailable");
+      },
+    };
+
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => rejectingProvider,
+        spawn,
+        newStreamId: () => "stream-provider-reject",
+      },
+    );
+
+    const { completion } = await bridge.speak({ text: "will reject" });
+
+    let caught: unknown;
+    try {
+      await completion;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(MeetTtsCancelledError);
+    // The propagated error should be the provider's original rejection or
+    // a wrapper that preserves the original message.
+    expect(caught).toBeInstanceOf(Error);
+
+    // Active stream map is clean after settlement.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+
+  test("caller cancel still produces MeetTtsCancelledError (not regressed)", async () => {
+    // Ensure the fix doesn't break the happy cancel path: when cancel() is
+    // called, the abort.signal.reason is a MeetTtsCancelledError, so
+    // runPost should still throw MeetTtsCancelledError.
+    const payload = [
+      new Uint8Array([1, 2]),
+      new Uint8Array([3, 4]),
+      new Uint8Array([5, 6]),
+    ];
+    const provider = makeCannedProvider({ chunks: payload, gapMs: 200 });
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-cancel-ok",
+      },
+    );
+
+    const { streamId, completion } = await bridge.speak({
+      text: "will be cancelled normally",
+    });
+
+    // Give the POST time to open.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Cancel via the bridge's cancel method — this sets abort.signal.reason
+    // to a MeetTtsCancelledError.
+    await bridge.cancel(streamId);
+
+    let caught: unknown;
+    try {
+      await completion;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MeetTtsCancelledError);
+    expect((caught as MeetTtsCancelledError).code).toBe("MEET_TTS_CANCELLED");
+    expect(bridge.activeStreamCount()).toBe(0);
+  });
+});
+
 describe("MeetTtsBridge constructor validation", () => {
   test("throws when meetingId is empty", () => {
     expect(

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -497,11 +497,23 @@ export class MeetTtsBridge {
       });
     } catch (err) {
       if (abort.signal.aborted) {
-        // Caller-initiated cancel (explicit cancel / cancelAll / barge-in).
-        // Surface via a typed sentinel so the session manager's classifier
-        // can publish `meet.speaking_ended { reason: "cancelled" }` instead
-        // of misclassifying the cancel as a natural completion.
-        throw new MeetTtsCancelledError();
+        // The AbortController is shared between caller-initiated cancels
+        // (which set the reason to a MeetTtsCancelledError) and internal
+        // error paths (ffmpeg crash, provider reject, stdin write error)
+        // which set the reason to the original error. Only surface a
+        // MeetTtsCancelledError when the abort was actually a cancel —
+        // otherwise propagate the original reason so the session manager's
+        // classifier emits `reason: "error"`.
+        if (abort.signal.reason instanceof MeetTtsCancelledError) {
+          throw abort.signal.reason;
+        }
+        // Internal error aborted the signal — propagate the original cause.
+        throw abort.signal.reason instanceof Error
+          ? abort.signal.reason
+          : new MeetTtsError(
+              "MEET_TTS_BOT_UNREACHABLE",
+              `Bot /play_audio aborted for streamId=${streamId}: ${String(abort.signal.reason)}`,
+            );
       }
       throw new MeetTtsError(
         "MEET_TTS_BOT_UNREACHABLE",
@@ -509,6 +521,21 @@ export class MeetTtsBridge {
       );
     }
     if (!response.ok) {
+      // Check abort before throwing BOT_REJECTED — a 4xx/5xx racing with
+      // a caller-cancel should classify as cancel, not error. Symmetric
+      // with the post-drain abort check on the 200 path below.
+      if (abort.signal.aborted) {
+        if (abort.signal.reason instanceof MeetTtsCancelledError) {
+          throw abort.signal.reason;
+        }
+        throw abort.signal.reason instanceof Error
+          ? abort.signal.reason
+          : new MeetTtsError(
+              "MEET_TTS_BOT_REJECTED",
+              `Bot /play_audio returned ${response.status} for streamId=${streamId} (aborted)`,
+              response.status,
+            );
+      }
       const detail = await response.text().catch(() => "");
       throw new MeetTtsError(
         "MEET_TTS_BOT_REJECTED",
@@ -524,7 +551,14 @@ export class MeetTtsBridge {
     // reports reason=cancelled even on races where the bot saw EOF and
     // replied 200 before the abort propagated.
     if (abort.signal.aborted) {
-      throw new MeetTtsCancelledError();
+      if (abort.signal.reason instanceof MeetTtsCancelledError) {
+        throw abort.signal.reason;
+      }
+      // Internal error aborted after a successful drain — propagate the
+      // original cause rather than misclassifying as cancelled.
+      throw abort.signal.reason instanceof Error
+        ? abort.signal.reason
+        : new Error(String(abort.signal.reason));
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes regression introduced by #25989.

**Gap:** After #25989, MeetTtsBridge.runPost threw MeetTtsCancelledError whenever abort.signal.aborted was true, including for internal failures (ffmpeg crash, provider reject, stdin write error) that share the same AbortController. That made meet.speaking_ended report reason=cancelled for genuine errors.
**What was expected:** Three distinct reasons (completed/cancelled/error); internal errors should surface as error.
**Fix:** runPost now checks abort.signal.reason instanceof MeetTtsCancelledError before classifying as cancel. Also added the abort check to the !response.ok path for symmetry with the 200 path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
