### PR TITLE
fix: make HomeRecapCardHeader title line limit configurable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeRecapCardHeader.swift
@@ -9,6 +9,7 @@ struct HomeRecapCardHeader: View {
     let iconColor: Color
     let title: String
     let subtitle: String?
+    var titleLineLimit: Int? = 1
     let showDismiss: Bool
     let onDismiss: (() -> Void)?
 
@@ -17,6 +18,7 @@ struct HomeRecapCardHeader: View {
         iconColor: Color = VColor.contentDisabled,
         title: String,
         subtitle: String? = nil,
+        titleLineLimit: Int? = 1,
         showDismiss: Bool = false,
         onDismiss: (() -> Void)? = nil
     ) {
@@ -24,6 +26,7 @@ struct HomeRecapCardHeader: View {
         self.iconColor = iconColor
         self.title = title
         self.subtitle = subtitle
+        self.titleLineLimit = titleLineLimit
         self.showDismiss = showDismiss
         self.onDismiss = onDismiss
     }
@@ -60,7 +63,7 @@ struct HomeRecapCardHeader: View {
             Text(title)
                 .font(VFont.bodyMediumEmphasised)
                 .foregroundStyle(VColor.contentEmphasized)
-                .lineLimit(1)
+                .lineLimit(titleLineLimit)
 
             if let subtitle {
                 Text(subtitle)

--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeReplyCard.swift
@@ -44,6 +44,7 @@ struct HomeReplyCard: View {
             icon: .messageCircle,
             title: title,
             subtitle: threadName,
+            titleLineLimit: nil,
             showDismiss: showDismiss,
             onDismiss: onDismiss
         )


### PR DESCRIPTION
## Summary
Makes title line limit configurable on HomeRecapCardHeader.
HomeReplyCard passes nil for multiline question titles.

**Gap:** lineLimit(1) truncated multiline reply card titles
**What was expected:** Multiline titles supported
**What was found:** Hard-coded lineLimit(1) truncated long questions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
