### PR TITLE
chore(scripts): pin @anthropic-ai/sdk to exact version

### DIFF
--- a/scripts/bun.lock
+++ b/scripts/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@vellumai/scripts",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/sdk": "0.39.0",
       },
     },
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0"
+    "@anthropic-ai/sdk": "0.39.0"
   }
 }


### PR DESCRIPTION
## Summary
- Converts `^` range for `@anthropic-ai/sdk` in `scripts/package.json` to an exact version from `scripts/bun.lock`.

Part of plan: pin-deps.md (PR 2 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
