### PR TITLE
fix(sidebar): filter _reflections_to_background_complete sentinel from group list

### DIFF
--- a/assistant/src/memory/group-crud.ts
+++ b/assistant/src/memory/group-crud.ts
@@ -25,6 +25,11 @@ export interface ConversationGroupRow {
 
 export function listGroups(): ConversationGroupRow[] {
   ensureGroupMigration();
+  // Migration markers are stored as rows in conversation_groups with a leading
+  // underscore (e.g. `_backfill_complete`). System groups use the `system:`
+  // prefix and custom groups use UUIDs, so no legitimate group id starts with
+  // `_`. GLOB treats `_` as literal (unlike LIKE), so `_*` matches any id
+  // whose first character is an underscore.
   const rows = rawAll<{
     id: string;
     name: string;
@@ -33,7 +38,7 @@ export function listGroups(): ConversationGroupRow[] {
     created_at: number;
     updated_at: number;
   }>(
-    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups WHERE id NOT IN ('_backfill_complete', '_backfill_all_complete', '_sort_shift_complete') ORDER BY sort_position ASC",
+    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups WHERE id NOT GLOB '_*' ORDER BY sort_position ASC",
   );
   return rows.map((r) => ({
     id: r.id,


### PR DESCRIPTION
## Summary
- \`_reflections_to_background_complete\` is a one-time migration marker stored as a row in \`conversation_groups\` (added in #25998 to track the reflections→background backfill). The hard-coded \`NOT IN\` filter in \`listGroups()\` missed it, so the marker rendered as a top-level folder in the sidebar.
- Replaced the hard-coded list with \`NOT GLOB '_*'\`, which filters all underscore-prefixed ids. System groups use the \`system:\` prefix and custom groups use UUIDs, so no legitimate group id starts with \`_\` — and future migration markers are filtered automatically without a code change.

## Original prompt
[Image #1] What is _reflections_to_background_complete??? Can we get rid of this?