### PR TITLE
fix(macos): widen Usage breakdown Group column so model names aren't truncated

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -591,10 +591,10 @@ struct UsageTabContent: View {
     }
 
     private var groupColumnWidth: CGFloat {
-        store.selectedGroupBy == .conversation ? 200 : 130
+        store.selectedGroupBy == .conversation ? 200 : 260
     }
 
-    private let breakdownTableWidth: CGFloat = 500
+    private let breakdownTableWidth: CGFloat = 640
 
     @ViewBuilder
     private func breakdownTable(_ entries: [UsageGroupBreakdownEntry]) -> some View {


### PR DESCRIPTION
## Summary
- Bump the Group column width from 130 → 260pt for non-conversation group-by dimensions (model/provider/actor) so long model names like \`anthropic/claude-sonnet-4-5-20250929\` display without truncation.
- Bump \`breakdownTableWidth\` from 500 → 640pt so the Tokens column still has comfortable room alongside the wider Group column.

## Original prompt
[Image #1] Give this column more space so the model names don't get truncated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
