### PR TITLE
Add support for Claude Opus 4.7 alongside 4.6

### DIFF
--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -42,7 +42,7 @@ export const SpeedSchema = z
   })
   .default("standard")
   .describe(
-    'Inference speed mode — "fast" enables higher output token throughput on supported models (Opus 4.6) at premium pricing',
+    'Inference speed mode — "fast" enables higher output token throughput on supported models (Opus 4.6, Opus 4.7) at premium pricing',
   );
 
 export type Speed = z.infer<typeof SpeedSchema>;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -961,7 +961,7 @@ export class AnthropicProvider implements Provider {
         finalMessage(): Promise<Anthropic.Message>;
       }
 
-      // Fast mode: use the beta endpoint with speed: "fast" for Opus 4.6
+      // Fast mode: use the beta endpoint with speed: "fast" for Opus models (4.6, 4.7)
       const useFastMode = speed === "fast" && effectiveModel.includes("opus");
 
       // Collect required betas: extended cache TTL for 1h system prompt caching,

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -18,6 +18,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "anthropic",
     displayName: "Anthropic",
     models: [
+      { id: "claude-opus-4-7", displayName: "Claude Opus 4.7" },
       { id: "claude-opus-4-6", displayName: "Claude Opus 4.6" },
       { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
       { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
@@ -77,6 +78,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     displayName: "OpenRouter",
     models: [
       // Anthropic
+      { id: "anthropic/claude-opus-4.7", displayName: "Claude Opus 4.7" },
       { id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6" },
       { id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4.5", displayName: "Claude Haiku 4.5" },

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -21,6 +21,7 @@ const ANTHROPIC_FAST_MODE_MULTIPLIER = 6;
  */
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
+    "claude-opus-4-7": { inputPer1M: 5, outputPer1M: 25 },
     "claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
     "claude-opus-4": { inputPer1M: 15, outputPer1M: 75 },
     "claude-sonnet-4": { inputPer1M: 3, outputPer1M: 15 },

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -23,6 +23,7 @@ struct APIKeyEntryStepView: View {
     private var providerCatalog: [ProviderCatalogEntry] {
         return [
             ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
+                CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
                 CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
                 CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
                 CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -274,6 +274,7 @@ extension ProviderCatalogEntry {
     /// model picker / model list has data before the first daemon fetch completes.
     public static let defaultCatalog: [ProviderCatalogEntry] = [
         ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
+            CatalogModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
             CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
             CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
             CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -262,7 +262,7 @@
       "scope": "assistant",
       "key": "fast-mode",
       "label": "Fast Mode",
-      "description": "Enable Anthropic fast mode for Opus 4.6, delivering up to 2.5x higher output tokens per second at premium pricing",
+      "description": "Enable Anthropic fast mode for Opus models (4.6, 4.7), delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
     },
     {

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -12,6 +12,7 @@ All known models by provider, so you can interpret model IDs from config:
 
 | Provider | Model ID | Display Name |
 |----------|----------|--------------|
+| Anthropic | `claude-opus-4-7` | Claude Opus 4.7 |
 | Anthropic | `claude-opus-4-6` | Claude Opus 4.6 |
 | Anthropic | `claude-sonnet-4-6` | Claude Sonnet 4.6 |
 | Anthropic | `claude-haiku-4-5-20251001` | Claude Haiku 4.5 |

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -16,6 +16,7 @@
 // ---------------------------------------------------------------------------
 
 const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  "claude-opus-4-7": "Claude Opus 4.7",
   "claude-opus-4-6": "Claude Opus 4.6",
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-haiku-4-5-20251001": "Claude Haiku 4.5",


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` (and `anthropic/claude-opus-4.7` via OpenRouter) to the provider catalog, pricing catalog (same 5/25 rates as 4.6), self-knowledge display-name map and reference table, and the Swift default catalogs used by onboarding and chat.
- Update fast-mode description/comments (feature flag registry, `SpeedSchema`, Anthropic client) to mention both Opus 4.6 and 4.7 — the existing `effectiveModel.includes("opus")` gate already covers 4.7 without code changes.
- Leave defaults (selected model, intent fallbacks, migration defaults) on 4.6 to avoid silently switching existing users; 4.7 is opt-in via the model picker.

## Original prompt
add support for opus 4.7 everywhere we have support for opus 4.6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
