### PR TITLE
feat(home): add HomeInvoicePreview body content for the Home detail side panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeInvoicePreview.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeInvoicePreview.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Pure body content for the Home detail side panel's invoice/document
+/// preview variant.
+///
+/// Renders a supplied `NSImage` scaled to fit the available width, or a
+/// placeholder block (document icon + caption) when no image is available
+/// yet. Matches Figma mock node `3216:63118` — the Slack invoice
+/// screenshot shown inside the auth/invoice side-panel variant.
+///
+/// This view is intentionally just body content: the enclosing
+/// `HomeDetailPanel` chrome supplies the header, action buttons, and
+/// dismiss affordance, so this component takes no header / title /
+/// action / dismiss props.
+struct HomeInvoicePreview: View {
+    let image: NSImage?
+    let placeholderCaption: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity, alignment: .top)
+            } else {
+                VStack(spacing: VSpacing.sm) {
+                    VIconView(.file, size: 32)
+                        .foregroundStyle(VColor.contentDisabled)
+                    Text(placeholderCaption ?? "Invoice preview unavailable")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, minHeight: 400, alignment: .center)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.xl, style: .continuous)
+                        .fill(VColor.surfaceOverlay)
+                )
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.lg)
+        .frame(maxWidth: .infinity)
+    }
+}


### PR DESCRIPTION
## Summary
- New `HomeInvoicePreview` pure body component in Features/Home/DetailPanel, displaying a document/invoice image or a placeholder when no image is supplied.
- Matches Figma node 3216:63118 (Slack invoice screenshot in the auth/invoice side panel variant).
- Pure body content — no header, actions, or dismiss props. Hosted inside `HomeDetailPanel` (PR 2).

Part of plan: home-detail-panel.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
