### PR TITLE
fix: stale comment and error message wording for wait_for_download

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -200,8 +200,8 @@ describe("browser skill migration end-state", () => {
     );
     expect(fs.existsSync(execPath)).toBe(true);
     const content = fs.readFileSync(execPath, "utf-8");
-    // browser_wait_for_download uses a standalone wrapper that calls
-    // browserManager.waitForDownload() directly — no execute* function.
+    // browser_wait_for_download has no matching executeBrowser* function
+    // exported from browser-execution.ts — it is handled via operations.ts.
     const TOOLS_WITH_EXECUTE_FN = BROWSER_TOOL_NAMES.filter(
       (name) => name !== "browser_wait_for_download",
     );

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -128,7 +128,7 @@ async function executeWaitForDownload(
   if (mode !== "auto" && mode !== "local") {
     return {
       content:
-        `Error: wait_for_download does not support browser_mode "${mode}". ` +
+        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
         `File downloads require the local Playwright backend. ` +
         `Use browser_mode "auto" or "local" instead.`,
       isError: true,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for assistant-browser-cli-decoupling.md.

**Gap 1:** Updated stale comment in browser-skill-endstate.test.ts that referenced removed wrapper behavior
**Gap 2:** Restored browser_ prefix in wait_for_download error message to match pre-refactor behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
