### PR TITLE
chore(clients): pin Swift Package.swift dependencies to exact versions

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -30,9 +30,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/containerization.git", exact: "0.30.1"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.0.0"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.0.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.8.1"),
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", exact: "1.11.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Replaces `from:` version ranges with `exact:` pins in `clients/Package.swift` for sentry-cocoa, Sparkle, and SwiftTerm, matching values already in `Package.resolved`.

Part of plan: pin-deps.md (PR 6 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
