### PR TITLE
Add explicit cancellable subscriptions to EventStreamClient

### DIFF
--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -12,21 +12,79 @@ public final class EventStreamClient {
 
     // MARK: - Broadcast Subscribers
 
-    private var subscribers: [UUID: AsyncStream<ServerMessage>.Continuation] = [:]
+    private struct Subscriber {
+        let continuation: AsyncStream<ServerMessage>.Continuation
+        let state: SubscriptionState
+    }
+
+    @MainActor
+    private final class SubscriptionState {
+        weak var client: EventStreamClient?
+        let id: UUID
+        private(set) var continuation: AsyncStream<ServerMessage>.Continuation?
+        private var isFinished = false
+
+        init(
+            client: EventStreamClient,
+            id: UUID,
+            continuation: AsyncStream<ServerMessage>.Continuation
+        ) {
+            self.client = client
+            self.id = id
+            self.continuation = continuation
+        }
+
+        func finish() {
+            guard !isFinished else { return }
+            isFinished = true
+            client?.subscribers.removeValue(forKey: id)
+            continuation?.finish()
+            continuation = nil
+        }
+    }
+
+    @MainActor
+    public final class ManagedSubscription {
+        public let stream: AsyncStream<ServerMessage>
+        private let state: SubscriptionState
+
+        fileprivate init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
+            self.stream = stream
+            self.state = state
+        }
+
+        public func cancel() {
+            finish()
+        }
+
+        public func finish() {
+            state.finish()
+        }
+    }
+
+    private var subscribers: [UUID: Subscriber] = [:]
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
     /// independently, enabling multiple consumers to filter for messages relevant to them
     /// without competing for elements.
     public func subscribe() -> AsyncStream<ServerMessage> {
+        subscribeManaged().stream
+    }
+
+    /// Creates a new message stream with an explicit teardown handle.
+    /// Call `finish()` or `cancel()` to synchronously remove the subscriber
+    /// from the broadcast set before finishing the stream.
+    public func subscribeManaged() -> ManagedSubscription {
         let id = UUID()
         let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
-        subscribers[id] = continuation
+        let state = SubscriptionState(client: self, id: id, continuation: continuation)
+        subscribers[id] = Subscriber(continuation: continuation, state: state)
         continuation.onTermination = { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.subscribers.removeValue(forKey: id)
+                self?.subscribers[id]?.state.finish()
             }
         }
-        return stream
+        return ManagedSubscription(stream: stream, state: state)
     }
 
     // MARK: - SSE State
@@ -131,10 +189,10 @@ public final class EventStreamClient {
     func teardown() {
         shouldReconnect = false
         stopSSE()
-        for continuation in subscribers.values {
-            continuation.finish()
+        let activeSubscribers = Array(subscribers.values)
+        for subscriber in activeSubscribers {
+            subscriber.state.finish()
         }
-        subscribers.removeAll()
     }
 
     // MARK: - Send User Message
@@ -525,8 +583,8 @@ public final class EventStreamClient {
 
     /// Broadcast a message to all subscribers.
     public func broadcastMessage(_ message: ServerMessage) {
-        for continuation in subscribers.values {
-            continuation.yield(message)
+        for subscriber in subscribers.values {
+            subscriber.continuation.yield(message)
         }
     }
 
@@ -572,9 +630,9 @@ public final class EventStreamClient {
 
     deinit {
         sseSession?.invalidateAndCancel()
-        let continuations = subscribers.values
-        for continuation in continuations {
-            continuation.finish()
+        let activeSubscribers = Array(subscribers.values)
+        for subscriber in activeSubscribers {
+            subscriber.state.finish()
         }
     }
 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -48,7 +48,7 @@ public final class EventStreamClient {
         public let stream: AsyncStream<ServerMessage>
         private let state: SubscriptionState
 
-        fileprivate init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
+        init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
             self.stream = stream
             self.state = state
         }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -187,8 +187,8 @@ public final class EventStreamClient {
         }
     }
 
-    /// Disconnect and finish all subscriber streams.
-    func teardown() {
+    /// Terminal cleanup for the client. Stops SSE and finishes all subscriber streams.
+    private func teardown() {
         shouldReconnect = false
         stopSSE()
         let activeSubscribers = Array(subscribers.values)
@@ -631,10 +631,6 @@ public final class EventStreamClient {
     }
 
     deinit {
-        sseSession?.invalidateAndCancel()
-        let activeSubscribers = Array(subscribers.values)
-        for subscriber in activeSubscribers {
-            subscriber.continuation.finish()
-        }
+        teardown()
     }
 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -635,8 +635,8 @@ public final class EventStreamClient {
         shouldReconnect = false
         tokenRotationTask?.cancel()
         sseReconnectTask?.cancel()
-        sseTask?.cancel()
         let continuations = subscribers.values.map(\.continuation)
         Self.teardown(session: sseSession, continuations: continuations)
+        sseTask?.cancel()
     }
 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -46,11 +46,11 @@ public final class EventStreamClient {
     @MainActor
     public final class ManagedSubscription {
         public let stream: AsyncStream<ServerMessage>
-        private let state: SubscriptionState
+        private let finishAction: @MainActor () -> Void
 
-        private init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
+        init(stream: AsyncStream<ServerMessage>, finishAction: @escaping @MainActor () -> Void) {
             self.stream = stream
-            self.state = state
+            self.finishAction = finishAction
         }
 
         public func cancel() {
@@ -58,7 +58,7 @@ public final class EventStreamClient {
         }
 
         public func finish() {
-            state.finish()
+            finishAction()
         }
     }
 
@@ -84,7 +84,9 @@ public final class EventStreamClient {
                 self?.subscribers[id]?.state.finish()
             }
         }
-        return ManagedSubscription(stream: stream, state: state)
+        return ManagedSubscription(stream: stream) {
+            state.finish()
+        }
     }
 
     // MARK: - SSE State

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -48,7 +48,7 @@ public final class EventStreamClient {
         public let stream: AsyncStream<ServerMessage>
         private let state: SubscriptionState
 
-        init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
+        private init(stream: AsyncStream<ServerMessage>, state: SubscriptionState) {
             self.stream = stream
             self.state = state
         }
@@ -632,7 +632,7 @@ public final class EventStreamClient {
         sseSession?.invalidateAndCancel()
         let activeSubscribers = Array(subscribers.values)
         for subscriber in activeSubscribers {
-            subscriber.state.finish()
+            subscriber.continuation.finish()
         }
     }
 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -187,13 +187,14 @@ public final class EventStreamClient {
         }
     }
 
-    /// Terminal cleanup for the client. Stops SSE and finishes all subscriber streams.
-    private func teardown() {
-        shouldReconnect = false
-        stopSSE()
-        let activeSubscribers = Array(subscribers.values)
-        for subscriber in activeSubscribers {
-            subscriber.state.finish()
+    /// Terminal cleanup for the client. Invalidates the session and finishes all subscriber streams.
+    private nonisolated static func teardown(
+        session: URLSession?,
+        continuations: [AsyncStream<ServerMessage>.Continuation]
+    ) {
+        session?.invalidateAndCancel()
+        for continuation in continuations {
+            continuation.finish()
         }
     }
 
@@ -631,6 +632,11 @@ public final class EventStreamClient {
     }
 
     deinit {
-        teardown()
+        shouldReconnect = false
+        tokenRotationTask?.cancel()
+        sseReconnectTask?.cancel()
+        sseTask?.cancel()
+        let continuations = subscribers.values.map(\.continuation)
+        Self.teardown(session: sseSession, continuations: continuations)
     }
 }

--- a/clients/shared/Tests/GatewayConnectionManagerTests.swift
+++ b/clients/shared/Tests/GatewayConnectionManagerTests.swift
@@ -122,6 +122,81 @@ final class GatewayConnectionManagerTests: XCTestCase {
         }
     }
 
+    func testCancelledManagedSubscriptionDoesNotReceiveNextBroadcast() async {
+        let client = GatewayConnectionManager()
+
+        let managedSubscription = client.eventStreamClient.subscribeManaged()
+        let passiveStream = client.eventStreamClient.subscribe()
+
+        let cancelledSubscriberDidReceiveMessage = XCTestExpectation(
+            description: "Cancelled managed subscription should not receive next broadcast"
+        )
+        cancelledSubscriberDidReceiveMessage.isInverted = true
+
+        let activeSubscriberDidReceiveMessage = XCTestExpectation(
+            description: "Active subscriber receives next broadcast"
+        )
+
+        var passiveReceivedMessage: ServerMessage?
+
+        let cancelledTask = Task {
+            for await _ in managedSubscription.stream {
+                cancelledSubscriberDidReceiveMessage.fulfill()
+                break
+            }
+        }
+
+        let passiveTask = Task {
+            for await message in passiveStream {
+                passiveReceivedMessage = message
+                activeSubscriberDidReceiveMessage.fulfill()
+                break
+            }
+        }
+
+        await Task.yield()
+
+        managedSubscription.cancel()
+        client.eventStreamClient.broadcastMessage(
+            .assistantTextDelta(AssistantTextDeltaMessage(text: "after cancel"))
+        )
+
+        await fulfillment(
+            of: [activeSubscriberDidReceiveMessage, cancelledSubscriberDidReceiveMessage],
+            timeout: 1.0
+        )
+
+        await cancelledTask.value
+        await passiveTask.value
+
+        if case .assistantTextDelta(let received) = passiveReceivedMessage {
+            XCTAssertEqual(received.text, "after cancel")
+        } else {
+            XCTFail("Expected active subscriber to receive .assistantTextDelta, got \(String(describing: passiveReceivedMessage))")
+        }
+    }
+
+    func testManagedSubscriptionFinishUnblocksSuspendedConsumerWithoutLaterBroadcast() async {
+        let client = GatewayConnectionManager()
+        let managedSubscription = client.eventStreamClient.subscribeManaged()
+
+        let consumerExited = XCTestExpectation(
+            description: "Consumer exits promptly after managed subscription is finished"
+        )
+
+        let consumerTask = Task {
+            for await _ in managedSubscription.stream {}
+            consumerExited.fulfill()
+        }
+
+        await Task.yield()
+
+        managedSubscription.finish()
+
+        await fulfillment(of: [consumerExited], timeout: 1.0)
+        await consumerTask.value
+    }
+
     // MARK: - Multiple Connect/Disconnect Cycles
 
     func testMultipleConnectDisconnectCycles() async throws {


### PR DESCRIPTION
## Summary
- add a managed EventStream subscription primitive with deterministic teardown
- keep passive subscribe behavior while giving restart-sensitive callers an explicit unsubscribe path
- add GatewayConnectionManagerTests coverage for teardown and broadcast behavior

Part of plan: fix-duplicate-sse-subscribers-revised.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
