### PR TITLE
config(llm): add unified llm schema with call-site enum and profile refines

### DIFF
--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import { LLMSchema } from "../config/schemas/llm.js";
+
+const fullDefault = {
+  provider: "anthropic" as const,
+  model: "claude-opus-4-7",
+  maxTokens: 64000,
+  effort: "max" as const,
+  speed: "standard" as const,
+  temperature: null,
+  thinking: { enabled: true, streamThinking: true },
+  contextWindow: {
+    enabled: true,
+    maxInputTokens: 200000,
+    targetBudgetRatio: 0.3,
+    compactThreshold: 0.8,
+    summaryBudgetRatio: 0.05,
+    overflowRecovery: {
+      enabled: true,
+      safetyMarginRatio: 0.05,
+      maxAttempts: 3,
+      interactiveLatestTurnCompression: "summarize" as const,
+      nonInteractiveLatestTurnCompression: "truncate" as const,
+    },
+  },
+};
+
+describe("LLMSchema", () => {
+  test("valid full config parses successfully (all fields present)", () => {
+    const parsed = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        fast: { speed: "fast", effort: "low" },
+        thorough: { effort: "high", maxTokens: 128000 },
+      },
+      callSites: {
+        mainAgent: { profile: "thorough" },
+        memoryExtraction: { profile: "fast", temperature: 0.2 },
+      },
+      pricingOverrides: [
+        {
+          provider: "anthropic",
+          modelPattern: "claude-opus-*",
+          inputPer1M: 15,
+          outputPer1M: 75,
+        },
+      ],
+    });
+    expect(parsed.default.provider).toBe("anthropic");
+    expect(parsed.profiles["fast"]?.speed).toBe("fast");
+    expect(parsed.callSites.mainAgent?.profile).toBe("thorough");
+    expect(parsed.pricingOverrides).toHaveLength(1);
+  });
+
+  test("minimal valid config (only `default` provided) parses with profiles: {} and callSites: {}", () => {
+    const parsed = LLMSchema.parse({ default: fullDefault });
+    expect(parsed.profiles).toEqual({});
+    expect(parsed.callSites).toEqual({});
+    expect(parsed.pricingOverrides).toEqual([]);
+  });
+
+  test("invalid provider rejected", () => {
+    const result = LLMSchema.safeParse({
+      default: { ...fullDefault, provider: "bogus-provider" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("invalid temperature (negative) rejected", () => {
+    const result = LLMSchema.safeParse({
+      default: { ...fullDefault, temperature: -0.1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("invalid temperature (> 2) rejected", () => {
+    const result = LLMSchema.safeParse({
+      default: { ...fullDefault, temperature: 2.5 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("call-site referencing undefined profile fails superRefine", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: { fast: { speed: "fast" } },
+      callSites: {
+        mainAgent: { profile: "ghost" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.join("\n")).toContain(
+        'Profile "ghost" referenced by call site "mainAgent" is not defined in llm.profiles',
+      );
+      const issue = result.error.issues.find(
+        (i) => i.message.includes("ghost") && i.message.includes("mainAgent"),
+      );
+      expect(issue?.path).toEqual(["callSites", "mainAgent", "profile"]);
+    }
+  });
+
+  test("call-site referencing defined profile passes", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: { fast: { speed: "fast" } },
+      callSites: {
+        mainAgent: { profile: "fast" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("unknown call-site key (typo) fails Zod parse", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      callSites: {
+        // typo of `mainAgent`
+        mainAgnt: { temperature: 0.5 },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("thinking partial override accepted (only `enabled`, no `streamThinking`)", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: {
+        terse: { thinking: { enabled: false } },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.profiles["terse"]?.thinking).toEqual({
+        enabled: false,
+      });
+    }
+  });
+
+  test("contextWindow deep-partial override accepted (nested overflowRecovery only)", () => {
+    const result = LLMSchema.safeParse({
+      default: fullDefault,
+      profiles: {
+        sturdy: {
+          contextWindow: {
+            overflowRecovery: { maxAttempts: 5 },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const cw = result.data.profiles["sturdy"]?.contextWindow as
+        | { overflowRecovery?: { maxAttempts?: number } }
+        | undefined;
+      expect(cw?.overflowRecovery?.maxAttempts).toBe(5);
+    }
+  });
+});

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -1,0 +1,234 @@
+import { z } from "zod";
+
+/**
+ * Unified LLM configuration schema.
+ *
+ * Defines the shape of the new top-level `llm` config block that consolidates
+ * provider/model/effort/speed/thinking/contextWindow/pricingOverrides for all
+ * call sites in the assistant.
+ *
+ * This file only defines the schema — it is not yet wired into the master
+ * `AssistantConfigSchema` (PR 3) and is not yet consumed by any resolver
+ * (PR 2). Downstream PRs handle migration, provider abstraction, and
+ * call-site adoption.
+ */
+
+// ---------------------------------------------------------------------------
+// Provider enum
+// ---------------------------------------------------------------------------
+
+export const LLMProvider = z.enum([
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "fireworks",
+  "openrouter",
+]);
+export type LLMProvider = z.infer<typeof LLMProvider>;
+
+// ---------------------------------------------------------------------------
+// Call-site enum
+// ---------------------------------------------------------------------------
+
+/**
+ * The complete set of LLM call-site identifiers the assistant emits.
+ *
+ * Each ID corresponds to a logical place in the codebase that produces an LLM
+ * request. Adding or removing a call site is a config-schema change — keep
+ * this list in sync with the resolver and registry (introduced in PR 2).
+ */
+export const LLMCallSiteEnum = z.enum([
+  "mainAgent",
+  "subagentSpawn",
+  "heartbeatAgent",
+  "filingAgent",
+  "analyzeConversation",
+  "callAgent",
+  "memoryExtraction",
+  "memoryConsolidation",
+  "memoryRetrieval",
+  "narrativeRefinement",
+  "patternScan",
+  "conversationSummarization",
+  "conversationStarters",
+  "conversationTitle",
+  "commitMessage",
+  "identityIntro",
+  "emptyStateGreeting",
+  "notificationDecision",
+  "preferenceExtraction",
+  "guardianQuestionCopy",
+  "watchCommentary",
+  "watchSummary",
+  "interactionClassifier",
+  "styleAnalyzer",
+  "inviteInstructionGenerator",
+  "skillCategoryInference",
+]);
+export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
+
+// ---------------------------------------------------------------------------
+// Effort & Speed
+// ---------------------------------------------------------------------------
+
+export const EffortEnum = z.enum(["low", "medium", "high", "max"]);
+export type Effort = z.infer<typeof EffortEnum>;
+
+export const SpeedEnum = z.enum(["standard", "fast"]);
+export type Speed = z.infer<typeof SpeedEnum>;
+
+// ---------------------------------------------------------------------------
+// Thinking & ContextWindow
+//
+// These mirror the shapes already declared in `schemas/inference.ts` but are
+// redeclared here so the new `llm` namespace owns its own types and we can
+// shrink them with `.partial()` for fragments without coupling back to
+// the legacy top-level config. PRs 3 and beyond will deprecate the legacy
+// declarations once the resolver is the single source of truth.
+// ---------------------------------------------------------------------------
+
+export const ThinkingSchema = z.object({
+  enabled: z.boolean(),
+  streamThinking: z.boolean(),
+});
+export type Thinking = z.infer<typeof ThinkingSchema>;
+
+const ContextOverflowRecoverySchema = z.object({
+  enabled: z.boolean(),
+  safetyMarginRatio: z.number().finite().gt(0).lt(1),
+  maxAttempts: z.number().int().positive(),
+  interactiveLatestTurnCompression: z.enum(["truncate", "summarize", "drop"]),
+  nonInteractiveLatestTurnCompression: z.enum([
+    "truncate",
+    "summarize",
+    "drop",
+  ]),
+});
+
+export const ContextWindowSchema = z.object({
+  enabled: z.boolean(),
+  maxInputTokens: z.number().int().positive(),
+  targetBudgetRatio: z.number().finite().gt(0).lte(1),
+  compactThreshold: z.number().finite().gt(0).lte(1),
+  summaryBudgetRatio: z.number().finite().gt(0).lte(1),
+  overflowRecovery: ContextOverflowRecoverySchema,
+});
+export type ContextWindow = z.infer<typeof ContextWindowSchema>;
+
+/**
+ * Manual deep-partial helper for `ContextWindowSchema`.
+ *
+ * Zod 4 dropped `ZodObject.deepPartial()`. This helper walks a single level
+ * of nested ZodObject shapes and rebuilds them with every leaf marked
+ * `.optional()`, which is the exact recursion depth `ContextWindowSchema`
+ * needs (one level of nesting via `overflowRecovery`).
+ */
+function deepPartialObject(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schema: z.ZodObject<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): z.ZodObject<any> {
+  const newShape: Record<string, z.ZodTypeAny> = {};
+  for (const [key, value] of Object.entries(schema.shape)) {
+    if (value instanceof z.ZodObject) {
+      newShape[key] = deepPartialObject(value).optional();
+    } else {
+      newShape[key] = (value as z.ZodTypeAny).optional();
+    }
+  }
+  return z.object(newShape);
+}
+
+const ContextWindowDeepPartialSchema = deepPartialObject(ContextWindowSchema);
+
+// ---------------------------------------------------------------------------
+// Pricing overrides
+// ---------------------------------------------------------------------------
+
+export const PricingOverrideSchema = z.object({
+  provider: z.string(),
+  modelPattern: z.string(),
+  inputPer1M: z.number().nonnegative(),
+  outputPer1M: z.number().nonnegative(),
+});
+export type PricingOverride = z.infer<typeof PricingOverrideSchema>;
+
+// ---------------------------------------------------------------------------
+// Base config (all fields required) and Fragment (all fields optional)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fully specified LLM config. Used for `llm.default` — every knob must be
+ * set so the resolver always has a complete fallback.
+ */
+export const LLMConfigBase = z.object({
+  provider: LLMProvider,
+  model: z.string().min(1),
+  maxTokens: z.number().int().positive(),
+  effort: EffortEnum,
+  speed: SpeedEnum,
+  temperature: z.number().min(0).max(2).nullable(),
+  thinking: ThinkingSchema,
+  contextWindow: ContextWindowSchema,
+});
+export type LLMConfigBase = z.infer<typeof LLMConfigBase>;
+
+/**
+ * Partial LLM config used for profiles and call-site overrides. Each top-level
+ * field is optional; nested `thinking` and `contextWindow` accept partial
+ * objects so callers can override individual leaves (e.g. `{ thinking:
+ * { enabled: false } }`).
+ */
+export const LLMConfigFragment = z.object({
+  provider: LLMProvider.optional(),
+  model: z.string().min(1).optional(),
+  maxTokens: z.number().int().positive().optional(),
+  effort: EffortEnum.optional(),
+  speed: SpeedEnum.optional(),
+  temperature: z.number().min(0).max(2).nullable().optional(),
+  thinking: ThinkingSchema.partial().optional(),
+  contextWindow: ContextWindowDeepPartialSchema.optional(),
+});
+export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
+
+/**
+ * Per-call-site config: a fragment plus an optional `profile` reference.
+ * The resolver merges in the named profile (if any) before applying
+ * call-site-level overrides.
+ */
+export const LLMCallSiteConfig = LLMConfigFragment.extend({
+  profile: z.string().min(1).optional(),
+});
+export type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
+
+// ---------------------------------------------------------------------------
+// Top-level LLM schema
+// ---------------------------------------------------------------------------
+
+export const LLMSchema = z
+  .object({
+    default: LLMConfigBase,
+    profiles: z.record(z.string().min(1), LLMConfigFragment).default({}),
+    // `partialRecord` (vs `record`) makes call-site keys optional while still
+    // rejecting keys that aren't members of `LLMCallSiteEnum` — exactly the
+    // behavior we want (typo detection without requiring callers to declare
+    // every call site).
+    callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
+    pricingOverrides: z.array(PricingOverrideSchema).default([]),
+  })
+  .superRefine((config, ctx) => {
+    const profileNames = new Set(Object.keys(config.profiles ?? {}));
+    for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
+      if (siteConfig?.profile == null) continue;
+      if (!profileNames.has(siteConfig.profile)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["callSites", siteId, "profile"],
+          message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
+        });
+      }
+    }
+  });
+
+export type LLMConfig = z.infer<typeof LLMSchema>;

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -116,31 +116,13 @@ export const ContextWindowSchema = z.object({
 });
 export type ContextWindow = z.infer<typeof ContextWindowSchema>;
 
-/**
- * Manual deep-partial helper for `ContextWindowSchema`.
- *
- * Zod 4 dropped `ZodObject.deepPartial()`. This helper walks a single level
- * of nested ZodObject shapes and rebuilds them with every leaf marked
- * `.optional()`, which is the exact recursion depth `ContextWindowSchema`
- * needs (one level of nesting via `overflowRecovery`).
- */
-function deepPartialObject(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  schema: z.ZodObject<any>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): z.ZodObject<any> {
-  const newShape: Record<string, z.ZodTypeAny> = {};
-  for (const [key, value] of Object.entries(schema.shape)) {
-    if (value instanceof z.ZodObject) {
-      newShape[key] = deepPartialObject(value).optional();
-    } else {
-      newShape[key] = (value as z.ZodTypeAny).optional();
-    }
-  }
-  return z.object(newShape);
-}
-
-const ContextWindowDeepPartialSchema = deepPartialObject(ContextWindowSchema);
+// Zod 4 dropped `ZodObject.deepPartial()`. ContextWindowSchema has a single
+// level of nesting (`overflowRecovery`), so we make both levels optional
+// explicitly — clearer than a generic walker and avoids tripping the readonly
+// `shape` typing that LSPs flag with TS2542.
+const ContextWindowDeepPartialSchema = ContextWindowSchema.partial().extend({
+  overflowRecovery: ContextOverflowRecoverySchema.partial().optional(),
+});
 
 // ---------------------------------------------------------------------------
 // Pricing overrides
@@ -223,7 +205,7 @@ export const LLMSchema = z
       if (siteConfig?.profile == null) continue;
       if (!profileNames.has(siteConfig.profile)) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           path: ["callSites", siteId, "profile"],
           message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
         });


### PR DESCRIPTION
## Summary
- New `assistant/src/config/schemas/llm.ts` defines `LLMSchema`, `LLMCallSiteEnum` (26 call sites), `LLMConfigBase`, `LLMConfigFragment`, `LLMCallSiteConfig`, and a `.superRefine` that catches unknown profile references at config load.
- New `assistant/src/__tests__/llm-schema.test.ts` covers valid/invalid configs, partial fragments, unknown call-site keys, and missing-profile validation.
- Not wired into `AssistantConfigSchema` yet (PR 3).

Part of plan: unify-llm-callsites.md (PR 1 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
