### PR TITLE
Add HomeImageCard and HomeFileCard for content previews

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeFileCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeFileCard.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Recap card displaying a file reference with name and size.
+/// Uses `HomeRecapCardView` as the outer container, `HomeRecapCardHeader`
+/// for the icon + title row, and `HomeLinkFileRow` for the file info.
+struct HomeFileCard: View {
+    let title: String
+    let threadName: String?
+    let fileName: String
+    let fileSize: String
+    let showDismiss: Bool
+    let onDismiss: (() -> Void)?
+
+    init(
+        title: String,
+        threadName: String? = nil,
+        fileName: String,
+        fileSize: String,
+        showDismiss: Bool = false,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.threadName = threadName
+        self.fileName = fileName
+        self.fileSize = fileSize
+        self.showDismiss = showDismiss
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+            VStack(spacing: VSpacing.md) {
+                HomeRecapCardHeader(
+                    icon: .file,
+                    title: title,
+                    subtitle: threadName,
+                    showDismiss: showDismiss,
+                    onDismiss: onDismiss
+                )
+
+                HomeLinkFileRow(
+                    icon: .file,
+                    fileName: fileName,
+                    fileSize: fileSize
+                )
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Recap card displaying a large image preview with Save and Open in Finder
+/// action buttons. Uses `HomeRecapCardView` as the outer container and
+/// `HomeRecapCardHeader` for the icon + title row.
+struct HomeImageCard: View {
+    let title: String
+    let threadName: String?
+    let image: NSImage?
+    let showDismiss: Bool
+    let onSave: () -> Void
+    let onOpenInFinder: () -> Void
+    let onDismiss: (() -> Void)?
+
+    init(
+        title: String,
+        threadName: String? = nil,
+        image: NSImage? = nil,
+        showDismiss: Bool = false,
+        onSave: @escaping () -> Void,
+        onOpenInFinder: @escaping () -> Void,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.threadName = threadName
+        self.image = image
+        self.showDismiss = showDismiss
+        self.onSave = onSave
+        self.onOpenInFinder = onOpenInFinder
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+            VStack(spacing: VSpacing.md) {
+                HomeRecapCardHeader(
+                    icon: .image,
+                    title: title,
+                    subtitle: threadName,
+                    showDismiss: showDismiss,
+                    onDismiss: onDismiss
+                )
+
+                imageArea
+
+                actionButtons
+            }
+        }
+    }
+
+    // MARK: - Image area
+
+    /// Large image preview filling the card width at 288pt tall with rounded
+    /// corners. Shows a placeholder surface when no image is provided.
+    private var imageArea: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Rectangle()
+                    .fill(VColor.surfaceActive)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 288)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous))
+    }
+
+    // MARK: - Action buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            Button(action: onSave) {
+                Text("Save")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.auxWhite)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .frame(height: 32)
+            }
+            .buttonStyle(.plain)
+            .background(
+                Capsule()
+                    .fill(VColor.primaryBase)
+            )
+
+            Button(action: onOpenInFinder) {
+                Text("Open in Finder")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .frame(height: 32)
+            }
+            .buttonStyle(.plain)
+            .background(
+                Capsule()
+                    .strokeBorder(VColor.borderBase, lineWidth: 1)
+            )
+
+            Spacer()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeImageCard with large image preview, Save and Open in Finder buttons
- Add HomeFileCard with file link row display
- Both use HomeRecapCardView container with optional dismiss

Part of plan: home-page-components.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
