### PR TITLE
ci(release): block macOS/iOS/Chrome extension publishes on Docker image failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1410,6 +1410,14 @@ jobs:
   # arm64 macOS build — builds Swift + Bun binaries in a single job,
   # creates DMG, notarizes, staples, and generates the Sparkle appcast.
   # This is the primary/default build.
+  #
+  # `needs:` gates on the three GCR service manifests. We intentionally do NOT
+  # list `push-dockerhub-image` here because this job runs in both staging
+  # and production, and `push-dockerhub-image` is prod-only (skipped in staging)
+  # — a skipped dep would cascade-skip this job in staging. The Docker Hub
+  # gate is applied downstream at the `release` job (GitHub Release), which
+  # is the sole publisher of the DMG produced here, and at `release-ios`
+  # for its sibling TestFlight publish.
   build-macos-arm64:
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
@@ -2483,6 +2491,10 @@ jobs:
         run: bun run test
         working-directory: credential-executor
 
+  # iOS build — produces .ipa for TestFlight upload via release-ios.
+  # As with the macOS builds, `needs:` gates on GCR manifests only because
+  # this job runs in staging too; the Docker Hub gate lives on `release-ios`
+  # (prod-only), which is the sole external publisher of this .ipa.
   build-ios:
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2522,7 +2522,7 @@ jobs:
         run: ./build.sh test
 
   release-ios:
-    needs: [extract-version, build-ios]
+    needs: [extract-version, build-ios, push-dockerhub-image]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: macos-15
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
           retention-days: 90
 
   publish-chrome-extension:
-    needs: [extract-version, build-chrome-extension]
+    needs: [extract-version, build-chrome-extension, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: >-
       needs.extract-version.outputs.chrome_extension_changed == 'true'
       && needs.extract-version.outputs.is_staging == 'false'
@@ -1411,7 +1411,7 @@ jobs:
   # creates DMG, notarizes, staples, and generates the Sparkle appcast.
   # This is the primary/default build.
   build-macos-arm64:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 45
     defaults:
@@ -1786,7 +1786,7 @@ jobs:
   # produces a separate DMG for Intel Macs.
   # Runs in parallel with build-macos-arm64 and does NOT block the release job.
   build-macos-x64:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 45
     continue-on-error: true
@@ -2484,7 +2484,7 @@ jobs:
         working-directory: credential-executor
 
   build-ios:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Add the three GCR service manifests to `build-macos-arm64`, `build-macos-x64`, and `build-ios` needs (no dockerhub — those jobs run in staging where dockerhub is skipped).
- Add the three GCR manifests plus `push-dockerhub-image` to `publish-chrome-extension` (prod-only job).
- `release-ios` inherits gating transitively via `build-ios`.
- No `if:` expressions changed; default cascading-skip applies.

Part of plan: release-gate-on-images.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
