### PR TITLE
chore(ci): pin actions to full version tags in benchmarks/dep-scan/dev-images workflows

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload results as new baseline
         if: always() && steps.run-benchmarks.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: benchmark-baseline
           path: assistant/benchmark-results.json

--- a/.github/workflows/ci-dependency-scan.yaml
+++ b/.github/workflows/ci-dependency-scan.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Trivy
         run: |

--- a/.github/workflows/ci-register-dev-images.yaml
+++ b/.github/workflows/ci-register-dev-images.yaml
@@ -56,14 +56,14 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
 
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Authenticate to GCP
 
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v2.1.13
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set up Docker Buildx
 
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Compute dev version
 


### PR DESCRIPTION
## Summary
- Replaces bare major-version action pins with full `@vX.Y.Z` tags in `ci-benchmarks.yaml`, `ci-dependency-scan.yaml`, and `ci-register-dev-images.yaml`.

Part of plan: pin-deps.md (PR 19 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
