### PR TITLE
fix: remove stale forward-reference comment in trust-rule types

### DIFF
--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -8,9 +8,6 @@ import type { TrustRuleBase } from "@vellumai/ces-contracts";
  * don't carry `executionTarget` or `allowHighRisk`. To maintain backward
  * compatibility with existing callsites that access those fields on any rule,
  * we flatten the union here by intersecting the base with the optional fields.
- *
- * PR 4 of this plan will tighten callsites to narrow the union properly,
- * at which point this re-export can be simplified to a direct re-export.
  */
 export type TrustRule = TrustRuleBase & {
   executionTarget?: string;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-rule-union-compat.md.

**Gap:** Stale forward-reference comment in types.ts
**What was expected:** Comment should not reference future changes that did not occur
**What was found:** Comment still said 'PR 4 will tighten callsites'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
