### PR TITLE
chore(ci): pin actions to full version tags in macOS workflows

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -23,11 +23,11 @@ jobs:
       bundled: ${{ steps.filter.outputs.bundled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Check changed paths
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
             clients:
@@ -52,13 +52,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Cancel if superseded by a newer run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.1.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -88,7 +88,7 @@ jobs:
             core.info('This is the newest run — proceeding.');
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -112,13 +112,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Cancel if superseded by a newer run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.1.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -148,7 +148,7 @@ jobs:
             core.info('This is the newest run — proceeding.');
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -185,7 +185,7 @@ jobs:
             || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
@@ -227,7 +227,7 @@ jobs:
           done
 
       - name: Cache Kata kernel
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
           key: kata-kernel-3.17.0-arm64
@@ -255,7 +255,7 @@ jobs:
           done
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: macos-app-dist
           path: clients/macos/dist/${{ env.APP_DISPLAY_NAME }}.app
@@ -274,7 +274,7 @@ jobs:
           ls -lh "vellum-assistant-${DEV_VERSION}.dmg"
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: vellum-assistant-${{ steps.version.outputs.dev_version }}.dmg
           path: clients/macos/vellum-assistant-${{ steps.version.outputs.dev_version }}.dmg
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Get Slack ID
         id: slack-id

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -34,7 +34,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Upload new baselines
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: always()
         with:
           name: perf-baselines

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -31,7 +31,7 @@ jobs:
         working-directory: clients
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -41,7 +41,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload baseline artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: periphery-baseline
           path: clients/.periphery_baseline.json
@@ -74,7 +74,7 @@ jobs:
       APP_DISPLAY_NAME: Vellum
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -84,7 +84,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -108,13 +108,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -122,7 +122,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.9'
 
@@ -131,7 +131,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -169,7 +169,7 @@ jobs:
           done
 
       - name: Cache Kata kernel
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: clients/macos/.container-cache/kata-3.17.0-arm64/vmlinux.container
           key: kata-kernel-3.17.0-arm64
@@ -190,7 +190,7 @@ jobs:
           done
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: macos-app-pr-${{ github.event.pull_request.number }}
           path: clients/macos/dist/${{ env.APP_DISPLAY_NAME }}.app
@@ -207,7 +207,7 @@ jobs:
             "vellum-assistant-pr-${PR_NUMBER}.dmg"
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: vellum-assistant-pr-${{ github.event.pull_request.number }}.dmg
           path: clients/macos/vellum-assistant-pr-${{ github.event.pull_request.number }}.dmg
@@ -222,12 +222,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Generate GitHub App token
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Replaces bare major-version action pins with full `@vX.Y.Z` tags in the three macOS workflow files.

Part of plan: pin-deps.md (PR 15 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
