### PR TITLE
Surface insufficient-balance errors for managed OAuth proxy requests

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -12,6 +12,7 @@ import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError, VellumError } from "../util/errors.js";
 import {
   CredentialRequiredError,
+  InsufficientBalanceError,
   PlatformOAuthConnection,
   ProviderUnreachableError,
 } from "./platform-connection.js";
@@ -199,6 +200,52 @@ describe("PlatformOAuthConnection", () => {
     const provErr = new ProviderUnreachableError();
     expect(provErr).toBeInstanceOf(BackendError);
     expect(provErr).toBeInstanceOf(VellumError);
+
+    const balErr = new InsufficientBalanceError();
+    expect(balErr).toBeInstanceOf(BackendError);
+    expect(balErr).toBeInstanceOf(VellumError);
+  });
+
+  test("402 response throws InsufficientBalanceError", async () => {
+    const client = makeMockClient(
+      mock(
+        async () => new Response("", { status: 402 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(InsufficientBalanceError);
+  });
+
+  test("402 response includes actionable billing message", async () => {
+    const client = makeMockClient(
+      mock(
+        async () => new Response("", { status: 402 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(/add funds/i);
+  });
+
+  test("does not retry on 402", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 402 });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(InsufficientBalanceError);
+    expect(callCount).toBe(1);
   });
 
   test("424 response throws CredentialRequiredError", async () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -26,7 +26,7 @@ export class ProviderUnreachableError extends BackendError {
 export class InsufficientBalanceError extends BackendError {
   constructor(
     message = "Your Vellum account balance is too low to use this managed OAuth connection. " +
-      "Please add funds at https://app.vellum.ai/billing or switch to using your own OAuth app.",
+      "You can add funds or switch to using your own OAuth app.",
   ) {
     super(message);
     this.name = "InsufficientBalanceError";

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,10 +1,6 @@
 import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError } from "../util/errors.js";
-import {
-  getHttpRetryDelay,
-  isRetryableStatus,
-  sleep,
-} from "../util/retry.js";
+import { getHttpRetryDelay, isRetryableStatus, sleep } from "../util/retry.js";
 import type {
   OAuthConnection,
   OAuthConnectionRequest,
@@ -24,6 +20,16 @@ export class ProviderUnreachableError extends BackendError {
   constructor(message = "Provider is unreachable") {
     super(message);
     this.name = "ProviderUnreachableError";
+  }
+}
+
+export class InsufficientBalanceError extends BackendError {
+  constructor(
+    message = "Your Vellum account balance is too low to use this managed OAuth connection. " +
+      "Please add funds at https://app.vellum.ai/billing or switch to using your own OAuth app.",
+  ) {
+    super(message);
+    this.name = "InsufficientBalanceError";
   }
 }
 
@@ -92,6 +98,10 @@ export class PlatformOAuthConnection implements OAuthConnection {
         body: JSON.stringify(body),
         signal: req.signal,
       });
+
+      if (response.status === 402) {
+        throw new InsufficientBalanceError();
+      }
 
       if (response.status === 424) {
         throw new CredentialRequiredError();


### PR DESCRIPTION
## Summary
Add assistant-side handling for platform OAuth proxy billing rejections so managed OAuth callers get actionable errors when a billable provider route is blocked for insufficient balance (HTTP 402). This keeps the initial Twitter billing rollout understandable to end users.

## Self-review result
PASS — all 3 review passes (external feedback, plan faithfulness, repo integration) passed with no gaps.

## PRs merged into feature branch
- #26197: Surface insufficient-balance errors for managed OAuth proxy requests

### Fix PRs
None

Part of plan: twitter-oauth-proxy-billing.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
