### PR TITLE
Use explicit EventStream teardown for ChatViewModel message-loop restarts

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2338,7 +2338,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // from incoming publisher events while the remaining cleanup runs.
         cancellables.removeAll()
         messageLoopTask?.cancel()
-        messageLoopSubscription?.cancel()
+        let messageLoopSubscription = messageLoopSubscription
+        Task { @MainActor in
+            messageLoopSubscription?.cancel()
+        }
         streamingFlushTask?.cancel()
         partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -686,6 +686,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// to decide whether it's safe to release the VM on archive.
     public var isBootstrapping: Bool { bootstrapCorrelationId != nil }
     @ObservationIgnored var messageLoopTask: Task<Void, Never>?
+    @ObservationIgnored var messageLoopSubscription: EventStreamClient.ManagedSubscription?
     /// Monotonically increasing ID used to distinguish successive message-loop
     /// tasks so that a cancelled loop's cleanup doesn't clear a newer replacement.
     @ObservationIgnored private var messageLoopGeneration: UInt64 = 0
@@ -1352,14 +1353,20 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     }
 
     public func startMessageLoop() {
-        messageLoopTask?.cancel()
-        let messageStream = eventStreamClient.subscribe()
+        let previousTask = messageLoopTask
+        let previousSubscription = messageLoopSubscription
 
         messageLoopGeneration &+= 1
         let generation = messageLoopGeneration
 
+        previousTask?.cancel()
+        previousSubscription?.cancel()
+
+        let managedSubscription = eventStreamClient.subscribeManaged()
+        messageLoopSubscription = managedSubscription
+
         messageLoopTask = Task { @MainActor [weak self] in
-            for await message in messageStream {
+            for await message in managedSubscription.stream {
                 guard let self, !Task.isCancelled else { break }
                 self.handleServerMessage(message)
             }
@@ -1370,6 +1377,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             // task reference, which would cause duplicate subscriptions.
             if self?.messageLoopGeneration == generation {
                 self?.messageLoopTask = nil
+                self?.messageLoopSubscription = nil
                 // Reset spinner state — if the connection drops mid-turn the client
                 // never receives message_complete, leaving the UI stuck.
                 self?.isThinking = false
@@ -2330,6 +2338,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // from incoming publisher events while the remaining cleanup runs.
         cancellables.removeAll()
         messageLoopTask?.cancel()
+        messageLoopSubscription?.cancel()
         streamingFlushTask?.cancel()
         partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()

--- a/clients/shared/Tests/ChatViewModelMessageLoopTests.swift
+++ b/clients/shared/Tests/ChatViewModelMessageLoopTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatViewModelMessageLoopTests: XCTestCase {
+
+    private var connectionManager: GatewayConnectionManager!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        viewModel = ChatViewModel(
+            connectionManager: connectionManager,
+            eventStreamClient: connectionManager.eventStreamClient
+        )
+        viewModel.conversationId = "sess-message-loop"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    func testRepeatedSynchronousRestartsDoNotDuplicateAssistantTextDelta() async {
+        for _ in 0..<4 {
+            viewModel.startMessageLoop()
+        }
+
+        connectionManager.eventStreamClient.broadcastMessage(
+            .assistantTextDelta(
+                AssistantTextDeltaMessage(text: "delta-once", conversationId: "sess-message-loop")
+            )
+        )
+
+        try? await Task.sleep(
+            nanoseconds: UInt64((ChatViewModel.streamingFlushInterval * 2) * 1_000_000_000)
+        )
+
+        let assistantMessages = viewModel.messages.filter { $0.role == .assistant }
+        XCTAssertEqual(assistantMessages.count, 1, "A single delta should render into one assistant row")
+        XCTAssertEqual(assistantMessages.first?.text, "delta-once")
+
+        let renderedCount = assistantMessages.first?.text.components(separatedBy: "delta-once").count ?? 0
+        XCTAssertEqual(renderedCount - 1, 1, "Rendered assistant text should contain the delta exactly once")
+    }
+
+    func testIdleRestartFinishesPreviousLoopWithoutWaitingForLaterTraffic() async {
+        viewModel.startMessageLoop()
+        let previousTask = viewModel.messageLoopTask
+
+        XCTAssertNotNil(previousTask, "Initial start should install a message-loop task")
+
+        viewModel.startMessageLoop()
+        let replacementTask = viewModel.messageLoopTask
+
+        XCTAssertNotNil(replacementTask, "Restart should install a replacement task immediately")
+
+        let previousLoopExited = expectation(
+            description: "Previous message-loop task exits promptly after synchronous subscription teardown"
+        )
+
+        Task {
+            await previousTask?.value
+            previousLoopExited.fulfill()
+        }
+
+        await fulfillment(of: [previousLoopExited], timeout: 1.0)
+
+        XCTAssertNotNil(viewModel.messageLoopTask, "Stale-loop cleanup must not clear the replacement task")
+        XCTAssertNotNil(viewModel.messageLoopSubscription, "Replacement subscription should remain installed")
+
+        connectionManager.eventStreamClient.broadcastMessage(
+            .assistantTextDelta(
+                AssistantTextDeltaMessage(text: "replacement-delta", conversationId: "sess-message-loop")
+            )
+        )
+
+        try? await Task.sleep(
+            nanoseconds: UInt64((ChatViewModel.streamingFlushInterval * 2) * 1_000_000_000)
+        )
+
+        let assistantMessages = viewModel.messages.filter { $0.role == .assistant }
+        XCTAssertEqual(assistantMessages.count, 1)
+        XCTAssertEqual(assistantMessages.first?.text, "replacement-delta")
+    }
+}


### PR DESCRIPTION
## Summary
- adopt the managed EventStream subscription handle in ChatViewModel's message loop
- make restart safety rely on explicit subscription teardown rather than task cancellation
- add focused message-loop regression coverage for duplicate delta delivery and idle restarts

Part of plan: fix-duplicate-sse-subscribers-revised.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
