### PR TITLE
fix: move HomeImageCard button backgrounds inside label closure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeImageCard.swift
@@ -80,12 +80,9 @@ struct HomeImageCard: View {
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .frame(height: 32)
+                    .background(Capsule().fill(VColor.primaryBase))
             }
             .buttonStyle(.plain)
-            .background(
-                Capsule()
-                    .fill(VColor.primaryBase)
-            )
 
             Button(action: onOpenInFinder) {
                 Text("Open in Finder")
@@ -94,12 +91,12 @@ struct HomeImageCard: View {
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .frame(height: 32)
+                    .background(
+                        Capsule()
+                            .strokeBorder(VColor.borderBase, lineWidth: 1)
+                    )
             }
             .buttonStyle(.plain)
-            .background(
-                Capsule()
-                    .strokeBorder(VColor.borderBase, lineWidth: 1)
-            )
 
             Spacer()
         }


### PR DESCRIPTION
## Summary
Moves button background modifiers inside label closures for consistency.

**Gap:** Button backgrounds outside label closure
**What was expected:** Backgrounds inside label (like HomeAuthCard)
**What was found:** Backgrounds applied after .buttonStyle(.plain)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
