### PR TITLE
feat: delegate shell output compression to rtk binary

### DIFF
--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  __setRtkAvailableForTest,
+  rewriteForRtk,
+} from "../tools/shared/rtk-rewrite.js";
+
+describe("rewriteForRtk", () => {
+  beforeEach(() => {
+    __setRtkAvailableForTest(true);
+  });
+
+  afterEach(() => {
+    __setRtkAvailableForTest(null);
+  });
+
+  describe("supported commands", () => {
+    test("rewrites bare git status", () => {
+      expect(rewriteForRtk("git status")).toBe("rtk git status");
+    });
+
+    test("rewrites pytest with flags", () => {
+      expect(rewriteForRtk("pytest -v --tb=short")).toBe(
+        "rtk pytest -v --tb=short",
+      );
+    });
+
+    test("rewrites ls with flags", () => {
+      expect(rewriteForRtk("ls -la")).toBe("rtk ls -la");
+    });
+
+    test("rewrites tsc --noEmit", () => {
+      expect(rewriteForRtk("tsc --noEmit")).toBe("rtk tsc --noEmit");
+    });
+
+    test("rewrites cargo test", () => {
+      expect(rewriteForRtk("cargo test --release")).toBe(
+        "rtk cargo test --release",
+      );
+    });
+  });
+
+  describe("prefix preservation", () => {
+    test("preserves cd && chain", () => {
+      expect(rewriteForRtk("cd /tmp && pytest -v")).toBe(
+        "cd /tmp && rtk pytest -v",
+      );
+    });
+
+    test("preserves env-var assignment", () => {
+      expect(rewriteForRtk("FOO=bar pytest")).toBe("FOO=bar rtk pytest");
+    });
+
+    test("preserves sudo", () => {
+      expect(rewriteForRtk("sudo docker ps")).toBe("sudo rtk docker ps");
+    });
+
+    test("preserves stacked prefixes", () => {
+      expect(rewriteForRtk("cd /x && FOO=bar sudo git log")).toBe(
+        "cd /x && FOO=bar sudo rtk git log",
+      );
+    });
+  });
+
+  describe("pipes", () => {
+    test("rewrites head of a pipeline, leaves tail intact", () => {
+      expect(rewriteForRtk("git status | less")).toBe("rtk git status | less");
+    });
+
+    test("leaves pipelines whose head isn't rtk-eligible", () => {
+      expect(rewriteForRtk("cat foo.txt | grep bar")).toBe(
+        "cat foo.txt | grep bar",
+      );
+    });
+  });
+
+  describe("non-rewritten cases", () => {
+    test("passes through unknown head commands", () => {
+      expect(rewriteForRtk("cat file.log")).toBe("cat file.log");
+      expect(rewriteForRtk("bash -c 'echo hi'")).toBe("bash -c 'echo hi'");
+    });
+
+    test("does not match executable names inside arguments", () => {
+      // `cat tsc.log` head is `cat`, not `tsc`.
+      expect(rewriteForRtk("cat tsc.log")).toBe("cat tsc.log");
+      // `echo "git status"` head is `echo`; the quoted content must not
+      // trigger a rewrite.
+      expect(rewriteForRtk('echo "git status"')).toBe('echo "git status"');
+    });
+
+    test("does not match against empty / whitespace-only input", () => {
+      expect(rewriteForRtk("")).toBe("");
+      expect(rewriteForRtk("   ")).toBe("   ");
+    });
+
+    test("does not rewrite when only prefixes are present", () => {
+      expect(rewriteForRtk("cd /tmp && ")).toBe("cd /tmp && ");
+    });
+  });
+
+  describe("rtk-availability fallback", () => {
+    test("passes through when rtk is not on PATH", () => {
+      __setRtkAvailableForTest(false);
+      expect(rewriteForRtk("git status")).toBe("git status");
+      expect(rewriteForRtk("pytest -v")).toBe("pytest -v");
+    });
+  });
+});

--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -5,6 +5,11 @@ import {
   rewriteForRtk,
 } from "../tools/shared/rtk-rewrite.js";
 
+// Most tests force availability via __setRtkAvailableForTest, so the
+// PATH value is irrelevant — pass a stub string consistently.
+const PATH_STUB = "/usr/bin:/bin";
+const rewrite = (cmd: string): string => rewriteForRtk(cmd, PATH_STUB);
+
 describe("rewriteForRtk", () => {
   beforeEach(() => {
     __setRtkAvailableForTest(true);
@@ -16,43 +21,37 @@ describe("rewriteForRtk", () => {
 
   describe("supported commands", () => {
     test("rewrites bare git status", () => {
-      expect(rewriteForRtk("git status")).toBe("rtk git status");
+      expect(rewrite("git status")).toBe("rtk git status");
     });
 
     test("rewrites pytest with flags", () => {
-      expect(rewriteForRtk("pytest -v --tb=short")).toBe(
-        "rtk pytest -v --tb=short",
-      );
+      expect(rewrite("pytest -v --tb=short")).toBe("rtk pytest -v --tb=short");
     });
 
     test("rewrites ls with flags", () => {
-      expect(rewriteForRtk("ls -la")).toBe("rtk ls -la");
+      expect(rewrite("ls -la")).toBe("rtk ls -la");
     });
 
     test("rewrites tsc --noEmit", () => {
-      expect(rewriteForRtk("tsc --noEmit")).toBe("rtk tsc --noEmit");
+      expect(rewrite("tsc --noEmit")).toBe("rtk tsc --noEmit");
     });
 
     test("rewrites cargo test", () => {
-      expect(rewriteForRtk("cargo test --release")).toBe(
-        "rtk cargo test --release",
-      );
+      expect(rewrite("cargo test --release")).toBe("rtk cargo test --release");
     });
   });
 
   describe("prefix preservation", () => {
     test("preserves cd && chain", () => {
-      expect(rewriteForRtk("cd /tmp && pytest -v")).toBe(
-        "cd /tmp && rtk pytest -v",
-      );
+      expect(rewrite("cd /tmp && pytest -v")).toBe("cd /tmp && rtk pytest -v");
     });
 
     test("preserves env-var assignment", () => {
-      expect(rewriteForRtk("FOO=bar pytest")).toBe("FOO=bar rtk pytest");
+      expect(rewrite("FOO=bar pytest")).toBe("FOO=bar rtk pytest");
     });
 
     test("preserves stacked prefixes without sudo", () => {
-      expect(rewriteForRtk("cd /x && FOO=bar git log")).toBe(
+      expect(rewrite("cd /x && FOO=bar git log")).toBe(
         "cd /x && FOO=bar rtk git log",
       );
     });
@@ -60,45 +59,43 @@ describe("rewriteForRtk", () => {
 
   describe("pipes", () => {
     test("rewrites head of a pipeline, leaves tail intact", () => {
-      expect(rewriteForRtk("git status | less")).toBe("rtk git status | less");
+      expect(rewrite("git status | less")).toBe("rtk git status | less");
     });
 
     test("leaves pipelines whose head isn't rtk-eligible", () => {
-      expect(rewriteForRtk("cat foo.txt | grep bar")).toBe(
-        "cat foo.txt | grep bar",
-      );
+      expect(rewrite("cat foo.txt | grep bar")).toBe("cat foo.txt | grep bar");
     });
   });
 
   describe("non-rewritten cases", () => {
     test("passes through unknown head commands", () => {
-      expect(rewriteForRtk("cat file.log")).toBe("cat file.log");
-      expect(rewriteForRtk("bash -c 'echo hi'")).toBe("bash -c 'echo hi'");
+      expect(rewrite("cat file.log")).toBe("cat file.log");
+      expect(rewrite("bash -c 'echo hi'")).toBe("bash -c 'echo hi'");
     });
 
     test("does not match executable names inside arguments", () => {
       // `cat tsc.log` head is `cat`, not `tsc`.
-      expect(rewriteForRtk("cat tsc.log")).toBe("cat tsc.log");
+      expect(rewrite("cat tsc.log")).toBe("cat tsc.log");
       // `echo "git status"` head is `echo`; the quoted content must not
       // trigger a rewrite.
-      expect(rewriteForRtk('echo "git status"')).toBe('echo "git status"');
+      expect(rewrite('echo "git status"')).toBe('echo "git status"');
     });
 
     test("does not rewrite bash builtins (test, read)", () => {
       // `test` and `read` are shell builtins — rewriting to
       // `rtk test -f foo` would dispatch to rtk's test-runner
       // subcommand and misinterpret the flags.
-      expect(rewriteForRtk("test -f /tmp/foo")).toBe("test -f /tmp/foo");
-      expect(rewriteForRtk("read var")).toBe("read var");
+      expect(rewrite("test -f /tmp/foo")).toBe("test -f /tmp/foo");
+      expect(rewrite("read var")).toBe("read var");
     });
 
     test("does not match against empty / whitespace-only input", () => {
-      expect(rewriteForRtk("")).toBe("");
-      expect(rewriteForRtk("   ")).toBe("   ");
+      expect(rewrite("")).toBe("");
+      expect(rewrite("   ")).toBe("   ");
     });
 
     test("does not rewrite when only prefixes are present", () => {
-      expect(rewriteForRtk("cd /tmp && ")).toBe("cd /tmp && ");
+      expect(rewrite("cd /tmp && ")).toBe("cd /tmp && ");
     });
   });
 
@@ -106,10 +103,10 @@ describe("rewriteForRtk", () => {
     test("skips rewrite when command scopes PATH in the prefix", () => {
       // We can't know whether rtk is reachable via the overridden PATH,
       // so leaving the command alone is safer than injecting `rtk`.
-      expect(rewriteForRtk("PATH=/usr/bin git status")).toBe(
+      expect(rewrite("PATH=/usr/bin git status")).toBe(
         "PATH=/usr/bin git status",
       );
-      expect(rewriteForRtk("cd /tmp && PATH=/opt/bin pytest -v")).toBe(
+      expect(rewrite("cd /tmp && PATH=/opt/bin pytest -v")).toBe(
         "cd /tmp && PATH=/opt/bin pytest -v",
       );
     });
@@ -118,22 +115,33 @@ describe("rewriteForRtk", () => {
       // sudo uses `secure_path`, which typically omits user-level bins
       // where rtk may live — injecting rtk would turn a working
       // privileged command into `rtk: command not found`.
-      expect(rewriteForRtk("sudo docker ps")).toBe("sudo docker ps");
-      expect(rewriteForRtk("cd /x && FOO=bar sudo git log")).toBe(
+      expect(rewrite("sudo docker ps")).toBe("sudo docker ps");
+      expect(rewrite("cd /x && FOO=bar sudo git log")).toBe(
         "cd /x && FOO=bar sudo git log",
       );
     });
 
     test("still rewrites when a non-PATH env var is scoped", () => {
-      expect(rewriteForRtk("CI=1 pytest -v")).toBe("CI=1 rtk pytest -v");
+      expect(rewrite("CI=1 pytest -v")).toBe("CI=1 rtk pytest -v");
     });
   });
 
   describe("rtk-availability fallback", () => {
     test("passes through when rtk is not on PATH", () => {
       __setRtkAvailableForTest(false);
-      expect(rewriteForRtk("git status")).toBe("git status");
-      expect(rewriteForRtk("pytest -v")).toBe("pytest -v");
+      expect(rewrite("git status")).toBe("git status");
+      expect(rewrite("pytest -v")).toBe("pytest -v");
+    });
+
+    test("probes the caller-supplied PATH, not process.env.PATH", () => {
+      // Clear test override so the real probe runs against the
+      // PATH we pass in. An empty PATH must fail the probe even if
+      // process.env.PATH on the test machine has rtk.
+      __setRtkAvailableForTest(null);
+      expect(rewriteForRtk("git status", "")).toBe("git status");
+      expect(rewriteForRtk("git status", "/nonexistent-path-xyz")).toBe(
+        "git status",
+      );
     });
   });
 });

--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -51,13 +51,9 @@ describe("rewriteForRtk", () => {
       expect(rewriteForRtk("FOO=bar pytest")).toBe("FOO=bar rtk pytest");
     });
 
-    test("preserves sudo", () => {
-      expect(rewriteForRtk("sudo docker ps")).toBe("sudo rtk docker ps");
-    });
-
-    test("preserves stacked prefixes", () => {
-      expect(rewriteForRtk("cd /x && FOO=bar sudo git log")).toBe(
-        "cd /x && FOO=bar sudo rtk git log",
+    test("preserves stacked prefixes without sudo", () => {
+      expect(rewriteForRtk("cd /x && FOO=bar git log")).toBe(
+        "cd /x && FOO=bar rtk git log",
       );
     });
   });
@@ -98,7 +94,7 @@ describe("rewriteForRtk", () => {
     });
   });
 
-  describe("PATH override guard", () => {
+  describe("PATH-visibility guard", () => {
     test("skips rewrite when command scopes PATH in the prefix", () => {
       // We can't know whether rtk is reachable via the overridden PATH,
       // so leaving the command alone is safer than injecting `rtk`.
@@ -107,6 +103,16 @@ describe("rewriteForRtk", () => {
       );
       expect(rewriteForRtk("cd /tmp && PATH=/opt/bin pytest -v")).toBe(
         "cd /tmp && PATH=/opt/bin pytest -v",
+      );
+    });
+
+    test("skips rewrite when the command runs under sudo", () => {
+      // sudo uses `secure_path`, which typically omits user-level bins
+      // where rtk may live — injecting rtk would turn a working
+      // privileged command into `rtk: command not found`.
+      expect(rewriteForRtk("sudo docker ps")).toBe("sudo docker ps");
+      expect(rewriteForRtk("cd /x && FOO=bar sudo git log")).toBe(
+        "cd /x && FOO=bar sudo git log",
       );
     });
 

--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -55,6 +55,18 @@ describe("rewriteForRtk", () => {
         "cd /x && FOO=bar rtk git log",
       );
     });
+
+    test("handles cd with a double-quoted path containing spaces", () => {
+      expect(rewrite('cd "/path with spaces" && git status')).toBe(
+        'cd "/path with spaces" && rtk git status',
+      );
+    });
+
+    test("handles cd with a single-quoted path containing spaces", () => {
+      expect(rewrite("cd '/my dir' && pytest -v")).toBe(
+        "cd '/my dir' && rtk pytest -v",
+      );
+    });
   });
 
   describe("pipes", () => {
@@ -64,6 +76,22 @@ describe("rewriteForRtk", () => {
 
     test("leaves pipelines whose head isn't rtk-eligible", () => {
       expect(rewrite("cat foo.txt | grep bar")).toBe("cat foo.txt | grep bar");
+    });
+
+    test("ignores `|` inside double-quoted arguments", () => {
+      // The `|` inside the grep pattern must not truncate the head
+      // segment — otherwise the classifier sees a broken token and
+      // decides the result by accident. Quote-aware detection picks
+      // the outer pipe.
+      expect(rewrite('git log --grep="a|b" | less')).toBe(
+        'rtk git log --grep="a|b" | less',
+      );
+    });
+
+    test("ignores `|` inside single-quoted arguments", () => {
+      expect(rewrite("grep -E 'foo|bar' file.txt")).toBe(
+        "rtk grep -E 'foo|bar' file.txt",
+      );
     });
   });
 

--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -84,6 +84,14 @@ describe("rewriteForRtk", () => {
       expect(rewriteForRtk('echo "git status"')).toBe('echo "git status"');
     });
 
+    test("does not rewrite bash builtins (test, read)", () => {
+      // `test` and `read` are shell builtins — rewriting to
+      // `rtk test -f foo` would dispatch to rtk's test-runner
+      // subcommand and misinterpret the flags.
+      expect(rewriteForRtk("test -f /tmp/foo")).toBe("test -f /tmp/foo");
+      expect(rewriteForRtk("read var")).toBe("read var");
+    });
+
     test("does not match against empty / whitespace-only input", () => {
       expect(rewriteForRtk("")).toBe("");
       expect(rewriteForRtk("   ")).toBe("   ");

--- a/assistant/src/__tests__/rtk-rewrite.test.ts
+++ b/assistant/src/__tests__/rtk-rewrite.test.ts
@@ -98,6 +98,23 @@ describe("rewriteForRtk", () => {
     });
   });
 
+  describe("PATH override guard", () => {
+    test("skips rewrite when command scopes PATH in the prefix", () => {
+      // We can't know whether rtk is reachable via the overridden PATH,
+      // so leaving the command alone is safer than injecting `rtk`.
+      expect(rewriteForRtk("PATH=/usr/bin git status")).toBe(
+        "PATH=/usr/bin git status",
+      );
+      expect(rewriteForRtk("cd /tmp && PATH=/opt/bin pytest -v")).toBe(
+        "cd /tmp && PATH=/opt/bin pytest -v",
+      );
+    });
+
+    test("still rewrites when a non-PATH env var is scoped", () => {
+      expect(rewriteForRtk("CI=1 pytest -v")).toBe("CI=1 rtk pytest -v");
+    });
+  });
+
   describe("rtk-availability fallback", () => {
     test("passes through when rtk is not on PATH", () => {
       __setRtkAvailableForTest(false);

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -18,6 +18,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -25,6 +26,7 @@ import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
+import { rewriteForRtk } from "../shared/rtk-rewrite.js";
 import { formatShellOutput } from "../shared/shell-output.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
@@ -200,7 +202,19 @@ class HostShellTool implements Tool {
         hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
       }
 
-      const child = spawn("bash", ["-c", "--", command], {
+      // When shell-output-compression is on, rewrite supported head
+      // commands (git, pytest, tsc, …) to `rtk <cmd>` so rtk does the
+      // compression before output reaches the context window. Falls
+      // through to the original command when rtk isn't installed or the
+      // head isn't rtk-eligible.
+      const effectiveCommand = isAssistantFeatureFlagEnabled(
+        "shell-output-compression",
+        config,
+      )
+        ? rewriteForRtk(command)
+        : command;
+
+      const child = spawn("bash", ["-c", "--", effectiveCommand], {
         cwd: workingDir,
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -204,14 +204,17 @@ class HostShellTool implements Tool {
 
       // When shell-output-compression is on, rewrite supported head
       // commands (git, pytest, tsc, …) to `rtk <cmd>` so rtk does the
-      // compression before output reaches the context window. Falls
-      // through to the original command when rtk isn't installed or the
-      // head isn't rtk-eligible.
+      // compression before output reaches the context window. Probe
+      // rtk against the PATH the subprocess will actually see — on
+      // macOS app launch, `process.env.PATH` can be minimal while
+      // `hostEnv.PATH` (from buildHostShellEnv) still resolves rtk.
+      // Falls through to the original command when rtk isn't installed
+      // or the head isn't rtk-eligible.
       const effectiveCommand = isAssistantFeatureFlagEnabled(
         "shell-output-compression",
         config,
       )
-        ? rewriteForRtk(command)
+        ? rewriteForRtk(command, hostEnv.PATH ?? "")
         : command;
 
       const child = spawn("bash", ["-c", "--", effectiveCommand], {

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -1,0 +1,153 @@
+import { accessSync, constants } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Shell commands that the `rtk` binary has a dedicated subcommand for.
+ * Derived from `rtk --help` (rtk 0.36.0). Anything not in this set is
+ * passed through unchanged.
+ */
+const RTK_SUBCOMMANDS = new Set([
+  "ls",
+  "tree",
+  "read",
+  "git",
+  "gh",
+  "aws",
+  "psql",
+  "pnpm",
+  "test",
+  "pytest",
+  "vitest",
+  "cargo",
+  "npm",
+  "npx",
+  "tsc",
+  "eslint",
+  "lint",
+  "grep",
+  "find",
+  "log",
+  "diff",
+  "docker",
+  "kubectl",
+  "wget",
+  "wc",
+  "prettier",
+  "format",
+  "playwright",
+  "prisma",
+  "next",
+  "ruff",
+  "mypy",
+  "rake",
+  "rubocop",
+  "rspec",
+  "pip",
+  "curl",
+]);
+
+let cachedAvailable: boolean | null = null;
+let testOverride: boolean | null = null;
+
+function defaultIsRtkAvailable(): boolean {
+  if (cachedAvailable !== null) return cachedAvailable;
+  const pathEntries = (process.env.PATH ?? "").split(":").filter(Boolean);
+  for (const dir of pathEntries) {
+    try {
+      accessSync(join(dir, "rtk"), constants.X_OK);
+      cachedAvailable = true;
+      return true;
+    } catch {
+      // Not in this PATH entry — keep looking.
+    }
+  }
+  cachedAvailable = false;
+  return false;
+}
+
+function isRtkAvailable(): boolean {
+  if (testOverride !== null) return testOverride;
+  return defaultIsRtkAvailable();
+}
+
+/**
+ * Test-only hook. Pass `true`/`false` to force the availability result,
+ * or `null` to revert to the real check (and clear the cache).
+ */
+export function __setRtkAvailableForTest(value: boolean | null): void {
+  testOverride = value;
+  if (value === null) cachedAvailable = null;
+}
+
+/**
+ * Find the byte offset in `command` where the head executable token
+ * begins, after stripping `cd <path> &&`, env-var assignments, and
+ * `sudo` prefixes in any order.
+ */
+function findHeadIndex(command: string): number {
+  let i = 0;
+  const n = command.length;
+  while (i < n && /\s/.test(command[i]!)) i++;
+
+  for (;;) {
+    const rest = command.slice(i);
+
+    const cd = /^cd\s+\S+\s*&&\s*/.exec(rest);
+    if (cd) {
+      i += cd[0].length;
+      continue;
+    }
+
+    const env = /^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/.exec(rest);
+    if (env) {
+      i += env[0].length;
+      continue;
+    }
+
+    const sudo = /^sudo\s+/.exec(rest);
+    if (sudo) {
+      i += sudo[0].length;
+      continue;
+    }
+
+    return i >= n ? -1 : i;
+  }
+}
+
+/**
+ * Rewrite a shell command to delegate supported head commands to the
+ * `rtk` binary (e.g. `git status` → `rtk git status`).
+ *
+ * Returns the command unchanged when:
+ * - rtk is not on PATH
+ * - the head executable isn't in {@link RTK_SUBCOMMANDS}
+ * - the head can't be identified (empty command, only prefixes)
+ *
+ * Only the head segment of a pipeline is inspected; everything after
+ * the first `|` stays verbatim. Prefixes like `cd X && `, env-var
+ * assignments (`FOO=bar`), and `sudo` are preserved in place.
+ */
+export function rewriteForRtk(command: string): string {
+  if (!command || !command.trim()) return command;
+  if (!isRtkAvailable()) return command;
+
+  // Pipes: only consider the head segment for classification. Insertion
+  // still uses the original-command offset, so the tail is unchanged.
+  const pipeIndex = command.indexOf("|");
+  const headSegment = pipeIndex >= 0 ? command.slice(0, pipeIndex) : command;
+
+  const headIdx = findHeadIndex(headSegment);
+  if (headIdx < 0) return command;
+
+  // Extract the first token — everything up to whitespace or a shell
+  // metacharacter. This intentionally skips tokens that start with a
+  // quote/backtick/variable so things like `"pytest"` or `$CMD` don't
+  // get classified as rtk-eligible.
+  const tokenMatch = /^([A-Za-z0-9_./-]+)/.exec(headSegment.slice(headIdx));
+  if (!tokenMatch) return command;
+
+  const token = tokenMatch[1]!;
+  if (!RTK_SUBCOMMANDS.has(token)) return command;
+
+  return command.slice(0, headIdx) + "rtk " + command.slice(headIdx);
+}

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -46,11 +46,14 @@ const RTK_SUBCOMMANDS = new Set([
   "curl",
 ]);
 
-let cachedAvailable: boolean | null = null;
+// Only positive results are cached. A negative result is rechecked on
+// every call so that installing rtk mid-session (or a later PATH
+// update) starts working without restarting the process.
+let cachedAvailable = false;
 let testOverride: boolean | null = null;
 
 function defaultIsRtkAvailable(): boolean {
-  if (cachedAvailable !== null) return cachedAvailable;
+  if (cachedAvailable) return true;
   const pathEntries = (process.env.PATH ?? "").split(":").filter(Boolean);
   for (const dir of pathEntries) {
     try {
@@ -61,7 +64,6 @@ function defaultIsRtkAvailable(): boolean {
       // Not in this PATH entry — keep looking.
     }
   }
-  cachedAvailable = false;
   return false;
 }
 
@@ -72,11 +74,11 @@ function isRtkAvailable(): boolean {
 
 /**
  * Test-only hook. Pass `true`/`false` to force the availability result,
- * or `null` to revert to the real check (and clear the cache).
+ * or `null` to revert to the real check (and clear the positive cache).
  */
 export function __setRtkAvailableForTest(value: boolean | null): void {
   testOverride = value;
-  if (value === null) cachedAvailable = null;
+  if (value === null) cachedAvailable = false;
 }
 
 /**
@@ -120,6 +122,8 @@ function findHeadIndex(command: string): number {
  *
  * Returns the command unchanged when:
  * - rtk is not on PATH
+ * - the caller overrides `PATH` in the command's env-var prefix
+ *   (we check rtk against the daemon's PATH, which may not apply)
  * - the head executable isn't in {@link RTK_SUBCOMMANDS}
  * - the head can't be identified (empty command, only prefixes)
  *
@@ -138,6 +142,13 @@ export function rewriteForRtk(command: string): string {
 
   const headIdx = findHeadIndex(headSegment);
   if (headIdx < 0) return command;
+
+  // PATH override guard: if the caller scopes `PATH=` to the command
+  // (e.g. `PATH=/usr/bin git status`), the daemon's rtk availability
+  // check doesn't reflect what the subprocess will see — blindly
+  // injecting `rtk` could break an otherwise-valid command. Skip.
+  const prefixBeforeHead = headSegment.slice(0, headIdx);
+  if (/(?:^|\s)PATH\s*=/.test(prefixBeforeHead)) return command;
 
   // Extract the first token — everything up to whitespace or a shell
   // metacharacter. This intentionally skips tokens that start with a

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -49,19 +49,22 @@ const RTK_SUBCOMMANDS = new Set([
   "curl",
 ]);
 
-// Only positive results are cached. A negative result is rechecked on
-// every call so that installing rtk mid-session (or a later PATH
-// update) starts working without restarting the process.
-let cachedAvailable = false;
+// Positive-only cache keyed by the PATH that was probed. Different
+// callers can use different PATHs (e.g. `host_bash` prepends
+// `~/.bun/bin` via buildHostShellEnv), so caching a single global
+// answer is wrong. A negative result is never cached — installing rtk
+// mid-session (or a PATH update) should start working without a
+// restart.
+let cachedPositive: { path: string } | null = null;
 let testOverride: boolean | null = null;
 
-function defaultIsRtkAvailable(): boolean {
-  if (cachedAvailable) return true;
-  const pathEntries = (process.env.PATH ?? "").split(":").filter(Boolean);
+function defaultIsRtkAvailable(pathEnv: string): boolean {
+  if (cachedPositive && cachedPositive.path === pathEnv) return true;
+  const pathEntries = pathEnv.split(":").filter(Boolean);
   for (const dir of pathEntries) {
     try {
       accessSync(join(dir, "rtk"), constants.X_OK);
-      cachedAvailable = true;
+      cachedPositive = { path: pathEnv };
       return true;
     } catch {
       // Not in this PATH entry — keep looking.
@@ -70,9 +73,9 @@ function defaultIsRtkAvailable(): boolean {
   return false;
 }
 
-function isRtkAvailable(): boolean {
+function isRtkAvailable(pathEnv: string): boolean {
   if (testOverride !== null) return testOverride;
-  return defaultIsRtkAvailable();
+  return defaultIsRtkAvailable(pathEnv);
 }
 
 /**
@@ -81,7 +84,7 @@ function isRtkAvailable(): boolean {
  */
 export function __setRtkAvailableForTest(value: boolean | null): void {
   testOverride = value;
-  if (value === null) cachedAvailable = false;
+  if (value === null) cachedPositive = null;
 }
 
 /**
@@ -123,8 +126,13 @@ function findHeadIndex(command: string): number {
  * Rewrite a shell command to delegate supported head commands to the
  * `rtk` binary (e.g. `git status` → `rtk git status`).
  *
+ * `pathEnv` must be the PATH the subprocess will actually execute with
+ * (not `process.env.PATH`, which on macOS app-launched daemons is
+ * minimal — `buildHostShellEnv` prepends `~/.bun/bin`, etc.). The rtk
+ * probe walks that PATH directly.
+ *
  * Returns the command unchanged when:
- * - rtk is not on PATH
+ * - rtk is not on the subprocess PATH
  * - the caller overrides `PATH` in the command's env-var prefix, or
  *   the command is run through `sudo` (both execute with a PATH we
  *   can't probe from the daemon — rtk may be missing there)
@@ -135,9 +143,9 @@ function findHeadIndex(command: string): number {
  * the first `|` stays verbatim. Prefixes like `cd X && ` and env-var
  * assignments (`FOO=bar`) are preserved in place.
  */
-export function rewriteForRtk(command: string): string {
+export function rewriteForRtk(command: string, pathEnv: string): string {
   if (!command || !command.trim()) return command;
-  if (!isRtkAvailable()) return command;
+  if (!isRtkAvailable(pathEnv)) return command;
 
   // Pipes: only consider the head segment for classification. Insertion
   // still uses the original-command offset, so the tail is unchanged.

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -122,14 +122,15 @@ function findHeadIndex(command: string): number {
  *
  * Returns the command unchanged when:
  * - rtk is not on PATH
- * - the caller overrides `PATH` in the command's env-var prefix
- *   (we check rtk against the daemon's PATH, which may not apply)
+ * - the caller overrides `PATH` in the command's env-var prefix, or
+ *   the command is run through `sudo` (both execute with a PATH we
+ *   can't probe from the daemon — rtk may be missing there)
  * - the head executable isn't in {@link RTK_SUBCOMMANDS}
  * - the head can't be identified (empty command, only prefixes)
  *
  * Only the head segment of a pipeline is inspected; everything after
- * the first `|` stays verbatim. Prefixes like `cd X && `, env-var
- * assignments (`FOO=bar`), and `sudo` are preserved in place.
+ * the first `|` stays verbatim. Prefixes like `cd X && ` and env-var
+ * assignments (`FOO=bar`) are preserved in place.
  */
 export function rewriteForRtk(command: string): string {
   if (!command || !command.trim()) return command;
@@ -143,12 +144,15 @@ export function rewriteForRtk(command: string): string {
   const headIdx = findHeadIndex(headSegment);
   if (headIdx < 0) return command;
 
-  // PATH override guard: if the caller scopes `PATH=` to the command
-  // (e.g. `PATH=/usr/bin git status`), the daemon's rtk availability
-  // check doesn't reflect what the subprocess will see — blindly
-  // injecting `rtk` could break an otherwise-valid command. Skip.
+  // PATH-visibility guard: if the caller scopes `PATH=` to the command
+  // (e.g. `PATH=/usr/bin git status`) or runs under `sudo` (which uses
+  // its own `secure_path` that typically omits user-level bins like
+  // ~/.bun/bin or /opt/homebrew/bin), the daemon's rtk probe doesn't
+  // reflect what the subprocess will see. Injecting `rtk` there could
+  // turn a working command into `rtk: command not found`. Bail out.
   const prefixBeforeHead = headSegment.slice(0, headIdx);
   if (/(?:^|\s)PATH\s*=/.test(prefixBeforeHead)) return command;
+  if (/(?:^|\s)sudo(?:\s|$)/.test(prefixBeforeHead)) return command;
 
   // Extract the first token — everything up to whitespace or a shell
   // metacharacter. This intentionally skips tokens that start with a

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -2,14 +2,21 @@ import { accessSync, constants } from "node:fs";
 import { join } from "node:path";
 
 /**
- * Shell commands that the `rtk` binary has a dedicated subcommand for.
+ * Shell commands that the `rtk` binary has a dedicated subcommand for
+ * AND whose rtk wrapper is documented to accept the native CLI flags.
  * Derived from `rtk --help` (rtk 0.36.0). Anything not in this set is
  * passed through unchanged.
  *
- * Deliberately excluded even though `rtk` has a matching subcommand:
- * - `test`, `read` — bash builtins. `test -f foo` or `read var` would
- *   mis-dispatch to rtk's test-runner / file-reader subcommand and
- *   misinterpret the flags.
+ * Deliberately excluded even though rtk has a matching subcommand:
+ * - `test`, `read` — bash builtins. `test -f foo` / `read var` would
+ *   mis-dispatch to rtk's test-runner / file-reader and misread flags.
+ * - `diff`, `wc`, `curl`, `log` — standard Unix utilities whose rtk
+ *   wrappers may diverge from the native CLI (`rtk curl` auto-detects
+ *   JSON and emits a schema; `rtk diff` produces an ultra-condensed
+ *   form; `rtk wc` strips paths/padding; on macOS `log` is also a
+ *   system utility whose semantics differ from rtk's log-filter).
+ *   Silently changing shape/semantics is too risky for an opt-in
+ *   compression feature; add them back once equivalence is verified.
  */
 const RTK_SUBCOMMANDS = new Set([
   "ls",
@@ -29,12 +36,9 @@ const RTK_SUBCOMMANDS = new Set([
   "lint",
   "grep",
   "find",
-  "log",
-  "diff",
   "docker",
   "kubectl",
   "wget",
-  "wc",
   "prettier",
   "format",
   "playwright",
@@ -46,25 +50,20 @@ const RTK_SUBCOMMANDS = new Set([
   "rubocop",
   "rspec",
   "pip",
-  "curl",
 ]);
 
-// Positive-only cache keyed by the PATH that was probed. Different
-// callers can use different PATHs (e.g. `host_bash` prepends
-// `~/.bun/bin` via buildHostShellEnv), so caching a single global
-// answer is wrong. A negative result is never cached — installing rtk
-// mid-session (or a PATH update) should start working without a
-// restart.
-let cachedPositive: { path: string } | null = null;
+// rtk availability is probed fresh on every call. The previous
+// positive cache could go stale if rtk was removed, upgraded, or lost
+// execute permission mid-session — commands would then be rewritten to
+// `rtk <cmd>` and fail with `command not found`. An fs.accessSync over
+// a typical PATH is microseconds; the spawn that follows dominates.
 let testOverride: boolean | null = null;
 
 function defaultIsRtkAvailable(pathEnv: string): boolean {
-  if (cachedPositive && cachedPositive.path === pathEnv) return true;
   const pathEntries = pathEnv.split(":").filter(Boolean);
   for (const dir of pathEntries) {
     try {
       accessSync(join(dir, "rtk"), constants.X_OK);
-      cachedPositive = { path: pathEnv };
       return true;
     } catch {
       // Not in this PATH entry — keep looking.
@@ -80,11 +79,10 @@ function isRtkAvailable(pathEnv: string): boolean {
 
 /**
  * Test-only hook. Pass `true`/`false` to force the availability result,
- * or `null` to revert to the real check (and clear the positive cache).
+ * or `null` to revert to the real check.
  */
 export function __setRtkAvailableForTest(value: boolean | null): void {
   testOverride = value;
-  if (value === null) cachedPositive = null;
 }
 
 /**

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -5,17 +5,20 @@ import { join } from "node:path";
  * Shell commands that the `rtk` binary has a dedicated subcommand for.
  * Derived from `rtk --help` (rtk 0.36.0). Anything not in this set is
  * passed through unchanged.
+ *
+ * Deliberately excluded even though `rtk` has a matching subcommand:
+ * - `test`, `read` — bash builtins. `test -f foo` or `read var` would
+ *   mis-dispatch to rtk's test-runner / file-reader subcommand and
+ *   misinterpret the flags.
  */
 const RTK_SUBCOMMANDS = new Set([
   "ls",
   "tree",
-  "read",
   "git",
   "gh",
   "aws",
   "psql",
   "pnpm",
-  "test",
   "pytest",
   "vitest",
   "cargo",

--- a/assistant/src/tools/shared/rtk-rewrite.ts
+++ b/assistant/src/tools/shared/rtk-rewrite.ts
@@ -88,9 +88,39 @@ export function __setRtkAvailableForTest(value: boolean | null): void {
 }
 
 /**
+ * Find the offset of the first `|` in `s` that is not inside a
+ * single- or double-quoted string. Returns -1 if none.
+ *
+ * Quote-aware so commands like `git log --grep="a|b" | less` split on
+ * the outer pipe instead of the one inside the quoted argument.
+ */
+function findUnquotedPipe(s: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "\\" && i + 1 < s.length) {
+      i++;
+      continue;
+    }
+    if (c === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (c === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (c === "|" && !inSingle && !inDouble) return i;
+  }
+  return -1;
+}
+
+/**
  * Find the byte offset in `command` where the head executable token
  * begins, after stripping `cd <path> &&`, env-var assignments, and
- * `sudo` prefixes in any order.
+ * `sudo` prefixes in any order. The `cd` form accepts a quoted path
+ * (single or double) so paths with spaces still strip cleanly.
  */
 function findHeadIndex(command: string): number {
   let i = 0;
@@ -100,7 +130,7 @@ function findHeadIndex(command: string): number {
   for (;;) {
     const rest = command.slice(i);
 
-    const cd = /^cd\s+\S+\s*&&\s*/.exec(rest);
+    const cd = /^cd\s+("[^"]*"|'[^']*'|\S+)\s*&&\s*/.exec(rest);
     if (cd) {
       i += cd[0].length;
       continue;
@@ -147,9 +177,11 @@ export function rewriteForRtk(command: string, pathEnv: string): string {
   if (!command || !command.trim()) return command;
   if (!isRtkAvailable(pathEnv)) return command;
 
-  // Pipes: only consider the head segment for classification. Insertion
+  // Pipes: only consider the head segment for classification. Use
+  // quote-aware detection so a `|` inside a quoted argument doesn't
+  // truncate the classifier's view of the head command. Insertion
   // still uses the original-command offset, so the tail is unchanged.
-  const pipeIndex = command.indexOf("|");
+  const pipeIndex = findUnquotedPipe(command);
   const headSegment = pipeIndex >= 0 ? command.slice(0, pipeIndex) : command;
 
   const headIdx = findHeadIndex(headSegment);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -331,14 +331,15 @@ class ShellTool implements Tool {
 
       // When shell-output-compression is on, rewrite supported head
       // commands (git, pytest, tsc, …) to `rtk <cmd>` so rtk does the
-      // compression before output reaches the context window. Falls
-      // through to the original command when rtk isn't installed or the
-      // head isn't rtk-eligible.
+      // compression before output reaches the context window. Probe
+      // rtk against the PATH the subprocess will actually see (`env`
+      // above), not `process.env.PATH`. Falls through to the original
+      // command when rtk isn't installed or the head isn't rtk-eligible.
       const effectiveCommand = isAssistantFeatureFlagEnabled(
         "shell-output-compression",
         config,
       )
-        ? rewriteForRtk(command)
+        ? rewriteForRtk(command, env.PATH ?? "")
         : command;
 
       const wrapped = wrapCommand(

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -20,6 +21,7 @@ import {
   getSessionEnv,
 } from "../network/script-proxy/index.js";
 import { registerTool } from "../registry.js";
+import { rewriteForRtk } from "../shared/rtk-rewrite.js";
 import { formatShellOutput } from "../shared/shell-output.js";
 import type {
   ProxyEnvVars,
@@ -327,10 +329,27 @@ class ShellTool implements Tool {
         ? buildCesProtectedPaths()
         : undefined;
 
-      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, {
-        networkMode,
-        denyReadPaths,
-      });
+      // When shell-output-compression is on, rewrite supported head
+      // commands (git, pytest, tsc, …) to `rtk <cmd>` so rtk does the
+      // compression before output reaches the context window. Falls
+      // through to the original command when rtk isn't installed or the
+      // head isn't rtk-eligible.
+      const effectiveCommand = isAssistantFeatureFlagEnabled(
+        "shell-output-compression",
+        config,
+      )
+        ? rewriteForRtk(command)
+        : command;
+
+      const wrapped = wrapCommand(
+        effectiveCommand,
+        context.workingDir,
+        sandboxConfig,
+        {
+          networkMode,
+          denyReadPaths,
+        },
+      );
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -360,6 +360,14 @@
       "label": "Google Meet",
       "description": "Enables the Google Meet joining bot and the meet-join skill.",
       "defaultEnabled": false
+    },
+    {
+      "id": "shell-output-compression",
+      "scope": "assistant",
+      "key": "shell-output-compression",
+      "label": "Shell output compression (rtk)",
+      "description": "Rewrite supported bash/host_bash commands (git, pytest, tsc, ls, grep, ...) to delegate to the `rtk` binary, which compresses output before it enters the context window. Passes through unchanged when rtk is not installed or the command isn't rtk-eligible.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,23 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# rtk: shell-output compression proxy used by the `shell-output-compression`
+# feature flag. Optional at runtime — the feature gracefully falls through
+# when rtk is missing — but we install it during setup so the flag is usable
+# out of the box on developer machines.
+# ---------------------------------------------------------------------------
+if command -v brew &>/dev/null; then
+  if ! command -v rtk &>/dev/null; then
+    info "Installing rtk via Homebrew (optional; powers shell-output-compression)"
+    brew install rtk || info "rtk install failed — feature flag will no-op until installed manually"
+  else
+    info "rtk already installed ($(rtk --version 2>/dev/null || echo "version unknown"))"
+  fi
+else
+  info "Skipping rtk (Homebrew not available — install manually if you want to enable shell-output-compression)"
+fi
+
+# ---------------------------------------------------------------------------
 # Install dependencies and register local packages as linkable
 # ---------------------------------------------------------------------------
 for dir in cli gateway assistant credential-executor; do


### PR DESCRIPTION
## Summary
- Adds `rewriteForRtk()` that rewrites supported head commands to `rtk <cmd>` (e.g. `git status` → `rtk git status`). Preserves `cd X && `, env-var, and `sudo` prefixes; only inspects the head segment of a pipeline; passes through when rtk isn't on PATH.
- Wires it into `bash` (`src/tools/terminal/shell.ts`) and `host_bash` (`src/tools/host-terminal/host-shell.ts`) just before `spawn()`, gated on the `shell-output-compression` feature flag (off by default).
- Adds the `shell-output-compression` entry to `meta/feature-flags/feature-flag-registry.json` and unit tests at `assistant/src/__tests__/rtk-rewrite.test.ts`.

## Why
Closes the design thread from #25870 (closed): instead of reimplementing rtk's per-category compression logic in TypeScript, delegate to the rtk binary which already does this. Single source of truth, far smaller surface to maintain.

## Out of scope
- Rewriting commands sent over `host_bash_proxy` to a remote client — the client's rtk availability is unknown from the server.
- Background analytics of rtk usage, auto-discovery of new rtk subcommands, and compression for long-lived host_bash sessions where individual commands aren't visible.

## Original prompt
Implement feature-flagged rtk command delegation for shell tool outputs (superseding the TS compressors from the closed PR #25870). Small, focused command-rewriter that delegates supported commands to the `rtk` binary via a PATH check + head-token classification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
