### PR TITLE
fix(ci): pin remaining bare-major workflow tags + bump slack call sites

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download previous baseline
         id: baseline
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           name: benchmark-baseline
           workflow: ci-benchmarks.yaml

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -56,7 +56,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Notify Slack of failure
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -134,7 +134,7 @@ jobs:
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack of release start
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Install assistant dependencies
         working-directory: assistant

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
         id: slack
         if: steps.check.outputs.skip != 'true'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -231,7 +231,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Install Chrome for CRX signing
         uses: browser-actions/setup-chrome@v1.7.3
@@ -383,7 +383,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -392,7 +392,7 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -484,7 +484,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -606,7 +606,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -615,7 +615,7 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -698,7 +698,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -707,7 +707,7 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -796,7 +796,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -926,7 +926,7 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGISTRY_HOST }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -1054,7 +1054,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Login to Docker Hub
         env:
@@ -1063,7 +1063,7 @@ jobs:
         run: bun scripts/docker-login-with-retry.ts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -1302,7 +1302,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -1334,7 +1334,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -1483,7 +1483,7 @@ jobs:
           echo "Display version: $DISPLAY_VERSION / Build version: $BUILD_VERSION / Full version: ${{ needs.extract-version.outputs.version }}"
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -1551,7 +1551,7 @@ jobs:
 
       - name: Cache Homebrew create-dmg
         id: cache-create-dmg
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/create-dmg
@@ -1697,7 +1697,7 @@ jobs:
 
       - name: Cache Homebrew Sparkle
         id: cache-sparkle
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Caskroom/sparkle
@@ -1856,7 +1856,7 @@ jobs:
           echo "version=${{ needs.extract-version.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -1983,7 +1983,7 @@ jobs:
 
       - name: Cache Homebrew create-dmg
         id: cache-create-dmg-x64
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/create-dmg
@@ -2155,7 +2155,7 @@ jobs:
           git tag "v$VERSION" 2>/dev/null || true
           git push origin "v$VERSION" 2>/dev/null || echo "Tag v$VERSION already exists on remote"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2330,7 +2330,7 @@ jobs:
           repository: vellum-ai/vellum-assistant-platform
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2373,7 +2373,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2411,7 +2411,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2434,7 +2434,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2461,7 +2461,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -2495,7 +2495,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen-build
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/xcodegen
@@ -2590,7 +2590,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen-release
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             /usr/local/Cellar/xcodegen
@@ -2805,7 +2805,7 @@ jobs:
       - name: Notify Slack
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -3024,7 +3024,7 @@ jobs:
       - name: Notify Slack
         id: slack
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for pin-deps.md:

**Gap 1** — PRs 18/19 left ~29 bare-major `@vN` `uses:` references in `release.yml`, `create-release-branch.yml`, and `ci-benchmarks.yaml`, which contradict the new AGENTS.md pinning policy from PR 21. Pinned each one:
- `oven-sh/setup-bun@v2` → `@v2.2.0`
- `docker/setup-qemu-action@v3` → `@v3.7.0`
- `actions/cache@v5` → `@v5.0.5`
- `dawidd6/action-download-artifact@v6` → pinned to commit SHA `bf251b5` (`# v6`) since upstream publishes only bare-major tags on v4+

**Gap 2** — The composite `send-build-alert` action was bumped to `slackapi/slack-github-action@v2.1.1` in PR 20, but 5 workflow call sites stayed on `v2.1.0`. Bumped all to `v2.1.1` for a single source of truth.

No major-version bumps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
