### PR TITLE
calls: route the call agent loop through callSite: 'callAgent'

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -221,6 +221,45 @@ describe("voice-session-bridge", () => {
     expect(abortCalled).toBe(true);
   });
 
+  test("startVoiceTurn passes callSite: 'callAgent' to runAgentLoop", async () => {
+    const conversation = createConversation("voice bridge callSite test");
+    const events: ServerMessage[] = [
+      { type: "message_complete", conversationId: conversation.id },
+    ];
+
+    let capturedOptions: Record<string, unknown> | undefined;
+    const session = {
+      ...makeStreamingSession(events),
+      runAgentLoop: async (
+        _content: string,
+        _messageId: string,
+        onEvent: (msg: ServerMessage) => void,
+        options?: Record<string, unknown>,
+      ) => {
+        capturedOptions = options;
+        for (const event of events) {
+          onEvent(event);
+        }
+      },
+    } as unknown as Conversation;
+
+    injectDeps(() => session);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: "Hello",
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions?.callSite).toBe("callAgent");
+  });
+
   test("external AbortSignal triggers turn abort", async () => {
     const conversation = createConversation("voice bridge signal test");
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -522,6 +522,11 @@ export async function startVoiceTurn(
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.
         },
+        // Route every voice-call agent loop turn through the unified
+        // `llm.callSites.callAgent` resolver. PR 4 backfilled this entry
+        // from the legacy `config.calls.model` setting, so existing
+        // overrides continue to apply.
+        { callSite: "callAgent" },
       );
       if (lastError) {
         log.error(


### PR DESCRIPTION
## Summary
- Phone call agent loop now passes `callSite: 'callAgent'` to the LLM call.
- Legacy `config.calls.model` read removed; resolved via `llm.callSites.callAgent` (populated by PR 4 migration).
- Tests updated.

Part of plan: unify-llm-callsites.md (PR 11 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
