### PR TITLE
fix: remove unused showDismiss/onDismiss from HomeRecapCardView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAssistantCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeAssistantCard.swift
@@ -29,7 +29,7 @@ struct HomeAssistantCard: View {
     }
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(spacing: VSpacing.md) {
                 HomeRecapCardHeader(
                     icon: .circleUser,

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeEmailPreviewCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeEmailPreviewCard.swift
@@ -38,7 +38,7 @@ struct HomeEmailPreviewCard: View {
     }
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(spacing: VSpacing.lg) {
                 HomeRecapCardHeader(
                     icon: .mail,

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeFileCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeFileCard.swift
@@ -29,7 +29,7 @@ struct HomeFileCard: View {
     }
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(spacing: VSpacing.md) {
                 HomeRecapCardHeader(
                     icon: .file,

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
@@ -32,7 +32,7 @@ struct HomeImageCard: View {
     }
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(spacing: VSpacing.md) {
                 HomeRecapCardHeader(
                     icon: .image,

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
@@ -18,7 +18,7 @@ struct HomePermissionCard: View {
     @State private var isExpanded = false
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 HomeRecapCardHeader(
                     icon: .shieldAlert,

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardView.swift
@@ -5,17 +5,11 @@ import VellumAssistantShared
 /// glassmorphic rounded surface with shadow that wraps arbitrary
 /// card content via a `@ViewBuilder` slot.
 struct HomeRecapCardView<Content: View>: View {
-    let showDismiss: Bool
-    let onDismiss: (() -> Void)?
     private let content: Content
 
     init(
-        showDismiss: Bool = false,
-        onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) {
-        self.showDismiss = showDismiss
-        self.onDismiss = onDismiss
         self.content = content()
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
@@ -28,7 +28,7 @@ struct HomeReplyCard: View {
     }
 
     var body: some View {
-        HomeRecapCardView(showDismiss: showDismiss, onDismiss: onDismiss) {
+        HomeRecapCardView {
             VStack(spacing: 0) {
                 header
                 composerBar


### PR DESCRIPTION
## Summary
Removes dead showDismiss/onDismiss properties from HomeRecapCardView container.
Dismiss logic is handled entirely by HomeRecapCardHeader.

**Gap:** HomeRecapCardView stored unused dismiss properties
**What was expected:** No dead code
**What was found:** Properties stored but never referenced in body
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
