### PR TITLE
[openai] Route inference-provider-native web search to Responses native web_search tool

### DIFF
--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -313,6 +313,90 @@ describe("Cross-Provider Web Search — OpenAI (Responses API)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// OpenAI Responses API — native web search tool mapping
+// ---------------------------------------------------------------------------
+
+describe("Cross-Provider Web Search — OpenAI (Responses API, native mode)", () => {
+  beforeEach(() => {
+    lastOpenAIResponsesParams = null;
+  });
+
+  test("maps web_search to native web_search_preview tool when useNativeWebSearch is enabled", async () => {
+    const provider = new OpenAIResponsesProvider("sk-test", "gpt-4o", {
+      useNativeWebSearch: true,
+    });
+
+    const tools = [
+      {
+        name: "file_read",
+        description: "Read a file",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+        },
+      },
+      {
+        name: "web_search",
+        description: "Search the web",
+        input_schema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      },
+    ];
+
+    await provider.sendMessage([userMsg("Search for something")], tools);
+
+    const sentTools = lastOpenAIResponsesParams!.tools as Array<
+      Record<string, unknown>
+    >;
+    expect(sentTools).toHaveLength(2);
+    // Non-web-search tools stay as function tools
+    expect(sentTools[0]).toMatchObject({ type: "function", name: "file_read" });
+    // web_search is replaced with native hosted tool
+    expect(sentTools[1]).toEqual({ type: "web_search_preview" });
+  });
+
+  test("still degrades web search history blocks in native mode", async () => {
+    const provider = new OpenAIResponsesProvider("sk-test", "gpt-4o", {
+      useNativeWebSearch: true,
+    });
+    await provider.sendMessage(webSearchConversation());
+
+    const input = lastOpenAIResponsesParams!.input as Array<{
+      type: string;
+      role?: string;
+      content?: Array<{ type: string; text?: string }>;
+    }>;
+
+    // server_tool_use in assistant history is still degraded to text placeholder
+    const assistantItems = input.filter(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    const hasWebSearchPlaceholder = assistantItems.some((item) =>
+      item.content?.some(
+        (part) =>
+          part.type === "output_text" &&
+          part.text?.includes("[Web search: web_search]"),
+      ),
+    );
+    expect(hasWebSearchPlaceholder).toBe(true);
+
+    // web_search_tool_result in user history is still degraded to text placeholder
+    const userItems = input.filter(
+      (item) => item.type === "message" && item.role === "user",
+    );
+    const hasWebSearchResult = userItems.some((item) =>
+      item.content?.some(
+        (part) =>
+          part.type === "input_text" && part.text === "[Web search results]",
+      ),
+    );
+    expect(hasWebSearchResult).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // OpenAI Chat Completions compatibility provider tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -1116,3 +1116,130 @@ describe("OpenAIResponsesProvider", () => {
     expect(result.stopReason).toBe("incomplete");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Native web search tool mapping
+// ---------------------------------------------------------------------------
+
+describe("OpenAIResponsesProvider — Native Web Search", () => {
+  const webSearchTool: ToolDefinition = {
+    name: "web_search",
+    description: "Search the web",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+    },
+  };
+
+  const fileReadTool: ToolDefinition = {
+    name: "file_read",
+    description: "Read a file",
+    input_schema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  };
+
+  beforeEach(() => {
+    fakeStreamEvents = [];
+    lastStreamParams = null;
+    lastStreamOptions = null;
+    lastConstructorOptions = null;
+    shouldThrow = null;
+  });
+
+  test("maps web_search to native web_search_preview tool when useNativeWebSearch is enabled", async () => {
+    const nativeProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.2", {
+      useNativeWebSearch: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await nativeProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Search for cats" }] }],
+      [webSearchTool],
+    );
+
+    const sentTools = lastStreamParams!.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(1);
+    expect(sentTools[0]).toEqual({ type: "web_search_preview" });
+  });
+
+  test("keeps web_search as function tool when useNativeWebSearch is disabled", async () => {
+    const nonNativeProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.2");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await nonNativeProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Search for cats" }] }],
+      [webSearchTool],
+    );
+
+    const sentTools = lastStreamParams!.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(1);
+    expect(sentTools[0]).toEqual({
+      type: "function",
+      name: "web_search",
+      description: "Search the web",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+      strict: null,
+    });
+  });
+
+  test("mixes native web_search_preview with regular function tools", async () => {
+    const nativeProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.2", {
+      useNativeWebSearch: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await nativeProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Search and read" }] }],
+      [fileReadTool, webSearchTool],
+    );
+
+    const sentTools = lastStreamParams!.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(2);
+    // Non-web-search tools remain as function tools
+    expect(sentTools[0]).toEqual({
+      type: "function",
+      name: "file_read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+      strict: null,
+    });
+    // web_search is mapped to native tool
+    expect(sentTools[1]).toEqual({ type: "web_search_preview" });
+  });
+
+  test("sends all tools as function tools when no web_search is present and native mode is on", async () => {
+    const nativeProvider = new OpenAIResponsesProvider("sk-test", "gpt-5.2", {
+      useNativeWebSearch: true,
+    });
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await nativeProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Read file" }] }],
+      [fileReadTool],
+    );
+
+    const sentTools = lastStreamParams!.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(1);
+    expect(sentTools[0]).toEqual({
+      type: "function",
+      name: "file_read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+      strict: null,
+    });
+  });
+});

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -20,6 +20,7 @@ export interface OpenAIResponsesProviderOptions {
   providerName?: string;
   providerLabel?: string;
   streamTimeoutMs?: number;
+  useNativeWebSearch?: boolean;
 }
 
 /** Map our internal effort values to the Responses API reasoning.effort parameter.
@@ -77,6 +78,7 @@ export class OpenAIResponsesProvider implements Provider {
   private client: OpenAI;
   private model: string;
   private streamTimeoutMs: number;
+  private useNativeWebSearch: boolean;
 
   constructor(
     apiKey: string,
@@ -91,6 +93,7 @@ export class OpenAIResponsesProvider implements Provider {
     });
     this.model = model;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
+    this.useNativeWebSearch = options.useNativeWebSearch ?? false;
   }
 
   async sendMessage(
@@ -133,13 +136,31 @@ export class OpenAIResponsesProvider implements Provider {
       }
 
       if (tools && tools.length > 0) {
-        params.tools = tools.map((t) => ({
-          type: "function" as const,
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema,
-          strict: null,
-        }));
+        if (
+          this.useNativeWebSearch &&
+          tools.some((t) => t.name === "web_search")
+        ) {
+          const otherTools = tools.filter((t) => t.name !== "web_search");
+          const mappedOther = otherTools.map((t) => ({
+            type: "function" as const,
+            name: t.name,
+            description: t.description,
+            parameters: t.input_schema,
+            strict: null,
+          }));
+          const webSearchTool = {
+            type: "web_search_preview" as const,
+          };
+          params.tools = [...mappedOther, webSearchTool];
+        } else {
+          params.tools = tools.map((t) => ({
+            type: "function" as const,
+            name: t.name,
+            description: t.description,
+            parameters: t.input_schema,
+            strict: null,
+          }));
+        }
       }
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -175,6 +175,7 @@ export async function initializeProviders(
       "openai",
       new RetryProvider(
         new OpenAIResponsesProvider(openaiCreds.apiKey, model, {
+          useNativeWebSearch,
           streamTimeoutMs,
           ...(openaiCreds.baseURL ? { baseURL: openaiCreds.baseURL } : {}),
         }),


### PR DESCRIPTION
## Summary
- Thread useNativeWebSearch into OpenAIResponsesProvider options
- Map web_search tool to OpenAI native hosted web search descriptor when native mode enabled
- Maintain backward compatibility when native mode is off
- Add provider and cross-provider tests for native web search behavior

Part of plan: managed-openai-native-web-search.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
