### PR TITLE
chore(ci): pin actions to full version tags in iOS workflows

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Cancel if superseded by a newer run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.1.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -54,7 +54,7 @@ jobs:
             core.info('This is the newest run — proceeding.');
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/xcodegen
@@ -82,7 +82,7 @@ jobs:
         run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Cache SPM artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ios-spm-${{ hashFiles('clients/Package.resolved') }}
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Get Slack ID
         id: slack-id

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -21,14 +21,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/xcodegen


### PR DESCRIPTION
## Summary
- Replaces bare major-version action pins with full `@vX.Y.Z` tags in `ci-main-ios.yaml` and `pr-ios.yaml`.

Part of plan: pin-deps.md (PR 16 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
