### PR TITLE
chore(ci): pin actions to full version tags in assistant workflows

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -21,15 +21,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -60,15 +60,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -99,15 +99,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -127,7 +127,7 @@ jobs:
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
 
       - name: Restore test durations cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v5.0.5
         with:
           path: assistant/.test-durations
           key: test-durations-unused
@@ -142,7 +142,7 @@ jobs:
 
       - name: Save test durations cache
         if: always()
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v5.0.5
         with:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}
@@ -156,15 +156,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -202,18 +202,18 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v2.1.13
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -222,7 +222,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -231,10 +231,10 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Compute image name
         id: image
@@ -246,7 +246,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.19.2
         with:
           context: .
           file: assistant/Dockerfile
@@ -268,7 +268,7 @@ jobs:
           echo "suffix=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: assistant-digests-dev-${{ steps.platform.outputs.suffix }}
           path: /tmp/digests/*
@@ -287,7 +287,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
@@ -299,12 +299,12 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v2.1.13
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -313,7 +313,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -322,12 +322,12 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
         with:
           version: latest
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           path: /tmp/digests
           pattern: assistant-digests-dev-*
@@ -368,7 +368,7 @@ jobs:
           echo "Image ref: $(cat /tmp/dev-image-ref/image-ref.txt)"
 
       - name: Upload image ref
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: dev-image-ref-assistant
           path: /tmp/dev-image-ref/image-ref.txt
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Get Slack ID
         id: slack-id

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -25,15 +25,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -67,15 +67,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -106,15 +106,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -150,13 +150,13 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Zip assistant artifact
         run: zip -r ../assistant-pr-${{ github.event.pull_request.number }}.zip . -x "node_modules/*"
 
       - name: Upload assistant artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: assistant-pr-${{ github.event.pull_request.number }}
           path: assistant-pr-${{ github.event.pull_request.number }}.zip
@@ -166,7 +166,7 @@ jobs:
       - name: Generate GitHub App token
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
@@ -197,15 +197,15 @@ jobs:
         working-directory: assistant
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -233,10 +233,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary
- Replaces bare major-version action pins (`@vN`) with full version tags (`@vN.X.Y`) in `ci-main-assistant.yaml` and `pr-assistant.yaml`. No major-version bumps.

Part of plan: pin-deps.md (PR 12 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
