### PR TITLE
fix(ios): manual Equatable for generated ModelInfo types

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2092,11 +2092,37 @@ public typealias ModelInfoMessage = ModelInfo
 
 // MARK: - Equatable conformance for generated types
 // Added here (not in GeneratedAPITypes.swift) because generated files must not
-// be edited manually. All stored properties are already Equatable, so Swift
-// auto-synthesizes the conformance.
+// be edited manually. Swift only auto-synthesizes Equatable when the
+// conformance is declared in the same file as the type, so the `==` operators
+// below are implemented by hand.
 
-extension CatalogModel: Equatable {}
-extension ModelInfo: Equatable {}
+extension CatalogModel: Equatable {
+    public static func == (lhs: CatalogModel, rhs: CatalogModel) -> Bool {
+        lhs.id == rhs.id && lhs.displayName == rhs.displayName
+    }
+}
+
+extension ProviderCatalogEntry: Equatable {
+    public static func == (lhs: ProviderCatalogEntry, rhs: ProviderCatalogEntry) -> Bool {
+        lhs.id == rhs.id
+            && lhs.displayName == rhs.displayName
+            && lhs.models == rhs.models
+            && lhs.defaultModel == rhs.defaultModel
+            && lhs.apiKeyUrl == rhs.apiKeyUrl
+            && lhs.apiKeyPlaceholder == rhs.apiKeyPlaceholder
+    }
+}
+
+extension ModelInfo: Equatable {
+    public static func == (lhs: ModelInfo, rhs: ModelInfo) -> Bool {
+        lhs.type == rhs.type
+            && lhs.model == rhs.model
+            && lhs.provider == rhs.provider
+            && lhs.configuredProviders == rhs.configuredProviders
+            && lhs.availableModels == rhs.availableModels
+            && lhs.allProviders == rhs.allProviders
+    }
+}
 
 // MARK: - Vercel API Config Messages
 


### PR DESCRIPTION
## Summary
- #25496 added `extension CatalogModel: Equatable {}` and `extension ModelInfo: Equatable {}` in `MessageTypes.swift`, but Swift only auto-synthesizes `Equatable` when the conformance is declared in the same file as the type. The types live in `GeneratedAPITypes.swift`, so the main iOS build failed with `Extension outside of file declaring struct 'CatalogModel' prevents automatic synthesis of '==' ...` and `Type 'ModelInfo' does not conform to protocol 'Equatable'`.
- Implement `==` by hand for `CatalogModel`, `ProviderCatalogEntry` (required so that `ModelInfo.allProviders` can be compared), and `ModelInfo`. Keep the conformances in `MessageTypes.swift` so the generated file remains untouched.

## Original prompt
fix the build https://github.com/vellum-ai/vellum-assistant/actions/runs/24529406671
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
