### PR TITLE
fix(chrome-extension): pin native-host package.json to exact versions

### DIFF
--- a/clients/chrome-extension/native-host/bun.lock
+++ b/clients/chrome-extension/native-host/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@vellum/chrome-extension-native-host",
       "devDependencies": {
-        "@types/node": "^20.0.0",
-        "typescript": "^5.5.0",
+        "@types/node": "20.19.39",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/clients/chrome-extension/native-host/package.json
+++ b/clients/chrome-extension/native-host/package.json
@@ -13,7 +13,7 @@
     "test": "bun test src/"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.5.0"
+    "@types/node": "20.19.39",
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for pin-deps.md:

**Gap 3** — `clients/chrome-extension/native-host/package.json` was missed by the plan's inventory and still contained `^` ranges for `@types/node` and `typescript`. Pinned both to their currently-resolved exact versions, matching the repo-wide policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
