### PR TITLE
chore(packages): pin devDependencies in credential-storage and egress-proxy

### DIFF
--- a/packages/credential-storage/bun.lock
+++ b/packages/credential-storage/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@vellumai/credential-storage",
       "devDependencies": {
-        "@types/bun": "^1.2.4",
-        "typescript": "^5.7.3",
+        "@types/bun": "1.3.10",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/packages/credential-storage/package.json
+++ b/packages/credential-storage/package.json
@@ -12,7 +12,7 @@
     "test": "bun test src/"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.4",
-    "typescript": "^5.7.3"
+    "@types/bun": "1.3.10",
+    "typescript": "5.9.3"
   }
 }

--- a/packages/egress-proxy/bun.lock
+++ b/packages/egress-proxy/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@vellumai/egress-proxy",
       "devDependencies": {
-        "@types/bun": "^1.2.4",
-        "typescript": "^5.7.3",
+        "@types/bun": "1.3.10",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/packages/egress-proxy/package.json
+++ b/packages/egress-proxy/package.json
@@ -12,7 +12,7 @@
     "test": "bun test src/"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.4",
-    "typescript": "^5.7.3"
+    "@types/bun": "1.3.10",
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Pins `@types/bun` and `typescript` devDependencies in `packages/credential-storage` and `packages/egress-proxy` to exact versions from their lockfiles.

Part of plan: pin-deps.md (PR 3 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
