### PR TITLE
chore(ci): pin bun-version in workflows that default to setup-bun latest

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Set up Bun
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
 
       - name: Login to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
## Summary
- Adds explicit `bun-version: 1.3.9` input to `oven-sh/setup-bun` steps in `ci-gateway-image.yml` and `ci-register-dev-images.yaml` so they don't fall back to whatever `setup-bun` defaults to.

Part of plan: pin-deps.md (PR 9 of 21). PR 11 will bump all bun pins to 1.3.11 together.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
