### PR TITLE
Add HomeUpdatesListCard for grouped update notifications

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeUpdatesListCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeUpdatesListCard.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A grouped card showing a list of low-priority update notifications.
+///
+/// Displays a count header ("N other updates") with a "Clear all" bordered
+/// pill button and a scrollable list of tappable update items, each showing
+/// an icon, title, and thread name in a pill row.
+struct HomeUpdatesListCard: View {
+
+    // MARK: - Update Item
+
+    struct UpdateItem {
+        let icon: VIcon
+        let title: String
+        let threadName: String
+    }
+
+    // MARK: - Properties
+
+    let updates: [UpdateItem]
+    let onClearAll: () -> Void
+    let onSelectUpdate: (Int) -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        HomeRecapCardView {
+            VStack(spacing: VSpacing.lg) {
+                headerRow
+                updatesList
+            }
+        }
+    }
+
+    // MARK: - Header Row
+
+    private var headerRow: some View {
+        HStack(spacing: VSpacing.sm) {
+            HomeRecapCardHeader(
+                icon: .list,
+                title: "\(updates.count) other updates"
+            )
+
+            clearAllButton
+        }
+    }
+
+    // MARK: - Clear All Button
+
+    private var clearAllButton: some View {
+        Button {
+            onClearAll()
+        } label: {
+            Text("Clear all")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.primaryBase)
+                .padding(.horizontal, VSpacing.md)
+                .frame(height: 32)
+                .background(
+                    Capsule()
+                        .strokeBorder(VColor.borderElement, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Clear all updates")
+    }
+
+    // MARK: - Updates List
+
+    private var updatesList: some View {
+        VStack(spacing: 4) {
+            ForEach(Array(updates.enumerated()), id: \.offset) { index, item in
+                updateRow(item: item)
+                    .onTapGesture {
+                        onSelectUpdate(index)
+                    }
+                    .pointerCursor()
+            }
+        }
+    }
+
+    // MARK: - Update Row
+
+    private func updateRow(item: UpdateItem) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            updateIconCircle(icon: item.icon)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(item.title)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Text(item.threadName)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(EdgeInsets(top: 2, leading: 2, bottom: 2, trailing: VSpacing.lg))
+        .background(
+            Capsule()
+                .fill(VColor.surfaceOverlay)
+        )
+    }
+
+    // MARK: - Update Icon Circle
+
+    /// 26pt circular container matching HomeLinkFileRow style.
+    private func updateIconCircle(icon: VIcon) -> some View {
+        ZStack {
+            Circle()
+                .fill(VColor.surfaceActive)
+                .frame(width: 26, height: 26)
+
+            VIconView(icon, size: 12)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomeUpdatesListCard for grouped low-priority updates on home page
- Shows update count header with Clear all button
- List of tappable update items with icon, title, and thread name

Part of plan: home-page-components.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
