### PR TITLE
feat(compaction): add 3-strike circuit breaker on consecutive compaction failures

### DIFF
--- a/assistant/src/__tests__/compaction-circuit-breaker.test.ts
+++ b/assistant/src/__tests__/compaction-circuit-breaker.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Circuit-breaker tests for the compaction path.
+ *
+ * These exercise the tiny helpers (`isCompactionCircuitOpen`,
+ * `trackCompactionOutcome`) that `conversation-agent-loop.ts` uses at every
+ * `maybeCompact()` call site. Covering the helpers — rather than wiring up a
+ * full `Conversation` — keeps the test fast and isolates the breaker logic
+ * from the rest of the loop, which is where bugs actually hide.
+ *
+ * Acceptance criteria (per plan PR 2):
+ *   (a) counter increments on `summaryFailed`
+ *   (b) circuit opens after exactly 3 failures
+ *   (c) successful compaction resets counter and circuit
+ *   (d) open circuit skips auto-compaction but admits `force: true`
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  isCompactionCircuitOpen,
+  trackCompactionOutcome,
+} from "../daemon/conversation-agent-loop.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+interface BreakerState {
+  consecutiveCompactionFailures: number;
+  compactionCircuitOpenUntil: number | null;
+}
+
+function makeState(): BreakerState {
+  return {
+    consecutiveCompactionFailures: 0,
+    compactionCircuitOpenUntil: null,
+  };
+}
+
+function collectEvents(): {
+  events: ServerMessage[];
+  onEvent: (msg: ServerMessage) => void;
+} {
+  const events: ServerMessage[] = [];
+  return { events, onEvent: (msg) => events.push(msg) };
+}
+
+describe("compaction circuit breaker", () => {
+  let originalDateNow: () => number;
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
+  test("(a) counter increments on each summaryFailed outcome", () => {
+    const state = makeState();
+    const { onEvent, events } = collectEvents();
+
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(1);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    expect(events).toHaveLength(0);
+
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(2);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  test("(b) circuit opens after exactly 3 consecutive failures", () => {
+    const fixedNow = 1_700_000_000_000;
+    Date.now = () => fixedNow;
+
+    const state = makeState();
+    const { onEvent, events } = collectEvents();
+
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    // Two failures — circuit still closed.
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+    expect(events).toHaveLength(0);
+
+    trackCompactionOutcome(state, true, onEvent);
+    // Third failure — circuit trips and fires the event exactly once.
+    expect(state.consecutiveCompactionFailures).toBe(3);
+    expect(state.compactionCircuitOpenUntil).toBe(fixedNow + 60 * 60 * 1000);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "compaction_circuit_open",
+      reason: "3_consecutive_failures",
+      openUntil: fixedNow + 60 * 60 * 1000,
+    });
+
+    // Further failures do not re-fire the event while the circuit is open.
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(4);
+    expect(events).toHaveLength(1);
+  });
+
+  test("(c) successful compaction resets counter and clears circuit", () => {
+    const fixedNow = 1_700_000_000_000;
+    Date.now = () => fixedNow;
+
+    const state = makeState();
+    const { onEvent } = collectEvents();
+
+    // Trip the breaker.
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.compactionCircuitOpenUntil).not.toBeNull();
+
+    // Success resets state.
+    trackCompactionOutcome(state, false, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(0);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+
+    // `summaryFailed` undefined (never attempted the LLM call) also counts
+    // as "not failed" — don't count a compaction that never ran.
+    trackCompactionOutcome(state, undefined, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(0);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+  });
+
+  test("(d) isCompactionCircuitOpen reflects state and expiry", () => {
+    const fixedNow = 1_700_000_000_000;
+    Date.now = () => fixedNow;
+
+    const state = makeState();
+    expect(isCompactionCircuitOpen(state)).toBe(false);
+
+    // Trip the breaker — now open.
+    const { onEvent } = collectEvents();
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(isCompactionCircuitOpen(state)).toBe(true);
+
+    // After cooldown expires the helper reports closed again, even without an
+    // explicit reset — the open-until timestamp is the only source of truth
+    // for the gate.
+    Date.now = () => fixedNow + 60 * 60 * 1000 + 1;
+    expect(isCompactionCircuitOpen(state)).toBe(false);
+  });
+
+  test("(d) open circuit skips auto-compaction but admits force:true", () => {
+    // Simulate the decision the agent-loop site makes with a counter that
+    // only increments when compaction actually runs.
+    const fixedNow = 1_700_000_000_000;
+    Date.now = () => fixedNow;
+
+    const state = makeState();
+    const { onEvent } = collectEvents();
+
+    let compactionCalls = 0;
+    const runCompactionIfAllowed = (opts: { force?: boolean }) => {
+      // Mirror conversation-agent-loop.ts site 1:
+      //   auto paths gate on !isCompactionCircuitOpen(ctx);
+      //   force paths bypass the gate.
+      if (!opts.force && isCompactionCircuitOpen(state)) {
+        return { ran: false };
+      }
+      compactionCalls += 1;
+      return { ran: true };
+    };
+
+    // Trip the breaker.
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(isCompactionCircuitOpen(state)).toBe(true);
+
+    // Auto-path is skipped while the circuit is open.
+    const autoAttempt = runCompactionIfAllowed({});
+    expect(autoAttempt.ran).toBe(false);
+    expect(compactionCalls).toBe(0);
+
+    // Force-path always runs, even with the breaker open.
+    const forceAttempt = runCompactionIfAllowed({ force: true });
+    expect(forceAttempt.ran).toBe(true);
+    expect(compactionCalls).toBe(1);
+
+    // After a forced compaction succeeds, the counter resets and the circuit
+    // closes, unblocking future auto attempts.
+    trackCompactionOutcome(state, false, onEvent);
+    expect(isCompactionCircuitOpen(state)).toBe(false);
+    expect(state.consecutiveCompactionFailures).toBe(0);
+
+    const autoRetry = runCompactionIfAllowed({});
+    expect(autoRetry.ran).toBe(true);
+    expect(compactionCalls).toBe(2);
+  });
+});

--- a/assistant/src/__tests__/compaction-circuit-breaker.test.ts
+++ b/assistant/src/__tests__/compaction-circuit-breaker.test.ts
@@ -7,11 +7,16 @@
  * full `Conversation` — keeps the test fast and isolates the breaker logic
  * from the rest of the loop, which is where bugs actually hide.
  *
- * Acceptance criteria (per plan PR 2):
+ * Acceptance criteria:
  *   (a) counter increments on `summaryFailed`
  *   (b) circuit opens after exactly 3 failures
  *   (c) successful compaction resets counter and circuit
  *   (d) open circuit skips auto-compaction but admits `force: true`
+ *   (e) circuit re-opens after cooldown expiry when 3 more failures accumulate
+ *   (f) call sites guard `undefined summaryFailed` so early returns do not
+ *       reset the counter
+ *   (g) forceCompact-style tracking: resets counter on success, increments on
+ *       failure, preserves state on early returns
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
@@ -115,8 +120,11 @@ describe("compaction circuit breaker", () => {
     expect(state.consecutiveCompactionFailures).toBe(0);
     expect(state.compactionCircuitOpenUntil).toBeNull();
 
-    // `summaryFailed` undefined (never attempted the LLM call) also counts
-    // as "not failed" — don't count a compaction that never ran.
+    // `summaryFailed` undefined (never attempted the LLM call) currently
+    // takes the "not failed" branch, which is why callers must guard the
+    // helper with `summaryFailed !== undefined` — otherwise an early-return
+    // `maybeCompact()` would silently reset the counter. The regression test
+    // below documents that invariant from the caller's perspective.
     trackCompactionOutcome(state, undefined, onEvent);
     expect(state.consecutiveCompactionFailures).toBe(0);
     expect(state.compactionCircuitOpenUntil).toBeNull();
@@ -189,5 +197,140 @@ describe("compaction circuit breaker", () => {
     const autoRetry = runCompactionIfAllowed({});
     expect(autoRetry.ran).toBe(true);
     expect(compactionCalls).toBe(2);
+  });
+
+  test("(e) circuit re-opens after cooldown expiry when 3 more failures accumulate", () => {
+    // Regression: before the fix, `trackCompactionOutcome` required
+    // `compactionCircuitOpenUntil === null` to open the circuit. Once a
+    // cooldown expired, `isCompactionCircuitOpen()` correctly reported
+    // "closed" but the stale past-timestamp stayed on the state, so the
+    // next 3-strike window could never trip a new cooldown. The fix
+    // treats any expired timestamp the same as null.
+    const t0 = 1_700_000_000_000;
+    Date.now = () => t0;
+
+    const state = makeState();
+    const { onEvent, events } = collectEvents();
+
+    // Trip the breaker the first time.
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.compactionCircuitOpenUntil).toBe(t0 + 60 * 60 * 1000);
+    expect(events).toHaveLength(1);
+
+    // Advance past the cooldown window. Manually reset the counter — in
+    // production this happens when a subsequent `maybeCompact()` call
+    // succeeds (`summaryFailed: false`) after the cooldown elapses, but
+    // the bug manifests even when the counter is reset: the stale
+    // `compactionCircuitOpenUntil` is what breaks re-opening.
+    const t1 = t0 + 60 * 60 * 1000 + 1;
+    Date.now = () => t1;
+    expect(isCompactionCircuitOpen(state)).toBe(false);
+    state.consecutiveCompactionFailures = 0;
+    // `compactionCircuitOpenUntil` is deliberately left as the old
+    // timestamp to reproduce the bug condition — in practice the null
+    // reset only happens on `summaryFailed: false`.
+    expect(state.compactionCircuitOpenUntil).toBe(t0 + 60 * 60 * 1000);
+
+    // Three more failures must trip a fresh cooldown even though the
+    // old timestamp is still set.
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(3);
+    expect(state.compactionCircuitOpenUntil).toBe(t1 + 60 * 60 * 1000);
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({
+      type: "compaction_circuit_open",
+      reason: "3_consecutive_failures",
+      openUntil: t1 + 60 * 60 * 1000,
+    });
+  });
+
+  test("(f) call sites guard undefined summaryFailed so early returns don't reset the counter", () => {
+    // Regression: `maybeCompact()` returns `summaryFailed: undefined` on
+    // early-return paths (no eligible messages, below threshold, cooldown
+    // active, truncation-only). Before the fix, the agent loop called
+    // `trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent)`
+    // unconditionally — `undefined` took the else branch and silently
+    // reset the 3-strike counter. Callers must now guard with
+    // `summaryFailed !== undefined` at every call site.
+    const state = makeState();
+    const { onEvent } = collectEvents();
+
+    // Accumulate two failures, close to tripping the breaker.
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(2);
+
+    // Simulate an early-return result from maybeCompact() (e.g. below
+    // threshold) — callers must skip the tracking call entirely.
+    const earlyReturn = {
+      compacted: false,
+      summaryFailed: undefined as boolean | undefined,
+    };
+    if (earlyReturn.summaryFailed !== undefined) {
+      trackCompactionOutcome(state, earlyReturn.summaryFailed, onEvent);
+    }
+    // Counter preserved — the early return did not reset progress toward
+    // tripping the breaker.
+    expect(state.consecutiveCompactionFailures).toBe(2);
+
+    // A third real failure then trips the breaker as expected.
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(3);
+    expect(state.compactionCircuitOpenUntil).not.toBeNull();
+  });
+
+  test("(g) forceCompact-style tracking resets counter on success, increments on failure", () => {
+    // Regression: `Conversation.forceCompact()` previously didn't track
+    // circuit-breaker outcomes. A successful user `/compact` wouldn't clear
+    // an accumulating counter and a failed forced compaction wouldn't
+    // contribute to tripping the breaker. The fix calls
+    // `trackCompactionOutcome(this, result.summaryFailed, this.sendToClient)`
+    // after `maybeCompact` — guarded by `summaryFailed !== undefined` so
+    // early-return paths don't reset the counter.
+    const state = makeState();
+    const { onEvent } = collectEvents();
+
+    // Simulate forceCompact: call maybeCompact with force:true, then
+    // track the outcome the same way forceCompact now does.
+    const trackForceCompact = (result: {
+      summaryFailed?: boolean;
+      compacted: boolean;
+    }): void => {
+      if (result.summaryFailed !== undefined) {
+        trackCompactionOutcome(state, result.summaryFailed, onEvent);
+      }
+    };
+
+    // Two failures via the auto path …
+    trackCompactionOutcome(state, true, onEvent);
+    trackCompactionOutcome(state, true, onEvent);
+    expect(state.consecutiveCompactionFailures).toBe(2);
+
+    // … then the user hits /compact and the forced call succeeds. This
+    // must clear the stuck counter so the conversation isn't one
+    // auto-failure away from a cooldown.
+    trackForceCompact({ summaryFailed: false, compacted: true });
+    expect(state.consecutiveCompactionFailures).toBe(0);
+    expect(state.compactionCircuitOpenUntil).toBeNull();
+
+    // Conversely, three forced failures must trip the breaker too — a
+    // run of broken summaries is a provider-health signal regardless of
+    // whether the caller bypassed the breaker.
+    trackForceCompact({ summaryFailed: true, compacted: true });
+    trackForceCompact({ summaryFailed: true, compacted: true });
+    trackForceCompact({ summaryFailed: true, compacted: true });
+    expect(state.consecutiveCompactionFailures).toBe(3);
+    expect(state.compactionCircuitOpenUntil).not.toBeNull();
+
+    // An early-return forceCompact (e.g. no eligible messages) must not
+    // reset the counter — the breaker should stay open.
+    const wasOpenUntil = state.compactionCircuitOpenUntil;
+    trackForceCompact({ summaryFailed: undefined, compacted: false });
+    expect(state.consecutiveCompactionFailures).toBe(3);
+    expect(state.compactionCircuitOpenUntil).toBe(wasOpenUntil);
   });
 });

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -242,6 +242,63 @@ describe("ContextWindowManager", () => {
     expect(result.summaryText).toContain("## Recent Progress");
   });
 
+  test("marks summaryFailed when the provider throws and fallback runs", async () => {
+    // The agent-loop circuit breaker distinguishes "LLM call failed but
+    // fallback rescued us" from "compaction succeeded end-to-end". The
+    // fallback path must set summaryFailed:true so callers can count
+    // consecutive failures without losing the compacted messages.
+    const provider = createProvider(async () => {
+      throw new Error("provider unavailable");
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 260,
+        targetBudgetRatio: 0.59,
+      }),
+    });
+    const long = "z".repeat(220);
+    const history = [
+      message("user", `task ${long}`),
+      message("assistant", `result ${long}`),
+      message("user", `followup ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    expect(result.summaryFailed).toBe(true);
+  });
+
+  test("does not mark summaryFailed on a successful provider call", async () => {
+    const provider = createProvider(() => ({
+      content: [
+        { type: "text", text: "## Goals\n- summary produced by provider" },
+      ],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 260,
+        targetBudgetRatio: 0.59,
+      }),
+    });
+    const long = "z".repeat(220);
+    const history = [
+      message("user", `task ${long}`),
+      message("assistant", `result ${long}`),
+      message("user", `followup ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    expect(result.summaryFailed).toBe(false);
+  });
+
   test("serializes file blocks for summary chunks", async () => {
     const prompts: string[] = [];
     const provider = createProvider((messages) => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -58,6 +58,13 @@ export interface ContextWindowResult {
   summaryRawResponses?: unknown[];
   summaryText: string;
   reason?: string;
+  /**
+   * True when the summary LLM call threw and the local fallback produced the
+   * summary. Callers use this to distinguish provider-side summary failures
+   * from successful compactions so they can apply circuit-breaker logic
+   * without losing the fallback-compacted messages.
+   */
+  summaryFailed?: boolean;
 }
 
 export interface ShouldCompactResult {
@@ -463,6 +470,7 @@ export class ContextWindowManager {
     const summaryCacheCreationInputTokens =
       summaryUpdate.cacheCreationInputTokens;
     const summaryCacheReadInputTokens = summaryUpdate.cacheReadInputTokens;
+    const summaryFailed = summaryUpdate.failed;
     const summaryRawResponses: unknown[] = [];
     if (Array.isArray(summaryUpdate.rawResponse)) {
       summaryRawResponses.push(...summaryUpdate.rawResponse);
@@ -499,7 +507,9 @@ export class ContextWindowManager {
     // the summary at index 0 as child-owned.
     this.nonPersistedPrefixCount = Math.max(
       0,
-      this.nonPersistedPrefixCount - injectedInCompactable - injectedSummaryOffset,
+      this.nonPersistedPrefixCount -
+        injectedInCompactable -
+        injectedSummaryOffset,
     );
     this.summaryIsInjected = false;
 
@@ -532,6 +542,7 @@ export class ContextWindowManager {
       summaryCacheReadInputTokens,
       summaryRawResponses,
       summaryText: summary,
+      summaryFailed,
     };
   }
 
@@ -643,7 +654,9 @@ export class ContextWindowManager {
     );
 
     const estimateBlockTokens = (b: ContentBlock): number =>
-      estimateContentBlockTokens(b, { providerName: this.estimationProviderName });
+      estimateContentBlockTokens(b, {
+        providerName: this.estimationProviderName,
+      });
 
     let totalTokens = 0;
     for (const block of blocks) {
@@ -656,7 +669,11 @@ export class ContextWindowManager {
     // images to drop. Images are high-cost and their text context (message
     // headers, surrounding tool_use/tool_result serializations) is preserved.
     const result = [...blocks];
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       if (result[i].type === "image") {
         totalTokens -= estimateBlockTokens(result[i]);
         const stub: ContentBlock = {
@@ -674,7 +691,11 @@ export class ContextWindowManager {
     // than dropping it entirely so the summarizer always has content to work with.
     let dropUntil = 0;
     let droppedTokens = 0;
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       const blockTokens = estimateBlockTokens(result[i]);
       const excess = totalTokens - maxTranscriptTokens;
       if (blockTokens > excess && result[i].type === "text") {
@@ -731,12 +752,19 @@ export class ContextWindowManager {
     cacheCreationInputTokens: number;
     cacheReadInputTokens: number;
     rawResponse?: unknown;
+    /**
+     * True when the provider.sendMessage call threw and the local fallback
+     * was used. Callers (the agent loop) use this to drive circuit-breaker
+     * state without having to reimplement the fallback themselves.
+     */
+    failed: boolean;
   }> {
     const contentBlocks = buildSummaryContentBlocks(
       currentSummary,
       transcriptBlocks,
     );
     const summaryMessage: Message = { role: "user", content: contentBlocks };
+    let failed = false;
     try {
       const response = await this.provider.sendMessage(
         [summaryMessage],
@@ -759,15 +787,19 @@ export class ContextWindowManager {
             response.usage.cacheCreationInputTokens ?? 0,
           cacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
           rawResponse: response.rawResponse,
+          failed: false,
         };
       }
     } catch (err) {
+      failed = true;
       log.warn({ err }, "Summary generation failed, using local fallback");
     }
 
     // Fallback: extract text-only transcript for local summary generation.
     const textTranscript = transcriptBlocks
-      .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text")
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
       .map((b) => b.text)
       .join("\n\n");
 
@@ -778,6 +810,7 @@ export class ContextWindowManager {
       model: "",
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      failed,
     };
   }
 
@@ -854,7 +887,11 @@ function adjustForToolPairs(
     // Collect tool_use_ids referenced by tool_results in this user message
     const referencedIds = new Set<string>();
     for (const block of msg.content) {
-      if ((block.type === "tool_result" || block.type === "web_search_tool_result") && "tool_use_id" in block) {
+      if (
+        (block.type === "tool_result" ||
+          block.type === "web_search_tool_result") &&
+        "tool_use_id" in block
+      ) {
         referencedIds.add((block as { tool_use_id: string }).tool_use_id);
       }
     }
@@ -970,7 +1007,8 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (block.type === "tool_result") { // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
+      } else if (block.type === "tool_result") {
+        // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];
         textLines.push(serializeToolResultBlock(block, collectedImages));

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -197,6 +197,71 @@ type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
 };
 
+// ── Compaction circuit-breaker constants ────────────────────────────
+//
+// The circuit opens after `COMPACTION_CIRCUIT_FAILURE_THRESHOLD` consecutive
+// summary-LLM failures and stays open for `COMPACTION_CIRCUIT_COOLDOWN_MS`
+// before auto-compaction is allowed to retry. User-initiated compaction
+// (`force: true`) bypasses the breaker regardless of its state.
+const COMPACTION_CIRCUIT_FAILURE_THRESHOLD = 3;
+const COMPACTION_CIRCUIT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Check whether the compaction circuit breaker is currently open for the
+ * given context. The breaker auto-closes once `compactionCircuitOpenUntil`
+ * has elapsed.
+ */
+export function isCompactionCircuitOpen(ctx: {
+  compactionCircuitOpenUntil: number | null;
+}): boolean {
+  return (
+    ctx.compactionCircuitOpenUntil !== null &&
+    Date.now() < ctx.compactionCircuitOpenUntil
+  );
+}
+
+/**
+ * Track the outcome of a `maybeCompact()` call against the circuit breaker.
+ *
+ * - When the summary LLM call failed (local fallback covered the result),
+ *   increment the consecutive-failure counter. If the counter reaches the
+ *   threshold, open the circuit for the cooldown window and emit
+ *   `compaction_circuit_open` so clients can surface a notice.
+ * - When the call did not fail, reset the counter and clear any open circuit.
+ *
+ * This is called by every `maybeCompact()` site (including forced ones),
+ * because a run of three failures is a provider-health signal regardless of
+ * whether the caller bypassed the breaker.
+ */
+export function trackCompactionOutcome(
+  ctx: {
+    consecutiveCompactionFailures: number;
+    compactionCircuitOpenUntil: number | null;
+  },
+  summaryFailed: boolean | undefined,
+  onEvent: (msg: ServerMessage) => void,
+): void {
+  if (summaryFailed) {
+    ctx.consecutiveCompactionFailures += 1;
+    if (
+      ctx.consecutiveCompactionFailures >=
+        COMPACTION_CIRCUIT_FAILURE_THRESHOLD &&
+      ctx.compactionCircuitOpenUntil === null
+    ) {
+      const openUntil = Date.now() + COMPACTION_CIRCUIT_COOLDOWN_MS;
+      ctx.compactionCircuitOpenUntil = openUntil;
+      onEvent({
+        type: "compaction_circuit_open",
+        reason: "3_consecutive_failures",
+        openUntil,
+      });
+    }
+  } else {
+    ctx.consecutiveCompactionFailures = 0;
+    ctx.compactionCircuitOpenUntil = null;
+  }
+}
+
 // ── Context Interface ────────────────────────────────────────────────
 
 export interface AgentLoopConversationContext {
@@ -213,6 +278,10 @@ export interface AgentLoopConversationContext {
   readonly contextWindowManager: ContextWindowManager;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
+  /** Tracks consecutive compaction failures (summary LLM call threw). */
+  consecutiveCompactionFailures: number;
+  /** Timestamp (ms since epoch) until which the circuit breaker is open. */
+  compactionCircuitOpenUntil: number | null;
 
   readonly memoryPolicy: { scopeId: string; includeDefaultFallback: boolean };
   readonly graphMemory: ConversationGraphMemory;
@@ -532,15 +601,23 @@ export async function runAgentLoopImpl(
         reqId,
       );
     }
-    const compacted = await ctx.contextWindowManager.maybeCompact(
-      ctx.messages,
-      abortController.signal,
-      {
-        lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-        precomputedEstimate: compactCheck.estimatedTokens,
-      },
-    );
-    if (compacted.compacted) {
+    // Skip auto-compaction while the circuit breaker is open. Force paths
+    // and user-initiated /compact bypass this check.
+    const autoCompactAllowed = !isCompactionCircuitOpen(ctx);
+    const compacted = autoCompactAllowed
+      ? await ctx.contextWindowManager.maybeCompact(
+          ctx.messages,
+          abortController.signal,
+          {
+            lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+            precomputedEstimate: compactCheck.estimatedTokens,
+          },
+        )
+      : null;
+    if (compacted) {
+      trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
+    }
+    if (compacted?.compacted) {
       ctx.messages = compacted.messages;
       ctx.contextCompactedMessageCount += compacted.compactedPersistedMessages;
       ctx.contextCompactedAt = Date.now();
@@ -938,6 +1015,18 @@ export async function runAgentLoopImpl(
         ctx.messages = step.messages;
         currentInjectionMode = step.state.injectionMode;
 
+        // Track circuit-breaker state whenever the reducer invoked compaction.
+        // The reducer's forced_compaction tier uses force:true, so it bypasses
+        // the open-circuit check, but we still want failure tracking to detect
+        // a run of broken summaries and clear the counter on success.
+        if (step.compactionResult) {
+          trackCompactionOutcome(
+            ctx,
+            step.compactionResult.summaryFailed,
+            onEvent,
+          );
+        }
+
         if (step.compactionResult?.compacted) {
           ctx.contextCompactedMessageCount +=
             step.compactionResult.compactedPersistedMessages;
@@ -1146,6 +1235,7 @@ export async function runAgentLoopImpl(
           targetInputTokensOverride: preflightBudget,
         },
       );
+      trackCompactionOutcome(ctx, midLoopCompact.summaryFailed, onEvent);
       if (midLoopCompact.compacted) {
         ctx.messages = midLoopCompact.messages;
         ctx.contextCompactedMessageCount +=
@@ -1369,6 +1459,15 @@ export async function runAgentLoopImpl(
         ctx.messages = step.messages;
         currentInjectionMode = step.state.injectionMode;
 
+        // See the preflight reducer call above for rationale.
+        if (step.compactionResult) {
+          trackCompactionOutcome(
+            ctx,
+            step.compactionResult.summaryFailed,
+            onEvent,
+          );
+        }
+
         if (step.compactionResult?.compacted) {
           ctx.contextCompactedMessageCount +=
             step.compactionResult.compactedPersistedMessages;
@@ -1496,6 +1595,11 @@ export async function runAgentLoopImpl(
                   targetInputTokensOverride: correctedTarget,
                 },
               );
+            trackCompactionOutcome(
+              ctx,
+              emergencyCompact.summaryFailed,
+              onEvent,
+            );
             if (emergencyCompact.compacted) {
               ctx.messages = emergencyCompact.messages;
               ctx.contextCompactedMessageCount +=
@@ -1619,6 +1723,7 @@ export async function runAgentLoopImpl(
               targetInputTokensOverride: correctedTarget,
             },
           );
+          trackCompactionOutcome(ctx, emergencyCompact.summaryFailed, onEvent);
           if (emergencyCompact.compacted) {
             ctx.messages = emergencyCompact.messages;
             ctx.contextCompactedMessageCount +=

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -243,10 +243,18 @@ export function trackCompactionOutcome(
 ): void {
   if (summaryFailed) {
     ctx.consecutiveCompactionFailures += 1;
+    // Treat a stale/expired open-until timestamp the same as null so a new
+    // 3-strike window can re-open the circuit after the prior cooldown
+    // elapses. Without this the second trip would no-op because
+    // `compactionCircuitOpenUntil` remains set to a past timestamp even
+    // though `isCompactionCircuitOpen()` correctly reports closed.
+    const circuitDormant =
+      ctx.compactionCircuitOpenUntil === null ||
+      Date.now() >= ctx.compactionCircuitOpenUntil;
     if (
       ctx.consecutiveCompactionFailures >=
         COMPACTION_CIRCUIT_FAILURE_THRESHOLD &&
-      ctx.compactionCircuitOpenUntil === null
+      circuitDormant
     ) {
       const openUntil = Date.now() + COMPACTION_CIRCUIT_COOLDOWN_MS;
       ctx.compactionCircuitOpenUntil = openUntil;
@@ -614,7 +622,12 @@ export async function runAgentLoopImpl(
           },
         )
       : null;
-    if (compacted) {
+    // Only track circuit-breaker state when a summary LLM call actually ran.
+    // `summaryFailed` is `undefined` on early returns (compaction disabled,
+    // below threshold, cooldown active, no eligible messages, truncation-only
+    // path) — treating those as "successful" compactions would silently reset
+    // the 3-strike counter and break the invariant.
+    if (compacted && compacted.summaryFailed !== undefined) {
       trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
     }
     if (compacted?.compacted) {
@@ -1018,8 +1031,14 @@ export async function runAgentLoopImpl(
         // Track circuit-breaker state whenever the reducer invoked compaction.
         // The reducer's forced_compaction tier uses force:true, so it bypasses
         // the open-circuit check, but we still want failure tracking to detect
-        // a run of broken summaries and clear the counter on success.
-        if (step.compactionResult) {
+        // a run of broken summaries and clear the counter on success. Only
+        // track when the summary LLM actually ran — `summaryFailed === undefined`
+        // indicates an early return (no eligible messages, truncation-only
+        // path, etc.) that shouldn't influence the breaker.
+        if (
+          step.compactionResult &&
+          step.compactionResult.summaryFailed !== undefined
+        ) {
           trackCompactionOutcome(
             ctx,
             step.compactionResult.summaryFailed,
@@ -1235,7 +1254,12 @@ export async function runAgentLoopImpl(
           targetInputTokensOverride: preflightBudget,
         },
       );
-      trackCompactionOutcome(ctx, midLoopCompact.summaryFailed, onEvent);
+      // `force: true` bypasses the cooldown/threshold gates but early returns
+      // for "no eligible messages" / "insufficient messages" still leave
+      // `summaryFailed` undefined. Only track when the summary LLM actually ran.
+      if (midLoopCompact.summaryFailed !== undefined) {
+        trackCompactionOutcome(ctx, midLoopCompact.summaryFailed, onEvent);
+      }
       if (midLoopCompact.compacted) {
         ctx.messages = midLoopCompact.messages;
         ctx.contextCompactedMessageCount +=
@@ -1459,8 +1483,14 @@ export async function runAgentLoopImpl(
         ctx.messages = step.messages;
         currentInjectionMode = step.state.injectionMode;
 
-        // See the preflight reducer call above for rationale.
-        if (step.compactionResult) {
+        // See the preflight reducer call above for rationale. Only track when
+        // the summary LLM actually ran — `summaryFailed === undefined`
+        // indicates the reducer's forced compaction took an early-return path
+        // without calling the summary LLM.
+        if (
+          step.compactionResult &&
+          step.compactionResult.summaryFailed !== undefined
+        ) {
           trackCompactionOutcome(
             ctx,
             step.compactionResult.summaryFailed,
@@ -1595,11 +1625,15 @@ export async function runAgentLoopImpl(
                   targetInputTokensOverride: correctedTarget,
                 },
               );
-            trackCompactionOutcome(
-              ctx,
-              emergencyCompact.summaryFailed,
-              onEvent,
-            );
+            // Only track when the summary LLM actually ran; `force: true`
+            // bypasses the cooldown but not the early-return paths.
+            if (emergencyCompact.summaryFailed !== undefined) {
+              trackCompactionOutcome(
+                ctx,
+                emergencyCompact.summaryFailed,
+                onEvent,
+              );
+            }
             if (emergencyCompact.compacted) {
               ctx.messages = emergencyCompact.messages;
               ctx.contextCompactedMessageCount +=
@@ -1723,7 +1757,15 @@ export async function runAgentLoopImpl(
               targetInputTokensOverride: correctedTarget,
             },
           );
-          trackCompactionOutcome(ctx, emergencyCompact.summaryFailed, onEvent);
+          // Only track when the summary LLM actually ran; `force: true`
+          // bypasses the cooldown but not the early-return paths.
+          if (emergencyCompact.summaryFailed !== undefined) {
+            trackCompactionOutcome(
+              ctx,
+              emergencyCompact.summaryFailed,
+              onEvent,
+            );
+          }
           if (emergencyCompact.compacted) {
             ctx.messages = emergencyCompact.messages;
             ctx.contextCompactedMessageCount +=

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -74,7 +74,10 @@ import type { OnboardingContext } from "../types/onboarding-context.js";
 import type { AbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
-import { runAgentLoopImpl } from "./conversation-agent-loop.js";
+import {
+  runAgentLoopImpl,
+  trackCompactionOutcome,
+} from "./conversation-agent-loop.js";
 import type { HistoryConversationContext } from "./conversation-history.js";
 import {
   regenerate as regenerateImpl,
@@ -1187,6 +1190,14 @@ export class Conversation {
       this.abortController?.signal ?? undefined,
       { force: true, lastCompactedAt: this.contextCompactedAt ?? undefined },
     );
+    // Track circuit-breaker state for user-initiated `/compact` and other
+    // forced paths so a successful forced compaction clears a stuck counter
+    // and a run of forced failures still trips the breaker. `summaryFailed`
+    // is `undefined` on early-return paths (no eligible messages, disabled,
+    // etc.) — skip those so they don't silently reset the counter.
+    if (result.summaryFailed !== undefined) {
+      trackCompactionOutcome(this, result.summaryFailed, this.sendToClient);
+    }
     if (result.compacted) {
       this.messages = result.messages;
       this.contextCompactedMessageCount += result.compactedPersistedMessages;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -190,6 +190,19 @@ export class Conversation {
   /** @internal */ contextWindowManager: ContextWindowManager;
   /** @internal */ contextCompactedMessageCount = 0;
   /** @internal */ contextCompactedAt: number | null = null;
+  /**
+   * Tracks consecutive compaction failures (summary LLM call threw). In-memory
+   * only — resets to 0 on process restart, which is the intended "one free
+   * retry after restart" behavior. Reset to 0 on any successful compaction.
+   */
+  /** @internal */ consecutiveCompactionFailures = 0;
+  /**
+   * When the circuit breaker is open, this timestamp (ms since epoch) marks
+   * when auto-compaction is allowed to resume. Set to `Date.now() + 1h` after
+   * 3 consecutive failures; cleared on a successful compaction. User-initiated
+   * compaction (`force: true`) bypasses the breaker regardless.
+   */
+  /** @internal */ compactionCircuitOpenUntil: number | null = null;
   /** @internal */ currentRequestId?: string;
   /** @internal */ hasNoClient = false;
   /** @internal */ isSubagent = false;
@@ -447,7 +460,9 @@ export class Conversation {
     // through to `providerConfig.model` on every turn.
     const resolvedModel: string | undefined =
       modelOverride ??
-      (modelIntent ? resolveModelIntent(provider.name, modelIntent) : undefined);
+      (modelIntent
+        ? resolveModelIntent(provider.name, modelIntent)
+        : undefined);
 
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -434,6 +434,19 @@ export interface ContextCompacted {
   summaryModel: string;
 }
 
+/**
+ * Emitted when the compaction circuit breaker trips. After three consecutive
+ * summary-LLM failures (with local fallback covering each), auto-compaction is
+ * suspended until `openUntil` to avoid repeatedly hammering a broken provider.
+ * User-initiated compaction (`/compact`, `force: true`) bypasses the breaker.
+ */
+export interface CompactionCircuitOpen {
+  type: "compaction_circuit_open";
+  reason: "3_consecutive_failures";
+  /** Timestamp (ms since epoch) when the breaker will allow auto-compaction again. */
+  openUntil: number;
+}
+
 export type ConversationErrorCode =
   | "PROVIDER_NETWORK"
   | "PROVIDER_RATE_LIMIT"
@@ -531,6 +544,7 @@ export type _ConversationsServerMessages =
   | UsageUpdate
   | UsageResponse
   | ContextCompacted
+  | CompactionCircuitOpen
   | ConversationErrorMessage
   | ConversationInfo
   | ConversationTitleUpdated


### PR DESCRIPTION
## Summary
- Track consecutiveCompactionFailures and compactionCircuitOpenUntil on Conversation (in-memory)
- summaryFailed bit on ContextWindowResult lets callers distinguish LLM failure from fallback success
- Circuit opens for 1h after 3 consecutive failures; force:true bypasses

Part of plan: compaction-simplification.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
