### PR TITLE
fix(config-loader): treat JSON null as key deletion in deepMergeOverwrite

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -65,6 +65,7 @@ afterAll(() => {
 
 import {
   deepMergeMissing,
+  deepMergeOverwrite,
   invalidateConfigCache,
   loadConfig,
 } from "../config/loader.js";
@@ -140,6 +141,130 @@ describe("deepMergeMissing", () => {
     const changed = deepMergeMissing(target, defaults);
     expect(changed).toBe(true);
     expect(target).toEqual({ slack: { deliverAuthBypass: false } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: deepMergeOverwrite (unit) — JSON-null-as-deletion semantics
+// ---------------------------------------------------------------------------
+
+describe("deepMergeOverwrite", () => {
+  test("overwrites top-level scalars", () => {
+    const target: Record<string, unknown> = { a: 1, b: "old" };
+    deepMergeOverwrite(target, { a: 2, c: "new" });
+    expect(target).toEqual({ a: 2, b: "old", c: "new" });
+  });
+
+  test("recursively merges nested objects, overwriting leaves", () => {
+    const target: Record<string, unknown> = {
+      nested: { keep: "yes", change: "before" },
+    };
+    deepMergeOverwrite(target, {
+      nested: { change: "after", added: 42 },
+    });
+    expect(target).toEqual({
+      nested: { keep: "yes", change: "after", added: 42 },
+    });
+  });
+
+  test("replaces arrays wholesale rather than merging", () => {
+    const target: Record<string, unknown> = { items: [1, 2, 3] };
+    deepMergeOverwrite(target, { items: [9] });
+    expect(target).toEqual({ items: [9] });
+  });
+
+  test("treats top-level null as key deletion", () => {
+    const target: Record<string, unknown> = { a: 1, b: 2 };
+    deepMergeOverwrite(target, { a: null });
+    expect(target).toEqual({ b: 2 });
+    expect("a" in target).toBe(false);
+  });
+
+  test("treats nested null as key deletion, preserving siblings", () => {
+    const target: Record<string, unknown> = {
+      a: { b: 1, c: 2, d: 3 },
+    };
+    deepMergeOverwrite(target, { a: { b: null } });
+    expect(target).toEqual({ a: { c: 2, d: 3 } });
+    expect("b" in (target.a as Record<string, unknown>)).toBe(false);
+  });
+
+  test("deletion of a nested key whose value is itself an object", () => {
+    // Models the macOS clear-call-site-override case:
+    // PATCH { llm: { callSites: { commitMessage: null } } } removes the
+    // commitMessage entry entirely while keeping other call-site entries
+    // and unrelated llm fields intact.
+    const target: Record<string, unknown> = {
+      llm: {
+        provider: "anthropic",
+        callSites: {
+          commitMessage: { provider: "openai", model: "gpt-4" },
+          memoryRetrieval: { profile: "fast" },
+        },
+      },
+    };
+    deepMergeOverwrite(target, {
+      llm: { callSites: { commitMessage: null } },
+    });
+    expect(target).toEqual({
+      llm: {
+        provider: "anthropic",
+        callSites: {
+          memoryRetrieval: { profile: "fast" },
+        },
+      },
+    });
+  });
+
+  test("deletion is a no-op when the key is already absent", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    deepMergeOverwrite(target, { missing: null });
+    expect(target).toEqual({ a: 1 });
+    expect("missing" in target).toBe(false);
+  });
+
+  test("strips null leaves when assigning a whole subtree to a missing key", () => {
+    // Models a PATCH that introduces a new call-site entry while clearing
+    // some of its sub-fields in the same payload — the nulls must not
+    // be persisted.
+    const target: Record<string, unknown> = { llm: { provider: "anthropic" } };
+    deepMergeOverwrite(target, {
+      llm: {
+        callSites: {
+          commitMessage: { provider: null, model: "gpt-4", profile: null },
+        },
+      },
+    });
+    expect(target).toEqual({
+      llm: {
+        provider: "anthropic",
+        callSites: {
+          commitMessage: { model: "gpt-4" },
+        },
+      },
+    });
+  });
+
+  test("strips null leaves when overwriting a scalar with an object subtree", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    deepMergeOverwrite(target, { a: { b: null, c: 5, d: { e: null, f: 6 } } });
+    expect(target).toEqual({ a: { c: 5, d: { f: 6 } } });
+  });
+
+  test("preserves explicit boolean false and zero (not treated as null)", () => {
+    const target: Record<string, unknown> = { a: true, b: 1 };
+    deepMergeOverwrite(target, { a: false, b: 0 });
+    expect(target).toEqual({ a: false, b: 0 });
+  });
+
+  test("undefined override values are passed through, not treated as deletion", () => {
+    // JSON.parse never produces undefined, but guard the in-process call path:
+    // an explicit undefined assignment should follow the same "scalar overwrite"
+    // path as before, not the null-deletion path.
+    const target: Record<string, unknown> = { a: 1 };
+    deepMergeOverwrite(target, { a: undefined });
+    expect("a" in target).toBe(true);
+    expect(target.a).toBeUndefined();
   });
 });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -207,9 +207,42 @@ export function deepMergeMissing(
 }
 
 /**
+ * Recursively strip `null` leaves from a plain-object value, returning a
+ * deep clone with all `null`-valued keys removed at every nesting level.
+ * Non-object inputs (scalars, arrays, `null` itself) are returned as-is.
+ *
+ * Used to sanitize `overrides` before assigning whole subtrees in
+ * `deepMergeOverwrite`, so deletion-sentinel semantics apply uniformly
+ * even when the corresponding `target` key does not yet exist.
+ */
+function stripNullLeaves(value: unknown): unknown {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v === null) continue;
+    out[k] = stripNullLeaves(v);
+  }
+  return out;
+}
+
+/**
  * Deep-merge `overrides` into `target`, overwriting leaf values.
  * Recursively merges nested objects; scalars and arrays from `overrides`
  * replace corresponding values in `target`.
+ *
+ * JSON `null` is treated as a deletion sentinel: any key whose override
+ * value is `null` is deleted from `target` instead of being assigned.
+ * This applies recursively, so PATCHing `{ a: { b: null } }` removes the
+ * nested `b` while preserving `a` and any other siblings of `b`. When an
+ * override assigns a whole object subtree to a key that does not yet
+ * exist on `target` (or whose existing value is a scalar/array), any
+ * `null` leaves inside that subtree are dropped before assignment so no
+ * `null`s ever get persisted. This matches the semantics expected by
+ * HTTP PATCH callers (e.g. macOS SettingsStore clearing call-site
+ * overrides) and prevents invalid `null` entries from accumulating on
+ * disk in `config.json`.
  */
 export function deepMergeOverwrite(
   target: Record<string, unknown>,
@@ -217,8 +250,10 @@ export function deepMergeOverwrite(
 ): void {
   for (const key of Object.keys(overrides)) {
     const ov = overrides[key];
-    if (
-      ov != null &&
+    if (ov === null) {
+      delete target[key];
+    } else if (
+      ov !== undefined &&
       typeof ov === "object" &&
       !Array.isArray(ov) &&
       target[key] != null &&
@@ -230,7 +265,7 @@ export function deepMergeOverwrite(
         ov as Record<string, unknown>,
       );
     } else {
-      target[key] = ov;
+      target[key] = stripNullLeaves(ov);
     }
   }
 }


### PR DESCRIPTION
## Summary
Self-review caught that macOS PATCHes for clearing call-site overrides were writing invalid JSON nulls to config.json. The loader's recovery path was stripping them so the in-memory state was correct, but the on-disk JSON was brittle.

Fix: deepMergeOverwrite now treats null values as key-deletion (recursive). PATCHing { llm: { callSites: { id: null } } } now removes the key cleanly, and PATCHing nested nulls in object values does the same per-leaf.