### PR TITLE
Define trust-rule family types and normalization parser in ces-contracts

### DIFF
--- a/packages/ces-contracts/src/__tests__/trust-rules.test.ts
+++ b/packages/ces-contracts/src/__tests__/trust-rules.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for trust-rule family types and canonical parsing/normalization.
+ *
+ * Verifies:
+ * 1. Scoped-rule parsing preserves executionTarget and allowHighRisk.
+ * 2. Non-scoped known-tool rules have executionTarget/allowHighRisk stripped.
+ * 3. Unknown-tool rules preserve all fields for forward compatibility.
+ * 4. Normalization flag behavior signals when a re-save is warranted.
+ * 5. parseTrustFileData handles full trust file objects.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  isManagedSkillRule,
+  isScopedRule,
+  isSkillLoadRule,
+  isUrlRule,
+  parseTrustFileData,
+  parseTrustRule,
+  SCOPED_TOOLS,
+  URL_TOOLS,
+  MANAGED_SKILL_TOOLS,
+  SKILL_LOAD_TOOL,
+} from "../trust-rules.js";
+import type {
+  GenericTrustRule,
+  ManagedSkillTrustRule,
+  ScopedTrustRule,
+  SkillLoadTrustRule,
+  TrustRule,
+  UrlTrustRule,
+} from "../trust-rules.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRaw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "test-rule-1",
+    tool: "bash",
+    pattern: "**",
+    scope: "everywhere",
+    decision: "allow",
+    priority: 100,
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scoped-rule parsing
+// ---------------------------------------------------------------------------
+
+describe("parseTrustRule — scoped tools", () => {
+  test.each([...SCOPED_TOOLS])("preserves executionTarget and allowHighRisk for %s", (tool) => {
+    const raw = makeRaw({
+      tool,
+      executionTarget: "container-a",
+      allowHighRisk: true,
+    });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe(tool);
+    expect((rule as ScopedTrustRule).executionTarget).toBe("container-a");
+    expect((rule as ScopedTrustRule).allowHighRisk).toBe(true);
+  });
+
+  test("scoped rule without optional fields is not normalized", () => {
+    const raw = makeRaw({ tool: "host_bash" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe("host_bash");
+    expect("executionTarget" in rule).toBe(false);
+    expect("allowHighRisk" in rule).toBe(false);
+  });
+
+  test("type guard isScopedRule narrows correctly", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "file_write" }));
+    expect(isScopedRule(rule)).toBe(true);
+    expect(isUrlRule(rule)).toBe(false);
+    expect(isManagedSkillRule(rule)).toBe(false);
+    expect(isSkillLoadRule(rule)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-scoped known-tool scope stripping
+// ---------------------------------------------------------------------------
+
+describe("parseTrustRule — URL tools strip invalid fields", () => {
+  test.each([...URL_TOOLS])("strips executionTarget and allowHighRisk from %s", (tool) => {
+    const raw = makeRaw({
+      tool,
+      executionTarget: "should-be-stripped",
+      allowHighRisk: true,
+    });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect(rule.tool).toBe(tool);
+    expect("executionTarget" in rule).toBe(false);
+    expect("allowHighRisk" in rule).toBe(false);
+  });
+
+  test("URL tool without invalid fields is not normalized", () => {
+    const raw = makeRaw({ tool: "web_fetch" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe("web_fetch");
+  });
+
+  test("type guard isUrlRule narrows correctly", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "browser_navigate" }));
+    expect(isUrlRule(rule)).toBe(true);
+    expect(isScopedRule(rule)).toBe(false);
+  });
+});
+
+describe("parseTrustRule — managed skill tools strip invalid fields", () => {
+  test.each([...MANAGED_SKILL_TOOLS])("strips executionTarget and allowHighRisk from %s", (tool) => {
+    const raw = makeRaw({
+      tool,
+      executionTarget: "x",
+      allowHighRisk: false,
+    });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect("executionTarget" in rule).toBe(false);
+    expect("allowHighRisk" in rule).toBe(false);
+  });
+
+  test("type guard isManagedSkillRule narrows correctly", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "scaffold_managed_skill" }));
+    expect(isManagedSkillRule(rule)).toBe(true);
+    expect(isScopedRule(rule)).toBe(false);
+  });
+});
+
+describe("parseTrustRule — skill_load strips invalid fields", () => {
+  test("strips executionTarget and allowHighRisk from skill_load", () => {
+    const raw = makeRaw({
+      tool: SKILL_LOAD_TOOL,
+      executionTarget: "container-b",
+      allowHighRisk: true,
+    });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect(rule.tool).toBe(SKILL_LOAD_TOOL);
+    expect("executionTarget" in rule).toBe(false);
+    expect("allowHighRisk" in rule).toBe(false);
+  });
+
+  test("skill_load without invalid fields is not normalized", () => {
+    const raw = makeRaw({ tool: SKILL_LOAD_TOOL, pattern: "skill_load:*" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe(SKILL_LOAD_TOOL);
+  });
+
+  test("type guard isSkillLoadRule narrows correctly", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: SKILL_LOAD_TOOL }));
+    expect(isSkillLoadRule(rule)).toBe(true);
+    expect(isScopedRule(rule)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown-tool preservation
+// ---------------------------------------------------------------------------
+
+describe("parseTrustRule — unknown tools", () => {
+  test("preserves executionTarget and allowHighRisk for unknown tools", () => {
+    const raw = makeRaw({
+      tool: "future_tool_v99",
+      executionTarget: "edge-worker",
+      allowHighRisk: true,
+    });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe("future_tool_v99");
+    expect((rule as GenericTrustRule).executionTarget).toBe("edge-worker");
+    expect((rule as GenericTrustRule).allowHighRisk).toBe(true);
+  });
+
+  test("unknown tool without optional fields is not normalized", () => {
+    const raw = makeRaw({ tool: "computer_use_click" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect(rule.tool).toBe("computer_use_click");
+    expect("executionTarget" in rule).toBe(false);
+    expect("allowHighRisk" in rule).toBe(false);
+  });
+
+  test("all type guards return false for generic rules", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "some_new_tool" }));
+    expect(isScopedRule(rule)).toBe(false);
+    expect(isUrlRule(rule)).toBe(false);
+    expect(isManagedSkillRule(rule)).toBe(false);
+    expect(isSkillLoadRule(rule)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalization flag behavior
+// ---------------------------------------------------------------------------
+
+describe("parseTrustRule — normalization flag", () => {
+  test("normalized is false when no changes needed", () => {
+    const raw = makeRaw({ tool: "host_bash", allowHighRisk: true });
+    const { normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+  });
+
+  test("normalized is true when invalid fields are stripped", () => {
+    const raw = makeRaw({ tool: "web_fetch", allowHighRisk: true });
+    const { normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+  });
+
+  test("normalized is true when decision is coerced", () => {
+    const raw = makeRaw({ tool: "bash", decision: "invalid_decision" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect(rule.decision).toBe("ask");
+  });
+
+  test("empty executionTarget string is not preserved on scoped rules", () => {
+    const raw = makeRaw({ tool: "bash", executionTarget: "" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect("executionTarget" in rule).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTrustFileData
+// ---------------------------------------------------------------------------
+
+describe("parseTrustFileData", () => {
+  test("parses a valid trust file with mixed rule families", () => {
+    const raw = {
+      version: 3,
+      starterBundleAccepted: true,
+      rules: [
+        makeRaw({ id: "r1", tool: "bash" }),
+        makeRaw({ id: "r2", tool: "web_fetch", pattern: "web_fetch:https://example.com/*" }),
+        makeRaw({ id: "r3", tool: "skill_load", pattern: "skill_load:*" }),
+      ],
+    };
+    const { data, normalized } = parseTrustFileData(raw);
+    expect(normalized).toBe(false);
+    expect(data.version).toBe(3);
+    expect(data.starterBundleAccepted).toBe(true);
+    expect(data.rules).toHaveLength(3);
+    expect(data.rules[0].tool).toBe("bash");
+    expect(data.rules[1].tool).toBe("web_fetch");
+    expect(data.rules[2].tool).toBe("skill_load");
+  });
+
+  test("reports normalized when any rule is modified", () => {
+    const raw = {
+      version: 3,
+      rules: [
+        makeRaw({ id: "r1", tool: "bash" }),
+        // This rule has an invalid field for its family
+        makeRaw({ id: "r2", tool: "web_fetch", executionTarget: "stale" }),
+      ],
+    };
+    const { data, normalized } = parseTrustFileData(raw);
+    expect(normalized).toBe(true);
+    expect(data.rules).toHaveLength(2);
+    expect("executionTarget" in data.rules[1]).toBe(false);
+  });
+
+  test("skips null/non-object entries and flags as normalized", () => {
+    const raw = {
+      version: 3,
+      rules: [null, 42, makeRaw({ id: "r1", tool: "bash" })],
+    };
+    const { data, normalized } = parseTrustFileData(raw);
+    expect(normalized).toBe(true);
+    expect(data.rules).toHaveLength(1);
+    expect(data.rules[0].id).toBe("r1");
+  });
+
+  test("handles missing rules array", () => {
+    const raw = { version: 3 };
+    const { data, normalized } = parseTrustFileData(raw);
+    expect(normalized).toBe(false);
+    expect(data.rules).toEqual([]);
+  });
+
+  test("handles missing version", () => {
+    const raw = { rules: [] };
+    const { data } = parseTrustFileData(raw);
+    expect(data.version).toBe(0);
+  });
+
+  test("starterBundleAccepted defaults to undefined when not true", () => {
+    const raw = { version: 3, rules: [], starterBundleAccepted: false };
+    const { data } = parseTrustFileData(raw);
+    expect(data.starterBundleAccepted).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level smoke tests (compile-time only — no runtime assertions)
+// ---------------------------------------------------------------------------
+
+describe("type-level compatibility", () => {
+  test("TrustRule union is assignable from all family interfaces", () => {
+    // These assignments verify that each family interface satisfies TrustRule.
+    // If any interface breaks the union, TypeScript will fail at compile time.
+    const scoped: ScopedTrustRule = {
+      id: "s1",
+      tool: "bash",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 50,
+      createdAt: 0,
+      executionTarget: "host",
+      allowHighRisk: true,
+    };
+    const url: UrlTrustRule = {
+      id: "u1",
+      tool: "web_fetch",
+      pattern: "web_fetch:*",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+      createdAt: 0,
+    };
+    const managed: ManagedSkillTrustRule = {
+      id: "m1",
+      tool: "scaffold_managed_skill",
+      pattern: "scaffold_managed_skill:*",
+      scope: "everywhere",
+      decision: "ask",
+      priority: 1000,
+      createdAt: 0,
+    };
+    const skillLoad: SkillLoadTrustRule = {
+      id: "sl1",
+      tool: "skill_load",
+      pattern: "skill_load:*",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 100,
+      createdAt: 0,
+    };
+    const generic: GenericTrustRule = {
+      id: "g1",
+      tool: "computer_use_click",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "ask",
+      priority: 1000,
+      createdAt: 0,
+    };
+
+    // All should be assignable to TrustRule
+    const rules: TrustRule[] = [scoped, url, managed, skillLoad, generic];
+    expect(rules).toHaveLength(5);
+  });
+});

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -217,19 +217,26 @@ export interface ParsedTrustRule {
 export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   let normalized = false;
 
-  // Extract base fields with coercion for safety
-  const id = typeof raw.id === "string" ? raw.id : "";
-  const tool = typeof raw.tool === "string" ? raw.tool : "";
-  const pattern = typeof raw.pattern === "string" ? raw.pattern : "";
-  const scope = typeof raw.scope === "string" ? raw.scope : "everywhere";
-  const decision = isValidDecision(raw.decision) ? raw.decision : "ask";
-  const priority = typeof raw.priority === "number" ? raw.priority : 100;
-  const createdAt = typeof raw.createdAt === "number" ? raw.createdAt : 0;
-
-  // Coerce decision if it was invalid
-  if (!isValidDecision(raw.decision)) {
-    normalized = true;
-  }
+  // Extract base fields with coercion for safety — mark normalized whenever
+  // a field is coerced to its default so callers know to re-save.
+  const id = typeof raw.id === "string" ? raw.id : ((normalized = true), "");
+  const tool =
+    typeof raw.tool === "string" ? raw.tool : ((normalized = true), "");
+  const pattern =
+    typeof raw.pattern === "string" ? raw.pattern : ((normalized = true), "");
+  const scope =
+    typeof raw.scope === "string"
+      ? raw.scope
+      : ((normalized = true), "everywhere");
+  const decision = isValidDecision(raw.decision)
+    ? raw.decision
+    : ((normalized = true), "ask" as const);
+  const priority =
+    typeof raw.priority === "number" ? raw.priority : ((normalized = true), 100);
+  const createdAt =
+    typeof raw.createdAt === "number"
+      ? raw.createdAt
+      : ((normalized = true), 0);
 
   // Build the base rule
   const base: TrustRuleBase = {
@@ -350,7 +357,7 @@ export function parseTrustFileData(
   const rules: TrustRule[] = [];
 
   for (const rawRule of rawRules) {
-    if (rawRule == null || typeof rawRule !== "object") {
+    if (rawRule == null || typeof rawRule !== "object" || Array.isArray(rawRule)) {
       anyNormalized = true;
       continue;
     }

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -291,9 +291,13 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
       raw.executionTarget.length > 0
     ) {
       rule.executionTarget = raw.executionTarget;
+    } else if (raw.executionTarget !== undefined) {
+      normalized = true;
     }
     if (typeof raw.allowHighRisk === "boolean") {
       rule.allowHighRisk = raw.allowHighRisk;
+    } else if (raw.allowHighRisk !== undefined) {
+      normalized = true;
     }
     return { rule, normalized };
   }
@@ -305,9 +309,13 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     raw.executionTarget.length > 0
   ) {
     rule.executionTarget = raw.executionTarget;
+  } else if (raw.executionTarget !== undefined) {
+    normalized = true;
   }
   if (typeof raw.allowHighRisk === "boolean") {
     rule.allowHighRisk = raw.allowHighRisk;
+  } else if (raw.allowHighRisk !== undefined) {
+    normalized = true;
   }
   return { rule, normalized };
 }

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -291,7 +291,7 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
       raw.executionTarget.length > 0
     ) {
       rule.executionTarget = raw.executionTarget;
-    } else if (raw.executionTarget !== undefined) {
+    } else if (raw.executionTarget !== undefined && raw.executionTarget !== "") {
       normalized = true;
     }
     if (typeof raw.allowHighRisk === "boolean") {
@@ -309,7 +309,7 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     raw.executionTarget.length > 0
   ) {
     rule.executionTarget = raw.executionTarget;
-  } else if (raw.executionTarget !== undefined) {
+  } else if (raw.executionTarget !== undefined && raw.executionTarget !== "") {
     normalized = true;
   }
   if (typeof raw.allowHighRisk === "boolean") {

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -4,6 +4,22 @@
  * These are extracted from `assistant/src/permissions/types.ts` and
  * `assistant/src/permissions/trust-store.ts` so that both packages can
  * reference a single canonical definition.
+ *
+ * Tools are grouped into "families" based on how their permission candidates
+ * are constructed and matched:
+ *
+ * - **Scoped**: tools whose candidates include a filesystem path and obey
+ *   directory-boundary scope constraints (`file_read`, `file_write`,
+ *   `file_edit`, `host_file_read`, `host_file_write`, `host_file_edit`,
+ *   `bash`, `host_bash`).
+ * - **URL**: tools whose candidates include a URL (`web_fetch`,
+ *   `browser_navigate`, `network_request`).
+ * - **Managed skill**: tools that manage first-party skill packages
+ *   (`scaffold_managed_skill`, `delete_managed_skill`).
+ * - **Skill load**: the `skill_load` tool, which uses a distinct candidate
+ *   namespace (`skill_load:selector` or `skill_load_dynamic:selector`).
+ * - **Generic**: everything else (computer-use tools, browser action tools,
+ *   UI surface tools, recall, skill_execute, etc.).
  */
 
 // ---------------------------------------------------------------------------
@@ -14,10 +30,60 @@
 export type TrustDecision = "allow" | "deny" | "ask";
 
 // ---------------------------------------------------------------------------
-// Trust rule
+// Tool family constants
 // ---------------------------------------------------------------------------
 
-export interface TrustRule {
+/**
+ * Tools whose permission candidates are scoped to a filesystem path and obey
+ * directory-boundary scope constraints.
+ */
+export const SCOPED_TOOLS = [
+  "file_read",
+  "file_write",
+  "file_edit",
+  "host_file_read",
+  "host_file_write",
+  "host_file_edit",
+  "bash",
+  "host_bash",
+] as const;
+
+/**
+ * Tools whose permission candidates include a URL.
+ */
+export const URL_TOOLS = [
+  "web_fetch",
+  "browser_navigate",
+  "network_request",
+] as const;
+
+/**
+ * Tools that manage first-party skill packages (scaffold/delete).
+ */
+export const MANAGED_SKILL_TOOLS = [
+  "scaffold_managed_skill",
+  "delete_managed_skill",
+] as const;
+
+/**
+ * The skill_load tool name. Separated from the array constants because
+ * skill_load is a singleton, not a family with multiple members.
+ */
+export const SKILL_LOAD_TOOL = "skill_load" as const;
+
+/** Set for O(1) lookups when classifying tool names. */
+const SCOPED_TOOLS_SET: ReadonlySet<string> = new Set(SCOPED_TOOLS);
+const URL_TOOLS_SET: ReadonlySet<string> = new Set(URL_TOOLS);
+const MANAGED_SKILL_TOOLS_SET: ReadonlySet<string> = new Set(
+  MANAGED_SKILL_TOOLS,
+);
+
+// ---------------------------------------------------------------------------
+// Trust rule — base and family-specific variants
+// ---------------------------------------------------------------------------
+
+/** Fields shared by all trust rule variants. */
+export interface TrustRuleBase {
   id: string;
   tool: string;
   pattern: string;
@@ -25,8 +91,222 @@ export interface TrustRule {
   decision: TrustDecision;
   priority: number;
   createdAt: number;
+}
+
+/**
+ * A trust rule for a scoped tool (filesystem-path-based candidates).
+ *
+ * Scoped rules may carry `executionTarget` to constrain matching to a
+ * specific execution environment and `allowHighRisk` to permit high-risk
+ * operations under the rule's allow decision.
+ */
+export interface ScopedTrustRule extends TrustRuleBase {
+  tool: (typeof SCOPED_TOOLS)[number];
   executionTarget?: string;
   allowHighRisk?: boolean;
+}
+
+/**
+ * A trust rule for a URL-based tool.
+ *
+ * URL rules do not use `executionTarget` or `allowHighRisk` — those
+ * semantics are specific to scoped (filesystem/shell) tools.
+ */
+export interface UrlTrustRule extends TrustRuleBase {
+  tool: (typeof URL_TOOLS)[number];
+}
+
+/**
+ * A trust rule for a managed-skill tool (scaffold/delete).
+ */
+export interface ManagedSkillTrustRule extends TrustRuleBase {
+  tool: (typeof MANAGED_SKILL_TOOLS)[number];
+}
+
+/**
+ * A trust rule for the `skill_load` tool.
+ */
+export interface SkillLoadTrustRule extends TrustRuleBase {
+  tool: typeof SKILL_LOAD_TOOL;
+}
+
+/**
+ * A trust rule for any tool that doesn't belong to a known family.
+ *
+ * Generic rules preserve `executionTarget` and `allowHighRisk` for backward
+ * compatibility — existing rules for unknown/new tools may carry these fields.
+ */
+export interface GenericTrustRule extends TrustRuleBase {
+  tool: string;
+  executionTarget?: string;
+  allowHighRisk?: boolean;
+}
+
+/**
+ * Discriminated union of all trust rule families.
+ *
+ * The union is discriminated on the `tool` field: known tool names narrow to
+ * the corresponding family variant, while unknown tool names fall through to
+ * `GenericTrustRule`.
+ *
+ * For backward compatibility, `TrustRule` remains the single type that all
+ * existing code uses. The family-specific interfaces exist so that new code
+ * can narrow the type when it knows the tool family.
+ */
+export type TrustRule =
+  | ScopedTrustRule
+  | UrlTrustRule
+  | ManagedSkillTrustRule
+  | SkillLoadTrustRule
+  | GenericTrustRule;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Narrow a TrustRule to a ScopedTrustRule. */
+export function isScopedRule(rule: TrustRule): rule is ScopedTrustRule {
+  return SCOPED_TOOLS_SET.has(rule.tool);
+}
+
+/** Narrow a TrustRule to a UrlTrustRule. */
+export function isUrlRule(rule: TrustRule): rule is UrlTrustRule {
+  return URL_TOOLS_SET.has(rule.tool);
+}
+
+/** Narrow a TrustRule to a ManagedSkillTrustRule. */
+export function isManagedSkillRule(
+  rule: TrustRule,
+): rule is ManagedSkillTrustRule {
+  return MANAGED_SKILL_TOOLS_SET.has(rule.tool);
+}
+
+/** Narrow a TrustRule to a SkillLoadTrustRule. */
+export function isSkillLoadRule(rule: TrustRule): rule is SkillLoadTrustRule {
+  return rule.tool === SKILL_LOAD_TOOL;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical parse / normalize
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of parsing a raw trust rule object. Includes the normalized rule
+ * and a flag indicating whether any normalization occurred (so callers can
+ * trigger a re-save of the trust file).
+ */
+export interface ParsedTrustRule {
+  rule: TrustRule;
+  /** True if any fields were stripped or modified during normalization. */
+  normalized: boolean;
+}
+
+/**
+ * Parse and normalize a raw trust rule object into a canonical `TrustRule`.
+ *
+ * Normalization strips fields that are invalid for the rule's tool family:
+ * - URL rules: `executionTarget` and `allowHighRisk` are stripped (URL tools
+ *   don't support these semantics).
+ * - Managed skill rules: `executionTarget` and `allowHighRisk` are stripped.
+ * - Skill load rules: `executionTarget` and `allowHighRisk` are stripped.
+ * - Scoped rules and generic rules: all fields are preserved.
+ *
+ * Unknown tools (generic family) preserve all fields for forward compatibility
+ * — we don't know what semantics future tools may require.
+ */
+export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
+  let normalized = false;
+
+  // Extract base fields with coercion for safety
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const tool = typeof raw.tool === "string" ? raw.tool : "";
+  const pattern = typeof raw.pattern === "string" ? raw.pattern : "";
+  const scope = typeof raw.scope === "string" ? raw.scope : "everywhere";
+  const decision = isValidDecision(raw.decision) ? raw.decision : "ask";
+  const priority = typeof raw.priority === "number" ? raw.priority : 100;
+  const createdAt = typeof raw.createdAt === "number" ? raw.createdAt : 0;
+
+  // Coerce decision if it was invalid
+  if (!isValidDecision(raw.decision)) {
+    normalized = true;
+  }
+
+  // Build the base rule
+  const base: TrustRuleBase = {
+    id,
+    tool,
+    pattern,
+    scope,
+    decision,
+    priority,
+    createdAt,
+  };
+
+  // Determine the family and strip invalid fields
+  if (URL_TOOLS_SET.has(tool)) {
+    // URL rules must not carry executionTarget or allowHighRisk
+    if (raw.executionTarget !== undefined || raw.allowHighRisk !== undefined) {
+      normalized = true;
+    }
+    const rule: UrlTrustRule = { ...base, tool: tool as UrlTrustRule["tool"] };
+    return { rule, normalized };
+  }
+
+  if (MANAGED_SKILL_TOOLS_SET.has(tool)) {
+    // Managed skill rules must not carry executionTarget or allowHighRisk
+    if (raw.executionTarget !== undefined || raw.allowHighRisk !== undefined) {
+      normalized = true;
+    }
+    const rule: ManagedSkillTrustRule = {
+      ...base,
+      tool: tool as ManagedSkillTrustRule["tool"],
+    };
+    return { rule, normalized };
+  }
+
+  if (tool === SKILL_LOAD_TOOL) {
+    // Skill load rules must not carry executionTarget or allowHighRisk
+    if (raw.executionTarget !== undefined || raw.allowHighRisk !== undefined) {
+      normalized = true;
+    }
+    const rule: SkillLoadTrustRule = { ...base, tool: SKILL_LOAD_TOOL };
+    return { rule, normalized };
+  }
+
+  if (SCOPED_TOOLS_SET.has(tool)) {
+    // Scoped rules preserve executionTarget and allowHighRisk
+    const rule: ScopedTrustRule = {
+      ...base,
+      tool: tool as ScopedTrustRule["tool"],
+    };
+    if (
+      typeof raw.executionTarget === "string" &&
+      raw.executionTarget.length > 0
+    ) {
+      rule.executionTarget = raw.executionTarget;
+    }
+    if (typeof raw.allowHighRisk === "boolean") {
+      rule.allowHighRisk = raw.allowHighRisk;
+    }
+    return { rule, normalized };
+  }
+
+  // Generic (unknown) tool — preserve all optional fields for forward compat
+  const rule: GenericTrustRule = { ...base };
+  if (
+    typeof raw.executionTarget === "string" &&
+    raw.executionTarget.length > 0
+  ) {
+    rule.executionTarget = raw.executionTarget;
+  }
+  if (typeof raw.allowHighRisk === "boolean") {
+    rule.allowHighRisk = raw.allowHighRisk;
+  }
+  return { rule, normalized };
+}
+
+function isValidDecision(value: unknown): value is TrustDecision {
+  return value === "allow" || value === "deny" || value === "ask";
 }
 
 // ---------------------------------------------------------------------------
@@ -39,4 +319,52 @@ export interface TrustFileData {
   rules: TrustRule[];
   /** Set to true when the user explicitly accepts the starter approval bundle. */
   starterBundleAccepted?: boolean;
+}
+
+/**
+ * Result of parsing a raw trust file. Includes the parsed data and a flag
+ * indicating whether any rules were normalized.
+ */
+export interface ParsedTrustFileData {
+  data: TrustFileData;
+  /** True if any rules were normalized during parsing. */
+  normalized: boolean;
+}
+
+/**
+ * Parse and normalize a raw trust file object.
+ *
+ * Each rule in the `rules` array is run through `parseTrustRule` for
+ * family-aware normalization. The `normalized` flag in the result is true
+ * if *any* rule was modified, signaling the caller that a re-save is warranted.
+ */
+export function parseTrustFileData(
+  raw: Record<string, unknown>,
+): ParsedTrustFileData {
+  const version = typeof raw.version === "number" ? raw.version : 0;
+  const starterBundleAccepted =
+    raw.starterBundleAccepted === true ? true : undefined;
+  const rawRules = Array.isArray(raw.rules) ? raw.rules : [];
+
+  let anyNormalized = false;
+  const rules: TrustRule[] = [];
+
+  for (const rawRule of rawRules) {
+    if (rawRule == null || typeof rawRule !== "object") {
+      anyNormalized = true;
+      continue;
+    }
+    const { rule, normalized } = parseTrustRule(
+      rawRule as Record<string, unknown>,
+    );
+    if (normalized) anyNormalized = true;
+    rules.push(rule);
+  }
+
+  const data: TrustFileData = { version, rules };
+  if (starterBundleAccepted) {
+    data.starterBundleAccepted = true;
+  }
+
+  return { data, normalized: anyNormalized };
 }


### PR DESCRIPTION
## Summary
- Replace flat TrustRule interface with family-aware discriminated union types
- Add canonical parseTrustRule/parseTrustFileData normalization helpers
- Add type guards and family constants for scoped, URL, managed-skill, and skill-load tool families

Part of plan: trust-rule-union-compat.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
