### PR TITLE
fix: make HomePermissionCard Show Details toggle functional

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomePermissionCard.swift
@@ -46,20 +46,23 @@ struct HomePermissionCard: View {
                 .foregroundStyle(VColor.contentSecondary)
                 .lineLimit(nil)
 
-            Divider()
-
-            Text(toolActionDescription)
-                .font(VFont.bodyMediumEmphasised)
-                .foregroundStyle(VColor.contentDefault)
-                .lineLimit(nil)
-
             showDetailsRow
+
+            if isExpanded {
+                Divider()
+
+                Text(toolActionDescription)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(nil)
+            }
         }
         .padding(VSpacing.md)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg, style: .continuous)
                 .fill(VColor.surfaceOverlay)
         )
+        .animation(.easeInOut(duration: 0.2), value: isExpanded)
     }
 
     // MARK: - Show Details toggle


### PR DESCRIPTION
## Summary
Makes the Show Details toggle actually show/hide the description.

**Gap:** Show Details toggle flipped chevron but showed no content
**What was expected:** Description shown/hidden on toggle
**What was found:** Description always visible regardless of toggle state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
