### PR TITLE
Normalize trust-rule HTTP payloads at assistant/gateway boundaries without breaking callers

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -55,16 +55,35 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
-// Mock the trust store so addRule doesn't touch disk or require full config
+// Mock the trust store so addRule doesn't touch disk or require full config.
+// Track calls to addRule so tests can verify canonicalization.
+const addRuleCalls: Array<{
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: string;
+  priority?: number;
+  options?: { allowHighRisk?: boolean; executionTarget?: string };
+}> = [];
 mock.module("../permissions/trust-store.js", () => ({
-  addRule: () => ({
-    id: "test-rule",
-    tool: "test",
-    pattern: "*",
-    scope: "everywhere",
-    decision: "allow",
-    priority: 100,
-  }),
+  addRule: (
+    tool: string,
+    pattern: string,
+    scope: string,
+    decision: string,
+    priority?: number,
+    options?: { allowHighRisk?: boolean; executionTarget?: string },
+  ) => {
+    addRuleCalls.push({ tool, pattern, scope, decision, priority, options });
+    return {
+      id: "test-rule",
+      tool,
+      pattern,
+      scope,
+      decision,
+      priority: priority ?? 100,
+    };
+  },
   getRules: () => [],
 }));
 
@@ -231,6 +250,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM conversation_keys");
     pendingInteractions.clear();
+    addRuleCalls.length = 0;
     eventHub = new AssistantEventHub();
   });
 
@@ -914,6 +934,128 @@ describe("standalone approval endpoints — HTTP layer", () => {
 
       // Interaction should still be present (not consumed)
       expect(pendingInteractions.get("req-keep")).toBeDefined();
+
+      await stopServer();
+    });
+
+    test("preserves allowHighRisk for scoped tool families (e.g. bash)", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-bash-hr", {
+        conversation: session,
+        conversationId: "conv-1",
+        kind: "confirmation",
+        confirmationDetails: {
+          toolName: "bash",
+          input: { command: "rm -rf /tmp/test" },
+          riskLevel: "high",
+          allowlistOptions: [
+            { label: "Allow rm", description: "test", pattern: "rm**" },
+          ],
+          scopeOptions: [{ label: "Everywhere", scope: "everywhere" }],
+        },
+      });
+
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-bash-hr",
+          pattern: "rm**",
+          scope: "everywhere",
+          decision: "allow",
+          allowHighRisk: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // Verify addRule was called with allowHighRisk preserved for the scoped tool
+      expect(addRuleCalls).toHaveLength(1);
+      expect(addRuleCalls[0].options?.allowHighRisk).toBe(true);
+
+      await stopServer();
+    });
+
+    test("strips allowHighRisk for non-scoped tool families via canonicalization", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      // web_fetch is a URL-family tool — allowHighRisk should be stripped
+      pendingInteractions.register("req-url-hr", {
+        conversation: session,
+        conversationId: "conv-1",
+        kind: "confirmation",
+        confirmationDetails: {
+          toolName: "web_fetch",
+          input: { url: "https://example.com" },
+          riskLevel: "medium",
+          allowlistOptions: [
+            {
+              label: "Allow fetch",
+              description: "test",
+              pattern: "https://example.com/**",
+            },
+          ],
+          scopeOptions: [],
+        },
+      });
+
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-url-hr",
+          pattern: "https://example.com/**",
+          scope: "everywhere",
+          decision: "allow",
+          allowHighRisk: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // Verify addRule was called without allowHighRisk (stripped by canonicalization)
+      expect(addRuleCalls).toHaveLength(1);
+      expect(addRuleCalls[0].options?.allowHighRisk).toBeUndefined();
+
+      await stopServer();
+    });
+
+    test("accepts scope 'everywhere' for non-scoped tools (backward compat)", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-nonscoped", {
+        conversation: session,
+        conversationId: "conv-1",
+        kind: "confirmation",
+        confirmationDetails: {
+          toolName: "web_fetch",
+          input: { url: "https://example.com" },
+          riskLevel: "medium",
+          allowlistOptions: [
+            {
+              label: "Allow fetch",
+              description: "test",
+              pattern: "https://example.com/**",
+            },
+          ],
+          scopeOptions: [],
+        },
+      });
+
+      const res = await fetch(url("trust-rules"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "req-nonscoped",
+          pattern: "https://example.com/**",
+          scope: "everywhere",
+          decision: "allow",
+        }),
+      });
+
+      expect(res.status).toBe(200);
 
       await stopServer();
     });

--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -8,9 +8,14 @@
  * Both async and synchronous variants are exported. The sync variants
  * use `Bun.spawnSync` + `curl` to make blocking HTTP calls — acceptable
  * for user-initiated write operations that are infrequent.
+ *
+ * All rule-returning endpoints parse response payloads through the shared
+ * `parseTrustRule` canonical parser so the client never returns unparsed
+ * or untyped raw rule objects.
  */
 
 import type { TrustRule } from "@vellumai/ces-contracts";
+import { parseTrustRule } from "@vellumai/ces-contracts";
 
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
@@ -166,13 +171,37 @@ function requestSync<T>(method: string, path: string, body?: unknown): T {
 }
 
 // ---------------------------------------------------------------------------
+// Response parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw rule object from a gateway response through the shared
+ * canonical parser. Ensures the trust client never returns unparsed or
+ * untyped rule objects, regardless of what the gateway sends back.
+ */
+function parseRuleResponse(raw: unknown): TrustRule {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Trust rule response is not a valid object");
+  }
+  const { rule } = parseTrustRule(raw as Record<string, unknown>);
+  return rule as TrustRule;
+}
+
+/**
+ * Parse an array of raw rule objects from a gateway response.
+ */
+function parseRulesResponse(raw: unknown[]): TrustRule[] {
+  return raw.map((r) => parseRuleResponse(r));
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /** Fetch all trust rules from the gateway. */
 export async function getAllRules(): Promise<TrustRule[]> {
-  const data = await request<{ rules: TrustRule[] }>("GET", "/v1/trust-rules");
-  return data.rules;
+  const data = await request<{ rules: unknown[] }>("GET", "/v1/trust-rules");
+  return parseRulesResponse(data.rules);
 }
 
 /** Create a new trust rule. */
@@ -185,12 +214,12 @@ export async function addRule(params: {
   allowHighRisk?: boolean;
   executionTarget?: string;
 }): Promise<TrustRule> {
-  const data = await request<{ rule: TrustRule }>(
+  const data = await request<{ rule: unknown }>(
     "POST",
     "/v1/trust-rules",
     params,
   );
-  return data.rule;
+  return parseRuleResponse(data.rule);
 }
 
 /** Update an existing trust rule by ID. */
@@ -206,12 +235,12 @@ export async function updateRule(
     executionTarget?: string;
   },
 ): Promise<TrustRule> {
-  const data = await request<{ rule: TrustRule }>(
+  const data = await request<{ rule: unknown }>(
     "PATCH",
     `/v1/trust-rules/${encodeURIComponent(id)}`,
     updates,
   );
-  return data.rule;
+  return parseRuleResponse(data.rule);
 }
 
 /** Remove a trust rule by ID. Returns true if the rule was found and deleted. */
@@ -245,11 +274,11 @@ export async function findMatchingRule(
     commands: candidates.join(","),
     scope,
   });
-  const data = await request<{ rule: TrustRule | null }>(
+  const data = await request<{ rule: unknown | null }>(
     "GET",
     `/v1/trust-rules/match?${params.toString()}`,
   );
-  return data.rule;
+  return data.rule != null ? parseRuleResponse(data.rule) : null;
 }
 
 /** Accept the starter approval bundle, seeding common low-risk allow rules. */
@@ -266,8 +295,8 @@ export async function acceptStarterBundle(): Promise<AcceptStarterBundleResult> 
 
 /** Fetch all trust rules from the gateway (synchronous). */
 export function getAllRulesSync(): TrustRule[] {
-  const data = requestSync<{ rules: TrustRule[] }>("GET", "/v1/trust-rules");
-  return data.rules;
+  const data = requestSync<{ rules: unknown[] }>("GET", "/v1/trust-rules");
+  return parseRulesResponse(data.rules);
 }
 
 /** Create a new trust rule (synchronous). */
@@ -280,12 +309,12 @@ export function addRuleSync(params: {
   allowHighRisk?: boolean;
   executionTarget?: string;
 }): TrustRule {
-  const data = requestSync<{ rule: TrustRule }>(
+  const data = requestSync<{ rule: unknown }>(
     "POST",
     "/v1/trust-rules",
     params,
   );
-  return data.rule;
+  return parseRuleResponse(data.rule);
 }
 
 /** Update an existing trust rule by ID (synchronous). */
@@ -301,12 +330,12 @@ export function updateRuleSync(
     executionTarget?: string;
   },
 ): TrustRule {
-  const data = requestSync<{ rule: TrustRule }>(
+  const data = requestSync<{ rule: unknown }>(
     "PATCH",
     `/v1/trust-rules/${encodeURIComponent(id)}`,
     updates,
   );
-  return data.rule;
+  return parseRuleResponse(data.rule);
 }
 
 /** Remove a trust rule by ID (synchronous). Returns true if deleted. */

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,6 +8,7 @@
  * header. Guardian decisions additionally verify that the actor is the
  * bound guardian.
  */
+import { parseTrustRule } from "@vellumai/ces-contracts";
 import { z } from "zod";
 
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
@@ -396,10 +397,40 @@ export async function handleTrustRule(
     const tool = getTool(confirmation.toolName);
     const executionTarget =
       tool?.origin === "skill" ? confirmation.executionTarget : undefined;
-    addRule(confirmation.toolName, pattern, scope, decision, undefined, {
-      allowHighRisk: allowHighRisk || undefined,
-      executionTarget,
+
+    // Canonicalize through the shared parser so fields invalid for the tool's
+    // family are stripped before persistence. The `always_allow_high_risk`
+    // decision maps to `allowHighRisk: true` on the persisted rule for scoped
+    // and generic tool families; the parser strips it for families that don't
+    // support it (URL, managed-skill, skill-load).
+    const { rule: canonical } = parseTrustRule({
+      id: "",
+      tool: confirmation.toolName,
+      pattern,
+      scope,
+      decision,
+      priority: 100,
+      createdAt: 0,
+      ...(allowHighRisk ? { allowHighRisk: true } : {}),
+      ...(executionTarget != null ? { executionTarget } : {}),
     });
+    const canonicalOpts =
+      "allowHighRisk" in canonical || "executionTarget" in canonical
+        ? {
+            allowHighRisk: (canonical as { allowHighRisk?: boolean })
+              .allowHighRisk,
+            executionTarget: (canonical as { executionTarget?: string })
+              .executionTarget,
+          }
+        : undefined;
+    addRule(
+      canonical.tool,
+      canonical.pattern,
+      canonical.scope,
+      canonical.decision,
+      undefined,
+      canonicalOpts,
+    );
     log.info(
       { tool: confirmation.toolName, pattern, scope, decision, requestId },
       "Trust rule added via HTTP (bound to pending confirmation)",

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -4,7 +4,13 @@
  * These endpoints manage persistent trust rules independently of
  * the approval-flow trust-rule endpoint in approval-routes.ts.
  * All endpoints are bearer-token authenticated (standard runtime auth).
+ *
+ * Payloads are canonicalized through the shared `parseTrustRule` parser
+ * before persistence: legacy clients can keep sending current shapes
+ * without 4xx regressions, but fields invalid for a tool's family
+ * (e.g. `executionTarget` on a URL-tool rule) are silently stripped.
  */
+import { parseTrustRule } from "@vellumai/ces-contracts";
 import { z } from "zod";
 
 import {
@@ -31,6 +37,10 @@ function handleListTrustRules(): Response {
  * POST /v1/trust-rules/manage — add a trust rule (standalone, not approval-flow).
  *
  * Body: { toolName, pattern, scope, decision, allowHighRisk?, executionTarget? }
+ *
+ * Legacy payloads that include fields invalid for the tool's family (e.g.
+ * `executionTarget` on a `web_fetch` rule) are accepted but canonicalized:
+ * the invalid fields are stripped before persistence.
  */
 export async function handleAddTrustRuleManage(
   req: Request,
@@ -76,14 +86,37 @@ export async function handleAddTrustRuleManage(
   }
 
   try {
-    const hasMetadata = allowHighRisk != null || executionTarget != null;
-    addRule(
-      toolName,
+    // Canonicalize through the shared parser so fields invalid for the tool's
+    // family are stripped before persistence. Legacy callers that send e.g.
+    // executionTarget on a URL-tool rule won't get a 4xx — the field is simply
+    // dropped during normalization.
+    const { rule: canonical } = parseTrustRule({
+      id: "",
+      tool: toolName,
       pattern,
       scope,
-      decision as "allow" | "deny" | "ask",
+      decision,
+      priority: 100,
+      createdAt: 0,
+      ...(allowHighRisk != null ? { allowHighRisk } : {}),
+      ...(executionTarget != null ? { executionTarget } : {}),
+    });
+    const canonicalOpts =
+      "allowHighRisk" in canonical || "executionTarget" in canonical
+        ? {
+            allowHighRisk: (canonical as { allowHighRisk?: boolean })
+              .allowHighRisk,
+            executionTarget: (canonical as { executionTarget?: string })
+              .executionTarget,
+          }
+        : undefined;
+    addRule(
+      canonical.tool,
+      canonical.pattern,
+      canonical.scope,
+      canonical.decision,
       undefined,
-      hasMetadata ? { allowHighRisk, executionTarget } : undefined,
+      canonicalOpts,
     );
     log.info(
       { toolName, pattern, scope, decision },

--- a/gateway/src/__tests__/trust-rules-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-routes.test.ts
@@ -264,7 +264,7 @@ describe("GET /v1/trust-rules/match — query", () => {
         {
           id: "m-1",
           tool: "bash",
-          pattern: "ls **",
+          pattern: "**",
           scope: "everywhere",
           decision: "allow",
           priority: 100,

--- a/gateway/src/__tests__/trust-rules-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-routes.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for gateway trust-rule route handlers.
+ *
+ * Verifies that the route handlers canonicalize payloads through the shared
+ * parseTrustRule parser before persistence: fields invalid for a tool's
+ * family are stripped, and legacy request shapes are accepted without 4xx.
+ */
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { clearCache } from "../trust-store.js";
+import {
+  createTrustRulesAddHandler,
+  createTrustRulesListHandler,
+  createTrustRulesMatchHandler,
+} from "../http/routes/trust-rules.js";
+
+// GATEWAY_SECURITY_DIR is set by test-preload.ts
+
+function getSecurityDir(): string {
+  return process.env.GATEWAY_SECURITY_DIR!;
+}
+
+function getTrustPath(): string {
+  return join(getSecurityDir(), "trust.json");
+}
+
+function writeTrustFile(data: Record<string, unknown>): void {
+  const dir = getSecurityDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(getTrustPath(), JSON.stringify(data));
+}
+
+beforeEach(() => {
+  clearCache();
+  try {
+    unlinkSync(getTrustPath());
+  } catch {
+    // file may not exist
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules — canonicalization at route boundary
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/trust-rules — canonicalization", () => {
+  test("strips executionTarget from URL-family tool rules", async () => {
+    const handler = createTrustRulesAddHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "web_fetch",
+        pattern: "https://example.com/**",
+        scope: "everywhere",
+        decision: "allow",
+        executionTarget: "host",
+        allowHighRisk: true,
+      }),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    expect(body.rule.tool).toBe("web_fetch");
+    // URL rules should NOT have executionTarget or allowHighRisk after canonicalization
+    expect("executionTarget" in body.rule).toBe(false);
+    expect("allowHighRisk" in body.rule).toBe(false);
+  });
+
+  test("preserves executionTarget and allowHighRisk for scoped tool rules", async () => {
+    const handler = createTrustRulesAddHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "bash",
+        pattern: "**",
+        scope: "everywhere",
+        decision: "allow",
+        executionTarget: "host",
+        allowHighRisk: true,
+      }),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    expect(body.rule.tool).toBe("bash");
+    expect(body.rule.executionTarget).toBe("host");
+    expect(body.rule.allowHighRisk).toBe(true);
+  });
+
+  test("strips executionTarget from managed-skill tool rules", async () => {
+    const handler = createTrustRulesAddHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "scaffold_managed_skill",
+        pattern: "**",
+        scope: "everywhere",
+        decision: "allow",
+        executionTarget: "host",
+      }),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    expect(body.rule.tool).toBe("scaffold_managed_skill");
+    expect("executionTarget" in body.rule).toBe(false);
+  });
+
+  test("strips executionTarget from skill_load rules", async () => {
+    const handler = createTrustRulesAddHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "skill_load",
+        pattern: "**",
+        scope: "everywhere",
+        decision: "allow",
+        executionTarget: "host",
+      }),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    expect(body.rule.tool).toBe("skill_load");
+    expect("executionTarget" in body.rule).toBe(false);
+  });
+
+  test("preserves executionTarget and allowHighRisk for generic (unknown) tool rules", async () => {
+    const handler = createTrustRulesAddHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "some_future_tool",
+        pattern: "**",
+        scope: "everywhere",
+        decision: "allow",
+        executionTarget: "container",
+        allowHighRisk: false,
+      }),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    expect(body.rule.tool).toBe("some_future_tool");
+    expect(body.rule.executionTarget).toBe("container");
+    expect(body.rule.allowHighRisk).toBe(false);
+  });
+
+  test("accepts legacy payloads with invalid-for-family fields without 4xx", async () => {
+    const handler = createTrustRulesAddHandler();
+    // Send a legacy payload with executionTarget on a URL tool — should succeed
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tool: "browser_navigate",
+        pattern: "https://example.com/**",
+        scope: "everywhere",
+        decision: "allow",
+        priority: 100,
+        executionTarget: "host",
+        allowHighRisk: true,
+      }),
+    });
+
+    const res = await handler(req);
+    // Should NOT return 4xx — legacy payloads are accepted
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> };
+    // But the persisted rule should have the invalid fields stripped
+    expect("executionTarget" in body.rule).toBe(false);
+    expect("allowHighRisk" in body.rule).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules — list
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/trust-rules — list", () => {
+  test("returns canonicalized rules", async () => {
+    // Write a rule with fields that should be stripped on load
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r-url",
+          tool: "web_fetch",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+        {
+          id: "r-bash",
+          tool: "bash",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+          executionTarget: "host",
+          allowHighRisk: true,
+        },
+      ],
+    });
+
+    const handler = createTrustRulesListHandler();
+    const req = new Request("http://localhost/v1/trust-rules", {
+      method: "GET",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rules: Array<Record<string, unknown>>;
+    };
+    expect(body.rules).toHaveLength(2);
+
+    // URL rule should have been normalized (fields stripped on load)
+    const urlRule = body.rules.find((r) => r.id === "r-url")!;
+    expect("executionTarget" in urlRule).toBe(false);
+    expect("allowHighRisk" in urlRule).toBe(false);
+
+    // Scoped rule should preserve fields
+    const bashRule = body.rules.find((r) => r.id === "r-bash")!;
+    expect(bashRule.executionTarget).toBe("host");
+    expect(bashRule.allowHighRisk).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules/match — query
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/trust-rules/match — query", () => {
+  test("returns matching rule for tool and candidates", async () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "m-1",
+          tool: "bash",
+          pattern: "ls **",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const handler = createTrustRulesMatchHandler();
+    const req = new Request(
+      "http://localhost/v1/trust-rules/match?tool=bash&commands=ls%20/tmp&scope=/some/dir",
+      { method: "GET" },
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { rule: Record<string, unknown> | null };
+    expect(body.rule).toBeTruthy();
+    expect(body.rule!.id).toBe("m-1");
+  });
+
+  test("returns null when no rule matches", async () => {
+    writeTrustFile({ version: 3, rules: [] });
+
+    const handler = createTrustRulesMatchHandler();
+    const req = new Request(
+      "http://localhost/v1/trust-rules/match?tool=bash&commands=rm%20-rf&scope=/tmp",
+      { method: "GET" },
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { rule: null };
+    expect(body.rule).toBeNull();
+  });
+});

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -4,7 +4,14 @@
  * All endpoints require "edge" auth. The assistant daemon will call these
  * endpoints instead of reading trust.json directly once the migration is
  * complete (PR 14-16 in the docker-volume-security plan).
+ *
+ * Payloads are canonicalized through the shared `parseTrustRule` parser
+ * before persistence: legacy clients can keep sending current shapes
+ * without 4xx regressions, but fields invalid for a tool's family
+ * (e.g. `executionTarget` on a URL-tool rule) are silently stripped.
  */
+
+import { parseTrustRule } from "@vellumai/ces-contracts/trust-rules";
 
 import { getLogger } from "../../logger.js";
 import {
@@ -68,8 +75,15 @@ export function createTrustRulesAddHandler() {
       );
     }
 
-    const { tool, pattern, scope, decision, priority, allowHighRisk, executionTarget } =
-      body as Record<string, unknown>;
+    const {
+      tool,
+      pattern,
+      scope,
+      decision,
+      priority,
+      allowHighRisk,
+      executionTarget,
+    } = body as Record<string, unknown>;
 
     if (typeof tool !== "string" || !tool) {
       return Response.json(
@@ -95,7 +109,10 @@ export function createTrustRulesAddHandler() {
         { status: 400 },
       );
     }
-    if (priority !== undefined && (typeof priority !== "number" || !Number.isFinite(priority))) {
+    if (
+      priority !== undefined &&
+      (typeof priority !== "number" || !Number.isFinite(priority))
+    ) {
       return Response.json(
         { error: '"priority" must be a finite number' },
         { status: 400 },
@@ -115,20 +132,53 @@ export function createTrustRulesAddHandler() {
     }
 
     try {
+      // Canonicalize through the shared parser so fields invalid for the
+      // tool's family are stripped before persistence. Legacy callers that
+      // send e.g. executionTarget on a URL-tool rule won't get a 4xx —
+      // the field is simply dropped during normalization.
+      const { rule: canonical } = parseTrustRule({
+        id: "",
+        tool: tool as string,
+        pattern: pattern as string,
+        scope: scope as string,
+        decision: (decision as TrustDecision) ?? "allow",
+        priority: (priority as number) ?? 100,
+        createdAt: 0,
+        ...(allowHighRisk != null ? { allowHighRisk } : {}),
+        ...(executionTarget != null ? { executionTarget } : {}),
+      });
+      const canonicalOpts: {
+        allowHighRisk?: boolean;
+        executionTarget?: string;
+      } = {};
+      if (
+        "allowHighRisk" in canonical &&
+        (canonical as { allowHighRisk?: boolean }).allowHighRisk != null
+      ) {
+        canonicalOpts.allowHighRisk = (
+          canonical as { allowHighRisk?: boolean }
+        ).allowHighRisk;
+      }
+      if (
+        "executionTarget" in canonical &&
+        (canonical as { executionTarget?: string }).executionTarget != null
+      ) {
+        canonicalOpts.executionTarget = (
+          canonical as { executionTarget?: string }
+        ).executionTarget;
+      }
       const rule = addRule(
-        tool,
-        pattern,
-        scope,
-        (decision as TrustDecision) ?? "allow",
-        (priority as number) ?? 100,
-        {
-          allowHighRisk: allowHighRisk as boolean | undefined,
-          executionTarget: executionTarget as string | undefined,
-        },
+        canonical.tool,
+        canonical.pattern,
+        canonical.scope,
+        canonical.decision,
+        canonical.priority,
+        Object.keys(canonicalOpts).length > 0 ? canonicalOpts : undefined,
       );
       return Response.json({ rule }, { status: 201 });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Internal server error";
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
       log.error({ err }, "Failed to add trust rule");
       return Response.json({ error: message }, { status: 400 });
     }
@@ -142,10 +192,7 @@ export function createTrustRulesAddHandler() {
 export function createTrustRulesUpdateHandler() {
   return async (req: Request, ruleId: string): Promise<Response> => {
     if (!ruleId) {
-      return Response.json(
-        { error: "Rule ID is required" },
-        { status: 400 },
-      );
+      return Response.json({ error: "Rule ID is required" }, { status: 400 });
     }
 
     let body: unknown;
@@ -165,8 +212,10 @@ export function createTrustRulesUpdateHandler() {
       );
     }
 
-    const { tool, pattern, scope, decision, priority } =
-      body as Record<string, unknown>;
+    const { tool, pattern, scope, decision, priority } = body as Record<
+      string,
+      unknown
+    >;
 
     if (tool !== undefined && (typeof tool !== "string" || !tool)) {
       return Response.json(
@@ -192,7 +241,10 @@ export function createTrustRulesUpdateHandler() {
         { status: 400 },
       );
     }
-    if (priority !== undefined && (typeof priority !== "number" || !Number.isFinite(priority))) {
+    if (
+      priority !== undefined &&
+      (typeof priority !== "number" || !Number.isFinite(priority))
+    ) {
       return Response.json(
         { error: '"priority" must be a finite number' },
         { status: 400 },
@@ -209,7 +261,8 @@ export function createTrustRulesUpdateHandler() {
       });
       return Response.json({ rule });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Internal server error";
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
       if (message.includes("not found")) {
         return Response.json({ error: message }, { status: 404 });
       }
@@ -226,10 +279,7 @@ export function createTrustRulesUpdateHandler() {
 export function createTrustRulesDeleteHandler() {
   return async (_req: Request, ruleId: string): Promise<Response> => {
     if (!ruleId) {
-      return Response.json(
-        { error: "Rule ID is required" },
-        { status: 400 },
-      );
+      return Response.json({ error: "Rule ID is required" }, { status: 400 });
     }
 
     try {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2721,7 +2721,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "List trust rules",
           description:
-            "Authenticated gateway endpoint that lists all trust rules via the assistant runtime.",
+            "Authenticated gateway endpoint that lists all trust rules. Returns canonicalized rules with family-aware field normalization.",
           operationId: "trustRulesGet",
           security: [{ BearerAuth: [] }],
           responses: {
@@ -2737,7 +2737,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Add a trust rule",
           description:
-            "Authenticated gateway endpoint that adds a new trust rule via the assistant runtime.",
+            "Authenticated gateway endpoint that adds a new trust rule. Payloads are canonicalized through family-aware parsing before persistence: fields invalid for the tool's family (e.g. executionTarget on URL-tool rules) are silently stripped. Legacy request shapes are accepted without 4xx regressions.",
           operationId: "trustRulesPost",
           security: [{ BearerAuth: [] }],
           requestBody: {


### PR DESCRIPTION
## Summary
- Canonicalize trust-rule payloads through shared parser at route boundaries
- Add response parsing in trust-client for all rule-returning endpoints
- Preserve backward compatibility for legacy request shapes and high-risk/executionTarget behavior

Part of plan: trust-rule-union-compat.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
