### PR TITLE
restrict gateway guardian data migration to ~/.vellum

### DIFF
--- a/gateway/src/__tests__/data-migration-m0001-guardian-init-lock.test.ts
+++ b/gateway/src/__tests__/data-migration-m0001-guardian-init-lock.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { up } from "../db/data-migrations/m0001-guardian-init-lock.js";
+
+let testHome: string;
+let legacyDir: string;
+let protectedDir: string;
+
+const savedHome = process.env.HOME;
+const savedGatewaySecurityDir = process.env.GATEWAY_SECURITY_DIR;
+
+function seedLegacy(file: string, contents: string): void {
+  mkdirSync(legacyDir, { recursive: true });
+  writeFileSync(join(legacyDir, file), contents);
+}
+
+beforeEach(() => {
+  testHome = join(
+    tmpdir(),
+    `vellum-m0001-test-${randomBytes(6).toString("hex")}`,
+  );
+  legacyDir = join(testHome, ".vellum");
+  protectedDir = join(legacyDir, "protected");
+  mkdirSync(protectedDir, { recursive: true });
+
+  process.env.HOME = testHome;
+  process.env.GATEWAY_SECURITY_DIR = protectedDir;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+  if (savedGatewaySecurityDir === undefined) {
+    delete process.env.GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.GATEWAY_SECURITY_DIR = savedGatewaySecurityDir;
+  }
+  try {
+    rmSync(testHome, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe("m0001-guardian-init-lock", () => {
+  test("copies both lock files into the protected dir", () => {
+    seedLegacy("guardian-init.lock", "2026-04-01T00:00:00.000Z");
+    seedLegacy("guardian-init-consumed.json", "[0]\n");
+
+    expect(up()).toBe("done");
+
+    expect(
+      readFileSync(join(protectedDir, "guardian-init.lock"), "utf-8"),
+    ).toBe("2026-04-01T00:00:00.000Z");
+    expect(
+      readFileSync(join(protectedDir, "guardian-init-consumed.json"), "utf-8"),
+    ).toBe("[0]\n");
+  });
+
+  test("copies only files that exist at the legacy path", () => {
+    seedLegacy("guardian-init.lock", "only-lock");
+
+    expect(up()).toBe("done");
+
+    expect(existsSync(join(protectedDir, "guardian-init.lock"))).toBe(true);
+    expect(existsSync(join(protectedDir, "guardian-init-consumed.json"))).toBe(
+      false,
+    );
+  });
+
+  test("no-op when legacy files are absent", () => {
+    expect(up()).toBe("done");
+    expect(existsSync(join(protectedDir, "guardian-init.lock"))).toBe(false);
+  });
+
+  test("does not overwrite files already at the new path", () => {
+    seedLegacy("guardian-init.lock", "legacy-lock");
+    writeFileSync(join(protectedDir, "guardian-init.lock"), "new-lock");
+
+    expect(up()).toBe("done");
+
+    expect(
+      readFileSync(join(protectedDir, "guardian-init.lock"), "utf-8"),
+    ).toBe("new-lock");
+  });
+
+  test("no-op for a named-instance layout (different GATEWAY_SECURITY_DIR)", () => {
+    // Simulate a named instance: its protected dir is NOT $HOME/.vellum/protected.
+    const namedInstanceProtected = join(
+      testHome,
+      ".local",
+      "share",
+      "vellum",
+      "assistants",
+      "work",
+      ".vellum",
+      "protected",
+    );
+    mkdirSync(namedInstanceProtected, { recursive: true });
+    process.env.GATEWAY_SECURITY_DIR = namedInstanceProtected;
+
+    // A stray lock at the user's ~/.vellum (e.g. left behind by first-local).
+    seedLegacy("guardian-init.lock", "first-local-lock");
+
+    expect(up()).toBe("done");
+
+    // Named instance's protected dir must NOT pick up first-local's lock.
+    expect(existsSync(join(namedInstanceProtected, "guardian-init.lock"))).toBe(
+      false,
+    );
+  });
+
+  test("tolerates trailing slash in GATEWAY_SECURITY_DIR", () => {
+    process.env.GATEWAY_SECURITY_DIR = `${protectedDir}/`;
+    seedLegacy("guardian-init.lock", "trailing-slash-lock");
+
+    expect(up()).toBe("done");
+
+    expect(
+      readFileSync(join(protectedDir, "guardian-init.lock"), "utf-8"),
+    ).toBe("trailing-slash-lock");
+  });
+});

--- a/gateway/src/db/data-migrations/m0001-guardian-init-lock.ts
+++ b/gateway/src/db/data-migrations/m0001-guardian-init-lock.ts
@@ -1,21 +1,21 @@
 /**
- * One-time migration: copy guardian-init lock files from the legacy path
- * (~/.vellum/) to the new gateway-security directory (~/.vellum/protected/
- * in bare-metal mode, or GATEWAY_SECURITY_DIR in Docker).
+ * One-time migration: copy guardian-init lock files for the original
+ * first-local assistant whose lock lived at `~/.vellum/`.
  *
- * Before this change, channel-verification-session-proxy.ts resolved the
- * lock directory as `GATEWAY_SECURITY_DIR || getRootDir()`. The refactor
- * to `getGatewaySecurityDir()` changed the bare-metal fallback from
- * `~/.vellum/` to `~/.vellum/protected/`. Without this migration, existing
- * bare-metal instances would lose their bootstrap lock and allow a second
- * guardian init.
+ * Guardian-init shipped 2026-03-15; the refactor that moved the lock into
+ * `.vellum/protected/` shipped 2026-04-14, one day after multi-instance.
+ * The only realistic case with a stranded legacy lock is the pre-multi-
+ * instance first-local whose instanceDir is `$HOME`. We restrict to
+ * exactly that case so the migration can never pick up an unrelated
+ * `guardian-init.lock` from elsewhere on the filesystem.
  */
 
+import { homedir } from "node:os";
 import { copyFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../../logger.js";
-import { getGatewaySecurityDir, getLegacyRootDir } from "../../paths.js";
+import { getGatewaySecurityDir } from "../../paths.js";
 
 import type { MigrationResult } from "./index.js";
 
@@ -24,13 +24,15 @@ const log = getLogger("m0001-guardian-init-lock");
 const FILES = ["guardian-init.lock", "guardian-init-consumed.json"] as const;
 
 export function up(): MigrationResult {
-  const legacyDir = getLegacyRootDir();
   const newDir = getGatewaySecurityDir();
+  const home = process.env.HOME || homedir();
+  const legacyDir = join(home, ".vellum");
 
-  // If both resolve to the same directory (e.g. GATEWAY_SECURITY_DIR is set
-  // and equals getLegacyRootDir()), there is nothing to migrate.
-  if (legacyDir === newDir) {
-    log.info("Legacy and new directories are identical — nothing to migrate");
+  // Only the original first-local assistant (instanceDir === $HOME) can
+  // have a stranded legacy lock — its new dir resolves to `~/.vellum/protected`.
+  // Any other shape means this isn't that instance; skip.
+  if (join(legacyDir, "protected") !== newDir) {
+    log.info({ newDir }, "Not the first-local layout — nothing to migrate");
     return "done";
   }
 

--- a/gateway/src/db/data-migrations/m0001-guardian-init-lock.ts
+++ b/gateway/src/db/data-migrations/m0001-guardian-init-lock.ts
@@ -10,12 +10,11 @@
  * `guardian-init.lock` from elsewhere on the filesystem.
  */
 
-import { homedir } from "node:os";
 import { copyFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { getLogger } from "../../logger.js";
-import { getGatewaySecurityDir } from "../../paths.js";
+import { getGatewaySecurityDir, getLegacyRootDir } from "../../paths.js";
 
 import type { MigrationResult } from "./index.js";
 
@@ -24,14 +23,15 @@ const log = getLogger("m0001-guardian-init-lock");
 const FILES = ["guardian-init.lock", "guardian-init-consumed.json"] as const;
 
 export function up(): MigrationResult {
+  const legacyDir = getLegacyRootDir();
   const newDir = getGatewaySecurityDir();
-  const home = process.env.HOME || homedir();
-  const legacyDir = join(home, ".vellum");
 
   // Only the original first-local assistant (instanceDir === $HOME) can
   // have a stranded legacy lock — its new dir resolves to `~/.vellum/protected`.
-  // Any other shape means this isn't that instance; skip.
-  if (join(legacyDir, "protected") !== newDir) {
+  // Any other shape means this isn't that instance; skip. Normalize both
+  // sides so a user-supplied GATEWAY_SECURITY_DIR with trailing slashes
+  // still matches.
+  if (resolve(legacyDir, "protected") !== resolve(newDir)) {
     log.info({ newDir }, "Not the first-local layout — nothing to migrate");
     return "done";
   }


### PR DESCRIPTION
This was bricking local hatches after environments work, since it would effectively copy guardian stuff to different assistants, from `~/.vellum` -> `$INSTANCE_DIR/.vellum/protected`.

This migration should be scoped to a particular assistant. I'm making this as conservative as possible because I don't like either of the approaches below:

## Other approaches

### Migrate from parent of `GATEWAY_SECURITY_DIR`
another approach is to use
- `newDir=env.GATEWAY_SECURITY_DIR` (`$INSTANCE_DIR/.vellum/protected`)
- `legacyDir=parent(env.GATEWAY_SECURITY_DIR)` (`$INSTANCE_DIR/.vellum`)

but traverse upwards out of security dir feels off

### Migrate using `instanceDir` from lockfile
Typically we set `env.BASE_DATA_DIR=instanceDir` from lockfile, but I don't think we want to introduce dependency on an env var we're actively deprecating

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
