### PR TITLE
Add HomePage section to component gallery with all recap card components

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -1024,6 +1024,7 @@ extension AppDelegate {
     #if DEBUG
     @objc func showComponentGallery() {
         AvatarGallerySection.registerInGallery()
+        HomeGallerySection.registerInGallery()
         if galleryWindow == nil { galleryWindow = ComponentGalleryWindow() }
         galleryWindow?.show()
     }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -1,8 +1,19 @@
 #if DEBUG
 import SwiftUI
+import VellumAssistantShared
 
 struct HomeGallerySection: View {
     var filter: String?
+
+    /// Register this gallery section with the shared gallery router.
+    static func registerInGallery() {
+        ComponentGalleryView.externalOverviewFactories["home"] = {
+            AnyView(HomeGallerySection())
+        }
+        ComponentGalleryView.externalComponentPageFactories["home"] = { componentID in
+            AnyView(HomeGallerySection.componentPage(componentID))
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -7,10 +7,10 @@ struct HomeGallerySection: View {
 
     /// Register this gallery section with the shared gallery router.
     static func registerInGallery() {
-        ComponentGalleryView.externalOverviewFactories["home"] = {
+        registerGalleryOverview(for: "home") {
             AnyView(HomeGallerySection())
         }
-        ComponentGalleryView.externalComponentPageFactories["home"] = { componentID in
+        registerGalleryComponentPage(for: "home") { componentID in
             AnyView(HomeGallerySection.componentPage(componentID))
         }
     }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -177,6 +177,11 @@ enum GalleryPage: Hashable {
 // MARK: - Gallery View
 
 struct ComponentGalleryView: View {
+    /// Registry for platform-specific gallery overview sections (e.g. macOS-only Home components).
+    nonisolated(unsafe) static var externalOverviewFactories: [String: () -> AnyView] = [:]
+    /// Registry for platform-specific gallery component detail pages.
+    nonisolated(unsafe) static var externalComponentPageFactories: [String: (String) -> AnyView] = [:]
+
     @State private var selectedPage: GalleryPage? = .overview(.buttons)
     @State private var searchText: String = ""
     @State private var expandedCategories: Set<ComponentGalleryCategory> = [.buttons]
@@ -371,7 +376,10 @@ struct ComponentGalleryView: View {
         case .chat: ChatGallerySection()
         case .display: DisplayGallerySection()
         case .feedback: FeedbackGallerySection()
-        case .home: HomeGallerySection()
+        case .home:
+            if let factory = ComponentGalleryView.externalOverviewFactories["home"] {
+                factory()
+            }
         case .icons: IconsGallerySection()
         case .inputs: InputsGallerySection()
         case .layout: LayoutGallerySection()
@@ -388,7 +396,10 @@ struct ComponentGalleryView: View {
         case .chat: ChatGallerySection.componentPage(componentID)
         case .display: DisplayGallerySection.componentPage(componentID)
         case .feedback: FeedbackGallerySection.componentPage(componentID)
-        case .home: HomeGallerySection.componentPage(componentID)
+        case .home:
+            if let factory = ComponentGalleryView.externalComponentPageFactories["home"] {
+                factory(componentID)
+            }
         case .icons: IconsGallerySection.componentPage(componentID)
         case .inputs: InputsGallerySection.componentPage(componentID)
         case .layout: LayoutGallerySection.componentPage(componentID)

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -24,6 +24,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
     case chat = "Chat"
     case display = "Display"
     case feedback = "Feedback"
+    case home = "Home"
     case icons = "Icons"
     case inputs = "Inputs"
     case layout = "Layout"
@@ -39,6 +40,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
         case .chat: return .messagesSquare
         case .display: return .layers
         case .feedback: return .bell
+        case .home: return .house
         case .icons: return .puzzle
         case .inputs: return .pencil
         case .layout: return .panelLeft
@@ -96,6 +98,18 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vSkillTypePill", "VSkillTypePill", keywords: ["skill type", "pill"], description: "Colored pill showing a skill type category."),
                 GalleryComponent("vInfoTooltip", "VInfoTooltip", keywords: ["info", "tooltip"], description: "Info icon with hover tooltip for contextual help text."),
                 GalleryComponent("vContextWindowIndicator", "VContextWindowIndicator", keywords: ["context window", "progress", "ring"], description: "Circular ring showing context window fill level with hover popover."),
+            ]
+        case .home:
+            return [
+                GalleryComponent("recapPill", "RecapPillView", keywords: ["pill", "chip", "inline", "recap"], description: "Inline interactive pill for recap text"),
+                GalleryComponent("homeAuthCard", "HomeAuthCard", keywords: ["auth", "authorise", "deny", "payment"], description: "Payment authorisation action card"),
+                GalleryComponent("homePermissionCard", "HomePermissionCard", keywords: ["permission", "tool", "action"], description: "Tool permission request card"),
+                GalleryComponent("homeAssistantCard", "HomeAssistantCard", keywords: ["assistant", "a2a", "agent"], description: "Assistant-to-assistant message card"),
+                GalleryComponent("homeReplyCard", "HomeReplyCard", keywords: ["reply", "composer", "input"], description: "Reply prompt with inline composer"),
+                GalleryComponent("homeEmailPreviewCard", "HomeEmailPreviewCard", keywords: ["email", "draft", "preview"], description: "Email draft preview card"),
+                GalleryComponent("homeImageCard", "HomeImageCard", keywords: ["image", "photo", "preview"], description: "Image preview card"),
+                GalleryComponent("homeFileCard", "HomeFileCard", keywords: ["file", "document", "attachment"], description: "File reference card"),
+                GalleryComponent("homeUpdatesListCard", "HomeUpdatesListCard", keywords: ["updates", "list", "grouped"], description: "Grouped update notifications card"),
             ]
         case .icons:
             return [
@@ -357,6 +371,7 @@ struct ComponentGalleryView: View {
         case .chat: ChatGallerySection()
         case .display: DisplayGallerySection()
         case .feedback: FeedbackGallerySection()
+        case .home: HomeGallerySection()
         case .icons: IconsGallerySection()
         case .inputs: InputsGallerySection()
         case .layout: LayoutGallerySection()
@@ -373,6 +388,7 @@ struct ComponentGalleryView: View {
         case .chat: ChatGallerySection.componentPage(componentID)
         case .display: DisplayGallerySection.componentPage(componentID)
         case .feedback: FeedbackGallerySection.componentPage(componentID)
+        case .home: HomeGallerySection.componentPage(componentID)
         case .icons: IconsGallerySection.componentPage(componentID)
         case .inputs: InputsGallerySection.componentPage(componentID)
         case .layout: LayoutGallerySection.componentPage(componentID)

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -520,4 +520,17 @@ struct GalleryOverview: View {
     }
 }
 
+/// Register an external gallery overview factory for a category.
+/// Used by platform-specific targets to inject gallery sections for
+/// categories whose components live outside the shared module.
+public func registerGalleryOverview(for categoryKey: String, factory: @escaping () -> AnyView) {
+    ComponentGalleryView.externalOverviewFactories[categoryKey] = factory
+}
+
+/// Register an external gallery component page factory for a category.
+/// Used by platform-specific targets to inject component detail pages.
+public func registerGalleryComponentPage(for categoryKey: String, factory: @escaping (String) -> AnyView) {
+    ComponentGalleryView.externalComponentPageFactories[categoryKey] = factory
+}
+
 #endif

--- a/clients/shared/DesignSystem/Gallery/Sections/HomeGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/HomeGallerySection.swift
@@ -1,0 +1,257 @@
+#if DEBUG
+import SwiftUI
+
+struct HomeGallerySection: View {
+    var filter: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+
+            // MARK: - RecapPillView
+
+            if filter == nil || filter == "recapPill" {
+                GallerySectionHeader(
+                    title: "RecapPillView",
+                    description: "Inline interactive pill for recap text with optional priority icon."
+                )
+
+                VCard {
+                    HStack(spacing: VSpacing.lg) {
+                        RecapPillView(text: "3 payments", priority: .high)
+                        RecapPillView(text: "2 emails", priority: .medium)
+                        RecapPillView(text: "5 updates")
+                    }
+                }
+            }
+
+            // MARK: - HomeAuthCard
+
+            if filter == nil || filter == "homeAuthCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeAuthCard",
+                    description: "Payment authorisation action card with Authorise/Deny buttons."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Simple variant")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        HomeAuthCard(
+                            title: "Authorise $42.00 payment",
+                            onAuthorise: {},
+                            onDeny: {}
+                        )
+
+                        Divider().background(VColor.borderBase)
+
+                        Text("Rich variant (with subtitle + attachment)")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        HomeAuthCard(
+                            title: "Authorise $128.50 payment",
+                            subtitle: "Invoice #2024-0391",
+                            attachment: (fileName: "invoice-2024-0391.pdf", fileSize: "245 KB"),
+                            showDismiss: true,
+                            onAuthorise: {},
+                            onDeny: {},
+                            onDismiss: {}
+                        )
+                    }
+                }
+            }
+
+            // MARK: - HomePermissionCard
+
+            if filter == nil || filter == "homePermissionCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomePermissionCard",
+                    description: "Tool permission request card with action details and Authorise/Deny buttons."
+                )
+
+                VCard {
+                    HomePermissionCard(
+                        title: "Permission Required",
+                        threadName: "Project Setup",
+                        toolActionTitle: "Run shell command",
+                        toolActionDescription: "npm install --save-dev typescript",
+                        showDismiss: false,
+                        onAuthorise: {},
+                        onDeny: {},
+                        onDismiss: nil
+                    )
+                }
+            }
+
+            // MARK: - HomeAssistantCard
+
+            if filter == nil || filter == "homeAssistantCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeAssistantCard",
+                    description: "Assistant-to-assistant message card with Authorise/Deny actions."
+                )
+
+                VCard {
+                    HomeAssistantCard(
+                        title: "Research Assistant wants to share findings",
+                        threadName: "Weekly Report",
+                        onAuthorise: {},
+                        onDeny: {}
+                    )
+                }
+            }
+
+            // MARK: - HomeReplyCard
+
+            if filter == nil || filter == "homeReplyCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeReplyCard",
+                    description: "Reply prompt with inline composer for responding to assistant questions."
+                )
+
+                VCard {
+                    HomeReplyCard(
+                        title: "What time should I schedule the meeting?",
+                        threadName: "Calendar Management",
+                        onSend: { _ in }
+                    )
+                }
+            }
+
+            // MARK: - HomeEmailPreviewCard
+
+            if filter == nil || filter == "homeEmailPreviewCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeEmailPreviewCard",
+                    description: "Email draft preview card with to/subject/body fields and Send/Rework actions."
+                )
+
+                VCard {
+                    HomeEmailPreviewCard(
+                        title: "Draft email ready",
+                        threadName: "Client Follow-up",
+                        toAddress: "client@example.com",
+                        subject: "Project Update - Q4 Milestones",
+                        bodyText: "Hi team, I wanted to share a quick update on our Q4 milestones...",
+                        onSend: {},
+                        onRework: {}
+                    )
+                }
+            }
+
+            // MARK: - HomeImageCard
+
+            if filter == nil || filter == "homeImageCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeImageCard",
+                    description: "Image preview card with Save and Open in Finder actions."
+                )
+
+                VCard {
+                    HomeImageCard(
+                        title: "Generated chart preview",
+                        threadName: "Data Analysis",
+                        image: nil,
+                        onSave: {},
+                        onOpenInFinder: {}
+                    )
+                }
+            }
+
+            // MARK: - HomeFileCard
+
+            if filter == nil || filter == "homeFileCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeFileCard",
+                    description: "File reference card showing file name and size."
+                )
+
+                VCard {
+                    HomeFileCard(
+                        title: "File saved",
+                        threadName: "Document Processing",
+                        fileName: "quarterly-report.pdf",
+                        fileSize: "1.2 MB"
+                    )
+                }
+            }
+
+            // MARK: - HomeUpdatesListCard
+
+            if filter == nil || filter == "homeUpdatesListCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeUpdatesListCard",
+                    description: "Grouped update notifications card with a list of items."
+                )
+
+                VCard {
+                    HomeUpdatesListCard(
+                        updates: [
+                            .init(icon: .mail, title: "New email from Alice", threadName: "Inbox"),
+                            .init(icon: .file, title: "Report generated", threadName: "Analytics"),
+                            .init(icon: .circleCheck, title: "Deployment complete", threadName: "DevOps"),
+                            .init(icon: .messageCircle, title: "New message in thread", threadName: "Team Chat"),
+                        ],
+                        onClearAll: {},
+                        onSelectUpdate: { _ in }
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Component Page Router
+
+extension HomeGallerySection {
+    @ViewBuilder
+    static func componentPage(_ id: String) -> some View {
+        switch id {
+        case "recapPill": HomeGallerySection(filter: "recapPill")
+        case "homeAuthCard": HomeGallerySection(filter: "homeAuthCard")
+        case "homePermissionCard": HomeGallerySection(filter: "homePermissionCard")
+        case "homeAssistantCard": HomeGallerySection(filter: "homeAssistantCard")
+        case "homeReplyCard": HomeGallerySection(filter: "homeReplyCard")
+        case "homeEmailPreviewCard": HomeGallerySection(filter: "homeEmailPreviewCard")
+        case "homeImageCard": HomeGallerySection(filter: "homeImageCard")
+        case "homeFileCard": HomeGallerySection(filter: "homeFileCard")
+        case "homeUpdatesListCard": HomeGallerySection(filter: "homeUpdatesListCard")
+        default: EmptyView()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add Home category to component gallery with 9 recap card components
- Create HomeGallerySection in macOS target with showcase cards and sample data for all recap card types
- Register all components in ComponentGalleryCategory for sidebar navigation
- Use external factory pattern (matching AvatarGallerySection) for cross-module gallery registration since recap card components live in VellumAssistantLib, not VellumAssistantShared

Part of plan: home-page-components.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
