### PR TITLE
feat: track costs for Anthropic models on OpenRouter

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -6,6 +6,7 @@ import {
   resolvePricing,
   resolvePricingForUsage,
   resolvePricingForUsageWithOverrides,
+  usesAnthropicPricingRules,
 } from "../util/pricing.js";
 
 describe("resolvePricing", () => {
@@ -424,5 +425,178 @@ describe("resolvePricingForUsageWithOverrides", () => {
 
     expect(result.pricingStatus).toBe("priced");
     expect(result.estimatedCostUsd).toBeCloseTo(32.6, 10);
+  });
+});
+
+describe("Anthropic models on OpenRouter", () => {
+  test("prices anthropic/claude-opus-4.6 at Opus 4.6 rates", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-opus-4.6",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("prices anthropic/claude-sonnet-4.6 at Sonnet 4 rates via prefix match", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-sonnet-4.6",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test("prices anthropic/claude-haiku-4.5 at Haiku 4 rates via prefix match", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-haiku-4.5",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(0.8 + 4);
+  });
+
+  test("prices bare claude-opus-4-6 slug returned unprefixed", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "claude-opus-4-6-20260205",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("prices dash-form anthropic/claude-opus-4-6 identically to dot form", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-opus-4-6",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("returns unpriced for unknown anthropic model on OpenRouter", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-neptune-99",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("unpriced");
+    expect(result.estimatedCostUsd).toBeNull();
+  });
+
+  test("returns unpriced for non-Anthropic OpenRouter model", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "x-ai/grok-4.20-beta",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("unpriced");
+    expect(result.estimatedCostUsd).toBeNull();
+  });
+
+  test("applies Anthropic cache discounts for prompt-cache reads via OpenRouter", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+      anthropicCacheCreation: null,
+    };
+    const openRouter = resolvePricingForUsage(
+      "openrouter",
+      "anthropic/claude-opus-4.6",
+      usage,
+    );
+    const direct = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+
+    // Cache-read tokens are charged at 10% of input rate for Anthropic models.
+    expect(openRouter.pricingStatus).toBe("priced");
+    expect(openRouter.estimatedCostUsd).toBeCloseTo(5 * 0.1, 10);
+    expect(openRouter.estimatedCostUsd).toBe(direct.estimatedCostUsd);
+  });
+
+  test("applies Anthropic cache-write multipliers via OpenRouter", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 2_000_000,
+      cacheCreationInputTokens: 300_000,
+      cacheReadInputTokens: 300_000,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 200_000,
+        ephemeral_1h_input_tokens: 100_000,
+      },
+    };
+    const openRouter = resolvePricingForUsage(
+      "openrouter",
+      "anthropic/claude-opus-4.6",
+      usage,
+    );
+    const direct = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
+
+    expect(openRouter.pricingStatus).toBe("priced");
+    expect(openRouter.estimatedCostUsd).toBe(direct.estimatedCostUsd);
+  });
+
+  test("applies fast-mode multiplier via OpenRouter", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
+      speed: "fast",
+    };
+
+    const result = resolvePricingForUsage(
+      "openrouter",
+      "anthropic/claude-opus-4.6",
+      usage,
+    );
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
+  });
+});
+
+describe("usesAnthropicPricingRules", () => {
+  test("returns true for direct Anthropic", () => {
+    expect(usesAnthropicPricingRules("anthropic", "claude-opus-4-6")).toBe(true);
+  });
+
+  test("returns true for anthropic/* on OpenRouter", () => {
+    expect(
+      usesAnthropicPricingRules("openrouter", "anthropic/claude-sonnet-4.6"),
+    ).toBe(true);
+  });
+
+  test("returns true for bare claude-* slug on OpenRouter", () => {
+    expect(
+      usesAnthropicPricingRules("openrouter", "claude-opus-4-5-20250929"),
+    ).toBe(true);
+  });
+
+  test("returns false for non-Anthropic OpenRouter models", () => {
+    expect(usesAnthropicPricingRules("openrouter", "x-ai/grok-4")).toBe(false);
+  });
+
+  test("returns false for other providers", () => {
+    expect(usesAnthropicPricingRules("openai", "gpt-4o")).toBe(false);
+    expect(usesAnthropicPricingRules("gemini", "gemini-2.5-pro")).toBe(false);
   });
 });

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -8,7 +8,10 @@ import type {
   PricingUsage,
 } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
-import { resolvePricingForUsageWithOverrides } from "../util/pricing.js";
+import {
+  resolvePricingForUsageWithOverrides,
+  usesAnthropicPricingRules,
+} from "../util/pricing.js";
 import type { ServerMessage, UsageStats } from "./message-protocol.js";
 
 const log = getLogger("conversation-usage");
@@ -142,16 +145,16 @@ export function recordUsage(
     0,
   );
 
-  const isAnthropic = ctx.providerName === "anthropic";
+  const useAnthropicRules = usesAnthropicPricingRules(ctx.providerName, model);
   const pricingUsage: PricingUsage = {
     directInputTokens,
     outputTokens,
     cacheCreationInputTokens: normalizedCacheCreationInputTokens,
     cacheReadInputTokens: normalizedCacheReadInputTokens,
-    anthropicCacheCreation: isAnthropic
+    anthropicCacheCreation: useAnthropicRules
       ? extractAnthropicCacheCreation(rawResponse)
       : null,
-    speed: isAnthropic ? extractAnthropicSpeed(rawResponse) : null,
+    speed: useAnthropicRules ? extractAnthropicSpeed(rawResponse) : null,
   };
   const pricing = resolveStructuredPricing(
     ctx.providerName,

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -56,6 +56,44 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
 };
 
 /**
+ * Identify a model ID as an Anthropic model — accepts both the OpenRouter
+ * prefix form (`anthropic/claude-opus-4.6`) and the bare Anthropic slug
+ * (`claude-opus-4-6`) that `response.model` sometimes carries.
+ */
+function isAnthropicModelId(model: string): boolean {
+  return model.startsWith("anthropic/") || model.startsWith("claude-");
+}
+
+/**
+ * Normalize an OpenRouter-style Anthropic model ID for lookup against the
+ * Anthropic catalog: strip the `anthropic/` prefix and convert OpenRouter's
+ * dot-separated version tokens (`claude-opus-4.6`) to the dash form Anthropic
+ * uses natively (`claude-opus-4-6`).
+ */
+function normalizeAnthropicModelId(model: string): string {
+  const bare = model.startsWith("anthropic/")
+    ? model.slice("anthropic/".length)
+    : model;
+  return bare.replace(/\./g, "-");
+}
+
+/**
+ * Whether Anthropic's pricing rules (cache-read/write multipliers, fast-mode
+ * surcharge) apply for the given provider/model. True for direct Anthropic
+ * calls and for Anthropic models routed through OpenRouter — OpenRouter
+ * proxies to Anthropic's Messages API, so the usage response carries the
+ * same cache and speed fields and is charged at Anthropic's rates.
+ */
+export function usesAnthropicPricingRules(
+  provider: string,
+  model: string,
+): boolean {
+  if (provider === "anthropic") return true;
+  if (provider === "openrouter" && isAnthropicModelId(model)) return true;
+  return false;
+}
+
+/**
  * Look up pricing for a model within a provider's catalog.
  * Tries exact match first, then longest prefix match.
  */
@@ -147,12 +185,14 @@ function getAnthropicCacheWriteTokens(usage: PricingUsage): {
  */
 function calculateUsageCost(
   provider: string,
+  model: string,
   pricing: ModelPricing,
   usage: PricingUsage,
 ): number {
+  const useAnthropicRules = usesAnthropicPricingRules(provider, model);
   // Anthropic fast mode: 6x multiplier on base rates (cache multipliers stack on top)
   const speedMultiplier =
-    provider === "anthropic" && usage.speed === "fast"
+    useAnthropicRules && usage.speed === "fast"
       ? ANTHROPIC_FAST_MODE_MULTIPLIER
       : 1;
   const effectivePricing: ModelPricing = {
@@ -169,7 +209,7 @@ function calculateUsageCost(
     usage.outputTokens,
   );
 
-  if (provider !== "anthropic") {
+  if (!useAnthropicRules) {
     return (
       directInputCost +
       outputCost +
@@ -223,6 +263,27 @@ export function resolvePricingForUsage(
   model: string,
   usage: PricingUsage,
 ): PricingResult {
+  // Anthropic models routed through OpenRouter: look up against the Anthropic
+  // catalog using the normalized bare slug. OpenRouter bills these calls at
+  // Anthropic's rates and the underlying Messages API response includes
+  // Anthropic's cache- and speed-metadata fields.
+  if (provider === "openrouter" && isAnthropicModelId(model)) {
+    const anthropicCatalog = PROVIDER_PRICING.anthropic;
+    if (anthropicCatalog) {
+      const pricing = findPricing(
+        anthropicCatalog,
+        normalizeAnthropicModelId(model),
+      );
+      if (pricing) {
+        return {
+          estimatedCostUsd: calculateUsageCost(provider, model, pricing, usage),
+          pricingStatus: "priced",
+        };
+      }
+    }
+    return { estimatedCostUsd: null, pricingStatus: "unpriced" };
+  }
+
   const providerCatalog = PROVIDER_PRICING[provider];
   if (!providerCatalog) {
     return { estimatedCostUsd: null, pricingStatus: "unpriced" };
@@ -234,7 +295,7 @@ export function resolvePricingForUsage(
   }
 
   return {
-    estimatedCostUsd: calculateUsageCost(provider, pricing, usage),
+    estimatedCostUsd: calculateUsageCost(provider, model, pricing, usage),
     pricingStatus: "priced",
   };
 }
@@ -253,6 +314,7 @@ export function resolvePricingForUsageWithOverrides(
     return {
       estimatedCostUsd: calculateUsageCost(
         provider,
+        model,
         {
           inputPer1M: bestOverride.inputPer1M,
           outputPer1M: bestOverride.outputPer1M,


### PR DESCRIPTION
## Summary
- Price `openrouter` + `anthropic/*` calls via the Anthropic catalog with a normalized slug (strip prefix, convert `.` → `-`) so Opus/Sonnet/Haiku rates apply.
- Share Anthropic cache and fast-mode rules with OpenRouter-routed Anthropic calls — both go to Anthropic's Messages API and carry the same `usage.cache_*` / `usage.speed` fields.
- Add pricing tests covering prefix/dash normalization, cache discounts, fast-mode, and unknown/non-Anthropic OpenRouter models.

## Original prompt
Add cost tracking for Anthropic models on OpenRouter