### PR TITLE
ci(release): block all release artifacts on Docker image/manifest build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1327,7 +1327,7 @@ jobs:
 
   # ── Staging: pack CLI tarball and dispatch QA to platform repo ──────
   pack-cli:
-    needs: [extract-version, ci-cli]
+    needs: [extract-version, ci-cli, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1112,7 +1112,8 @@ jobs:
           echo "**Docker Hub:** \`${{ steps.tags.outputs.image }}:v${{ needs.extract-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   register-release:
-    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
+    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && (needs.extract-version.outputs.is_staging == 'true' || needs.push-dockerhub-image.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
           retention-days: 90
 
   publish-chrome-extension:
-    needs: [extract-version, build-chrome-extension]
+    needs: [extract-version, build-chrome-extension, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: >-
       needs.extract-version.outputs.chrome_extension_changed == 'true'
       && needs.extract-version.outputs.is_staging == 'false'
@@ -1410,8 +1410,16 @@ jobs:
   # arm64 macOS build — builds Swift + Bun binaries in a single job,
   # creates DMG, notarizes, staples, and generates the Sparkle appcast.
   # This is the primary/default build.
+  #
+  # `needs:` gates on the three GCR service manifests. We intentionally do NOT
+  # list `push-dockerhub-image` here because this job runs in both staging
+  # and production, and `push-dockerhub-image` is prod-only (skipped in staging)
+  # — a skipped dep would cascade-skip this job in staging. The Docker Hub
+  # gate is applied downstream at the `release` job (GitHub Release), which
+  # is the sole publisher of the DMG produced here, and at `release-ios`
+  # for its sibling TestFlight publish.
   build-macos-arm64:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 45
     defaults:
@@ -1786,7 +1794,7 @@ jobs:
   # produces a separate DMG for Intel Macs.
   # Runs in parallel with build-macos-arm64 and does NOT block the release job.
   build-macos-x64:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 45
     continue-on-error: true
@@ -2484,8 +2492,12 @@ jobs:
         run: bun run test
         working-directory: credential-executor
 
+  # iOS build — produces .ipa for TestFlight upload via release-ios.
+  # As with the macOS builds, `needs:` gates on GCR manifests only because
+  # this job runs in staging too; the Docker Hub gate lives on `release-ios`
+  # (prod-only), which is the sole external publisher of this .ipa.
   build-ios:
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -2523,7 +2535,7 @@ jobs:
         run: ./build.sh test
 
   release-ios:
-    needs: [extract-version, build-ios]
+    needs: [extract-version, build-ios, push-dockerhub-image]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: macos-15
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2131,7 +2131,7 @@ jobs:
 
   release:
     needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, ci-playwright, build-chrome-extension]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos-arm64.result == 'success' && needs.ci-playwright.result == 'success' }}
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-meta.result == 'success' && needs.build-macos-arm64.result == 'success' && needs.ci-playwright.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.register-release.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1290,7 +1290,7 @@ jobs:
           echo "**Version:** \`${{ needs.extract-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   publish-npm:
-    needs: [extract-version, ci-cli, ci-gateway, ci-playwright]
+    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2363,9 +2363,10 @@ jobs:
           sleep 10
           gh pr merge "$PR_URL" --auto --squash
 
-  # ci-assistant runs for visibility in the Slack notification but does not
-  # block the release. It is deliberately excluded from publish-npm's needs
-  # so that a failure here never gates downstream jobs.
+  # ci-assistant runs lint/typecheck/test for the assistant service. It also
+  # transitively gates the release pipeline because push-assistant-image and
+  # push-dockerhub-image depend on it — a failure here blocks Docker image
+  # builds, which in turn blocks npm publish, the macOS DMG, and GitHub Release.
   ci-assistant:
     needs: extract-version
     runs-on: ubuntu-latest-8-cores


### PR DESCRIPTION
## Summary
Gates every release artifact job in `.github/workflows/release.yml` on the Docker image/manifest/dockerhub build chain, so a failed image build halts npm publishes, the macOS DMG, iOS TestFlight, the Chrome extension, the GitHub Release, platform bump, and staging CLI pack. The user's explicit goal: "none of the npm packages, macOS app, or anything else should be released if any of those [image/manifest] jobs fail."

## Self-review result
PASS (after remediation — 1 gap caught and fixed during review).

### What was gated (per-job)
- `release` (GitHub Release) — `if:` extended with explicit `result == 'success'` checks for all 3 GCR manifests, `push-dockerhub-image`, and `register-release`. Uses `always()` so explicit checks are the only way to gate.
- `publish-npm` / `publish-meta` / `update-platform` — `publish-npm` gained all 3 manifests + dockerhub in `needs:`; the other two inherit transitively.
- `build-macos-arm64` / `build-macos-x64` / `build-ios` — gained the 3 GCR manifests (no dockerhub; those jobs run in both staging and prod, and dockerhub is prod-only). Documentation comments added explaining the staging/prod asymmetry.
- `release-ios` (TestFlight) — gained `push-dockerhub-image` directly (prod-only, so safe to add; closes the TestFlight publish gap).
- `publish-chrome-extension` — gained all 3 manifests + dockerhub (prod-only).
- `pack-cli` / `trigger-platform-qa` — `pack-cli` gained the 3 GCR manifests (no dockerhub; staging-only); `trigger-platform-qa` inherits transitively.
- `register-release` — gained `push-dockerhub-image` in `needs:` and a new `if:` that allows staging to run (dockerhub is skipped there) but requires dockerhub success in prod.
- Comment above `ci-assistant:` updated to reflect the new transitive gating (the old comment claimed ci-assistant was deliberately excluded, which is no longer true).

## PRs merged into feature branch
- #26145: `ci(release): gate GitHub Release creation on image/manifest/dockerhub/register success`
- #26146: `ci(release): block npm publish and platform bump on Docker image failure`
- #26147: `ci(release): block staging CLI pack and platform-QA trigger on image failure`
- #26148: `ci(release): block macOS/iOS/Chrome extension publishes on Docker image failure`
- #26162: `ci(release): gate register-release on push-dockerhub-image in production` (self-review remediation)

## Out-of-scope / acknowledged non-gaps
- macOS dSYM upload to Sentry inside `build-macos-arm64`/`build-macos-x64` is not gated on dockerhub. Low severity (debug symbols, not user-visible) and would require restructuring the build jobs to fix. Flagged in review but not addressed.
- `release` does not check `build-chrome-extension.result` — pre-existing behavior, not introduced by this plan.

Part of plan: release-gate-on-images.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
