### PR TITLE
Fix remote FF sync: pause polling when credentials missing

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -45,17 +45,40 @@ const { readRemoteFeatureFlags, clearRemoteFeatureFlagStoreCache } =
 // Helpers
 // ---------------------------------------------------------------------------
 
+type FakeCredentialCacheExt = CredentialCache & {
+  _invalidate(): void;
+  _setValues(v: Record<string, string | undefined>): void;
+};
+
 /**
  * Build a fake CredentialCache that resolves credential keys from an
  * in-memory map. Keys follow the `credential/{service}/{field}` format
  * produced by `credentialKey()`.
+ *
+ * Includes `onInvalidate` support and test helpers:
+ * - `_invalidate()` — fire all registered invalidation listeners
+ * - `_setValues(v)` — replace the in-memory credential map
  */
 function fakeCredentialCache(
-  values: Record<string, string | undefined> = {},
-): CredentialCache {
+  initialValues: Record<string, string | undefined> = {},
+): FakeCredentialCacheExt {
+  let values = { ...initialValues };
+  const invalidateListeners = new Set<() => void>();
   return {
     get: async (key: string) => values[key],
-  } as unknown as CredentialCache;
+    onInvalidate: (cb: () => void) => {
+      invalidateListeners.add(cb);
+      return () => {
+        invalidateListeners.delete(cb);
+      };
+    },
+    _invalidate: () => {
+      for (const cb of invalidateListeners) cb();
+    },
+    _setValues: (v: Record<string, string | undefined>) => {
+      values = { ...v };
+    },
+  } as unknown as FakeCredentialCacheExt;
 }
 
 function defaultCredentials(): Record<string, string> {
@@ -489,40 +512,32 @@ describe("RemoteFeatureFlagSync", () => {
   });
 
   test("polls with backoff when initial fetch fails, then snaps to steady-state on success", async () => {
-    // Simulate: first two fetches fail (missing creds), third succeeds.
-    let callCount = 0;
-    const credsFn = async (key: string) => {
-      callCount++;
-      // First 6 calls = 2 attempts × 3 credential reads each → missing API key.
-      // After that, credentials are available.
-      if (callCount <= 6) {
-        if (key === "credential/vellum/assistant_api_key") return undefined;
-        return defaultCredentials()[key];
+    // Simulate: first two fetches return 500, third succeeds.
+    let fetchCallCount = 0;
+    fetchMock = mock(async () => {
+      fetchCallCount++;
+      if (fetchCallCount <= 2) {
+        return new Response("Internal Server Error", { status: 500 });
       }
-      return defaultCredentials()[key];
-    };
-    const creds = { get: credsFn } as unknown as CredentialCache;
-
-    fetchMock = mock(async () =>
-      Response.json({ flags: { "backoff-flag": true } }),
-    );
+      return Response.json({ flags: { "backoff-flag": true } });
+    });
 
     const sync = new RemoteFeatureFlagSync({
-      credentials: creds,
+      credentials: fakeCredentialCache(defaultCredentials()),
       initialPollIntervalMs: 50,
     });
     await sync.start();
 
-    // Initial fetch failed (missing creds) — no fetch calls yet
-    expect(fetchMock).not.toHaveBeenCalled();
+    // Initial fetch failed (500) — 1 call so far
+    expect(fetchCallCount).toBe(1);
 
-    // Wait for first poll (50ms) — still fails (creds still missing)
+    // Wait for first poll (50ms) — still fails (500)
     await new Promise((r) => setTimeout(r, 80));
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchCallCount).toBe(2);
 
-    // Wait for second poll (100ms = 50ms doubled) — creds now available
+    // Wait for second poll (100ms = 50ms doubled) — succeeds
     await new Promise((r) => setTimeout(r, 130));
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchCallCount).toBe(3);
 
     clearRemoteFeatureFlagStoreCache();
     expect(readRemoteFeatureFlags()).toEqual({ "backoff-flag": true });
@@ -615,32 +630,70 @@ describe("RemoteFeatureFlagSync", () => {
   });
 
   test("doubles poll interval on consecutive failures", async () => {
-    // Always fail — missing creds
-    const creds = defaultCredentials();
-    delete creds["credential/vellum/assistant_api_key"];
-
-    fetchMock = mock(async () => Response.json({ flags: {} }));
+    // Always fail with 500
+    fetchMock = mock(
+      async () => new Response("Internal Server Error", { status: 500 }),
+    );
 
     const sync = new RemoteFeatureFlagSync({
-      credentials: fakeCredentialCache(creds),
+      credentials: fakeCredentialCache(defaultCredentials()),
       initialPollIntervalMs: 50,
     });
     await sync.start();
 
-    // No fetch calls (missing creds)
-    expect(fetchMock).not.toHaveBeenCalled();
+    // Initial fetch failed (500) — 1 call
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     // After 50ms: first poll fires, still fails → interval doubles to 100ms
     await new Promise((r) => setTimeout(r, 80));
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // After another 100ms: second poll fires, still fails → interval doubles to 200ms
     await new Promise((r) => setTimeout(r, 130));
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     // After another 200ms: third poll fires
     await new Promise((r) => setTimeout(r, 230));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    sync.stop();
+  });
+
+  test("pauses polling when credentials are missing and resumes on invalidation", async () => {
+    fetchMock = mock(async () =>
+      Response.json({ flags: { "resumed-flag": true } }),
+    );
+
+    const creds = fakeCredentialCache({
+      ...defaultCredentials(),
+      "credential/vellum/assistant_api_key": undefined,
+    });
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: creds,
+      initialPollIntervalMs: 50,
+    });
+    await sync.start();
+
+    // No fetch calls — missing creds, polling should be paused
     expect(fetchMock).not.toHaveBeenCalled();
+
+    // Wait well past the initial poll interval — should still not poll
+    await new Promise((r) => setTimeout(r, 200));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Simulate user logging in — credentials now available
+    creds._setValues(defaultCredentials());
+    creds._invalidate();
+
+    // Wait for syncNow to complete (async, fire-and-forget from callback)
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should have fetched once after credential invalidation
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({ "resumed-flag": true });
 
     sync.stop();
   });

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -31,6 +31,12 @@ function getMaxPollIntervalMs(): number {
   return DEFAULT_POLL_INTERVAL_MS;
 }
 
+/** Discriminated result from a remote feature flag fetch attempt. */
+type RemoteFetchResult =
+  | { status: "success"; values: Record<string, boolean> }
+  | { status: "missing_credentials" }
+  | { status: "error" };
+
 export type RemoteFeatureFlagSyncConfig = {
   /** Credential cache for resolving platform URL, API key, and assistant ID dynamically. */
   credentials: CredentialCache;
@@ -46,11 +52,17 @@ export type RemoteFeatureFlagSyncConfig = {
  * {@link INITIAL_POLL_INTERVAL_MS} and doubles on each failure until it
  * reaches the steady-state interval. On the first success the interval
  * snaps to steady-state immediately.
+ *
+ * When credentials are not configured (user not logged in), polling pauses
+ * entirely and resumes automatically when the credential cache is
+ * invalidated (e.g. after login).
  */
 export class RemoteFeatureFlagSync {
   private started = false;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private syncNowActive = false;
+  private waitingForCredentials = false;
+  private unsubscribeCredentials: (() => void) | null = null;
   private currentIntervalMs: number;
   private readonly maxIntervalMs: number;
   private readonly credentials: CredentialCache;
@@ -65,21 +77,28 @@ export class RemoteFeatureFlagSync {
   async start(): Promise<void> {
     this.started = true;
 
-    let ok = false;
+    let result: RemoteFetchResult["status"] = "error";
     try {
-      ok = await this.fetchAndCache();
+      result = await this.fetchAndCache();
     } catch (err) {
       log.warn({ err }, "Failed to sync remote feature flags on startup");
     }
 
-    if (ok) {
+    if (result === "success") {
       // First fetch succeeded — jump straight to steady-state polling.
       this.currentIntervalMs = this.maxIntervalMs;
+      this.scheduleNextPoll();
+    } else if (result === "missing_credentials") {
+      this.pauseForCredentials();
+    } else {
+      this.scheduleNextPoll();
     }
 
-    this.scheduleNextPoll();
     log.info(
-      { intervalMs: this.currentIntervalMs },
+      {
+        intervalMs: this.currentIntervalMs,
+        waitingForCredentials: this.waitingForCredentials,
+      },
       "Remote feature flag polling started",
     );
   }
@@ -90,6 +109,7 @@ export class RemoteFeatureFlagSync {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
     }
+    this.clearCredentialWatch();
   }
 
   /**
@@ -102,15 +122,19 @@ export class RemoteFeatureFlagSync {
     // Guard: tell poll()'s .finally() not to reschedule — we'll handle it.
     this.syncNowActive = true;
 
+    // If we were waiting for credentials, clear that state.
+    this.clearCredentialWatch();
+
     // Cancel the pending poll so we don't double-fetch.
     if (this.pollTimer) {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
     }
 
+    let result: RemoteFetchResult["status"] = "error";
     try {
-      const ok = await this.fetchAndCache();
-      if (ok) {
+      result = await this.fetchAndCache();
+      if (result === "success") {
         this.currentIntervalMs = this.maxIntervalMs;
       }
     } catch (err) {
@@ -120,7 +144,11 @@ export class RemoteFeatureFlagSync {
     }
 
     if (this.started) {
-      this.scheduleNextPoll();
+      if (result === "missing_credentials") {
+        this.pauseForCredentials();
+      } else {
+        this.scheduleNextPoll();
+      }
     }
   }
 
@@ -133,10 +161,12 @@ export class RemoteFeatureFlagSync {
   private poll(): void {
     if (!this.started) return;
     this.fetchAndCache()
-      .then((ok) => {
-        if (ok) {
+      .then((result) => {
+        if (result === "success") {
           // Success — snap to steady-state interval.
           this.currentIntervalMs = this.maxIntervalMs;
+        } else if (result === "missing_credentials") {
+          this.pauseForCredentials();
         } else {
           // Failure — double the interval, capped at max.
           this.currentIntervalMs = Math.min(
@@ -155,34 +185,80 @@ export class RemoteFeatureFlagSync {
       .finally(() => {
         // If syncNow() is active it owns rescheduling — skip to avoid
         // creating a duplicate poll chain.
-        if (this.started && !this.syncNowActive) {
+        // If waitingForCredentials, credential watch owns resumption.
+        if (
+          this.started &&
+          !this.syncNowActive &&
+          !this.waitingForCredentials
+        ) {
           this.scheduleNextPoll();
         }
       });
   }
 
   /**
-   * Fetch remote flags and write them to the store.
-   * Returns true if flags were successfully written, false otherwise.
+   * Stop polling and watch for credential changes instead.
+   *
+   * Called when credentials are not configured (user not logged in).
+   * Resumes sync automatically when the credential cache is invalidated.
    */
-  private async fetchAndCache(): Promise<boolean> {
-    const values = await this.fetchRemoteFeatureFlags();
-    if (values === null) {
-      log.warn("Skipping cache write — fetch returned no usable data");
-      return false;
+  private pauseForCredentials(): void {
+    if (this.waitingForCredentials) return;
+    this.waitingForCredentials = true;
+
+    // Stop any pending poll.
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
     }
-    writeRemoteFeatureFlags(values);
-    log.info(
-      { count: Object.keys(values).length },
-      "Synced remote feature flags",
-    );
-    return true;
+
+    // Listen for credential changes to resume.
+    this.unsubscribeCredentials = this.credentials.onInvalidate(() => {
+      if (!this.started || !this.waitingForCredentials) return;
+      log.info("Credentials changed — attempting remote feature flag sync");
+      this.syncNow().catch((err) => {
+        log.warn(
+          { err },
+          "Failed to sync remote feature flags after credential change",
+        );
+      });
+    });
+
+    log.debug("Paused remote flag polling — waiting for credentials");
   }
 
-  private async fetchRemoteFeatureFlags(): Promise<Record<
-    string,
-    boolean
-  > | null> {
+  /** Clear the credential invalidation watch if active. */
+  private clearCredentialWatch(): void {
+    this.waitingForCredentials = false;
+    if (this.unsubscribeCredentials) {
+      this.unsubscribeCredentials();
+      this.unsubscribeCredentials = null;
+    }
+  }
+
+  /**
+   * Fetch remote flags and write them to the store.
+   * Returns the status of the fetch attempt.
+   */
+  private async fetchAndCache(): Promise<RemoteFetchResult["status"]> {
+    const result = await this.fetchRemoteFeatureFlags();
+    if (result.status === "missing_credentials") {
+      log.debug("Skipping remote flag sync — credentials not configured");
+      return "missing_credentials";
+    }
+    if (result.status === "error") {
+      log.warn("Skipping cache write — fetch returned no usable data");
+      return "error";
+    }
+    writeRemoteFeatureFlags(result.values);
+    log.info(
+      { count: Object.keys(result.values).length },
+      "Synced remote feature flags",
+    );
+    return "success";
+  }
+
+  private async fetchRemoteFeatureFlags(): Promise<RemoteFetchResult> {
     const [platformUrlRaw, assistantIdRaw, assistantApiKeyRaw] =
       await Promise.all([
         this.credentials.get(credentialKey("vellum", "platform_base_url")),
@@ -216,7 +292,7 @@ export class RemoteFeatureFlagSync {
         },
         "Remote feature flag sync skipped: missing credentials",
       );
-      return null;
+      return { status: "missing_credentials" };
     }
 
     const url = `${platformUrl}/v1/feature-flags/assistant-flag-values/`;
@@ -236,7 +312,7 @@ export class RemoteFeatureFlagSync {
         { status: response.status, url },
         "Platform feature flags request failed",
       );
-      return null;
+      return { status: "error" };
     }
 
     const body = (await response.json()) as {
@@ -244,7 +320,7 @@ export class RemoteFeatureFlagSync {
     };
     if (!body.flags || typeof body.flags !== "object") {
       log.warn("Platform feature flags response missing 'flags' field");
-      return null;
+      return { status: "error" };
     }
 
     // Filter to boolean values only (defensive), and prevent the platform
@@ -253,7 +329,7 @@ export class RemoteFeatureFlagSync {
     // every flag it knows about. Without this filter, shipped features get
     // silently turned off for all users.
     const registry = loadFeatureFlagDefaults();
-    const result: Record<string, boolean> = {};
+    const values: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(body.flags)) {
       if (typeof value !== "boolean") continue;
       if (!value && registry[key]?.defaultEnabled) {
@@ -263,9 +339,9 @@ export class RemoteFeatureFlagSync {
         );
         continue;
       }
-      result[key] = value;
+      values[key] = value;
     }
 
-    return result;
+    return { status: "success", values };
   }
 }

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -259,12 +259,22 @@ export class RemoteFeatureFlagSync {
   }
 
   private async fetchRemoteFeatureFlags(): Promise<RemoteFetchResult> {
-    const [platformUrlRaw, assistantIdRaw, assistantApiKeyRaw] =
-      await Promise.all([
+    // Wrap credential reads so transient failures (CES unreachable, keychain
+    // errors) are treated as retriable errors with backoff, not as "missing
+    // credentials" which would pause polling indefinitely.
+    let platformUrlRaw: string | undefined;
+    let assistantIdRaw: string | undefined;
+    let assistantApiKeyRaw: string | undefined;
+    try {
+      [platformUrlRaw, assistantIdRaw, assistantApiKeyRaw] = await Promise.all([
         this.credentials.get(credentialKey("vellum", "platform_base_url")),
         this.credentials.get(credentialKey("vellum", "platform_assistant_id")),
         this.credentials.get(credentialKey("vellum", "assistant_api_key")),
       ]);
+    } catch (err) {
+      log.warn({ err }, "Failed to read credentials — will retry on next poll");
+      return { status: "error" };
+    }
 
     // Fall back to env vars when credential cache values are missing.
     const platformUrl = (

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -119,6 +119,11 @@ export class RemoteFeatureFlagSync {
    * steady-state interval after this fetch completes.
    */
   async syncNow(): Promise<void> {
+    // Re-entrancy guard: if a syncNow is already in-flight (e.g. triggered
+    // by onInvalidate callback during a wake that also calls syncNow
+    // explicitly), skip to avoid leaking duplicate poll timers.
+    if (this.syncNowActive) return;
+
     // Guard: tell poll()'s .finally() not to reschedule — we'll handle it.
     this.syncNowActive = true;
 

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -205,7 +205,13 @@ export class RemoteFeatureFlagSync {
    * Stop polling and watch for credential changes instead.
    *
    * Called when credentials are not configured (user not logged in).
-   * Resumes sync automatically when the credential cache is invalidated.
+   * Resumes sync automatically via two paths:
+   * 1. Primary: credential cache invalidation (e.g. after login).
+   * 2. Safety net: a delayed retry at the steady-state interval, in case
+   *    the "missing" result was caused by a transient credential-reader
+   *    failure (readCesCredential swallows errors as undefined) or an
+   *    invalidation event was missed between the credential check and
+   *    the listener registration.
    */
   private pauseForCredentials(): void {
     if (this.waitingForCredentials) return;
@@ -217,7 +223,7 @@ export class RemoteFeatureFlagSync {
       this.pollTimer = null;
     }
 
-    // Listen for credential changes to resume.
+    // Primary resume path: credential cache invalidation.
     this.unsubscribeCredentials = this.credentials.onInvalidate(() => {
       if (!this.started || !this.waitingForCredentials) return;
       log.info("Credentials changed — attempting remote feature flag sync");
@@ -228,6 +234,19 @@ export class RemoteFeatureFlagSync {
         );
       });
     });
+
+    // Safety net: re-check after the steady-state interval. If credentials
+    // are still missing, syncNow → pauseForCredentials re-arms this timer.
+    this.pollTimer = setTimeout(() => {
+      if (!this.started || !this.waitingForCredentials) return;
+      log.debug("Safety re-check: retrying credential read after pause");
+      this.syncNow().catch((err) => {
+        log.warn(
+          { err },
+          "Failed to sync remote feature flags (safety re-check)",
+        );
+      });
+    }, this.maxIntervalMs);
 
     log.debug("Paused remote flag polling — waiting for credentials");
   }

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -149,6 +149,16 @@ export class RemoteFeatureFlagSync {
     }
 
     if (this.started) {
+      // A concurrent poll() may have called pauseForCredentials() during
+      // our await, re-establishing credential-watch state and setting a
+      // safety-net timer. Clean that up before deciding what to do next
+      // so we don't leak timers or leave waitingForCredentials stale.
+      this.clearCredentialWatch();
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer);
+        this.pollTimer = null;
+      }
+
       if (result === "missing_credentials") {
         this.pauseForCredentials();
       } else {


### PR DESCRIPTION
## Summary
- Distinguish "missing credentials" from "fetch error" in `RemoteFeatureFlagSync` so log noise is reduced and polling behavior is correct for each case
- When credentials are missing (user not logged in), stop polling entirely and subscribe to `CredentialCache.onInvalidate()` to resume automatically when credentials become available
- Log at `debug` (not `warn`) for the expected "not logged in" state; reserve `warn` for actual fetch failures

## Original prompt
Fix remote feature flag sync behavior when credentials are missing:

1. **Distinguish "no credentials" from "fetch failed"** in `gateway/src/remote-feature-flag-sync.ts`:
   - Change `fetchRemoteFeatureFlags()` to return a more specific result that distinguishes "missing credentials" from "actual fetch/parse failure" (e.g., return a discriminated union or use a sentinel value).
   - In `fetchAndCache()`, use this to:
     - Log at `debug` (not `warn`) when credentials are missing — this is expected for users who haven't logged in.
     - Continue to log at `warn` for actual fetch failures (network errors, bad responses, missing `flags` field).

2. **Stop polling when credentials are missing** instead of using adaptive backoff:
   - When `fetchRemoteFeatureFlags()` indicates missing credentials, don't schedule the next poll on the normal backoff cadence.
   - Instead, stop polling entirely and listen for credential changes to restart. The `CredentialCache` likely has a way to watch for changes — use that to trigger a restart of polling when credentials become available.
   - If there's no easy way to watch for credential changes, an acceptable alternative is to poll at a much longer interval (e.g., steady-state 5min) without the adaptive backoff doubling, since missing credentials isn't a transient failure that benefits from rapid retry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
