### PR TITLE
feat(compaction): add deterministic microcompact module for stale tool results

### DIFF
--- a/assistant/src/context/__tests__/microcompact.test.ts
+++ b/assistant/src/context/__tests__/microcompact.test.ts
@@ -1,0 +1,595 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Message,
+  ToolResultContent,
+  ToolUseContent,
+} from "../../providers/types.js";
+import { microcompact } from "../microcompact.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function userText(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function assistantToolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): Message {
+  const block: ToolUseContent = { type: "tool_use", id, name, input };
+  return { role: "assistant", content: [block] };
+}
+
+function toolResult(
+  tool_use_id: string,
+  content: string,
+  extras: Partial<
+    Omit<ToolResultContent, "type" | "tool_use_id" | "content">
+  > = {},
+): Message {
+  const block: ToolResultContent = {
+    type: "tool_result",
+    tool_use_id,
+    content,
+    ...extras,
+  };
+  return { role: "user", content: [block] };
+}
+
+/**
+ * Build a realistic multi-turn conversation where every "exchange" is a
+ * user text message followed by a tool_use + tool_result pair.
+ *
+ * turns[i].tool = the tool name used on turn i.
+ * turns[i].resultBody = the text of the tool_result for that turn.
+ */
+function buildConversation(
+  turns: Array<{ tool: string; resultBody: string; userText?: string }>,
+): Message[] {
+  const out: Message[] = [];
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i];
+    const id = `tu-${i}`;
+    out.push(userText(t.userText ?? `user says ${i}`));
+    out.push(assistantToolUse(id, t.tool));
+    out.push(toolResult(id, t.resultBody));
+  }
+  return out;
+}
+
+/** Large payload sized to dominate the token budget. */
+function big(label: string, size = 10_000): string {
+  return `${label}:${"x".repeat(size)}`;
+}
+
+/** Count tool_result blocks whose content equals the cleared placeholder. */
+function countClearedToolResults(messages: Message[]): number {
+  let n = 0;
+  for (const m of messages) {
+    for (const b of m.content) {
+      if (
+        b.type === "tool_result" &&
+        b.content === "[Old tool result content cleared]"
+      ) {
+        n += 1;
+      }
+    }
+  }
+  return n;
+}
+
+function findToolResults(messages: Message[]): ToolResultContent[] {
+  const out: ToolResultContent[] = [];
+  for (const m of messages) {
+    for (const b of m.content) {
+      if (b.type === "tool_result") out.push(b);
+    }
+  }
+  return out;
+}
+
+function findToolUses(messages: Message[]): ToolUseContent[] {
+  const out: ToolUseContent[] = [];
+  for (const m of messages) {
+    for (const b of m.content) {
+      if (b.type === "tool_use") out.push(b);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// (a) last-N-turns-protected invariant
+// ---------------------------------------------------------------------------
+
+describe("microcompact — protectRecentTurns invariant", () => {
+  test("leaves the last N user turns untouched", () => {
+    const turns = Array.from({ length: 8 }, () => ({
+      tool: "Bash",
+      resultBody: big("stale"),
+    }));
+    const messages = buildConversation(turns);
+
+    // Cleared count *in the stripped region* should be exactly 8 - 4 = 4
+    // when protectRecentTurns = 4 (default).
+    const result = microcompact(messages);
+
+    expect(result.clearedToolResults).toBe(4);
+    expect(result.reclaimedTokens).toBeGreaterThan(0);
+
+    // The last 4 user turns occupy indices 12..23 of a 24-message array
+    // (3 messages per turn × 8 turns). Every tool_result at index >= 12
+    // must still contain the original body.
+    const trs = findToolResults(result.messages);
+    // tool_results are at message indices 2,5,8,...23 — the 4 newest are
+    // at positions 4..7 in this list (i.e. turns 4..7).
+    for (let i = 0; i < 4; i++) {
+      expect(trs[i].content).toBe("[Old tool result content cleared]");
+    }
+    for (let i = 4; i < 8; i++) {
+      expect(trs[i].content.startsWith("stale:")).toBe(true);
+    }
+  });
+
+  test("when history has fewer turns than protectRecentTurns, nothing is cleared", () => {
+    const messages = buildConversation([
+      { tool: "Bash", resultBody: big("stale") },
+      { tool: "Bash", resultBody: big("stale") },
+    ]);
+    const result = microcompact(messages, { protectRecentTurns: 4 });
+    expect(result.clearedToolResults).toBe(0);
+    expect(result.reclaimedTokens).toBe(0);
+    expect(result.messages).toBe(messages);
+  });
+
+  test("tool_result-only user messages do not count as a user turn", () => {
+    // A single exchange where the user sends text, then the model makes 3
+    // separate tool calls. Providers emit one user message per tool_result,
+    // all of which are tool_result-only. Those should not each count as a
+    // user turn — otherwise protectRecentTurns=1 would protect everything.
+    const msgs: Message[] = [
+      userText("first real user turn"),
+      assistantToolUse("tu-1", "Bash"),
+      toolResult("tu-1", big("body-1")),
+      assistantToolUse("tu-2", "Bash"),
+      toolResult("tu-2", big("body-2")),
+      assistantToolUse("tu-3", "Bash"),
+      toolResult("tu-3", big("body-3")),
+      userText("second real user turn"),
+      assistantToolUse("tu-4", "Bash"),
+      toolResult("tu-4", big("body-4")),
+    ];
+    // protectRecentTurns=1 should protect ONLY the "second real user turn"
+    // and its tool_result (tu-4). tu-1..tu-3 should be cleared.
+    const result = microcompact(msgs, { protectRecentTurns: 1 });
+    expect(result.clearedToolResults).toBe(3);
+
+    const trs = findToolResults(result.messages);
+    expect(trs[0].content).toBe("[Old tool result content cleared]");
+    expect(trs[1].content).toBe("[Old tool result content cleared]");
+    expect(trs[2].content).toBe("[Old tool result content cleared]");
+    expect(trs[3].content.startsWith("body-4:")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) protected tools never cleared
+// ---------------------------------------------------------------------------
+
+describe("microcompact — protected tools", () => {
+  test("never replaces the body of a tool_result from a protected tool", () => {
+    // 6 turns: 1 Task, 1 subagent, 1 skill, 3 Bash — plus 4 protected turns
+    // at the tail to push the first 6 into the stripped region.
+    const turns = [
+      { tool: "Task", resultBody: big("task-result") },
+      { tool: "subagent", resultBody: big("subagent-result") },
+      { tool: "skill", resultBody: big("skill-result") },
+      { tool: "Bash", resultBody: big("bash-1") },
+      { tool: "Bash", resultBody: big("bash-2") },
+      { tool: "Bash", resultBody: big("bash-3") },
+      // Protected tail — 4 recent turns.
+      { tool: "Bash", resultBody: "recent-1" },
+      { tool: "Bash", resultBody: "recent-2" },
+      { tool: "Bash", resultBody: "recent-3" },
+      { tool: "Bash", resultBody: "recent-4" },
+    ];
+    const messages = buildConversation(turns);
+    const result = microcompact(messages);
+
+    // Only the 3 Bash calls in the stripped region should have been cleared.
+    expect(result.clearedToolResults).toBe(3);
+
+    const trs = findToolResults(result.messages);
+    // Turn 0 (Task) — body preserved
+    expect(trs[0].content.startsWith("task-result:")).toBe(true);
+    // Turn 1 (subagent) — body preserved
+    expect(trs[1].content.startsWith("subagent-result:")).toBe(true);
+    // Turn 2 (skill) — body preserved
+    expect(trs[2].content.startsWith("skill-result:")).toBe(true);
+    // Turns 3,4,5 — cleared
+    expect(trs[3].content).toBe("[Old tool result content cleared]");
+    expect(trs[4].content).toBe("[Old tool result content cleared]");
+    expect(trs[5].content).toBe("[Old tool result content cleared]");
+  });
+
+  test("custom protectedTools override the default list", () => {
+    const turns = [
+      { tool: "Task", resultBody: big("task-body") },
+      { tool: "MyTool", resultBody: big("mytool-body") },
+      // Protected tail
+      { tool: "Bash", resultBody: "recent-1" },
+      { tool: "Bash", resultBody: "recent-2" },
+      { tool: "Bash", resultBody: "recent-3" },
+      { tool: "Bash", resultBody: "recent-4" },
+    ];
+    const messages = buildConversation(turns);
+    const result = microcompact(messages, { protectedTools: ["MyTool"] });
+
+    const trs = findToolResults(result.messages);
+    // Task is NO LONGER protected (not in the custom list) — should be cleared.
+    expect(trs[0].content).toBe("[Old tool result content cleared]");
+    // MyTool is protected — body preserved.
+    expect(trs[1].content.startsWith("mytool-body:")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) idempotency
+// ---------------------------------------------------------------------------
+
+describe("microcompact — idempotency", () => {
+  test("running twice produces zero incremental reclaim", () => {
+    const turns = Array.from({ length: 8 }, () => ({
+      tool: "Bash",
+      resultBody: big("stale"),
+    }));
+    const messages = buildConversation(turns);
+
+    const first = microcompact(messages);
+    expect(first.reclaimedTokens).toBeGreaterThan(0);
+    expect(first.clearedToolResults).toBeGreaterThan(0);
+
+    const second = microcompact(first.messages);
+    expect(second.reclaimedTokens).toBe(0);
+    expect(second.clearedToolResults).toBe(0);
+    // Second pass returns the same reference when there's nothing to do.
+    expect(second.messages).toBe(first.messages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) minGainTokens no-op
+// ---------------------------------------------------------------------------
+
+describe("microcompact — minGainTokens", () => {
+  test("returns original messages when reclaim is below the floor", () => {
+    // Tiny bodies — stale region exists but compaction saves very little.
+    const turns = Array.from({ length: 8 }, (_, i) => ({
+      tool: "Bash",
+      resultBody: `tiny-${i}`,
+    }));
+    const messages = buildConversation(turns);
+
+    const result = microcompact(messages, { minGainTokens: 10_000 });
+    expect(result.reclaimedTokens).toBe(0);
+    expect(result.clearedToolResults).toBe(0);
+    // Original reference returned verbatim.
+    expect(result.messages).toBe(messages);
+  });
+
+  test("returns compacted messages when reclaim meets the floor", () => {
+    const turns = Array.from({ length: 8 }, () => ({
+      tool: "Bash",
+      resultBody: big("stale"),
+    }));
+    const messages = buildConversation(turns);
+
+    const result = microcompact(messages, { minGainTokens: 100 });
+    expect(result.reclaimedTokens).toBeGreaterThanOrEqual(100);
+    expect(result.messages).not.toBe(messages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) <ax-tree> block stripping
+// ---------------------------------------------------------------------------
+
+describe("microcompact — ax-tree stripping", () => {
+  test("strips ax-tree blocks from protected tool_results in the stripped region", () => {
+    // Place a protected (Task) tool_result in the stripped region and verify
+    // that its ax-tree is collapsed even though the rest of its body is
+    // preserved.
+    const axTreeBody = `Task output before.\n<ax-tree>\n${"<node/>".repeat(
+      1000,
+    )}\n</ax-tree>\nTask output after.`;
+
+    const turns = [
+      { tool: "Task", resultBody: axTreeBody },
+      // Protected tail
+      { tool: "Bash", resultBody: "recent-1" },
+      { tool: "Bash", resultBody: "recent-2" },
+      { tool: "Bash", resultBody: "recent-3" },
+      { tool: "Bash", resultBody: "recent-4" },
+    ];
+    const messages = buildConversation(turns);
+    const result = microcompact(messages, { minGainTokens: 100 });
+
+    const trs = findToolResults(result.messages);
+    // Task body preserved (it's protected), but ax-tree is collapsed.
+    expect(trs[0].content).not.toContain("<ax-tree>");
+    expect(trs[0].content).not.toContain("</ax-tree>");
+    expect(trs[0].content).toContain("<ax_tree_omitted />");
+    expect(trs[0].content).toContain("Task output before.");
+    expect(trs[0].content).toContain("Task output after.");
+  });
+
+  test("leaves ax-tree blocks in the protected tail untouched", () => {
+    const axTreeBody = `recent output.\n<ax-tree>\n${"<node/>".repeat(
+      500,
+    )}\n</ax-tree>`;
+
+    // Only 2 turns — protectRecentTurns defaults to 4, so everything is
+    // protected and ax-trees must not be touched.
+    const messages = buildConversation([
+      { tool: "Task", resultBody: axTreeBody },
+      { tool: "Task", resultBody: axTreeBody },
+    ]);
+    const result = microcompact(messages);
+
+    const trs = findToolResults(result.messages);
+    expect(trs[0].content).toContain("<ax-tree>");
+    expect(trs[1].content).toContain("<ax-tree>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) image / file block stubbing
+// ---------------------------------------------------------------------------
+
+describe("microcompact — image/file stubbing", () => {
+  test("replaces image and file blocks in the stripped region with text stubs", () => {
+    const bigBase64 = "A".repeat(20_000);
+
+    const msgs: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at these" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: bigBase64,
+            },
+          },
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: bigBase64,
+              filename: "report.pdf",
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      // Push 4 follow-up user turns so the image-bearing message is in the
+      // stripped region.
+      userText("t1"),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      userText("t2"),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      userText("t3"),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      userText("t4"),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+    ];
+
+    const result = microcompact(msgs);
+
+    expect(result.clearedImages).toBe(2);
+    expect(result.reclaimedTokens).toBeGreaterThan(0);
+
+    // The image and file blocks should be replaced with text stubs.
+    const first = result.messages[0];
+    expect(first.content[0]).toEqual({ type: "text", text: "look at these" });
+    expect(first.content[1]).toEqual({ type: "text", text: "[image omitted]" });
+    expect(first.content[2]).toEqual({ type: "text", text: "[file omitted]" });
+
+    // No image or file blocks remain anywhere in the output.
+    const hasImageOrFile = result.messages.some((m) =>
+      m.content.some((b) => b.type === "image" || b.type === "file"),
+    );
+    expect(hasImageOrFile).toBe(false);
+  });
+
+  test("leaves image blocks in the protected tail untouched", () => {
+    const bigBase64 = "A".repeat(5_000);
+
+    const msgs: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "recent user turn" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: bigBase64,
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    ];
+
+    const result = microcompact(msgs);
+    expect(result.clearedImages).toBe(0);
+    expect(result.messages).toBe(msgs);
+
+    const firstBlocks = result.messages[0].content;
+    expect(firstBlocks[1].type).toBe("image");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (g) tool_use / tool_result pairing invariant
+// ---------------------------------------------------------------------------
+
+describe("microcompact — tool_use/tool_result pairing", () => {
+  test("every tool_use retains a matching tool_result after compaction", () => {
+    const turns = Array.from({ length: 8 }, () => ({
+      tool: "Bash",
+      resultBody: big("stale"),
+    }));
+    const messages = buildConversation(turns);
+    const result = microcompact(messages);
+
+    const tuIds = new Set(findToolUses(result.messages).map((b) => b.id));
+    const trIds = new Set(
+      findToolResults(result.messages).map((b) => b.tool_use_id),
+    );
+
+    expect(tuIds.size).toBe(8);
+    expect(trIds.size).toBe(8);
+    for (const id of tuIds) {
+      expect(trIds.has(id)).toBe(true);
+    }
+  });
+
+  test("message roles and block types are preserved — only bodies mutate", () => {
+    const turns = Array.from({ length: 6 }, () => ({
+      tool: "Bash",
+      resultBody: big("stale"),
+    }));
+    const messages = buildConversation(turns);
+    const result = microcompact(messages);
+
+    expect(result.messages.length).toBe(messages.length);
+    for (let i = 0; i < messages.length; i++) {
+      expect(result.messages[i].role).toBe(messages[i].role);
+      expect(result.messages[i].content.length).toBe(
+        messages[i].content.length,
+      );
+      for (let j = 0; j < messages[i].content.length; j++) {
+        expect(result.messages[i].content[j].type).toBe(
+          messages[i].content[j].type,
+        );
+      }
+    }
+
+    // And every cleared tool_result retains its tool_use_id.
+    const resultTrs = findToolResults(result.messages);
+    const originalTrs = findToolResults(messages);
+    for (let i = 0; i < resultTrs.length; i++) {
+      expect(resultTrs[i].tool_use_id).toBe(originalTrs[i].tool_use_id);
+    }
+  });
+
+  test("preserves is_error flag when clearing", () => {
+    const messages: Message[] = [
+      userText("initial"),
+      assistantToolUse("tu-err", "Bash"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu-err",
+            content: big("error-body"),
+            is_error: true,
+          },
+        ],
+      },
+      // Push 4 turns to strip the first.
+      userText("t1"),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      userText("t2"),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      userText("t3"),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      userText("t4"),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+    ];
+
+    const result = microcompact(messages);
+    const errBlock = result.messages[2].content[0] as ToolResultContent;
+    expect(errBlock.type).toBe("tool_result");
+    expect(errBlock.content).toBe("[Old tool result content cleared]");
+    expect(errBlock.is_error).toBe(true);
+  });
+
+  test("strips contentBlocks (rich content) from cleared tool_results", () => {
+    const messages: Message[] = [
+      userText("initial"),
+      assistantToolUse("tu-rich", "Bash"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu-rich",
+            content: big("body"),
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "X".repeat(10_000),
+                },
+              },
+            ],
+          } as ToolResultContent,
+        ],
+      },
+      // Push 4 turns to strip the first.
+      userText("t1"),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      userText("t2"),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      userText("t3"),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      userText("t4"),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+    ];
+
+    const result = microcompact(messages);
+    const cleared = result.messages[2].content[0] as ToolResultContent;
+    expect(cleared.contentBlocks).toBeUndefined();
+    expect(cleared.content).toBe("[Old tool result content cleared]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary counters sanity
+// ---------------------------------------------------------------------------
+
+describe("microcompact — counter sanity", () => {
+  test("counts match what was actually cleared", () => {
+    const messages = buildConversation(
+      Array.from({ length: 8 }, () => ({
+        tool: "Bash",
+        resultBody: big("stale"),
+      })),
+    );
+    const result = microcompact(messages);
+    expect(countClearedToolResults(result.messages)).toBe(
+      result.clearedToolResults,
+    );
+  });
+
+  test("empty input returns zero counters and original reference", () => {
+    const result = microcompact([]);
+    expect(result.reclaimedTokens).toBe(0);
+    expect(result.clearedToolResults).toBe(0);
+    expect(result.clearedImages).toBe(0);
+  });
+});

--- a/assistant/src/context/__tests__/microcompact.test.ts
+++ b/assistant/src/context/__tests__/microcompact.test.ts
@@ -393,7 +393,7 @@ describe("microcompact — image/file stubbing", () => {
 
     const result = microcompact(msgs);
 
-    expect(result.clearedImages).toBe(2);
+    expect(result.clearedMedia).toBe(2);
     expect(result.reclaimedTokens).toBeGreaterThan(0);
 
     // The image and file blocks should be replaced with text stubs.
@@ -431,7 +431,7 @@ describe("microcompact — image/file stubbing", () => {
     ];
 
     const result = microcompact(msgs);
-    expect(result.clearedImages).toBe(0);
+    expect(result.clearedMedia).toBe(0);
     expect(result.messages).toBe(msgs);
 
     const firstBlocks = result.messages[0].content;
@@ -566,6 +566,216 @@ describe("microcompact — tool_use/tool_result pairing", () => {
     expect(cleared.contentBlocks).toBeUndefined();
     expect(cleared.content).toBe("[Old tool result content cleared]");
   });
+
+  test("preserves text entries in contentBlocks on protected tool_results, drops media", () => {
+    // A protected (Task) tool_result in the stripped region carrying both a
+    // text entry AND an image entry in its `contentBlocks`. Before the P2
+    // fix, BOTH were dropped; text entries can be meaningful (protected-tool
+    // narration) and must survive.
+    const messages: Message[] = [
+      userText("initial"),
+      assistantToolUse("tu-prot", "Task"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu-prot",
+            content: big("task-body"),
+            contentBlocks: [
+              { type: "text", text: "important narration from subagent" },
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "X".repeat(10_000),
+                },
+              },
+            ],
+          } as ToolResultContent,
+        ],
+      },
+      // Push 4 turns to strip the first.
+      userText("t1"),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      userText("t2"),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      userText("t3"),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      userText("t4"),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+    ];
+
+    const result = microcompact(messages);
+    const preserved = result.messages[2].content[0] as ToolResultContent;
+
+    // Body is preserved (protected tool — ax-tree stripping only, body kept).
+    expect(preserved.type).toBe("tool_result");
+    expect(preserved.content.startsWith("task-body:")).toBe(true);
+
+    // Text contentBlock entry survives.
+    expect(preserved.contentBlocks).toBeDefined();
+    expect(preserved.contentBlocks!.length).toBe(1);
+    expect(preserved.contentBlocks![0]).toEqual({
+      type: "text",
+      text: "important narration from subagent",
+    });
+
+    // Media entry was dropped, which saved tokens.
+    expect(result.reclaimedTokens).toBeGreaterThan(0);
+  });
+
+  test("protected tool_result with only text contentBlocks is a no-op (body unchanged, text kept)", () => {
+    // No media to strip and no ax-tree in body — nothing should change.
+    const messages: Message[] = [
+      userText("initial"),
+      assistantToolUse("tu-prot-txt", "Task"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu-prot-txt",
+            content: "task body without ax-tree",
+            contentBlocks: [
+              { type: "text", text: "only a text attachment here" },
+            ],
+          } as ToolResultContent,
+        ],
+      },
+      userText("t1"),
+      { role: "assistant", content: [{ type: "text", text: "r1" }] },
+      userText("t2"),
+      { role: "assistant", content: [{ type: "text", text: "r2" }] },
+      userText("t3"),
+      { role: "assistant", content: [{ type: "text", text: "r3" }] },
+      userText("t4"),
+      { role: "assistant", content: [{ type: "text", text: "r4" }] },
+    ];
+
+    const result = microcompact(messages, { minGainTokens: 0 });
+    // No reclaim for the protected tool_result, so it keeps its original text
+    // entries and body.
+    const kept = result.messages[2].content[0] as ToolResultContent;
+    expect(kept.content).toBe("task body without ax-tree");
+    expect(kept.contentBlocks).toBeDefined();
+    expect(kept.contentBlocks!.length).toBe(1);
+    expect(kept.contentBlocks![0]).toEqual({
+      type: "text",
+      text: "only a text attachment here",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (h) web_search_tool_result & system_notice classifier
+// ---------------------------------------------------------------------------
+
+describe("microcompact — tool-response-only user message classifier", () => {
+  test("web_search_tool_result-only user messages do not count as a user turn", () => {
+    // Single real user turn followed by an assistant server_tool_use and a
+    // web_search_tool_result-only user message. protectRecentTurns=1 should
+    // still protect the single real user turn plus its trailing assistant
+    // response — NOT wastefully also protect the web_search_tool_result
+    // message (which would push the real tool_result on the prior turn out of
+    // reach).
+    const msgs: Message[] = [
+      userText("first real user turn"),
+      assistantToolUse("tu-old", "Bash"),
+      toolResult("tu-old", big("old-body")),
+      userText("second real user turn"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srv-1",
+            name: "web_search",
+            input: { query: "x" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srv-1",
+            content: [],
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+
+    // protectRecentTurns=1 should protect ONLY "second real user turn" and
+    // everything after. tu-old (attached to "first real user turn") should be
+    // cleared.
+    const result = microcompact(msgs, { protectRecentTurns: 1 });
+    expect(result.clearedToolResults).toBe(1);
+
+    const trs = findToolResults(result.messages);
+    expect(trs[0].content).toBe("[Old tool result content cleared]");
+  });
+
+  test("system_notice-only text user messages do not count as a user turn", () => {
+    // System notices (retry nudges / progress checks) are injected as
+    // user-role text blocks wrapped in <system_notice>...</system_notice>.
+    // They must not be treated as real user turns.
+    const msgs: Message[] = [
+      userText("first real user turn"),
+      assistantToolUse("tu-old", "Bash"),
+      toolResult("tu-old", big("old-body")),
+      userText("second real user turn"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "some response" }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<system_notice>please continue</system_notice>",
+          },
+        ],
+      },
+    ];
+
+    const result = microcompact(msgs, { protectRecentTurns: 1 });
+    expect(result.clearedToolResults).toBe(1);
+
+    const trs = findToolResults(result.messages);
+    expect(trs[0].content).toBe("[Old tool result content cleared]");
+  });
+
+  test("mixed user message (real text + tool_result) still counts as a user turn", () => {
+    // A user message containing both real text AND tool-response blocks is
+    // still a real user turn — don't misclassify.
+    const msgs: Message[] = [
+      userText("older turn"),
+      assistantToolUse("tu-old", "Bash"),
+      toolResult("tu-old", big("old-body")),
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "new user message with context" },
+          {
+            type: "tool_result",
+            tool_use_id: "tu-old",
+            content: "inline result",
+          } as ToolResultContent,
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "response" }] },
+    ];
+
+    // protectRecentTurns=1 should protect the mixed message + trailing
+    // assistant response; the older turn's tool_result should be cleared.
+    const result = microcompact(msgs, { protectRecentTurns: 1 });
+    expect(result.clearedToolResults).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -590,6 +800,6 @@ describe("microcompact — counter sanity", () => {
     const result = microcompact([]);
     expect(result.reclaimedTokens).toBe(0);
     expect(result.clearedToolResults).toBe(0);
-    expect(result.clearedImages).toBe(0);
+    expect(result.clearedMedia).toBe(0);
   });
 });

--- a/assistant/src/context/microcompact.ts
+++ b/assistant/src/context/microcompact.ts
@@ -1,0 +1,387 @@
+import type {
+  ContentBlock,
+  Message,
+  ToolResultContent,
+} from "../providers/types.js";
+import { estimateTextTokens } from "./token-estimator.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default number of recent user-assistant exchanges to keep untouched. */
+const DEFAULT_PROTECT_RECENT_TURNS = 4;
+
+/** Default minimum reclaimable tokens required before we commit a pass. */
+const DEFAULT_MIN_GAIN_TOKENS = 2_000;
+
+/**
+ * Default list of tool names whose results are never wholesale-cleared.
+ * Matches opencode's `PRUNE_PROTECTED_TOOLS` and Claude Code's equivalent —
+ * protects subagent outputs and curated skill results, which are expensive
+ * to regenerate and usually load-bearing for the rest of the conversation.
+ *
+ * Note: ax-tree stripping still applies to protected tool results. Only the
+ * full-body replacement is skipped.
+ */
+const DEFAULT_PROTECTED_TOOLS: readonly string[] = [
+  "Task",
+  "subagent",
+  "skill",
+];
+
+/** Replacement body for cleared tool-result content. */
+const CLEARED_TOOL_RESULT_TEXT = "[Old tool result content cleared]";
+
+/** Replacement text for stubbed image blocks. */
+const CLEARED_IMAGE_TEXT = "[image omitted]";
+
+/** Replacement text for stubbed file blocks. */
+const CLEARED_FILE_TEXT = "[file omitted]";
+
+/**
+ * Regex that matches `<ax-tree>...</ax-tree>` blocks (non-greedy).
+ * Kept in sync with `AX_TREE_PATTERN` in `assistant/src/agent/loop.ts`; this
+ * module subsumes that function's responsibility for stale tool results.
+ */
+const AX_TREE_PATTERN = /<ax-tree>[\s\S]*?<\/ax-tree>/g;
+
+/** Placeholder inserted in place of a stripped ax-tree block. */
+const AX_TREE_PLACEHOLDER = "<ax_tree_omitted />";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MicrocompactOptions {
+  /** Preserve the last N user-assistant exchanges verbatim. Default 4. */
+  protectRecentTurns?: number;
+  /** Tool names whose results are never microcompacted (e.g. "Task", sub-agents). */
+  protectedTools?: string[];
+  /** Minimum reclaimable tokens required to bother — skip no-op passes. Default 2000. */
+  minGainTokens?: number;
+}
+
+export interface MicrocompactResult {
+  messages: Message[];
+  reclaimedTokens: number;
+  clearedToolResults: number;
+  clearedImages: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministically compact stale content in the message history.
+ *
+ * Walks `messages` from newest to oldest. The most recent
+ * `protectRecentTurns` user-assistant exchanges are left untouched. In the
+ * older region:
+ *
+ *  - Each `tool_result` whose owning tool is NOT in `protectedTools` has its
+ *    `content` replaced with a short placeholder.
+ *  - Every `image` / `file` block is replaced with a text stub.
+ *  - `<ax-tree>...</ax-tree>` blocks inside any tool_result (including
+ *    protected ones) are collapsed to a placeholder, subsuming the old
+ *    `compactAxTreeHistory` in `assistant/src/agent/loop.ts`.
+ *
+ * The `tool_use` / `tool_result` block structure is preserved — we only
+ * mutate block bodies, never the block types or their pairing — so provider
+ * serialization remains valid after compaction.
+ *
+ * If the estimated savings (`reclaimedTokens`) is below `minGainTokens`, the
+ * original `messages` reference is returned unchanged. The pass is
+ * idempotent: re-invoking on a previously compacted history produces zero
+ * incremental reclaim.
+ */
+export function microcompact(
+  messages: Message[],
+  options?: MicrocompactOptions,
+): MicrocompactResult {
+  const protectRecentTurns =
+    options?.protectRecentTurns ?? DEFAULT_PROTECT_RECENT_TURNS;
+  const minGainTokens = options?.minGainTokens ?? DEFAULT_MIN_GAIN_TOKENS;
+  const protectedToolSet = new Set(
+    options?.protectedTools ?? DEFAULT_PROTECTED_TOOLS,
+  );
+
+  if (messages.length === 0) {
+    return {
+      messages,
+      reclaimedTokens: 0,
+      clearedToolResults: 0,
+      clearedImages: 0,
+    };
+  }
+
+  // Build a lookup of tool_use_id -> tool name by scanning every assistant
+  // message. Tool_use_ids are globally unique within a conversation so a
+  // single map is valid for the whole history.
+  const toolNameById = buildToolNameLookup(messages);
+
+  // Determine the index up to which messages are "protected" (left alone).
+  // Anything at index >= firstProtectedIdx is in the protected tail; the
+  // older region (indices < firstProtectedIdx) is where we clear.
+  const firstProtectedIdx = computeProtectedBoundary(
+    messages,
+    protectRecentTurns,
+  );
+
+  if (firstProtectedIdx <= 0) {
+    // Every message is protected — nothing to clear.
+    return {
+      messages,
+      reclaimedTokens: 0,
+      clearedToolResults: 0,
+      clearedImages: 0,
+    };
+  }
+
+  let reclaimedTokens = 0;
+  let clearedToolResults = 0;
+  let clearedImages = 0;
+  let anyChange = false;
+
+  const nextMessages: Message[] = messages.map((msg, idx) => {
+    if (idx >= firstProtectedIdx) return msg;
+
+    let changed = false;
+    const nextContent: ContentBlock[] = msg.content.map((block) => {
+      if (block.type === "tool_result") {
+        const tr = block as ToolResultContent;
+        const toolName = toolNameById.get(tr.tool_use_id);
+        const isProtected = toolName != null && protectedToolSet.has(toolName);
+
+        const { replacement, tokensSaved, didChange, cleared } =
+          compactToolResult(tr, isProtected);
+        if (didChange) {
+          reclaimedTokens += tokensSaved;
+          if (cleared) clearedToolResults += 1;
+          changed = true;
+          return replacement;
+        }
+        return block;
+      }
+
+      if (block.type === "image") {
+        const saved = estimateImageReclaim(block);
+        // Only count a reclaim if stubbing actually shrinks the block.
+        // The stub is always valid, but avoid double-counting no-op cases.
+        reclaimedTokens += saved;
+        clearedImages += 1;
+        changed = true;
+        return { type: "text", text: CLEARED_IMAGE_TEXT };
+      }
+
+      if (block.type === "file") {
+        const saved = estimateFileReclaim(block);
+        reclaimedTokens += saved;
+        clearedImages += 1;
+        changed = true;
+        return { type: "text", text: CLEARED_FILE_TEXT };
+      }
+
+      return block;
+    });
+
+    if (!changed) return msg;
+    anyChange = true;
+    return { ...msg, content: nextContent };
+  });
+
+  if (!anyChange || reclaimedTokens < minGainTokens) {
+    return {
+      messages,
+      reclaimedTokens: 0,
+      clearedToolResults: 0,
+      clearedImages: 0,
+    };
+  }
+
+  return {
+    messages: nextMessages,
+    reclaimedTokens,
+    clearedToolResults,
+    clearedImages,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function buildToolNameLookup(messages: Message[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content) {
+      if (block.type === "tool_use") {
+        map.set(block.id, block.name);
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Return the index of the first message that is inside the "protected tail".
+ *
+ * A user-assistant exchange begins at a user message that carries real user
+ * content (i.e. not a tool_result-only follow-up, which is how the provider
+ * encodes the tool response turn). We walk newest-to-oldest and, once we've
+ * seen `protectRecentTurns` such user-turn starts, return the index of the
+ * oldest such start. Everything at or after that index is protected.
+ *
+ * If the history has fewer than `protectRecentTurns` user turns, protect the
+ * entire history by returning 0.
+ */
+function computeProtectedBoundary(
+  messages: Message[],
+  protectRecentTurns: number,
+): number {
+  if (protectRecentTurns <= 0) return messages.length;
+
+  let seen = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    if (isToolResultOnlyUserMessage(msg)) continue;
+    seen += 1;
+    if (seen >= protectRecentTurns) {
+      return i;
+    }
+  }
+  // Fewer user turns than the protection budget — protect everything.
+  return 0;
+}
+
+/**
+ * A user message that contains only tool_result blocks represents the
+ * response side of a tool call rather than a fresh user turn.
+ */
+function isToolResultOnlyUserMessage(message: Message): boolean {
+  if (message.content.length === 0) return false;
+  return message.content.every((b) => b.type === "tool_result");
+}
+
+/**
+ * Compact a single tool_result block in the stripped region.
+ *
+ *  - If `isProtected` is true, we keep the body but strip `<ax-tree>` blocks
+ *    and drop any rich `contentBlocks` (images attached to the tool result).
+ *  - Otherwise we replace the body with a short placeholder and drop
+ *    `contentBlocks` entirely.
+ *
+ * `tokensSaved` is the delta between the original and the replacement as
+ * measured by `estimateTextTokens`, floored at 0. `cleared` is true only when
+ * we fully replaced the body (i.e. counted against `clearedToolResults`).
+ */
+function compactToolResult(
+  block: ToolResultContent,
+  isProtected: boolean,
+): {
+  replacement: ToolResultContent;
+  tokensSaved: number;
+  didChange: boolean;
+  cleared: boolean;
+} {
+  const originalContent = block.content;
+  const originalContentTokens = estimateTextTokens(originalContent);
+
+  // Rich contentBlocks (e.g. tool-attached images) are always dropped in
+  // the stripped region, regardless of protection. Protected tools retain
+  // their text body; the images are not the expensive part of a subagent
+  // result and are rarely load-bearing once the turn is stale.
+  let contentBlocksTokens = 0;
+  const hadContentBlocks =
+    block.contentBlocks != null && block.contentBlocks.length > 0;
+  if (hadContentBlocks) {
+    for (const cb of block.contentBlocks!) {
+      contentBlocksTokens += estimateContentBlockTokenCost(cb);
+    }
+  }
+
+  let newContent: string;
+  let cleared: boolean;
+  if (isProtected) {
+    // Strip ax-tree blocks but keep the rest of the text body.
+    newContent = originalContent.replace(AX_TREE_PATTERN, AX_TREE_PLACEHOLDER);
+    cleared = false;
+  } else {
+    newContent = CLEARED_TOOL_RESULT_TEXT;
+    cleared = true;
+  }
+
+  const newContentTokens = estimateTextTokens(newContent);
+  const bodyTokensSaved = originalContentTokens - newContentTokens;
+
+  const bodyChanged = newContent !== originalContent;
+  const didChange = bodyChanged || hadContentBlocks;
+
+  if (!didChange) {
+    return {
+      replacement: block,
+      tokensSaved: 0,
+      didChange: false,
+      cleared: false,
+    };
+  }
+
+  const tokensSaved = Math.max(0, bodyTokensSaved + contentBlocksTokens);
+
+  const replacement: ToolResultContent = {
+    type: "tool_result",
+    tool_use_id: block.tool_use_id,
+    content: newContent,
+  };
+  if (block.is_error != null) {
+    replacement.is_error = block.is_error;
+  }
+
+  return {
+    replacement,
+    tokensSaved,
+    didChange,
+    cleared: cleared && bodyChanged,
+  };
+}
+
+function estimateImageReclaim(
+  block: Extract<ContentBlock, { type: "image" }>,
+): number {
+  // Base64 payloads are the expensive part of image blocks for our naive
+  // char/4 heuristic. The Anthropic-aware estimator in `token-estimator.ts`
+  // charges per-pixel — we deliberately use the simpler heuristic here so
+  // the reclaim number is a conservative lower bound on actual savings.
+  const payloadTokens = estimateTextTokens(block.source.data);
+  const stubTokens = estimateTextTokens(CLEARED_IMAGE_TEXT);
+  return Math.max(0, payloadTokens - stubTokens);
+}
+
+function estimateFileReclaim(
+  block: Extract<ContentBlock, { type: "file" }>,
+): number {
+  const payloadTokens =
+    estimateTextTokens(block.source.data) +
+    estimateTextTokens(block.extracted_text ?? "");
+  const stubTokens = estimateTextTokens(CLEARED_FILE_TEXT);
+  return Math.max(0, payloadTokens - stubTokens);
+}
+
+function estimateContentBlockTokenCost(block: ContentBlock): number {
+  switch (block.type) {
+    case "text":
+      return estimateTextTokens(block.text);
+    case "image":
+      return estimateTextTokens(block.source.data);
+    case "file":
+      return (
+        estimateTextTokens(block.source.data) +
+        estimateTextTokens(block.extracted_text ?? "")
+      );
+    default:
+      return 0;
+  }
+}

--- a/assistant/src/context/microcompact.ts
+++ b/assistant/src/context/microcompact.ts
@@ -66,7 +66,8 @@ export interface MicrocompactResult {
   messages: Message[];
   reclaimedTokens: number;
   clearedToolResults: number;
-  clearedImages: number;
+  /** Count of image + file blocks that were replaced with text stubs. */
+  clearedMedia: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +113,7 @@ export function microcompact(
       messages,
       reclaimedTokens: 0,
       clearedToolResults: 0,
-      clearedImages: 0,
+      clearedMedia: 0,
     };
   }
 
@@ -135,13 +136,13 @@ export function microcompact(
       messages,
       reclaimedTokens: 0,
       clearedToolResults: 0,
-      clearedImages: 0,
+      clearedMedia: 0,
     };
   }
 
   let reclaimedTokens = 0;
   let clearedToolResults = 0;
-  let clearedImages = 0;
+  let clearedMedia = 0;
   let anyChange = false;
 
   const nextMessages: Message[] = messages.map((msg, idx) => {
@@ -149,6 +150,11 @@ export function microcompact(
 
     let changed = false;
     const nextContent: ContentBlock[] = msg.content.map((block) => {
+      // guard:allow-tool-result-only — compaction here operates on locally-
+      // executed `tool_result` bodies (string `.content`, possible
+      // `.contentBlocks` media). `web_search_tool_result` has an opaque
+      // encrypted content shape and is never microcompacted; it's treated as
+      // a tool-response only in `isToolResultOnlyUserMessage` above.
       if (block.type === "tool_result") {
         const tr = block as ToolResultContent;
         const toolName = toolNameById.get(tr.tool_use_id);
@@ -170,7 +176,7 @@ export function microcompact(
         // Only count a reclaim if stubbing actually shrinks the block.
         // The stub is always valid, but avoid double-counting no-op cases.
         reclaimedTokens += saved;
-        clearedImages += 1;
+        clearedMedia += 1;
         changed = true;
         return { type: "text", text: CLEARED_IMAGE_TEXT };
       }
@@ -178,7 +184,7 @@ export function microcompact(
       if (block.type === "file") {
         const saved = estimateFileReclaim(block);
         reclaimedTokens += saved;
-        clearedImages += 1;
+        clearedMedia += 1;
         changed = true;
         return { type: "text", text: CLEARED_FILE_TEXT };
       }
@@ -196,7 +202,7 @@ export function microcompact(
       messages,
       reclaimedTokens: 0,
       clearedToolResults: 0,
-      clearedImages: 0,
+      clearedMedia: 0,
     };
   }
 
@@ -204,7 +210,7 @@ export function microcompact(
     messages: nextMessages,
     reclaimedTokens,
     clearedToolResults,
-    clearedImages,
+    clearedMedia,
   };
 }
 
@@ -258,19 +264,44 @@ function computeProtectedBoundary(
 }
 
 /**
- * A user message that contains only tool_result blocks represents the
- * response side of a tool call rather than a fresh user turn.
+ * A user message that contains only tool-response blocks (or system-injected
+ * metadata) represents the response side of a tool call rather than a fresh
+ * user turn.
+ *
+ * Qualifying blocks:
+ *  - `tool_result` — locally-executed tool responses.
+ *  - `web_search_tool_result` — server-side web-search responses. Same
+ *    semantic as `tool_result` (paired with a prior `server_tool_use`), just
+ *    a distinct discriminant. Missing this variant would cause these
+ *    messages to masquerade as real user turns and eat `protectRecentTurns`
+ *    budget on tool churn.
+ *  - `text` blocks whose body is wholly inside `<system_notice>...</system_notice>`.
+ *    Those are system-injected reminders/progress checks, not user-authored.
  */
 function isToolResultOnlyUserMessage(message: Message): boolean {
   if (message.content.length === 0) return false;
-  return message.content.every((b) => b.type === "tool_result");
+  return message.content.every(isToolResponseOrSystemNoticeBlock);
+}
+
+function isToolResponseOrSystemNoticeBlock(block: ContentBlock): boolean {
+  if (block.type === "tool_result" || block.type === "web_search_tool_result") {
+    return true;
+  }
+  if (block.type === "text") {
+    const text = block.text;
+    return (
+      text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
+    );
+  }
+  return false;
 }
 
 /**
  * Compact a single tool_result block in the stripped region.
  *
  *  - If `isProtected` is true, we keep the body but strip `<ax-tree>` blocks
- *    and drop any rich `contentBlocks` (images attached to the tool result).
+ *    and drop media (image/file) entries from `contentBlocks`, preserving
+ *    any text entries so meaningful tool output isn't silently removed.
  *  - Otherwise we replace the body with a short placeholder and drop
  *    `contentBlocks` entirely.
  *
@@ -290,16 +321,34 @@ function compactToolResult(
   const originalContent = block.content;
   const originalContentTokens = estimateTextTokens(originalContent);
 
-  // Rich contentBlocks (e.g. tool-attached images) are always dropped in
-  // the stripped region, regardless of protection. Protected tools retain
-  // their text body; the images are not the expensive part of a subagent
-  // result and are rarely load-bearing once the turn is stale.
-  let contentBlocksTokens = 0;
+  // Rich contentBlocks may include text (meaningful tool output) alongside
+  // media (images/files). For UNPROTECTED results we drop the entire array
+  // (the body is being wholesale-replaced). For PROTECTED results we keep
+  // text entries but strip media — images aren't the expensive part of a
+  // subagent result and are rarely load-bearing once the turn is stale, but
+  // text entries can carry real content we must not silently erase.
+  const originalContentBlocks = block.contentBlocks;
   const hadContentBlocks =
-    block.contentBlocks != null && block.contentBlocks.length > 0;
+    originalContentBlocks != null && originalContentBlocks.length > 0;
+
+  let preservedContentBlocks: ContentBlock[] | undefined;
+  let droppedBlocksTokens = 0;
   if (hadContentBlocks) {
-    for (const cb of block.contentBlocks!) {
-      contentBlocksTokens += estimateContentBlockTokenCost(cb);
+    if (isProtected) {
+      const kept: ContentBlock[] = [];
+      for (const cb of originalContentBlocks) {
+        if (cb.type === "text") {
+          kept.push(cb);
+        } else {
+          droppedBlocksTokens += estimateContentBlockTokenCost(cb);
+        }
+      }
+      preservedContentBlocks = kept;
+    } else {
+      for (const cb of originalContentBlocks) {
+        droppedBlocksTokens += estimateContentBlockTokenCost(cb);
+      }
+      preservedContentBlocks = undefined;
     }
   }
 
@@ -318,7 +367,11 @@ function compactToolResult(
   const bodyTokensSaved = originalContentTokens - newContentTokens;
 
   const bodyChanged = newContent !== originalContent;
-  const didChange = bodyChanged || hadContentBlocks;
+  // A protected result with only text contentBlocks would be a no-op — nothing
+  // meaningful would be dropped. Only count contentBlocks as a "change" when
+  // we actually drop at least one entry.
+  const contentBlocksChanged = hadContentBlocks && droppedBlocksTokens > 0;
+  const didChange = bodyChanged || contentBlocksChanged;
 
   if (!didChange) {
     return {
@@ -329,7 +382,7 @@ function compactToolResult(
     };
   }
 
-  const tokensSaved = Math.max(0, bodyTokensSaved + contentBlocksTokens);
+  const tokensSaved = Math.max(0, bodyTokensSaved + droppedBlocksTokens);
 
   const replacement: ToolResultContent = {
     type: "tool_result",
@@ -338,6 +391,9 @@ function compactToolResult(
   };
   if (block.is_error != null) {
     replacement.is_error = block.is_error;
+  }
+  if (preservedContentBlocks != null && preservedContentBlocks.length > 0) {
+    replacement.contentBlocks = preservedContentBlocks;
   }
 
   return {


### PR DESCRIPTION
## Summary
- New assistant/src/context/microcompact.ts with pure microcompact() function
- Clears stale tool_result bodies (beyond protectRecentTurns) and image/file blocks
- Strips ax-tree blocks; respects protectedTools allowlist; idempotent
- Module is unused until PR 9 wires it into the preflight path

Part of plan: compaction-simplification.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
