### PR TITLE
fix: wire up HomeReplyCard onSend via TextField onSubmit

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
@@ -84,6 +84,11 @@ struct HomeReplyCard: View {
                 .font(VFont.bodyLargeDefault)
                 .foregroundStyle(VColor.contentEmphasized)
                 .accessibilityLabel(Text("Reply message"))
+                .onSubmit {
+                    if !inputText.isEmpty {
+                        onSend(inputText)
+                    }
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap: HomeReplyCard onSend callback was stored but never invoked.

**Gap:** HomeReplyCard onSend never invoked
**What was expected:** User can submit text from inline composer
**What was found:** No submit mechanism existed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
