### PR TITLE
feat(home): add HomeEmailEditor body content for the Home detail side panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -55,7 +55,6 @@ struct HomeEmailEditor: View {
                 .frame(minHeight: 240, alignment: .topLeading)
                 .padding(VSpacing.md)
 
-            Spacer(minLength: 0)
 
             if !attachments.isEmpty {
                 Divider()

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Pure body content for the Home detail side panel's email composer
+/// variant.
+///
+/// Matches Figma node `3216:63021` — formatting toolbar, divider,
+/// To/Subject labeled fields, editable body text, and a horizontal
+/// scroll of attachment chips at the bottom. The enclosing
+/// `HomeDetailPanel` chrome supplies the header, title, action buttons,
+/// and dismiss affordance, so this component takes no header / title /
+/// action / dismiss props — it's slotted directly into the panel's
+/// `content:` closure.
+struct HomeEmailEditor: View {
+
+    struct Attachment: Identifiable, Hashable {
+        let id: UUID
+        let fileName: String
+        let fileSize: String
+    }
+
+    @Binding var toAddress: String
+    @Binding var subject: String
+    @Binding var bodyText: String
+    let attachments: [Attachment]
+    let onAttachmentTap: (Attachment) -> Void
+    var onFormatAction: (VFormattingToolbar.Action) -> Void = { _ in }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VFormattingToolbar(onAction: onFormatAction)
+
+            Divider()
+                .background(VColor.borderBase)
+
+            VStack(alignment: .leading, spacing: 0) {
+                labeledField("to:", $toAddress)
+
+                Divider()
+                    .background(VColor.borderBase)
+
+                labeledField("subject:", $subject)
+
+                Divider()
+                    .background(VColor.borderBase)
+            }
+
+            TextField("Compose your reply…", text: $bodyText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(VColor.contentDefault)
+                .frame(minHeight: 240, alignment: .topLeading)
+                .padding(VSpacing.md)
+
+            Spacer(minLength: 0)
+
+            if !attachments.isEmpty {
+                Divider()
+                    .background(VColor.borderBase)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Attachments")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: VSpacing.sm) {
+                            ForEach(attachments) { att in
+                                HomeLinkFileRow(
+                                    icon: .file,
+                                    fileName: att.fileName,
+                                    fileSize: att.fileSize
+                                )
+                                .onTapGesture { onAttachmentTap(att) }
+                                .accessibilityAddTraits(.isButton)
+                                .accessibilityLabel("\(att.fileName), \(att.fileSize)")
+                            }
+                        }
+                    }
+                }
+                .padding(EdgeInsets(
+                    top: VSpacing.sm,
+                    leading: VSpacing.lg,
+                    bottom: VSpacing.lg,
+                    trailing: VSpacing.lg
+                ))
+            }
+        }
+    }
+
+    // MARK: - Labeled field
+
+    @ViewBuilder
+    private func labeledField(_ label: String, _ value: Binding<String>) -> some View {
+        TextField(label, text: value)
+            .textFieldStyle(.plain)
+            .font(VFont.bodyMediumLighter)
+            .foregroundStyle(VColor.contentSecondary)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -32,17 +32,20 @@ struct HomeEmailEditor: View {
 
             Divider()
                 .background(VColor.borderBase)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 0) {
                 labeledField("to:", $toAddress)
 
                 Divider()
                     .background(VColor.borderBase)
+                    .accessibilityHidden(true)
 
                 labeledField("subject:", $subject)
 
                 Divider()
                     .background(VColor.borderBase)
+                    .accessibilityHidden(true)
             }
 
             TextField("Compose your reply…", text: $bodyText, axis: .vertical)
@@ -57,6 +60,7 @@ struct HomeEmailEditor: View {
             if !attachments.isEmpty {
                 Divider()
                     .background(VColor.borderBase)
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Attachments")
@@ -72,8 +76,10 @@ struct HomeEmailEditor: View {
                                     fileSize: att.fileSize
                                 )
                                 .onTapGesture { onAttachmentTap(att) }
+                                .accessibilityElement(children: .combine)
                                 .accessibilityAddTraits(.isButton)
                                 .accessibilityLabel("\(att.fileName), \(att.fileSize)")
+                                .accessibilityAction { onAttachmentTap(att) }
                             }
                         }
                     }
@@ -96,7 +102,6 @@ struct HomeEmailEditor: View {
             .textFieldStyle(.plain)
             .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentSecondary)
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
+            .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
     }
 }


### PR DESCRIPTION
## Summary
- New `HomeEmailEditor` pure body component: formatting toolbar, editable To/Subject fields, body text, attachment chips.
- No header / title / dismiss props — pure body content hosted inside `HomeDetailPanel` at the call site.

Part of plan: home-detail-panel.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
