### PR TITLE
fix(lint): sort imports in secure-keys files

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -23,9 +23,9 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import type { CesClient } from "../credential-execution/client.js";
 import * as encryptedStore from "../security/encrypted-store.js";
 import { _setStorePath } from "../security/encrypted-store.js";
-import type { CesClient } from "../credential-execution/client.js";
 import {
   _resetBackend,
   deleteSecureKeyAsync,

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -17,12 +17,12 @@
  * sidecar and credential data.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import type {
   SecureKeyBackend,
   SecureKeyDeleteResult,
 } from "@vellumai/credential-storage";
-
-import { AsyncLocalStorage } from "node:async_hooks";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import type { CesClient } from "../credential-execution/client.js";


### PR DESCRIPTION
## Summary
- Ran eslint --fix on the two files flagged by \`simple-import-sort/imports\` in the Lint CI job: \`assistant/src/security/secure-keys.ts\` and \`assistant/src/__tests__/secure-keys.test.ts\`.
- Pure import reordering, no behavioral changes.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24499318954/job/71601776449
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
