### PR TITLE
Add HomePermissionCard for tool action permission requests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card requesting the user's permission for a tool action.
+/// Displays a header with title/thread name, a content area showing
+/// the tool action details with an expandable "Show Details" section,
+/// and Authorise/Deny action buttons.
+struct HomePermissionCard: View {
+    let title: String
+    let threadName: String?
+    let toolActionTitle: String
+    let toolActionDescription: String
+    let showDismiss: Bool
+    let onAuthorise: () -> Void
+    let onDeny: () -> Void
+    let onDismiss: (() -> Void)?
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                HomeRecapCardHeader(
+                    icon: .shieldAlert,
+                    title: title,
+                    subtitle: threadName,
+                    showDismiss: showDismiss,
+                    onDismiss: onDismiss
+                )
+
+                contentArea
+
+                actionButtons
+            }
+        }
+    }
+
+    // MARK: - Content area
+
+    /// Tool action content with distinct background, divider, and
+    /// expandable details toggle.
+    private var contentArea: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text(toolActionTitle)
+                .font(VFont.menuCompact)
+                .foregroundStyle(VColor.contentSecondary)
+                .lineLimit(nil)
+
+            Divider()
+
+            Text(toolActionDescription)
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .lineLimit(nil)
+
+            showDetailsRow
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        )
+    }
+
+    // MARK: - Show Details toggle
+
+    /// Tappable row with "Show Details" text and a chevron icon.
+    private var showDetailsRow: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Text("Show Details")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                VIconView(isExpanded ? .chevronDown : .chevronRight, size: 10)
+                    .foregroundStyle(VColor.contentDefault)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Action buttons
+
+    /// Authorise and Deny bordered pill buttons.
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            Button {
+                onAuthorise()
+            } label: {
+                Text("Authorise")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.buttonV)
+                    .background(
+                        Capsule()
+                            .strokeBorder(VColor.borderBase, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                onDeny()
+            } label: {
+                Text("Deny")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.buttonV)
+                    .background(
+                        Capsule()
+                            .strokeBorder(VColor.borderBase, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HomePermissionCard for tool permission requests on home page
- Shows tool action title, description, and expandable details
- Authorise/Deny action buttons

Part of plan: home-page-components.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
