### PR TITLE
memory: route narrative/pattern/summarization/starters through call-site IDs

### DIFF
--- a/assistant/src/memory/graph/narrative.ts
+++ b/assistant/src/memory/graph/narrative.ts
@@ -196,7 +196,7 @@ export async function runNarrativeRefinement(
     systemPrompt,
     {
       config: {
-        modelIntent: "quality-optimized" as const,
+        callSite: "narrativeRefinement" as const,
         tool_choice: { type: "tool" as const, name: "refine_narratives" },
       },
     },

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -165,7 +165,7 @@ export async function runPatternScan(
     systemPrompt,
     {
       config: {
-        modelIntent: "quality-optimized" as const,
+        callSite: "patternScan" as const,
         tool_choice: { type: "tool" as const, name: "detect_patterns" },
       },
     },

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -330,7 +330,7 @@ Bad → Good (incomplete phrase → complete):
       systemPrompt,
       {
         config: {
-          modelIntent: "quality-optimized",
+          callSite: "conversationStarters" as const,
           max_tokens: 2048,
           tool_choice: {
             type: "tool" as const,

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -189,7 +189,7 @@ async function summarizeWithLLM(
         systemPrompt,
         {
           config: {
-            modelIntent: summarizationConfig.modelIntent,
+            callSite: "conversationSummarization" as const,
             max_tokens: SUMMARY_MAX_TOKENS,
           },
           signal,


### PR DESCRIPTION
## Summary
- `memory/graph/narrative.ts` → `callSite: 'narrativeRefinement'`
- `memory/graph/pattern-scan.ts` → `callSite: 'patternScan'`
- `memory/job-handlers/summarization.ts` → `callSite: 'conversationSummarization'` (legacy `memory.summarization.modelIntent` config read removed; routed through new schema)
- `memory/job-handlers/conversation-starters.ts` → `callSite: 'conversationStarters'`
- Tests updated.

Part of plan: unify-llm-callsites.md (PR 13 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
