### PR TITLE
Switch gateway trust-store to shared ces-contracts trust-rule types and parser

### DIFF
--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "vellum-gateway",
       "dependencies": {
+        "@vellumai/ces-contracts": "file:../packages/ces-contracts",
         "file-type": "21.3.0",
         "minimatch": "10.2.4",
         "pino": "9.14.0",
@@ -121,6 +122,8 @@
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/type-utils": "8.56.0", "@typescript-eslint/utils": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg=="],
@@ -140,6 +143,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
+
+    "@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -387,6 +392,10 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
+    "@vellumai/ces-contracts/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "@vellumai/ces-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
     "eslint/minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -396,6 +405,8 @@
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@vellumai/ces-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,4 +1,5 @@
 {
   "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
-  "project": ["src/**/*.ts"]
+  "project": ["src/**/*.ts"],
+  "ignoreDependencies": ["@vellumai/ces-contracts"]
 }

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -23,6 +23,7 @@
     "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
+    "@vellumai/ces-contracts": "file:../packages/ces-contracts",
     "file-type": "21.3.0",
     "minimatch": "10.2.4",
     "pino": "9.14.0",

--- a/gateway/src/__tests__/trust-store.test.ts
+++ b/gateway/src/__tests__/trust-store.test.ts
@@ -163,8 +163,8 @@ describe("normalization on load", () => {
 
     const rules = loadRules();
     expect(rules).toHaveLength(1);
-    expect((rules[0] as Record<string, unknown>).executionTarget).toBe("host");
-    expect((rules[0] as Record<string, unknown>).allowHighRisk).toBe(true);
+    expect((rules[0] as any).executionTarget).toBe("host");
+    expect((rules[0] as any).allowHighRisk).toBe(true);
   });
 
   test("preserves executionTarget and allowHighRisk on generic (unknown) tool rules", () => {
@@ -187,10 +187,8 @@ describe("normalization on load", () => {
 
     const rules = loadRules();
     expect(rules).toHaveLength(1);
-    expect((rules[0] as Record<string, unknown>).executionTarget).toBe(
-      "container",
-    );
-    expect((rules[0] as Record<string, unknown>).allowHighRisk).toBe(false);
+    expect((rules[0] as any).executionTarget).toBe("container");
+    expect((rules[0] as any).allowHighRisk).toBe(false);
   });
 
   test("strips legacy principal-scoped fields and re-saves", () => {

--- a/gateway/src/__tests__/trust-store.test.ts
+++ b/gateway/src/__tests__/trust-store.test.ts
@@ -163,8 +163,8 @@ describe("normalization on load", () => {
 
     const rules = loadRules();
     expect(rules).toHaveLength(1);
-    expect(rules[0].executionTarget).toBe("host");
-    expect(rules[0].allowHighRisk).toBe(true);
+    expect((rules[0] as Record<string, unknown>).executionTarget).toBe("host");
+    expect((rules[0] as Record<string, unknown>).allowHighRisk).toBe(true);
   });
 
   test("preserves executionTarget and allowHighRisk on generic (unknown) tool rules", () => {
@@ -187,8 +187,10 @@ describe("normalization on load", () => {
 
     const rules = loadRules();
     expect(rules).toHaveLength(1);
-    expect(rules[0].executionTarget).toBe("container");
-    expect(rules[0].allowHighRisk).toBe(false);
+    expect((rules[0] as Record<string, unknown>).executionTarget).toBe(
+      "container",
+    );
+    expect((rules[0] as Record<string, unknown>).allowHighRisk).toBe(false);
   });
 
   test("strips legacy principal-scoped fields and re-saves", () => {

--- a/gateway/src/__tests__/trust-store.test.ts
+++ b/gateway/src/__tests__/trust-store.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Tests for gateway trust-store normalization behavior and matching parity
+ * with the assistant trust-store logic.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { describe, test, expect, beforeEach } from "bun:test";
+
+import {
+  loadRules,
+  getAllRules,
+  addRule,
+  findMatchingRule,
+  findHighestPriorityRule,
+  clearRules,
+  clearCache,
+} from "../trust-store.js";
+
+// GATEWAY_SECURITY_DIR is set by test-preload.ts — all trust.json reads/writes
+// go to the per-file temp directory.
+
+function getSecurityDir(): string {
+  return process.env.GATEWAY_SECURITY_DIR!;
+}
+
+function getTrustPath(): string {
+  return join(getSecurityDir(), "trust.json");
+}
+
+function writeTrustFile(data: Record<string, unknown>): void {
+  const dir = getSecurityDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(getTrustPath(), JSON.stringify(data));
+}
+
+function readTrustFile(): Record<string, unknown> {
+  return JSON.parse(readFileSync(getTrustPath(), "utf-8"));
+}
+
+beforeEach(() => {
+  clearCache();
+  // Remove any leftover trust.json from previous test
+  try {
+    unlinkSync(getTrustPath());
+  } catch {
+    // file may not exist
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Normalization on load
+// ---------------------------------------------------------------------------
+
+describe("normalization on load", () => {
+  test("strips executionTarget and allowHighRisk from URL tool rules and re-saves", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r1",
+          tool: "web_fetch",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("r1");
+    // URL rules should not have executionTarget or allowHighRisk
+    expect("executionTarget" in rules[0]).toBe(false);
+    expect("allowHighRisk" in rules[0]).toBe(false);
+
+    // Verify file was re-saved with normalized rules
+    const saved = readTrustFile();
+    expect(saved.version).toBe(3);
+    const savedRules = saved.rules as Array<Record<string, unknown>>;
+    expect(savedRules).toHaveLength(1);
+    expect("executionTarget" in savedRules[0]).toBe(false);
+    expect("allowHighRisk" in savedRules[0]).toBe(false);
+  });
+
+  test("strips executionTarget and allowHighRisk from managed skill tool rules", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r2",
+          tool: "scaffold_managed_skill",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect("executionTarget" in rules[0]).toBe(false);
+    expect("allowHighRisk" in rules[0]).toBe(false);
+  });
+
+  test("strips executionTarget and allowHighRisk from skill_load rules", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r3",
+          tool: "skill_load",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect("executionTarget" in rules[0]).toBe(false);
+    expect("allowHighRisk" in rules[0]).toBe(false);
+  });
+
+  test("preserves executionTarget and allowHighRisk on scoped tool rules", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r4",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].executionTarget).toBe("host");
+    expect(rules[0].allowHighRisk).toBe(true);
+  });
+
+  test("preserves executionTarget and allowHighRisk on generic (unknown) tool rules", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r5",
+          tool: "future_tool",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "container",
+          allowHighRisk: false,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].executionTarget).toBe("container");
+    expect(rules[0].allowHighRisk).toBe(false);
+  });
+
+  test("strips legacy principal-scoped fields and re-saves", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r6",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          principalKind: "user",
+          principalId: "u-123",
+          principalVersion: 1,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    const r = rules[0] as unknown as Record<string, unknown>;
+    expect("principalKind" in r).toBe(false);
+    expect("principalId" in r).toBe(false);
+    expect("principalVersion" in r).toBe(false);
+  });
+
+  test("strips __internal: rules on load", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r7-good",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+        {
+          id: "r7-bad",
+          tool: "__internal:debug",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("r7-good");
+  });
+
+  test("does not re-save when no normalization is needed", () => {
+    // Write a clean v3 file — loadRules should NOT re-save
+    const data = {
+      version: 3,
+      rules: [
+        {
+          id: "r8",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    };
+    writeTrustFile(data);
+    const originalContent = readFileSync(getTrustPath(), "utf-8");
+
+    loadRules();
+
+    // File content should not have changed (no re-save)
+    const afterContent = readFileSync(getTrustPath(), "utf-8");
+    expect(afterContent).toBe(originalContent);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version handling
+// ---------------------------------------------------------------------------
+
+describe("version handling", () => {
+  test("migrates v1 trust files to current version on re-save", () => {
+    writeTrustFile({
+      version: 1,
+      rules: [
+        {
+          id: "v1-rule",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("v1-rule");
+
+    // File should have been re-saved with current version
+    const saved = readTrustFile();
+    expect(saved.version).toBe(3);
+  });
+
+  test("migrates v2 trust files to current version on re-save", () => {
+    writeTrustFile({
+      version: 2,
+      rules: [
+        {
+          id: "v2-rule",
+          tool: "file_read",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 90,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+
+    const saved = readTrustFile();
+    expect(saved.version).toBe(3);
+  });
+
+  test("returns empty rules for unknown future versions", () => {
+    writeTrustFile({
+      version: 99,
+      rules: [
+        {
+          id: "future-rule",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(0);
+
+    // Original file should NOT be overwritten
+    const saved = readTrustFile();
+    expect(saved.version).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope matching
+// ---------------------------------------------------------------------------
+
+describe("scope matching", () => {
+  test("'everywhere' scope matches any working directory", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "scope-1",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+
+    expect(findMatchingRule("bash", "ls", "/any/path")).toBeTruthy();
+    expect(findMatchingRule("bash", "ls", "/another/path")).toBeTruthy();
+  });
+
+  test("directory-scoped rule matches exact dir and subdirectories", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "scope-2",
+          tool: "bash",
+          pattern: "**",
+          scope: "/home/user/project",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    expect(findMatchingRule("bash", "ls", "/home/user/project")).toBeTruthy();
+    expect(
+      findMatchingRule("bash", "ls", "/home/user/project/sub"),
+    ).toBeTruthy();
+    expect(
+      findMatchingRule("bash", "ls", "/home/user/project-evil"),
+    ).toBeNull();
+    expect(findMatchingRule("bash", "ls", "/home/user/other")).toBeNull();
+  });
+
+  test("rule without scope field defaults to everywhere", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "scope-3",
+          tool: "bash",
+          pattern: "**",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    // Rule has no scope — parseTrustRule defaults it to "everywhere"
+    expect(findMatchingRule("bash", "ls", "/any/path")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule matching
+// ---------------------------------------------------------------------------
+
+describe("rule matching", () => {
+  test("findMatchingRule matches by tool and pattern", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "match-1",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+        {
+          id: "match-2",
+          tool: "file_read",
+          pattern: "/home/**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    // ** matches any command for the bash tool
+    expect(findMatchingRule("bash", "ls /tmp", "everywhere")).toBeTruthy();
+    expect(findMatchingRule("bash", "rm -rf /", "everywhere")).toBeTruthy();
+    // Wrong tool does not match
+    expect(findMatchingRule("file_write", "ls /tmp", "everywhere")).toBeNull();
+    // file_read pattern only matches /home/**
+    expect(
+      findMatchingRule("file_read", "/home/user/file.txt", "everywhere"),
+    ).toBeTruthy();
+    expect(
+      findMatchingRule("file_read", "/etc/passwd", "everywhere"),
+    ).toBeNull();
+  });
+
+  test("findHighestPriorityRule returns highest priority match across candidates", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "hp-1",
+          tool: "bash",
+          pattern: "ls **",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 50,
+          createdAt: 1000,
+        },
+        {
+          id: "hp-2",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "deny",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    const rule = findHighestPriorityRule("bash", ["ls /tmp"], "everywhere");
+    expect(rule).toBeTruthy();
+    expect(rule!.id).toBe("hp-2");
+    expect(rule!.decision).toBe("deny");
+  });
+
+  test("deny wins ties at same priority", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "tie-allow",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+        {
+          id: "tie-deny",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "deny",
+          priority: 100,
+          createdAt: 2000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    const rule = findHighestPriorityRule("bash", ["anything"], "everywhere");
+    expect(rule).toBeTruthy();
+    expect(rule!.id).toBe("tie-deny");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CRUD operations
+// ---------------------------------------------------------------------------
+
+describe("CRUD operations", () => {
+  test("addRule persists a new rule", () => {
+    const rule = addRule("bash", "echo **", "everywhere", "allow", 80);
+    expect(rule.id).toBeTruthy();
+    expect(rule.tool).toBe("bash");
+    expect(rule.pattern).toBe("echo **");
+    expect(rule.decision).toBe("allow");
+    expect(rule.priority).toBe(80);
+
+    const all = getAllRules();
+    expect(all.some((r) => r.id === rule.id)).toBe(true);
+  });
+
+  test("addRule rejects __internal: tools", () => {
+    expect(() => addRule("__internal:debug", "**", "everywhere")).toThrow(
+      "Cannot create internal pseudo-rule",
+    );
+  });
+
+  test("clearRules empties the rule list", () => {
+    addRule("bash", "**", "everywhere");
+    expect(getAllRules().length).toBeGreaterThan(0);
+
+    clearRules();
+    expect(getAllRules()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty file / no file
+// ---------------------------------------------------------------------------
+
+describe("empty and missing files", () => {
+  test("returns empty rules when trust file does not exist", () => {
+    const rules = loadRules();
+    expect(rules).toHaveLength(0);
+  });
+
+  test("handles empty rules array gracefully", () => {
+    writeTrustFile({ version: 3, rules: [] });
+    const rules = loadRules();
+    expect(rules).toHaveLength(0);
+  });
+
+  test("handles malformed JSON gracefully", () => {
+    const dir = getSecurityDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(getTrustPath(), "not json at all");
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(0);
+  });
+});

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -23,8 +23,8 @@ import type {
   TrustDecision,
   TrustFileData,
   TrustRule,
-} from "@vellumai/ces-contracts/trust-rules";
-import { parseTrustFileData } from "@vellumai/ces-contracts/trust-rules";
+} from "@vellumai/ces-contracts";
+import { parseTrustFileData } from "@vellumai/ces-contracts";
 
 import { getLogger } from "./logger.js";
 import { getGatewaySecurityDir } from "./paths.js";

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -23,8 +23,8 @@ import type {
   TrustDecision,
   TrustFileData,
   TrustRule,
-} from "@vellumai/ces-contracts";
-import { parseTrustFileData } from "@vellumai/ces-contracts";
+} from "@vellumai/ces-contracts/trust-rules";
+import { parseTrustFileData } from "@vellumai/ces-contracts/trust-rules";
 
 import { getLogger } from "./logger.js";
 import { getGatewaySecurityDir } from "./paths.js";

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -19,37 +19,21 @@ import { dirname, join } from "node:path";
 import { Minimatch } from "minimatch";
 import { v4 as uuid } from "uuid";
 
+import type {
+  TrustDecision,
+  TrustFileData,
+  TrustRule,
+} from "@vellumai/ces-contracts/trust-rules";
+import { parseTrustFileData } from "@vellumai/ces-contracts/trust-rules";
+
 import { getLogger } from "./logger.js";
 import { getGatewaySecurityDir } from "./paths.js";
+
+export type { TrustDecision, TrustRule };
 
 const log = getLogger("trust-store");
 
 const TRUST_FILE_VERSION = 3;
-
-// ---------------------------------------------------------------------------
-// Types — duplicated from ces-contracts to avoid adding a package dep for now.
-// These match the TrustRule / TrustFileData / TrustDecision shapes exactly.
-// ---------------------------------------------------------------------------
-
-export type TrustDecision = "allow" | "deny" | "ask";
-
-export interface TrustRule {
-  id: string;
-  tool: string;
-  pattern: string;
-  scope: string;
-  decision: TrustDecision;
-  priority: number;
-  createdAt: number;
-  executionTarget?: string;
-  allowHighRisk?: boolean;
-}
-
-interface TrustFileData {
-  version: number;
-  rules: TrustRule[];
-  starterBundleAccepted?: boolean;
-}
 
 // ---------------------------------------------------------------------------
 // Starter bundle definitions
@@ -198,8 +182,11 @@ function ruleOrder(a: TrustRule, b: TrustRule): number {
 // Scope matching
 // ---------------------------------------------------------------------------
 
-function matchesScope(ruleScope: string, workingDir: string): boolean {
-  if (ruleScope === "everywhere") return true;
+function matchesScope(
+  ruleScope: string | undefined,
+  workingDir: string,
+): boolean {
+  if (!ruleScope || ruleScope === "everywhere") return true;
   const prefix = ruleScope.replace(/\*$/, "").replace(/\/+$/, "");
   const dir = workingDir.replace(/\/+$/, "");
   return dir === prefix || dir.startsWith(prefix + "/");
@@ -215,60 +202,89 @@ let cachedStarterBundleAccepted: boolean | null = null;
 function loadFromDisk(): TrustRule[] {
   const path = getTrustPath();
   let rules: TrustRule[] = [];
+  let needsSave = false;
 
   if (existsSync(path)) {
     try {
       const raw = readFileSync(path, "utf-8");
-      const data = JSON.parse(raw) as TrustFileData;
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const version = typeof parsed.version === "number" ? parsed.version : 0;
 
-      const rawRules = Array.isArray(data.rules) ? data.rules : [];
+      // Unknown future version — return empty rules for safety; do NOT
+      // overwrite the file so a newer gateway can still read it.
+      if (version !== TRUST_FILE_VERSION && version !== 1 && version !== 2) {
+        log.warn(
+          { version },
+          "Unknown trust file version, returning empty rules",
+        );
+        return [];
+      }
+
+      // Parse and normalize using the shared canonical parser
+      const { data, normalized } = parseTrustFileData(parsed);
+
       cachedStarterBundleAccepted = data.starterBundleAccepted === true;
 
+      if (normalized) {
+        needsSave = true;
+      }
+
+      // Version upgrade triggers re-save
+      if (version !== TRUST_FILE_VERSION) {
+        needsSave = true;
+        log.info(
+          { version, targetVersion: TRUST_FILE_VERSION },
+          "Migrating legacy trust file version",
+        );
+      }
+
       // Strip __internal: rules that may have been hand-edited in
-      const sanitizedRules = rawRules.filter((r) => {
+      const sanitizedRules = data.rules.filter((r) => {
         if (typeof r.tool === "string" && r.tool.startsWith("__internal:")) {
           log.warn(
             { ruleId: r.id, tool: r.tool },
             "Stripping __internal: rule from trust file on load",
           );
+          needsSave = true;
           return false;
         }
         return true;
       });
 
-      if (
-        data.version === TRUST_FILE_VERSION ||
-        data.version === 1 ||
-        data.version === 2
-      ) {
-        rules = sanitizedRules;
-
-        // Strip legacy principal-scoped fields
-        for (const rule of rules) {
-          const r = rule as unknown as Record<string, unknown>;
-          if (
-            "principalKind" in r ||
-            "principalId" in r ||
-            "principalVersion" in r
-          ) {
-            delete r.principalKind;
-            delete r.principalId;
-            delete r.principalVersion;
-          }
+      // Strip legacy principal-scoped fields
+      for (const rule of sanitizedRules) {
+        const r = rule as unknown as Record<string, unknown>;
+        if (
+          "principalKind" in r ||
+          "principalId" in r ||
+          "principalVersion" in r
+        ) {
+          delete r.principalKind;
+          delete r.principalId;
+          delete r.principalVersion;
+          needsSave = true;
         }
-      } else {
-        log.warn(
-          { version: data.version },
-          "Unknown trust file version, returning empty rules",
-        );
-        return [];
       }
+
+      rules = sanitizedRules;
     } catch (err) {
       log.error({ err }, "Failed to load trust file");
     }
   }
 
   rules.sort(ruleOrder);
+
+  if (needsSave) {
+    try {
+      saveToDisk(rules);
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to persist normalized trust rules (continuing with in-memory rules)",
+      );
+    }
+  }
+
   return rules;
 }
 

--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -9,7 +9,8 @@
     "./handles": "./src/handles.ts",
     "./grants": "./src/grants.ts",
     "./rpc": "./src/rpc.ts",
-    "./rendering": "./src/rendering.ts"
+    "./rendering": "./src/rendering.ts",
+    "./trust-rules": "./src/trust-rules.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -9,8 +9,7 @@
     "./handles": "./src/handles.ts",
     "./grants": "./src/grants.ts",
     "./rpc": "./src/rpc.ts",
-    "./rendering": "./src/rendering.ts",
-    "./trust-rules": "./src/trust-rules.ts"
+    "./rendering": "./src/rendering.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",


### PR DESCRIPTION
## Summary
- Add @vellumai/ces-contracts dependency to gateway
- Remove duplicated trust-rule type declarations, import from shared contracts
- Integrate parseTrustFileData with version gate and normalization re-save semantics
- Add trust-rules subpath export to ces-contracts package for zod-free import
- Add comprehensive trust-store tests (normalization, version handling, scope matching, CRUD)

Part of plan: trust-rule-union-compat.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
