### PR TITLE
Add RecapPillView inline interactive pill component

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// An inline pill/chip view for recap flowing text.
+///
+/// Displays text with an optional trailing priority icon. Background opacity
+/// increases on hover to provide interactive feedback.
+struct RecapPillView: View {
+
+    // MARK: - Priority
+
+    enum Priority {
+        case high
+        case medium
+    }
+
+    // MARK: - Properties
+
+    let text: String
+    var priority: Priority?
+    var isHighlighted: Bool = false
+    var onTap: (() -> Void)?
+
+    @State private var isHovered = false
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(text)
+                .font(VFont.titleMedium)
+                .foregroundStyle(VColor.contentEmphasized)
+
+            if let priority {
+                VIconView(.circleAlert, size: 18)
+                    .foregroundStyle(iconColor(for: priority))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 5)
+        .background(
+            Color.white.opacity(backgroundOpacity)
+        )
+        .clipShape(Capsule())
+        .pointerCursor(onHover: { hovering in
+            isHovered = hovering
+        })
+        .onTapGesture {
+            onTap?()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var backgroundOpacity: Double {
+        (isHighlighted || isHovered) ? 0.5 : 0.1
+    }
+
+    private func iconColor(for priority: Priority) -> Color {
+        switch priority {
+        case .high:
+            return VColor.systemNegativeStrong
+        case .medium:
+            return VColor.systemMidStrong
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("High Priority") {
+    RecapPillView(
+        text: "authorising a transaction to NBA",
+        priority: .high
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}
+
+#Preview("Medium Priority") {
+    RecapPillView(
+        text: "schedule team standup",
+        priority: .medium
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}
+
+#Preview("No Priority") {
+    RecapPillView(
+        text: "review pull request",
+        priority: nil
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}
+
+#Preview("Highlighted") {
+    RecapPillView(
+        text: "authorising a transaction to NBA",
+        priority: .high,
+        isHighlighted: true
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}


### PR DESCRIPTION
## Summary
- Add RecapPillView for inline interactive pills in home page recap text
- Support high/medium/none priority with colored exclamation icons
- Hover state with background opacity change and pointer cursor

Part of plan: home-page-components.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
