### PR TITLE
memory: route extraction/consolidation/retrieval through call-site IDs

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -282,7 +282,7 @@ async function identifyDuplicateGroups(
     systemPrompt,
     {
       config: {
-        modelIntent: "quality-optimized" as const,
+        callSite: "memoryConsolidation" as const,
         tool_choice: { type: "tool" as const, name: "report_duplicate_groups" },
       },
     },
@@ -459,7 +459,7 @@ async function consolidateChunk(
     systemPrompt,
     {
       config: {
-        modelIntent: "quality-optimized" as const,
+        callSite: "memoryConsolidation" as const,
         tool_choice: { type: "tool" as const, name: "consolidate_diff" },
       },
     },

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -929,7 +929,7 @@ export async function runGraphExtraction(
     systemPrompt,
     {
       config: {
-        modelIntent: "quality-optimized" as const,
+        callSite: "memoryExtraction" as const,
         tool_choice: { type: "tool" as const, name: "extract_graph_diff" },
       },
     },

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -111,7 +111,7 @@ Your job:
 3. Return the IDs in order of importance (most important first).`,
       {
         config: {
-          modelIntent: "quality-optimized" as const,
+          callSite: "memoryRetrieval" as const,
           tool_choice: { type: "tool" as const, name: "select_memories" },
           thinking: { type: "disabled" },
           temperature: 0,
@@ -202,7 +202,7 @@ async function dedupForTurn(
       `Dedupe + rerank the following numbered items. Pick the most relevant items to the query. Call the select_items tool.\n\nBe aggressive on dedup — when multiple items describe the same event, fact, or status, keep ONLY the richest version. But be generous on relevance — only cut items that are completely irrelevant to the query. If it's even tangentially related, keep it.`,
       {
         config: {
-          modelIntent: "latency-optimized" as const,
+          callSite: "memoryRetrieval" as const,
           tool_choice: { type: "tool" as const, name: "select_items" },
           thinking: { type: "disabled" },
           temperature: 0,
@@ -294,7 +294,7 @@ async function dedupCrossCategory(
       `Deduplicate the following numbered items. When multiple items describe the same event, fact, or status, keep ONLY the richest version. Keep ALL items that are not duplicates — do not filter by relevance or topic. Call the select_items tool with every item that survives dedup.`,
       {
         config: {
-          modelIntent: "latency-optimized" as const,
+          callSite: "memoryRetrieval" as const,
           tool_choice: { type: "tool" as const, name: "select_items" },
           thinking: { type: "disabled" },
           temperature: 0,


### PR DESCRIPTION
## Summary
- `memory/graph/extraction.ts` → `callSite: 'memoryExtraction'`
- `memory/graph/consolidation.ts` → `callSite: 'memoryConsolidation'`
- `memory/graph/retriever.ts` → `callSite: 'memoryRetrieval'` (collapses two prior intents into one configurable site)
- Tests updated to assert on `callSite`.

Part of plan: unify-llm-callsites.md (PR 12 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
