### PR TITLE
feat(config): add 'xhigh' effort tier between 'high' and 'max'

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1345,6 +1345,13 @@ describe("OpenAIProvider reasoning_effort", () => {
     expect(lastCreateParams!.reasoning_effort).toBe("high");
   });
 
+  test('effort: "xhigh" maps to reasoning_effort: "high"', async () => {
+    await provider.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "xhigh" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+  });
+
   test("no effort config means no reasoning_effort in params", async () => {
     await provider.sendMessage([userMsg("hi")], undefined, "system", {
       config: {},

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -499,6 +499,19 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
   });
 
+  test('effort: "xhigh" maps to reasoning: { effort: "high" }', async () => {
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { effort: "xhigh" } },
+    );
+
+    expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
+  });
+
   test("no effort config means no reasoning in params", async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -23,7 +23,7 @@ export interface AgentLoopConfig {
   maxTokens: number;
   maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean };
-  effort: "low" | "medium" | "high" | "max";
+  effort: "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   toolChoice?:
     | { type: "auto" }

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -26,12 +26,12 @@ export const ThinkingConfigSchema = z
   .describe("Extended thinking (chain-of-thought) configuration");
 
 export const EffortSchema = z
-  .enum(["low", "medium", "high", "max"], {
-    error: 'effort must be "low", "medium", "high", or "max"',
+  .enum(["low", "medium", "high", "xhigh", "max"], {
+    error: 'effort must be "low", "medium", "high", "xhigh", or "max"',
   })
   .default("max")
   .describe(
-    "How much effort the model should put into its response — lower effort is faster and cheaper",
+    "How much effort the model should put into its response — lower effort is faster and cheaper. Ordered low < medium < high < xhigh < max. 'xhigh' is an intermediate tier between 'high' and 'max' for models that support it (e.g. Opus 4.7).",
   );
 
 export type Effort = z.infer<typeof EffortSchema>;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -747,7 +747,11 @@ export class AnthropicProvider implements Provider {
         max_tokens: callerMaxTokens,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
-        effort?: Anthropic.OutputConfig["effort"];
+        // "xhigh" is an intermediate tier between "high" and "max" supported
+        // by newer Anthropic models (e.g. Opus 4.7). The SDK's OutputConfig
+        // type doesn't yet include it, so we widen to the internal effort
+        // union and cast when building mergedOutputConfig.
+        effort?: "low" | "medium" | "high" | "xhigh" | "max";
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
       };
@@ -761,7 +765,9 @@ export class AnthropicProvider implements Provider {
       const supportsEffort = !isHaiku;
       const mergedOutputConfig = {
         ...(output_config ?? {}),
-        ...(effort && supportsEffort ? { effort } : {}),
+        ...(effort && supportsEffort
+          ? { effort: effort as Anthropic.OutputConfig["effort"] }
+          : {}),
       };
       // Build cache_control objects: Haiku doesn't support the extended
       // cache TTL beta, so omit the ttl field for Haiku models.

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -24,7 +24,9 @@ export interface OpenAIChatCompletionsProviderOptions {
   extraCreateParams?: Record<string, unknown>;
 }
 
-/** Map our internal effort values to OpenAI's reasoning_effort parameter. */
+/** Map our internal effort values to OpenAI's reasoning_effort parameter.
+ *  OpenAI's reasoning_effort caps at "high", so "xhigh" and "max" both
+ *  collapse to "high" on this transport. */
 const EFFORT_TO_REASONING_EFFORT: Record<
   string,
   NonNullable<
@@ -34,6 +36,7 @@ const EFFORT_TO_REASONING_EFFORT: Record<
   low: "low",
   medium: "medium",
   high: "high",
+  xhigh: "high",
   max: "high",
 };
 

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -22,11 +22,13 @@ export interface OpenAIResponsesProviderOptions {
   streamTimeoutMs?: number;
 }
 
-/** Map our internal effort values to the Responses API reasoning.effort parameter. */
+/** Map our internal effort values to the Responses API reasoning.effort parameter.
+ *  The Responses API caps at "high", so "xhigh" and "max" both collapse to "high". */
 const EFFORT_TO_REASONING_EFFORT: Record<string, "low" | "medium" | "high"> = {
   low: "low",
   medium: "medium",
   high: "high",
+  xhigh: "high",
   max: "high",
 };
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -131,7 +131,7 @@ export type ProviderEvent =
 export interface SendMessageConfig {
   model?: string;
   modelIntent?: ModelIntent;
-  effort?: "low" | "medium" | "high" | "max";
+  effort?: "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   [key: string]: unknown;
 }

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -49,7 +49,7 @@ Relevant config paths and what they control:
 | `services.inference.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
 | `services.inference.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
 | `services.inference.mode` | `"your-own"` (user's API key) vs `"managed"` (platform proxy) |
-| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"max"` |
+| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` (`xhigh` sits between `high` and `max`, for models that support it — e.g. Opus 4.7) |
 | `thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
 
 Read any of these with `assistant config get <path>`, e.g.:


### PR DESCRIPTION
## Summary

- Adds a new \`xhigh\` effort level to \`EffortSchema\`, ordered \`low < medium < high < xhigh < max\`, so configs targeting Opus 4.7's intermediate reasoning tier no longer fail schema validation.
- OpenAI transports (chat-completions + responses) collapse \`xhigh\` → \`high\` since OpenAI's \`reasoning_effort\` caps at \`high\`; Anthropic passes it through to \`output_config.effort\` via a cast (SDK types haven't caught up with the new tier).
- Added unit tests for both OpenAI transports and updated the self-knowledge inference reference doc.

## Original prompt

Add support for a new effort level "xhigh" alongside the existing "low" | "medium" | "high" | "max".

Starting points:
- \`assistant/src/config/schemas/inference.ts:28-37\` — \`EffortSchema\` enum and \`Effort\` type. Add "xhigh" to the enum and update the error message.
- Grep for all uses of the \`Effort\` type and the literal \`"max"\` to find every place that maps effort → thinking budget / token budgets / model parameters.
- Check \`assistant/src/providers/\` for how effort gets translated into provider-specific params (Anthropic thinking budget, etc.).
- Check the macOS/iOS clients (\`clients/\`) for any effort pickers/UI.
- Update any tests that enumerate effort values.

Context: I'm running a double-blind A/B test of Opus 4.6 (max effort) vs Opus 4.7 (xhigh effort) on Velissa, and the config write would fail without xhigh in the schema.

Clarification from user mid-implementation: xhigh is an intermediate tier between \`high\` and \`max\`, not above \`max\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
