### PR TITLE
Add HomeAuthCard for payment authorisation actions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAuthCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAuthCard.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for payment authorisation actions. Supports two layouts:
+/// - **Simple**: title + Authorise/Deny buttons in a single row.
+/// - **Rich**: title + subtitle + Authorise/Deny/Dismiss buttons,
+///   with an optional file attachment row below.
+struct HomeAuthCard: View {
+    let title: String
+    let subtitle: String?
+    let attachment: (fileName: String, fileSize: String)?
+    let showDismiss: Bool
+    let onAuthorise: () -> Void
+    let onDeny: () -> Void
+    let onDismiss: (() -> Void)?
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        attachment: (fileName: String, fileSize: String)? = nil,
+        showDismiss: Bool = false,
+        onAuthorise: @escaping () -> Void,
+        onDeny: @escaping () -> Void,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.attachment = attachment
+        self.showDismiss = showDismiss
+        self.onAuthorise = onAuthorise
+        self.onDeny = onDeny
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HomeRecapCardView {
+            VStack(spacing: VSpacing.sm) {
+                headerRow
+                if let attachment {
+                    HomeLinkFileRow(
+                        icon: .file,
+                        fileName: attachment.fileName,
+                        fileSize: attachment.fileSize
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(spacing: VSpacing.sm) {
+            HomeRecapCardHeader(
+                icon: .file,
+                title: title,
+                subtitle: subtitle
+            )
+
+            Spacer(minLength: 0)
+
+            actionButtons
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.xs) {
+            authoriseButton
+            denyButton
+            if showDismiss {
+                dismissButton
+            }
+        }
+    }
+
+    private var authoriseButton: some View {
+        Button {
+            onAuthorise()
+        } label: {
+            Text("Authorise")
+                .font(VFont.bodySmallEmphasised)
+                .foregroundStyle(VColor.auxWhite)
+                .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+                .frame(height: 32)
+                .background(Capsule().fill(VColor.primaryBase))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Authorise")
+    }
+
+    private var denyButton: some View {
+        Button {
+            onDeny()
+        } label: {
+            Text("Deny")
+                .font(VFont.bodySmallEmphasised)
+                .foregroundStyle(VColor.auxWhite)
+                .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+                .frame(height: 32)
+                .background(Capsule().fill(VColor.systemNegativeStrong))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Deny")
+    }
+
+    private var dismissButton: some View {
+        Button {
+            onDismiss?()
+        } label: {
+            VIconView(.x, size: 12)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(VSpacing.xs)
+                .background(
+                    Capsule()
+                        .strokeBorder(VColor.borderBase, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// An inline pill/chip view for recap flowing text.
 ///

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/RecapPillView.swift
@@ -39,7 +39,7 @@ struct RecapPillView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 5)
         .background(
-            Color.white.opacity(backgroundOpacity)
+            VColor.auxWhite.opacity(backgroundOpacity)
         )
         .clipShape(Capsule())
         .pointerCursor(onHover: { hovering in
@@ -64,43 +64,4 @@ struct RecapPillView: View {
             return VColor.systemMidStrong
         }
     }
-}
-
-// MARK: - Previews
-
-#Preview("High Priority") {
-    RecapPillView(
-        text: "authorising a transaction to NBA",
-        priority: .high
-    )
-    .padding()
-    .background(Color.gray.opacity(0.3))
-}
-
-#Preview("Medium Priority") {
-    RecapPillView(
-        text: "schedule team standup",
-        priority: .medium
-    )
-    .padding()
-    .background(Color.gray.opacity(0.3))
-}
-
-#Preview("No Priority") {
-    RecapPillView(
-        text: "review pull request",
-        priority: nil
-    )
-    .padding()
-    .background(Color.gray.opacity(0.3))
-}
-
-#Preview("Highlighted") {
-    RecapPillView(
-        text: "authorising a transaction to NBA",
-        priority: .high,
-        isHighlighted: true
-    )
-    .padding()
-    .background(Color.gray.opacity(0.3))
 }


### PR DESCRIPTION
## Summary
- Add HomeAuthCard with simple and rich variants
- Simple: title + Authorise/Deny buttons
- Rich: title + subtitle + Authorise/Deny/X + file attachment
- Fix pre-existing RecapPillView issues: add missing VellumAssistantShared import, replace raw Color.white with VColor.auxWhite, remove #Preview blocks per convention

Part of plan: home-page-components.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
