### PR TITLE
fix(macos): unblock app update for Docker/Managed topologies

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -624,18 +624,17 @@ extension AppDelegate {
     }
 
     @objc public func checkForUpdates() {
-        // Docker/managed topologies: always navigate to Settings > General
-        // where the Software Update card lives and auto-loads releases.
-        // Sparkle is only relevant for local topology.
         let assistants = LockfileAssistant.loadAll()
         let connectedId = LockfileAssistant.loadActiveAssistantId()
         if let id = connectedId,
            let assistant = assistants.first(where: { $0.assistantId == id }),
            assistant.isDocker || assistant.isManaged {
             showSettingsTab("General")
+            // Also check for client app updates — Sparkle handles this independently
+            // of the service group update shown in Settings.
+            updateManager.checkForUpdates()
             return
         }
-        // Local topology: use Sparkle
         updateManager.checkForUpdates()
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -500,15 +500,15 @@ struct MainWindowView: View {
                 ) {
                     if updateManager.isDeferredUpdateReady {
                         updateManager.installDeferredUpdateIfAvailable()
-                    } else if updateManager.isUpdateAvailable {
-                        // App update available — show the native update dialog directly,
-                        // bypassing AppDelegate's topology routing which would redirect
-                        // Docker/managed users to Settings instead.
-                        updateManager.checkForUpdates()
                     } else if updateManager.isServiceGroupUpdateAvailable {
-                        // Service group update only — navigate to Settings
+                        // Service group update available (possibly with app update too)
+                        // — navigate to Settings where the upgrade flow also triggers
+                        // the app update dialog when the client is behind.
                         settingsStore.pendingSettingsTab = .general
                         windowState.selection = .panel(.settings)
+                    } else if updateManager.isUpdateAvailable {
+                        // App update only — show the native update dialog directly.
+                        updateManager.checkForUpdates()
                     }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -499,17 +499,16 @@ struct MainWindowView: View {
                             : "A new version is available")
                 ) {
                     if updateManager.isDeferredUpdateReady {
-                        // Trigger Sparkle's installer directly — it handles
-                        // termination and relaunch.  Calling NSApp.terminate
-                        // first creates a race where the installer starts
-                        // mid-teardown and can't coordinate the relaunch.
                         updateManager.installDeferredUpdateIfAvailable()
-                    } else if updateManager.isServiceGroupUpdateAvailable && !updateManager.isUpdateAvailable {
-                        // Service group update only — navigate to Settings where the upgrade controls live
+                    } else if updateManager.isUpdateAvailable {
+                        // App update available — show the native update dialog directly,
+                        // bypassing AppDelegate's topology routing which would redirect
+                        // Docker/managed users to Settings instead.
+                        updateManager.checkForUpdates()
+                    } else if updateManager.isServiceGroupUpdateAvailable {
+                        // Service group update only — navigate to Settings
                         settingsStore.pendingSettingsTab = .general
                         windowState.selection = .panel(.settings)
-                    } else {
-                        AppDelegate.shared?.checkForUpdates()
                     }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -183,9 +183,14 @@ struct AboutVellumView: View {
                     Text("Version \(version) available")
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.primaryBase)
-                    Button("Update in Settings") {
-                        AppDelegate.shared?.aboutWindow?.close()
-                        AppDelegate.shared?.showSettingsTab("General")
+                    Button(topology == .local ? "Update" : "Update in Settings") {
+                        if topology == .local {
+                            AppDelegate.shared?.updateManager.checkForUpdates()
+                            AppDelegate.shared?.aboutWindow?.close()
+                        } else {
+                            AppDelegate.shared?.aboutWindow?.close()
+                            AppDelegate.shared?.showSettingsTab("General")
+                        }
                     }
                     .buttonStyle(.plain)
                     .font(VFont.labelDefault)
@@ -273,20 +278,27 @@ struct AboutVellumView: View {
             isCheckingForUpdates = false
 
         case .docker, .managed:
-            // Docker/managed: check platform API and show result inline
             defer { isCheckingForUpdates = false }
 
+            // Check service group update
             await AppDelegate.shared?.updateManager.checkServiceGroupUpdate()
+            let sgAvailable = AppDelegate.shared?.updateManager.isServiceGroupUpdateAvailable == true
+            let sgVersion = AppDelegate.shared?.updateManager.serviceGroupUpdateVersion
 
-            if let updateManager = AppDelegate.shared?.updateManager {
-                if updateManager.isServiceGroupUpdateAvailable,
-                   let version = updateManager.serviceGroupUpdateVersion {
-                    updateCheckResult = .updateAvailable(version: version)
-                } else {
-                    updateCheckResult = .upToDate
-                }
+            // Also check for client app updates
+            let appUpdateAvailable: Bool
+            if let manager = AppDelegate.shared?.updateManager {
+                appUpdateAvailable = await manager.checkForUpdatesAsync()
             } else {
-                updateCheckResult = .error
+                appUpdateAvailable = false
+            }
+
+            if sgAvailable, let version = sgVersion {
+                updateCheckResult = .updateAvailable(version: version)
+            } else if appUpdateAvailable, let version = AppDelegate.shared?.updateManager.availableUpdateVersion {
+                updateCheckResult = .updateAvailable(version: version)
+            } else {
+                updateCheckResult = .upToDate
             }
 
         case .remote:

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -53,6 +53,19 @@ struct AboutVellumView: View {
         return sgParsed.coreEquals(appParsed)
     }
 
+    /// Label for the update action button.
+    /// Shows "Update in Settings" when there is a service group update to manage,
+    /// otherwise plain "Update" for Sparkle-only client app updates.
+    private var updateButtonLabel: String {
+        if topology == .local {
+            return "Update"
+        }
+        if AppDelegate.shared?.updateManager.isServiceGroupUpdateAvailable == true {
+            return "Update in Settings"
+        }
+        return "Update"
+    }
+
     var body: some View {
         VStack(spacing: VSpacing.lg) {
             // App Icon
@@ -183,13 +196,18 @@ struct AboutVellumView: View {
                     Text("Version \(version) available")
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.primaryBase)
-                    Button(topology == .local ? "Update" : "Update in Settings") {
+                    Button(updateButtonLabel) {
                         if topology == .local {
                             AppDelegate.shared?.updateManager.checkForUpdates()
                             AppDelegate.shared?.aboutWindow?.close()
-                        } else {
+                        } else if AppDelegate.shared?.updateManager.isServiceGroupUpdateAvailable == true {
+                            // Service group update — direct to Settings where the upgrade UI lives
                             AppDelegate.shared?.aboutWindow?.close()
                             AppDelegate.shared?.showSettingsTab("General")
+                        } else {
+                            // Client app update only — trigger Sparkle directly
+                            AppDelegate.shared?.updateManager.checkForUpdates()
+                            AppDelegate.shared?.aboutWindow?.close()
                         }
                     }
                     .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -59,10 +59,6 @@ struct AssistantUpgradeSection: View {
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
     @State private var backwardReleasesEnabled = false
-    /// Whether a Sparkle check was triggered as part of the coordinated upgrade flow.
-    @State private var sparkleCheckTriggered = false
-    /// Whether the triggered Sparkle check has actually finished resolving.
-    @State private var sparkleCheckCompleted = false
     private let featureFlagClient = FeatureFlagClient()
 
     private var latestRelease: AssistantRelease? {
@@ -317,7 +313,18 @@ struct AssistantUpgradeSection: View {
                         label: isLoadingReleases ? "Checking..." : "Check for Updates",
                         style: .outlined
                     ) {
-                        Task { await loadReleases() }
+                        Task {
+                            await loadReleases()
+                            // If the client app is behind the latest release,
+                            // also trigger the app update dialog.
+                            if let latest = latestRelease?.version,
+                               let clientVersion = appVersion,
+                               let latestParsed = VersionCompat.parse(latest),
+                               let clientParsed = VersionCompat.parse(clientVersion),
+                               latestParsed > clientParsed {
+                                AppDelegate.shared?.updateManager.checkForUpdates()
+                            }
+                        }
                     }
                     .disabled(isLoadingReleases || isUpgrading)
 
@@ -359,20 +366,6 @@ struct AssistantUpgradeSection: View {
                 Text(success)
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.systemPositiveStrong)
-            }
-
-            if sparkleCheckTriggered && sparkleCheckCompleted && successMessage != nil {
-                if updateManager.isUpdateAvailable {
-                    VInlineMessage(
-                        "An app update is available. Follow the Sparkle dialog to install it, or use Check for Updates in the menu bar.",
-                        tone: .info
-                    )
-                } else {
-                    VInlineMessage(
-                        "App update check complete. If the update dialog was dismissed, use Check for Updates in the menu bar to try again.",
-                        tone: .info
-                    )
-                }
             }
 
             if isServiceGroupUpdateInProgress && !isUpgrading && (topology == .managed || topology == .docker) {
@@ -529,11 +522,10 @@ struct AssistantUpgradeSection: View {
             successMessage = isRollback ? "Rollback complete." : "Upgrade complete."
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update…"
-                sparkleCheckTriggered = true
-                Task {
-                    _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
-                    sparkleCheckCompleted = true
-                }
+                // Trigger the interactive app update dialog so the user can
+                // install the client update. The dialog handles download,
+                // verification, and install/restart.
+                AppDelegate.shared?.updateManager.checkForUpdates()
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
@@ -573,15 +565,11 @@ struct AssistantUpgradeSection: View {
                 ? "Rollback initiated. The assistant may be briefly unavailable."
                 : "Upgrade initiated. The assistant may be briefly unavailable."
             if !isRollback && isAppBehindTarget {
-                successMessage! += " Checking for app update in the background…"
-                sparkleCheckTriggered = true
-                // Use background check (no modal) — the managed upgrade only means
-                // the platform accepted the request, not that the service group has
-                // restarted. A modal Sparkle dialog would be premature here.
-                Task {
-                    _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
-                    sparkleCheckCompleted = true
-                }
+                successMessage! += " Checking for app update…"
+                // Trigger the interactive app update dialog so the user can
+                // install the client update. The dialog handles download,
+                // verification, and install/restart.
+                AppDelegate.shared?.updateManager.checkForUpdates()
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
@@ -630,8 +618,6 @@ struct AssistantUpgradeSection: View {
         errorMessage = nil
         successMessage = nil
         showFeedbackOption = false
-        sparkleCheckTriggered = false
-        sparkleCheckCompleted = false
     }
 
     private func guidanceForError(_ error: VellumCli.CliError) -> String {


### PR DESCRIPTION
## Summary
- Fix all update paths (menu bar, title bar button, Settings, About window, post-upgrade) to trigger client app updates for Docker/Managed topologies
- Remove silent background update check in favor of interactive dialog after service group upgrade
- Remove Sparkle-referencing copy from user-facing info banners

Part of plan: fix-managed-app-update.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
