### PR TITLE
[macOS] Allow provider-native web search when managed inference provider supports it

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -59,7 +59,7 @@ struct InferenceServiceCard: View {
 
         // Switching to Your Own inference while web search is Managed
         // (managed web search requires managed inference).
-        if draftMode == "your-own" && store.webSearchMode == "managed" {
+        if modeChanging && draftMode == "your-own" && store.webSearchMode == "managed" {
             return true
         }
         // Switching to Managed inference while web search uses Provider Native —

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -64,14 +64,16 @@ struct InferenceServiceCard: View {
         }
         // Switching to Managed inference while web search uses Provider Native —
         // only invalidate when the resulting provider cannot support native web search.
-        if draftMode == "managed" && store.webSearchProvider == "inference-provider-native" {
+        // Skip when web search is in managed mode (webSearchProvider is stale).
+        if draftMode == "managed" && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
             if !store.isNativeWebSearchCapable(draftProvider) {
                 return true
             }
         }
         // Switching providers while web search uses Provider Native — invalidate
         // when the new provider cannot support native web search.
-        if providerChanging && store.webSearchProvider == "inference-provider-native" {
+        // Skip when web search is in managed mode (webSearchProvider is stale).
+        if providerChanging && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
             if !store.isNativeWebSearchCapable(draftProvider) {
                 return true
             }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -302,7 +302,7 @@ struct InferenceServiceCard: View {
             Button("Continue") { performSave() }
         } message: {
             Text(
-                "Changing your inference mode will also update your Web Search settings."
+                "Changing your inference settings will also update your Web Search settings."
                     + " You'll need to review and save them below."
             )
         }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -51,20 +51,30 @@ struct InferenceServiceCard: View {
         authManager.isAuthenticated
     }
 
-    /// True when changing inference mode would invalidate the current web search config.
+    /// True when changing inference mode/provider would invalidate the current web search config.
     private var wouldInvalidateWebSearch: Bool {
         let modeChanging = draftMode != store.inferenceMode
-        guard modeChanging else { return false }
+        let providerChanging = draftProvider != store.selectedInferenceProvider
+        guard modeChanging || providerChanging else { return false }
 
         // Switching to Your Own inference while web search is Managed
         // (managed web search requires managed inference).
         if draftMode == "your-own" && store.webSearchMode == "managed" {
             return true
         }
-        // Switching to Managed inference while web search uses Provider Native
-        // (Provider Native requires Your Own inference).
+        // Switching to Managed inference while web search uses Provider Native —
+        // only invalidate when the resulting provider cannot support native web search.
         if draftMode == "managed" && store.webSearchProvider == "inference-provider-native" {
-            return true
+            if !store.isNativeWebSearchCapable(draftProvider) {
+                return true
+            }
+        }
+        // Switching providers while web search uses Provider Native — invalidate
+        // when the new provider cannot support native web search.
+        if providerChanging && store.webSearchProvider == "inference-provider-native" {
+            if !store.isNativeWebSearchCapable(draftProvider) {
+                return true
+            }
         }
         return false
     }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -7,8 +7,9 @@ import VellumAssistantShared
 /// - **Managed + Managed inference + logged in**: Message that web search is included.
 /// - **Managed + Managed inference + not logged in**: Login prompt.
 /// - **Managed + Your Own inference**: Message that managed web search is not yet available.
-/// - **Your Own + Your Own inference**: Provider picker (Provider Native, Perplexity, Brave) + API key.
-/// - **Your Own + Managed inference**: Provider picker (Perplexity, Brave only) + API key.
+/// - **Your Own**: Provider picker + API key. Provider Native is available whenever the
+///   inference provider supports native web search (e.g. Anthropic, OpenAI), regardless of
+///   inference mode. Perplexity and Brave are always available as key-based alternatives.
 @MainActor
 struct WebSearchServiceCard: View {
     @ObservedObject var store: SettingsStore
@@ -44,10 +45,11 @@ struct WebSearchServiceCard: View {
         authManager.isAuthenticated
     }
 
-    /// The available providers depend on the current inference mode.
-    /// Provider Native requires Your Own inference (it uses the user's own API key).
+    /// The available providers depend on the current inference provider's capabilities.
+    /// Provider Native is available whenever the inference provider supports native web search
+    /// (e.g. Anthropic, OpenAI), regardless of whether inference is managed or your-own.
     private var availableProviders: [String] {
-        store.inferenceMode == "your-own"
+        store.isNativeWebSearchCapable(store.selectedInferenceProvider)
             ? ["inference-provider-native", "perplexity", "brave"]
             : ["perplexity", "brave"]
     }
@@ -156,7 +158,16 @@ struct WebSearchServiceCard: View {
                 draftMode = "your-own"
             }
             if newValue == "managed" && draftProvider == "inference-provider-native" {
-                // Provider Native requires Your Own inference.
+                // Only auto-correct when the managed provider lacks native web search support.
+                if !store.isNativeWebSearchCapable(store.selectedInferenceProvider) {
+                    draftProvider = "perplexity"
+                }
+            }
+        }
+        .onChange(of: store.selectedInferenceProvider) { _, newProvider in
+            // Auto-correct when the inference provider changes to one that
+            // does not support native web search while provider-native is selected.
+            if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(newProvider) {
                 draftProvider = "perplexity"
             }
         }

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
@@ -158,6 +158,70 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
                        "expected gemini to be persisted as the inference provider, got: \(providerPatches)")
     }
 
+    // MARK: - Managed Provider + Native Web Search Capability Gating
+
+    func testManagedOpenAIPlusProviderNativeIsValid() {
+        // OpenAI is both managed-capable and native-web-search-capable,
+        // so managed inference + inference-provider-native should be allowed.
+        XCTAssertTrue(store.isManagedCapable("openai"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("openai"))
+    }
+
+    func testManagedAnthropicPlusProviderNativeIsValid() {
+        // Anthropic is both managed-capable and native-web-search-capable.
+        XCTAssertTrue(store.isManagedCapable("anthropic"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("anthropic"))
+    }
+
+    func testManagedGeminiPlusProviderNativeIsInvalid() {
+        // Gemini is managed-capable but NOT native-web-search-capable,
+        // so managed Gemini + inference-provider-native should be rejected.
+        XCTAssertTrue(store.isManagedCapable("gemini"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("gemini"))
+    }
+
+    func testManagedOpenAIProviderNativeWebSearchCanBePersisted() {
+        let mockClient = MockSettingsClient()
+        mockClient.patchConfigResponse = true
+        let testStore = SettingsStore(settingsClient: mockClient)
+
+        // Configure managed OpenAI inference + provider-native web search
+        testStore.selectedInferenceProvider = "openai"
+        testStore.inferenceMode = "managed"
+        testStore.webSearchProvider = "inference-provider-native"
+
+        // Persist the web search provider
+        testStore.setWebSearchProvider("inference-provider-native")
+
+        let predicate = NSPredicate { _, _ in
+            mockClient.patchConfigCalls.count >= 1
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        // Verify inference-provider-native was persisted (not rewritten to perplexity)
+        let webSearchPatches = mockClient.patchConfigCalls.compactMap { call -> String? in
+            guard let services = call["services"] as? [String: Any],
+                  let webSearch = services["web-search"] as? [String: Any],
+                  let provider = webSearch["provider"] as? String else {
+                return nil
+            }
+            return provider
+        }
+        XCTAssertTrue(webSearchPatches.contains("inference-provider-native"),
+                       "expected inference-provider-native to be persisted with managed OpenAI, got: \(webSearchPatches)")
+    }
+
+    func testNonNativeWebSearchCapableProviderFallsBackToPerplexity() {
+        // When the inference provider doesn't support native web search,
+        // isNativeWebSearchCapable should return false, indicating the UI
+        // should enforce fallback to perplexity or brave.
+        XCTAssertFalse(store.isNativeWebSearchCapable("gemini"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("ollama"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("fireworks"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter"))
+    }
+
     // MARK: - Model Validation Against Selected Provider
 
     func testOpenAIModelsAreAvailableForOpenAIProvider() {


### PR DESCRIPTION
## Summary
- Update InferenceServiceCard.wouldInvalidateWebSearch for capability-based checks
- Allow inference-provider-native in WebSearchServiceCard when provider supports it
- Remove unconditional managed-mode rewrite to perplexity
- Extend tests for capability gating with managed OpenAI + provider-native

Part of plan: managed-openai-native-web-search.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
