### PR TITLE
calls+watcher: route guardian copy and watch handlers through call-site IDs

### DIFF
--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -82,7 +82,7 @@ export async function generateGuardianCopy(
       [userMessage(prompt)],
       undefined,
       undefined,
-      { signal, config: { modelIntent: "latency-optimized" } },
+      { signal, config: { callSite: "guardianQuestionCopy" } },
     );
 
     const text = extractText(response);

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -164,7 +164,7 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       systemPrompt,
       {
         config: {
-          modelIntent: "latency-optimized",
+          callSite: "watchCommentary",
           max_tokens: 200,
         },
       },
@@ -329,7 +329,7 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       systemPrompt,
       {
         config: {
-          modelIntent: "quality-optimized",
+          callSite: "watchSummary",
           max_tokens: 2000,
         },
       },


### PR DESCRIPTION
## Summary
- `calls/guardian-question-copy.ts` -> `callSite: 'guardianQuestionCopy'`.
- `daemon/watch-handler.ts` (commentary path) -> `callSite: 'watchCommentary'`.
- `daemon/watch-handler.ts` (summary path) -> `callSite: 'watchSummary'`.
- Tests updated.

Part of plan: unify-llm-callsites.md (PR 17 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
