### PR TITLE
feat(cli): disjoint port windows per environment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,21 +122,13 @@ All instances are created with explicit names via `vellum hatch --name <name>`.
 
 Each instance gets its own:
 - **`BASE_DATA_DIR`**: Set to `resources.instanceDir`. The daemon (and gateway) append `.vellum` to this to derive the root directory, so all runtime files land under the instance.
-- **Daemon port** (`RUNTIME_HTTP_PORT`): Allocated by scanning from base port 7821.
-- **Gateway port** (`GATEWAY_PORT`): Allocated by scanning from base port 7830.
-- **Qdrant port** (`QDRANT_HTTP_PORT`): Allocated by scanning from base port 6333.
+- **Daemon port** (`RUNTIME_HTTP_PORT`), **Gateway port** (`GATEWAY_PORT`), **Qdrant port** (`QDRANT_HTTP_PORT`): Allocated by scanning upward from the environment's base port — see "Port allocation" below.
 - **PID file**: `<instanceDir>/.vellum/vellum.pid`
 - **SQLite database, logs, memory indices**: All under `<instanceDir>/.vellum/workspace/data/`
 
 ### Port allocation
 
-Ports are allocated sequentially by `allocateLocalResources()` in `cli/src/lib/assistant-config.ts`:
-
-1. Scan from `DEFAULT_DAEMON_PORT` (7821) upward to find the first available port.
-2. Scan from `DEFAULT_GATEWAY_PORT` (7830) upward, excluding the daemon port.
-3. Scan from `DEFAULT_QDRANT_PORT` (6333) upward, excluding both previously allocated ports.
-
-Availability is checked via TCP connect probe. Each scan range spans up to 100 ports. Allocated ports are persisted in the lockfile `resources` field so `wake`/`sleep` can restart instances on the same ports.
+`allocateLocalResources()` in `cli/src/lib/assistant-config.ts` takes each service's base port from `getDefaultPorts(env)` and scans upward for the first port not bound by another local instance in that env's lockfile. Each environment has its own disjoint port window so running prod + non-prod assistants side by side doesn't collide; the concrete numbers live in `cli/src/lib/environments/seeds.ts`. Allocated ports are persisted in the lockfile `resources` field so `wake`/`sleep` restart instances on the same ports.
 
 ### Lockfile schema
 

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -159,6 +159,36 @@ describe("multi-local", () => {
       }
     });
 
+    test("allocation picks env-specific port bases for non-prod envs", async () => {
+      // Each non-prod env sits in its own 1000-port window (see
+      // environments/seeds.ts). Hatching under VELLUM_ENVIRONMENT=dev should
+      // produce ports in the dev block (18000+), not the production defaults.
+      const prevEnv = process.env.VELLUM_ENVIRONMENT;
+      const prevXdg = process.env.XDG_DATA_HOME;
+      const xdgDataHome = mkdtempSync(join(tmpdir(), "cli-multi-xdg-ports-"));
+      process.env.VELLUM_ENVIRONMENT = "dev";
+      process.env.XDG_DATA_HOME = xdgDataHome;
+      try {
+        const res = await allocateLocalResources("dev-a");
+        expect(res.daemonPort).toBe(18000);
+        expect(res.gatewayPort).toBe(18100);
+        expect(res.qdrantPort).toBe(18200);
+        expect(res.cesPort).toBe(18300);
+      } finally {
+        if (prevEnv !== undefined) {
+          process.env.VELLUM_ENVIRONMENT = prevEnv;
+        } else {
+          delete process.env.VELLUM_ENVIRONMENT;
+        }
+        if (prevXdg !== undefined) {
+          process.env.XDG_DATA_HOME = prevXdg;
+        } else {
+          delete process.env.XDG_DATA_HOME;
+        }
+        rmSync(xdgDataHome, { recursive: true, force: true });
+      }
+    });
+
     test("second instance gets distinct ports and dir when first instance is saved", async () => {
       // GIVEN a first local assistant already exists in the lockfile
       saveAssistantEntry(makeEntry("instance-a"));

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -10,14 +10,9 @@ import {
 import { homedir } from "os";
 import { dirname, join } from "path";
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./constants.js";
 import {
-  DAEMON_INTERNAL_ASSISTANT_ID,
-  DEFAULT_CES_PORT,
-  DEFAULT_DAEMON_PORT,
-  DEFAULT_GATEWAY_PORT,
-  DEFAULT_QDRANT_PORT,
-} from "./constants.js";
-import {
+  getDefaultPorts,
   getLockfilePath,
   getLockfilePaths,
   getMultiInstanceDir,
@@ -187,6 +182,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
   }
 
   const env = getCurrentEnvironment();
+  const defaultPorts = getDefaultPorts(env);
   let mutated = false;
 
   // Migrate top-level `baseDataDir` → `resources.instanceDir`
@@ -206,7 +202,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
   // Synthesise missing `resources` for local entries
   if (!raw.resources || typeof raw.resources !== "object") {
     const gatewayPort =
-      parsePortFromUrl(raw.runtimeUrl) ?? DEFAULT_GATEWAY_PORT;
+      parsePortFromUrl(raw.runtimeUrl) ?? defaultPorts.gateway;
     const instanceDir = join(
       getMultiInstanceDir(env),
       typeof raw.assistantId === "string"
@@ -215,10 +211,10 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     );
     raw.resources = {
       instanceDir,
-      daemonPort: DEFAULT_DAEMON_PORT,
+      daemonPort: defaultPorts.daemon,
       gatewayPort,
-      qdrantPort: DEFAULT_QDRANT_PORT,
-      cesPort: DEFAULT_CES_PORT,
+      qdrantPort: defaultPorts.qdrant,
+      cesPort: defaultPorts.ces,
       pidFile: join(instanceDir, ".vellum", "vellum.pid"),
     };
     mutated = true;
@@ -235,20 +231,20 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
       mutated = true;
     }
     if (typeof res.daemonPort !== "number") {
-      res.daemonPort = DEFAULT_DAEMON_PORT;
+      res.daemonPort = defaultPorts.daemon;
       mutated = true;
     }
     if (typeof res.gatewayPort !== "number") {
       res.gatewayPort =
-        parsePortFromUrl(raw.runtimeUrl) ?? DEFAULT_GATEWAY_PORT;
+        parsePortFromUrl(raw.runtimeUrl) ?? defaultPorts.gateway;
       mutated = true;
     }
     if (typeof res.qdrantPort !== "number") {
-      res.qdrantPort = DEFAULT_QDRANT_PORT;
+      res.qdrantPort = defaultPorts.qdrant;
       mutated = true;
     }
     if (typeof res.cesPort !== "number") {
-      res.cesPort = DEFAULT_CES_PORT;
+      res.cesPort = defaultPorts.ces;
       mutated = true;
     }
     if (typeof res.pidFile !== "string") {
@@ -451,20 +447,21 @@ export async function allocateLocalResources(
     );
   }
 
-  const daemonPort = await findAvailablePort(
-    DEFAULT_DAEMON_PORT,
-    reservedPorts,
-  );
-  const gatewayPort = await findAvailablePort(DEFAULT_GATEWAY_PORT, [
+  // Env-aware bases: non-prod envs sit in their own 1000-port window so
+  // running prod and staging assistants side-by-side doesn't collide. See
+  // `environments/seeds.ts:portBlock` for the layout.
+  const basePorts = getDefaultPorts(env);
+  const daemonPort = await findAvailablePort(basePorts.daemon, reservedPorts);
+  const gatewayPort = await findAvailablePort(basePorts.gateway, [
     ...reservedPorts,
     daemonPort,
   ]);
-  const qdrantPort = await findAvailablePort(DEFAULT_QDRANT_PORT, [
+  const qdrantPort = await findAvailablePort(basePorts.qdrant, [
     ...reservedPorts,
     daemonPort,
     gatewayPort,
   ]);
-  const cesPort = await findAvailablePort(DEFAULT_CES_PORT, [
+  const cesPort = await findAvailablePort(basePorts.ces, [
     ...reservedPorts,
     daemonPort,
     gatewayPort,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -13,9 +13,10 @@ import {
 } from "./assistant-config";
 import type { AssistantEntry } from "./assistant-config";
 import { writeInitialConfig } from "./config-utils";
-import { DEFAULT_GATEWAY_PORT } from "./constants";
 import { PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
 import type { Species } from "./constants";
+import { getDefaultPorts } from "./environments/paths.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
 import { leaseGuardianToken } from "./guardian-token";
 import { isVellumProcess, stopProcess } from "./process";
 import { generateInstanceName } from "./random-name";
@@ -1074,7 +1075,7 @@ export async function hatchDocker(
     await ensureDockerInstalled();
 
     const instanceName = generateInstanceName(species, name);
-    const gatewayPort = DEFAULT_GATEWAY_PORT;
+    const gatewayPort = getDefaultPorts(getCurrentEnvironment()).gateway;
 
     const imageTags: Record<ServiceName, string> = {
       assistant: "",

--- a/cli/src/lib/environments/__tests__/paths.test.ts
+++ b/cli/src/lib/environments/__tests__/paths.test.ts
@@ -200,16 +200,10 @@ describe("path helpers", () => {
       expect(ports.tcp).toBe(8765);
     });
 
-    test("returns identical defaults for dev (Phase 5 deferred)", () => {
+    test("returns base defaults for a bare env with no portsOverride", () => {
+      // Bare env literal (no portsOverride) falls through to DEFAULT_PORTS.
+      // Real non-prod seeds populate portsOverride — see seeds.test cases.
       expect(getDefaultPorts(dev)).toEqual(getDefaultPorts(prod));
-    });
-
-    test("returns identical defaults for staging", () => {
-      const staging: EnvironmentDefinition = {
-        name: "staging",
-        platformUrl: "https://staging-platform.vellum.ai",
-      };
-      expect(getDefaultPorts(staging)).toEqual(getDefaultPorts(prod));
     });
 
     test("merges env.portsOverride on top of defaults", () => {

--- a/cli/src/lib/environments/__tests__/seeds.test.ts
+++ b/cli/src/lib/environments/__tests__/seeds.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import { getDefaultPorts } from "../paths.js";
+import { SEEDS } from "../seeds.js";
+
+describe("SEEDS port blocks", () => {
+  test("production uses the legacy (pre-MVP) port layout", () => {
+    const ports = getDefaultPorts(SEEDS.production!);
+    expect(ports).toEqual({
+      daemon: 7821,
+      gateway: 7830,
+      qdrant: 6333,
+      ces: 8090,
+      outboundProxy: 8080,
+      tcp: 8765,
+    });
+  });
+
+  test.each([
+    ["staging", 17000],
+    ["dev", 18000],
+    ["test", 19000],
+    ["local", 20000],
+  ] as const)("%s block starts at %i with 100-apart services", (name, base) => {
+    const ports = getDefaultPorts(SEEDS[name]!);
+    expect(ports).toEqual({
+      daemon: base,
+      gateway: base + 100,
+      qdrant: base + 200,
+      ces: base + 300,
+      outboundProxy: base + 400,
+      tcp: base + 500,
+    });
+  });
+
+  test("non-prod blocks are disjoint across environments", () => {
+    // 100 instances per service is the scan headroom in findAvailablePort,
+    // so a block "occupies" base…base+599 from daemon through tcp. Verify no
+    // two blocks overlap for any service.
+    const blocks = (["staging", "dev", "test", "local"] as const).map(
+      (name) => ({
+        name,
+        ports: getDefaultPorts(SEEDS[name]!),
+      }),
+    );
+    const allPorts = new Set<number>();
+    for (const { name, ports } of blocks) {
+      for (const port of Object.values(ports)) {
+        // Within each block, each service has 100 slots (base…base+99).
+        for (let offset = 0; offset < 100; offset++) {
+          const p = port + offset;
+          if (allPorts.has(p)) {
+            throw new Error(
+              `port ${p} (in ${name}'s block) overlaps another env's block`,
+            );
+          }
+          allPorts.add(p);
+        }
+      }
+    }
+  });
+
+  test("non-prod blocks sit below Linux's default ephemeral range (32768)", () => {
+    for (const name of ["staging", "dev", "test", "local"] as const) {
+      const ports = getDefaultPorts(SEEDS[name]!);
+      for (const port of Object.values(ports)) {
+        // Max port we'll ever scan to is base+99 for daemon/gateway/etc.
+        expect(port + 99).toBeLessThan(32768);
+      }
+    }
+  });
+});

--- a/cli/src/lib/environments/paths.ts
+++ b/cli/src/lib/environments/paths.ts
@@ -86,11 +86,10 @@ export function getMultiInstanceDir(env: EnvironmentDefinition): string {
 }
 
 /**
- * Default port set for an environment. Phase 5 (per-env port offsets) was
- * deferred from MVP — this currently returns the same ports for every
- * environment. Per-env specialization lands in a later phase without
- * changing the function signature or call sites. `env.portsOverride` is
- * merged on top of the defaults when set.
+ * Default port set for an environment.
+ * Seed entries for non-prod environments come with separate port ranges
+ * to avoid collisions in multi-env / multi-instance setups.
+ * Longer term, consider allocating ports dynamically at hatch/wake time.
  */
 export function getDefaultPorts(env: EnvironmentDefinition): PortMap {
   return {

--- a/cli/src/lib/environments/seeds.ts
+++ b/cli/src/lib/environments/seeds.ts
@@ -1,4 +1,28 @@
-import type { EnvironmentDefinition } from "./types.js";
+import type { EnvironmentDefinition, PortMap } from "./types.js";
+
+/**
+ * Non-prod port blocks. Each environment gets a 1000-port window in the
+ * 17000–21000 band. Within a block, services are spaced 100 apart so up to
+ * 100 assistants can coexist without the scan (`findAvailablePort`) running
+ * one service's range into the next. Band chosen to sit below Linux's
+ * default ephemeral start (32768) and macOS's (49152), and away from the
+ * 3000/5000/8000/9000 dev-tool swamp. Production keeps its legacy,
+ * non-contiguous port set (7821/7830/6333/8090/8080/8765): cross-env
+ * collision is the only problem this change targets, prod is unaffected
+ * because only one env's assistants compete on a given machine, and
+ * churning it would leave existing hatches on 7821 while new ones
+ * allocated elsewhere.
+ */
+function portBlock(base: number): PortMap {
+  return {
+    daemon: base,
+    gateway: base + 100,
+    qdrant: base + 200,
+    ces: base + 300,
+    outboundProxy: base + 400,
+    tcp: base + 500,
+  };
+}
 
 /**
  * Built-in environment definitions. Mirrors Swift's
@@ -25,16 +49,19 @@ export const SEEDS: Record<string, EnvironmentDefinition> = {
   staging: {
     name: "staging",
     platformUrl: "https://staging-platform.vellum.ai",
+    portsOverride: portBlock(17000),
   },
   test: {
     name: "test",
     // Non-functional URL — used only by unit tests for URL resolution, never
     // hit in production.
     platformUrl: "https://test-platform.vellum.ai",
+    portsOverride: portBlock(19000),
   },
   dev: {
     name: "dev",
     platformUrl: "https://dev-platform.vellum.ai",
+    portsOverride: portBlock(18000),
   },
   local: {
     name: "local",
@@ -42,5 +69,6 @@ export const SEEDS: Record<string, EnvironmentDefinition> = {
     // assistantPlatformUrl: "http://host.docker.internal:8000",
     // ^ uncomment this once dockerized hatch path is live.
     // The assistant runs in a different network namespace than the host.
+    portsOverride: portBlock(20000),
   },
 };


### PR DESCRIPTION
## Summary

- Prevents cross-env port collisions when running assistants bare metal. Each non-prod env (staging/dev/test/local) now allocates from its own 1000-port window in the 17000–21000 band via `getDefaultPorts(env)`.
- Production keeps its legacy, non-contiguous port set (7821/7830/6333/8090/8080/8765) — cross-env is the only problem this targets, and churning prod would pointlessly split old and new hatches.
- Band chosen to sit below Linux's default ephemeral start (32768) and away from the 3000/5000/8000/9000 dev-tool swamp; concrete numbers live in `cli/src/lib/environments/seeds.ts:portBlock`.

## Thoughts
Longer term, it might be worth dynamically allocate ports at hatch/wake time. Ports in lockfiles could only be considered as reserved for actively running assistants. I did a brief audit, and it this *should* be safe since ports are only tracked client side and not in assistant data.

Still feels bad to allocate port ranges for specific environments (especially if we need to make these more configurable later). There's always a chance for conflict with other services when using these hardcoded ranges

## Test plan

- [x] `bun test` — 241 pass / 0 fail (1 pre-existing unrelated error from a locally-running gateway on 7830)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] New `environments/__tests__/seeds.test.ts` pins per-env block layout, disjointness, and that blocks stay below 32768
- [x] New `multi-local.test.ts` case: hatching under `VELLUM_ENVIRONMENT=dev` produces 18000-range ports
- [ ] Manual: hatch under `VELLUM_ENVIRONMENT=dev` with a prod assistant already running; confirm no port conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
