### PR TITLE
feat(flags): register compaction-v2 feature flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -98,3 +98,32 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     ).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// compaction-v2 flag (opt-in): ensures registry-declared defaultEnabled=false
+// is honored and that an explicit override can flip it on. Guards the rollout
+// gate for the boundary-message-based compaction pipeline introduced in
+// later PRs.
+// ---------------------------------------------------------------------------
+
+describe("compaction-v2 flag", () => {
+  test("defaults to false (disabled) when no override is set", () => {
+    const config = {} as any;
+
+    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(false);
+  });
+
+  test("returns true when explicitly overridden to true", () => {
+    _setOverridesForTesting({ "compaction-v2": true });
+    const config = {} as any;
+
+    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(true);
+  });
+
+  test("returns false when explicitly overridden to false", () => {
+    _setOverridesForTesting({ "compaction-v2": false });
+    const config = {} as any;
+
+    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(false);
+  });
+});

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -360,6 +360,14 @@
       "label": "Google Meet",
       "description": "Enables the Google Meet joining bot and the meet-join skill.",
       "defaultEnabled": false
+    },
+    {
+      "id": "compaction-v2",
+      "scope": "assistant",
+      "key": "compaction-v2",
+      "label": "Compaction v2",
+      "description": "Boundary-message-based compaction pipeline with forked prompt-cache-shared summarization and microcompact pre-pass. Replaces the four-tier overflow reducer and cursor-based storage.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register 'compaction-v2' flag in meta/feature-flags/feature-flag-registry.json (scope=assistant, defaultEnabled=false)
- Gate for new boundary-message-based compaction pipeline introduced in later PRs
- Companion PR required in vellum-assistant-platform/terraform to provision on LaunchDarkly

## Platform follow-up
- [ ] Open PR in vellum-assistant-platform to add 'compaction-v2' to LaunchDarkly Terraform config

Part of plan: compaction-simplification.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
