### PR TITLE
macos(settings): show 'N call-site overrides' badge with read-only list sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
@@ -3,12 +3,7 @@ import VellumAssistantShared
 
 /// Read-only sheet listing every call site that has at least one explicit
 /// `provider`, `model`, or `profile` override set under `llm.callSites.<id>`
-/// in the workspace config. Grouped by `CallSiteDomain` so the rendering
-/// matches the picker UI introduced in PRs 23-24.
-///
-/// PR 22 ships the read-only view + a "N per-task overrides" badge in the
-/// Inference card. PR 23 makes individual rows editable. PR 24 layers in
-/// reset / preset actions on top.
+/// in the workspace config. Grouped by `CallSiteDomain`.
 @MainActor
 struct CallSiteOverridesSheet: View {
     @ObservedObject var store: SettingsStore

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Read-only sheet listing every call site that has at least one explicit
+/// `provider`, `model`, or `profile` override set under `llm.callSites.<id>`
+/// in the workspace config. Grouped by `CallSiteDomain` so the rendering
+/// matches the picker UI introduced in PRs 23-24.
+///
+/// PR 22 ships the read-only view + a "N per-task overrides" badge in the
+/// Inference card. PR 23 makes individual rows editable. PR 24 layers in
+/// reset / preset actions on top.
+@MainActor
+struct CallSiteOverridesSheet: View {
+    @ObservedObject var store: SettingsStore
+    @Binding var isPresented: Bool
+
+    /// Catalog entries that currently have at least one explicit override,
+    /// keyed by domain in catalog order. Domains with no overridden call
+    /// sites are omitted so the empty-state message renders cleanly when
+    /// the user has nothing configured.
+    private var overridesByDomain: [(domain: CallSiteDomain, entries: [CallSiteOverride])] {
+        let active = store.callSiteOverrides.filter { $0.hasOverride }
+        var grouped: [CallSiteDomain: [CallSiteOverride]] = [:]
+        for entry in active {
+            grouped[entry.domain, default: []].append(entry)
+        }
+        return CallSiteDomain.allCases
+            .sorted { $0.sortOrder < $1.sortOrder }
+            .compactMap { domain in
+                guard let entries = grouped[domain], !entries.isEmpty else { return nil }
+                return (domain: domain, entries: entries)
+            }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header: title + subtitle + close button. Built with VStack
+            // chrome rather than VModal so the inner List can manage its
+            // own scrolling without nesting inside VModal's ScrollView.
+            header
+            SettingsDivider()
+
+            if overridesByDomain.isEmpty {
+                emptyState
+            } else {
+                overridesList
+            }
+
+            SettingsDivider()
+            footer
+        }
+        .frame(width: 520, height: 480)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+    }
+
+    // MARK: - Header / Footer
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Per-Task Model Overrides")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("Tasks listed here use a specific provider or model instead of your default.")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            VButton(
+                label: "Close",
+                iconOnly: VIcon.x.rawValue,
+                style: .ghost,
+                tintColor: VColor.contentTertiary
+            ) {
+                isPresented = false
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            VButton(label: "Done", style: .outlined) {
+                isPresented = false
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: VSpacing.sm) {
+            Spacer(minLength: 0)
+            Text("No overrides set. All tasks use your default model.")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.lg)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Overrides List
+
+    private var overridesList: some View {
+        List {
+            ForEach(overridesByDomain, id: \.domain.id) { group in
+                Section {
+                    ForEach(group.entries) { entry in
+                        overrideRow(entry)
+                    }
+                } header: {
+                    Text(group.domain.displayName)
+                }
+            }
+        }
+        .listStyle(.inset)
+        .frame(maxHeight: .infinity)
+    }
+
+    private func overrideRow(_ entry: CallSiteOverride) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(entry.displayName)
+                .font(VFont.bodyMediumDefault)
+            Text(summary(for: entry))
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, VSpacing.xxs)
+    }
+
+    /// Compose the secondary line for a given override entry.
+    ///
+    /// Format precedence:
+    /// - `provider + model` → `"<Provider> · <model>"` (e.g. `"Anthropic · claude-haiku-4-5"`).
+    /// - `model` only       → `"<model>"`.
+    /// - `provider` only    → `"Provider: <Provider>"`.
+    /// - `profile`          → `"Profile: <profile>"` (appended when paired with provider/model).
+    private func summary(for entry: CallSiteOverride) -> String {
+        var parts: [String] = []
+        if let provider = entry.provider, let model = entry.model {
+            parts.append("\(store.dynamicProviderDisplayName(provider)) \u{00B7} \(model)")
+        } else if let model = entry.model {
+            parts.append(model)
+        } else if let provider = entry.provider {
+            parts.append("Provider: \(store.dynamicProviderDisplayName(provider))")
+        }
+        if let profile = entry.profile {
+            parts.append("Profile: \(profile)")
+        }
+        return parts.joined(separator: " \u{00B7} ")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -34,6 +34,8 @@ struct InferenceServiceCard: View {
     @State private var isSyncingProviderFromStore = false
     /// Whether the current provider has a stored API key (fetched per-component).
     @State private var providerHasKey = false
+    /// Whether the read-only per-call-site overrides sheet is presented.
+    @State private var showOverridesSheet = false
 
     // MARK: - Provider Helpers
 
@@ -88,51 +90,63 @@ struct InferenceServiceCard: View {
     }
 
     var body: some View {
-        ServiceModeCard(
-            title: "Inference",
-            subtitle: draftMode == "managed"
-                ? "Configure which model to use to power your assistant"
-                : "Configure which LLM provider and model to use to power your assistant",
-            draftMode: $draftMode,
-            managedContent: {
-                if isLoggedIn {
-                    PickerWithInlineSave(
-                        hasChanges: hasChanges,
-                        isSaving: store.apiKeySaving,
-                        onSave: { save() }
-                    ) {
-                        modelPicker
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            ServiceModeCard(
+                title: "Inference",
+                subtitle: draftMode == "managed"
+                    ? "Configure which model to use to power your assistant"
+                    : "Configure which LLM provider and model to use to power your assistant",
+                draftMode: $draftMode,
+                managedContent: {
+                    if isLoggedIn {
+                        PickerWithInlineSave(
+                            hasChanges: hasChanges,
+                            isSaving: store.apiKeySaving,
+                            onSave: { save() }
+                        ) {
+                            modelPicker
+                        }
+                    } else {
+                        managedLoginPrompt
                     }
-                } else {
-                    managedLoginPrompt
+                },
+                yourOwnContent: {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        providerPicker
+
+                        // Model picker
+                        modelPicker
+
+                        // API Key field
+                        apiKeyField
+
+                        // Action buttons
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: store.apiKeySaving,
+                            onSave: { save() },
+                            savingLabel: "Validating...",
+                            onReset: {
+                                store.clearAPIKeyForProvider(effectiveProvider)
+                                providerHasKey = false
+                                apiKeyText = ""
+                            },
+                            showReset: providerHasKey
+                        )
+                    }
                 }
-            },
-            yourOwnContent: {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    providerPicker
+            )
 
-                    // Model picker
-                    modelPicker
-
-                    // API Key field
-                    apiKeyField
-
-                    // Action buttons
-                    ServiceCardActions(
-                        hasChanges: hasChanges,
-                        isSaving: store.apiKeySaving,
-                        onSave: { save() },
-                        savingLabel: "Validating...",
-                        onReset: {
-                            store.clearAPIKeyForProvider(effectiveProvider)
-                            providerHasKey = false
-                            apiKeyText = ""
-                        },
-                        showReset: providerHasKey
-                    )
-                }
+            // Per-call-site overrides badge — only visible when the user has
+            // at least one override configured. Tapping opens the read-only
+            // overrides sheet (PR 22). PR 23 makes this sheet editable.
+            if store.overridesCount > 0 {
+                overridesBadge
             }
-        )
+        }
+        .sheet(isPresented: $showOverridesSheet) {
+            CallSiteOverridesSheet(store: store, isPresented: $showOverridesSheet)
+        }
         .onAppear {
             draftMode = store.inferenceMode
             draftModel = store.selectedModel
@@ -285,6 +299,28 @@ struct InferenceServiceCard: View {
                     + " You'll need to review and save them below."
             )
         }
+    }
+
+    // MARK: - Per-Call-Site Overrides Badge
+
+    /// Compact link-styled label that surfaces the count of explicit per-task
+    /// overrides and opens the read-only overrides sheet on tap. Hidden by
+    /// the parent when `store.overridesCount == 0`.
+    private var overridesBadge: some View {
+        Button {
+            showOverridesSheet = true
+        } label: {
+            Text(
+                "\(store.overridesCount) per-task override"
+                    + (store.overridesCount == 1 ? "" : "s")
+            )
+            .font(VFont.bodySmallDefault)
+            .foregroundStyle(.secondary)
+            .underline()
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+        .accessibilityLabel("View per-task model overrides")
     }
 
     // MARK: - Managed Login Prompt

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -138,8 +138,8 @@ struct InferenceServiceCard: View {
             )
 
             // Per-call-site overrides badge — only visible when the user has
-            // at least one override configured. Tapping opens the read-only
-            // overrides sheet (PR 22). PR 23 makes this sheet editable.
+            // at least one override configured. Tapping opens the overrides
+            // sheet.
             if store.overridesCount > 0 {
                 overridesBadge
             }


### PR DESCRIPTION
## Summary
- New `CallSiteOverridesSheet` lists every call site that has a provider/model/profile override, grouped by domain.
- `InferenceServiceCard` shows a small "N per-task overrides" link below the Save row when `store.overridesCount > 0`. Tap opens the sheet.
- Read-only this PR; PR 23 makes it editable.

Part of plan: unify-llm-callsites.md (PR 22 of 24)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
