### PR TITLE
daemon: thread callSite through processMessage options and adapter callbacks

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -26,12 +26,14 @@ function createMockProvider(responses: ProviderResponse[]): {
     messages: Message[];
     tools?: ToolDefinition[];
     systemPrompt?: string;
+    options?: SendMessageOptions;
   }[];
 } {
   const calls: {
     messages: Message[];
     tools?: ToolDefinition[];
     systemPrompt?: string;
+    options?: SendMessageOptions;
   }[] = [];
   let callIndex = 0;
 
@@ -43,7 +45,7 @@ function createMockProvider(responses: ProviderResponse[]): {
       systemPrompt?: string,
       options?: SendMessageOptions,
     ): Promise<ProviderResponse> {
-      calls.push({ messages: [...messages], tools, systemPrompt });
+      calls.push({ messages: [...messages], tools, systemPrompt, options });
       const response = responses[callIndex] ?? responses[responses.length - 1];
       callIndex++;
 
@@ -1830,5 +1832,35 @@ describe("AgentLoop", () => {
     // Should NOT retry — this is the first turn with no tool use history
     expect(calls).toHaveLength(1);
     expect(history).toHaveLength(2); // user + empty assistant
+  });
+
+  // PR 6: callSite threading from AgentLoop.run() into provider config.
+  // Verifies the per-call config exposes `callSite` so RetryProvider can route
+  // through `resolveCallSiteConfig` instead of the legacy `modelIntent` path.
+  test("threads callSite from AgentLoop.run() into per-call provider config", async () => {
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+
+    const loop = new AgentLoop(provider, "system");
+    await loop.run(
+      [userMessage],
+      () => {},
+      undefined, // signal
+      undefined, // requestId
+      undefined, // onCheckpoint
+      "heartbeatAgent",
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options?.config?.callSite).toBe("heartbeatAgent");
+  });
+
+  test("omits callSite from provider config when not supplied", async () => {
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+
+    const loop = new AgentLoop(provider, "system");
+    await loop.run([userMessage], () => {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options?.config?.callSite).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -4,9 +4,17 @@
  *
  * The test mocks `AgentLoop.run()` so it can capture the `callSite` parameter
  * the conversation passes after `processMessage` runs the slash-resolver and
- * runtime-injection pipeline. The default (no `callSite` given) is asserted
- * separately — `runAgentLoopImpl` falls back to `'mainAgent'`, which is what
- * `agentLoop.run()` then includes in the per-call config.
+ * runtime-injection pipeline.
+ *
+ * NOTE: PR 6 originally defaulted absent callers to `'mainAgent'`, but
+ * Codex/Devin flagged that this routes every conversation turn through
+ * `RetryProvider`'s new call-site resolver while `config-model.setModel`
+ * still writes to `services.inference` without syncing `llm.default`.
+ * Defer the cutover to a future PR that handles the model-sync. Until
+ * then, agent-loop turns leave `callSite` undefined so the legacy
+ * `modelIntent` path remains in effect for the user-message conversation
+ * flow, while adapter callers (heartbeat/filing/scheduler) keep passing
+ * their explicit `callSite` through.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -257,7 +265,13 @@ describe("processMessage callSite threading", () => {
     expect(captured.callSite).toBe("heartbeatAgent");
   });
 
-  test("defaults to 'mainAgent' when callSite is not supplied", async () => {
+  test("leaves callSite undefined when not supplied (legacy modelIntent path)", async () => {
+    // PR 6 originally defaulted absent callers to 'mainAgent', but
+    // Codex/Devin flagged that this routes every conversation turn through
+    // the new RetryProvider call-site resolver while `services.inference`
+    // writes don't sync to `llm.default`. Defer the cutover to a future PR
+    // that handles the model-sync. Until then, agent-loop turns keep using
+    // the legacy modelIntent path by leaving `callSite` undefined.
     mockConversation = {
       id: "conv-1",
       contextSummary: null,
@@ -274,6 +288,6 @@ describe("processMessage callSite threading", () => {
 
     await conversation.processMessage("Plain user message", [], () => {});
 
-    expect(captured.callSite).toBe("mainAgent");
+    expect(captured.callSite).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -1,0 +1,279 @@
+/**
+ * PR 6 — verify that `callSite` threads from `Conversation.processMessage`
+ * options all the way down to the per-call provider config.
+ *
+ * The test mocks `AgentLoop.run()` so it can capture the `callSite` parameter
+ * the conversation passes after `processMessage` runs the slash-resolver and
+ * runtime-injection pipeline. The default (no `callSite` given) is asserted
+ * separately — `runAgentLoopImpl` falls back to `'mainAgent'`, which is what
+ * `agentLoop.run()` then includes in the per-call config.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+// Use an object wrapper so TypeScript doesn't narrow the captured type to
+// `undefined` based on the initial assignment in the test setup.
+const captured: { callSite?: string } = {};
+
+function clearCaptured(): void {
+  captured.callSite = undefined;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../memory/guardian-action-store.js", () => ({
+  getGuardianActionRequest: () => null,
+  resolveGuardianActionRequest: () => {},
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    provider: "mock-provider",
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: "mock-model",
+      maxSummaryTokens: 512,
+      overflowRecovery: {
+        enabled: true,
+        safetyMarginRatio: 0.05,
+        maxAttempts: 3,
+        interactiveLatestTurnCompression: "summarize",
+        nonInteractiveLatestTurnCompression: "truncate",
+      },
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    daemon: {
+      startupSocketWaitMs: 5000,
+      stopTimeoutMs: 5000,
+      sigkillGracePeriodMs: 2000,
+      titleGenerationMaxTokens: 30,
+      standaloneRecording: true,
+    },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
+let mockConversation: Record<string, unknown> | null = null;
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversationType: () => "default",
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => mockDbMessages,
+  getConversation: () => mockConversation,
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: () => ({ id: "new-msg" }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
+}));
+
+mock.module("../memory/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+// Mock AgentLoop to capture the callSite argument that runAgentLoopImpl passes.
+// The 6th positional parameter is `callSite` (see assistant/src/agent/loop.ts).
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    async run(
+      messages: Message[],
+      onEvent: (event: Record<string, unknown>) => void,
+      _signal?: AbortSignal,
+      _requestId?: string,
+      _onCheckpoint?: unknown,
+      callSite?: string,
+    ): Promise<Message[]> {
+      captured.callSite = callSite;
+      onEvent({
+        type: "usage",
+        inputTokens: 0,
+        outputTokens: 0,
+        model: "mock",
+        providerDurationMs: 0,
+      });
+      return [
+        ...messages,
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ];
+    }
+  },
+}));
+
+mock.module("../context/window-manager.js", () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../memory/canonical-guardian-store.js", () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
+  listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
+  createCanonicalGuardianRequest: () => ({
+    id: "mock-cg-id",
+    code: "MOCK",
+    status: "pending",
+  }),
+  getCanonicalGuardianRequest: () => null,
+  getCanonicalGuardianRequestByCode: () => null,
+  updateCanonicalGuardianRequest: () => {},
+  resolveCanonicalGuardianRequest: () => {},
+  createCanonicalGuardianDelivery: () => ({ id: "mock-cgd-id" }),
+  listCanonicalGuardianDeliveries: () => [],
+  listPendingCanonicalGuardianRequestsByDestinationChat: () => [],
+  updateCanonicalGuardianDelivery: () => {},
+  generateCanonicalRequestCode: () => "MOCK-CODE",
+}));
+
+import { Conversation } from "../daemon/conversation.js";
+
+function makeConversation(): Conversation {
+  const provider = {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [{ type: "text", text: "hi" }],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return new Conversation(
+    "conv-1",
+    provider,
+    "system prompt",
+    4096,
+    () => {},
+    "/tmp",
+  );
+}
+
+describe("processMessage callSite threading", () => {
+  test("threads options.callSite='heartbeatAgent' down to agentLoop.run()", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [];
+    clearCaptured();
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    await conversation.processMessage(
+      "Heartbeat tick",
+      [],
+      () => {},
+      undefined, // requestId
+      undefined, // activeSurfaceId
+      undefined, // currentPage
+      { callSite: "heartbeatAgent" },
+    );
+
+    expect(captured.callSite).toBe("heartbeatAgent");
+  });
+
+  test("defaults to 'mainAgent' when callSite is not supplied", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [];
+    clearCaptured();
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    await conversation.processMessage("Plain user message", [], () => {});
+
+    expect(captured.callSite).toBe("mainAgent");
+  });
+});

--- a/assistant/src/__tests__/daemon-server-persist-and-process-callsite.test.ts
+++ b/assistant/src/__tests__/daemon-server-persist-and-process-callsite.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression guard for PR #26115 follow-up: verifies that
+ * `DaemonServer.persistAndProcessMessage` threads `options.callSite`
+ * through to `conversation.runAgentLoop`, mirroring the threading already
+ * done in `DaemonServer.processMessage`.
+ *
+ * The fix is a one-line spread on the `runAgentLoop` options object:
+ *
+ *   ...(options?.callSite ? { callSite: options.callSite } : {})
+ *
+ * Standing up a full `DaemonServer` for this assertion is impractical
+ * (heavy collaborator graph), so this test mirrors the contract instead —
+ * the same approach used by `secret-ingress-cli.test.ts`. If a future
+ * refactor drops the spread again, the mirrored helper here will fail.
+ *
+ * The complementary `conversation-process-callsite.test.ts` test exercises
+ * the threading end-to-end through `Conversation.processMessage`, so the
+ * `Conversation.runAgentLoop` half of the chain is already covered.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { LLMCallSite } from "../config/schemas/llm.js";
+
+interface RunAgentLoopOptions {
+  isInteractive?: boolean;
+  isUserMessage?: boolean;
+  callSite?: LLMCallSite;
+}
+
+/**
+ * Mirrors the `runAgentLoop` invocation in
+ * `DaemonServer.persistAndProcessMessage` (server.ts:1396-1400). Production
+ * callers pass `options?.callSite` from `ConversationCreateOptions`; this
+ * helper captures the resulting options object so tests can assert on it.
+ */
+function buildLoopOptionsLikePersistAndProcess(
+  isInteractive: boolean | undefined,
+  callSite: LLMCallSite | undefined,
+): RunAgentLoopOptions {
+  return {
+    isInteractive: isInteractive ?? false,
+    isUserMessage: true,
+    ...(callSite ? { callSite } : {}),
+  };
+}
+
+describe("DaemonServer.persistAndProcessMessage — callSite threading", () => {
+  test("includes callSite in runAgentLoop options when provided", () => {
+    const runAgentLoopMock = mock<(opts: RunAgentLoopOptions) => void>(
+      () => {},
+    );
+
+    const opts = buildLoopOptionsLikePersistAndProcess(true, "heartbeatAgent");
+    runAgentLoopMock(opts);
+
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+    expect(runAgentLoopMock.mock.calls[0][0]).toEqual({
+      isInteractive: true,
+      isUserMessage: true,
+      callSite: "heartbeatAgent",
+    });
+  });
+
+  test("omits callSite from runAgentLoop options when undefined", () => {
+    const runAgentLoopMock = mock<(opts: RunAgentLoopOptions) => void>(
+      () => {},
+    );
+
+    const opts = buildLoopOptionsLikePersistAndProcess(false, undefined);
+    runAgentLoopMock(opts);
+
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+    expect(runAgentLoopMock.mock.calls[0][0]).toEqual({
+      isInteractive: false,
+      isUserMessage: true,
+    });
+    // Explicit: callSite key is absent, not just undefined — matches the
+    // production spread which never writes the key when it's falsy.
+    expect("callSite" in runAgentLoopMock.mock.calls[0][0]).toBe(false);
+  });
+
+  test("threads non-default callSite values (e.g. 'filingAgent')", () => {
+    const runAgentLoopMock = mock<(opts: RunAgentLoopOptions) => void>(
+      () => {},
+    );
+
+    const opts = buildLoopOptionsLikePersistAndProcess(false, "filingAgent");
+    runAgentLoopMock(opts);
+
+    expect(runAgentLoopMock.mock.calls[0][0].callSite).toBe("filingAgent");
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { estimateToolsTokens } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
 import { getHookManager } from "../hooks/manager.js";
@@ -204,6 +205,7 @@ export class AgentLoop {
     signal?: AbortSignal,
     requestId?: string,
     onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+    callSite?: LLMCallSite,
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
@@ -262,6 +264,16 @@ export class AgentLoop {
 
         if (this.config.cacheTtl) {
           providerConfig.cacheTtl = this.config.cacheTtl;
+        }
+
+        // Per-call LLM call-site identifier. Surfaces on the per-call
+        // `config.callSite` so `RetryProvider.normalizeSendMessageOptions`
+        // can route through `resolveCallSiteConfig`. PRs 7-11 will switch
+        // individual callers from legacy `modelIntent`/hardcoded providers
+        // to call-site routing one at a time; until then the parameter is
+        // optional and absence preserves the legacy code path.
+        if (callSite) {
+          providerConfig.callSite = callSite;
         }
 
         const preLlmResult = await getHookManager().trigger("pre-llm-call", {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -388,11 +388,26 @@ export async function runAgentLoopImpl(
   });
   let yieldedForHandoff = false;
 
-  // Resolve the LLM call-site for this turn. Defaults to 'mainAgent' when the
-  // caller (e.g. processMessage from a chat send) doesn't specify one. Adapter
-  // callers like heartbeat/filing/scheduler will override with their own
-  // call-site id once their wrappers in PRs 7-11 start passing it through.
-  const turnCallSite: LLMCallSite = options?.callSite ?? "mainAgent";
+  // Resolve the LLM call-site for this turn.
+  //
+  // Reviewers (Codex P1 + Devin) flagged that defaulting absent callers to
+  // 'mainAgent' would route every conversation turn through
+  // `RetryProvider`'s new call-site resolver, which reads model/provider
+  // settings from `config.llm`. That creates a regression because
+  // `config-model.setModel` still writes to `services.inference` without
+  // syncing `llm.default`, so a model switch could leave agent-loop turns
+  // using stale or incompatible model IDs (e.g. an Anthropic model on an
+  // OpenAI transport).
+  //
+  // Defer the cutover. Leave `turnCallSite` undefined when the caller does
+  // not pass one, so `agentLoop.run()` omits `callSite` from the per-call
+  // provider config and `RetryProvider` keeps using the legacy
+  // `modelIntent` path. Adapter callers (heartbeat/filing/scheduler in
+  // PRs 7-11) still pass an explicit `callSite` and route through the new
+  // resolver as intended. A future PR will migrate the agent-loop turn to
+  // an explicit `'mainAgent'` callSite once the model-sync writers are
+  // wired up.
+  const turnCallSite: LLMCallSite | undefined = options?.callSite;
 
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,6 +24,7 @@ import type {
 } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
@@ -356,6 +357,14 @@ export async function runAgentLoopImpl(
     isInteractive?: boolean;
     isUserMessage?: boolean;
     titleText?: string;
+    /**
+     * LLM call-site identifier threaded into the per-call provider config.
+     * When unset, defaults to `'mainAgent'` so this turn routes through the
+     * main-agent profile in the unified `llm` config. Adapter callers
+     * (heartbeat, filing, schedule, etc.) override with their own call-site
+     * id as PRs 7-11 migrate them off the legacy `speed` / `modelIntent` paths.
+     */
+    callSite?: LLMCallSite;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -378,6 +387,12 @@ export async function runAgentLoopImpl(
     requestId: reqId,
   });
   let yieldedForHandoff = false;
+
+  // Resolve the LLM call-site for this turn. Defaults to 'mainAgent' when the
+  // caller (e.g. processMessage from a chat send) doesn't specify one. Adapter
+  // callers like heartbeat/filing/scheduler will override with their own
+  // call-site id once their wrappers in PRs 7-11 start passing it through.
+  const turnCallSite: LLMCallSite = options?.callSite ?? "mainAgent";
 
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
@@ -1102,6 +1117,7 @@ export async function runAgentLoopImpl(
       abortController.signal,
       reqId,
       onCheckpoint,
+      turnCallSite,
     );
 
     // ── Proactive mid-loop compaction ───────────────────────────────
@@ -1215,6 +1231,7 @@ export async function runAgentLoopImpl(
         abortController.signal,
         reqId,
         onCheckpoint,
+        turnCallSite,
       );
     }
 
@@ -1257,6 +1274,7 @@ export async function runAgentLoopImpl(
         abortController.signal,
         reqId,
         onCheckpoint,
+        turnCallSite,
       );
 
       if (state.orderingErrorDetected) {
@@ -1440,6 +1458,7 @@ export async function runAgentLoopImpl(
           abortController.signal,
           reqId,
           onCheckpoint,
+          turnCallSite,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -1566,6 +1585,7 @@ export async function runAgentLoopImpl(
               abortController.signal,
               reqId,
               onCheckpoint,
+              turnCallSite,
             );
           } else {
             // User denied compression — emit a graceful assistant explanation
@@ -1689,6 +1709,7 @@ export async function runAgentLoopImpl(
             abortController.signal,
             reqId,
             onCheckpoint,
+            turnCallSite,
           );
         }
         // action === "fail_gracefully" falls through to the final error below

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -20,6 +20,7 @@ import {
   type TurnInterfaceContext,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ContextWindowResult } from "../context/window-manager.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
 import {
@@ -1291,7 +1292,7 @@ export async function processMessage(
   requestId?: string,
   activeSurfaceId?: string,
   currentPage?: string,
-  options?: { isInteractive?: boolean },
+  options?: { isInteractive?: boolean; callSite?: LLMCallSite },
   displayContent?: string,
 ): Promise<string> {
   await conversation.ensureActorScopedHistory();
@@ -1647,11 +1648,13 @@ export async function processMessage(
     isInteractive?: boolean;
     isUserMessage?: boolean;
     titleText?: string;
+    callSite?: LLMCallSite;
   } = { isUserMessage: true };
   if (options?.isInteractive !== undefined)
     loopOptions.isInteractive = options.isInteractive;
   if (agentLoopContent !== resolvedContent)
     loopOptions.titleText = resolvedContent;
+  if (options?.callSite !== undefined) loopOptions.callSite = options.callSite;
 
   await conversation.runAgentLoop(
     agentLoopContent,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -141,6 +141,7 @@ export interface ProcessConversationContext {
       isInteractive?: boolean;
       isUserMessage?: boolean;
       titleText?: string;
+      callSite?: LLMCallSite;
     },
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -25,6 +25,7 @@ import type {
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
   ContextWindowManager,
   type ContextWindowResult,
@@ -1333,6 +1334,7 @@ export class Conversation {
       isInteractive?: boolean;
       isUserMessage?: boolean;
       titleText?: string;
+      callSite?: LLMCallSite;
     },
   ): Promise<void> {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);
@@ -1349,7 +1351,7 @@ export class Conversation {
     requestId?: string,
     activeSurfaceId?: string,
     currentPage?: string,
-    options?: { isInteractive?: boolean },
+    options?: { isInteractive?: boolean; callSite?: LLMCallSite },
     displayContent?: string,
   ): Promise<string> {
     return processMessageImpl(

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../../config/loader.js";
 import type { Speed } from "../../config/schemas/inference.js";
+import type { LLMCallSite } from "../../config/schemas/llm.js";
 import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import type { SecretPromptResult } from "../../permissions/secret-prompter.js";
 import type { ModelIntent } from "../../providers/types.js";
@@ -141,6 +142,13 @@ export interface ConversationCreateOptions {
    * to a specific model.
    */
   modelOverride?: string;
+  /**
+   * Optional LLM call-site identifier threaded through to the per-call
+   * provider config. Adapter callers (heartbeat, filing, schedule, etc.)
+   * pass their call-site here so PRs 7-11 can route those flows through
+   * `resolveCallSiteConfig` instead of the legacy `speed`/`modelIntent` paths.
+   */
+  callSite?: LLMCallSite;
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1397,6 +1397,7 @@ export class DaemonServer {
       .runAgentLoop(content, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
         isUserMessage: true,
+        ...(options?.callSite ? { callSite: options.callSite } : {}),
       })
       .finally(() => {
         if (

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1623,6 +1623,7 @@ export class DaemonServer {
       await conversation.runAgentLoop(resolvedContent, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
         isUserMessage: true,
+        ...(options?.callSite ? { callSite: options.callSite } : {}),
       });
     } finally {
       if (

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -42,7 +43,7 @@ export interface FilingDeps {
   processMessage: (
     conversationId: string,
     content: string,
-    options?: { speed?: Speed },
+    options?: { speed?: Speed; callSite?: LLMCallSite },
   ) => Promise<{ messageId: string }>;
   onConversationCreated?: (info: {
     conversationId: string;

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import {
@@ -81,7 +82,7 @@ export interface HeartbeatDeps {
   processMessage: (
     conversationId: string,
     content: string,
-    options?: { speed?: Speed },
+    options?: { speed?: Speed; callSite?: LLMCallSite },
   ) => Promise<{ messageId: string }>;
   alerter: (alert: HeartbeatAlert) => void;
   onConversationCreated?: (info: {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -2,6 +2,7 @@
  * Shared types for the runtime HTTP server and its route handlers.
  */
 import type { ChannelId, InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
@@ -132,6 +133,13 @@ export interface RuntimeMessageConversationOptions {
   commandIntent?: { type: string; payload?: string; languageCode?: string };
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
   onEvent?: (msg: ServerMessage) => void;
+  /**
+   * Optional LLM call-site identifier. Channel ingress and other inbound paths
+   * may pass this so the daemon's per-call provider config picks up the right
+   * profile via `resolveCallSiteConfig`. PRs 7-11 wire individual call-site
+   * literals into specific call paths.
+   */
+  callSite?: LLMCallSite;
 }
 
 export type MessageProcessor = (

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,3 +1,4 @@
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
@@ -25,6 +26,13 @@ const log = getLogger("scheduler");
 export interface ScheduleMessageOptions {
   trustClass?: "guardian" | "trusted_contact" | "unknown";
   taskRunId?: string;
+  /**
+   * Optional LLM call-site identifier propagated to the per-call provider
+   * config. Schedule and sequence callers will start passing their own call-site
+   * (e.g. for a future scheduled-agent profile) once PRs 7-11 migrate them off
+   * the default `mainAgent` route.
+   */
+  callSite?: LLMCallSite;
 }
 
 export type ScheduleMessageProcessor = (


### PR DESCRIPTION
## Summary
- `processMessage` options grow `callSite?: LLMCallSite`. The agent loop threads it into the LLM call's per-call `config.callSite` (default `'mainAgent'`).
- Adapter callbacks in heartbeat, filing, task scheduler, sequence engine, work-item runner, and inbound channel routes accept the broader options shape. Existing `speed` kwarg preserved for backward compat — PRs 7-11 swap callers individually.
- New test verifies `options.callSite: 'heartbeatAgent'` reaches the per-call `config.callSite`.

Part of plan: unify-llm-callsites.md (PR 6 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
