### PR TITLE
fix(credentials): break CES reconnect deadlock on nested credential reads

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -25,12 +25,15 @@ mock.module("../util/logger.js", () => ({
 
 import * as encryptedStore from "../security/encrypted-store.js";
 import { _setStorePath } from "../security/encrypted-store.js";
+import type { CesClient } from "../credential-execution/client.js";
 import {
   _resetBackend,
   deleteSecureKeyAsync,
   getSecureKeyAsync,
   getSecureKeyResultAsync,
   listSecureKeysAsync,
+  setCesClient,
+  setCesReconnect,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 
@@ -289,6 +292,110 @@ describe("secure-keys", () => {
       const result = await getSecureKeyResultAsync("missing-key");
       expect(result.value).toBeUndefined();
       expect(result.unreachable).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CES reconnection reentrancy
+  // -----------------------------------------------------------------------
+  //
+  // The reconnect callback runs while the credential resolver is waiting on
+  // `_reconnectInFlight`. A nested `getSecureKeyAsync()` from inside the
+  // callback — e.g. `resolveManagedProxyContext()` reading the assistant API
+  // key for the handshake — would recursively `await` the same in-flight
+  // promise and deadlock for 45 seconds until `CREDENTIAL_OP_TIMEOUT_MS`
+  // fires. The guard in `attemptCesReconnection` short-circuits that
+  // reentrant case so nested reads resolve immediately (as "unreachable")
+  // and the outer reconnect makes progress.
+  describe("reconnect callback reentrancy", () => {
+    interface ControllableClient extends CesClient {
+      setReady: (ready: boolean) => void;
+    }
+
+    function makeControllableClient(initialReady = true): ControllableClient {
+      let ready = initialReady;
+      return {
+        handshake: async () => ({ accepted: true }),
+        call: async () => ({ found: false, value: undefined }) as never,
+        isReady: () => ready,
+        close: () => {
+          ready = false;
+        },
+        updateAssistantApiKey: async () => ({ updated: true }),
+        setReady: (r: boolean) => {
+          ready = r;
+        },
+      } as ControllableClient;
+    }
+
+    test("nested credential read inside reconnect callback does not deadlock", async () => {
+      // Seed the encrypted store with a value so nested reads have something
+      // to target if they were to accidentally succeed via fallback paths.
+      encryptedStore.setKey("test-key", "encrypted-value");
+
+      // Install a CES client that starts ready so the first read resolves
+      // the backend to CES RPC, then flip it to unready so the NEXT read
+      // triggers the reconnect path.
+      const client = makeControllableClient(true);
+      setCesClient(client);
+
+      // Prime the resolver so `_resolvedBackend` points at CES RPC.
+      await getSecureKeyAsync("test-key");
+      client.setReady(false);
+
+      let nestedReadResolved = false;
+      let reconnectCallbackRan = 0;
+
+      setCesReconnect(async () => {
+        reconnectCallbackRan++;
+        // Yield once so `_reconnectInFlight` (assigned after this IIFE's
+        // first await) is observable to any nested resolver. This matches
+        // production timing, where the callback awaits `pm.stop()` /
+        // `pm.start()` before reading credentials — those awaits complete
+        // the outer assignment, so the subsequent nested read sees a live
+        // `_reconnectInFlight` and is the recursion that caused the 45s
+        // deadlock.
+        await Promise.resolve();
+        await getSecureKeyAsync("test-key");
+        nestedReadResolved = true;
+        return makeControllableClient(true);
+      });
+
+      const start = Date.now();
+      await getSecureKeyAsync("test-key");
+      const elapsed = Date.now() - start;
+
+      expect(reconnectCallbackRan).toBe(1);
+      expect(nestedReadResolved).toBe(true);
+      // Pre-fix, this took 45s (CREDENTIAL_OP_TIMEOUT_MS). Post-fix it's
+      // bounded only by the mock callback's own work.
+      expect(elapsed).toBeLessThan(2000);
+    });
+
+    test("reconnect callback that throws still releases the reentrancy flag", async () => {
+      const client = makeControllableClient(true);
+      setCesClient(client);
+      await getSecureKeyAsync("any-key"); // prime the resolver
+      client.setReady(false);
+
+      setCesReconnect(async () => {
+        throw new Error("boom");
+      });
+
+      await getSecureKeyAsync("any-key");
+
+      // Swap in a reconnect that succeeds and wait past the 3s cooldown
+      // in `attemptCesReconnection`. A stuck reentrancy flag from the
+      // throwing callback would prevent this second attempt from running.
+      let secondCallbackRan = 0;
+      setCesReconnect(async () => {
+        secondCallbackRan++;
+        return makeControllableClient(true);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 3_100));
+
+      await getSecureKeyAsync("any-key");
+      expect(secondCallbackRan).toBe(1);
     });
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -628,18 +628,34 @@ export async function runDaemon(): Promise<void> {
       // falling back to the encrypted file store.
       if (cesResult.processManager) {
         const pm = cesResult.processManager;
+
+        // Snapshot the managed-proxy context and assistant ID at CES startup
+        // so the reconnect closure below never calls back into
+        // `resolveManagedProxyContext()`. That function reads the assistant
+        // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
+        // has resolved the backend to CES RPC — routes the read through CES
+        // itself. During a reconnect the old transport is dead and a new
+        // one is being set up by this very closure, so the nested credential
+        // read recursively awaits its own in-flight reconnection and
+        // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
+        // 45-second stall delays every CES restart and causes dependent
+        // credential reads (e.g. Meet's STT provider resolution) to return
+        // `undefined` during the window. API key rotation uses the
+        // `updateAssistantApiKey` RPC on the live client, not a reconnect,
+        // so caching at startup is safe.
+        const startupProxyCtx = await resolveManagedProxyContext();
+        const startupAssistantId = getPlatformAssistantId();
+
         setCesReconnect(async () => {
           try {
             await pm.stop();
             const transport = await pm.start();
             const newClient = createCesClient(transport);
-            const proxyCtx = await resolveManagedProxyContext();
-            const assistantId = getPlatformAssistantId();
             const { accepted, reason } = await newClient.handshake({
-              ...(proxyCtx.assistantApiKey
-                ? { assistantApiKey: proxyCtx.assistantApiKey }
+              ...(startupProxyCtx.assistantApiKey
+                ? { assistantApiKey: startupProxyCtx.assistantApiKey }
                 : {}),
-              ...(assistantId ? { assistantId } : {}),
+              ...(startupAssistantId ? { assistantId: startupAssistantId } : {}),
             });
             if (accepted) {
               log.info("CES reconnection handshake accepted");

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -22,6 +22,8 @@ import type {
   SecureKeyDeleteResult,
 } from "@vellumai/credential-storage";
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { getIsContainerized } from "../config/env-registry.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
@@ -74,6 +76,18 @@ let _lastReconnectAttempt = 0;
 
 /** In-flight reconnection promise — concurrent callers share the same attempt. */
 let _reconnectInFlight: Promise<boolean> | undefined;
+
+/**
+ * Per-async-context flag set while we are running the user-registered
+ * `_cesReconnect` callback. Reentrant credential reads from within the
+ * callback (on the same async call chain) must not `await`
+ * `_reconnectInFlight` — that would await the caller's own reconnect and
+ * deadlock until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. Using
+ * AsyncLocalStorage (rather than a module-level boolean) scopes the guard
+ * to the actual reentrant stack, so unrelated concurrent callers keep
+ * sharing the in-flight reconnect promise normally.
+ */
+const _reconnectContext = new AsyncLocalStorage<true>();
 
 /**
  * Set to true when a ces-http operation returns an unreachable result.
@@ -240,6 +254,15 @@ function tryFailoverToCesHttpBackend(
 async function attemptCesReconnection(): Promise<boolean> {
   if (!_cesReconnect) return false;
 
+  // Reentrancy guard. A nested credential read from inside the reconnect
+  // callback must not `await` our own in-flight promise — that would
+  // deadlock on the 45-second credential-op timeout. Report the reconnect
+  // as failed so the caller sees "unreachable" and falls back (env vars,
+  // dead-backend response) without blocking. Concurrent callers on other
+  // async chains don't see the ALS store, so they still share the
+  // in-flight promise normally.
+  if (_reconnectContext.getStore()) return false;
+
   // If a reconnection is already in flight, share it.
   if (_reconnectInFlight) return _reconnectInFlight;
 
@@ -249,7 +272,7 @@ async function attemptCesReconnection(): Promise<boolean> {
   _lastReconnectAttempt = Date.now();
   log.warn("Credential backend unavailable — attempting CES reconnection");
 
-  _reconnectInFlight = (async () => {
+  _reconnectInFlight = _reconnectContext.run(true, async () => {
     try {
       const newClient = await _cesReconnect!();
       if (newClient) {
@@ -262,7 +285,7 @@ async function attemptCesReconnection(): Promise<boolean> {
       log.warn({ err }, "CES reconnection failed");
     }
     return false;
-  })();
+  });
 
   try {
     return await _reconnectInFlight;


### PR DESCRIPTION
## Summary

- **Root cause**: `setCesReconnect`'s callback in `lifecycle.ts` called `resolveManagedProxyContext()` → `getSecureKeyAsync`, which once CES RPC was the resolved backend re-entered `attemptCesReconnection` and awaited `_reconnectInFlight` — the very promise it was inside. Deadlock held until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fired.
- **Symptom**: Every CES reconnection stalled ~45s. Credential reads during the window returned `undefined`, so Meet joins failed with "The configured STT provider is unusable for Meet transcription" even though the Deepgram key was saved in `keys.enc`.
- **Fix**: (1) cache managed-proxy context + assistant ID at CES startup so the reconnect closure never re-reads via `getSecureKeyAsync`; (2) guard `attemptCesReconnection` with AsyncLocalStorage so reentrant calls on the reconnect's own async chain short-circuit instead of deadlocking, while concurrent callers on other chains keep sharing the in-flight promise.
- Regression test verified to fail (45s timeout) without the ALS guard.

## Original prompt

fix(credentials): break CES reconnect deadlock on nested credential reads
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
