### PR TITLE
Route quality-optimized intent to Claude Opus 4.7

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -59,7 +59,7 @@ describe("model intents", () => {
       "claude-haiku-4-5-20251001",
     );
     expect(resolveModelIntent("anthropic", "quality-optimized")).toBe(
-      "claude-opus-4-6",
+      "claude-opus-4-7",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
       "claude-opus-4-6",
@@ -94,7 +94,7 @@ describe("RetryProvider model intent normalization", () => {
     });
 
     const config = seen?.config as Record<string, unknown>;
-    expect(config.model).toBe("claude-opus-4-6");
+    expect(config.model).toBe("claude-opus-4-7");
     expect(config.modelIntent).toBeUndefined();
     expect(config.max_tokens).toBe(123);
   });

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -13,7 +13,7 @@ export const PROVIDER_DEFAULT_MODELS: Record<string, string> =
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     "latency-optimized": "claude-haiku-4-5-20251001",
-    "quality-optimized": "claude-opus-4-6",
+    "quality-optimized": "claude-opus-4-7",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
@@ -38,7 +38,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   openrouter: {
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-opus-4.6",
+    "quality-optimized": "anthropic/claude-opus-4.7",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };


### PR DESCRIPTION
## Summary
- Swap `PROVIDER_MODEL_INTENTS.anthropic["quality-optimized"]` from `claude-opus-4-6` to `claude-opus-4-7`, and the OpenRouter mirror from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7`.
- Update the two assertions in `model-intents.test.ts` that hardcoded the old resolved target.
- `vision-optimized` is intentionally left on 4.6 — this PR only retargets `quality-optimized`, matching the user's request.

## Original prompt
make opus 4.7 the quality optimized model intent everywhere opus 4.6 is current the quality optimized model intent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
