### PR TITLE
heartbeat: pass callSite: 'heartbeatAgent' instead of speed kwarg

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -126,11 +126,44 @@ const IDENTITY_TEMPLATE = readFileSync(
 const { stripCommentLines } = await import("../util/strip-comment-lines.js");
 const SCAFFOLD_PERSONA = stripCommentLines(GUARDIAN_PERSONA_TEMPLATE).trim();
 
+// Resolver wiring — used by the end-to-end resolution test below to verify
+// that `callSite: 'heartbeatAgent'` resolves to the correct config when
+// `llm.callSites.heartbeatAgent` is defined.
+const { resolveCallSiteConfig } = await import("../config/llm-resolver.js");
+const { LLMSchema } = await import("../config/schemas/llm.js");
+
+// Minimal fully-specified `llm.default` block. The resolver requires every
+// `LLMConfigBase` field to be present in `default`, so we provide the same
+// fixture the resolver test suite uses.
+const LLM_DEFAULT = {
+  provider: "anthropic" as const,
+  model: "claude-opus-4-7",
+  maxTokens: 64000,
+  effort: "max" as const,
+  speed: "standard" as const,
+  temperature: null,
+  thinking: { enabled: true, streamThinking: true },
+  contextWindow: {
+    enabled: true,
+    maxInputTokens: 200000,
+    targetBudgetRatio: 0.3,
+    compactThreshold: 0.8,
+    summaryBudgetRatio: 0.05,
+    overflowRecovery: {
+      enabled: true,
+      safetyMarginRatio: 0.05,
+      maxAttempts: 3,
+      interactiveLatestTurnCompression: "summarize" as const,
+      nonInteractiveLatestTurnCompression: "truncate" as const,
+    },
+  },
+};
+
 describe("HeartbeatService", () => {
   let processMessageCalls: Array<{
     conversationId: string;
     content: string;
-    options?: { speed?: string };
+    options?: { callSite?: string };
   }>;
   let alerterCalls: Array<{ type: string; title: string; body: string }>;
 
@@ -163,7 +196,7 @@ describe("HeartbeatService", () => {
     processMessage?: (
       id: string,
       content: string,
-      options?: { speed?: string },
+      options?: { callSite?: string },
     ) => Promise<{ messageId: string }>;
     getCurrentHour?: () => number;
   }) {
@@ -173,7 +206,7 @@ describe("HeartbeatService", () => {
         (async (
           conversationId: string,
           content: string,
-          options?: { speed?: string },
+          options?: { callSite?: string },
         ) => {
           processMessageCalls.push({ conversationId, content, options });
           return { messageId: "msg-1" };
@@ -504,32 +537,51 @@ describe("HeartbeatService", () => {
     expect(service.nextRunAt).toBeNull();
   });
 
-  test("passes heartbeat config speed to processMessage", async () => {
-    mockConfig.heartbeat.speed = "standard";
+  test("passes callSite='heartbeatAgent' to processMessage", async () => {
     const service = createService();
     await service.runOnce();
 
     expect(processMessageCalls).toHaveLength(1);
-    expect(processMessageCalls[0].options).toEqual({ speed: "standard" });
+    expect(processMessageCalls[0].options).toEqual({
+      callSite: "heartbeatAgent",
+    });
   });
 
-  test("heartbeat uses its own speed even when global config differs", async () => {
-    // Simulate: global config has fast, but heartbeat config has standard
-    mockConfig.heartbeat.speed = "standard";
-    const service = createService();
-    await service.runOnce();
-
-    expect(processMessageCalls).toHaveLength(1);
-    expect(processMessageCalls[0].options?.speed).toBe("standard");
-  });
-
-  test("heartbeat passes fast speed when explicitly configured", async () => {
+  test("callSite is passed regardless of legacy heartbeat.speed value", async () => {
+    // The legacy `heartbeat.speed` field is no longer read by the heartbeat
+    // service — every run unconditionally passes `callSite: 'heartbeatAgent'`
+    // and the resolver maps that to whatever `llm.callSites.heartbeatAgent`
+    // (or the default) configures. PR 19 will remove the schema field.
     mockConfig.heartbeat.speed = "fast";
     const service = createService();
     await service.runOnce();
 
     expect(processMessageCalls).toHaveLength(1);
-    expect(processMessageCalls[0].options?.speed).toBe("fast");
+    expect(processMessageCalls[0].options?.callSite).toBe("heartbeatAgent");
+  });
+
+  test("end-to-end: llm.callSites.heartbeatAgent.speed resolves to 'fast'", async () => {
+    // Verifies the contract that PR 7 establishes: heartbeat passes
+    // `callSite: 'heartbeatAgent'`, and the LLM resolver maps that to the
+    // configured speed via `llm.callSites.heartbeatAgent`. The heartbeat
+    // service itself doesn't call the resolver — that happens downstream in
+    // the provider layer (see PR 5) — so this test asserts both halves of
+    // the wiring: (a) the call site identifier flows through to
+    // processMessage, and (b) the resolver maps that identifier to the
+    // user's configured speed.
+    const llm = LLMSchema.parse({
+      default: LLM_DEFAULT,
+      callSites: {
+        heartbeatAgent: { speed: "fast" },
+      },
+    });
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options?.callSite).toBe("heartbeatAgent");
+    const resolved = resolveCallSiteConfig("heartbeatAgent", llm);
+    expect(resolved.speed).toBe("fast");
   });
 
   describe("isShallowProfile", () => {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
-import type { Speed } from "../config/schemas/inference.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
@@ -82,7 +81,7 @@ export interface HeartbeatDeps {
   processMessage: (
     conversationId: string,
     content: string,
-    options?: { speed?: Speed; callSite?: LLMCallSite },
+    options?: { callSite?: LLMCallSite },
   ) => Promise<{ messageId: string }>;
   alerter: (alert: HeartbeatAlert) => void;
   onConversationCreated?: (info: {
@@ -334,7 +333,6 @@ export class HeartbeatService {
     await this.runCredentialHealthCheck();
 
     try {
-      const config = getConfig().heartbeat;
       const checklist = this.readChecklist();
       const { prompt, includedReengagement } = this.buildPrompt(checklist);
 
@@ -352,7 +350,7 @@ export class HeartbeatService {
       });
 
       await this.deps.processMessage(conversation.id, prompt, {
-        speed: config.speed,
+        callSite: "heartbeatAgent",
       });
 
       if (includedReengagement) {


### PR DESCRIPTION
## Summary
- Heartbeat service now passes `callSite: 'heartbeatAgent'` to processMessage; the legacy `speed: config.speed` kwarg is removed (schema field deprecated, removed in PR 19).
- Tests updated to assert callSite plumbing + end-to-end resolution from `llm.callSites.heartbeatAgent`.

Part of plan: unify-llm-callsites.md (PR 7 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
