### PR TITLE
ci(release): block staging CLI pack and platform-QA trigger on image failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1327,7 +1327,7 @@ jobs:
 
   # ── Staging: pack CLI tarball and dispatch QA to platform repo ──────
   pack-cli:
-    needs: [extract-version, ci-cli]
+    needs: [extract-version, ci-cli, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Add the three GCR service manifests to `pack-cli`'s `needs:` so staging CLI packs are blocked when any image fails.
- Do NOT add `push-dockerhub-image` — `pack-cli` is staging-only and dockerhub push is skipped in staging.
- `trigger-platform-qa` inherits the gate transitively via `pack-cli`.

Part of plan: release-gate-on-images.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
