### PR TITLE
Add HomeRecapCard base container, shared header, and LinkFileRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeLinkFileRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeLinkFileRow.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Pill-shaped row displaying a file reference with icon, file name,
+/// and size. Used inside recap cards to show linked attachments.
+struct HomeLinkFileRow: View {
+    let icon: VIcon
+    let fileName: String
+    let fileSize: String
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            iconCircle
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(fileName)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Text(fileSize)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(EdgeInsets(top: 2, leading: 2, bottom: 2, trailing: VSpacing.lg))
+        .background(
+            Capsule()
+                .fill(VColor.surfaceOverlay)
+        )
+    }
+
+    // MARK: - Icon circle
+
+    /// 26pt circular container with active surface background.
+    private var iconCircle: some View {
+        ZStack {
+            Circle()
+                .fill(VColor.surfaceActive)
+                .frame(width: 26, height: 26)
+
+            VIconView(icon, size: 12)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardHeader.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Reusable header row for recap cards. Displays a circular icon
+/// container, title, optional subtitle (thread name), and an
+/// optional dismiss button.
+struct HomeRecapCardHeader: View {
+    let icon: VIcon
+    let iconColor: Color
+    let title: String
+    let subtitle: String?
+    let showDismiss: Bool
+    let onDismiss: (() -> Void)?
+
+    init(
+        icon: VIcon,
+        iconColor: Color = VColor.contentDisabled,
+        title: String,
+        subtitle: String? = nil,
+        showDismiss: Bool = false,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.icon = icon
+        self.iconColor = iconColor
+        self.title = title
+        self.subtitle = subtitle
+        self.showDismiss = showDismiss
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            iconCircle
+            titleStack
+            Spacer(minLength: 0)
+            if showDismiss {
+                dismissButton
+            }
+        }
+    }
+
+    // MARK: - Icon circle
+
+    /// 38pt circular container with white background housing the icon.
+    private var iconCircle: some View {
+        ZStack {
+            Circle()
+                .fill(VColor.auxWhite)
+                .frame(width: 38, height: 38)
+
+            VIconView(icon, size: 18)
+                .foregroundStyle(iconColor)
+        }
+    }
+
+    // MARK: - Title stack
+
+    private var titleStack: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(title)
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentEmphasized)
+                .lineLimit(1)
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    // MARK: - Dismiss button
+
+    /// Bordered pill dismiss button with an X icon.
+    private var dismissButton: some View {
+        Button {
+            onDismiss?()
+        } label: {
+            VIconView(.x, size: 12)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(VSpacing.xs)
+                .background(
+                    Capsule()
+                        .strokeBorder(VColor.borderBase, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Container view for recap cards on the Home page. Provides a
+/// glassmorphic rounded surface with shadow that wraps arbitrary
+/// card content via a `@ViewBuilder` slot.
+struct HomeRecapCardView<Content: View>: View {
+    let showDismiss: Bool
+    let onDismiss: (() -> Void)?
+    private let content: Content
+
+    init(
+        showDismiss: Bool = false,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.showDismiss = showDismiss
+        self.onDismiss = onDismiss
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
+                    .fill(VColor.surfaceLift.opacity(0.1))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous))
+            .vShadow(VShadow.md)
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeRecapCardView container with glassmorphic background and shadow
- Add HomeRecapCardHeader with icon circle, title, subtitle, and dismiss button
- Add HomeLinkFileRow for file reference display

Part of plan: home-page-components.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
