### PR TITLE
config(llm): add llm field to AssistantConfigSchema (no behavior change)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -161,6 +161,145 @@ describe("AssistantConfigSchema", () => {
     expect(result.secretDetection.action).toBe("block");
   });
 
+  test("applies llm defaults when llm key is omitted", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.llm).toBeDefined();
+    expect(result.llm.default).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 64000,
+      effort: "max",
+      speed: "standard",
+      temperature: null,
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        enabled: true,
+        maxInputTokens: 200000,
+        targetBudgetRatio: 0.3,
+        compactThreshold: 0.8,
+        summaryBudgetRatio: 0.05,
+        overflowRecovery: {
+          enabled: true,
+          safetyMarginRatio: 0.05,
+          maxAttempts: 3,
+          interactiveLatestTurnCompression: "summarize",
+          nonInteractiveLatestTurnCompression: "truncate",
+        },
+      },
+    });
+    expect(result.llm.profiles).toEqual({});
+    expect(result.llm.callSites).toEqual({});
+    expect(result.llm.pricingOverrides).toEqual([]);
+  });
+
+  test("accepts an explicit llm block with profiles and call sites", () => {
+    const input = {
+      llm: {
+        default: {
+          provider: "anthropic" as const,
+          model: "claude-opus-4-7",
+          maxTokens: 32000,
+          effort: "high" as const,
+          speed: "fast" as const,
+          temperature: null,
+          thinking: { enabled: true, streamThinking: false },
+          contextWindow: {
+            enabled: true,
+            maxInputTokens: 200000,
+            targetBudgetRatio: 0.3,
+            compactThreshold: 0.8,
+            summaryBudgetRatio: 0.05,
+            overflowRecovery: {
+              enabled: true,
+              safetyMarginRatio: 0.05,
+              maxAttempts: 3,
+              interactiveLatestTurnCompression: "summarize" as const,
+              nonInteractiveLatestTurnCompression: "truncate" as const,
+            },
+          },
+        },
+        profiles: {
+          fast: { speed: "fast" as const, effort: "low" as const },
+        },
+        callSites: {
+          mainAgent: { profile: "fast" },
+          commitMessage: { maxTokens: 256 },
+        },
+        pricingOverrides: [],
+      },
+    };
+    const result = AssistantConfigSchema.parse(input);
+    expect(result.llm.default.model).toBe("claude-opus-4-7");
+    expect(result.llm.default.speed).toBe("fast");
+    expect(result.llm.profiles?.fast).toEqual({
+      speed: "fast",
+      effort: "low",
+    });
+    expect(result.llm.callSites?.mainAgent).toEqual({ profile: "fast" });
+    expect(result.llm.callSites?.commitMessage).toEqual({ maxTokens: 256 });
+  });
+
+  test("rejects an llm.callSites entry that references an undefined profile", () => {
+    const input = {
+      llm: {
+        default: {
+          provider: "anthropic" as const,
+          model: "claude-opus-4-6",
+          maxTokens: 64000,
+          effort: "max" as const,
+          speed: "standard" as const,
+          temperature: null,
+          thinking: { enabled: true, streamThinking: true },
+          contextWindow: {
+            enabled: true,
+            maxInputTokens: 200000,
+            targetBudgetRatio: 0.3,
+            compactThreshold: 0.8,
+            summaryBudgetRatio: 0.05,
+            overflowRecovery: {
+              enabled: true,
+              safetyMarginRatio: 0.05,
+              maxAttempts: 3,
+              interactiveLatestTurnCompression: "summarize" as const,
+              nonInteractiveLatestTurnCompression: "truncate" as const,
+            },
+          },
+        },
+        callSites: {
+          mainAgent: { profile: "missing-profile" },
+        },
+      },
+    };
+    expect(() => AssistantConfigSchema.parse(input)).toThrow(
+      /missing-profile/,
+    );
+  });
+
+  test("legacy top-level inference keys still parse alongside the new llm block", () => {
+    // Backward compatibility: configs that set the legacy top-level keys
+    // (maxTokens, effort, speed, thinking, contextWindow, services.inference)
+    // continue to parse correctly. PR 19 removes these once adoption is done.
+    const input = {
+      services: {
+        inference: { provider: "openai" as const, model: "gpt-4" },
+      },
+      maxTokens: 8000,
+      effort: "medium" as const,
+      speed: "fast" as const,
+      thinking: { enabled: false, streamThinking: false },
+    };
+    const result = AssistantConfigSchema.parse(input);
+    expect(result.services.inference.provider).toBe("openai");
+    expect(result.maxTokens).toBe(8000);
+    expect(result.effort).toBe("medium");
+    expect(result.speed).toBe("fast");
+    expect(result.thinking.enabled).toBe(false);
+    // The new llm block falls back to its own defaults (independent of the
+    // legacy top-level keys until the migration in PR 4 backfills it).
+    expect(result.llm.default.provider).toBe("anthropic");
+    expect(result.llm.default.model).toBe("claude-opus-4-6");
+  });
+
   test("applies rollout defaults for dynamic budget", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.retrieval.dynamicBudget).toEqual({

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -270,9 +270,7 @@ describe("AssistantConfigSchema", () => {
         },
       },
     };
-    expect(() => AssistantConfigSchema.parse(input)).toThrow(
-      /missing-profile/,
-    );
+    expect(() => AssistantConfigSchema.parse(input)).toThrow(/missing-profile/);
   });
 
   test("legacy top-level inference keys still parse alongside the new llm block", () => {
@@ -298,6 +296,37 @@ describe("AssistantConfigSchema", () => {
     // legacy top-level keys until the migration in PR 4 backfills it).
     expect(result.llm.default.provider).toBe("anthropic");
     expect(result.llm.default.model).toBe("claude-opus-4-6");
+  });
+
+  test("partial llm config (empty `llm: {}`) doesn't trigger full config reset", () => {
+    // Regression guard: previously LLMConfigBase had no schema-level defaults,
+    // so any `llm: {}` block would fail validation and the loader's recovery
+    // path would fall through to `cloneDefaultConfig()`, discarding unrelated
+    // valid settings (like a custom `maxTokens`). With leaf-level defaults,
+    // `llm: {}` parses cleanly and the user's other settings are preserved.
+    const result = AssistantConfigSchema.parse({
+      maxTokens: 32000,
+      llm: {},
+    });
+    expect(result.maxTokens).toBe(32000);
+    expect(result.llm.default.provider).toBe("anthropic");
+    expect(result.llm.default.model).toBe("claude-opus-4-6");
+    expect(result.llm.default.maxTokens).toBe(64000);
+  });
+
+  test("llm.default with one missing field still parses (defaults applied)", () => {
+    // A user can override a single field of `llm.default` without specifying
+    // the rest — schema-level defaults fill in everything that wasn't set.
+    const result = AssistantConfigSchema.parse({
+      llm: { default: { model: "claude-haiku-4-5" } },
+    });
+    expect(result.llm.default.model).toBe("claude-haiku-4-5");
+    expect(result.llm.default.provider).toBe("anthropic");
+    expect(result.llm.default.maxTokens).toBe(64000);
+    expect(result.llm.default.thinking).toEqual({
+      enabled: true,
+      streamThinking: true,
+    });
   });
 
   test("applies rollout defaults for dynamic budget", () => {

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -60,6 +60,42 @@ describe("LLMSchema", () => {
     expect(parsed.pricingOverrides).toEqual([]);
   });
 
+  test("empty `llm: {}` parses with all schema defaults applied", () => {
+    // Critical regression guard: every leaf of LLMConfigBase has a
+    // schema-level default, so `LLMSchema.parse({})` must return a
+    // fully-populated object. This is what lets the loader's leaf-deletion
+    // recovery path repair partially invalid `llm` blocks instead of falling
+    // through to `cloneDefaultConfig()` and discarding unrelated valid
+    // settings.
+    const parsed = LLMSchema.parse({});
+    expect(parsed.default).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 64000,
+      effort: "max",
+      speed: "standard",
+      temperature: null,
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        enabled: true,
+        maxInputTokens: 200000,
+        targetBudgetRatio: 0.3,
+        compactThreshold: 0.8,
+        summaryBudgetRatio: 0.05,
+        overflowRecovery: {
+          enabled: true,
+          safetyMarginRatio: 0.05,
+          maxAttempts: 3,
+          interactiveLatestTurnCompression: "summarize",
+          nonInteractiveLatestTurnCompression: "truncate",
+        },
+      },
+    });
+    expect(parsed.profiles).toEqual({});
+    expect(parsed.callSites).toEqual({});
+    expect(parsed.pricingOverrides).toEqual([]);
+  });
+
   test("invalid provider rejected", () => {
     const result = LLMSchema.safeParse({
       default: { ...fullDefault, provider: "bogus-provider" },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -248,6 +248,7 @@ import {
 } from "./schemas/inference.js";
 import { IngressConfigSchema } from "./schemas/ingress.js";
 import { JournalConfigSchema } from "./schemas/journal.js";
+import { LLMSchema } from "./schemas/llm.js";
 import {
   AuditLogConfigSchema,
   LogFileConfigSchema,
@@ -311,6 +312,40 @@ export const AssistantConfigSchema = z
       .describe(
         "Custom pricing overrides for specific provider/model combinations",
       ),
+    // Unified LLM configuration block. Defaults mirror the legacy top-level
+    // inference settings (services.inference, maxTokens, effort, speed,
+    // thinking, contextWindow) so existing configs without an `llm` block
+    // continue to behave identically. No callers consume this yet — PRs 5+
+    // migrate call sites to read through the resolver. PR 19 removes the
+    // legacy keys once adoption is complete.
+    llm: LLMSchema.default({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        maxTokens: 64000,
+        effort: "max",
+        speed: "standard",
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    }),
     filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     updates: UpdatesConfigSchema.default(UpdatesConfigSchema.parse({})),

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -318,34 +318,13 @@ export const AssistantConfigSchema = z
     // continue to behave identically. No callers consume this yet — PRs 5+
     // migrate call sites to read through the resolver. PR 19 removes the
     // legacy keys once adoption is complete.
-    llm: LLMSchema.default({
-      default: {
-        provider: "anthropic",
-        model: "claude-opus-4-6",
-        maxTokens: 64000,
-        effort: "max",
-        speed: "standard",
-        temperature: null,
-        thinking: { enabled: true, streamThinking: true },
-        contextWindow: {
-          enabled: true,
-          maxInputTokens: 200000,
-          targetBudgetRatio: 0.3,
-          compactThreshold: 0.8,
-          summaryBudgetRatio: 0.05,
-          overflowRecovery: {
-            enabled: true,
-            safetyMarginRatio: 0.05,
-            maxAttempts: 3,
-            interactiveLatestTurnCompression: "summarize",
-            nonInteractiveLatestTurnCompression: "truncate",
-          },
-        },
-      },
-      profiles: {},
-      callSites: {},
-      pricingOverrides: [],
-    }),
+    //
+    // Default values live on each leaf inside `LLMSchema` (see
+    // `schemas/llm.ts`), so `LLMSchema.parse({})` returns a fully-populated
+    // object. This matches the pattern used by sibling schemas above and
+    // ensures the loader's leaf-deletion recovery path can repair a partially
+    // invalid `llm` block without falling back to `cloneDefaultConfig()`.
+    llm: LLMSchema.default(LLMSchema.parse({})),
     filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     updates: UpdatesConfigSchema.default(UpdatesConfigSchema.parse({})),

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -79,49 +79,122 @@ export const SpeedEnum = z.enum(["standard", "fast"]);
 export type Speed = z.infer<typeof SpeedEnum>;
 
 // ---------------------------------------------------------------------------
+// Leaf primitives (shared between LLMConfigBase and LLMConfigFragment)
+//
+// Each primitive is a Zod schema with no defaults attached. `LLMConfigBase`
+// composes them with `.default(...)` so `LLMConfigBase.parse({})` returns a
+// fully-defaulted object; `LLMConfigFragment` composes them with `.optional()`
+// so absent fields stay absent. Centralizing the validation rules here keeps
+// the two views consistent.
+// ---------------------------------------------------------------------------
+
+const ModelSchema = z.string().min(1);
+const MaxTokensSchema = z.number().int().positive();
+const TemperatureSchema = z.number().min(0).max(2).nullable();
+
+// ---------------------------------------------------------------------------
 // Thinking & ContextWindow
 //
 // These mirror the shapes already declared in `schemas/inference.ts` but are
-// redeclared here so the new `llm` namespace owns its own types and we can
-// shrink them with `.partial()` for fragments without coupling back to
-// the legacy top-level config. PRs 3 and beyond will deprecate the legacy
-// declarations once the resolver is the single source of truth.
+// redeclared here so the new `llm` namespace owns its own types. PRs 3 and
+// beyond will deprecate the legacy declarations once the resolver is the
+// single source of truth.
+//
+// Every leaf in the defaulted view carries a `.default(...)`, so
+// `Schema.parse({})` returns a fully-defaulted object. This is critical for
+// the loader's leaf-deletion recovery path: if any leaf in the user's config
+// is invalid, the loader strips that leaf and re-parses; without
+// schema-level defaults the parse would fail on missing required siblings,
+// and the loader would fall back to `cloneDefaultConfig()`, discarding the
+// user's other valid settings.
+//
+// Each defaulted schema has a sibling "fragment" schema with the same leaves
+// wrapped in `.optional()` instead of `.default(...)`. The fragment view is
+// used by `LLMConfigFragment` so partial overrides remain partial — Zod
+// would inject defaults for absent fields if we used `Schema.partial()`, and
+// the fragment contract is "any field may be absent and stays absent".
 // ---------------------------------------------------------------------------
 
+// Leaf primitives for thinking fields — defined once and reused by both the
+// defaulted (`ThinkingSchema`) and fragment (`ThinkingFragmentSchema`) views.
+const ThinkingEnabledSchema = z.boolean();
+const ThinkingStreamThinkingSchema = z.boolean();
+
 export const ThinkingSchema = z.object({
-  enabled: z.boolean(),
-  streamThinking: z.boolean(),
+  enabled: ThinkingEnabledSchema.default(true),
+  streamThinking: ThinkingStreamThinkingSchema.default(true),
 });
 export type Thinking = z.infer<typeof ThinkingSchema>;
 
-const ContextOverflowRecoverySchema = z.object({
-  enabled: z.boolean(),
-  safetyMarginRatio: z.number().finite().gt(0).lt(1),
-  maxAttempts: z.number().int().positive(),
-  interactiveLatestTurnCompression: z.enum(["truncate", "summarize", "drop"]),
-  nonInteractiveLatestTurnCompression: z.enum([
-    "truncate",
-    "summarize",
-    "drop",
-  ]),
+// Fragment view: every field optional, no defaults injected. Defining this
+// separately (rather than `ThinkingSchema.partial()`) avoids having Zod
+// inject defaults for absent fields when a partial override is parsed —
+// the fragment contract is "any field may be absent and stays absent".
+const ThinkingFragmentSchema = z.object({
+  enabled: ThinkingEnabledSchema.optional(),
+  streamThinking: ThinkingStreamThinkingSchema.optional(),
 });
 
+// Leaf primitives for context-overflow recovery.
+const OverflowEnabledSchema = z.boolean();
+const OverflowSafetyMarginRatioSchema = z.number().finite().gt(0).lt(1);
+const OverflowMaxAttemptsSchema = z.number().int().positive();
+const OverflowLatestTurnCompressionSchema = z.enum([
+  "truncate",
+  "summarize",
+  "drop",
+]);
+
+const ContextOverflowRecoverySchema = z.object({
+  enabled: OverflowEnabledSchema.default(true),
+  safetyMarginRatio: OverflowSafetyMarginRatioSchema.default(0.05),
+  maxAttempts: OverflowMaxAttemptsSchema.default(3),
+  interactiveLatestTurnCompression:
+    OverflowLatestTurnCompressionSchema.default("summarize"),
+  nonInteractiveLatestTurnCompression:
+    OverflowLatestTurnCompressionSchema.default("truncate"),
+});
+
+const ContextOverflowRecoveryFragmentSchema = z.object({
+  enabled: OverflowEnabledSchema.optional(),
+  safetyMarginRatio: OverflowSafetyMarginRatioSchema.optional(),
+  maxAttempts: OverflowMaxAttemptsSchema.optional(),
+  interactiveLatestTurnCompression:
+    OverflowLatestTurnCompressionSchema.optional(),
+  nonInteractiveLatestTurnCompression:
+    OverflowLatestTurnCompressionSchema.optional(),
+});
+
+// Leaf primitives for context-window fields.
+const ContextEnabledSchema = z.boolean();
+const ContextMaxInputTokensSchema = z.number().int().positive();
+const ContextTargetBudgetRatioSchema = z.number().finite().gt(0).lte(1);
+const ContextCompactThresholdSchema = z.number().finite().gt(0).lte(1);
+const ContextSummaryBudgetRatioSchema = z.number().finite().gt(0).lte(1);
+
 export const ContextWindowSchema = z.object({
-  enabled: z.boolean(),
-  maxInputTokens: z.number().int().positive(),
-  targetBudgetRatio: z.number().finite().gt(0).lte(1),
-  compactThreshold: z.number().finite().gt(0).lte(1),
-  summaryBudgetRatio: z.number().finite().gt(0).lte(1),
-  overflowRecovery: ContextOverflowRecoverySchema,
+  enabled: ContextEnabledSchema.default(true),
+  maxInputTokens: ContextMaxInputTokensSchema.default(200000),
+  targetBudgetRatio: ContextTargetBudgetRatioSchema.default(0.3),
+  compactThreshold: ContextCompactThresholdSchema.default(0.8),
+  summaryBudgetRatio: ContextSummaryBudgetRatioSchema.default(0.05),
+  overflowRecovery: ContextOverflowRecoverySchema.default(
+    ContextOverflowRecoverySchema.parse({}),
+  ),
 });
 export type ContextWindow = z.infer<typeof ContextWindowSchema>;
 
-// Zod 4 dropped `ZodObject.deepPartial()`. ContextWindowSchema has a single
-// level of nesting (`overflowRecovery`), so we make both levels optional
-// explicitly — clearer than a generic walker and avoids tripping the readonly
-// `shape` typing that LSPs flag with TS2542.
-const ContextWindowDeepPartialSchema = ContextWindowSchema.partial().extend({
-  overflowRecovery: ContextOverflowRecoverySchema.partial().optional(),
+// Fragment view of `ContextWindowSchema` — all fields optional and no defaults
+// injected. Nested `overflowRecovery` likewise uses its fragment view, so a
+// partial override like `{ overflowRecovery: { maxAttempts: 5 } }` produces
+// exactly that and nothing else.
+const ContextWindowDeepPartialSchema = z.object({
+  enabled: ContextEnabledSchema.optional(),
+  maxInputTokens: ContextMaxInputTokensSchema.optional(),
+  targetBudgetRatio: ContextTargetBudgetRatioSchema.optional(),
+  compactThreshold: ContextCompactThresholdSchema.optional(),
+  summaryBudgetRatio: ContextSummaryBudgetRatioSchema.optional(),
+  overflowRecovery: ContextOverflowRecoveryFragmentSchema.optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -137,22 +210,24 @@ export const PricingOverrideSchema = z.object({
 export type PricingOverride = z.infer<typeof PricingOverrideSchema>;
 
 // ---------------------------------------------------------------------------
-// Base config (all fields required) and Fragment (all fields optional)
+// Base config (all fields defaulted) and Fragment (all fields optional)
 // ---------------------------------------------------------------------------
 
 /**
- * Fully specified LLM config. Used for `llm.default` — every knob must be
- * set so the resolver always has a complete fallback.
+ * Fully specified LLM config. Used for `llm.default` — every knob has a
+ * schema-level default, so `LLMConfigBase.parse({})` returns a complete
+ * fallback object. This is essential for the loader's leaf-deletion recovery
+ * path; see the comment on `ThinkingSchema` above.
  */
 export const LLMConfigBase = z.object({
-  provider: LLMProvider,
-  model: z.string().min(1),
-  maxTokens: z.number().int().positive(),
-  effort: EffortEnum,
-  speed: SpeedEnum,
-  temperature: z.number().min(0).max(2).nullable(),
-  thinking: ThinkingSchema,
-  contextWindow: ContextWindowSchema,
+  provider: LLMProvider.default("anthropic"),
+  model: ModelSchema.default("claude-opus-4-6"),
+  maxTokens: MaxTokensSchema.default(64000),
+  effort: EffortEnum.default("max"),
+  speed: SpeedEnum.default("standard"),
+  temperature: TemperatureSchema.default(null),
+  thinking: ThinkingSchema.default(ThinkingSchema.parse({})),
+  contextWindow: ContextWindowSchema.default(ContextWindowSchema.parse({})),
 });
 export type LLMConfigBase = z.infer<typeof LLMConfigBase>;
 
@@ -164,12 +239,12 @@ export type LLMConfigBase = z.infer<typeof LLMConfigBase>;
  */
 export const LLMConfigFragment = z.object({
   provider: LLMProvider.optional(),
-  model: z.string().min(1).optional(),
-  maxTokens: z.number().int().positive().optional(),
+  model: ModelSchema.optional(),
+  maxTokens: MaxTokensSchema.optional(),
   effort: EffortEnum.optional(),
   speed: SpeedEnum.optional(),
-  temperature: z.number().min(0).max(2).nullable().optional(),
-  thinking: ThinkingSchema.partial().optional(),
+  temperature: TemperatureSchema.optional(),
+  thinking: ThinkingFragmentSchema.optional(),
   contextWindow: ContextWindowDeepPartialSchema.optional(),
 });
 export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
@@ -190,7 +265,7 @@ export type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
 
 export const LLMSchema = z
   .object({
-    default: LLMConfigBase,
+    default: LLMConfigBase.default(LLMConfigBase.parse({})),
     profiles: z.record(z.string().min(1), LLMConfigFragment).default({}),
     // `partialRecord` (vs `record`) makes call-site keys optional while still
     // rejecting keys that aren't members of `LLMCallSiteEnum` — exactly the


### PR DESCRIPTION
## Summary
- Added `llm: LLMSchema` to `AssistantConfigSchema` with defaults mirroring existing top-level inference settings.
- Old keys (`maxTokens`, `effort`, `speed`, `services.inference`, etc.) still parse — backward compatible. Migration in PR 4 populates `llm.*` from these; PR 19 removes them.
- No callers consume `llm` yet.

Part of plan: unify-llm-callsites.md (PR 3 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
