### PR TITLE
Drop `assistant doctor --verbose` from CLI risk-guard test

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -84,11 +84,7 @@ describe("CLI command risk guard: assistant commands", () => {
   });
 
   test("assistant with flags classifies as Low risk", async () => {
-    const flagCommands = [
-      "assistant --version",
-      "assistant --help",
-      "assistant doctor --verbose",
-    ];
+    const flagCommands = ["assistant --version", "assistant --help"];
 
     for (const command of flagCommands) {
       const risk = await classifyRisk("bash", { command });


### PR DESCRIPTION
## Summary
- Remove the hardcoded `assistant doctor --verbose` entry from `flagCommands` in `cli-command-risk-guard.test.ts` so the test no longer references a command that no longer exists. Dynamic subcommand discovery handles the rest.

Part of plan: remove-doctor-cli.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
