### PR TITLE
fix(r2): catalog test count, skill self-knowledge doc, AGENTS.md, loader docstring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,9 +132,9 @@ Feature flags use simple kebab-case keys (e.g., `browser`, `ces-tools`). Declare
 
 ## LLM Provider Abstraction
 
-All LLM calls must go through the provider abstraction — use `getConfiguredProvider()` from `providers/provider-send-message.ts`. Never import `@anthropic-ai/sdk` directly (only `providers/anthropic/client.ts` may). Guard test: `no-direct-anthropic-sdk-imports.test.ts`.
+All LLM calls must go through the provider abstraction — use `getConfiguredProvider(callSite)` from `providers/provider-send-message.ts`. The `callSite: LLMCallSite` argument is required so the resolver can pick the right per-call-site config. Never import `@anthropic-ai/sdk` directly (only `providers/anthropic/client.ts` may). Guard test: `no-direct-anthropic-sdk-imports.test.ts`.
 
-Use `modelIntent` (`'latency-optimized'`, `'quality-optimized'`, `'vision-optimized'`) instead of hardcoded model IDs. Use provider-agnostic language in comments and logs ('LLM' not 'Haiku'/'Sonnet'). Route text generation through the daemon process — direct provider calls discard user context and preferences.
+Each LLM call site has a stable identifier (`LLMCallSite` from `assistant/src/config/schemas/llm.ts`). Pick the appropriate call-site ID for the request — the provider layer resolves provider/model/maxTokens/effort/thinking/contextWindow/etc. via `resolveCallSiteConfig` against `llm.callSites.<id>` (with fallback to an optional `llm.profiles.<name>` and finally to `llm.default`). Use provider-agnostic language in comments and logs ('LLM' not 'Haiku'/'Sonnet'). Route text generation through the daemon process — direct provider calls discard user context and preferences.
 
 ## Skill Isolation
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -234,15 +234,22 @@ function stripNullLeaves(value: unknown): unknown {
  *
  * JSON `null` is treated as a deletion sentinel: any key whose override
  * value is `null` is deleted from `target` instead of being assigned.
- * This applies recursively, so PATCHing `{ a: { b: null } }` removes the
+ * This applies recursively, so merging `{ a: { b: null } }` removes the
  * nested `b` while preserving `a` and any other siblings of `b`. When an
  * override assigns a whole object subtree to a key that does not yet
- * exist on `target` (or whose existing value is a scalar/array), any
- * `null` leaves inside that subtree are dropped before assignment so no
- * `null`s ever get persisted. This matches the semantics expected by
- * HTTP PATCH callers (e.g. macOS SettingsStore clearing call-site
- * overrides) and prevents invalid `null` entries from accumulating on
- * disk in `config.json`.
+ * exist on `target` (or whose existing value is a scalar/array),
+ * `stripNullLeaves` drops any `null` leaves inside that subtree before
+ * assignment so no `null`s ever get persisted.
+ *
+ * These deletion semantics apply to **every** caller of
+ * `deepMergeOverwrite`, not just the HTTP PATCH path. That includes
+ * `mergeDefaultWorkspaceConfig` and any future in-process consumer.
+ * Today the HTTP PATCH path is the only producer that emits `null`
+ * values (for example, the macOS SettingsStore clearing call-site
+ * overrides), so no in-process caller is affected — but contributors
+ * adding new callers should be aware that emitting `null` will delete
+ * the corresponding key, and prefer omitting the key entirely if that
+ * is not the intent.
  */
 export function deepMergeOverwrite(
   target: Record<string, unknown>,

--- a/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
@@ -51,12 +51,13 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
     // MARK: - Catalog
 
     func testCatalogCoversEveryCallSite() {
-        // The plan calls out 26 sites grouped across 7 domains. If this
-        // count drifts, the catalog and the backend `LLMCallSiteEnum`
-        // have diverged.
-        XCTAssertEqual(CallSiteCatalog.all.count, 26)
-        XCTAssertEqual(CallSiteCatalog.byId.count, 26)
-        XCTAssertEqual(CallSiteCatalog.validIds.count, 26)
+        // The catalog enumerates 28 sites grouped across 8 domains
+        // (agent loop, memory, workspace, UI, notifications, voice,
+        // utility, skills). If this count drifts, the catalog and the
+        // backend `LLMCallSiteEnum` have diverged.
+        XCTAssertEqual(CallSiteCatalog.all.count, 28)
+        XCTAssertEqual(CallSiteCatalog.byId.count, 28)
+        XCTAssertEqual(CallSiteCatalog.validIds.count, 28)
     }
 
     func testCatalogHasUniqueIdsAndNonEmptyDisplayNames() {

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -46,21 +46,21 @@ Relevant config paths and what they control:
 
 | Config Path | Description |
 |-------------|-------------|
-| `services.inference.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
-| `services.inference.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
+| `llm.default.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
+| `llm.default.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
 | `services.inference.mode` | `"your-own"` (user's API key) vs `"managed"` (platform proxy) |
-| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"max"` |
-| `thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
+| `llm.default.effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"max"` |
+| `llm.default.thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
 
 Read any of these with `assistant config get <path>`, e.g.:
 
 ```bash
-assistant config get services.inference.model
-assistant config get services.inference.provider
+assistant config get llm.default.model
+assistant config get llm.default.provider
 ```
 
 ## How Inference Routing Works
 
-The assistant initializes a provider registry on startup with the configured provider from config. Available providers are determined by which API keys are present. Model intents route to appropriate models within the configured provider.
+The assistant initializes a provider registry on startup with the providers whose API keys are present. Each LLM request is tagged with a stable call-site identifier (`LLMCallSite` from `assistant/src/config/schemas/llm.ts`) — for example `mainAgent`, `memoryRetrieval`, or `watchSummary`. The provider layer resolves the effective config for that call site by layering `llm.callSites.<id>` on top of an optional named profile (`llm.profiles.<name>`) on top of the required `llm.default` base.
 
-Model intents (`latency-optimized`, `quality-optimized`, `vision-optimized`) can select different models within the same provider, allowing the system to route to a faster or more capable model depending on the task without switching providers.
+Per-call-site overrides live under `llm.callSites.<id>.{provider, model, maxTokens, effort, speed, temperature, thinking, contextWindow, profile}`. Any field omitted at the call-site level falls through to the profile (if `profile` is set) and finally to `llm.default`. Read a specific override with `assistant config get llm.callSites.<id>` (e.g. `assistant config get llm.callSites.memoryRetrieval`); the catalog of valid call-site IDs is the `LLMCallSiteEnum` in `assistant/src/config/schemas/llm.ts`.


### PR DESCRIPTION
## Summary
Round-2 self-review cleanup:
- Updated SettingsStoreCallSiteOverrideTests catalog count assertion from 26 to 28 (catches up with fix-r1-a's meetConsentMonitor + meetChatOpportunity additions).
- Refreshed skills/vellum-self-knowledge/references/inference.md to reference llm.default.* and llm.callSites.* instead of stripped legacy keys (services.inference.{provider,model}, top-level effort/thinking, modelIntent).
- Rewrote AGENTS.md 'LLM Provider Abstraction' section to reflect the post-PR-19 contract: getConfiguredProvider(callSite) requires the call-site argument; per-call-site routing replaces modelIntent.
- Tightened deepMergeOverwrite docstring to note that null-as-delete semantics apply to ALL callers, not just PATCH.