### PR TITLE
fix(meet-bot): resilient prejoin flow, diagnostics, and aligned timeouts

### DIFF
--- a/clients/macos/.gitignore
+++ b/clients/macos/.gitignore
@@ -13,6 +13,7 @@ Local.xcconfig
 daemon-bin/
 cli-bin/
 gateway-bin/
+ces-bin/
 *.o
 *.d
 *.swiftdeps

--- a/skills/meet-join/bot/__tests__/dom-selectors.test.ts
+++ b/skills/meet-join/bot/__tests__/dom-selectors.test.ts
@@ -47,6 +47,17 @@ describe("prejoin selectors", () => {
     expect(input.getAttribute("aria-label")).toBe("Your name");
   });
 
+  test("MEDIA_PROMPT_ACCEPT_BUTTON resolves the media-permission accept button", () => {
+    const nodes = doc.querySelectorAll(
+      prejoinSelectors.MEDIA_PROMPT_ACCEPT_BUTTON,
+    );
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).tagName).toBe("BUTTON");
+    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe(
+      "Use microphone and camera",
+    );
+  });
+
   test("ASK_TO_JOIN_BUTTON resolves the ask-to-join button", () => {
     const nodes = doc.querySelectorAll(prejoinSelectors.ASK_TO_JOIN_BUTTON);
     expect(nodes.length).toBe(1);
@@ -194,6 +205,10 @@ describe("flat selectors aggregate", () => {
   test("exposes each named constant from the individual groups", () => {
     const cases: Array<[keyof typeof selectors, string]> = [
       ["PREJOIN_NAME_INPUT", prejoinSelectors.NAME_INPUT],
+      [
+        "PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON",
+        prejoinSelectors.MEDIA_PROMPT_ACCEPT_BUTTON,
+      ],
       ["PREJOIN_ASK_TO_JOIN_BUTTON", prejoinSelectors.ASK_TO_JOIN_BUTTON],
       ["PREJOIN_JOIN_NOW_BUTTON", prejoinSelectors.JOIN_NOW_BUTTON],
       ["INGAME_CHAT_PANEL_BUTTON", chatSelectors.PANEL_BUTTON],

--- a/skills/meet-join/bot/__tests__/fixtures/meet-dom-prejoin.html
+++ b/skills/meet-join/bot/__tests__/fixtures/meet-dom-prejoin.html
@@ -47,6 +47,20 @@
           </button>
         </div>
       </div>
+
+      <!--
+        Media-permission modal Meet overlays on the prejoin screen for
+        anonymous joiners. Blocks the underlying UI until the "Use microphone
+        and camera" button (or the "Continue without" link) is clicked.
+      -->
+      <div role="dialog" aria-label="Do you want people to see and hear you in the meeting?">
+        <button type="button" aria-label="Use microphone and camera">
+          Use microphone and camera
+        </button>
+        <button type="button" aria-label="Continue without microphone and camera">
+          Continue without microphone and camera
+        </button>
+      </div>
     </div>
   </body>
 </html>

--- a/skills/meet-join/bot/__tests__/join-flow.test.ts
+++ b/skills/meet-join/bot/__tests__/join-flow.test.ts
@@ -35,6 +35,7 @@ function makePage(): FakePage {
   // Default: both prejoin buttons + the leave button are present so tests can
   // opt into the "only one branch visible" scenarios by overriding specific
   // entries.
+  locatorCounts.set(selectors.PREJOIN_NAME_INPUT, 1);
   locatorCounts.set(selectors.PREJOIN_JOIN_NOW_BUTTON, 1);
   locatorCounts.set(selectors.PREJOIN_ASK_TO_JOIN_BUTTON, 1);
   // Chat input: present by default so postConsentMessage skips the toggle
@@ -43,6 +44,13 @@ function makePage(): FakePage {
   locatorCounts.set(selectors.INGAME_CHAT_INPUT, 1);
 
   const waitRejectors = new Map<string, Error>();
+  // Default: the media-permission modal is NOT shown (signed-in happy path).
+  // Tests that want to exercise the modal-dismissal branch delete this entry
+  // so the wait resolves instead of rejecting.
+  waitRejectors.set(
+    selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+    new Error("Timeout 5000ms exceeded."),
+  );
 
   const page: FakePage = {
     __locatorCounts: locatorCounts,
@@ -89,18 +97,23 @@ describe("joinMeet", () => {
       consentMessage: "Hi, Vellum is listening.",
     });
 
-    // Expected selector order:
-    //   1. wait for prejoin name input
-    //   2. wait for leave button (signals the bot is in the meeting)
-    //   3. wait for chat input (inside postConsentMessage)
+    // Expected waitForSelector calls include:
+    //   - the prejoin name input (part of the race)
+    //   - the leave button (signals the bot is in the meeting)
+    //   - the chat input (inside postConsentMessage)
     const waits = waitedSelectors(page);
     expect(waits).toContain(selectors.PREJOIN_NAME_INPUT);
     expect(waits).toContain(selectors.INGAME_LEAVE_BUTTON);
     expect(waits).toContain(selectors.INGAME_CHAT_INPUT);
 
     // Display name was filled into the prejoin input.
-    expect(page.fill.mock.calls[0]?.[0]).toBe(selectors.PREJOIN_NAME_INPUT);
-    expect(page.fill.mock.calls[0]?.[1]).toBe("Vellum Bot");
+    const fillCalls = page.fill.mock.calls.map(
+      (call) => [String(call[0]), String(call[1])] as const,
+    );
+    expect(fillCalls).toContainEqual([
+      selectors.PREJOIN_NAME_INPUT,
+      "Vellum Bot",
+    ]);
 
     // "Join now" clicked, "Ask to join" NOT clicked.
     const clicks = clickedSelectors(page);
@@ -108,9 +121,6 @@ describe("joinMeet", () => {
     expect(clicks).not.toContain(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
 
     // Chat input was filled with the consent message and submitted.
-    const fillCalls = page.fill.mock.calls.map(
-      (call) => [String(call[0]), String(call[1])] as const,
-    );
     expect(fillCalls).toContainEqual([
       selectors.INGAME_CHAT_INPUT,
       "Hi, Vellum is listening.",
@@ -123,6 +133,10 @@ describe("joinMeet", () => {
     const page = makePage();
     // Simulate a locked meeting: "Join now" is NOT rendered.
     page.__locatorCounts.set(selectors.PREJOIN_JOIN_NOW_BUTTON, 0);
+    page.__waitForSelectorRejectors.set(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+      new Error("Timeout 30000ms exceeded."),
+    );
 
     await joinMeet(page as never, {
       displayName: "Vellum Bot",
@@ -132,6 +146,53 @@ describe("joinMeet", () => {
     const clicks = clickedSelectors(page);
     expect(clicks).toContain(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
     expect(clicks).not.toContain(selectors.PREJOIN_JOIN_NOW_BUTTON);
+  });
+
+  test("dismisses the media-permission modal when Meet renders it", async () => {
+    const page = makePage();
+    // Modal IS present — remove the default rejector so the wait resolves.
+    page.__waitForSelectorRejectors.delete(
+      selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+    );
+
+    await joinMeet(page as never, {
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+    });
+
+    const clicks = clickedSelectors(page);
+    expect(clicks).toContain(selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON);
+    // Dismissal runs before the join button click.
+    const modalIdx = clicks.indexOf(
+      selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+    );
+    const joinIdx = clicks.indexOf(selectors.PREJOIN_JOIN_NOW_BUTTON);
+    expect(modalIdx).toBeGreaterThanOrEqual(0);
+    expect(joinIdx).toBeGreaterThan(modalIdx);
+  });
+
+  test("skips the name fill when the input is not rendered (signed-in flow)", async () => {
+    const page = makePage();
+    // Signed-in flow: no "Your name" input, but the join buttons are still
+    // there.
+    page.__locatorCounts.set(selectors.PREJOIN_NAME_INPUT, 0);
+    page.__waitForSelectorRejectors.set(
+      selectors.PREJOIN_NAME_INPUT,
+      new Error("Timeout 30000ms exceeded."),
+    );
+
+    await joinMeet(page as never, {
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+    });
+
+    // No fill call on the name input.
+    const fillCalls = page.fill.mock.calls.map((call) => String(call[0]));
+    expect(fillCalls).not.toContain(selectors.PREJOIN_NAME_INPUT);
+
+    // Join-now still clicked — the flow proceeded past the missing name input.
+    const clicks = clickedSelectors(page);
+    expect(clicks).toContain(selectors.PREJOIN_JOIN_NOW_BUTTON);
   });
 
   test("opens the chat panel when the composer is not yet mounted", async () => {
@@ -174,10 +235,20 @@ describe("joinMeet", () => {
     ).rejects.toThrow(/in-meeting UI did not appear/i);
   });
 
-  test("throws a descriptive error when the prejoin name input never appears", async () => {
+  test("throws a descriptive error when no prejoin surface appears", async () => {
     const page = makePage();
+    // All three prejoin selectors never appear (e.g. Meet served a login
+    // redirect or an error screen).
     page.__waitForSelectorRejectors.set(
       selectors.PREJOIN_NAME_INPUT,
+      new Error("Timeout 30000ms exceeded."),
+    );
+    page.__waitForSelectorRejectors.set(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+      new Error("Timeout 30000ms exceeded."),
+    );
+    page.__waitForSelectorRejectors.set(
+      selectors.PREJOIN_ASK_TO_JOIN_BUTTON,
       new Error("Timeout 30000ms exceeded."),
     );
 
@@ -186,7 +257,7 @@ describe("joinMeet", () => {
         displayName: "Vellum Bot",
         consentMessage: "Hi, Vellum is listening.",
       }),
-    ).rejects.toThrow(/prejoin name input did not appear/i);
+    ).rejects.toThrow(/prejoin surface did not appear/i);
   });
 
   test("does not attempt the consent message when the join transition fails", async () => {

--- a/skills/meet-join/bot/src/browser/dom-selectors.ts
+++ b/skills/meet-join/bot/src/browser/dom-selectors.ts
@@ -50,8 +50,22 @@ export const prejoinSelectors = {
   /**
    * Text input where the joining participant types their display name. Meet
    * exposes this with `aria-label="Your name"` when the user is not signed in.
+   * Signed-in flows skip this input (the name comes from the Google account),
+   * so callers must treat it as optional.
    */
   NAME_INPUT: 'input[aria-label="Your name"]',
+
+  /**
+   * "Use microphone and camera" button in the media-permission modal Meet
+   * overlays on the prejoin screen for anonymous joiners. The modal blocks the
+   * underlying prejoin UI until it is dismissed, so the bot must click this
+   * (or the "Continue without microphone and camera" link) before any other
+   * prejoin selector becomes interactable. Chromium's
+   * `--use-fake-ui-for-media-stream` only auto-accepts the *browser's* native
+   * permission prompt — this dialog is rendered by Meet itself and must be
+   * clicked through explicitly.
+   */
+  MEDIA_PROMPT_ACCEPT_BUTTON: 'button[aria-label="Use microphone and camera"]',
 
   /**
    * "Ask to join" button shown when the meeting is locked and the bot needs
@@ -172,6 +186,7 @@ export const controlSelectors = {
 export const selectors = {
   // Prejoin
   PREJOIN_NAME_INPUT: prejoinSelectors.NAME_INPUT,
+  PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON: prejoinSelectors.MEDIA_PROMPT_ACCEPT_BUTTON,
   PREJOIN_ASK_TO_JOIN_BUTTON: prejoinSelectors.ASK_TO_JOIN_BUTTON,
   PREJOIN_JOIN_NOW_BUTTON: prejoinSelectors.JOIN_NOW_BUTTON,
 

--- a/skills/meet-join/bot/src/browser/join-flow.ts
+++ b/skills/meet-join/bot/src/browser/join-flow.ts
@@ -7,15 +7,19 @@
  *
  * Call graph:
  *
- *   1. Wait for the prejoin name input.
- *   2. Fill the name input with `displayName`.
- *   3. Branch on the admission policy:
+ *   1. Dismiss the media-permission modal if Meet rendered one (blocks the
+ *      prejoin UI underneath for anonymous joiners).
+ *   2. Wait for either the prejoin name input OR a join button — signed-in
+ *      flows skip the name input entirely, so treating it as mandatory would
+ *      hang the bot for 30s on a page that's otherwise interactable.
+ *   3. Fill the name input with `displayName` if it is present.
+ *   4. Branch on the admission policy:
  *        - If "Join now" is present, click it (signed-in / same-domain flow).
  *        - Else click "Ask to join" (locked meeting — host admits the bot).
- *   4. Wait for the in-meeting UI (the red "Leave call" button is the
+ *   5. Wait for the in-meeting UI (the red "Leave call" button is the
  *      canonical marker — it only mounts once the bot is actually in the
  *      meeting room).
- *   5. Post `consentMessage` in chat so human participants are informed that
+ *   6. Post `consentMessage` in chat so human participants are informed that
  *      an AI assistant is listening.
  *
  * Error strategy: every step throws a descriptive `Error` when a selector
@@ -23,13 +27,23 @@
  * container orchestrator notices the failure.
  */
 
+import { writeFile } from "node:fs/promises";
+
 import type { Page } from "playwright";
 
 import { postConsentMessage } from "./chat-bridge.js";
 import { selectors } from "./dom-selectors.js";
 
-/** How long to wait for the prejoin name input to mount. */
+/** How long to wait for the prejoin surface to mount. */
 const PREJOIN_TIMEOUT_MS = 30_000;
+
+/**
+ * How long to wait for Meet's media-permission modal. Short by design — if
+ * Meet didn't render the modal (signed-in flows, older UI variants) we want
+ * to fall through to the prejoin wait quickly rather than spending the full
+ * prejoin budget on a dialog that will never appear.
+ */
+const MEDIA_PROMPT_TIMEOUT_MS = 5_000;
 
 /**
  * How long to wait for the meeting-room UI after clicking the join button.
@@ -60,7 +74,9 @@ const DIAGNOSTICS_DIR = "/out";
  * Best-effort: snapshot the current page to `/out/<name>.png` so an
  * operator can see exactly what Google Meet was showing when a selector
  * timed out. Never re-throws — diagnostics must not mask the real join
- * failure that triggered the capture.
+ * failure that triggered the capture. Logs capture failures to stderr so
+ * the operator can tell "capture was attempted and failed" apart from
+ * "capture was never attempted".
  */
 async function captureFailureSnapshot(
   page: Page,
@@ -70,7 +86,36 @@ async function captureFailureSnapshot(
   try {
     await page.screenshot({ path: snapPath, fullPage: true });
     return snapPath;
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `meet-bot: screenshot capture failed for ${name}: ${msg}\n`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Best-effort: dump the current page's HTML to `/out/<name>.html`. Useful
+ * when the screenshot path fails (page crashed, missing display) or when
+ * Meet served an entirely different surface (sign-in wall, unsupported-
+ * browser interstitial) and we want to inspect what selectors WOULD have
+ * matched.
+ */
+async function captureFailureHtml(
+  page: Page,
+  name: string,
+): Promise<string | null> {
+  const htmlPath = `${DIAGNOSTICS_DIR}/${name}.html`;
+  try {
+    const html = await page.content();
+    await writeFile(htmlPath, html, "utf8");
+    return htmlPath;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `meet-bot: html capture failed for ${name}: ${msg}\n`,
+    );
     return null;
   }
 }
@@ -90,6 +135,20 @@ async function safePageUrl(page: Page): Promise<string | null> {
 }
 
 /**
+ * Best-effort: capture the current page title. A title like "Meet — <code>"
+ * means the prejoin DOM loaded but our selectors are wrong; a title like
+ * "Sign in — Google Accounts" or "Unsupported browser" tells us Meet served
+ * something else entirely.
+ */
+async function safePageTitle(page: Page): Promise<string | null> {
+  try {
+    return await page.title();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Drive the Google Meet prejoin surface to completion and deliver the consent
  * notice.
  *
@@ -103,27 +162,63 @@ export async function joinMeet(
 ): Promise<void> {
   const { displayName, consentMessage } = opts;
 
-  // Step 1 — wait for the prejoin name input so we know the page has reached
-  // the "Ready to join?" stage (rather than, say, a Google login redirect).
+  // Step 1 — dismiss the media-permission modal if Meet rendered one. The
+  // modal blocks the underlying prejoin UI from being interacted with (even
+  // from visible selectors), so the bot must click through it before doing
+  // anything else. Best-effort — a missing modal is the signed-in happy path
+  // and must not fail the join.
   try {
-    await page.waitForSelector(selectors.PREJOIN_NAME_INPUT, {
-      timeout: PREJOIN_TIMEOUT_MS,
+    await page.waitForSelector(selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON, {
+      timeout: MEDIA_PROMPT_TIMEOUT_MS,
     });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    await page.click(selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON);
+  } catch {
+    // No modal — proceed directly to the prejoin surface.
+  }
+
+  // Step 2 — wait for the prejoin surface to be ready. Meet shows the
+  // "Your name" input only for anonymous joiners; signed-in flows skip
+  // straight to the join buttons. `Promise.any` resolves as soon as any one
+  // of the three selectors becomes visible, and only rejects if all three
+  // time out — which is the signal that Meet served something other than a
+  // prejoin (login redirect, error screen, etc.).
+  try {
+    await Promise.any([
+      page.waitForSelector(selectors.PREJOIN_NAME_INPUT, {
+        timeout: PREJOIN_TIMEOUT_MS,
+      }),
+      page.waitForSelector(selectors.PREJOIN_JOIN_NOW_BUTTON, {
+        timeout: PREJOIN_TIMEOUT_MS,
+      }),
+      page.waitForSelector(selectors.PREJOIN_ASK_TO_JOIN_BUTTON, {
+        timeout: PREJOIN_TIMEOUT_MS,
+      }),
+    ]);
+  } catch {
     const url = await safePageUrl(page);
+    const title = await safePageTitle(page);
     const snap = await captureFailureSnapshot(page, "prejoin-failure");
+    const html = await captureFailureHtml(page, "prejoin-failure");
     throw new Error(
-      `meet-bot: prejoin name input did not appear within ${PREJOIN_TIMEOUT_MS}ms: ${msg}` +
+      `meet-bot: prejoin surface did not appear within ${PREJOIN_TIMEOUT_MS}ms` +
         (url ? ` (final URL: ${url})` : "") +
-        (snap ? ` (screenshot: ${snap})` : ""),
+        (title ? ` (page title: ${JSON.stringify(title)})` : "") +
+        (snap ? ` (screenshot: ${snap})` : "") +
+        (html ? ` (html: ${html})` : ""),
     );
   }
 
-  // Step 2 — populate the display name.
-  await page.fill(selectors.PREJOIN_NAME_INPUT, displayName);
+  // Step 3 — populate the display name if the input is present. Signed-in
+  // flows (and some Meet UI variants) don't render it, in which case the
+  // account's name is used instead.
+  const nameInputCount = await page
+    .locator(selectors.PREJOIN_NAME_INPUT)
+    .count();
+  if (nameInputCount > 0) {
+    await page.fill(selectors.PREJOIN_NAME_INPUT, displayName);
+  }
 
-  // Step 3 — choose the admission button. Prefer "Join now" because it is the
+  // Step 4 — choose the admission button. Prefer "Join now" because it is the
   // happy-path branch for signed-in / same-domain sessions; fall back to
   // "Ask to join" for locked meetings.
   const joinNowCount = await page
@@ -135,7 +230,7 @@ export async function joinMeet(
     await page.click(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
   }
 
-  // Step 4 — wait for the in-meeting UI. The "Leave call" button only mounts
+  // Step 5 — wait for the in-meeting UI. The "Leave call" button only mounts
   // once the bot is inside the meeting room, so it is our canonical signal
   // that the admission flow succeeded.
   try {
@@ -153,7 +248,7 @@ export async function joinMeet(
     );
   }
 
-  // Step 5 — drop the consent notice. `postConsentMessage` handles opening
+  // Step 6 — drop the consent notice. `postConsentMessage` handles opening
   // the chat panel if it is still collapsed.
   await postConsentMessage(page, consentMessage);
 }

--- a/skills/meet-join/bot/src/browser/session.ts
+++ b/skills/meet-join/bot/src/browser/session.ts
@@ -60,6 +60,14 @@ export const CHROMIUM_ARGS: readonly string[] = [
   "--no-sandbox",
   "--disable-dev-shm-usage",
   "--disable-setuid-sandbox",
+  // Disable GPU acceleration — there is no GPU in the container and Chromium's
+  // GPU-process initialization is a common source of early crashes in
+  // containerized Xvfb setups, even with `--headless=new` disabled.
+  "--disable-gpu",
+  // Silence crash-reporter and background-networking subsystems that are
+  // irrelevant for a short-lived bot and occasionally misbehave under Xvfb.
+  "--disable-background-networking",
+  "--disable-breakpad",
   "--window-size=1280,720",
 ];
 

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -59,8 +59,16 @@ const log = getLogger("meet-audio-ingest");
  * after `start()` opens it. Exceeding this rejects `start()` with a clear
  * error so the session manager can abort the join and clean up the
  * container.
+ *
+ * Must be larger than the bot's worst-case prejoin+admission path, not just
+ * its connect cost. The bot only opens the audio socket *after* `joinMeet`
+ * returns, and `joinMeet` may legitimately block for `MEETING_ROOM_TIMEOUT_MS`
+ * (90s) while a host admits the bot through the "Ask to join" lobby. Plus
+ * cold-start (Chrome launch + Meet page load + modal dismissal) adds another
+ * ~10s. Anything under ~100s races the join flow and causes the daemon to
+ * rollback a bot that was still legitimately mid-join.
  */
-export const BOT_CONNECT_TIMEOUT_MS = 30_000;
+export const BOT_CONNECT_TIMEOUT_MS = 120_000;
 
 /**
  * Sample rate (Hz) of the PCM frames the meet-bot captures and forwards over

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -698,6 +698,13 @@ export function buildCreateBody(
     // `host-gateway` value is required. Applied unconditionally because
     // the resolution is identical either way on modern engines.
     ExtraHosts: [HOST_GATEWAY_ALIAS],
+    // Docker's default `/dev/shm` is 64 MiB, which Chromium exhausts when
+    // loading a JS-heavy page like Google Meet — the renderer then crashes
+    // with a cryptic "Target page, context or browser has been closed". 2 GiB
+    // is the commonly-cited safe default for Puppeteer/Playwright in Docker.
+    // (`--disable-dev-shm-usage` in the Chromium launch args routes shared
+    // memory to `/tmp` as a separate belt-and-suspenders hedge.)
+    ShmSize: 2 * 1024 * 1024 * 1024,
     ...(opts.network ? { NetworkMode: opts.network } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Bot now dismisses Meet's media-permission modal and treats the name input as optional, clearing two distinct prejoin stalls (anonymous modal-block and signed-in name-skip).
- Daemon's `BOT_CONNECT_TIMEOUT_MS` bumped 30s → 120s so it covers the bot's worst-case join path (`MEETING_ROOM_TIMEOUT_MS` is 90s) instead of racing it and rolling back live containers.
- Chrome/Docker hardening (`--disable-gpu`, breakpad/background-networking off, `ShmSize: 2 GiB`) plus richer diagnostics (HTML + title + screenshot dumped on prejoin failure).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
