### PR TITLE
fix: use per-service SHAs in dev image registration

### DIFF
--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -170,11 +170,11 @@ jobs:
                 run_num="${info##* }"
                 echo "${sha}"
                 echo "dev.${run_num}.${sha:0:7}"
-                return
+                return 0
               fi
             done
-            echo "::error::No recent CI run with successful push-dev-manifest found for ${wf_file}"
-            exit 1
+            echo "::error::No recent CI run with successful push-dev-manifest found for ${wf_file}" >&2
+            return 1
           }
 
           # Resolve SHA and digest for a non-triggered service using its
@@ -183,7 +183,7 @@ jobs:
           resolve_service() {
             local wf_file="$1" image="$2"
             local info sha tag
-            info=$(get_latest_dev_pusher_info "$wf_file")
+            info=$(get_latest_dev_pusher_info "$wf_file") || return 1
             sha=$(echo "$info" | sed -n '1p')
             tag=$(echo "$info" | sed -n '2p')
             local digest
@@ -195,18 +195,24 @@ jobs:
             *Assistant*)
               ASSISTANT_SHA="$TRIGGERED_SHA"
               ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
-              read GATEWAY_SHA GATEWAY_DIGEST <<< "$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE")"
-              read CE_SHA CE_DIGEST <<< "$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE")"
+              RESOLVE_OUT=$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE") || exit 1
+              read GATEWAY_SHA GATEWAY_DIGEST <<< "$RESOLVE_OUT"
+              RESOLVE_OUT=$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE") || exit 1
+              read CE_SHA CE_DIGEST <<< "$RESOLVE_OUT"
               ;;
             *Gateway*)
-              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE")"
+              RESOLVE_OUT=$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE") || exit 1
+              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$RESOLVE_OUT"
               GATEWAY_SHA="$TRIGGERED_SHA"
               GATEWAY_DIGEST="$TRIGGERED_DIGEST"
-              read CE_SHA CE_DIGEST <<< "$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE")"
+              RESOLVE_OUT=$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE") || exit 1
+              read CE_SHA CE_DIGEST <<< "$RESOLVE_OUT"
               ;;
             *Credential*)
-              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE")"
-              read GATEWAY_SHA GATEWAY_DIGEST <<< "$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE")"
+              RESOLVE_OUT=$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE") || exit 1
+              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$RESOLVE_OUT"
+              RESOLVE_OUT=$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE") || exit 1
+              read GATEWAY_SHA GATEWAY_DIGEST <<< "$RESOLVE_OUT"
               CE_SHA="$TRIGGERED_SHA"
               CE_DIGEST="$TRIGGERED_DIGEST"
               ;;

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -218,6 +218,16 @@ jobs:
 
         id: migration-ceilings
         run: |
+          # Migration ceilings must reflect the assistant image's commit,
+          # not the triggering workflow's commit (which may be for a
+          # different service). Temporarily check out the assistant's SHA.
+          ASSISTANT_SHA="${{ steps.images.outputs.assistant_sha }}"
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$ASSISTANT_SHA" != "$CURRENT_SHA" ]; then
+            echo "Checking out assistant SHA ${ASSISTANT_SHA:0:7} for migration ceilings (current: ${CURRENT_SHA:0:7})"
+            git checkout "$ASSISTANT_SHA" -- assistant/src/memory/migrations/registry.ts assistant/src/workspace/migrations/
+          fi
+
           # Extract max DB migration version from the registry
           DB_VERSION=$(node -e "
             const fs = require('fs');

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -123,7 +123,7 @@ jobs:
           GATEWAY_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
           CE_IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CREDENTIAL_EXECUTOR_IMAGE_NAME }}"
 
-          SHA="${{ github.event.workflow_run.head_sha }}"
+          TRIGGERED_SHA="${{ github.event.workflow_run.head_sha }}"
           VERSION="${{ steps.version.outputs.version }}"
           VERSION_TAG="v${VERSION}"
 
@@ -132,7 +132,7 @@ jobs:
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.event.workflow_run.id }}"
           RUN_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.run_number')
-          SHORT_SHA="${SHA:0:7}"
+          SHORT_SHA="${TRIGGERED_SHA:0:7}"
           IMMUTABLE_TAG="dev.${RUN_NUMBER}.${SHORT_SHA}"
 
           # Determine which service was just built.
@@ -147,37 +147,60 @@ jobs:
           TRIGGERED_DIGEST=$(docker buildx imagetools inspect "${TRIGGERED_IMAGE}:${IMMUTABLE_TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Triggered service digest (${WF_NAME}): ${TRIGGERED_DIGEST}"
 
-          # For the other two services, capture the current :dev digest.
+          # Look up the correct head_sha for each non-triggered service by
+          # finding its most recent successful CI run. This avoids the bug
+          # where all three services were registered with the triggering
+          # workflow's SHA even though the :dev images for the other two
+          # services were built from different commits.
+          get_latest_ci_sha() {
+            local wf_file="$1"
+            gh api "repos/${REPO}/actions/workflows/${wf_file}/runs?branch=main&status=success&per_page=1" \
+              --jq '.workflow_runs[0].head_sha'
+          }
+
           case "$WF_NAME" in
             *Assistant*)
+              ASSISTANT_SHA="$TRIGGERED_SHA"
               ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
+              GATEWAY_SHA=$(get_latest_ci_sha "ci-main-gateway.yaml")
               GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              CE_SHA=$(get_latest_ci_sha "ci-main-credential-executor.yaml")
               CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               ;;
             *Gateway*)
+              ASSISTANT_SHA=$(get_latest_ci_sha "ci-main-assistant.yaml")
               ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              GATEWAY_SHA="$TRIGGERED_SHA"
               GATEWAY_DIGEST="$TRIGGERED_DIGEST"
+              CE_SHA=$(get_latest_ci_sha "ci-main-credential-executor.yaml")
               CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               ;;
             *Credential*)
+              ASSISTANT_SHA=$(get_latest_ci_sha "ci-main-assistant.yaml")
               ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              GATEWAY_SHA=$(get_latest_ci_sha "ci-main-gateway.yaml")
               GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              CE_SHA="$TRIGGERED_SHA"
               CE_DIGEST="$TRIGGERED_DIGEST"
               ;;
           esac
 
-          # Tag all three images with the version tag and SHA tag.
+          echo "SHAs: assistant=${ASSISTANT_SHA:0:7}, gateway=${GATEWAY_SHA:0:7}, ce=${CE_SHA:0:7}"
+
+          # Tag all three images with the version tag and their own SHA tag.
           # Uses digest-pinned retags so even if :dev moves, we tag the
           # exact digests we captured above.
-          for IMAGE_REF in \
-            "${ASSISTANT_IMAGE}@${ASSISTANT_DIGEST}" \
-            "${GATEWAY_IMAGE}@${GATEWAY_DIGEST}" \
-            "${CE_IMAGE}@${CE_DIGEST}"; do
+          for ENTRY in \
+            "${ASSISTANT_IMAGE}@${ASSISTANT_DIGEST}|${ASSISTANT_SHA}" \
+            "${GATEWAY_IMAGE}@${GATEWAY_DIGEST}|${GATEWAY_SHA}" \
+            "${CE_IMAGE}@${CE_DIGEST}|${CE_SHA}"; do
+            IMAGE_REF="${ENTRY%%|*}"
+            IMAGE_SHA="${ENTRY##*|}"
             BASE="${IMAGE_REF%%@*}"
-            echo "Tagging ${BASE} with ${VERSION_TAG} and ${SHA}"
+            echo "Tagging ${BASE} with ${VERSION_TAG} and ${IMAGE_SHA:0:7}"
             docker buildx imagetools create \
               -t "${BASE}:${VERSION_TAG}" \
-              -t "${BASE}:${SHA}" \
+              -t "${BASE}:${IMAGE_SHA}" \
               "${IMAGE_REF}"
           done
 
@@ -187,6 +210,9 @@ jobs:
           echo "assistant_digest=$ASSISTANT_DIGEST" >> "$GITHUB_OUTPUT"
           echo "gateway_digest=$GATEWAY_DIGEST" >> "$GITHUB_OUTPUT"
           echo "ce_digest=$CE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "assistant_sha=$ASSISTANT_SHA" >> "$GITHUB_OUTPUT"
+          echo "gateway_sha=$GATEWAY_SHA" >> "$GITHUB_OUTPUT"
+          echo "ce_sha=$CE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Compute migration ceilings
 
@@ -225,7 +251,6 @@ jobs:
       - name: Register with platform
 
         run: |
-          SHA="${{ github.event.workflow_run.head_sha }}"
           VERSION="${{ steps.version.outputs.version }}"
           VERSION_TAG="v${VERSION}"
           ASSISTANT_REPO="${{ steps.images.outputs.assistant_image }}"
@@ -241,15 +266,15 @@ jobs:
             --arg last_workspace_migration_id "${{ steps.migration-ceilings.outputs.ws_id }}" \
             --arg assistant_repo "$ASSISTANT_REPO" \
             --arg assistant_tag "$VERSION_TAG" \
-            --arg assistant_sha "$SHA" \
+            --arg assistant_sha "${{ steps.images.outputs.assistant_sha }}" \
             --arg assistant_digest "${{ steps.images.outputs.assistant_digest }}" \
             --arg gateway_repo "$GATEWAY_REPO" \
             --arg gateway_tag "$VERSION_TAG" \
-            --arg gateway_sha "$SHA" \
+            --arg gateway_sha "${{ steps.images.outputs.gateway_sha }}" \
             --arg gateway_digest "${{ steps.images.outputs.gateway_digest }}" \
             --arg credential_executor_repo "$CREDENTIAL_EXECUTOR_REPO" \
             --arg credential_executor_tag "$VERSION_TAG" \
-            --arg credential_executor_sha "$SHA" \
+            --arg credential_executor_sha "${{ steps.images.outputs.ce_sha }}" \
             --arg credential_executor_digest "${{ steps.images.outputs.ce_digest }}" \
             '{
               version: $version,

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -147,22 +147,29 @@ jobs:
           TRIGGERED_DIGEST=$(docker buildx imagetools inspect "${TRIGGERED_IMAGE}:${IMMUTABLE_TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Triggered service digest (${WF_NAME}): ${TRIGGERED_DIGEST}"
 
-          # Look up the head_sha of the most recent CI run whose
-          # push-dev-manifest job succeeded. We can't filter by overall
-          # run status=success because the :dev tag is pushed by the
-          # push-dev-manifest job, which can succeed even when unrelated
-          # jobs in the same run fail.
-          get_latest_dev_pusher_sha() {
+          # Look up the most recent CI run whose push-dev-manifest job
+          # succeeded and return its head_sha and immutable image tag.
+          # We can't filter by overall run status=success because the
+          # :dev tag is pushed by push-dev-manifest, which can succeed
+          # even when unrelated jobs in the same run fail.
+          # Outputs two lines: head_sha, then the immutable tag.
+          get_latest_dev_pusher_info() {
             local wf_file="$1"
             local run_ids
-            run_ids=$(gh api "repos/${REPO}/actions/workflows/${wf_file}/runs?branch=main&per_page=5" \
+            run_ids=$(gh api "repos/${REPO}/actions/workflows/${wf_file}/runs?branch=main&per_page=20" \
               --jq '.workflow_runs[].id')
             for rid in $run_ids; do
               local manifest_ok
               manifest_ok=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" \
                 --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
               if [ "$manifest_ok" = "success" ]; then
-                gh api "repos/${REPO}/actions/runs/${rid}" --jq '.head_sha'
+                local info
+                info=$(gh api "repos/${REPO}/actions/runs/${rid}" --jq '[.head_sha, (.run_number | tostring)] | join(" ")')
+                local sha run_num
+                sha="${info%% *}"
+                run_num="${info##* }"
+                echo "${sha}"
+                echo "dev.${run_num}.${sha:0:7}"
                 return
               fi
             done
@@ -170,28 +177,36 @@ jobs:
             exit 1
           }
 
+          # Resolve SHA and digest for a non-triggered service using its
+          # immutable tag (not the floating :dev tag) so the two are
+          # guaranteed to come from the same CI run.
+          resolve_service() {
+            local wf_file="$1" image="$2"
+            local info sha tag
+            info=$(get_latest_dev_pusher_info "$wf_file")
+            sha=$(echo "$info" | sed -n '1p')
+            tag=$(echo "$info" | sed -n '2p')
+            local digest
+            digest=$(docker buildx imagetools inspect "${image}:${tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+            echo "${sha} ${digest}"
+          }
+
           case "$WF_NAME" in
             *Assistant*)
               ASSISTANT_SHA="$TRIGGERED_SHA"
               ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
-              GATEWAY_SHA=$(get_latest_dev_pusher_sha "ci-main-gateway.yaml")
-              GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-              CE_SHA=$(get_latest_dev_pusher_sha "ci-main-credential-executor.yaml")
-              CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              read GATEWAY_SHA GATEWAY_DIGEST <<< "$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE")"
+              read CE_SHA CE_DIGEST <<< "$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE")"
               ;;
             *Gateway*)
-              ASSISTANT_SHA=$(get_latest_dev_pusher_sha "ci-main-assistant.yaml")
-              ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE")"
               GATEWAY_SHA="$TRIGGERED_SHA"
               GATEWAY_DIGEST="$TRIGGERED_DIGEST"
-              CE_SHA=$(get_latest_dev_pusher_sha "ci-main-credential-executor.yaml")
-              CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              read CE_SHA CE_DIGEST <<< "$(resolve_service ci-main-credential-executor.yaml "$CE_IMAGE")"
               ;;
             *Credential*)
-              ASSISTANT_SHA=$(get_latest_dev_pusher_sha "ci-main-assistant.yaml")
-              ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-              GATEWAY_SHA=$(get_latest_dev_pusher_sha "ci-main-gateway.yaml")
-              GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
+              read ASSISTANT_SHA ASSISTANT_DIGEST <<< "$(resolve_service ci-main-assistant.yaml "$ASSISTANT_IMAGE")"
+              read GATEWAY_SHA GATEWAY_DIGEST <<< "$(resolve_service ci-main-gateway.yaml "$GATEWAY_IMAGE")"
               CE_SHA="$TRIGGERED_SHA"
               CE_DIGEST="$TRIGGERED_DIGEST"
               ;;

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -147,38 +147,50 @@ jobs:
           TRIGGERED_DIGEST=$(docker buildx imagetools inspect "${TRIGGERED_IMAGE}:${IMMUTABLE_TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Triggered service digest (${WF_NAME}): ${TRIGGERED_DIGEST}"
 
-          # Look up the correct head_sha for each non-triggered service by
-          # finding its most recent successful CI run. This avoids the bug
-          # where all three services were registered with the triggering
-          # workflow's SHA even though the :dev images for the other two
-          # services were built from different commits.
-          get_latest_ci_sha() {
+          # Look up the head_sha of the most recent CI run whose
+          # push-dev-manifest job succeeded. We can't filter by overall
+          # run status=success because the :dev tag is pushed by the
+          # push-dev-manifest job, which can succeed even when unrelated
+          # jobs in the same run fail.
+          get_latest_dev_pusher_sha() {
             local wf_file="$1"
-            gh api "repos/${REPO}/actions/workflows/${wf_file}/runs?branch=main&status=success&per_page=1" \
-              --jq '.workflow_runs[0].head_sha'
+            local run_ids
+            run_ids=$(gh api "repos/${REPO}/actions/workflows/${wf_file}/runs?branch=main&per_page=5" \
+              --jq '.workflow_runs[].id')
+            for rid in $run_ids; do
+              local manifest_ok
+              manifest_ok=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" \
+                --jq '[.jobs[] | select(.name | startswith("Push Dev Manifest")) | .conclusion] | first')
+              if [ "$manifest_ok" = "success" ]; then
+                gh api "repos/${REPO}/actions/runs/${rid}" --jq '.head_sha'
+                return
+              fi
+            done
+            echo "::error::No recent CI run with successful push-dev-manifest found for ${wf_file}"
+            exit 1
           }
 
           case "$WF_NAME" in
             *Assistant*)
               ASSISTANT_SHA="$TRIGGERED_SHA"
               ASSISTANT_DIGEST="$TRIGGERED_DIGEST"
-              GATEWAY_SHA=$(get_latest_ci_sha "ci-main-gateway.yaml")
+              GATEWAY_SHA=$(get_latest_dev_pusher_sha "ci-main-gateway.yaml")
               GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-              CE_SHA=$(get_latest_ci_sha "ci-main-credential-executor.yaml")
+              CE_SHA=$(get_latest_dev_pusher_sha "ci-main-credential-executor.yaml")
               CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               ;;
             *Gateway*)
-              ASSISTANT_SHA=$(get_latest_ci_sha "ci-main-assistant.yaml")
+              ASSISTANT_SHA=$(get_latest_dev_pusher_sha "ci-main-assistant.yaml")
               ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               GATEWAY_SHA="$TRIGGERED_SHA"
               GATEWAY_DIGEST="$TRIGGERED_DIGEST"
-              CE_SHA=$(get_latest_ci_sha "ci-main-credential-executor.yaml")
+              CE_SHA=$(get_latest_dev_pusher_sha "ci-main-credential-executor.yaml")
               CE_DIGEST=$(docker buildx imagetools inspect "${CE_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               ;;
             *Credential*)
-              ASSISTANT_SHA=$(get_latest_ci_sha "ci-main-assistant.yaml")
+              ASSISTANT_SHA=$(get_latest_dev_pusher_sha "ci-main-assistant.yaml")
               ASSISTANT_DIGEST=$(docker buildx imagetools inspect "${ASSISTANT_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
-              GATEWAY_SHA=$(get_latest_ci_sha "ci-main-gateway.yaml")
+              GATEWAY_SHA=$(get_latest_dev_pusher_sha "ci-main-gateway.yaml")
               GATEWAY_DIGEST=$(docker buildx imagetools inspect "${GATEWAY_IMAGE}:dev" --format '{{json .Manifest.Digest}}' | tr -d '"')
               CE_SHA="$TRIGGERED_SHA"
               CE_DIGEST="$TRIGGERED_DIGEST"


### PR DESCRIPTION
## Summary
- Previously, when one service's CI (e.g. Assistant) triggered the registration workflow, all three services (assistant, gateway, credential-executor) were registered with the **same** commit SHA — the triggering workflow's `head_sha`. This was wrong for the non-triggered services, whose `:dev` images were built from different commits.
- Now each non-triggered service's SHA is looked up from its most recent successful CI run via the GitHub API (`get_latest_ci_sha`), ensuring the registered SHA matches the actual commit each image was built from.
- The image tagging loop also now uses per-service SHAs instead of a single shared one.

## Original prompt
fix this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
