### PR TITLE
fix: use actual provider token count for context window indicator

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -64,6 +64,8 @@ export interface EventHandlerState {
   exchangeCacheCreationInputTokens: number;
   exchangeCacheReadInputTokens: number;
   exchangeOutputTokens: number;
+  /** Input tokens from the most recent LLM API call (overwritten, not accumulated). */
+  lastCallInputTokens: number;
   /** Number of actual LLM API calls within this exchange. */
   exchangeLlmCallCount: number;
   readonly exchangeRawResponses: unknown[];
@@ -135,6 +137,7 @@ export function createEventHandlerState(): EventHandlerState {
     exchangeCacheCreationInputTokens: 0,
     exchangeCacheReadInputTokens: 0,
     exchangeOutputTokens: 0,
+    lastCallInputTokens: 0,
     exchangeLlmCallCount: 0,
     exchangeRawResponses: [],
     model: "",
@@ -833,6 +836,7 @@ export function handleUsage(
   state.exchangeProviderName = providerName;
   state.exchangeLlmCallCount += 1;
   state.exchangeInputTokens += event.inputTokens;
+  state.lastCallInputTokens = event.inputTokens;
   state.exchangeCacheCreationInputTokens += event.cacheCreationInputTokens ?? 0;
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;
   state.exchangeOutputTokens += event.outputTokens;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1847,12 +1847,6 @@ export async function runAgentLoopImpl(
       }
     }
 
-    const postLoopContextEstimate = estimatePromptTokens(
-      restoredHistory,
-      ctx.systemPrompt,
-      { providerName: ctx.provider.name, toolTokenBudget },
-    );
-
     // Persist injections in history: runtime-injected context stays on
     // historical user messages so the conversation prefix is stable for
     // Anthropic's prefix caching.  Stripping only happens during
@@ -1873,7 +1867,7 @@ export async function runAgentLoopImpl(
       state.exchangeProviderName,
       state.exchangeLlmCallCount,
       {
-        tokens: postLoopContextEstimate,
+        tokens: state.lastCallInputTokens,
         maxTokens: config.contextWindow.maxInputTokens,
       },
     );


### PR DESCRIPTION
## Summary
- Replaced heuristic token estimation (`estimatePromptTokens()`) with actual `input_tokens` from the LLM provider's API response for the context window indicator
- Added `lastCallInputTokens` field to `EventHandlerState` that tracks the most recent (not accumulated) input token count from the provider
- The estimation heuristic (~4 chars/token) was producing wildly inaccurate values (e.g. 1766k / 400k); the actual API response gives exact numbers

## Original prompt
Use actual provider token count instead of heuristic estimate for the context window indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
