### PR TITLE
ci(release): gate register-release on push-dockerhub-image in production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1112,7 +1112,8 @@ jobs:
           echo "**Docker Hub:** \`${{ steps.tags.outputs.image }}:v${{ needs.extract-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   register-release:
-    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
+    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && (needs.extract-version.outputs.is_staging == 'true' || needs.push-dockerhub-image.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for release-gate-on-images.md.

**Gap:** `register-release` is an external publisher but is not gated on `push-dockerhub-image` in production.
**What was expected:** `register-release` should not run in production when `push-dockerhub-image` fails (it POSTs to the platform API with `is_stable: true`).
**What was found:** `register-release` only gated on the three GCR manifests, not on Docker Hub.

Fix: add `push-dockerhub-image` to `needs:` and add an `if:` expression that requires either `is_staging == 'true'` (where dockerhub is skipped by design) or dockerhub success (in prod).

Part of plan: release-gate-on-images.md (self-review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
