### PR TITLE
Add HomeAssistantCard for assistant-to-assistant messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAssistantCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAssistantCard.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Recap card for agent-to-agent messages. Displays an assistant
+/// avatar, the message title, an optional thread name, and
+/// Authorise / Deny action buttons.
+struct HomeAssistantCard: View {
+    let title: String
+    let threadName: String?
+    let showDismiss: Bool
+    let onAuthorise: () -> Void
+    let onDeny: () -> Void
+    let onDismiss: (() -> Void)?
+
+    init(
+        title: String,
+        threadName: String? = nil,
+        showDismiss: Bool = false,
+        onAuthorise: @escaping () -> Void,
+        onDeny: @escaping () -> Void,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.threadName = threadName
+        self.showDismiss = showDismiss
+        self.onAuthorise = onAuthorise
+        self.onDeny = onDeny
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+            VStack(spacing: VSpacing.md) {
+                HomeRecapCardHeader(
+                    icon: .circleUser,
+                    iconColor: VColor.contentSecondary,
+                    title: title,
+                    subtitle: threadName,
+                    showDismiss: showDismiss,
+                    onDismiss: onDismiss
+                )
+
+                actionButtons
+            }
+        }
+    }
+
+    // MARK: - Action buttons
+
+    /// Authorise and Deny bordered pill buttons.
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            actionButton(label: "Authorise", action: onAuthorise)
+            actionButton(label: "Deny", action: onDeny)
+        }
+    }
+
+    /// Bordered pill button with capsule outline, 32pt height.
+    private func actionButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(VFont.bodySmallEmphasised)
+                .foregroundStyle(VColor.primaryBase)
+                .frame(height: 32)
+                .padding(.horizontal, VSpacing.md)
+                .background(
+                    Capsule()
+                        .strokeBorder(VColor.borderElement, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeAssistantCard for A2A message display on home page
- Shows assistant avatar icon, message title, thread name
- Authorise/Deny action buttons in bordered pill style

Part of plan: home-page-components.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
