### PR TITLE
fix(onboarding): de-emphasize "Continue Without Account" button to ghost style

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -81,7 +81,7 @@ struct WakeUpStepView: View {
                     onContinueWithVellum()
                 }
 
-                VButton(label: "Continue Without Account", style: .outlined, isFullWidth: true) {
+                VButton(label: "Continue without account", style: .ghost) {
                     state?.skippedAuth = true
                     onStartWithAPIKey()
                 }


### PR DESCRIPTION
## Summary
Change the "Continue Without Account" button on the WakeUp onboarding step from `.outlined` (equally prominent) to `.ghost` (de-emphasized text link), drawing more attention to the "Log In" primary action.

## Self-review result
PASS — single-line change matches the plan exactly.

## PRs merged into feature branch
- #26059: fix(onboarding): de-emphasize "Continue Without Account" button to ghost style

Part of plan: deemphasize-continue-btn.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
