### PR TITLE
macos(settings): migrate InferenceServiceCard reads/writes to llm.default.*

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -450,10 +450,10 @@ struct HatchingStepView: View {
     private func buildOnboardingConfigValues() -> [String: String] {
         var configValues: [String: String] = [:]
         if !state.selectedProvider.isEmpty {
-            configValues["services.inference.provider"] = state.selectedProvider
+            configValues["llm.default.provider"] = state.selectedProvider
         }
         if !state.selectedModel.isEmpty {
-            configValues["services.inference.model"] = state.selectedModel
+            configValues["llm.default.model"] = state.selectedModel
         }
         if managedSignInEnabled && !state.skippedAuth {
             configValues["services.inference.mode"] = "managed"

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -398,7 +398,7 @@ struct InferenceServiceCard: View {
         // match initialProvider (ensures config stays consistent).
         let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
         let providerChanged = persistProvider != initialProvider || modeChanged
-        let pendingProvider = providerChanged ? store.setInferenceProvider(persistProvider) : nil
+        let pendingProvider = providerChanged ? store.setLLMDefaultProvider(persistProvider) : nil
         if providerChanged {
             initialProvider = persistProvider
         }
@@ -431,7 +431,11 @@ struct InferenceServiceCard: View {
         Task {
             if let pendingMode { _ = await pendingMode.value }
             if let pendingProvider { _ = await pendingProvider.value }
-            store.setModel(capturedModel, provider: saveProvider, force: forceSend)
+            _ = await store.setLLMDefaultModel(
+                capturedModel,
+                provider: saveProvider,
+                force: forceSend
+            ).value
         }
         initialModel = draftModel
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2157,18 +2157,35 @@ public final class SettingsStore: ObservableObject {
     /// Loads service modes (inference, image-generation) from workspace config.
     /// Called during init and when the daemon reconnects.
     func loadServiceModes(config: [String: Any]) {
-        guard let services = config["services"] as? [String: Any] else { return }
-        if let inference = services["inference"] as? [String: Any] {
-            if let mode = inference["mode"] as? String { self.inferenceMode = mode }
-            // Only apply local config provider/model as a fallback when the daemon
-            // hasn't yet reported an authoritative value. Once the daemon responds
-            // via applyModelInfoResponse, its values take precedence over local
-            // config which may be stale (especially for remote assistants).
-            if lastDaemonProvider == nil,
-               let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
-            if lastDaemonProvider == nil,
-               let model = inference["model"] as? String { self.selectedModel = model }
+        // Resolve inference provider/model with `llm.default.*` as the
+        // canonical source (PR 4 backfills it from `services.inference`).
+        // Fall back to `services.inference.{provider,model}` for unmigrated
+        // configs — defensive, since the migration should have run for
+        // existing users but skips early-return cases (missing config,
+        // malformed JSON, etc.).
+        let services = config["services"] as? [String: Any]
+        let llmDefault = (config["llm"] as? [String: Any])?["default"] as? [String: Any]
+        let inference = services?["inference"] as? [String: Any]
+
+        // Inference mode remains under `services.inference.mode` — it is an
+        // inference-delivery setting (managed vs. your-own), not part of the
+        // LLM model config.
+        if let inference, let mode = inference["mode"] as? String {
+            self.inferenceMode = mode
         }
+        // Only apply local config provider/model as a fallback when the daemon
+        // hasn't yet reported an authoritative value. Once the daemon responds
+        // via applyModelInfoResponse, its values take precedence over local
+        // config which may be stale (especially for remote assistants).
+        if lastDaemonProvider == nil {
+            if let provider = (llmDefault?["provider"] as? String) ?? (inference?["provider"] as? String) {
+                self.selectedInferenceProvider = provider
+            }
+            if let model = (llmDefault?["model"] as? String) ?? (inference?["model"] as? String) {
+                self.selectedModel = model
+            }
+        }
+        guard let services else { return }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {
                 self.imageGenMode = mode
@@ -2930,6 +2947,9 @@ public final class SettingsStore: ObservableObject {
         return task
     }
 
+    // TODO PR 19: remove. Superseded by setLLMDefaultProvider — kept for any
+    // legacy callers / tests that still write to `services.inference.provider`
+    // directly while the unification rollout is in progress.
     @discardableResult
     func setInferenceProvider(_ provider: String) -> Task<Bool, Never> {
         selectedInferenceProvider = provider
@@ -2939,6 +2959,63 @@ public final class SettingsStore: ObservableObject {
             ])
             if !success {
                 log.error("Failed to patch config for inference provider")
+            }
+            return success
+        }
+        scheduleRoutingSourceRefresh()
+        return task
+    }
+
+    /// Persists the selected default LLM provider to the daemon config under
+    /// the unified `llm.default.provider` key. This is the canonical write
+    /// path now that the workspace migration consolidates LLM call-site
+    /// settings under `llm.*` (see PR 4 of the unify-llm-callsites plan).
+    @discardableResult
+    func setLLMDefaultProvider(_ provider: String) -> Task<Bool, Never> {
+        selectedInferenceProvider = provider
+        let task = Task {
+            let success = await settingsClient.patchConfig([
+                "llm": ["default": ["provider": provider]]
+            ])
+            if !success {
+                log.error("Failed to patch config for llm.default.provider")
+            }
+            return success
+        }
+        scheduleRoutingSourceRefresh()
+        return task
+    }
+
+    /// Persists the default LLM provider+model pair under `llm.default`.
+    /// Both keys are written together so the daemon's read-modify-write cycle
+    /// observes a consistent pair.
+    @discardableResult
+    func setLLMDefaultModel(
+        _ model: String,
+        provider: String,
+        force: Bool = false
+    ) -> Task<Bool, Never> {
+        if !force {
+            let modelUnchanged = model == lastDaemonModel
+            let providerUnchanged = provider == lastDaemonProvider
+            if modelUnchanged && providerUnchanged {
+                return Task { true }
+            }
+        }
+        lastDaemonModel = model
+        lastDaemonProvider = provider
+        selectedModel = model
+        selectedInferenceProvider = provider
+        let task = Task {
+            let success = await settingsClient.patchConfig([
+                "llm": ["default": ["provider": provider, "model": model]]
+            ])
+            if !success {
+                log.error("Failed to patch config for llm.default.{provider,model}")
+                if lastDaemonModel == model {
+                    lastDaemonModel = nil
+                    lastDaemonProvider = nil
+                }
             }
             return success
         }
@@ -3464,6 +3541,10 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Model Actions
 
+    // TODO PR 19: remove. Superseded by setLLMDefaultModel — kept for any
+    // legacy callers (e.g. routes through the daemon's set-model HTTP endpoint
+    // which still enriches state via applyModelInfoResponse) while the
+    // unification rollout is in progress.
     func setModel(_ model: String, provider: String? = nil, force: Bool = false) {
         // Skip if neither model nor provider changed (unless forced,
         // e.g. after an inference-mode switch that requires re-persisting

--- a/clients/macos/vellum-assistantTests/SettingsStoreInferenceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreInferenceTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Verifies that `SettingsStore` reads inference provider/model from the
+/// unified `llm.default.*` keys (with a fallback to `services.inference.*`
+/// for unmigrated configs) and writes through the new
+/// `setLLMDefaultProvider` / `setLLMDefaultModel` APIs.
+@MainActor
+final class SettingsStoreInferenceTests: XCTestCase {
+
+    private var mockSettingsClient: MockSettingsClient!
+    private var store: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockSettingsClient = MockSettingsClient()
+        mockSettingsClient.patchConfigResponse = true
+        store = SettingsStore(settingsClient: mockSettingsClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockSettingsClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the most recent `llm.default` patch payload captured by the
+    /// mock client, or `nil` if no such patch has been emitted.
+    private func lastLLMDefaultPatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let llm = payload["llm"] as? [String: Any],
+               let defaultBlock = llm["default"] as? [String: Any] {
+                return defaultBlock
+            }
+        }
+        return nil
+    }
+
+    /// Returns the most recent `services.inference` patch payload captured
+    /// by the mock client, or `nil` if no such patch has been emitted.
+    private func lastServicesInferencePatch() -> [String: Any]? {
+        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+            if let services = payload["services"] as? [String: Any],
+               let inference = services["inference"] as? [String: Any] {
+                return inference
+            }
+        }
+        return nil
+    }
+
+    /// Waits for the background `Task` started by a store helper to flush
+    /// its patch into the mock client.
+    private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
+        let predicate = NSPredicate { _, _ in
+            self.mockSettingsClient.patchConfigCalls.count >= expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: - Read path: prefer llm.default.*
+
+    /// When both `llm.default.*` and `services.inference.*` are present, the
+    /// store must prefer `llm.default.*` — that is the canonical post-PR-4
+    /// location and the one PR 19 will keep.
+    func testLoadServiceModesPrefersLLMDefaultWhenBothPresent() {
+        let config: [String: Any] = [
+            "llm": [
+                "default": [
+                    "provider": "openai",
+                    "model": "gpt-4.1"
+                ]
+            ],
+            "services": [
+                "inference": [
+                    "provider": "anthropic",
+                    "model": "claude-opus-4-6",
+                    "mode": "your-own"
+                ]
+            ]
+        ]
+
+        store.loadServiceModes(config: config)
+
+        XCTAssertEqual(
+            store.selectedInferenceProvider,
+            "openai",
+            "loadServiceModes must prefer llm.default.provider over services.inference.provider"
+        )
+        XCTAssertEqual(
+            store.selectedModel,
+            "gpt-4.1",
+            "loadServiceModes must prefer llm.default.model over services.inference.model"
+        )
+        XCTAssertEqual(
+            store.inferenceMode,
+            "your-own",
+            "loadServiceModes must continue to read inferenceMode from services.inference.mode"
+        )
+    }
+
+    /// When only `services.inference.*` is present (unmigrated config), the
+    /// read path must fall back to it. The PR 4 workspace migration should
+    /// have backfilled `llm.default.*` for existing users, but this fallback
+    /// guards against the early-return cases (missing config.json, malformed
+    /// JSON, fresh installs that missed the migration window).
+    func testLoadServiceModesFallsBackToServicesInferenceWhenLLMDefaultAbsent() {
+        let config: [String: Any] = [
+            "services": [
+                "inference": [
+                    "provider": "anthropic",
+                    "model": "claude-opus-4-6",
+                    "mode": "managed"
+                ]
+            ]
+        ]
+
+        store.loadServiceModes(config: config)
+
+        XCTAssertEqual(
+            store.selectedInferenceProvider,
+            "anthropic",
+            "loadServiceModes must fall back to services.inference.provider when llm.default is absent"
+        )
+        XCTAssertEqual(
+            store.selectedModel,
+            "claude-opus-4-6",
+            "loadServiceModes must fall back to services.inference.model when llm.default is absent"
+        )
+        XCTAssertEqual(
+            store.inferenceMode,
+            "managed",
+            "loadServiceModes must read inferenceMode from services.inference.mode"
+        )
+    }
+
+    /// When `llm.default` is partial (only provider, no model), the store
+    /// should take provider from `llm.default` and fall back to
+    /// `services.inference` for the missing model.
+    func testLoadServiceModesMixesLLMDefaultProviderWithServicesInferenceModel() {
+        let config: [String: Any] = [
+            "llm": [
+                "default": [
+                    "provider": "openai"
+                ]
+            ],
+            "services": [
+                "inference": [
+                    "provider": "anthropic",
+                    "model": "claude-opus-4-6"
+                ]
+            ]
+        ]
+
+        store.loadServiceModes(config: config)
+
+        XCTAssertEqual(store.selectedInferenceProvider, "openai")
+        XCTAssertEqual(store.selectedModel, "claude-opus-4-6")
+    }
+
+    // MARK: - Write path: setLLMDefaultProvider
+
+    func testSetLLMDefaultProviderEmitsExpectedPatch() {
+        store.setLLMDefaultProvider("openai")
+        waitForPatchCount(1)
+
+        let patch = lastLLMDefaultPatch()
+        XCTAssertNotNil(patch, "expected an llm.default patch payload")
+        XCTAssertEqual(patch?["provider"] as? String, "openai")
+        XCTAssertNil(
+            patch?["model"],
+            "setLLMDefaultProvider must not write a model field"
+        )
+    }
+
+    func testSetLLMDefaultProviderDoesNotEmitServicesInferencePatch() {
+        store.setLLMDefaultProvider("openai")
+        waitForPatchCount(1)
+
+        XCTAssertNil(
+            lastServicesInferencePatch(),
+            "setLLMDefaultProvider must not write to services.inference.*"
+        )
+    }
+
+    func testSetLLMDefaultProviderUpdatesSelectedInferenceProvider() {
+        store.setLLMDefaultProvider("openai")
+        waitForPatchCount(1)
+
+        XCTAssertEqual(store.selectedInferenceProvider, "openai")
+    }
+
+    // MARK: - Write path: setLLMDefaultModel
+
+    func testSetLLMDefaultModelEmitsExpectedPatch() {
+        _ = store.setLLMDefaultModel("gpt-4.1", provider: "openai", force: true)
+        waitForPatchCount(1)
+
+        let patch = lastLLMDefaultPatch()
+        XCTAssertNotNil(patch, "expected an llm.default patch payload")
+        XCTAssertEqual(patch?["provider"] as? String, "openai")
+        XCTAssertEqual(patch?["model"] as? String, "gpt-4.1")
+    }
+
+    func testSetLLMDefaultModelDoesNotEmitServicesInferencePatch() {
+        _ = store.setLLMDefaultModel("gpt-4.1", provider: "openai", force: true)
+        waitForPatchCount(1)
+
+        XCTAssertNil(
+            lastServicesInferencePatch(),
+            "setLLMDefaultModel must not write to services.inference.*"
+        )
+    }
+
+    func testSetLLMDefaultModelUpdatesSelectedState() {
+        _ = store.setLLMDefaultModel("gpt-4.1", provider: "openai", force: true)
+        waitForPatchCount(1)
+
+        XCTAssertEqual(store.selectedModel, "gpt-4.1")
+        XCTAssertEqual(store.selectedInferenceProvider, "openai")
+    }
+
+    // MARK: - Legacy setInferenceMode is preserved
+
+    /// `setInferenceMode` continues to write to `services.inference.mode` —
+    /// the mode toggle is an inference-delivery setting, not part of the
+    /// LLM model config, so it stays under `services.inference`.
+    func testSetInferenceModeStillWritesToServicesInference() {
+        _ = store.setInferenceMode("managed")
+        waitForPatchCount(1)
+
+        let patch = lastServicesInferencePatch()
+        XCTAssertNotNil(patch, "expected a services.inference patch payload")
+        XCTAssertEqual(patch?["mode"] as? String, "managed")
+        XCTAssertNil(
+            lastLLMDefaultPatch(),
+            "setInferenceMode must not write to llm.default.*"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `SettingsStore.swift` read path prefers `llm.default.{provider, model}`, falls back to `services.inference` for unmigrated configs.
- New `setLLMDefaultProvider`/`setLLMDefaultModel` APIs PATCH the new keys; legacy `setInferenceProvider`/`setModel` retained pending PR 19 cleanup.
- `InferenceServiceCard.performSave()` and `HatchingStepView` onboarding now write `llm.default.*`.
- Tests updated for the new read priority and write paths.
- iOS: `clients/ios/Views/Settings/ModelsServicesSection.swift` does not write `services.inference.*` directly — it routes through the daemon's `PUT /assistants/{id}/model` HTTP endpoint via the shared `SettingsClient.setModel` and is unaffected by this PR.

Part of plan: unify-llm-callsites.md (PR 20 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
