### PR TITLE
fix: remove orphaned getProviderKeyViaDaemon helper after doctor removal

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -29,10 +29,7 @@ function nextUUID(): string {
 // healthz fallback in daemon-credential-client).
 // ---------------------------------------------------------------------------
 
-function normalizeCredentialAccount(
-  type: string,
-  name: string,
-): string {
+function normalizeCredentialAccount(type: string, name: string): string {
   if (type !== "credential") return name;
   if (name.startsWith("credential/")) return name;
   const colonIdx = name.lastIndexOf(":");
@@ -73,11 +70,6 @@ mock.module("../cli/lib/daemon-credential-client.js", () => ({
     value: secureKeyStore.get(account),
     unreachable: mockBrokerUnreachable,
   }),
-  getProviderKeyViaDaemon: async (
-    provider: string,
-  ): Promise<string | undefined> => {
-    return secureKeyStore.get(provider);
-  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
@@ -32,7 +32,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
   getSecureKeyViaDaemon: async () => undefined,
   deleteSecureKeyViaDaemon: async () => "not-found" as const,
   setSecureKeyViaDaemon: async () => false,
-  getProviderKeyViaDaemon: async () => undefined,
   getSecureKeyResultViaDaemon: async () => ({
     value: undefined,
     unreachable: false,

--- a/assistant/src/cli/commands/platform/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/connect.test.ts
@@ -21,7 +21,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
     mockGetSecureKeyViaDaemon(account),
   deleteSecureKeyViaDaemon: async () => "not-found" as const,
   setSecureKeyViaDaemon: async () => true,
-  getProviderKeyViaDaemon: async () => undefined,
   getSecureKeyResultViaDaemon: async () => ({
     value: undefined,
     unreachable: false,

--- a/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
@@ -57,7 +57,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
     return mockDeleteSecureKeyViaDaemonResult;
   },
   setSecureKeyViaDaemon: async () => false,
-  getProviderKeyViaDaemon: async () => undefined,
   getSecureKeyResultViaDaemon: async () => ({
     value: undefined,
     unreachable: false,

--- a/assistant/src/cli/commands/platform/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/status.test.ts
@@ -37,7 +37,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
     mockGetSecureKeyViaDaemon(account),
   deleteSecureKeyViaDaemon: async () => "not-found" as const,
   setSecureKeyViaDaemon: async () => false,
-  getProviderKeyViaDaemon: async () => undefined,
   getSecureKeyResultViaDaemon: async () => ({
     value: undefined,
     unreachable: false,

--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -24,7 +24,6 @@ import {
   getSecureKeyResultAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
-import { PROVIDER_ENV_VAR_NAMES } from "../../shared/provider-env-vars.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("daemon-credential-client");
@@ -32,8 +31,6 @@ const CREDENTIAL_KEY_PREFIX = "credential/";
 
 /** Hard timeout for daemon HTTP requests to prevent CLI commands from hanging. */
 const DAEMON_FETCH_TIMEOUT_MS = 60_000;
-
-const PROVIDER_ENV_VARS: Record<string, string> = PROVIDER_ENV_VAR_NAMES;
 
 // ---------------------------------------------------------------------------
 // Private daemon fetch helper
@@ -252,20 +249,4 @@ export async function deleteSecureKeyViaDaemon(
     }
   }
   return deleteSecureKeyAsync(name);
-}
-
-/**
- * Retrieve a provider API key via the daemon, with env var fallback.
- *
- * Mirrors the behavior of `getProviderKeyAsync()` from secure-keys.ts:
- * first checks the secure store (via daemon), then falls back to the
- * corresponding `<PROVIDER>_API_KEY` environment variable.
- */
-export async function getProviderKeyViaDaemon(
-  provider: string,
-): Promise<string | undefined> {
-  const stored = await getSecureKeyViaDaemon(provider);
-  if (stored) return stored;
-  const envVar = PROVIDER_ENV_VARS[provider];
-  return envVar ? process.env[envVar] : undefined;
 }


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for remove-doctor-cli.md.

**Gap:** `getProviderKeyViaDaemon` (exported from `assistant/src/cli/lib/daemon-credential-client.ts`) was only ever called by the now-deleted `assistant/src/cli/commands/doctor.ts`. Per the project's own `assistant/src/cli/AGENTS.md` § Deprecation Hygiene rule ("Remove all implementation code — the command registration, handler, and any helper functions that only served the removed command"), this orphan should be cleaned up.

**What changed:**
- Delete `getProviderKeyViaDaemon` and its supporting `PROVIDER_ENV_VARS` constant from `daemon-credential-client.ts`.
- Drop the `getProviderKeyViaDaemon` mock entries from the 5 test files that mocked the daemon-credential-client module.

Part of plan: remove-doctor-cli.md (cleanup gap, round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
