### PR TITLE
feat(clients): default to Claude Opus 4.7

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -55,7 +55,7 @@ final class ChatViewModelIOSTests: XCTestCase {
     }
 
     func testInitStartsWithDefaultModel() {
-        XCTAssertEqual(viewModel.selectedModel, "claude-opus-4-6")
+        XCTAssertEqual(viewModel.selectedModel, "claude-opus-4-7")
     }
 
     // MARK: - Send Message

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -27,7 +27,7 @@ struct APIKeyEntryStepView: View {
                 CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
                 CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
                 CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
+            ], defaultModel: "claude-opus-4-7", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
             ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
                 CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
                 CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -334,7 +334,7 @@ struct APIKeyStepView: View {
         if isAuthenticated {
             // Authenticated user: skip API key entry, advance to consent step
             state.selectedProvider = "anthropic"
-            state.selectedModel = "claude-opus-4-6"
+            state.selectedModel = "claude-opus-4-7"
             state.skippedAPIKeyEntry = true
             state.advance(by: 2)
         } else {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -86,7 +86,7 @@ final class OnboardingState {
     var sshUser: String = ""
     var sshPrivateKey: String = ""
     var customQRCodeImageData: Data = Data()
-    var selectedModel: String = "claude-opus-4-6"
+    var selectedModel: String = "claude-opus-4-7"
     var selectedProvider: String = "anthropic"
     /// When true, the onboarding flow was launched from the developer tab's
     /// "Hatch New Assistant" button. This prevents auto-completing when the user
@@ -228,7 +228,7 @@ final class OnboardingState {
         }
 
         selectedProvider = "anthropic"
-        selectedModel = "claude-opus-4-6"
+        selectedModel = "claude-opus-4-7"
 
         // Reset hosting selection and cloud credentials
         selectedHostingMode = .vellumCloud

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -260,7 +260,7 @@ struct InferenceServiceCard: View {
                 let isCurrentModelAnthropic = anthropicModels.contains { $0.id == draftModel }
                 if !isCurrentModelAnthropic {
                     let defaultModel = store.dynamicProviderDefaultModel("anthropic")
-                    draftModel = defaultModel.isEmpty ? "claude-opus-4-6" : defaultModel
+                    draftModel = defaultModel.isEmpty ? "claude-opus-4-7" : defaultModel
                 }
             } else if newMode == "your-own" {
                 let providerModels = store.dynamicProviderModels(draftProvider)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -47,7 +47,7 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Model Selection
 
-    @Published var selectedModel: String = "claude-opus-4-6"
+    @Published var selectedModel: String = "claude-opus-4-7"
     @Published var configuredProviders: Set<String> = ["ollama"]
     @Published var selectedImageGenModel: String = "gemini-3.1-flash-image-preview"
 

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -258,7 +258,7 @@ public final class ChatMessageManager {
     // MARK: - Model / provider
 
     /// The currently active model ID, updated via `model_info` messages.
-    public var selectedModel: String = "claude-opus-4-6"
+    public var selectedModel: String = "claude-opus-4-7"
     /// Set of provider keys with configured API keys, updated via `model_info` messages.
     public var configuredProviders: Set<String> = ["anthropic"]
     /// Full provider catalog from daemon, updated via `model_info` messages.
@@ -278,7 +278,7 @@ extension ProviderCatalogEntry {
             CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
             CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
             CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-        ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
+        ], defaultModel: "claude-opus-4-7", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
         ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
             CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
             CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),


### PR DESCRIPTION
## Summary
- Flip the default model from `claude-opus-4-6` to `claude-opus-4-7` across `SettingsStore`, onboarding flows, and the shared provider-catalog seed.
- Update the shared `ChatMessageManager` default (also affects iOS) and the iOS init-model test to match.

## Original prompt
make the default model in the vellum desktop app Claude Opus 4.7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
