### PR TITLE
notifications: route decision and preference extraction through call-site IDs

### DIFF
--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -11,16 +11,6 @@ mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum", "telegram", "slack"],
 }));
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-
-    notifications: {
-      decisionModelIntent: "latency-optimized",
-    },
-  }),
-}));
-
 mock.module("../notifications/decisions-store.js", () => ({
   createDecision: () => {},
 }));

--- a/assistant/src/__tests__/notification-decision-identity.test.ts
+++ b/assistant/src/__tests__/notification-decision-identity.test.ts
@@ -14,15 +14,6 @@ mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum"],
 }));
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    notifications: {
-      decisionModelIntent: "latency-optimized",
-    },
-  }),
-}));
-
 mock.module("../notifications/decisions-store.js", () => ({
   createDecision: () => {},
 }));

--- a/assistant/src/__tests__/notification-decision-recipient-context.test.ts
+++ b/assistant/src/__tests__/notification-decision-recipient-context.test.ts
@@ -15,15 +15,6 @@ mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum"],
 }));
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    notifications: {
-      decisionModelIntent: "latency-optimized",
-    },
-  }),
-}));
-
 mock.module("../notifications/decisions-store.js", () => ({
   createDecision: () => {},
 }));

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -12,7 +12,6 @@
 import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
-import { getConfig } from "../config/loader.js";
 import { listGuardianChannels } from "../contacts/contact-store.js";
 import { resolveGuardianPersona } from "../prompts/persona-resolver.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
@@ -22,7 +21,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
-import type { ModelIntent, Provider } from "../providers/types.js";
+import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
 import {
@@ -717,9 +716,6 @@ export async function evaluateSignal(
   availableChannels: NotificationChannel[],
   preferenceContext?: string,
 ): Promise<NotificationDecision> {
-  const config = getConfig();
-  const decisionModelIntent = config.notifications.decisionModelIntent;
-
   // When no explicit preference context is provided, load the user's
   // stored notification preferences from the memory-backed store.
   // Wrapped in try/catch so a DB failure doesn't break the decision path.
@@ -750,7 +746,7 @@ export async function evaluateSignal(
     );
   }
 
-  const provider = await getConfiguredProvider();
+  const provider = await getConfiguredProvider("notificationDecision");
   if (!provider) {
     log.warn(
       "Configured provider unavailable for notification decision, using fallback",
@@ -774,7 +770,6 @@ export async function evaluateSignal(
       signal,
       availableChannels,
       resolvedPreferenceContext,
-      decisionModelIntent,
       candidateSet,
     );
   } catch (err) {
@@ -805,7 +800,6 @@ async function classifyWithLLM(
   signal: NotificationSignal,
   availableChannels: NotificationChannel[],
   preferenceContext: string | undefined,
-  modelIntent: ModelIntent,
   candidateSet?: ConversationCandidateSet,
 ): Promise<NotificationDecision> {
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
@@ -858,7 +852,7 @@ async function classifyWithLLM(
       systemPrompt,
       {
         config: {
-          modelIntent,
+          callSite: "notificationDecision",
           max_tokens: 2048,
           tool_choice: {
             type: "tool" as const,

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -11,7 +11,6 @@
  * - "Weeknights after 10pm: only critical notifications"
  */
 
-import { getConfig } from "../config/loader.js";
 import {
   createTimeout,
   extractToolUse,
@@ -140,14 +139,11 @@ const EXTRACTION_TOOL = {
 export async function extractPreferences(
   message: string,
 ): Promise<ExtractionResult> {
-  const provider = await getConfiguredProvider();
+  const provider = await getConfiguredProvider("preferenceExtraction");
   if (!provider) {
     log.debug("No provider available for preference extraction");
     return { detected: false, preferences: [] };
   }
-
-  const config = getConfig();
-  const modelIntent = config.notifications.decisionModelIntent;
 
   const { signal, cleanup } = createTimeout(EXTRACTION_TIMEOUT_MS);
 
@@ -158,7 +154,7 @@ export async function extractPreferences(
       SYSTEM_PROMPT,
       {
         config: {
-          modelIntent,
+          callSite: "preferenceExtraction",
           max_tokens: 1024,
           tool_choice: {
             type: "tool" as const,


### PR DESCRIPTION
## Summary
- `notifications/decision-engine.ts` → `callSite: 'notificationDecision'`. Legacy `notifications.decisionModelIntent` read removed.
- `notifications/preference-extractor.ts` → `callSite: 'preferenceExtraction'`. Legacy read removed.
- Both call sites resolved independently via `llm.callSites.*`.
- Tests updated.

Part of plan: unify-llm-callsites.md (PR 16 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
