### PR TITLE
workspace: migrate scattered LLM config keys into unified llm structure

### DIFF
--- a/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
@@ -100,7 +100,9 @@ describe("038-unify-llm-callsite-configs migration", () => {
           temperature: null,
         },
       },
-      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+      services: {
+        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+      },
       maxTokens: 64000,
     };
     writeConfig(original);
@@ -265,7 +267,10 @@ describe("038-unify-llm-callsite-configs migration", () => {
     // ui.greetingModelIntent ("quality-optimized") for openai → gpt-5.4
     expect(llm.callSites.emptyStateGreeting).toEqual({ model: "gpt-5.4" });
     // notifications.decisionModelIntent ("vision-optimized") for openai → gpt-5.4
+    // The same intent drives BOTH notificationDecision and
+    // preferenceExtraction (both legacy readers consult the same key).
     expect(llm.callSites.notificationDecision).toEqual({ model: "gpt-5.4" });
+    expect(llm.callSites.preferenceExtraction).toEqual({ model: "gpt-5.4" });
     // calls.model copied verbatim
     expect(llm.callSites.callAgent).toEqual({ model: "gpt-5.4-nano" });
 
@@ -383,7 +388,9 @@ describe("038-unify-llm-callsite-configs migration", () => {
 
   test("analysis.modelIntent (no override) resolves intent against active provider", () => {
     writeConfig({
-      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+      services: {
+        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+      },
       analysis: { modelIntent: "latency-optimized" },
     });
 
@@ -424,6 +431,165 @@ describe("038-unify-llm-callsite-configs migration", () => {
       callSites?: Record<string, Record<string, unknown>>;
     };
     expect(llm.callSites?.callAgent).toEqual({ model: "gpt-5.4-nano" });
+  });
+
+  // ─── Regression: notifications.decisionModelIntent → both call sites ──
+
+  test("notifications.decisionModelIntent seeds BOTH notificationDecision and preferenceExtraction", () => {
+    // The legacy `notifications.decisionModelIntent` is the single source of
+    // truth for two readers: `notifications/decision-engine.ts` (notification
+    // classification) and `notifications/preference-extractor.ts` (preference
+    // extraction). The migration must seed both call sites from the same
+    // intent so neither path silently regresses to the schema default.
+    writeConfig({
+      services: {
+        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+      },
+      notifications: { decisionModelIntent: "latency-optimized" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    // anthropic + latency-optimized → claude-haiku-4-5-20251001
+    expect(llm.callSites?.notificationDecision).toEqual({
+      model: "claude-haiku-4-5-20251001",
+    });
+    expect(llm.callSites?.preferenceExtraction).toEqual({
+      model: "claude-haiku-4-5-20251001",
+    });
+  });
+
+  // ─── Regression: pre-existing llm subtree is preserved ────────────────
+
+  test("pre-existing llm.callSites and llm.profiles survive migration", () => {
+    // A workspace can legitimately have `llm.callSites` and/or
+    // `llm.profiles` set without `llm.default` (defaults are schema-injected
+    // at parse time). The migration's idempotency check looks at
+    // `llm.default`, so it will run against this workspace — and must
+    // preserve the user-defined entries instead of clobbering the entire
+    // `llm` block. Migration-derived call sites should still appear, but
+    // pre-existing call-site keys not produced by the migration must be
+    // retained, and `llm.profiles` must pass through verbatim.
+    writeConfig({
+      llm: {
+        callSites: {
+          memoryRetrieval: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        profiles: { fast: { speed: "fast" } },
+      },
+      services: {
+        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+      },
+      analysis: { modelOverride: "anthropic/claude-opus-4-7" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      default: Record<string, unknown>;
+      callSites: Record<string, Record<string, unknown>>;
+      profiles: Record<string, unknown>;
+    };
+
+    // Default block was synthesized from legacy keys.
+    expect(llm.default.provider).toBe("anthropic");
+    expect(llm.default.model).toBe("claude-opus-4-6");
+
+    // Pre-existing call-site survives.
+    expect(llm.callSites.memoryRetrieval).toEqual({
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    // Migration-derived call-site is added.
+    expect(llm.callSites.analyzeConversation).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+
+    // Pre-existing profiles survive verbatim.
+    expect(llm.profiles).toEqual({ fast: { speed: "fast" } });
+  });
+
+  test("pre-existing llm.callSites entry with same key is overwritten by migration", () => {
+    // When a pre-existing call-site key collides with a migration-derived
+    // one, the migration value wins (legacy scattered config is the source
+    // of truth being unified). This documents the merge precedence.
+    writeConfig({
+      llm: {
+        callSites: {
+          // Stale value the user wrote directly; will be overwritten because
+          // the migration also produces `analyzeConversation` from
+          // `analysis.modelOverride`.
+          analyzeConversation: { model: "stale-model" },
+        },
+      },
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites.analyzeConversation).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+  });
+
+  test("pre-existing llm.pricingOverrides is preserved when legacy top-level is absent", () => {
+    // If the user has only `llm.pricingOverrides` (no top-level
+    // `pricingOverrides`), the migration must not drop them.
+    const overrides = [
+      {
+        provider: "anthropic",
+        modelPattern: "claude-*",
+        inputPer1M: 5,
+        outputPer1M: 25,
+      },
+    ];
+    writeConfig({
+      llm: { pricingOverrides: overrides },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { pricingOverrides?: unknown };
+    expect(llm.pricingOverrides).toEqual(overrides);
+  });
+
+  test("legacy top-level pricingOverrides wins over pre-existing llm.pricingOverrides", () => {
+    // When both sources exist, the legacy top-level wins (it's the
+    // canonical source the migration is unifying from). This documents the
+    // precedence rule.
+    const legacy = [
+      {
+        provider: "openai",
+        modelPattern: "gpt-5.4",
+        inputPer1M: 1,
+        outputPer1M: 2,
+      },
+    ];
+    const preExisting = [
+      {
+        provider: "anthropic",
+        modelPattern: "claude-*",
+        inputPer1M: 99,
+        outputPer1M: 99,
+      },
+    ];
+    writeConfig({
+      llm: { pricingOverrides: preExisting },
+      pricingOverrides: legacy,
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { pricingOverrides?: unknown };
+    expect(llm.pricingOverrides).toEqual(legacy);
   });
 
   // ─── Old keys preserved ────────────────────────────────────────────────
@@ -582,7 +748,9 @@ describe("038-unify-llm-callsite-configs migration", () => {
   test("down() is a no-op when llm block is absent", () => {
     const original = {
       maxTokens: 32000,
-      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+      services: {
+        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+      },
     };
     writeConfig(original);
 

--- a/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
@@ -1,0 +1,594 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { unifyLlmCallSiteConfigsMigration } from "../workspace/migrations/038-unify-llm-callsite-configs.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-038-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("038-unify-llm-callsite-configs migration", () => {
+  test("has correct migration id and description", () => {
+    expect(unifyLlmCallSiteConfigsMigration.id).toBe(
+      "038-unify-llm-callsite-configs",
+    );
+    expect(unifyLlmCallSiteConfigsMigration.description).toBe(
+      "Consolidate scattered LLM config keys into unified llm.{default,profiles,callSites} structure",
+    );
+  });
+
+  // ─── No-op cases ────────────────────────────────────────────────────────
+
+  test("no-op when config.json does not exist", () => {
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("gracefully handles invalid JSON in config file", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("gracefully handles array-shaped config", () => {
+    writeFileSync(join(workspaceDir, "config.json"), JSON.stringify([1, 2, 3]));
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    const raw = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(raw).toEqual([1, 2, 3]);
+  });
+
+  test("idempotent: early-returns when llm.default is already present", () => {
+    const original = {
+      llm: {
+        default: {
+          provider: "openai",
+          model: "gpt-5.4",
+          maxTokens: 32000,
+          effort: "high",
+          speed: "fast",
+          temperature: null,
+        },
+      },
+      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+      maxTokens: 64000,
+    };
+    writeConfig(original);
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const config = readConfig();
+    expect(config).toEqual(original);
+  });
+
+  // ─── Defaults from schema (no scattered keys) ──────────────────────────
+
+  test("workspace with no scattered keys produces minimal llm.default from schema defaults", () => {
+    writeConfig({});
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const config = readConfig();
+    expect(config.llm).toEqual({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        maxTokens: 64000,
+        effort: "max",
+        speed: "standard",
+        temperature: null,
+      },
+    });
+  });
+
+  // ─── Default block reads from scattered sources ────────────────────────
+
+  test("llm.default reads provider/model from services.inference when present", () => {
+    writeConfig({
+      services: {
+        inference: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { default: Record<string, unknown> };
+    expect(llm.default.provider).toBe("openai");
+    expect(llm.default.model).toBe("gpt-5.4");
+  });
+
+  test("llm.default falls back to top-level provider/model when services.inference absent", () => {
+    writeConfig({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { default: Record<string, unknown> };
+    expect(llm.default.provider).toBe("openai");
+    expect(llm.default.model).toBe("gpt-5.4");
+  });
+
+  test("llm.default reads top-level maxTokens/effort/speed/thinking/contextWindow", () => {
+    writeConfig({
+      maxTokens: 16000,
+      effort: "low",
+      speed: "fast",
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { enabled: true, maxInputTokens: 100000 },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { default: Record<string, unknown> };
+    expect(llm.default.maxTokens).toBe(16000);
+    expect(llm.default.effort).toBe("low");
+    expect(llm.default.speed).toBe("fast");
+    expect(llm.default.thinking).toEqual({
+      enabled: false,
+      streamThinking: false,
+    });
+    expect(llm.default.contextWindow).toEqual({
+      enabled: true,
+      maxInputTokens: 100000,
+    });
+  });
+
+  test("llm.default.temperature is null (no current source)", () => {
+    writeConfig({});
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { default: Record<string, unknown> };
+    expect(llm.default.temperature).toBeNull();
+  });
+
+  // ─── Full mapping (every scattered key) ────────────────────────────────
+
+  test("workspace with every scattered key set maps all entries correctly", () => {
+    writeConfig({
+      services: {
+        inference: { provider: "openai", model: "gpt-5.4" },
+      },
+      maxTokens: 32000,
+      effort: "high",
+      speed: "standard",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 150000 },
+      heartbeat: { speed: "fast" },
+      filing: { speed: "fast" },
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+      memory: { summarization: { modelIntent: "latency-optimized" } },
+      workspaceGit: {
+        commitMessageLLM: { maxTokens: 200, temperature: 0.4 },
+      },
+      ui: { greetingModelIntent: "quality-optimized" },
+      notifications: { decisionModelIntent: "vision-optimized" },
+      calls: { model: "gpt-5.4-nano" },
+      pricingOverrides: [
+        {
+          provider: "openai",
+          modelPattern: "gpt-5.4",
+          inputPer1M: 1,
+          outputPer1M: 2,
+        },
+      ],
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      default: Record<string, unknown>;
+      callSites: Record<string, Record<string, unknown>>;
+      pricingOverrides: unknown;
+    };
+
+    expect(llm.default).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      maxTokens: 32000,
+      effort: "high",
+      speed: "standard",
+      temperature: null,
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 150000 },
+    });
+
+    // heartbeat/filing speeds differ from default ("standard") so they appear
+    expect(llm.callSites.heartbeatAgent).toEqual({ speed: "fast" });
+    expect(llm.callSites.filingAgent).toEqual({ speed: "fast" });
+    // analysis.modelOverride parses as provider/model pair
+    expect(llm.callSites.analyzeConversation).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    // memory.summarization.modelIntent ("latency-optimized") for openai → gpt-5.4-nano
+    expect(llm.callSites.conversationSummarization).toEqual({
+      model: "gpt-5.4-nano",
+    });
+    // commit message overrides forward
+    expect(llm.callSites.commitMessage).toEqual({
+      maxTokens: 200,
+      temperature: 0.4,
+    });
+    // ui.greetingModelIntent ("quality-optimized") for openai → gpt-5.4
+    expect(llm.callSites.emptyStateGreeting).toEqual({ model: "gpt-5.4" });
+    // notifications.decisionModelIntent ("vision-optimized") for openai → gpt-5.4
+    expect(llm.callSites.notificationDecision).toEqual({ model: "gpt-5.4" });
+    // calls.model copied verbatim
+    expect(llm.callSites.callAgent).toEqual({ model: "gpt-5.4-nano" });
+
+    expect(llm.pricingOverrides).toEqual([
+      {
+        provider: "openai",
+        modelPattern: "gpt-5.4",
+        inputPer1M: 1,
+        outputPer1M: 2,
+      },
+    ]);
+  });
+
+  // ─── Partial mapping (only some scattered keys) ────────────────────────
+
+  test("only heartbeat.speed set produces only heartbeatAgent call site", () => {
+    writeConfig({
+      heartbeat: { speed: "fast" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.heartbeatAgent).toEqual({ speed: "fast" });
+    expect(llm.callSites?.filingAgent).toBeUndefined();
+    expect(llm.callSites?.analyzeConversation).toBeUndefined();
+  });
+
+  test("heartbeat.speed equal to default speed is dropped (no override needed)", () => {
+    writeConfig({
+      speed: "fast",
+      heartbeat: { speed: "fast" }, // matches default → no override
+      filing: { speed: "standard" }, // differs → override
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      default: Record<string, unknown>;
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.default.speed).toBe("fast");
+    expect(llm.callSites?.heartbeatAgent).toBeUndefined();
+    expect(llm.callSites?.filingAgent).toEqual({ speed: "standard" });
+  });
+
+  test("only analysis.modelOverride set produces only analyzeConversation call site", () => {
+    writeConfig({
+      analysis: { modelOverride: "anthropic/claude-opus-4-7" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.analyzeConversation).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    expect(llm.callSites?.heartbeatAgent).toBeUndefined();
+  });
+
+  test("analysis.modelOverride parsing handles 'anthropic/claude-opus-4-6'", () => {
+    writeConfig({
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.analyzeConversation).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+  });
+
+  test("analysis.modelOverride without slash treats whole value as model", () => {
+    writeConfig({
+      analysis: { modelOverride: "claude-opus-4-6" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.analyzeConversation).toEqual({
+      model: "claude-opus-4-6",
+    });
+  });
+
+  test("analysis.modelOverride with multi-segment model preserves rest of path", () => {
+    // Some providers (e.g. fireworks, openrouter) use multi-segment model IDs
+    writeConfig({
+      analysis: {
+        modelOverride: "fireworks/accounts/fireworks/models/kimi-k2p5",
+      },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.analyzeConversation).toEqual({
+      provider: "fireworks",
+      model: "accounts/fireworks/models/kimi-k2p5",
+    });
+  });
+
+  test("analysis.modelIntent (no override) resolves intent against active provider", () => {
+    writeConfig({
+      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+      analysis: { modelIntent: "latency-optimized" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    // anthropic + latency-optimized → claude-haiku-4-5-20251001
+    expect(llm.callSites?.analyzeConversation).toEqual({
+      model: "claude-haiku-4-5-20251001",
+    });
+  });
+
+  test("commitMessage only includes set fields", () => {
+    writeConfig({
+      workspaceGit: {
+        commitMessageLLM: { maxTokens: 150 },
+      },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.commitMessage).toEqual({ maxTokens: 150 });
+  });
+
+  test("calls.model only set produces only callAgent override", () => {
+    writeConfig({
+      calls: { model: "gpt-5.4-nano" },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.callAgent).toEqual({ model: "gpt-5.4-nano" });
+  });
+
+  // ─── Old keys preserved ────────────────────────────────────────────────
+
+  test("old keys are still present after migration (not deleted)", () => {
+    const original = {
+      services: { inference: { provider: "openai", model: "gpt-5.4" } },
+      maxTokens: 32000,
+      effort: "high",
+      speed: "fast",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 150000 },
+      heartbeat: { speed: "standard" },
+      filing: { speed: "standard" },
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+      memory: { summarization: { modelIntent: "quality-optimized" } },
+      workspaceGit: {
+        commitMessageLLM: { maxTokens: 120, temperature: 0.2 },
+      },
+      ui: { greetingModelIntent: "latency-optimized" },
+      notifications: { decisionModelIntent: "latency-optimized" },
+      calls: { model: "gpt-5.4-nano" },
+      pricingOverrides: [
+        {
+          provider: "openai",
+          modelPattern: "gpt-5.4",
+          inputPer1M: 1,
+          outputPer1M: 2,
+        },
+      ],
+    };
+    writeConfig(original);
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const config = readConfig();
+    // Every original key must still be present
+    for (const key of Object.keys(original)) {
+      expect(config[key]).toEqual(
+        original[key as keyof typeof original] as unknown,
+      );
+    }
+    expect(config.llm).toBeDefined();
+  });
+
+  // ─── Idempotency ───────────────────────────────────────────────────────
+
+  test("idempotency: running twice produces identical output", () => {
+    writeConfig({
+      services: { inference: { provider: "openai", model: "gpt-5.4" } },
+      maxTokens: 32000,
+      heartbeat: { speed: "fast" },
+      filing: { speed: "fast" },
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+      ui: { greetingModelIntent: "quality-optimized" },
+      pricingOverrides: [
+        {
+          provider: "openai",
+          modelPattern: "gpt-5.4",
+          inputPer1M: 1,
+          outputPer1M: 2,
+        },
+      ],
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    const afterFirst = readConfig();
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  // ─── pricingOverrides handling ─────────────────────────────────────────
+
+  test("pricingOverrides copied to llm.pricingOverrides", () => {
+    const overrides = [
+      {
+        provider: "anthropic",
+        modelPattern: "claude-*",
+        inputPer1M: 3,
+        outputPer1M: 15,
+      },
+    ];
+    writeConfig({ pricingOverrides: overrides });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as { pricingOverrides?: unknown };
+    expect(llm.pricingOverrides).toEqual(overrides);
+  });
+
+  test("missing pricingOverrides results in no llm.pricingOverrides field", () => {
+    writeConfig({});
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, unknown>;
+    expect("pricingOverrides" in llm).toBe(false);
+  });
+
+  // ─── down() rollback ───────────────────────────────────────────────────
+
+  test("down() reverses a migrated config to original shape", () => {
+    const original = {
+      services: { inference: { provider: "openai", model: "gpt-5.4" } },
+      maxTokens: 32000,
+      effort: "high",
+      speed: "standard",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 150000 },
+      heartbeat: { speed: "fast" },
+      filing: { speed: "fast" },
+      analysis: { modelOverride: "anthropic/claude-opus-4-6" },
+      workspaceGit: {
+        commitMessageLLM: { maxTokens: 200, temperature: 0.4 },
+      },
+      calls: { model: "gpt-5.4-nano" },
+      pricingOverrides: [
+        {
+          provider: "openai",
+          modelPattern: "gpt-5.4",
+          inputPer1M: 1,
+          outputPer1M: 2,
+        },
+      ],
+    };
+    writeConfig(original);
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+    // Sanity: llm block exists after run()
+    expect((readConfig() as { llm?: unknown }).llm).toBeDefined();
+
+    unifyLlmCallSiteConfigsMigration.down(workspaceDir);
+
+    const config = readConfig();
+    // The llm block must be removed.
+    expect("llm" in config).toBe(false);
+    // Every original scalar/object key that had a reverse mapping must be
+    // restored to its original value.
+    expect(config.services).toEqual(original.services);
+    expect(config.maxTokens).toBe(original.maxTokens);
+    expect(config.effort).toBe(original.effort);
+    expect(config.speed).toBe(original.speed);
+    expect(config.thinking).toEqual(original.thinking);
+    expect(config.contextWindow).toEqual(original.contextWindow);
+    expect(config.heartbeat).toEqual(original.heartbeat);
+    expect(config.filing).toEqual(original.filing);
+    expect(config.analysis).toEqual(original.analysis);
+    expect(config.workspaceGit).toEqual(original.workspaceGit);
+    expect(config.calls).toEqual(original.calls);
+    expect(config.pricingOverrides).toEqual(original.pricingOverrides);
+  });
+
+  test("down() is a no-op when llm block is absent", () => {
+    const original = {
+      maxTokens: 32000,
+      services: { inference: { provider: "anthropic", model: "claude-opus-4-6" } },
+    };
+    writeConfig(original);
+
+    unifyLlmCallSiteConfigsMigration.down(workspaceDir);
+
+    const config = readConfig();
+    expect(config).toEqual(original);
+  });
+});

--- a/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
+++ b/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
@@ -18,7 +18,8 @@ import type { WorkspaceMigration } from "./types.js";
  *     `analysis.modelIntent`/`modelOverride`,
  *     `memory.summarization.modelIntent`,
  *     `workspaceGit.commitMessageLLM.{maxTokens,temperature}`,
- *     `ui.greetingModelIntent`, `notifications.decisionModelIntent`,
+ *     `ui.greetingModelIntent`, `notifications.decisionModelIntent` (which
+ *     drives both `notificationDecision` and `preferenceExtraction`),
  *     `calls.model`).
  *   - `llm.pricingOverrides` — copied from the top-level `pricingOverrides`.
  *
@@ -72,9 +73,13 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
 
     const defaultBlock: Record<string, unknown> = {
       provider:
-        readString(inference.provider) ?? readString(config.provider) ?? "anthropic",
+        readString(inference.provider) ??
+        readString(config.provider) ??
+        "anthropic",
       model:
-        readString(inference.model) ?? readString(config.model) ?? "claude-opus-4-6",
+        readString(inference.model) ??
+        readString(config.model) ??
+        "claude-opus-4-6",
       maxTokens: readPositiveInt(config.maxTokens) ?? 64000,
       effort: readEnum(config.effort, EFFORT_VALUES) ?? "max",
       speed: readEnum(config.speed, SPEED_VALUES) ?? "standard",
@@ -205,7 +210,13 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
         notificationIntent,
       );
       if (resolvedModel !== undefined) {
+        // `notifications.decisionModelIntent` drives BOTH the notification
+        // decision engine (`notifications/decision-engine.ts`) AND the
+        // preference extractor (`notifications/preference-extractor.ts`), so
+        // seed both call sites from the same source intent. Confirmed via
+        // grep — those are the only two readers of the legacy key.
         callSites.notificationDecision = { model: resolvedModel };
+        callSites.preferenceExtraction = { model: resolvedModel };
       }
     }
 
@@ -216,15 +227,52 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
     }
 
     // ── Build llm block ────────────────────────────────────────────────
+    //
+    // Preserve any pre-existing `llm` subtree. Reaching this point means
+    // `llm.default` was absent (idempotency check at the top), but a user
+    // may still have defined `llm.callSites`, `llm.profiles`, or
+    // `llm.pricingOverrides` directly. Wholesale-replacing `config.llm`
+    // would silently drop those user overrides, so deep-merge instead:
+    //   - `default`: always taken from this migration (we just synthesized
+    //     it from legacy keys).
+    //   - `callSites`: per-key merge, with migration-derived entries
+    //     overwriting pre-existing entries that share the same key.
+    //   - `profiles`: preserved verbatim from existing `llm.profiles`.
+    //   - `pricingOverrides`: prefer the migration-derived value (legacy
+    //     top-level `pricingOverrides`); fall back to existing
+    //     `llm.pricingOverrides` if the legacy key is absent.
     const llmBlock: Record<string, unknown> = {
       default: defaultBlock,
     };
-    if (Object.keys(callSites).length > 0) {
-      llmBlock.callSites = callSites;
+    const existingProfiles = existingLlm
+      ? readObject(existingLlm.profiles)
+      : null;
+    if (existingProfiles !== null) {
+      llmBlock.profiles = existingProfiles;
+    }
+    const existingCallSites = existingLlm
+      ? readObject(existingLlm.callSites)
+      : null;
+    const mergedCallSites: Record<string, Record<string, unknown>> = {};
+    if (existingCallSites !== null) {
+      for (const [key, value] of Object.entries(existingCallSites)) {
+        const obj = readObject(value);
+        if (obj !== null) {
+          mergedCallSites[key] = obj;
+        }
+      }
+    }
+    for (const [key, value] of Object.entries(callSites)) {
+      mergedCallSites[key] = value;
+    }
+    if (Object.keys(mergedCallSites).length > 0) {
+      llmBlock.callSites = mergedCallSites;
     }
     const pricingOverrides = config.pricingOverrides;
     if (Array.isArray(pricingOverrides)) {
       llmBlock.pricingOverrides = pricingOverrides;
+    } else if (existingLlm && Array.isArray(existingLlm.pricingOverrides)) {
+      llmBlock.pricingOverrides = existingLlm.pricingOverrides;
     }
 
     config.llm = llmBlock;
@@ -341,11 +389,12 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
         }
       }
     }
-    // Note: `conversationSummarization`, `emptyStateGreeting`, and
-    // `notificationDecision` were derived from `modelIntent` keys — `down()`
-    // intentionally does not synthesize a reverse intent (we only have a
-    // resolved model, not the intent that produced it). Callers reading those
-    // legacy keys after a rollback will fall back to schema defaults.
+    // Note: `conversationSummarization`, `emptyStateGreeting`,
+    // `notificationDecision`, and `preferenceExtraction` were derived from
+    // `modelIntent` keys — `down()` intentionally does not synthesize a
+    // reverse intent (we only have a resolved model, not the intent that
+    // produced it). Callers reading those legacy keys after a rollback will
+    // fall back to schema defaults.
 
     // ── Reverse llm.pricingOverrides → top-level pricingOverrides ─────
     if (Array.isArray(llm.pricingOverrides)) {
@@ -377,7 +426,10 @@ const MODEL_INTENT_VALUES = new Set([
  * is frozen against the catalog as it existed when users upgraded across this
  * boundary, even if the runtime catalog evolves later.
  */
-const PROVIDER_MODEL_INTENTS_SNAPSHOT: Record<string, Record<string, string>> = {
+const PROVIDER_MODEL_INTENTS_SNAPSHOT: Record<
+  string,
+  Record<string, string>
+> = {
   anthropic: {
     "latency-optimized": "claude-haiku-4-5-20251001",
     "quality-optimized": "claude-opus-4-7",
@@ -429,9 +481,7 @@ function readString(value: unknown): string | undefined {
 }
 
 function readPositiveInt(value: unknown): number | undefined {
-  return typeof value === "number" &&
-    Number.isInteger(value) &&
-    value > 0
+  return typeof value === "number" && Number.isInteger(value) && value > 0
     ? value
     : undefined;
 }

--- a/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
+++ b/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
@@ -1,0 +1,476 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Consolidate scattered LLM-related config keys into the unified `llm` block
+ * introduced in PR 1 of the LLM call-site unification plan.
+ *
+ * What this migration writes (under `llm.*`):
+ *   - `llm.default` — provider/model/maxTokens/effort/speed/thinking/contextWindow
+ *     pulled from `services.inference.{provider,model}` and the legacy
+ *     top-level `maxTokens`/`effort`/`speed`/`thinking`/`contextWindow` keys.
+ *     `temperature` is seeded as `null` because no current config source maps to
+ *     it.
+ *   - `llm.callSites.<id>` — per-call-site overrides derived from the existing
+ *     scattered config (`heartbeat.speed`, `filing.speed`,
+ *     `analysis.modelIntent`/`modelOverride`,
+ *     `memory.summarization.modelIntent`,
+ *     `workspaceGit.commitMessageLLM.{maxTokens,temperature}`,
+ *     `ui.greetingModelIntent`, `notifications.decisionModelIntent`,
+ *     `calls.model`).
+ *   - `llm.pricingOverrides` — copied from the top-level `pricingOverrides`.
+ *
+ * What this migration does NOT do:
+ *   - Delete any of the source keys. The legacy keys remain on disk so
+ *     existing readers continue to work. PR 19 of the plan removes them from
+ *     the schema once every call site has been switched over to read through
+ *     the resolver.
+ *
+ * Idempotency:
+ *   - Early-returns when `config.llm.default` is already present, so re-runs
+ *     and runs against an already-migrated workspace are no-ops.
+ *   - Early-returns on missing/malformed `config.json`.
+ *
+ * Rollback (`down`):
+ *   - Reverses the mapping best-effort by extracting `llm.default.*` back to
+ *     top-level + `services.inference`, extracting `llm.callSites.*` back to
+ *     scattered keys, copying `llm.pricingOverrides` back to top-level
+ *     `pricingOverrides`, and finally removing `llm`. After PRs 7-18 land and
+ *     callers stop reading the old keys, rollback fidelity will degrade
+ *     (callers will only see what `down` writes back), which is acceptable
+ *     for a development rollback path.
+ */
+export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
+  id: "038-unify-llm-callsite-configs",
+  description:
+    "Consolidate scattered LLM config keys into unified llm.{default,profiles,callSites} structure",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // Idempotency: if `llm.default` already present, the workspace has
+    // already been migrated.
+    const existingLlm = readObject(config.llm);
+    if (existingLlm !== null && readObject(existingLlm.default) !== null) {
+      return;
+    }
+
+    // ── Build llm.default ──────────────────────────────────────────────
+    const services = readObject(config.services) ?? {};
+    const inference = readObject(services.inference) ?? {};
+
+    const defaultBlock: Record<string, unknown> = {
+      provider:
+        readString(inference.provider) ?? readString(config.provider) ?? "anthropic",
+      model:
+        readString(inference.model) ?? readString(config.model) ?? "claude-opus-4-6",
+      maxTokens: readPositiveInt(config.maxTokens) ?? 64000,
+      effort: readEnum(config.effort, EFFORT_VALUES) ?? "max",
+      speed: readEnum(config.speed, SPEED_VALUES) ?? "standard",
+      // No current config key maps to temperature — seed null to match
+      // `LLMConfigBase` defaults.
+      temperature: null,
+    };
+    const thinking = readObject(config.thinking);
+    if (thinking !== null) {
+      defaultBlock.thinking = thinking;
+    }
+    const contextWindow = readObject(config.contextWindow);
+    if (contextWindow !== null) {
+      defaultBlock.contextWindow = contextWindow;
+    }
+
+    // ── Build llm.callSites ────────────────────────────────────────────
+    const callSites: Record<string, Record<string, unknown>> = {};
+
+    const heartbeat = readObject(config.heartbeat);
+    const heartbeatSpeed = heartbeat
+      ? readEnum(heartbeat.speed, SPEED_VALUES)
+      : undefined;
+    if (heartbeatSpeed !== undefined && heartbeatSpeed !== defaultBlock.speed) {
+      callSites.heartbeatAgent = { speed: heartbeatSpeed };
+    }
+
+    const filing = readObject(config.filing);
+    const filingSpeed = filing
+      ? readEnum(filing.speed, SPEED_VALUES)
+      : undefined;
+    if (filingSpeed !== undefined && filingSpeed !== defaultBlock.speed) {
+      callSites.filingAgent = { speed: filingSpeed };
+    }
+
+    const analysis = readObject(config.analysis);
+    if (analysis !== null) {
+      const analysisOverride = readString(analysis.modelOverride);
+      const analysisIntent = readModelIntent(analysis.modelIntent);
+      const analysisCallSite: Record<string, unknown> = {};
+      // `modelOverride` is shaped as `"provider/model"` — explode into the
+      // resolver's separate provider/model fields. If the string lacks a
+      // slash, treat the whole value as the model and inherit the active
+      // provider implicitly via the resolver's default merge.
+      if (analysisOverride !== undefined) {
+        const [providerPart, ...modelParts] = analysisOverride.split("/");
+        if (modelParts.length > 0 && providerPart.length > 0) {
+          analysisCallSite.provider = providerPart;
+          analysisCallSite.model = modelParts.join("/");
+        } else {
+          analysisCallSite.model = analysisOverride;
+        }
+      } else if (analysisIntent !== undefined) {
+        // Resolve intent to provider/model using the same lookup the runtime
+        // uses (mirrors `providers/model-intents.ts` PROVIDER_MODEL_INTENTS).
+        const provider = String(defaultBlock.provider);
+        const resolvedModel = resolveModelIntentForProvider(
+          provider,
+          analysisIntent,
+        );
+        if (resolvedModel !== undefined) {
+          analysisCallSite.model = resolvedModel;
+        }
+      }
+      if (Object.keys(analysisCallSite).length > 0) {
+        callSites.analyzeConversation = analysisCallSite;
+      }
+    }
+
+    const memory = readObject(config.memory);
+    const summarization = memory ? readObject(memory.summarization) : null;
+    const summarizationIntent = summarization
+      ? readModelIntent(summarization.modelIntent)
+      : undefined;
+    if (summarizationIntent !== undefined) {
+      const provider = String(defaultBlock.provider);
+      const resolvedModel = resolveModelIntentForProvider(
+        provider,
+        summarizationIntent,
+      );
+      if (resolvedModel !== undefined) {
+        callSites.conversationSummarization = { model: resolvedModel };
+      }
+    }
+
+    const workspaceGit = readObject(config.workspaceGit);
+    const commitMessageLLM = workspaceGit
+      ? readObject(workspaceGit.commitMessageLLM)
+      : null;
+    if (commitMessageLLM !== null) {
+      const commitOverride: Record<string, unknown> = {};
+      const cmMaxTokens = readPositiveInt(commitMessageLLM.maxTokens);
+      if (cmMaxTokens !== undefined) {
+        commitOverride.maxTokens = cmMaxTokens;
+      }
+      const cmTemperature = readTemperature(commitMessageLLM.temperature);
+      if (cmTemperature !== undefined) {
+        commitOverride.temperature = cmTemperature;
+      }
+      if (Object.keys(commitOverride).length > 0) {
+        callSites.commitMessage = commitOverride;
+      }
+    }
+
+    const ui = readObject(config.ui);
+    const greetingIntent = ui
+      ? readModelIntent(ui.greetingModelIntent)
+      : undefined;
+    if (greetingIntent !== undefined) {
+      const provider = String(defaultBlock.provider);
+      const resolvedModel = resolveModelIntentForProvider(
+        provider,
+        greetingIntent,
+      );
+      if (resolvedModel !== undefined) {
+        callSites.emptyStateGreeting = { model: resolvedModel };
+      }
+    }
+
+    const notifications = readObject(config.notifications);
+    const notificationIntent = notifications
+      ? readModelIntent(notifications.decisionModelIntent)
+      : undefined;
+    if (notificationIntent !== undefined) {
+      const provider = String(defaultBlock.provider);
+      const resolvedModel = resolveModelIntentForProvider(
+        provider,
+        notificationIntent,
+      );
+      if (resolvedModel !== undefined) {
+        callSites.notificationDecision = { model: resolvedModel };
+      }
+    }
+
+    const calls = readObject(config.calls);
+    const callsModel = calls ? readString(calls.model) : undefined;
+    if (callsModel !== undefined) {
+      callSites.callAgent = { model: callsModel };
+    }
+
+    // ── Build llm block ────────────────────────────────────────────────
+    const llmBlock: Record<string, unknown> = {
+      default: defaultBlock,
+    };
+    if (Object.keys(callSites).length > 0) {
+      llmBlock.callSites = callSites;
+    }
+    const pricingOverrides = config.pricingOverrides;
+    if (Array.isArray(pricingOverrides)) {
+      llmBlock.pricingOverrides = pricingOverrides;
+    }
+
+    config.llm = llmBlock;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    // ── Reverse llm.default → top-level + services.inference ──────────
+    const defaultBlock = readObject(llm.default);
+    if (defaultBlock !== null) {
+      const services = ensureObj(config, "services");
+      const inference = ensureObj(services, "inference");
+      const provider = readString(defaultBlock.provider);
+      if (provider !== undefined) {
+        inference.provider = provider;
+      }
+      const model = readString(defaultBlock.model);
+      if (model !== undefined) {
+        inference.model = model;
+      }
+      const maxTokens = readPositiveInt(defaultBlock.maxTokens);
+      if (maxTokens !== undefined) {
+        config.maxTokens = maxTokens;
+      }
+      const effort = readEnum(defaultBlock.effort, EFFORT_VALUES);
+      if (effort !== undefined) {
+        config.effort = effort;
+      }
+      const speed = readEnum(defaultBlock.speed, SPEED_VALUES);
+      if (speed !== undefined) {
+        config.speed = speed;
+      }
+      const thinking = readObject(defaultBlock.thinking);
+      if (thinking !== null) {
+        config.thinking = thinking;
+      }
+      const contextWindow = readObject(defaultBlock.contextWindow);
+      if (contextWindow !== null) {
+        config.contextWindow = contextWindow;
+      }
+    }
+
+    // ── Reverse llm.callSites → scattered keys ────────────────────────
+    const callSites = readObject(llm.callSites) ?? {};
+
+    const heartbeatAgent = readObject(callSites.heartbeatAgent);
+    if (heartbeatAgent !== null) {
+      const speed = readEnum(heartbeatAgent.speed, SPEED_VALUES);
+      if (speed !== undefined) {
+        const heartbeat = ensureObj(config, "heartbeat");
+        heartbeat.speed = speed;
+      }
+    }
+
+    const filingAgent = readObject(callSites.filingAgent);
+    if (filingAgent !== null) {
+      const speed = readEnum(filingAgent.speed, SPEED_VALUES);
+      if (speed !== undefined) {
+        const filing = ensureObj(config, "filing");
+        filing.speed = speed;
+      }
+    }
+
+    const analyzeConversation = readObject(callSites.analyzeConversation);
+    if (analyzeConversation !== null) {
+      const provider = readString(analyzeConversation.provider);
+      const model = readString(analyzeConversation.model);
+      const recombined =
+        provider !== undefined && model !== undefined
+          ? `${provider}/${model}`
+          : (model ?? undefined);
+      if (recombined !== undefined) {
+        const analysis = ensureObj(config, "analysis");
+        analysis.modelOverride = recombined;
+      }
+    }
+
+    const callAgent = readObject(callSites.callAgent);
+    if (callAgent !== null) {
+      const model = readString(callAgent.model);
+      if (model !== undefined) {
+        const calls = ensureObj(config, "calls");
+        calls.model = model;
+      }
+    }
+
+    const commitMessage = readObject(callSites.commitMessage);
+    if (commitMessage !== null) {
+      const cmMaxTokens = readPositiveInt(commitMessage.maxTokens);
+      const cmTemperature = readTemperature(commitMessage.temperature);
+      if (cmMaxTokens !== undefined || cmTemperature !== undefined) {
+        const workspaceGit = ensureObj(config, "workspaceGit");
+        const commitMessageLLM = ensureObj(workspaceGit, "commitMessageLLM");
+        if (cmMaxTokens !== undefined) {
+          commitMessageLLM.maxTokens = cmMaxTokens;
+        }
+        if (cmTemperature !== undefined) {
+          commitMessageLLM.temperature = cmTemperature;
+        }
+      }
+    }
+    // Note: `conversationSummarization`, `emptyStateGreeting`, and
+    // `notificationDecision` were derived from `modelIntent` keys — `down()`
+    // intentionally does not synthesize a reverse intent (we only have a
+    // resolved model, not the intent that produced it). Callers reading those
+    // legacy keys after a rollback will fall back to schema defaults.
+
+    // ── Reverse llm.pricingOverrides → top-level pricingOverrides ─────
+    if (Array.isArray(llm.pricingOverrides)) {
+      config.pricingOverrides = llm.pricingOverrides;
+    }
+
+    delete config.llm;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const EFFORT_VALUES = new Set(["low", "medium", "high", "max"]);
+const SPEED_VALUES = new Set(["standard", "fast"]);
+const MODEL_INTENT_VALUES = new Set([
+  "latency-optimized",
+  "quality-optimized",
+  "vision-optimized",
+]);
+
+/**
+ * Mirror of `providers/model-intents.ts:PROVIDER_MODEL_INTENTS` snapshotted at
+ * the time this migration was authored. Migrations are write-once and must be
+ * self-contained — duplicating the table here means the migration's behavior
+ * is frozen against the catalog as it existed when users upgraded across this
+ * boundary, even if the runtime catalog evolves later.
+ */
+const PROVIDER_MODEL_INTENTS_SNAPSHOT: Record<string, Record<string, string>> = {
+  anthropic: {
+    "latency-optimized": "claude-haiku-4-5-20251001",
+    "quality-optimized": "claude-opus-4-7",
+    "vision-optimized": "claude-opus-4-6",
+  },
+  openai: {
+    "latency-optimized": "gpt-5.4-nano",
+    "quality-optimized": "gpt-5.4",
+    "vision-optimized": "gpt-5.4",
+  },
+  gemini: {
+    "latency-optimized": "gemini-3-flash",
+    "quality-optimized": "gemini-3-flash",
+    "vision-optimized": "gemini-3-flash",
+  },
+  ollama: {
+    "latency-optimized": "llama3.2",
+    "quality-optimized": "llama3.2",
+    "vision-optimized": "llama3.2",
+  },
+  fireworks: {
+    "latency-optimized": "accounts/fireworks/models/kimi-k2p5",
+    "quality-optimized": "accounts/fireworks/models/kimi-k2p5",
+    "vision-optimized": "accounts/fireworks/models/kimi-k2p5",
+  },
+  openrouter: {
+    "latency-optimized": "anthropic/claude-haiku-4.5",
+    "quality-optimized": "anthropic/claude-opus-4.7",
+    "vision-optimized": "anthropic/claude-opus-4.6",
+  },
+};
+
+function resolveModelIntentForProvider(
+  provider: string,
+  intent: string,
+): string | undefined {
+  return PROVIDER_MODEL_INTENTS_SNAPSHOT[provider]?.[intent];
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0
+    ? value
+    : undefined;
+}
+
+function readEnum<T extends string>(
+  value: unknown,
+  allowed: Set<string>,
+): T | undefined {
+  return typeof value === "string" && allowed.has(value)
+    ? (value as T)
+    : undefined;
+}
+
+function readModelIntent(value: unknown): string | undefined {
+  return typeof value === "string" && MODEL_INTENT_VALUES.has(value)
+    ? value
+    : undefined;
+}
+
+function readTemperature(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= 2
+    ? value
+    : undefined;
+}
+
+function ensureObj(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  if (
+    !(key in parent) ||
+    parent[key] == null ||
+    typeof parent[key] !== "object" ||
+    Array.isArray(parent[key])
+  ) {
+    parent[key] = {};
+  }
+  return parent[key] as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -35,6 +35,7 @@ import { removeCallsVoiceTranscriptionProviderMigration } from "./034-remove-cal
 import { seedSlackChannelPersonaMigration } from "./035-seed-slack-channel-persona.js";
 import { updatePkbIndexBarMigration } from "./036-update-pkb-index-bar.js";
 import { createMeetsDirMigration } from "./037-create-meets-dir.js";
+import { unifyLlmCallSiteConfigsMigration } from "./038-unify-llm-callsite-configs.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -81,4 +82,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedSlackChannelPersonaMigration,
   updatePkbIndexBarMigration,
   createMeetsDirMigration,
+  unifyLlmCallSiteConfigsMigration,
 ];


### PR DESCRIPTION
## Summary
- New workspace migration consolidates scattered LLM config keys (`services.inference`, top-level `maxTokens`/`effort`/`speed`/`thinking`/`contextWindow`, `heartbeat.speed`, `filing.speed`, `analysis.modelIntent`/`modelOverride`, `memory.summarization.modelIntent`, `workspaceGit.commitMessageLLM.{maxTokens,temperature}`, `ui.greetingModelIntent`, `notifications.decisionModelIntent`, `calls.model`) into unified `llm.{default, callSites}` and `llm.pricingOverrides`.
- Idempotent: early-returns if `llm.default` already present.
- Old keys are preserved (PR 19 removes them after adoption is complete).

Part of plan: unify-llm-callsites.md (PR 4 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
