### PR TITLE
refactor: make browser skill wrappers thin adapters over browser operations

### DIFF
--- a/assistant/src/config/bundled-skills/browser/tools/__tests__/wrapper-adapters.test.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/__tests__/wrapper-adapters.test.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { BROWSER_OPERATIONS } from "../../../../../browser/types.js";
+
+const TOOLS_DIR = join(import.meta.dir, "..");
+
+describe("browser skill wrappers are thin adapters", () => {
+  // Collect all browser-*.ts wrapper files (excluding shared.ts and test dirs).
+  const wrapperFiles = readdirSync(TOOLS_DIR)
+    .filter((f) => f.startsWith("browser-") && f.endsWith(".ts"))
+    .sort();
+
+  test("has exactly 17 wrapper files matching BROWSER_OPERATIONS", () => {
+    expect(wrapperFiles).toHaveLength(17);
+    expect(wrapperFiles).toHaveLength(BROWSER_OPERATIONS.length);
+  });
+
+  test("every wrapper file maps to a valid browser_* tool name", () => {
+    for (const file of wrapperFiles) {
+      // browser-navigate.ts -> browser_navigate
+      const toolName = file.replace(".ts", "").replace(/-/g, "_");
+      const operation = toolName.replace("browser_", "");
+      expect(
+        (BROWSER_OPERATIONS as readonly string[]).includes(operation),
+      ).toBe(true);
+    }
+  });
+
+  test("every wrapper delegates through shared.ts runBrowserTool", () => {
+    for (const file of wrapperFiles) {
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      // Wrapper must import from shared.ts
+      expect(source).toContain("./shared.js");
+      expect(source).toContain("runBrowserTool");
+    }
+  });
+
+  test("no wrapper imports browser-execution, browser-manager, or browser-mode directly", () => {
+    for (const file of wrapperFiles) {
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      expect(source).not.toContain("browser-execution");
+      expect(source).not.toContain("browser-manager");
+      expect(source).not.toContain("browser-mode");
+    }
+  });
+
+  test("shared.ts exists and exports runBrowserTool", () => {
+    const sharedSource = readFileSync(join(TOOLS_DIR, "shared.ts"), "utf-8");
+    expect(sharedSource).toContain("export async function runBrowserTool");
+    expect(sharedSource).toContain("browserToolNameToOperation");
+    expect(sharedSource).toContain("executeBrowserOperation");
+  });
+
+  test("shared.ts does not depend on TOOLS.json or bundled-skills internals", () => {
+    const sharedSource = readFileSync(join(TOOLS_DIR, "shared.ts"), "utf-8");
+    expect(sharedSource).not.toContain("TOOLS.json");
+  });
+
+  test("each wrapper passes the correct tool name to runBrowserTool", () => {
+    for (const file of wrapperFiles) {
+      const toolName = file.replace(".ts", "").replace(/-/g, "_");
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      expect(source).toContain(`"${toolName}"`);
+    }
+  });
+});

--- a/assistant/src/config/bundled-skills/browser/tools/browser-attach.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-attach.ts
@@ -1,12 +1,12 @@
-import { executeBrowserAttach } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserAttach(input, context);
+  return runBrowserTool("browser_attach", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-click.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-click.ts
@@ -1,12 +1,12 @@
-import { executeBrowserClick } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserClick(input, context);
+  return runBrowserTool("browser_click", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-close.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-close.ts
@@ -1,12 +1,12 @@
-import { executeBrowserClose } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserClose(input, context);
+  return runBrowserTool("browser_close", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-detach.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-detach.ts
@@ -1,12 +1,12 @@
-import { executeBrowserDetach } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserDetach(input, context);
+  return runBrowserTool("browser_detach", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-extract.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-extract.ts
@@ -1,12 +1,12 @@
-import { executeBrowserExtract } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserExtract(input, context);
+  return runBrowserTool("browser_extract", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-fill-credential.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-fill-credential.ts
@@ -1,12 +1,12 @@
-import { executeBrowserFillCredential } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserFillCredential(input, context);
+  return runBrowserTool("browser_fill_credential", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-hover.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-hover.ts
@@ -1,12 +1,12 @@
-import { executeBrowserHover } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserHover(input, context);
+  return runBrowserTool("browser_hover", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-navigate.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-navigate.ts
@@ -1,12 +1,12 @@
-import { executeBrowserNavigate } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserNavigate(input, context);
+  return runBrowserTool("browser_navigate", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-press-key.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-press-key.ts
@@ -1,12 +1,12 @@
-import { executeBrowserPressKey } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserPressKey(input, context);
+  return runBrowserTool("browser_press_key", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-screenshot.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-screenshot.ts
@@ -1,12 +1,12 @@
-import { executeBrowserScreenshot } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserScreenshot(input, context);
+  return runBrowserTool("browser_screenshot", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-scroll.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-scroll.ts
@@ -1,12 +1,12 @@
-import { executeBrowserScroll } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserScroll(input, context);
+  return runBrowserTool("browser_scroll", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-select-option.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-select-option.ts
@@ -1,12 +1,12 @@
-import { executeBrowserSelectOption } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserSelectOption(input, context);
+  return runBrowserTool("browser_select_option", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-snapshot.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-snapshot.ts
@@ -1,12 +1,12 @@
-import { executeBrowserSnapshot } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserSnapshot(input, context);
+  return runBrowserTool("browser_snapshot", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
@@ -1,12 +1,12 @@
-import { executeBrowserStatus } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserStatus(input, context);
+  return runBrowserTool("browser_status", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-type.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-type.ts
@@ -1,12 +1,12 @@
-import { executeBrowserType } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserType(input, context);
+  return runBrowserTool("browser_type", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
@@ -1,49 +1,12 @@
-import { browserManager } from "../../../../tools/browser/browser-manager.js";
-import { normalizeBrowserMode } from "../../../../tools/browser/browser-mode.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  // Validate browser_mode: only auto/local are supported for downloads.
-  const modeResult = normalizeBrowserMode(input.browser_mode);
-  if ("error" in modeResult) {
-    return { content: `Error: ${modeResult.error}`, isError: true };
-  }
-  const { mode } = modeResult;
-  if (mode !== "auto" && mode !== "local") {
-    return {
-      content:
-        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
-        `File downloads require the local Playwright backend. ` +
-        `Use browser_mode "auto" or "local" instead.`,
-      isError: true,
-    };
-  }
-
-  const timeout =
-    typeof input.timeout === "number"
-      ? Math.min(Math.max(input.timeout, 1000), 120_000)
-      : 30_000;
-
-  try {
-    const download = await browserManager.waitForDownload(
-      context.conversationId,
-      timeout,
-    );
-    return {
-      content: JSON.stringify({
-        filename: download.filename,
-        path: download.path,
-      }),
-      isError: false,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { content: `Error: ${msg}`, isError: true };
-  }
+  return runBrowserTool("browser_wait_for_download", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for.ts
@@ -1,12 +1,12 @@
-import { executeBrowserWaitFor } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserWaitFor(input, context);
+  return runBrowserTool("browser_wait_for", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/shared.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared adapter for browser skill wrappers.
+ *
+ * Each browser tool wrapper delegates to this helper, which maps
+ * the `browser_*` tool name to a canonical operation identifier
+ * and dispatches through {@link executeBrowserOperation}.
+ *
+ * This keeps every wrapper as a thin adapter with no independent
+ * execution logic — all behavior flows through the shared browser
+ * operations contract.
+ */
+
+import {
+  browserToolNameToOperation,
+  executeBrowserOperation,
+} from "../../../../browser/operations.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+/**
+ * Execute a browser tool by its `browser_*` tool name.
+ *
+ * Resolves the tool name to a canonical operation via
+ * {@link browserToolNameToOperation}, then dispatches through
+ * {@link executeBrowserOperation}. Returns an error result if the
+ * tool name does not map to a known operation.
+ *
+ * @param toolName - The `browser_*` tool name (e.g. `"browser_navigate"`).
+ * @param input    - Flat input object from the tool call.
+ * @param context  - Tool execution context.
+ */
+export async function runBrowserTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const operation = browserToolNameToOperation(toolName);
+  if (!operation) {
+    return {
+      content: `Error: "${toolName}" does not map to a known browser operation.`,
+      isError: true,
+    };
+  }
+  return executeBrowserOperation(operation, input, context);
+}


### PR DESCRIPTION
## Summary
- Add shared.ts helper for browser wrapper delegation to operations contract
- Repoint all 17 browser tool wrappers to use the shared contract via executeBrowserOperation
- Remove direct imports of browser-execution.ts, browser-manager.ts, browser-mode.ts from wrappers

Part of plan: assistant-browser-cli-decoupling.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
