### PR TITLE
Add HomeReplyCard with inline message composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Recap card that presents a reply prompt with an inline message
+/// composer. Used on the Home page when the assistant wants the user
+/// to respond to a question in a thread.
+struct HomeReplyCard: View {
+    let title: String
+    let threadName: String?
+    let showDismiss: Bool
+    let onDismiss: (() -> Void)?
+    let onSend: (String) -> Void
+
+    @State private var inputText: String = ""
+
+    init(
+        title: String,
+        threadName: String? = nil,
+        showDismiss: Bool = false,
+        onDismiss: (() -> Void)? = nil,
+        onSend: @escaping (String) -> Void
+    ) {
+        self.title = title
+        self.threadName = threadName
+        self.showDismiss = showDismiss
+        self.onDismiss = onDismiss
+        self.onSend = onSend
+    }
+
+    var body: some View {
+        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+            VStack(spacing: 0) {
+                header
+                composerBar
+                    .padding(.top, VSpacing.md)
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HomeRecapCardHeader(
+            icon: .messageCircle,
+            title: title,
+            subtitle: threadName,
+            showDismiss: showDismiss,
+            onDismiss: onDismiss
+        )
+    }
+
+    // MARK: - Inline Composer
+
+    private var composerBar: some View {
+        HStack(spacing: VSpacing.sm) {
+            composerInput
+            composerIcons
+        }
+        .padding(.leading, VSpacing.md)
+        .padding(.trailing, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.window, style: .continuous)
+                .fill(VColor.auxWhite)
+        )
+        .shadow(
+            color: VColor.auxBlack.opacity(0.05),
+            radius: 2,
+            x: 0,
+            y: 2
+        )
+    }
+
+    private var composerInput: some View {
+        ZStack(alignment: .leading) {
+            if inputText.isEmpty {
+                Text("What would you like to do?")
+                    .font(VFont.bodyLargeDefault)
+                    .foregroundStyle(VColor.contentDisabled)
+            }
+
+            TextField("", text: $inputText)
+                .textFieldStyle(.plain)
+                .font(VFont.bodyLargeDefault)
+                .foregroundStyle(VColor.contentEmphasized)
+                .accessibilityLabel(Text("Reply message"))
+        }
+    }
+
+    private var composerIcons: some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(.paperclip, size: 20)
+                .foregroundStyle(VColor.contentTertiary)
+
+            VIconView(.mic, size: 20)
+                .foregroundStyle(VColor.contentTertiary)
+
+            VIconView(.audioWaveform, size: 32)
+                .foregroundStyle(VColor.contentDefault)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeReplyCard for reply prompts on home page
- Shows question text, thread name, and inline message composer
- Composer includes placeholder, attachment, mic, and voice icons

Part of plan: home-page-components.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
