### PR TITLE
fix(macos): scope OAuth API paths for managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2279,7 +2279,7 @@ public final class SettingsStore: ObservableObject {
             do {
                 let (decoded, response): (OAuthProvidersListResponse?, _) =
                     try await GatewayHTTPClient.get(
-                        path: "oauth/providers",
+                        path: "assistants/{assistantId}/oauth/providers",
                         params: ["supports_managed_mode": "true"],
                         timeout: 10
                     )
@@ -2684,7 +2684,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let (decoded, response): (YourOwnOAuthAppsResponse?, _) = try await GatewayHTTPClient.get(
-                    path: "oauth/apps",
+                    path: "assistants/{assistantId}/oauth/apps",
                     params: ["provider_key": providerKey],
                     timeout: 10
                 )
@@ -2717,7 +2717,7 @@ public final class SettingsStore: ObservableObject {
     func fetchYourOwnOAuthConnections(appId: String) async {
         do {
             let (decoded, response): (YourOwnOAuthConnectionsResponse?, _) = try await GatewayHTTPClient.get(
-                path: "oauth/apps/\(appId)/connections",
+                path: "assistants/{assistantId}/oauth/apps/\(appId)/connections",
                 timeout: 10
             )
             if response.isSuccess, let decoded {
@@ -2738,7 +2738,7 @@ public final class SettingsStore: ObservableObject {
         let secretKey = "client" + "_secret"
         body[secretKey] = clientSecret
         do {
-            let response = try await GatewayHTTPClient.post(path: "oauth/apps", json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/oauth/apps", json: body, timeout: 10)
             if response.isSuccess {
                 self.fetchYourOwnOAuthApps(providerKey: providerKey)
             } else {
@@ -2760,7 +2760,7 @@ public final class SettingsStore: ObservableObject {
     func deleteYourOwnOAuthApp(id: String, providerKey: String) async {
         yourOwnOAuthError[providerKey] = nil
         do {
-            let response = try await GatewayHTTPClient.delete(path: "oauth/apps/\(id)", timeout: 10)
+            let response = try await GatewayHTTPClient.delete(path: "assistants/{assistantId}/oauth/apps/\(id)", timeout: 10)
             if response.isSuccess {
                 self.yourOwnOAuthApps[providerKey]?.removeAll { $0.id == id }
                 self.yourOwnOAuthConnectionsByApp.removeValue(forKey: id)
@@ -2784,7 +2784,7 @@ public final class SettingsStore: ObservableObject {
         let providerKey = yourOwnOAuthApps.first(where: { $0.value.contains(where: { $0.id == appId }) })?.key
         if let providerKey { yourOwnOAuthError[providerKey] = nil }
         do {
-            let response = try await GatewayHTTPClient.delete(path: "oauth/connections/\(id)", timeout: 10)
+            let response = try await GatewayHTTPClient.delete(path: "assistants/{assistantId}/oauth/connections/\(id)", timeout: 10)
             if response.isSuccess {
                 await self.fetchYourOwnOAuthConnections(appId: appId)
             } else {
@@ -2815,7 +2815,7 @@ public final class SettingsStore: ObservableObject {
         if let providerKey { yourOwnOAuthError[providerKey] = nil }
         Task {
             do {
-                let response = try await GatewayHTTPClient.post(path: "oauth/apps/\(appId)/connect", json: [:], timeout: 10)
+                let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/oauth/apps/\(appId)/connect", json: [:], timeout: 10)
                 guard response.isSuccess else {
                     let errorMsg: String
                     if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],


### PR DESCRIPTION
## Summary
- OAuth API paths in SettingsStore.swift were missing the standard `assistants/{assistantId}/` scope prefix that all other GatewayHTTPClient callers use
- This caused a 404 on managed (cloud) assistants where requests route through `platform.vellum.ai`, which requires the scoped path to proxy to the correct gateway
- Affected all 7 OAuth endpoints: provider listing, app CRUD, connection management, and OAuth connect flow

## Original prompt
Integrations tab on the production macOS client shows "No integrations available" because `fetchManagedOAuthProviders` hits `platform.vellum.ai/v1/oauth/providers/` (404) instead of the correctly scoped `platform.vellum.ai/v1/assistants/{id}/oauth/providers/`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
