### PR TITLE
fix(onboarding): de-emphasize "Continue Without Account" button to ghost style

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -81,7 +81,7 @@ struct WakeUpStepView: View {
                     onContinueWithVellum()
                 }
 
-                VButton(label: "Continue Without Account", style: .outlined, isFullWidth: true) {
+                VButton(label: "Continue without account", style: .ghost) {
                     state?.skippedAuth = true
                     onStartWithAPIKey()
                 }


### PR DESCRIPTION
## Summary
- Change "Continue Without Account" button from .outlined to .ghost style
- Remove isFullWidth: true so it renders as a compact text link
- Revert label to sentence case ("Continue without account")

Part of plan: deemphasize-continue-btn.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
