### PR TITLE
feat: add `assistant browser` command namespace with 17 browser subcommands

### DIFF
--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -227,12 +227,26 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Loads the given URL and waits for the page to reach a stable state.
+Returns the page title on success.
+
+Examples:
+  $ assistant browser navigate --url https://example.com
+  $ assistant browser navigate --url http://localhost:3000 --allow-private-network
+  $ assistant browser --session s1 navigate --url https://github.com`,
   },
   {
     operation: "snapshot",
     description:
       "List interactive elements on the current page with unique IDs.",
     fields: [],
+    helpText: `Returns a structured list of interactive elements (buttons, links,
+inputs, etc.) with stable element IDs that can be passed to click,
+type, and other element-targeting commands.
+
+Examples:
+  $ assistant browser snapshot
+  $ assistant browser --json snapshot`,
   },
   {
     operation: "screenshot",
@@ -246,6 +260,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Captures a JPEG screenshot. Use --output to save to a file, or
+--json to receive base64-encoded image data in the output.
+
+Examples:
+  $ assistant browser screenshot --output page.jpg
+  $ assistant browser screenshot --full-page --output full.jpg
+  $ assistant browser --json screenshot`,
   },
   {
     operation: "close",
@@ -258,16 +279,35 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Closes the browser page for the current session. Use --close-all-pages
+to tear down the entire browser context including all pages.
+
+Examples:
+  $ assistant browser close
+  $ assistant browser close --close-all-pages
+  $ assistant browser --session s1 close`,
   },
   {
     operation: "attach",
     description: "Attach the Chrome debugger to the active browser tab.",
     fields: [],
+    helpText: `Connects the assistant to a running Chrome instance via the Chrome
+DevTools Protocol. Required before interacting with Chrome-attached tabs.
+
+Examples:
+  $ assistant browser attach
+  $ assistant browser --session s1 attach`,
   },
   {
     operation: "detach",
     description: "Detach the Chrome debugger from the active browser tab.",
     fields: [],
+    helpText: `Disconnects the assistant from the Chrome DevTools Protocol session.
+The browser tab continues running but is no longer controlled.
+
+Examples:
+  $ assistant browser detach
+  $ assistant browser --session s1 detach`,
   },
   {
     operation: "click",
@@ -286,6 +326,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Clicks an element identified by element ID (from snapshot) or CSS
+selector. Provide at least one of --element-id or --selector.
+
+Examples:
+  $ assistant browser click --element-id e14
+  $ assistant browser click --selector "#login-button"
+  $ assistant browser click --selector "a.nav-link"`,
   },
   {
     operation: "type",
@@ -322,6 +369,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Types text into the focused or targeted element. By default, existing
+content is cleared first (--clear-first). Use --no-clear-first to
+append to existing content. Use --press-enter to submit after typing.
+
+Examples:
+  $ assistant browser type --text "hello world" --element-id e14
+  $ assistant browser type --text "search query" --selector "#search" --press-enter
+  $ assistant browser type --text "append this" --no-clear-first`,
   },
   {
     operation: "press_key",
@@ -347,6 +402,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Sends a keyboard key press. If --element-id or --selector is given,
+the key is dispatched to that element; otherwise to the focused element.
+
+Examples:
+  $ assistant browser press-key --key Enter
+  $ assistant browser press-key --key Tab --element-id e5
+  $ assistant browser press-key --key Escape`,
   },
   {
     operation: "scroll",
@@ -378,6 +440,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Scrolls the page or a specific scrollable element. Direction is
+required; amount defaults to 500 pixels.
+
+Examples:
+  $ assistant browser scroll --direction down
+  $ assistant browser scroll --direction up --amount 1000
+  $ assistant browser scroll --direction down --element-id e8`,
   },
   {
     operation: "select_option",
@@ -414,6 +483,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Selects an option in a <select> element by value, label, or index.
+Provide at least one of --value, --label, or --index to identify
+the option, and --element-id or --selector to identify the <select>.
+
+Examples:
+  $ assistant browser select-option --element-id e12 --label "United States"
+  $ assistant browser select-option --selector "#country" --value "us"
+  $ assistant browser select-option --element-id e12 --index 3`,
   },
   {
     operation: "hover",
@@ -432,6 +509,12 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Moves the mouse cursor over an element to trigger hover effects
+(tooltips, dropdowns, etc.). Provide --element-id or --selector.
+
+Examples:
+  $ assistant browser hover --element-id e7
+  $ assistant browser hover --selector ".dropdown-trigger"`,
   },
   {
     operation: "wait_for",
@@ -464,6 +547,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Blocks until a condition is met: an element appears (--selector),
+text appears (--text), or a fixed duration elapses (--duration).
+Provide exactly one condition. --timeout caps the overall wait.
+
+Examples:
+  $ assistant browser wait-for --selector ".results-loaded"
+  $ assistant browser wait-for --text "Success"
+  $ assistant browser wait-for --duration 2000`,
   },
   {
     operation: "extract",
@@ -476,6 +567,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Extracts the visible text content of the current page. Optionally
+includes a list of all links found on the page.
+
+Examples:
+  $ assistant browser extract
+  $ assistant browser extract --include-links
+  $ assistant browser --json extract`,
   },
   {
     operation: "wait_for_download",
@@ -490,6 +588,12 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Waits for an in-progress file download to complete and returns the
+filename and path. Only supported in "auto" and "local" browser modes.
+
+Examples:
+  $ assistant browser wait-for-download
+  $ assistant browser wait-for-download --timeout 60000`,
   },
   {
     operation: "fill_credential",
@@ -527,6 +631,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Fills a credential from the assistant's credential vault into a form
+field. The credential value is never exposed in CLI output. Use
+'assistant credentials list' to see available service:field pairs.
+
+Examples:
+  $ assistant browser fill-credential --service github --field token --element-id e9
+  $ assistant browser fill-credential --service github --field password --selector "#password" --press-enter`,
   },
   {
     operation: "status",
@@ -540,6 +651,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Reports the readiness of available browser backends (local Playwright,
+Chrome extension). Includes remediation steps if a backend is not ready.
+Use --check-local-launch for an active Playwright launch probe (slower).
+
+Examples:
+  $ assistant browser status
+  $ assistant browser status --check-local-launch
+  $ assistant browser --json status`,
   },
 ];
 

--- a/assistant/src/browser/types.ts
+++ b/assistant/src/browser/types.ts
@@ -72,4 +72,10 @@ export interface BrowserOperationMeta {
    * `["auto", "local"]`.
    */
   allowedModes?: readonly string[];
+  /**
+   * Extended help text appended after the auto-generated options list.
+   * Should include behavioral notes and 2-3 concrete examples per
+   * CLI AGENTS.md Help Text Standards.
+   */
+  helpText?: string;
 }

--- a/assistant/src/cli/commands/__tests__/browser.test.ts
+++ b/assistant/src/cli/commands/__tests__/browser.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Tests for the `assistant browser` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration count and names
+ *   - Required-argument enforcement (navigate, type, press-key, scroll, fill-credential)
+ *   - Correct IPC payload mapping (kebab-case CLI -> snake_case input)
+ *   - --json and error exit-code behavior
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import { BROWSER_OPERATION_META } from "../../../browser/operations.js";
+import { BROWSER_OPERATIONS } from "../../../browser/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { content: "ok", isError: false } };
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerBrowserCommand } = await import("../browser.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerBrowserCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: { content: "ok", isError: false },
+  };
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers exactly 17 subcommands", () => {
+    const program = new Command();
+    registerBrowserCommand(program);
+    const browser = program.commands.find((c) => c.name() === "browser");
+    expect(browser).toBeDefined();
+    const subcommands = browser!.commands;
+    expect(subcommands).toHaveLength(17);
+  });
+
+  test("subcommand names match kebab-cased BROWSER_OPERATIONS", () => {
+    const program = new Command();
+    registerBrowserCommand(program);
+    const browser = program.commands.find((c) => c.name() === "browser");
+    const subcommandNames = browser!.commands.map((c) => c.name()).sort();
+    const expectedNames = BROWSER_OPERATIONS.map((op) =>
+      op.replace(/_/g, "-"),
+    ).sort();
+    expect(subcommandNames).toEqual(expectedNames);
+  });
+
+  test("all 17 operations from BROWSER_OPERATIONS are covered", () => {
+    expect(BROWSER_OPERATIONS).toHaveLength(17);
+    expect(BROWSER_OPERATION_META).toHaveLength(17);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Required-argument enforcement
+// ---------------------------------------------------------------------------
+
+describe("required-argument enforcement", () => {
+  test("navigate requires --url", async () => {
+    const { exitCode } = await runCommand(["browser", "navigate"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("type requires --text", async () => {
+    const { exitCode } = await runCommand(["browser", "type"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("press-key requires --key", async () => {
+    const { exitCode } = await runCommand(["browser", "press-key"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("scroll requires --direction", async () => {
+    const { exitCode } = await runCommand(["browser", "scroll"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("fill-credential requires --service and --field", async () => {
+    // Missing both
+    const { exitCode: e1 } = await runCommand(["browser", "fill-credential"]);
+    expect(e1).not.toBe(0);
+
+    // Missing --field
+    const { exitCode: e2 } = await runCommand([
+      "browser",
+      "fill-credential",
+      "--service",
+      "github",
+    ]);
+    expect(e2).not.toBe(0);
+
+    // Missing --service
+    const { exitCode: e3 } = await runCommand([
+      "browser",
+      "fill-credential",
+      "--field",
+      "token",
+    ]);
+    expect(e3).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IPC payload mapping
+// ---------------------------------------------------------------------------
+
+describe("IPC payload mapping", () => {
+  test("navigate sends correct operation and input", async () => {
+    await runCommand(["browser", "navigate", "--url", "https://example.com"]);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("browser_execute");
+    expect(lastIpcCall!.params!.operation).toBe("navigate");
+    expect(lastIpcCall!.params!.input).toEqual({
+      url: "https://example.com",
+    });
+    expect(lastIpcCall!.params!.sessionId).toBe("default");
+  });
+
+  test("navigate with --allow-private-network maps to allow_private_network", async () => {
+    await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "http://localhost:3000",
+      "--allow-private-network",
+    ]);
+    expect(lastIpcCall!.params!.input).toEqual({
+      url: "http://localhost:3000",
+      allow_private_network: true,
+    });
+  });
+
+  test("type maps --text, --element-id, --clear-first", async () => {
+    await runCommand([
+      "browser",
+      "type",
+      "--text",
+      "hello world",
+      "--element-id",
+      "e14",
+      "--clear-first",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("type");
+    expect(lastIpcCall!.params!.input).toEqual({
+      text: "hello world",
+      element_id: "e14",
+      clear_first: true,
+    });
+  });
+
+  test("scroll maps --direction and --amount (number coercion)", async () => {
+    await runCommand([
+      "browser",
+      "scroll",
+      "--direction",
+      "down",
+      "--amount",
+      "300",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("scroll");
+    const input = lastIpcCall!.params!.input as Record<string, unknown>;
+    expect(input.direction).toBe("down");
+    expect(input.amount).toBe(300);
+    expect(typeof input.amount).toBe("number");
+  });
+
+  test("press-key maps --key", async () => {
+    await runCommand(["browser", "press-key", "--key", "Enter"]);
+    expect(lastIpcCall!.params!.operation).toBe("press_key");
+    expect(lastIpcCall!.params!.input).toEqual({ key: "Enter" });
+  });
+
+  test("fill-credential maps --service, --field, --press-enter", async () => {
+    await runCommand([
+      "browser",
+      "fill-credential",
+      "--service",
+      "github",
+      "--field",
+      "token",
+      "--press-enter",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("fill_credential");
+    expect(lastIpcCall!.params!.input).toEqual({
+      service: "github",
+      field: "token",
+      press_enter: true,
+    });
+  });
+
+  test("select-option maps to select_option operation", async () => {
+    await runCommand([
+      "browser",
+      "select-option",
+      "--value",
+      "us",
+      "--selector",
+      "#country",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("select_option");
+    expect(lastIpcCall!.params!.input).toEqual({
+      value: "us",
+      selector: "#country",
+    });
+  });
+
+  test("wait-for maps to wait_for operation", async () => {
+    await runCommand([
+      "browser",
+      "wait-for",
+      "--selector",
+      ".loaded",
+      "--timeout",
+      "5000",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("wait_for");
+    const input = lastIpcCall!.params!.input as Record<string, unknown>;
+    expect(input.selector).toBe(".loaded");
+    expect(input.timeout).toBe(5000);
+  });
+
+  test("wait-for-download maps to wait_for_download operation", async () => {
+    await runCommand(["browser", "wait-for-download"]);
+    expect(lastIpcCall!.params!.operation).toBe("wait_for_download");
+  });
+
+  test("snapshot sends empty input", async () => {
+    await runCommand(["browser", "snapshot"]);
+    expect(lastIpcCall!.params!.operation).toBe("snapshot");
+    expect(lastIpcCall!.params!.input).toEqual({});
+  });
+
+  test("screenshot sends empty input by default", async () => {
+    await runCommand(["browser", "screenshot"]);
+    expect(lastIpcCall!.params!.operation).toBe("screenshot");
+    expect(lastIpcCall!.params!.input).toEqual({});
+  });
+
+  test("status maps --check-local-launch", async () => {
+    await runCommand(["browser", "status", "--check-local-launch"]);
+    expect(lastIpcCall!.params!.operation).toBe("status");
+    expect(lastIpcCall!.params!.input).toEqual({
+      check_local_launch: true,
+    });
+  });
+
+  test("--session flag is passed through as sessionId", async () => {
+    await runCommand([
+      "browser",
+      "--session",
+      "myflow",
+      "navigate",
+      "--url",
+      "https://example.com",
+    ]);
+    expect(lastIpcCall!.params!.sessionId).toBe("myflow");
+  });
+
+  test("default session is 'default'", async () => {
+    await runCommand(["browser", "snapshot"]);
+    expect(lastIpcCall!.params!.sessionId).toBe("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --json and error exit-code behavior
+// ---------------------------------------------------------------------------
+
+describe("--json output", () => {
+  test("--json outputs JSON with ok:true on success", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { content: "Page title: Example", isError: false },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "snapshot",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.content).toBe("Page title: Example");
+  });
+
+  test("--json includes screenshots when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Screenshot taken",
+        isError: false,
+        screenshots: [{ mediaType: "image/jpeg", data: "abc123base64" }],
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "screenshot",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.screenshots).toHaveLength(1);
+    expect(parsed.screenshots[0].mediaType).toBe("image/jpeg");
+    expect(parsed.screenshots[0].data).toBe("abc123base64");
+  });
+
+  test("--json outputs ok:false when IPC connection fails", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "Could not connect to assistant daemon. Is it running?",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "snapshot",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Could not connect");
+  });
+
+  test("--json outputs ok:false when operation returns isError:true", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Error: Element not found",
+        isError: true,
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "click",
+      "--selector",
+      "#missing",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Error: Element not found");
+  });
+});
+
+describe("error exit codes", () => {
+  test("exits with non-zero code when IPC fails", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "Connection refused",
+    };
+
+    const { exitCode } = await runCommand(["browser", "snapshot"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with non-zero code when operation returns error", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Error: Navigation failed",
+        isError: true,
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "https://broken.test",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with zero code on successful operation", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { content: "Done", isError: false },
+    };
+
+    const { exitCode } = await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "https://example.com",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -32,11 +32,14 @@ function toKebab(snakeCase: string): string {
 /**
  * Convert a snake_case field name to a kebab-case CLI option flag
  * (e.g. `allow_private_network` -> `--allow-private-network`).
+ *
+ * Boolean fields use Commander's negation pattern (`--flag / --no-flag`)
+ * so callers can explicitly send both `true` and `false` values.
  */
 function fieldToFlag(field: OperationField): string {
   const kebab = toKebab(field.name);
   if (field.type === "boolean") {
-    return `--${kebab}`;
+    return `--${kebab}, --no-${kebab}`;
   }
   return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
 }
@@ -59,7 +62,7 @@ function parseFieldValue(
   value: unknown,
   field: OperationField,
 ): string | number | boolean {
-  if (field.type === "boolean") return true;
+  if (field.type === "boolean") return Boolean(value);
   if (field.type === "number") {
     const num = Number(value);
     if (!Number.isFinite(num)) {
@@ -96,6 +99,11 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
     } else {
       subcmd.option(flag, field.description);
     }
+  }
+
+  // Append per-operation help text with behavioral notes and examples
+  if (meta.helpText) {
+    subcmd.addHelpText("after", `\n${meta.helpText}`);
   }
 
   // screenshot gets an --output <path> option for writing JPEG to disk
@@ -177,7 +185,23 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
     ) {
       const screenshot = result.screenshots[0];
       const buffer = Buffer.from(screenshot.data, "base64");
-      writeFileSync(String(opts.output), buffer);
+      try {
+        writeFileSync(String(opts.output), buffer);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (jsonMode) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: false,
+              error: `Failed to write screenshot to ${opts.output}: ${msg}`,
+            }) + "\n",
+          );
+        } else {
+          log.error(`Failed to write screenshot to ${opts.output}: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
       if (!jsonMode) {
         log.info(`Screenshot saved to ${opts.output}`);
       }
@@ -206,7 +230,7 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
 export function registerBrowserCommand(program: Command): void {
   const browser = program
     .command("browser")
-    .description("Control the browser via the assistant daemon.")
+    .description("Control the browser via the running assistant.")
     .option(
       "--session <id>",
       "Session ID to preserve browser state across invocations.",
@@ -217,9 +241,9 @@ export function registerBrowserCommand(program: Command): void {
   browser.addHelpText(
     "after",
     `
-Browser operations are executed through the running assistant daemon.
-Each subcommand maps to a browser operation and communicates via
-the CLI IPC socket.
+Browser operations are executed through the running assistant.
+Each subcommand maps to a browser operation and communicates
+with the assistant process.
 
 The --session flag groups sequential commands so they share browser
 state (same page, cookies, etc.). Different session IDs create

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -9,7 +9,7 @@
 
 import { writeFileSync } from "node:fs";
 
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 
 import { BROWSER_OPERATION_META } from "../../browser/operations.js";
 import type {
@@ -33,13 +33,15 @@ function toKebab(snakeCase: string): string {
  * Convert a snake_case field name to a kebab-case CLI option flag
  * (e.g. `allow_private_network` -> `--allow-private-network`).
  *
- * Boolean fields use Commander's negation pattern (`--flag / --no-flag`)
- * so callers can explicitly send both `true` and `false` values.
+ * Boolean fields declare only `--flag`; Commander 13 auto-generates
+ * the `--no-flag` negation variant. Declaring both in a single spec
+ * string (e.g. `--flag, --no-flag`) breaks in Commander 13 because
+ * `--flag` still parses to `false`.
  */
 function fieldToFlag(field: OperationField): string {
   const kebab = toKebab(field.name);
   if (field.type === "boolean") {
-    return `--${kebab}, --no-${kebab}`;
+    return `--${kebab}`;
   }
   return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
 }
@@ -94,7 +96,17 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
   // Add per-operation field options
   for (const field of meta.fields) {
     const flag = fieldToFlag(field);
-    if (field.required) {
+
+    if (field.enum) {
+      // Use Commander's Option class with .choices() for enum-constrained
+      // fields so invalid values are rejected at the CLI level and
+      // --help lists the allowed values.
+      const opt = new Option(flag, field.description).choices([...field.enum]);
+      if (field.required) {
+        opt.makeOptionMandatory(true);
+      }
+      subcmd.addOption(opt);
+    } else if (field.required) {
       subcmd.requiredOption(flag, field.description);
     } else {
       subcmd.option(flag, field.description);

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -1,0 +1,242 @@
+/**
+ * `assistant browser` CLI namespace.
+ *
+ * One subcommand per browser operation, driven from the shared
+ * browser operations contract ({@link BROWSER_OPERATION_META}).
+ * Each subcommand maps CLI kebab-case flags into snake_case input
+ * keys and calls `browser_execute` over the CLI IPC socket.
+ */
+
+import { writeFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { BROWSER_OPERATION_META } from "../../browser/operations.js";
+import type {
+  BrowserOperationMeta,
+  OperationField,
+} from "../../browser/types.js";
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+// ── Naming helpers ───────────────────────────────────────────────────
+
+/**
+ * Convert a snake_case operation name to kebab-case for CLI subcommand
+ * names (e.g. `press_key` -> `press-key`).
+ */
+function toKebab(snakeCase: string): string {
+  return snakeCase.replace(/_/g, "-");
+}
+
+/**
+ * Convert a snake_case field name to a kebab-case CLI option flag
+ * (e.g. `allow_private_network` -> `--allow-private-network`).
+ */
+function fieldToFlag(field: OperationField): string {
+  const kebab = toKebab(field.name);
+  if (field.type === "boolean") {
+    return `--${kebab}`;
+  }
+  return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
+}
+
+/**
+ * Convert a kebab-case option key back to snake_case for the IPC
+ * input object (e.g. `allowPrivateNetwork` -> `allow_private_network`).
+ *
+ * Commander camelCases option names, so we convert from camelCase
+ * to snake_case.
+ */
+function camelToSnake(camel: string): string {
+  return camel.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
+}
+
+/**
+ * Parse a CLI option value according to its field type.
+ */
+function parseFieldValue(
+  value: unknown,
+  field: OperationField,
+): string | number | boolean {
+  if (field.type === "boolean") return true;
+  if (field.type === "number") {
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+      throw new Error(`Invalid number for --${toKebab(field.name)}: ${value}`);
+    }
+    return num;
+  }
+  return String(value);
+}
+
+// ── IPC response shape ───────────────────────────────────────────────
+
+interface BrowserExecuteResult {
+  content: string;
+  isError: boolean;
+  screenshots?: Array<{ mediaType: string; data: string }>;
+}
+
+// ── Subcommand builder ───────────────────────────────────────────────
+
+/**
+ * Build a Commander subcommand for a single browser operation.
+ */
+function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
+  const subcmd = parent
+    .command(toKebab(meta.operation))
+    .description(meta.description);
+
+  // Add per-operation field options
+  for (const field of meta.fields) {
+    const flag = fieldToFlag(field);
+    if (field.required) {
+      subcmd.requiredOption(flag, field.description);
+    } else {
+      subcmd.option(flag, field.description);
+    }
+  }
+
+  // screenshot gets an --output <path> option for writing JPEG to disk
+  if (meta.operation === "screenshot") {
+    subcmd.option(
+      "--output <path>",
+      "Write the screenshot JPEG to a file path on disk.",
+    );
+  }
+
+  subcmd.action(async (opts: Record<string, unknown>) => {
+    const parentOpts = parent.opts() as {
+      session?: string;
+      json?: boolean;
+    };
+    const sessionId = parentOpts.session ?? "default";
+    const jsonMode = parentOpts.json ?? false;
+
+    // Map Commander camelCase options back to snake_case input keys,
+    // filtering out parent-level options (session, json) and screenshot
+    // ergonomics (output).
+    const input: Record<string, unknown> = {};
+    const excludeKeys = new Set(["session", "json", "output"]);
+
+    for (const [key, value] of Object.entries(opts)) {
+      if (excludeKeys.has(key)) continue;
+      if (value === undefined) continue;
+
+      const snakeKey = camelToSnake(key);
+      // Find the matching field for type coercion
+      const field = meta.fields.find((f) => f.name === snakeKey);
+      if (field) {
+        input[snakeKey] = parseFieldValue(value, field);
+      } else {
+        input[snakeKey] = value;
+      }
+    }
+
+    const ipcResult = await cliIpcCall<BrowserExecuteResult>(
+      "browser_execute",
+      {
+        operation: meta.operation,
+        input,
+        sessionId,
+      },
+    );
+
+    if (!ipcResult.ok) {
+      if (jsonMode) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+        );
+      } else {
+        log.error(`Error: ${ipcResult.error}`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = ipcResult.result!;
+
+    if (result.isError) {
+      if (jsonMode) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: result.content }) + "\n",
+        );
+      } else {
+        log.error(result.content);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    // Handle screenshot --output: write JPEG to disk
+    if (
+      meta.operation === "screenshot" &&
+      opts.output &&
+      result.screenshots?.length
+    ) {
+      const screenshot = result.screenshots[0];
+      const buffer = Buffer.from(screenshot.data, "base64");
+      writeFileSync(String(opts.output), buffer);
+      if (!jsonMode) {
+        log.info(`Screenshot saved to ${opts.output}`);
+      }
+    }
+
+    if (jsonMode) {
+      const payload: Record<string, unknown> = {
+        ok: true,
+        content: result.content,
+      };
+      // Include base64 screenshot data in JSON output
+      if (result.screenshots?.length) {
+        payload.screenshots = result.screenshots;
+      }
+      process.stdout.write(JSON.stringify(payload) + "\n");
+    } else {
+      if (result.content) {
+        log.info(result.content);
+      }
+    }
+  });
+}
+
+// ── Registration ─────────────────────────────────────────────────────
+
+export function registerBrowserCommand(program: Command): void {
+  const browser = program
+    .command("browser")
+    .description("Control the browser via the assistant daemon.")
+    .option(
+      "--session <id>",
+      "Session ID to preserve browser state across invocations.",
+      "default",
+    )
+    .option("--json", "Output results as machine-readable JSON.");
+
+  browser.addHelpText(
+    "after",
+    `
+Browser operations are executed through the running assistant daemon.
+Each subcommand maps to a browser operation and communicates via
+the CLI IPC socket.
+
+The --session flag groups sequential commands so they share browser
+state (same page, cookies, etc.). Different session IDs create
+independent browser contexts.
+
+Examples:
+  $ assistant browser navigate --url https://example.com
+  $ assistant browser snapshot
+  $ assistant browser click --selector "#login"
+  $ assistant browser type --text "hello" --element-id e14
+  $ assistant browser screenshot --output page.jpg
+  $ assistant browser --session myflow navigate --url https://example.com
+  $ assistant browser --json screenshot`,
+  );
+
+  // Register one subcommand per browser operation
+  for (const meta of BROWSER_OPERATION_META) {
+    buildSubcommand(browser, meta);
+  }
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -14,6 +14,7 @@ import { registerAutonomyCommand } from "./commands/autonomy.js";
 import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBackupCommand } from "./commands/backup.js";
 import { registerBashCommand } from "./commands/bash.js";
+import { registerBrowserCommand } from "./commands/browser.js";
 import { registerChannelVerificationSessionsCommand } from "./commands/channel-verification-sessions.js";
 import { registerCompletionsCommand } from "./commands/completions.js";
 import { registerConfigCommand } from "./commands/config.js";
@@ -64,6 +65,7 @@ Examples:
   registerDefaultAction(program);
   registerBackupCommand(program);
   registerBashCommand(program);
+  registerBrowserCommand(program);
   registerConversationsCommand(program);
   registerConfigCommand(program);
   registerKeysCommand(program);


### PR DESCRIPTION
## Summary
- Create assistant/src/cli/commands/browser.ts with top-level browser command and 17 subcommands
- Add --session and --json shared flags, screenshot --output path support
- Map CLI kebab-case options to snake_case operation input keys via cliIpcCall browser_execute
- Register in program.ts

Part of plan: assistant-browser-cli-decoupling.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
