### PR TITLE
subagent: pass callSite: 'subagentSpawn' when spawning isolated agents

### DIFF
--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -439,7 +439,9 @@ export class SubagentManager {
           ].join("\n")
         : objective;
       const messageId = await conversation.persistUserMessage(message, []);
-      await conversation.runAgentLoop(message, messageId, onEvent);
+      await conversation.runAgentLoop(message, messageId, onEvent, {
+        callSite: "subagentSpawn",
+      });
 
       // Agent loop completed successfully.
       // Copy usage stats from the conversation before sending status (which includes usage).
@@ -634,7 +636,9 @@ export class SubagentManager {
       const conversation = managed.conversation;
       const messageId = await conversation.persistUserMessage(trimmed, []);
       conversation
-        .runAgentLoop(trimmed, messageId, onEvent)
+        .runAgentLoop(trimmed, messageId, onEvent, {
+          callSite: "subagentSpawn",
+        })
         .catch((err) => {
           log.error({ subagentId, err }, "Subagent message processing failed");
         });


### PR DESCRIPTION
## Summary
- Subagent spawn now passes `callSite: 'subagentSpawn'` to the agent loop, routing through `llm.callSites.subagentSpawn` resolution.
- Tests updated where applicable.

Part of plan: unify-llm-callsites.md (PR 10 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
