### PR TITLE
ci(release): block npm publish and platform bump on Docker image failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1290,7 +1290,7 @@ jobs:
           echo "**Version:** \`${{ needs.extract-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   publish-npm:
-    needs: [extract-version, ci-cli, ci-gateway, ci-playwright]
+    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2363,9 +2363,10 @@ jobs:
           sleep 10
           gh pr merge "$PR_URL" --auto --squash
 
-  # ci-assistant runs for visibility in the Slack notification but does not
-  # block the release. It is deliberately excluded from publish-npm's needs
-  # so that a failure here never gates downstream jobs.
+  # ci-assistant runs lint/typecheck/test for the assistant service. It also
+  # transitively gates the release pipeline because push-assistant-image and
+  # push-dockerhub-image depend on it — a failure here blocks Docker image
+  # builds, which in turn blocks npm publish, the macOS DMG, and GitHub Release.
   ci-assistant:
     needs: extract-version
     runs-on: ubuntu-latest-8-cores


### PR DESCRIPTION
## Summary
- Add the three service manifests and `push-dockerhub-image` to `publish-npm`'s `needs:`.
- `publish-meta` and `update-platform` inherit the gate transitively via `publish-npm`.
- No `if:` expressions changed; default cascading-skip applies since `publish-npm` does not use `always()`.

Part of plan: release-gate-on-images.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
