### PR TITLE
fix: centralize trust-rule canonicalization in addRule/updateRule

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -423,11 +423,11 @@ function fileAddRule(
 ): TrustRule {
   if (tool.startsWith("__internal:"))
     throw new Error(`Cannot create internal pseudo-rule via addRule: ${tool}`);
-  // Re-read from disk to avoid lost updates if another call modified rules
-  // between our last read and now (e.g. two rapid trust rule additions).
-  cachedRules = null;
-  const rules = [...getRules()];
-  const rule: TrustRule = {
+
+  // Canonicalize through the shared parser so fields invalid for the tool's
+  // family are stripped before persistence, regardless of which callsite
+  // invoked addRule.
+  const { rule: canonical } = parseTrustRule({
     id: uuid(),
     tool,
     pattern,
@@ -441,7 +441,13 @@ function fileAddRule(
     ...(options?.executionTarget != null
       ? { executionTarget: options.executionTarget }
       : {}),
-  };
+  });
+  const rule = canonical as TrustRule;
+
+  // Re-read from disk to avoid lost updates if another call modified rules
+  // between our last read and now (e.g. two rapid trust rule additions).
+  cachedRules = null;
+  const rules = [...getRules()];
   rules.push(rule);
   rules.sort(ruleOrder);
   cachedRules = rules;
@@ -1011,15 +1017,46 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       throw new Error(
         `Cannot create internal pseudo-rule via addRule: ${tool}`,
       );
-    this.ensureInitialized();
-    const rule = trustClient.addRuleSync({
+
+    // Canonicalize through the shared parser so fields invalid for the tool's
+    // family are stripped before sending to the gateway.
+    const { rule: canonical } = parseTrustRule({
+      id: "",
       tool,
       pattern,
       scope,
       decision,
       priority,
-      allowHighRisk: options?.allowHighRisk,
-      executionTarget: options?.executionTarget,
+      createdAt: 0,
+      ...(options?.allowHighRisk != null
+        ? { allowHighRisk: options.allowHighRisk }
+        : {}),
+      ...(options?.executionTarget != null
+        ? { executionTarget: options.executionTarget }
+        : {}),
+    });
+    const canonicalOpts: { allowHighRisk?: boolean; executionTarget?: string } =
+      {};
+    if ("allowHighRisk" in canonical) {
+      canonicalOpts.allowHighRisk = (
+        canonical as { allowHighRisk?: boolean }
+      ).allowHighRisk;
+    }
+    if ("executionTarget" in canonical) {
+      canonicalOpts.executionTarget = (
+        canonical as { executionTarget?: string }
+      ).executionTarget;
+    }
+
+    this.ensureInitialized();
+    const rule = trustClient.addRuleSync({
+      tool: canonical.tool,
+      pattern: canonical.pattern,
+      scope: canonical.scope,
+      decision: canonical.decision,
+      priority: canonical.priority,
+      allowHighRisk: canonicalOpts.allowHighRisk,
+      executionTarget: canonicalOpts.executionTarget,
     });
     // Update local cache
     this.rules = [...this.rules, rule].sort(ruleOrder);
@@ -1044,6 +1081,23 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
         `Cannot update tool to internal pseudo-rule: ${updates.tool}`,
       );
     this.ensureInitialized();
+
+    // Canonicalize the merged rule so fields invalid for the (possibly new)
+    // tool family are stripped before sending to the gateway.
+    const existing = this.rules.find((r) => r.id === id);
+    if (existing) {
+      const merged = { ...existing, ...updates };
+      const { rule: canonical } = parseTrustRule(merged);
+      // Send the canonical fields as the update
+      updates = {
+        tool: canonical.tool,
+        pattern: canonical.pattern,
+        scope: canonical.scope,
+        decision: canonical.decision,
+        priority: canonical.priority,
+      };
+    }
+
     const rule = trustClient.updateRuleSync(id, updates);
     // Update local cache
     const idx = this.rules.findIndex((r) => r.id === id);

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,7 +8,6 @@
  * header. Guardian decisions additionally verify that the actor is the
  * bound guardian.
  */
-import { parseTrustRule } from "@vellumai/ces-contracts";
 import { z } from "zod";
 
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
@@ -398,39 +397,11 @@ export async function handleTrustRule(
     const executionTarget =
       tool?.origin === "skill" ? confirmation.executionTarget : undefined;
 
-    // Canonicalize through the shared parser so fields invalid for the tool's
-    // family are stripped before persistence. The `always_allow_high_risk`
-    // decision maps to `allowHighRisk: true` on the persisted rule for scoped
-    // and generic tool families; the parser strips it for families that don't
-    // support it (URL, managed-skill, skill-load).
-    const { rule: canonical } = parseTrustRule({
-      id: "",
-      tool: confirmation.toolName,
-      pattern,
-      scope,
-      decision,
-      priority: 100,
-      createdAt: 0,
+    // Canonicalization is handled inside addRule — no need to pre-parse here.
+    addRule(confirmation.toolName, pattern, scope, decision, undefined, {
       ...(allowHighRisk ? { allowHighRisk: true } : {}),
       ...(executionTarget != null ? { executionTarget } : {}),
     });
-    const canonicalOpts =
-      "allowHighRisk" in canonical || "executionTarget" in canonical
-        ? {
-            allowHighRisk: (canonical as { allowHighRisk?: boolean })
-              .allowHighRisk,
-            executionTarget: (canonical as { executionTarget?: string })
-              .executionTarget,
-          }
-        : undefined;
-    addRule(
-      canonical.tool,
-      canonical.pattern,
-      canonical.scope,
-      canonical.decision,
-      undefined,
-      canonicalOpts,
-    );
     log.info(
       { tool: confirmation.toolName, pattern, scope, decision, requestId },
       "Trust rule added via HTTP (bound to pending confirmation)",

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -5,12 +5,11 @@
  * the approval-flow trust-rule endpoint in approval-routes.ts.
  * All endpoints are bearer-token authenticated (standard runtime auth).
  *
- * Payloads are canonicalized through the shared `parseTrustRule` parser
- * before persistence: legacy clients can keep sending current shapes
- * without 4xx regressions, but fields invalid for a tool's family
- * (e.g. `executionTarget` on a URL-tool rule) are silently stripped.
+ * Canonicalization is handled centrally inside `addRule`/`updateRule` in
+ * trust-store.ts: legacy clients can keep sending current shapes without
+ * 4xx regressions, but fields invalid for a tool's family (e.g.
+ * `executionTarget` on a URL-tool rule) are silently stripped.
  */
-import { parseTrustRule } from "@vellumai/ces-contracts";
 import { z } from "zod";
 
 import {
@@ -86,37 +85,19 @@ export async function handleAddTrustRuleManage(
   }
 
   try {
-    // Canonicalize through the shared parser so fields invalid for the tool's
-    // family are stripped before persistence. Legacy callers that send e.g.
-    // executionTarget on a URL-tool rule won't get a 4xx — the field is simply
-    // dropped during normalization.
-    const { rule: canonical } = parseTrustRule({
-      id: "",
-      tool: toolName,
+    // Canonicalization is handled inside addRule — no need to pre-parse here.
+    // Legacy callers that send e.g. executionTarget on a URL-tool rule won't
+    // get a 4xx — the field is simply dropped during normalization in addRule.
+    addRule(
+      toolName,
       pattern,
       scope,
-      decision,
-      priority: 100,
-      createdAt: 0,
-      ...(allowHighRisk != null ? { allowHighRisk } : {}),
-      ...(executionTarget != null ? { executionTarget } : {}),
-    });
-    const canonicalOpts =
-      "allowHighRisk" in canonical || "executionTarget" in canonical
-        ? {
-            allowHighRisk: (canonical as { allowHighRisk?: boolean })
-              .allowHighRisk,
-            executionTarget: (canonical as { executionTarget?: string })
-              .executionTarget,
-          }
-        : undefined;
-    addRule(
-      canonical.tool,
-      canonical.pattern,
-      canonical.scope,
-      canonical.decision,
+      decision as "allow" | "deny" | "ask",
       undefined,
-      canonicalOpts,
+      {
+        ...(allowHighRisk != null ? { allowHighRisk } : {}),
+        ...(executionTarget != null ? { executionTarget } : {}),
+      },
     );
     log.info(
       { toolName, pattern, scope, decision },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for trust-rule-union-compat.md.

**Gap:** Multiple assistant addRule callsites skip canonicalization
**What was expected:** All trust rules should be canonicalized before persistence
**What was found:** Only route handlers canonicalize; internal callers bypass it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
