### PR TITLE
Revert failed assistant flag writes and forward gateway security env

### DIFF
--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -33,6 +33,7 @@ export const SAFE_ENV_VARS = [
   "VELLUM_WORKSPACE_DIR",
   "CES_BOOTSTRAP_SOCKET_DIR",
   "GATEWAY_INTERNAL_URL",
+  "GATEWAY_SECURITY_DIR",
   "VELLUM_PLATFORM_URL",
   "VELLUM_ASSISTANT_PLATFORM_URL",
   "VELLUM_DOCS_BASE_URL",
@@ -82,8 +83,7 @@ export function buildSanitizedEnv(): Record<string, string> {
   // Ensure UTF-8 locale so multi-byte characters (em dashes, curly quotes,
   // arrows, etc.) survive piping through tools like pbcopy without corruption.
   // macOS (Darwin) does not provide C.UTF-8, so use en_US.UTF-8 there.
-  const utf8Locale =
-    process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8";
+  const utf8Locale = process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8";
   if (!env.LANG) env.LANG = utf8Locale;
   if (!env.LC_ALL) env.LC_ALL = utf8Locale;
   return env;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1059,6 +1059,7 @@ struct SettingsDeveloperTab: View {
             set: { newValue in
                 switch flag.scope {
                 case .assistant:
+                    let previousValue = assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
                     if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
                         assistantFlags[index] = AssistantFeatureFlag(
                             key: flag.key,
@@ -1078,12 +1079,26 @@ struct SettingsDeveloperTab: View {
                         do {
                             try await featureFlagClient.setFeatureFlag(key: flag.key, enabled: newValue)
                         } catch {
-                            // Best-effort: the local cache already has the override for
-                            // optimistic UI. The gateway PATCH may fail for managed
-                            // assistants where the platform doesn't support the write
-                            // endpoint. Log but don't revert.
+                            await MainActor.run {
+                                guard let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) else { return }
+                                // Avoid clobbering a newer user toggle while this request was in flight.
+                                guard assistantFlags[index].enabled == newValue else { return }
+                                assistantFlags[index] = AssistantFeatureFlag(
+                                    key: flag.key,
+                                    enabled: previousValue,
+                                    defaultEnabled: flag.defaultEnabled,
+                                    description: flag.description.isEmpty ? nil : flag.description,
+                                    label: flag.label
+                                )
+                                NotificationCenter.default.post(
+                                    name: .assistantFeatureFlagDidChange,
+                                    object: nil,
+                                    userInfo: ["key": flag.key, "enabled": previousValue]
+                                )
+                                AssistantFeatureFlagResolver.mergeCachedFlag(key: flag.key, enabled: previousValue)
+                            }
                             os.Logger(subsystem: Bundle.appBundleIdentifier, category: "FeatureFlags")
-                                .warning("Failed to sync feature flag '\(flag.key)' to gateway: \(error.localizedDescription)")
+                                .warning("Failed to sync feature flag '\(flag.key)' to gateway; reverted local toggle: \(error.localizedDescription)")
                         }
                     }
                 case .macos:


### PR DESCRIPTION
## Summary
- Revert optimistic assistant feature-flag toggles in macOS Developer Settings when the write request fails, while guarding against stale rollbacks if the user toggled again.
- Keep local notification/cache state in sync during rollback so UI and resolver behavior match the persisted value.
- Add `GATEWAY_SECURITY_DIR` to the sanitized child-process env allowlist so CLI fallback reads gateway security files from the correct containerized path. Apple refs checked (2026-04-17): SwiftUI main-actor UI mutation guidance and structured concurrency task handoff guidance.

## Original prompt
Yeah can you [$do](/Users/noaflaherty/Repos/vellum-ai/claude-skills/skills/do/SKILL.md) any of the fixes that you deem to be relevant?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
