### PR TITLE
chore(meet-bot): pin oven/bun base image to exact version + SHA digest

### DIFF
--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -25,7 +25,7 @@
 #     targets different images. See:
 #     https://docs.docker.com/build/concepts/context/#dockerignore-files
 
-FROM oven/bun:1-debian
+FROM oven/bun:1.3.9-debian@sha256:d48b40bf0106dc1e94462c7086fbf4e8aab97f0870db2c87a05ecf8765f964df
 
 # System dependencies. Keep this list grouped and sorted so future PRs can
 # add/remove packages cleanly.


### PR DESCRIPTION
## Summary
- Replaces floating `oven/bun:1-debian` tag in the meet-bot Dockerfile with `oven/bun:1.3.9-debian` pinned to its SHA digest.

Part of plan: pin-deps.md (PR 10 of 21). PR 11 will bump this to 1.3.11 along with the rest of the repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
