### PR TITLE
chore(ci): bump slackapi/slack-github-action to latest v2.1.1 in composite action

### DIFF
--- a/.github/actions/send-build-alert/action.yml
+++ b/.github/actions/send-build-alert/action.yml
@@ -87,7 +87,7 @@ runs:
         echo "payload_file=$PAYLOAD_FILE" >> "$GITHUB_OUTPUT"
 
     - name: Send Slack message
-      uses: slackapi/slack-github-action@v2.1.0
+      uses: slackapi/slack-github-action@v2.1.1
       with:
         webhook: ${{ inputs.webhook }}
         webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary
- Bumps `slackapi/slack-github-action` pin in `send-build-alert` composite action from `v2.1.0` to `v2.1.1` (latest under major v2).

Part of plan: pin-deps.md (PR 20 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
