### PR TITLE
fix: IPC timeout for browser operations, JSDoc accuracy, and misleading comments

### DIFF
--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -196,7 +196,8 @@ const DISPATCH_HANDLERS: Record<BrowserOperation, OperationHandler> = {
  * @param input     - Flat input object matching the operation's field schema.
  * @param context   - Tool execution context (conversation ID, signal, etc.).
  * @returns The tool execution result from the underlying handler.
- * @throws If the operation identifier is not recognized.
+ *   If the operation identifier is not recognized, returns an error
+ *   result (`isError: true`) rather than throwing.
  */
 export async function executeBrowserOperation(
   operation: BrowserOperation,
@@ -220,8 +221,8 @@ export async function executeBrowserOperation(
  * constraints. Used by the CLI command builder to generate subcommands.
  *
  * The `browser_mode` and `activity` fields are omitted from per-operation
- * metadata because they are common to all operations and handled by the
- * CLI framework as global options.
+ * metadata because they are not exposed through the CLI. Operations
+ * invoked via the CLI always use the default browser mode.
  */
 export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
   {

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -154,6 +154,9 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
       }
     }
 
+    // Browser operations can be long-running (page loads, auth
+    // challenges, downloads up to 120s, etc.), so use a generous
+    // IPC timeout that exceeds any server-side operation timeout.
     const ipcResult = await cliIpcCall<BrowserExecuteResult>(
       "browser_execute",
       {
@@ -161,6 +164,7 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
         input,
         sessionId,
       },
+      { timeoutMs: 180_000 },
     );
 
     if (!ipcResult.ok) {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for assistant-browser-cli-decoupling.md.

**Gap 1:** IPC timeout mismatch — browser CLI commands now use 180s timeout to accommodate long-running operations like wait_for_download (max 120s)
**Gap 2:** JSDoc @throws on executeBrowserOperation replaced with accurate return-value docs
**Gap 3:** Misleading comment about browser_mode/activity as CLI global options corrected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
