### PR TITLE
fix(macos): make SoundManager.audioQueue nonisolated

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -32,7 +32,7 @@ final class SoundManager {
     /// one queue — `NSSound(named:)` can return cached instances, so concurrent
     /// volume mutations from separate queues would race.
     /// See: https://developer.apple.com/documentation/appkit/nssound/play()
-    @ObservationIgnored static let audioQueue = DispatchQueue(
+    @ObservationIgnored nonisolated static let audioQueue = DispatchQueue(
         label: "com.vellum.assistant.audio-playback", qos: .userInitiated
     )
 


### PR DESCRIPTION
## Summary
- `SoundManager` is `@MainActor`-isolated, which implicitly isolates `static let audioQueue` to the main actor. `VoiceFeedback.playActivationChime()` / `playDeactivationChime()` are nonisolated static methods, so referencing `SoundManager.audioQueue` from them produced a Swift 6 main-actor-isolation warning (error under Swift 6 language mode).
- Marked `audioQueue` `nonisolated`. The queue is an immutable `let` holding a `Sendable` `DispatchQueue`, so sharing it across isolation domains is safe — it's literally designed to hop work off the main actor.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Voice/VoiceFeedback.swift:16:22: warning: main actor-isolated static property 'audioQueue' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
