### PR TITLE
fix(skills): use bash instead of host_bash for mcp-setup

### DIFF
--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -12,7 +12,7 @@ Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion)
 
 ## CLI Commands
 
-All commands use `assistant mcp`. Run them via `host_bash`.
+All commands use `assistant mcp`. Run them via the `bash` tool — the `assistant` CLI runs fine in the sandbox and does not need host access.
 
 ### List servers
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -12,7 +12,7 @@ Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion)
 
 ## CLI Commands
 
-All commands use `assistant mcp`. Run them via the `bash` tool — the `assistant` CLI runs fine in the sandbox and does not need host access.
+All commands use `assistant mcp`. Run `list`, `add`, and `remove` via the `bash` tool — they just read/write config and don't need host access. Run `auth` via `host_bash` because it binds a localhost OAuth callback server that the user's host browser must redirect back to.
 
 ### List servers
 


### PR DESCRIPTION
## Summary
- The mcp-setup skill told callers to run `assistant mcp` commands via `host_bash`, which unnecessarily required host-machine access
- The `assistant` CLI runs fine in the sandbox (it communicates with the running daemon over IPC), so the regular `bash` tool is sufficient
- Matches the pattern already used by sibling skills like `vellum-sounds` and `vellum-avatar` that explicitly opt out of `host_bash`

## Original prompt
fix this please i dont think host_bash should be required for using MCP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
