### PR TITLE
fix(ios): wire pull-to-refresh on Chats list

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -601,37 +601,53 @@ class IOSConversationStore: ObservableObject {
     private func sendPageOneConversationList(daemon: GatewayConnectionManager) {
         let currentGeneration = conversationListGeneration
         Task { [weak self] in
-            guard let self else { return }
-            // Fetch foreground and background conversations in parallel so
-            // background conversations don't consume pagination slots.
-            async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: nil)
-            async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: "background")
-            let foreground = await foregroundResult
-            let background = await backgroundResult
+            await self?.performPageOneFetch(daemon: daemon, generation: currentGeneration)
+        }
+    }
 
-            if let foreground {
-                guard currentGeneration == self.conversationListGeneration else { return }
-                // Deduplicate by conversation ID so that daemons that don't
-                // yet support the conversationType query param (which return
-                // the same conversations for both requests) don't produce
-                // duplicate sidebar entries.
-                var seenIds = Set(foreground.conversations.map(\.id))
-                let uniqueBackground = (background?.conversations ?? []).filter {
-                    seenIds.insert($0.id).inserted
-                }
-                let merged = ConversationListResponse(
-                    type: foreground.type,
-                    conversations: foreground.conversations + uniqueBackground,
-                    hasMore: foreground.hasMore
-                )
-                self.expectedConversationListGeneration = currentGeneration
-                self.lastFetchError = nil
-                self.handleConversationListResponse(merged)
-            } else {
-                guard currentGeneration == self.conversationListGeneration else { return }
-                self.lastFetchError = "Foreground conversation fetch returned nil — check gateway connectivity"
-                self.isLoadingInitialConversations = false
+    /// Awaitable public entry point for manual refresh (e.g. SwiftUI `.refreshable`).
+    /// Resets pagination state, bumps the generation counter, and awaits the page-1
+    /// fetch so the refresh indicator reflects network latency.
+    func refreshConversationList(daemon: GatewayConnectionManager) async {
+        conversationListOffset = 0
+        hasMoreConversations = false
+        conversationListGeneration += 1
+        await performPageOneFetch(daemon: daemon, generation: conversationListGeneration)
+    }
+
+    /// Async body of the page-1 fetch. Shared by the fire-and-forget
+    /// `sendPageOneConversationList` path and the awaitable `refreshConversationList`
+    /// path so both routes use the same generation-guard and dedup logic.
+    private func performPageOneFetch(daemon: GatewayConnectionManager, generation: UInt64) async {
+        // Fetch foreground and background conversations in parallel so
+        // background conversations don't consume pagination slots.
+        async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: nil)
+        async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: "background")
+        let foreground = await foregroundResult
+        let background = await backgroundResult
+
+        if let foreground {
+            guard generation == conversationListGeneration else { return }
+            // Deduplicate by conversation ID so that daemons that don't
+            // yet support the conversationType query param (which return
+            // the same conversations for both requests) don't produce
+            // duplicate sidebar entries.
+            var seenIds = Set(foreground.conversations.map(\.id))
+            let uniqueBackground = (background?.conversations ?? []).filter {
+                seenIds.insert($0.id).inserted
             }
+            let merged = ConversationListResponse(
+                type: foreground.type,
+                conversations: foreground.conversations + uniqueBackground,
+                hasMore: foreground.hasMore
+            )
+            expectedConversationListGeneration = generation
+            lastFetchError = nil
+            handleConversationListResponse(merged)
+        } else {
+            guard generation == conversationListGeneration else { return }
+            lastFetchError = "Foreground conversation fetch returned nil — check gateway connectivity"
+            isLoadingInitialConversations = false
         }
     }
 

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -168,6 +168,7 @@ struct ChatsDisconnectedView: View {
 
 struct ConversationListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @EnvironmentObject var clientProvider: ClientProvider
     @ObservedObject var store: IOSConversationStore
     @State private var navigationPath: [UUID] = []
     @State private var selectedConversationId: UUID?
@@ -594,6 +595,9 @@ struct ConversationListView: View {
         }
         .searchable(text: $searchText, prompt: "Search chats")
         .navigationTitle("Chats")
+        .refreshable {
+            await store.refreshConversationList(daemon: clientProvider.client)
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {


### PR DESCRIPTION
## Summary
- The iOS Chats list had no `.refreshable` modifier — pulling down triggered the bounce animation but never refetched from the server. Reproduced when another client (web/macOS) created a conversation and iOS missed the SSE `conversation_list_invalidated` event (e.g. app backgrounded), leaving iOS stuck on a stale list with no way to recover short of an app restart.
- Adds an awaitable `refreshConversationList(daemon:)` on `IOSConversationStore` that shares the existing generation-guard and page-1 merge logic with the SSE-invalidation and reconnect paths. Wires it into the Chats `List` via `.refreshable` so the SwiftUI spinner reflects actual network latency.
- No existing call sites change. `sendPageOneConversationList` remains a fire-and-forget wrapper over the new shared `performPageOneFetch`, so reconnect and SSE-debounce behavior is unchanged.

## Test plan
- [ ] Manual: create a conversation on web (same dev platform), confirm iOS sidebar does not update (reproduces stale-list scenario). Pull down on iOS Chats list — spinner shows, new conversation appears after refetch.
- [ ] Manual: pull-to-refresh with no pending changes — spinner shows briefly, list unchanged, no flicker or duplicate rows.
- [ ] Manual: pull-to-refresh while an SSE-driven refetch is in flight — generation guard ensures only the later response is applied; no stale rows.
- [ ] Regression: existing reconnect and invalidation-debounce paths still refresh page 1 correctly (same `performPageOneFetch` code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
