### PR TITLE
refactor(compaction): move summary system prompt to compact.md

### DIFF
--- a/assistant/.prettierignore
+++ b/assistant/.prettierignore
@@ -5,3 +5,8 @@
 # Prompt template files use _ as a comment marker prefix. Prettier escapes
 # these to \_ which breaks the comment-stripping preprocessor.
 src/prompts/templates/**/*.md
+
+# Compaction prompt assets are consumed verbatim as the LLM system prompt.
+# Prettier's markdown formatting (blank lines between headers, trailing
+# newlines) would change the prompt content, so we skip formatting here.
+src/context/prompts/**/*.md

--- a/assistant/src/context/__tests__/compact-prompt.test.ts
+++ b/assistant/src/context/__tests__/compact-prompt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadCompactPrompt } from "../window-manager.js";
+
+describe("compact.md prompt asset", () => {
+  test("loads a non-empty prompt string", () => {
+    const prompt = loadCompactPrompt();
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  test("contains the '## Goals' section header (canary for truncation)", () => {
+    const prompt = loadCompactPrompt();
+    expect(prompt).toContain("## Goals");
+  });
+});

--- a/assistant/src/context/__tests__/compact-prompt.test.ts
+++ b/assistant/src/context/__tests__/compact-prompt.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { loadCompactPrompt } from "../window-manager.js";
+import {
+  loadCompactPrompt,
+  loadCompactPromptOrFallback,
+} from "../window-manager.js";
 
 describe("compact.md prompt asset", () => {
   test("loads a non-empty prompt string", () => {
@@ -11,5 +14,32 @@ describe("compact.md prompt asset", () => {
   test("contains the '## Goals' section header (canary for truncation)", () => {
     const prompt = loadCompactPrompt();
     expect(prompt).toContain("## Goals");
+  });
+});
+
+describe("loadCompactPromptOrFallback", () => {
+  test("returns loader output when the loader succeeds", () => {
+    const loaded = "custom loaded prompt";
+    const result = loadCompactPromptOrFallback(() => loaded);
+    expect(result).toBe(loaded);
+  });
+
+  test("returns inline fallback when the loader throws", () => {
+    const result = loadCompactPromptOrFallback(() => {
+      throw new Error("compact.md missing");
+    });
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("## Goals");
+    expect(result).toContain("## Constraints");
+    expect(result).toContain("## Decisions");
+    expect(result).toContain("## Open Conversations");
+    expect(result).toContain("## Key Artifacts");
+    expect(result).toContain("## Recent Progress");
+  });
+
+  test("uses loadCompactPrompt as the default loader", () => {
+    const result = loadCompactPromptOrFallback();
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("## Goals");
   });
 });

--- a/assistant/src/context/prompts/compact.md
+++ b/assistant/src/context/prompts/compact.md
@@ -1,0 +1,11 @@
+You compress long assistant conversations into durable working memory.
+Focus on actionable state, not prose.
+Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.
+Remove repetition and stale details that were superseded.
+Return concise markdown using these section headers exactly:
+## Goals
+## Constraints
+## Decisions
+## Open Conversations
+## Key Artifacts
+## Recent Progress

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -52,9 +52,9 @@ export function loadCompactPrompt(): string {
 }
 
 /**
- * Hardcoded fallback matching the original inline prompt. Used if the bundled
- * `compact.md` asset is missing or unreadable so the daemon can still compact
- * conversations rather than failing module import at startup.
+ * Hardcoded fallback prompt used when the bundled `compact.md` asset is
+ * missing or unreadable, so the daemon can still compact conversations
+ * rather than failing module import at startup.
  */
 const SUMMARY_PROMPT_FALLBACK = [
   "You compress long assistant conversations into durable working memory.",

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type { ContextWindowConfig } from "../config/types.js";
 import type {
   ContentBlock,
@@ -5,6 +9,7 @@ import type {
   Message,
   Provider,
 } from "../providers/types.js";
+import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import { safeStringSlice } from "../util/unicode.js";
 import {
@@ -26,19 +31,29 @@ const COMPACTION_TOOL_RESULT_MAX_CHARS = 6_000;
 const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
-const SUMMARY_SYSTEM_PROMPT = [
-  "You compress long assistant conversations into durable working memory.",
-  "Focus on actionable state, not prose.",
-  "Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.",
-  "Remove repetition and stale details that were superseded.",
-  "Return concise markdown using these section headers exactly:",
-  "## Goals",
-  "## Constraints",
-  "## Decisions",
-  "## Open Conversations",
-  "## Key Artifacts",
-  "## Recent Progress",
-].join("\n");
+/**
+ * Load the compaction summary system prompt from the bundled markdown asset.
+ *
+ * Resolved via `import.meta.url` + `fileURLToPath` so this works in both
+ * source mode (`prompts/compact.md` sits next to this TS file) and bundled
+ * forms. `resolveBundledDir` handles the compiled-binary case where the
+ * caller path points to `/$bunfs/` and the asset lives next to the
+ * executable (macOS app bundle `Contents/Resources/` or sibling dir).
+ */
+export function loadCompactPrompt(): string {
+  const callerDir = dirname(fileURLToPath(import.meta.url));
+  const promptsDir = resolveBundledDir(callerDir, "prompts", "compact-prompts");
+  const promptPath = join(promptsDir, "compact.md");
+  const contents = readFileSync(promptPath, "utf-8");
+  if (contents.length === 0) {
+    throw new Error(
+      `compact.md at ${promptPath} is empty — compaction summary prompt missing`,
+    );
+  }
+  return contents;
+}
+
+const SUMMARY_SYSTEM_PROMPT = loadCompactPrompt();
 
 export interface ContextWindowResult {
   messages: Message[];
@@ -499,7 +514,9 @@ export class ContextWindowManager {
     // the summary at index 0 as child-owned.
     this.nonPersistedPrefixCount = Math.max(
       0,
-      this.nonPersistedPrefixCount - injectedInCompactable - injectedSummaryOffset,
+      this.nonPersistedPrefixCount -
+        injectedInCompactable -
+        injectedSummaryOffset,
     );
     this.summaryIsInjected = false;
 
@@ -643,7 +660,9 @@ export class ContextWindowManager {
     );
 
     const estimateBlockTokens = (b: ContentBlock): number =>
-      estimateContentBlockTokens(b, { providerName: this.estimationProviderName });
+      estimateContentBlockTokens(b, {
+        providerName: this.estimationProviderName,
+      });
 
     let totalTokens = 0;
     for (const block of blocks) {
@@ -656,7 +675,11 @@ export class ContextWindowManager {
     // images to drop. Images are high-cost and their text context (message
     // headers, surrounding tool_use/tool_result serializations) is preserved.
     const result = [...blocks];
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       if (result[i].type === "image") {
         totalTokens -= estimateBlockTokens(result[i]);
         const stub: ContentBlock = {
@@ -674,7 +697,11 @@ export class ContextWindowManager {
     // than dropping it entirely so the summarizer always has content to work with.
     let dropUntil = 0;
     let droppedTokens = 0;
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       const blockTokens = estimateBlockTokens(result[i]);
       const excess = totalTokens - maxTranscriptTokens;
       if (blockTokens > excess && result[i].type === "text") {
@@ -767,7 +794,9 @@ export class ContextWindowManager {
 
     // Fallback: extract text-only transcript for local summary generation.
     const textTranscript = transcriptBlocks
-      .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text")
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
       .map((b) => b.text)
       .join("\n\n");
 
@@ -854,7 +883,11 @@ function adjustForToolPairs(
     // Collect tool_use_ids referenced by tool_results in this user message
     const referencedIds = new Set<string>();
     for (const block of msg.content) {
-      if ((block.type === "tool_result" || block.type === "web_search_tool_result") && "tool_use_id" in block) {
+      if (
+        (block.type === "tool_result" ||
+          block.type === "web_search_tool_result") &&
+        "tool_use_id" in block
+      ) {
         referencedIds.add((block as { tool_use_id: string }).tool_use_id);
       }
     }
@@ -970,7 +1003,8 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (block.type === "tool_result") { // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
+      } else if (block.type === "tool_result") {
+        // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];
         textLines.push(serializeToolResultBlock(block, collectedImages));

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import type { ContextWindowConfig } from "../config/types.js";
 import type {
@@ -34,14 +33,13 @@ const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 /**
  * Load the compaction summary system prompt from the bundled markdown asset.
  *
- * Resolved via `import.meta.url` + `fileURLToPath` so this works in both
- * source mode (`prompts/compact.md` sits next to this TS file) and bundled
- * forms. `resolveBundledDir` handles the compiled-binary case where the
- * caller path points to `/$bunfs/` and the asset lives next to the
- * executable (macOS app bundle `Contents/Resources/` or sibling dir).
+ * `resolveBundledDir` handles the compiled-binary case where the caller path
+ * points to `/$bunfs/` and the asset lives next to the executable (macOS app
+ * bundle `Contents/Resources/` or sibling dir). In source mode it falls back
+ * to the sibling `prompts/` directory.
  */
 export function loadCompactPrompt(): string {
-  const callerDir = dirname(fileURLToPath(import.meta.url));
+  const callerDir = import.meta.dirname ?? __dirname;
   const promptsDir = resolveBundledDir(callerDir, "prompts", "compact-prompts");
   const promptPath = join(promptsDir, "compact.md");
   const contents = readFileSync(promptPath, "utf-8");
@@ -53,7 +51,46 @@ export function loadCompactPrompt(): string {
   return contents;
 }
 
-const SUMMARY_SYSTEM_PROMPT = loadCompactPrompt();
+/**
+ * Hardcoded fallback matching the original inline prompt. Used if the bundled
+ * `compact.md` asset is missing or unreadable so the daemon can still compact
+ * conversations rather than failing module import at startup.
+ */
+const SUMMARY_PROMPT_FALLBACK = [
+  "You compress long assistant conversations into durable working memory.",
+  "Focus on actionable state, not prose.",
+  "Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.",
+  "Remove repetition and stale details that were superseded.",
+  "Return concise markdown using these section headers exactly:",
+  "## Goals",
+  "## Constraints",
+  "## Decisions",
+  "## Open Conversations",
+  "## Key Artifacts",
+  "## Recent Progress",
+].join("\n");
+
+/**
+ * Load the compact prompt with graceful fallback. If `loader` throws (missing
+ * or unreadable bundled asset, partial deployment, filesystem corruption),
+ * logs a warning and returns the hardcoded fallback string so module import
+ * never fails. The loader is injectable for testability.
+ */
+export function loadCompactPromptOrFallback(
+  loader: () => string = loadCompactPrompt,
+): string {
+  try {
+    return loader();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to load compact.md from bundle; using inline fallback prompt. The bundled asset may be missing or unreadable.",
+    );
+    return SUMMARY_PROMPT_FALLBACK;
+  }
+}
+
+const SUMMARY_SYSTEM_PROMPT = loadCompactPromptOrFallback();
 
 export interface ContextWindowResult {
   messages: Message[];

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -418,6 +418,8 @@ build_binaries() {
     cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" "$SCRIPT_DIR/daemon-bin/templates"
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
     cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
+    rm -rf "$SCRIPT_DIR/daemon-bin/compact-prompts"
+    cp -R "$ASSISTANT_SRC_DIR/src/context/prompts" "$SCRIPT_DIR/daemon-bin/compact-prompts"
     rm -rf "$SCRIPT_DIR/daemon-bin/brain-graph"
     mkdir -p "$SCRIPT_DIR/daemon-bin/brain-graph"
     cp "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" "$SCRIPT_DIR/daemon-bin/brain-graph/"
@@ -730,6 +732,10 @@ if [ -d "$ASSISTANT_SRC_DIR/hook-templates" ]; then
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
     cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
 fi
+if [ -d "$ASSISTANT_SRC_DIR/src/context/prompts" ]; then
+    rm -rf "$SCRIPT_DIR/daemon-bin/compact-prompts"
+    cp -R "$ASSISTANT_SRC_DIR/src/context/prompts" "$SCRIPT_DIR/daemon-bin/compact-prompts"
+fi
 if [ -f "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" ]; then
     rm -rf "$SCRIPT_DIR/daemon-bin/brain-graph"
     mkdir -p "$SCRIPT_DIR/daemon-bin/brain-graph"
@@ -996,6 +1002,10 @@ fi
 if [ -d "$SCRIPT_DIR/daemon-bin/hook-templates" ]; then
     rm -rf "$RESOURCES_DIR/hook-templates"
     cp -R "$SCRIPT_DIR/daemon-bin/hook-templates" "$RESOURCES_DIR/hook-templates"
+fi
+if [ -d "$SCRIPT_DIR/daemon-bin/compact-prompts" ]; then
+    rm -rf "$RESOURCES_DIR/compact-prompts"
+    cp -R "$SCRIPT_DIR/daemon-bin/compact-prompts" "$RESOURCES_DIR/compact-prompts"
 fi
 if [ -d "$SCRIPT_DIR/daemon-bin/brain-graph" ]; then
     rm -rf "$RESOURCES_DIR/brain-graph"


### PR DESCRIPTION
## Summary
- Extract SUMMARY_SYSTEM_PROMPT to assistant/src/context/prompts/compact.md (verbatim)
- window-manager.ts now loads the prompt via loadCompactPrompt() at module init
- Adds canary test asserting non-empty prompt with '## Goals' header present

Part of plan: compaction-simplification.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
