### PR TITLE
chore(assistant): pin package.json overrides to exact versions

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -54,8 +54,8 @@
     },
   },
   "overrides": {
-    "lodash": "^4.18.0",
-    "path-to-regexp": "^8.4.0",
+    "lodash": "4.18.1",
+    "path-to-regexp": "8.4.2",
   },
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -70,8 +70,8 @@
     "@vellumai/egress-proxy"
   ],
   "overrides": {
-    "lodash": "^4.18.0",
-    "path-to-regexp": "^8.4.0"
+    "lodash": "4.18.1",
+    "path-to-regexp": "8.4.2"
   },
   "devDependencies": {
     "@types/archiver": "7.0.0",


### PR DESCRIPTION
## Summary
- Converts `lodash` and `path-to-regexp` overrides in `assistant/package.json` from `^` ranges to exact resolved versions.

Part of plan: pin-deps.md (PR 5 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
