### PR TITLE
Update trust CLI presentation for family-aware rules and finalize regression coverage

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2,6 +2,7 @@
 // bun test src/__tests__/checker.test.ts src/__tests__/trust-store.test.ts src/__tests__/conversation-skill-tools.test.ts src/__tests__/skill-script-runner-host.test.ts
 
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   realpathSync,
@@ -2418,6 +2419,120 @@ describe("Permission Checker", () => {
       );
       expect(match).not.toBeNull();
       expect(match!.decision).toBe("allow");
+    });
+  });
+
+  // ── Family-aware rule shape regression ─────────────────────────
+  //
+  // Validates that trust rules conform to canonical family-aware shapes
+  // after disk round-trips. The canonical parser in ces-contracts strips
+  // fields that are invalid for a rule's tool family.
+
+  describe("family-aware rule shape regression", () => {
+    test("scoped tool (bash) preserves executionTarget and allowHighRisk through disk round-trip", () => {
+      const rule = addRule("bash", "kill *", "everywhere", "allow", 100, {
+        allowHighRisk: true,
+        executionTarget: "/usr/local/bin/node",
+      });
+      expect(rule.allowHighRisk).toBe(true);
+      expect(rule.executionTarget).toBe("/usr/local/bin/node");
+
+      // Force a disk round-trip by clearing the cache and re-reading
+      clearCache();
+      const reloaded = findHighestPriorityRule(
+        "bash",
+        ["kill -9 1234"],
+        "/tmp",
+        { executionTarget: "/usr/local/bin/node" },
+      );
+      expect(reloaded).not.toBeNull();
+      // Scoped tools retain both fields after canonical normalization
+      expect(reloaded!.allowHighRisk).toBe(true);
+      expect(reloaded!.executionTarget).toBe("/usr/local/bin/node");
+    });
+
+    test("URL tool (web_fetch) has allowHighRisk stripped after disk round-trip", () => {
+      // addRule stores allowHighRisk in-memory even for URL tools,
+      // but the canonical parser strips it when loading from disk.
+      const rule = addRule(
+        "web_fetch",
+        "web_fetch:http://localhost:3000/*",
+        "/tmp",
+        "allow",
+        100,
+        { allowHighRisk: true },
+      );
+      // In-memory rule still has allowHighRisk (not yet parsed)
+      expect(rule.allowHighRisk).toBe(true);
+
+      // Force a disk round-trip
+      clearCache();
+      const reloaded = findHighestPriorityRule(
+        "web_fetch",
+        ["web_fetch:http://localhost:3000/health"],
+        "/tmp",
+      );
+      expect(reloaded).not.toBeNull();
+      // URL tools lose allowHighRisk after canonical normalization
+      expect(reloaded!.allowHighRisk).toBeUndefined();
+    });
+
+    test("generic tool (skill_test_tool) preserves optional fields through round-trip", () => {
+      const rule = addRule(
+        "skill_test_tool",
+        "skill_test_tool:*",
+        "/tmp",
+        "allow",
+        2000,
+        { allowHighRisk: true },
+      );
+      expect(rule.allowHighRisk).toBe(true);
+
+      clearCache();
+      const reloaded = findHighestPriorityRule(
+        "skill_test_tool",
+        ["skill_test_tool:test"],
+        "/tmp",
+      );
+      expect(reloaded).not.toBeNull();
+      // Generic tools preserve allowHighRisk for forward compatibility
+      expect(reloaded!.allowHighRisk).toBe(true);
+    });
+
+    test("rule without scope defaults to 'everywhere' after parsing", () => {
+      // Write a rule directly with no scope field to simulate legacy data
+      const trustPath = join(checkerTestDir, "protected", "trust.json");
+      const trustDir = join(checkerTestDir, "protected");
+      if (!existsSync(trustDir)) mkdirSync(trustDir, { recursive: true });
+      writeFileSync(
+        trustPath,
+        JSON.stringify({
+          version: 3,
+          rules: [
+            {
+              id: "test-no-scope",
+              tool: "bash",
+              pattern: "echo *",
+              decision: "allow",
+              priority: 100,
+              createdAt: Date.now(),
+              // No scope field — should default to "everywhere"
+            },
+          ],
+        }),
+      );
+      clearCache();
+
+      const reloaded = findHighestPriorityRule(
+        "bash",
+        ["echo hello"],
+        "/any/path",
+      );
+      // The rule matches from any scope because missing scope
+      // is normalized to "everywhere" by the canonical parser.
+      expect(reloaded).not.toBeNull();
+      expect(reloaded!.id).toBe("test-no-scope");
+      expect(reloaded!.scope).toBe("everywhere");
     });
   });
 

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -306,6 +306,97 @@ describe("ephemeral-permissions", () => {
     });
   });
 
+  // ── Canonical shape and scope fallback semantics ──────────────────
+  //
+  // Validates that ephemeral rules follow canonical persisted shapes
+  // and that optional scope behaves correctly as a fallback.
+
+  describe("canonical shape and scope fallback semantics", () => {
+    beforeEach(() => {
+      clearCache();
+    });
+
+    test("ephemeral rule with scope 'everywhere' matches from any working directory", () => {
+      // Use a tool (host_file_read) that has no default allow rule and a
+      // high priority so the ephemeral rule wins over the default ask rule.
+      const ephemeralRules: TrustRule[] = [
+        {
+          id: "ephemeral:run-scope:host_file_read",
+          tool: "host_file_read",
+          pattern: "**",
+          scope: "everywhere",
+          decision: "allow",
+          priority: 2000,
+          createdAt: Date.now(),
+        },
+      ];
+
+      const ctx: PolicyContext = { ephemeralRules };
+
+      // Should match from /tmp
+      const r1 = findHighestPriorityRule(
+        "host_file_read",
+        ["host_file_read:/tmp/foo.txt"],
+        "/tmp",
+        ctx,
+      );
+      expect(r1).not.toBeNull();
+      expect(r1!.id).toBe("ephemeral:run-scope:host_file_read");
+
+      // Should match from /home/user/project
+      const r2 = findHighestPriorityRule(
+        "host_file_read",
+        ["host_file_read:/home/user/project/bar.ts"],
+        "/home/user/project",
+        ctx,
+      );
+      expect(r2).not.toBeNull();
+      expect(r2!.id).toBe("ephemeral:run-scope:host_file_read");
+    });
+
+    test("ephemeral rule does not carry stray metadata fields for non-scoped tools", () => {
+      // buildTaskRules generates canonical ephemeral rules.
+      // For a tool like file_read (scoped family), the generated rule
+      // should have no executionTarget or allowHighRisk.
+      const rules = buildTaskRules("run-canon", ["file_read", "bash"], "/tmp");
+
+      for (const rule of rules) {
+        expect(rule.scope).toBe("everywhere");
+        expect(rule.allowHighRisk).toBeUndefined();
+        expect(rule.executionTarget).toBeUndefined();
+      }
+    });
+
+    test("ephemeral rule with project scope does not match sibling project", () => {
+      const ephemeralRules: TrustRule[] = [
+        {
+          id: "ephemeral:run-proj:file_write",
+          tool: "file_write",
+          pattern: "**",
+          scope: "/home/user/project-a",
+          decision: "allow",
+          priority: 75,
+          createdAt: Date.now(),
+        },
+      ];
+
+      const ctx: PolicyContext = { ephemeralRules };
+
+      // Should NOT match from a sibling directory
+      const result = findHighestPriorityRule(
+        "file_write",
+        ["file_write:/home/user/project-b/file.ts"],
+        "/home/user/project-b",
+        ctx,
+      );
+
+      // The ephemeral rule should not be the match (scope mismatch)
+      if (result) {
+        expect(result.id).not.toBe("ephemeral:run-proj:file_write");
+      }
+    });
+  });
+
   describe("workspace mode interactions", () => {
     beforeEach(() => {
       clearCache();

--- a/assistant/src/__tests__/starter-bundle.test.ts
+++ b/assistant/src/__tests__/starter-bundle.test.ts
@@ -135,4 +135,36 @@ describe("Starter approval bundle", () => {
       expect(defaultIds.has(starterRule.id)).toBe(false);
     }
   });
+
+  test("accepted starter rules have canonical persisted shape after disk round-trip", () => {
+    acceptStarterBundle();
+
+    // Force a disk round-trip by clearing the cache
+    clearCache();
+    const allRules = getAllRules();
+    const starterRuleIds = new Set(getStarterBundleRules().map((r) => r.id));
+    const starterRules = allRules.filter((r) => starterRuleIds.has(r.id));
+
+    expect(starterRules.length).toBe(getStarterBundleRules().length);
+
+    for (const rule of starterRules) {
+      // Canonical shape: scope is always present and set to "everywhere"
+      expect(rule.scope).toBe("everywhere");
+
+      // Starter rules are all allow decisions — they should not carry
+      // family-specific metadata signals (allowHighRisk, executionTarget).
+      // These rules cover read-only/information-gathering tools that are
+      // either generic or scoped family, but none require high-risk access.
+      expect(rule.allowHighRisk).toBeUndefined();
+      expect(rule.executionTarget).toBeUndefined();
+
+      // Base fields must be present
+      expect(rule.id).toBeTruthy();
+      expect(rule.tool).toBeTruthy();
+      expect(rule.pattern).toBeTruthy();
+      expect(rule.decision).toBe("allow");
+      expect(rule.priority).toBeGreaterThan(0);
+      expect(rule.createdAt).toBeGreaterThan(0);
+    }
+  });
 });

--- a/assistant/src/cli/commands/trust.ts
+++ b/assistant/src/cli/commands/trust.ts
@@ -38,9 +38,11 @@ Displays a table of all trust rules with the following columns:
   ID        First 8 characters of the full rule UUID
   Tool      Tool name the rule applies to (e.g. bash, host_bash)
   Pattern   Glob pattern matched against the tool's command argument
-  Scope     Context scope for the rule (e.g. workspace path)
-  Dcn       Decision: allow or deny
+  Scope     Context scope for the rule (shown only when rules have
+            non-global scopes, i.e. not "everywhere")
+  Dcn       Decision: allow, deny, or ask
   Pri       Priority (higher values take precedence)
+  Flags     Metadata: H = allowHighRisk, T:<target> = executionTarget
   Created   Date the rule was created (YYYY-MM-DD)
 
 IDs are shown truncated to 8 characters. Use the full ID or any unique
@@ -55,34 +57,65 @@ Examples:
         log.info("No trust rules");
         return;
       }
+
+      // Only show the Scope column when at least one rule has a
+      // non-global scope (i.e. something other than "everywhere").
+      const hasNonGlobalScope = rules.some(
+        (r) => r.scope && r.scope !== "everywhere",
+      );
+
+      // Only show the Flags column when at least one rule carries
+      // metadata signals (allowHighRisk or executionTarget).
+      const hasFlags = rules.some(
+        (r) => r.allowHighRisk != null || r.executionTarget != null,
+      );
+
       const idW = 8;
       const toolW = 12;
       const patternW = 30;
-      const scopeW = 20;
+      const scopeW = hasNonGlobalScope ? 20 : 0;
       const decW = 6;
       const priW = 4;
+      const flagsW = hasFlags ? 16 : 0;
+
+      let header =
+        "ID".padEnd(idW) + "Tool".padEnd(toolW) + "Pattern".padEnd(patternW);
+      if (hasNonGlobalScope) header += "Scope".padEnd(scopeW);
+      header += "Dcn".padEnd(decW) + "Pri".padEnd(priW);
+      if (hasFlags) header += "Flags".padEnd(flagsW);
+      header += "Created";
+      log.info(header);
       log.info(
-        "ID".padEnd(idW) +
-          "Tool".padEnd(toolW) +
-          "Pattern".padEnd(patternW) +
-          "Scope".padEnd(scopeW) +
-          "Dcn".padEnd(decW) +
-          "Pri".padEnd(priW) +
-          "Created",
+        "-".repeat(idW + toolW + patternW + scopeW + decW + priW + flagsW + 20),
       );
-      log.info("-".repeat(idW + toolW + patternW + scopeW + decW + priW + 20));
+
       for (const r of rules) {
         const id = r.id.slice(0, SHORT_HASH_LENGTH);
         const created = new Date(r.createdAt).toISOString().slice(0, 10);
-        log.info(
+
+        let line =
           id.padEnd(idW) +
-            r.tool.padEnd(toolW) +
-            r.pattern.slice(0, patternW - 2).padEnd(patternW) +
-            r.scope.slice(0, scopeW - 2).padEnd(scopeW) +
-            r.decision.slice(0, decW - 1).padEnd(decW) +
-            String(r.priority).padEnd(priW) +
-            created,
-        );
+          r.tool.padEnd(toolW) +
+          r.pattern.slice(0, patternW - 2).padEnd(patternW);
+
+        if (hasNonGlobalScope) {
+          const scope = r.scope || "everywhere";
+          line += scope.slice(0, scopeW - 2).padEnd(scopeW);
+        }
+
+        line +=
+          r.decision.slice(0, decW - 1).padEnd(decW) +
+          String(r.priority).padEnd(priW);
+
+        if (hasFlags) {
+          const flags: string[] = [];
+          if (r.allowHighRisk === true) flags.push("H");
+          if (r.executionTarget) flags.push(`T:${r.executionTarget}`);
+          line += (flags.join(" ") || "").slice(0, flagsW - 2).padEnd(flagsW);
+        }
+
+        line += created;
+        log.info(line);
       }
     });
 


### PR DESCRIPTION
## Summary
- Update trust list CLI output for conditional scope display and metadata signals
- Adjust checker, starter-bundle, and ephemeral permission test fixtures for canonical shapes
- Run platform proxy compatibility gate

Part of plan: trust-rule-union-compat.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
