### PR TITLE
fix(memory): stop re-injecting memory onto tool_result messages during compaction

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -462,6 +462,7 @@ function makeCtx(
         runMessages: messages,
         injectedTokens: 0,
       }),
+      retrackCachedNodes: () => {},
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -451,6 +451,7 @@ function makeCtx(
         runMessages: messages,
         injectedTokens: 0,
       }),
+      retrackCachedNodes: () => {},
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1204,8 +1204,7 @@ export async function runAgentLoopImpl(
         mode: currentInjectionMode,
       });
       if (isTrustedActor && currentInjectionMode !== "minimal") {
-        const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
-        runMessages = memResult.runMessages;
+        ctx.graphMemory.retrackCachedNodes();
       }
       preRepairMessages = runMessages;
       preRunHistoryLength = runMessages.length;
@@ -1428,8 +1427,7 @@ export async function runAgentLoopImpl(
           mode: currentInjectionMode,
         });
         if (isTrustedActor && currentInjectionMode !== "minimal") {
-          const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
-          runMessages = memResult.runMessages;
+          ctx.graphMemory.retrackCachedNodes();
         }
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
@@ -1556,9 +1554,7 @@ export async function runAgentLoopImpl(
               mode: currentInjectionMode,
             });
             if (isTrustedActor && currentInjectionMode !== "minimal") {
-              const memResult =
-                ctx.graphMemory.reinjectCachedMemory(runMessages);
-              runMessages = memResult.runMessages;
+              ctx.graphMemory.retrackCachedNodes();
             }
             preRepairMessages = runMessages;
             preRunHistoryLength = runMessages.length;
@@ -1681,8 +1677,7 @@ export async function runAgentLoopImpl(
             mode: currentInjectionMode,
           });
           if (isTrustedActor && currentInjectionMode !== "minimal") {
-            const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
-            runMessages = memResult.runMessages;
+            ctx.graphMemory.retrackCachedNodes();
           }
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -253,6 +253,21 @@ export class ConversationGraphMemory {
   }
 
   /**
+   * Re-register cached node IDs with the InContextTracker after compaction
+   * WITHOUT modifying messages. Use this at post-agent-loop compaction sites
+   * where the memory block already survives on the original user message
+   * (since `<memory __injected>` is not stripped by stripInjectionsForCompaction).
+   *
+   * Calling reinjectCachedMemory at these sites would inject a duplicate
+   * onto the last user message — which after tool calls is a tool_result,
+   * not the original user message.
+   */
+  retrackCachedNodes(): void {
+    if (this.lastInjectedNodeIds.length === 0) return;
+    this.tracker.add(this.lastInjectedNodeIds);
+  }
+
+  /**
    * Main entry point — called on every turn before the LLM sees the messages.
    *
    * Dispatches to the appropriate retrieval mode:


### PR DESCRIPTION
## Summary
- During mid-turn compaction, `reinjectCachedMemory()` was injecting ~5000 char memory blocks onto tool_result messages (the "last user message" after tool calls), duplicating the block that already survived on the original user message
- Added `retrackCachedNodes()` method that re-registers tracker state without modifying messages
- Replaced `reinjectCachedMemory` with `retrackCachedNodes` at the 4 post-agent-loop compaction sites; kept the preflight site unchanged since the last user message is still correct there

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/25995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
