### PR TITLE
Remove `doctor` from assistant shell completions

### DIFF
--- a/assistant/src/cli/commands/completions.ts
+++ b/assistant/src/cli/commands/completions.ts
@@ -54,7 +54,6 @@ Examples:
         "contacts",
         "autonomy",
         "audit",
-        "doctor",
         "completions",
         "help",
       ];
@@ -137,7 +136,6 @@ _assistant() {
         'contacts:Manage the contact graph'
         'autonomy:View and configure autonomy tiers'
         'audit:Show recent tool invocations'
-        'doctor:Run diagnostic checks'
         'completions:Generate shell completion script'
         'help:Display help'
     )
@@ -178,7 +176,6 @@ function generateFishCompletion(
     contacts: "Manage the contact graph",
     autonomy: "View and configure autonomy tiers",
     audit: "Show recent tool invocations",
-    doctor: "Run diagnostic checks",
     completions: "Generate shell completion script",
     help: "Display help",
   };


### PR DESCRIPTION
## Summary
- Drop the `doctor` entry from `topLevel`, the zsh `commands` array, and the fish `descriptions` map in `assistant/src/cli/commands/completions.ts` so generated bash/zsh/fish completions no longer suggest the removed command.

Part of plan: remove-doctor-cli.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
