### PR TITLE
utility: route classifier and analyzer LLM calls through call-site IDs

### DIFF
--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -65,7 +65,7 @@ export async function classifyInteraction(
         "You are a classifier. Determine whether the user's request requires computer use (controlling the GUI — clicking, scrolling, typing into app windows, navigating between apps) or can be handled with local tools (answering questions, running terminal commands, creating/editing/reading files, web searches, writing code). GUI tasks → computer_use. Everything else → text_qa.",
         {
           config: {
-            modelIntent: "latency-optimized",
+            callSite: "interactionClassifier",
             max_tokens: 128,
             tool_choice: {
               type: "tool" as const,

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1539,7 +1539,7 @@ export async function draftSkill(
               [],
               undefined,
               {
-                config: { modelIntent: "latency-optimized", max_tokens: 256 },
+                config: { callSite: "skillCategoryInference", max_tokens: 256 },
                 signal,
               },
             );

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -147,7 +147,10 @@ export async function extractStylePatterns(
     promptMessages,
     [storeStyleAnalysisTool],
     STYLE_EXTRACTION_SYSTEM_PROMPT,
-    { signal: AbortSignal.timeout(30_000) },
+    {
+      signal: AbortSignal.timeout(30_000),
+      config: { callSite: "styleAnalyzer" },
+    },
   );
 
   const toolBlock = response.content.find((b) => b.type === "tool_use");

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -123,7 +123,7 @@ export async function generateInviteInstruction(params: {
       [userMessage(prompt)],
       undefined,
       undefined,
-      { signal, config: { modelIntent: "latency-optimized" } },
+      { signal, config: { callSite: "inviteInstructionGenerator" } },
     );
 
     const text = extractText(response).trim();


### PR DESCRIPTION
## Summary
- `daemon/classifier.ts` -> `callSite: 'interactionClassifier'`.
- `messaging/style-analyzer.ts` -> `callSite: 'styleAnalyzer'` (added; previous code had no per-call config).
- `runtime/invite-instruction-generator.ts` -> `callSite: 'inviteInstructionGenerator'`.
- `daemon/handlers/skills.ts` -> `callSite: 'skillCategoryInference'` (keeps per-call `max_tokens: 256` override since it's a tight budget).

## Audit of remaining `modelIntent:` literals (per plan PR 18 step 5)
Each plan-flagged candidate was classified:

- `daemon/conversation.ts:341` - **deferred**. This is a constructor parameter type signature (`modelIntent?: ModelIntent`), not a per-call config literal. The actual LLM call lives inside the AgentLoop; routing it through a `mainAgent` call site is a much larger refactor that needs to thread `callSite` through the agent loop. Out of scope for utility classifiers.
- `runtime/routes/conversation-routes.ts:2184` - **deferred**. This generates a tab-complete autocomplete suggestion for the user's next reply. Doesn't fit any existing call-site ID (not `identityIntro`, not `emptyStateGreeting`, not `mainAgent`). Needs a new call-site ID like `replySuggestion` - flagged for follow-up.
- `daemon/guardian-action-generators.ts:55` - **deferred**. This is guardian *action* copy (timeout messages, etc.), distinct in purpose from `guardianQuestionCopy` (which is question text). Folding both under `guardianQuestionCopy` would lose per-call-site tunability later. Needs a new `guardianActionCopy` call-site ID.
- `daemon/guardian-action-generators.ts:149` - **deferred**. Guardian follow-up disposition decision (tool-use call producing a structured disposition + reply). Different from action copy. Needs a new `guardianFollowupDecision` call-site ID.
- `config/skills.ts:1166` - **deferred**. This is the **icon generation** call (returns a 16x16 SVG), NOT category inference. The `skillCategoryInference` ID does not fit semantically. Needs a new `skillIconGeneration` call-site ID.

Other production `modelIntent:` literals not in this PR's scope are owned by sibling plan PRs:
- PRs 14-17 (in flight) cover `conversation-title-service.ts`, `btw-sidechain.ts`/`btw-routes.ts`, `decision-engine.ts`, `guardian-question-copy.ts`, `watch-handler.ts`.
- Memory pipeline (`memory/graph/*`, `memory/job-handlers/*`) and `analyze-conversation.ts` are owned by earlier wiring PRs (7-13).
- `runtime/routes/diagnostics-routes.ts` is a diagnostics endpoint without a clear call-site ID match.

Tests: `classifier.test.ts` (6 pass), `invite-routes-http.test.ts` (25 pass), all skills-handler tests pass individually. `bunx tsc --noEmit` passes.

Part of plan: unify-llm-callsites.md (PR 18 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
