### PR TITLE
fix(meet): bump Docker Engine API version to v1.44

### DIFF
--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -46,8 +46,16 @@ const log = getLogger("meet-docker-runner");
 /** Path to the Docker Engine unix socket. */
 export const DEFAULT_DOCKER_SOCKET_PATH = "/var/run/docker.sock";
 
-/** Docker Engine API version used in request paths. */
-const DOCKER_API_VERSION = "v1.43";
+/**
+ * Docker Engine API version used in request paths.
+ *
+ * Must be <= the daemon's `ApiVersion` and >= its `MinAPIVersion`. Docker 28+
+ * raised `MinAPIVersion` to 1.44 and rejects older clients with a 400. We pin
+ * to the lowest version that's still supported by current Docker releases —
+ * v1.44 (Docker 25.0, January 2024) — to maximise backwards compatibility
+ * while clearing the new floor.
+ */
+const DOCKER_API_VERSION = "v1.44";
 
 /** Host for unix-socket HTTP requests (ignored by the socket transport). */
 const UNIX_SOCKET_HOST = "localhost";


### PR DESCRIPTION
## Summary
- Docker 28+ raised \`MinAPIVersion\` to 1.44 and rejects v1.43 clients with a 400, breaking meet-bot container creation.
- Bump \`DOCKER_API_VERSION\` in \`skills/meet-join/daemon/docker-runner.ts\` from \`v1.43\` to \`v1.44\` (Docker 25.0, Jan 2024) — the lowest version that clears the new floor while remaining widely compatible.
- Observed error: \`Docker API POST /v1.43/containers/create?name=vellum-meet-… failed (400): {"message":"client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}\`.

## Original prompt
Velissa is running into this issue when trying to join my google meet (screenshot shows the v1.43 400 error from Docker).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
