### PR TITLE
fix: canonicalize trust-rule payloads in update route handlers

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { parseTrustFileData } from "@vellumai/ces-contracts";
+import { parseTrustFileData, parseTrustRule } from "@vellumai/ces-contracts";
 import { Minimatch } from "minimatch";
 import { v4 as uuid } from "uuid";
 
@@ -475,12 +475,18 @@ function fileUpdateRule(
   const rules = [...getRules()];
   const index = rules.findIndex((r) => r.id === id);
   if (index === -1) throw new Error(`Trust rule not found: ${id}`);
-  const rule = { ...rules[index] };
-  if (updates.tool != null) rule.tool = updates.tool;
-  if (updates.pattern != null) rule.pattern = updates.pattern;
-  if (updates.scope != null) rule.scope = updates.scope;
-  if (updates.decision != null) rule.decision = updates.decision;
-  if (updates.priority != null) rule.priority = updates.priority;
+  const merged = { ...rules[index] };
+  if (updates.tool != null) merged.tool = updates.tool;
+  if (updates.pattern != null) merged.pattern = updates.pattern;
+  if (updates.scope != null) merged.scope = updates.scope;
+  if (updates.decision != null) merged.decision = updates.decision;
+  if (updates.priority != null) merged.priority = updates.priority;
+
+  // Canonicalize through parseTrustRule so that fields invalid for the
+  // (potentially changed) tool family are stripped. For example, if a rule's
+  // tool is changed from "bash" to "web_fetch", executionTarget and
+  // allowHighRisk are dropped because URL-family tools don't support them.
+  const { rule } = parseTrustRule(merged as unknown as Record<string, unknown>);
   rules[index] = rule;
   rules.sort(ruleOrder);
   cachedRules = rules;

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -24,7 +24,10 @@ import type {
   TrustFileData,
   TrustRule,
 } from "@vellumai/ces-contracts/trust-rules";
-import { parseTrustFileData } from "@vellumai/ces-contracts/trust-rules";
+import {
+  parseTrustFileData,
+  parseTrustRule,
+} from "@vellumai/ces-contracts/trust-rules";
 
 import { getLogger } from "./logger.js";
 import { getGatewaySecurityDir } from "./paths.js";
@@ -392,12 +395,18 @@ export function updateRule(
   const rules = [...getRules()];
   const index = rules.findIndex((r) => r.id === id);
   if (index === -1) throw new Error(`Trust rule not found: ${id}`);
-  const rule = { ...rules[index] };
-  if (updates.tool != null) rule.tool = updates.tool;
-  if (updates.pattern != null) rule.pattern = updates.pattern;
-  if (updates.scope != null) rule.scope = updates.scope;
-  if (updates.decision != null) rule.decision = updates.decision;
-  if (updates.priority != null) rule.priority = updates.priority;
+  const merged = { ...rules[index] };
+  if (updates.tool != null) merged.tool = updates.tool;
+  if (updates.pattern != null) merged.pattern = updates.pattern;
+  if (updates.scope != null) merged.scope = updates.scope;
+  if (updates.decision != null) merged.decision = updates.decision;
+  if (updates.priority != null) merged.priority = updates.priority;
+
+  // Canonicalize through parseTrustRule so that fields invalid for the
+  // (potentially changed) tool family are stripped. For example, if a rule's
+  // tool is changed from "bash" to "web_fetch", executionTarget and
+  // allowHighRisk are dropped because URL-family tools don't support them.
+  const { rule } = parseTrustRule(merged as unknown as Record<string, unknown>);
   rules[index] = rule;
   rules.sort(ruleOrder);
   cachedRules = rules;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-rule-union-compat.md.

**Gap:** Gateway and assistant update routes don't canonicalize
**What was expected:** Update handlers should canonicalize like add handlers
**What was found:** Raw update fields passed directly without parseTrustRule
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
