### PR TITLE
docs(agents): document dependency pinning policy and refresh cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,29 @@ When adding a new dependency:
 3. If unsure about compatibility, flag it in the PR for review.
 4. Verify the version in `package.json` is pinned to an exact version (no `^` or `~`).
 
+### GitHub Actions
+
+All `uses:` steps in `.github/workflows/**` and `.github/actions/**` must pin to a full `vX.Y.Z` release tag (e.g. `actions/checkout@v6.0.2`). Never use a bare major tag like `@v6` — that's a floating reference and silently pulls in new releases. To upgrade, look up the new release tag for the currently-pinned major and replace it. Avoid bumping major versions in the same PR as a pin-refresh; treat major upgrades as separate, explicit changes.
+
+### Swift SPM
+
+In `clients/Package.swift` and any future `Package.swift`, use `.package(url: ..., exact: "X.Y.Z")`. Do not use `.package(url: ..., from: "X.Y.Z")` or other range syntax — the `from:` form silently pulls in new minor/patch releases on each `swift package resolve`.
+
+### Docker base images
+
+In every `Dockerfile`, `FROM` lines must pin the base image to both an exact version tag and an `@sha256:` digest (e.g. `FROM debian:trixie-slim@sha256:...`). Rebuild the digest reference when intentionally upgrading. Do NOT pin `apt-get install` package versions inside Dockerfiles — Debian rotates them out of APT quickly; rely on the base-image digest for reproducibility instead.
+
+### Tool versions
+
+`.tool-versions`, `.nvmrc`, `setup.sh`, all `bun-version:` workflow inputs, and all production `Dockerfile` bun installs must reference the same exact version string. When bumping any of them, bump all of them in the same PR so the repo never has drifted copies. The same rule applies to Node — `.nvmrc` and every workflow `node-version:` input must match.
+
+### What we explicitly do not pin
+
+- `apt-get install` package versions inside Dockerfiles (Debian rotates them out).
+- `brew install` formulae in `setup.sh` (Homebrew lacks clean exact-version pinning and it's developer-local).
+- Xcode point releases beyond the major tag already set via `sudo xcode-select -s`.
+- GitHub-hosted runner system libraries.
+
 ## Testing
 
 The full test suite is large and will hang or timeout if run unscoped. **Never run `bun test` without specifying file paths.**
@@ -67,17 +90,6 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
   - **Status sync**: Set In Progress when starting work. For single-PR workflows, move to In Review when the PR is opened. For multi-PR plans, do not toggle status between PRs — let the final PR's `Closes` keyword handle the Done transition.
 - **Track merged PRs**: Append PR URL to `.private/UNREVIEWED_PRS.md` so `/check-reviews` can triage.
 - **Human attention comments**: After creating a PR with non-routine changes (architectural decisions, security, complex logic, deletions, low confidence), leave a `gh pr comment` highlighting where to focus review and the risk level. Skip for routine changes.
-
-## GitHub Actions Allowlist
-
-This repository uses a **GitHub Actions allowlist** — only pre-approved actions can run in workflows. The allowlist is managed at https://github.com/vellum-ai/vellum-assistant/settings/actions.
-
-When adding or changing a `uses:` step in any `.github/workflows/*.yml` file (e.g. a new action, or bumping an existing action to a new major version), you **must** also add the action to the allowlist. If you don't, CI and release workflows will fail with a permissions error.
-
-**Checklist for workflow changes:**
-1. Before merging, verify every `uses:` reference in your diff is already on the allowlist.
-2. If a new action is needed, request that a repo admin add it at the settings URL above.
-3. Include this in PR descriptions when adding new actions so reviewers know the allowlist needs updating.
 
 ## Keep Docs Up to Date
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,10 @@ In every `Dockerfile`, `FROM` lines must pin the base image to both an exact ver
 
 ### Tool versions
 
-`.tool-versions`, `.nvmrc`, `setup.sh`, all `bun-version:` workflow inputs, and all production `Dockerfile` bun installs must reference the same exact version string. When bumping any of them, bump all of them in the same PR so the repo never has drifted copies. The same rule applies to Node — `.nvmrc` and every workflow `node-version:` input must match.
+Bun and Node are tracked as separate toolchains; each has its own set of files that must stay in sync. When bumping any file in a set, bump all of them in the same PR so the repo never has drifted copies.
+
+- **Bun**: `.tool-versions`, `setup.sh`, all `bun-version:` workflow inputs, and all production `Dockerfile` bun installs must reference the same exact version string.
+- **Node**: `.nvmrc` and every workflow `node-version:` input must reference the same exact version string. (`.nvmrc` is Node-only and is intentionally not tied to the Bun version.)
 
 ### What we explicitly do not pin
 


### PR DESCRIPTION
## Summary
- Extends the `## Dependencies` section in `AGENTS.md` with new subsections covering GitHub Actions, Swift SPM, Docker base images, tool versions, and what we intentionally do not pin.
- Removes the stale `## GitHub Actions Allowlist` section — the allowlist it describes is not actually enforced on this repo and the section misled contributors.

Part of plan: pin-deps.md (PR 21 of 21, final)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
