### PR TITLE
Migrate assistant trust-store loading and matching to canonical trust-rule parsing

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1678,3 +1678,297 @@ describe("computer-use tool trust rule matching", () => {
     }
   });
 });
+
+// ── canonical parser normalization-on-load ─────────────────────────────────
+
+describe("canonical parser normalization-on-load", () => {
+  beforeEach(() => {
+    clearCache();
+    try {
+      rmSync(trustPath);
+    } catch {
+      /* may not exist */
+    }
+  });
+
+  test("URL rule with executionTarget is stripped on load and re-saved", () => {
+    // A URL rule (web_fetch) should not carry executionTarget — the canonical
+    // parser strips it and marks the file for re-save.
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 3,
+        rules: [
+          {
+            id: "url-rule-with-et",
+            tool: "web_fetch",
+            pattern: "web_fetch:https://example.com/*",
+            scope: "everywhere",
+            decision: "allow",
+            priority: 100,
+            createdAt: 1000,
+            executionTarget: "/usr/bin/node",
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    const found = rules.find((r) => r.id === "url-rule-with-et");
+    expect(found).toBeDefined();
+    // executionTarget should have been stripped by the canonical parser
+    expect(found).not.toHaveProperty("executionTarget");
+
+    // Verify the re-save persisted the normalized rule
+    const disk = JSON.parse(readFileSync(trustPath, "utf-8"));
+    const diskRule = disk.rules.find(
+      (r: { id: string }) => r.id === "url-rule-with-et",
+    );
+    expect(diskRule).toBeDefined();
+    expect(diskRule).not.toHaveProperty("executionTarget");
+  });
+
+  test("URL rule with allowHighRisk is stripped on load and re-saved", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 3,
+        rules: [
+          {
+            id: "url-rule-with-ahr",
+            tool: "browser_navigate",
+            pattern: "**",
+            scope: "everywhere",
+            decision: "allow",
+            priority: 100,
+            createdAt: 2000,
+            allowHighRisk: true,
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    const found = rules.find((r) => r.id === "url-rule-with-ahr");
+    expect(found).toBeDefined();
+    expect(found).not.toHaveProperty("allowHighRisk");
+  });
+
+  test("scoped rule preserves executionTarget and allowHighRisk on load", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 3,
+        rules: [
+          {
+            id: "scoped-rule-with-opts",
+            tool: "bash",
+            pattern: "npm *",
+            scope: "/tmp",
+            decision: "allow",
+            priority: 100,
+            createdAt: 3000,
+            executionTarget: "/usr/local/bin/node",
+            allowHighRisk: true,
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    const found = rules.find((r) => r.id === "scoped-rule-with-opts");
+    expect(found).toBeDefined();
+    expect((found as { executionTarget?: string }).executionTarget).toBe(
+      "/usr/local/bin/node",
+    );
+    expect((found as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+  });
+
+  test("normalization on v2 file triggers re-save as v3", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 2,
+        rules: [
+          {
+            id: "v2-url-rule",
+            tool: "network_request",
+            pattern: "network_request:https://api.test.com/*",
+            scope: "everywhere",
+            decision: "allow",
+            priority: 100,
+            createdAt: 4000,
+            executionTarget: "stale-value",
+          },
+        ],
+      }),
+    );
+    clearCache();
+    getAllRules();
+
+    // File should be re-saved as v3 with normalized rules
+    const disk = JSON.parse(readFileSync(trustPath, "utf-8"));
+    expect(disk.version).toBe(3);
+    const diskRule = disk.rules.find(
+      (r: { id: string }) => r.id === "v2-url-rule",
+    );
+    expect(diskRule).toBeDefined();
+    expect(diskRule).not.toHaveProperty("executionTarget");
+  });
+});
+
+// ── optional-scope matching fallback ──────────────────────────────────────
+
+describe("optional-scope matching fallback", () => {
+  beforeEach(() => {
+    clearCache();
+    try {
+      rmSync(trustPath);
+    } catch {
+      /* may not exist */
+    }
+  });
+
+  test("rule with missing scope is normalized to everywhere and matches any dir", () => {
+    // Simulate a persisted rule that somehow lacks a scope field —
+    // the canonical parser normalizes it to "everywhere".
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 3,
+        rules: [
+          {
+            id: "no-scope-rule",
+            tool: "bash",
+            pattern: "echo *",
+            decision: "allow",
+            priority: 200,
+            createdAt: 5000,
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    const found = rules.find((r) => r.id === "no-scope-rule");
+    expect(found).toBeDefined();
+    expect(found!.scope).toBe("everywhere");
+
+    // Should match any working directory since scope defaults to everywhere
+    const match = findHighestPriorityRule(
+      "bash",
+      ["echo hello"],
+      "/any/random/dir",
+    );
+    expect(match).not.toBeNull();
+    expect(match!.id).toBe("no-scope-rule");
+  });
+
+  test("rule with empty-string scope is normalized to everywhere", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 3,
+        rules: [
+          {
+            id: "empty-scope-rule",
+            tool: "bash",
+            pattern: "ls *",
+            scope: "",
+            decision: "allow",
+            priority: 200,
+            createdAt: 6000,
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    const found = rules.find((r) => r.id === "empty-scope-rule");
+    expect(found).toBeDefined();
+    // The effectiveScope helper treats "" as "everywhere"
+    const match = findHighestPriorityRule(
+      "bash",
+      ["ls -la"],
+      "/some/other/dir",
+    );
+    expect(match).not.toBeNull();
+    expect(match!.id).toBe("empty-scope-rule");
+  });
+});
+
+// ── unknown-version no-overwrite semantics ────────────────────────────────
+
+describe("unknown-version no-overwrite semantics", () => {
+  beforeEach(() => {
+    clearCache();
+    try {
+      rmSync(trustPath);
+    } catch {
+      /* may not exist */
+    }
+  });
+
+  test("unknown version file is never overwritten even if normalization would apply", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    // A future version file with rules that would normally be normalized —
+    // the unknown-version guard must prevent any disk writes.
+    const originalContent = JSON.stringify({
+      version: 9999,
+      rules: [
+        {
+          id: "future-url-rule",
+          tool: "web_fetch",
+          pattern: "web_fetch:https://future.io/*",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 50,
+          createdAt: 7000,
+          executionTarget: "should-be-stripped-but-file-not-overwritten",
+        },
+      ],
+    });
+    writeFileSync(trustPath, originalContent);
+    clearCache();
+    const rules = getAllRules();
+    // Defaults should be present in-memory
+    const defaults = rules.filter((r) => r.id.startsWith("default:"));
+    expect(defaults).toHaveLength(NUM_DEFAULTS);
+    // The on-disk file must NOT be overwritten
+    const diskContent = readFileSync(trustPath, "utf-8");
+    expect(diskContent).toBe(originalContent);
+  });
+
+  test("unknown version returns only in-memory defaults, not file rules", () => {
+    mkdirSync(dirname(trustPath), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 42,
+        rules: [
+          {
+            id: "v42-rule",
+            tool: "bash",
+            pattern: "dangerous *",
+            scope: "everywhere",
+            decision: "allow",
+            priority: 500,
+            createdAt: 8000,
+          },
+        ],
+      }),
+    );
+    clearCache();
+    const rules = getAllRules();
+    // The file's rules should NOT appear in the loaded set
+    expect(rules.find((r) => r.id === "v42-rule")).toBeUndefined();
+    // Only defaults should be present
+    expect(rules.every((r) => r.id.startsWith("default:"))).toBe(true);
+  });
+});

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { parseTrustFileData } from "@vellumai/ces-contracts";
 import { Minimatch } from "minimatch";
 import { v4 as uuid } from "uuid";
 
@@ -151,7 +152,7 @@ function ruleOrder(a: TrustRule, b: TrustRule): number {
   if (b.priority !== a.priority) return b.priority - a.priority;
   if (a.decision !== b.decision) {
     // deny > ask > allow
-    const order = { deny: 0, ask: 1, allow: 2 };
+    const order: Record<string, number> = { deny: 0, ask: 1, allow: 2 };
     return (order[a.decision] ?? 2) - (order[b.decision] ?? 2);
   }
   return 0;
@@ -240,6 +241,8 @@ function backfillDefaults(rules: TrustRule[]): boolean {
 
   for (const template of getDefaultRuleTemplates()) {
     if (!existingIds.has(template.id)) {
+      // Default rules may carry allowHighRisk (e.g. bash container rules).
+      // Build as GenericTrustRule to accommodate all optional fields.
       const rule: TrustRule = {
         id: template.id,
         tool: template.tool,
@@ -248,10 +251,10 @@ function backfillDefaults(rules: TrustRule[]): boolean {
         decision: template.decision,
         priority: template.priority,
         createdAt: Date.now(),
+        ...(template.allowHighRisk != null
+          ? { allowHighRisk: template.allowHighRisk }
+          : {}),
       };
-      if (template.allowHighRisk != null) {
-        rule.allowHighRisk = template.allowHighRisk;
-      }
       rules.push(rule);
       changed = true;
       log.info({ ruleId: template.id }, "Backfilled default trust rule");
@@ -294,7 +297,6 @@ function loadFromDisk(): TrustRule[] {
         data.version === 1 ||
         data.version === 2
       ) {
-        rules = sanitizedRules;
         if (sanitizedRules.length < rawRules.length) {
           needsSave = true;
         }
@@ -304,6 +306,21 @@ function loadFromDisk(): TrustRule[] {
             { version: data.version, targetVersion: TRUST_FILE_VERSION },
             "Migrating legacy trust file version",
           );
+        }
+
+        // Apply canonical parser for family-aware normalization.
+        // The parser strips fields that are invalid for a rule's tool family
+        // (e.g. executionTarget on URL rules) and coerces malformed values.
+        const { data: parsedData, normalized } = parseTrustFileData({
+          ...data,
+          rules: sanitizedRules,
+        });
+        // The contracts parser returns the union TrustRule type; our local
+        // TrustRule flattens the union with optional fields for backward
+        // compatibility. The structural overlap is safe to cast here.
+        rules = parsedData.rules as TrustRule[];
+        if (normalized) {
+          needsSave = true;
         }
 
         // Strip legacy principal-scoped fields from persisted v3 rules.
@@ -418,13 +435,13 @@ function fileAddRule(
     decision,
     priority,
     createdAt: Date.now(),
+    ...(options?.allowHighRisk != null
+      ? { allowHighRisk: options.allowHighRisk }
+      : {}),
+    ...(options?.executionTarget != null
+      ? { executionTarget: options.executionTarget }
+      : {}),
   };
-  if (options?.allowHighRisk != null) {
-    rule.allowHighRisk = options.allowHighRisk;
-  }
-  if (options?.executionTarget != null) {
-    rule.executionTarget = options.executionTarget;
-  }
   rules.push(rule);
   rules.sort(ruleOrder);
   cachedRules = rules;
@@ -493,6 +510,18 @@ function fileRemoveRule(id: string): boolean {
   return true;
 }
 
+/**
+ * Resolve the effective scope of a trust rule.
+ *
+ * Not all trust rule families require a scope — after canonical parsing,
+ * rules that had no scope are normalized to `"everywhere"`. This helper
+ * ensures any residual rules without a scope field default to `"everywhere"`
+ * for safe matching.
+ */
+function effectiveScope(rule: TrustRule): string {
+  return rule.scope || "everywhere";
+}
+
 function matchesScope(ruleScope: string, workingDir: string): boolean {
   if (ruleScope === "everywhere") return true;
   // Strip optional trailing wildcard, then enforce a directory-boundary match
@@ -514,7 +543,7 @@ function findRuleByDecision(
     if (rule.decision !== decision) continue;
     const compiled = getCompiledPattern(rule.pattern);
     if (!compiled || !compiled.match(command)) continue;
-    if (!matchesScope(rule.scope, scope)) continue;
+    if (!matchesScope(effectiveScope(rule), scope)) continue;
     return rule;
   }
   return null;
@@ -525,6 +554,10 @@ function findRuleByDecision(
  *
  * If the rule does not specify an executionTarget it matches any target
  * (wildcard). If specified, it must match exactly.
+ *
+ * Not all trust rule families carry `executionTarget` — URL, managed-skill,
+ * and skill-load rules never have it. For those families the check is a
+ * no-op (wildcard match).
  */
 function matchesExecutionTarget(rule: TrustRule, ctx?: PolicyContext): boolean {
   if (rule.executionTarget == null) return true;
@@ -561,7 +594,7 @@ function fileFindHighestPriorityRule(
 
   for (const rule of allRules) {
     if (rule.tool !== tool) continue;
-    if (!matchesScope(rule.scope, scope)) continue;
+    if (!matchesScope(effectiveScope(rule), scope)) continue;
     if (!matchesExecutionTarget(rule, ctx)) continue;
     const compiled = getCompiledPattern(rule.pattern);
     if (!compiled) continue;
@@ -914,7 +947,7 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
 
     for (const rule of allRules) {
       if (rule.tool !== tool) continue;
-      if (!matchesScope(rule.scope, scope)) continue;
+      if (!matchesScope(effectiveScope(rule), scope)) continue;
       if (!matchesExecutionTarget(rule, ctx)) continue;
       const compiled = this.getCompiledPattern(rule.pattern);
       if (!compiled) continue;
@@ -938,7 +971,7 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       if (rule.decision !== "allow") continue;
       const compiled = this.getCompiledPattern(rule.pattern);
       if (!compiled || !compiled.match(command)) continue;
-      if (!matchesScope(rule.scope, scope)) continue;
+      if (!matchesScope(effectiveScope(rule), scope)) continue;
       return rule;
     }
     return null;
@@ -951,7 +984,7 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       if (rule.decision !== "deny") continue;
       const compiled = this.getCompiledPattern(rule.pattern);
       if (!compiled || !compiled.match(command)) continue;
-      if (!matchesScope(rule.scope, scope)) continue;
+      if (!matchesScope(effectiveScope(rule), scope)) continue;
       return rule;
     }
     return null;

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -1,19 +1,26 @@
+import type { TrustRuleBase } from "@vellumai/ces-contracts";
+
+/**
+ * Re-exported TrustRule type from `@vellumai/ces-contracts`.
+ *
+ * The contracts package defines `TrustRule` as a discriminated union over tool
+ * families (scoped, URL, managed-skill, skill-load, generic). Some variants
+ * don't carry `executionTarget` or `allowHighRisk`. To maintain backward
+ * compatibility with existing callsites that access those fields on any rule,
+ * we flatten the union here by intersecting the base with the optional fields.
+ *
+ * PR 4 of this plan will tighten callsites to narrow the union properly,
+ * at which point this re-export can be simplified to a direct re-export.
+ */
+export type TrustRule = TrustRuleBase & {
+  executionTarget?: string;
+  allowHighRisk?: boolean;
+};
+
 export enum RiskLevel {
   Low = "low",
   Medium = "medium",
   High = "high",
-}
-
-export interface TrustRule {
-  id: string;
-  tool: string;
-  pattern: string;
-  scope: string;
-  decision: "allow" | "deny" | "ask";
-  priority: number;
-  createdAt: number;
-  executionTarget?: string;
-  allowHighRisk?: boolean;
 }
 
 export type UserDecision =


### PR DESCRIPTION
## Summary
- Remove local TrustRule interface, import/re-export from @vellumai/ces-contracts
- Integrate parseTrustFileData into loadFromDisk with version-gate and normalization re-save
- Update scope matching to handle family-aware optional scope with everywhere fallback

Part of plan: trust-rule-union-compat.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
