### PR TITLE
ui: route identity intro and empty-state greeting through call-site IDs

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -73,6 +73,15 @@ mock.module("../prompts/persona-resolver.js", () => ({
   resolveUserSlug: () => null,
 }));
 
+// Force the identity-intro fast-path to miss so the handler always falls
+// through to the LLM call — the call-site assertions need a real provider
+// invocation to inspect.
+mock.module("../runtime/routes/identity-intro-cache.js", () => ({
+  getCachedIntro: () => null,
+  setCachedIntro: () => {},
+  computeIdentityContentHash: () => "test-hash",
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -325,6 +334,40 @@ describe("POST /v1/btw", () => {
     // Options: tool_choice must be "none"
     expect(options!.config!.tool_choice).toEqual({ type: "none" });
     expect(options!.config!.modelIntent).toBe("latency-optimized");
+    // Default call-site for the BTW side-chain is the identity intro path.
+    expect(options!.config!.callSite).toBe("identityIntro");
+  });
+
+  test("greeting requests pass callSite: 'emptyStateGreeting'", async () => {
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    const deps = makeSendMessageDeps(session);
+
+    const res = await callHandler(
+      { conversationKey: "greeting", content: "Generate a greeting" },
+      { sendMessageDeps: deps },
+    );
+    await readStream(res);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const [, , , options] = provider.sendMessage.mock.calls[0];
+    expect(options!.config!.callSite).toBe("emptyStateGreeting");
+  });
+
+  test("identity intro requests pass callSite: 'identityIntro'", async () => {
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    const deps = makeSendMessageDeps(session);
+
+    const res = await callHandler(
+      { conversationKey: "identity-intro", content: "Generate an intro" },
+      { sendMessageDeps: deps },
+    );
+    await readStream(res);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const [, , , options] = provider.sendMessage.mock.calls[0];
+    expect(options!.config!.callSite).toBe("identityIntro");
   });
 
   // -- No persistence --

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -1,3 +1,4 @@
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { buildToolDefinitions } from "../daemon/conversation-tool-setup.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import {
@@ -30,6 +31,15 @@ export interface RunBtwSidechainParams {
   tools?: ToolDefinition[];
   maxTokens?: number;
   modelIntent?: ModelIntent;
+  /**
+   * Unified call-site identifier. When set, the provider layer resolves
+   * provider/model/maxTokens/effort/speed/temperature/thinking/contextWindow
+   * via `resolveCallSiteConfig(callSite, config.llm)`. Defaults to
+   * `'identityIntro'` since this side-chain runner was originally introduced
+   * for the identity intro generation path; callers (greeting, title, etc.)
+   * override it with their own call-site ID.
+   */
+  callSite?: LLMCallSite;
   signal?: AbortSignal;
   timeoutMs?: number;
   onEvent?: (event: ProviderEvent) => void;
@@ -90,6 +100,7 @@ export async function runBtwSidechain(
         max_tokens: params.maxTokens ?? 1024,
         tool_choice: { type: "none" },
         modelIntent: params.modelIntent ?? "latency-optimized",
+        callSite: params.callSite ?? "identityIntro",
       },
       onEvent: (event) => {
         if (event.type === "text_delta") {

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -16,7 +16,6 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { z } from "zod";
 
-import { getConfig } from "../../config/loader.js";
 import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { resolvePersonaContext } from "../../prompts/persona-resolver.js";
@@ -178,9 +177,7 @@ async function handleBtw(
             userPersona,
             channelPersona,
             userSlug,
-            ...(isGreeting
-              ? { modelIntent: getConfig().ui.greetingModelIntent }
-              : {}),
+            ...(isGreeting ? { callSite: "emptyStateGreeting" as const } : {}),
             onEvent: (event) => {
               if (event.type === "text_delta") {
                 controller.enqueue(


### PR DESCRIPTION
## Summary
- `runtime/btw-sidechain.ts` -> `callSite: 'identityIntro'` (default; greeting/title overrides supported via the new optional `callSite` param).
- `runtime/routes/btw-routes.ts` -> `callSite: 'emptyStateGreeting'` (legacy `ui.greetingModelIntent` config read removed; unused `getConfig` import dropped).
- Tests updated: assert default callSite is `identityIntro` and greeting requests pass `emptyStateGreeting`. Added a mock for the identity-intro cache so the LLM-call path is deterministic.

Part of plan: unify-llm-callsites.md (PR 15 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
