### PR TITLE
feat: add `assistant browser` CLI with decoupled operations contract

### DIFF
--- a/assistant/src/__tests__/browser-identifier-parity-guard.test.ts
+++ b/assistant/src/__tests__/browser-identifier-parity-guard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Parity guard for browser identifier sets.
+ *
+ * Verifies that four independently-consumed browser identifier sources
+ * remain in sync:
+ *
+ *   1. Shared operation list        (BROWSER_OPERATIONS from browser/types.ts)
+ *   2. Shared browser_* tool names  (BROWSER_TOOL_NAMES from browser/operations.ts)
+ *   3. TOOLS.json tool names        (browser skill manifest)
+ *   4. CLI subcommand registrations (BROWSER_OPERATION_META from browser/operations.ts)
+ *
+ * Drift between any of these causes silent mismatches between the CLI,
+ * tool dispatch, permission defaults, and skill manifest. This guard
+ * catches additions or removals in one source that aren't mirrored in
+ * the others.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  BROWSER_OPERATION_META,
+  BROWSER_TOOL_NAMES,
+} from "../browser/operations.js";
+import { BROWSER_OPERATIONS } from "../browser/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function sorted(arr: readonly string[]): string[] {
+  return [...arr].sort();
+}
+
+const TOOLS_JSON_PATH = resolve(
+  __dirname,
+  "../config/bundled-skills/browser/TOOLS.json",
+);
+
+function readToolsJsonNames(): string[] {
+  const raw = readFileSync(TOOLS_JSON_PATH, "utf-8");
+  const manifest = JSON.parse(raw) as {
+    tools: Array<{ name: string }>;
+  };
+  return manifest.tools.map((t) => t.name);
+}
+
+// ── Parity tests ─────────────────────────────────────────────────────
+
+describe("browser identifier parity guard", () => {
+  test("BROWSER_TOOL_NAMES matches BROWSER_OPERATIONS via browser_ prefix", () => {
+    const derivedToolNames = BROWSER_OPERATIONS.map((op) => `browser_${op}`);
+    expect(sorted(BROWSER_TOOL_NAMES)).toEqual(sorted(derivedToolNames));
+  });
+
+  test("TOOLS.json tool names match BROWSER_TOOL_NAMES", () => {
+    const toolsJsonNames = readToolsJsonNames();
+    expect(sorted(toolsJsonNames)).toEqual(sorted(BROWSER_TOOL_NAMES));
+  });
+
+  test("CLI subcommand operations match BROWSER_OPERATIONS", () => {
+    const metaOperations = BROWSER_OPERATION_META.map((m) => m.operation);
+    expect(sorted(metaOperations)).toEqual(sorted(BROWSER_OPERATIONS));
+  });
+
+  test("all four sources agree on the same count", () => {
+    const toolsJsonNames = readToolsJsonNames();
+    const metaOperations = BROWSER_OPERATION_META.map((m) => m.operation);
+
+    const counts = {
+      BROWSER_OPERATIONS: BROWSER_OPERATIONS.length,
+      BROWSER_TOOL_NAMES: BROWSER_TOOL_NAMES.length,
+      TOOLS_JSON: toolsJsonNames.length,
+      BROWSER_OPERATION_META: metaOperations.length,
+    };
+
+    // All counts must be identical.
+    const uniqueCounts = new Set(Object.values(counts));
+    expect(uniqueCounts.size).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -10,6 +10,7 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => ({}),
 }));
 
+import { BROWSER_TOOL_NAMES } from "../browser/operations.js";
 import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import {
   projectSkillTools,
@@ -26,7 +27,6 @@ import { eagerModuleToolNames } from "../tools/tool-manifest.js";
 import {
   BROWSER_SKILL_ID,
   BROWSER_TOOL_COUNT,
-  BROWSER_TOOL_NAMES,
   buildSkillLoadHistory,
 } from "./test-support/browser-skill-harness.js";
 
@@ -44,37 +44,20 @@ describe("browser skill migration end-state", () => {
     await initializeTools();
   });
 
-  const BROWSER_TOOLS = [
-    "browser_navigate",
-    "browser_snapshot",
-    "browser_screenshot",
-    "browser_close",
-    "browser_attach",
-    "browser_detach",
-    "browser_click",
-    "browser_type",
-    "browser_press_key",
-    "browser_scroll",
-    "browser_select_option",
-    "browser_hover",
-    "browser_wait_for",
-    "browser_extract",
-    "browser_wait_for_download",
-    "browser_fill_credential",
-    "browser_status",
-  ] as const;
+  // Browser tool names sourced from the shared browser operations contract
+  // (BROWSER_TOOL_NAMES) — no independent list maintained here.
 
   // ── 1. Startup payload excludes browser tools ──────────────────────
 
   test("browser tools are NOT in startup core registry", () => {
     const toolNames = getAllTools().map((t) => t.name);
-    for (const name of BROWSER_TOOLS) {
+    for (const name of BROWSER_TOOL_NAMES) {
       expect(toolNames).not.toContain(name);
     }
   });
 
   test("browser tool names are NOT in eagerModuleToolNames", () => {
-    for (const name of BROWSER_TOOLS) {
+    for (const name of BROWSER_TOOL_NAMES) {
       expect(eagerModuleToolNames).not.toContain(name);
     }
   });
@@ -89,7 +72,7 @@ describe("browser skill migration end-state", () => {
     expect(definitions.length).toBeLessThanOrEqual(50);
 
     const defNames = definitions.map((d) => d.name);
-    for (const name of BROWSER_TOOLS) {
+    for (const name of BROWSER_TOOL_NAMES) {
       expect(defNames).not.toContain(name);
     }
 
@@ -122,9 +105,9 @@ describe("browser skill migration end-state", () => {
     );
     const manifest = JSON.parse(fs.readFileSync(toolsPath, "utf-8"));
     expect(manifest.version).toBe(1);
-    expect(manifest.tools).toHaveLength(BROWSER_TOOLS.length);
+    expect(manifest.tools).toHaveLength(BROWSER_TOOL_NAMES.length);
     const toolNames = manifest.tools.map((t: { name: string }) => t.name);
-    for (const name of BROWSER_TOOLS) {
+    for (const name of BROWSER_TOOL_NAMES) {
       expect(toolNames).toContain(name);
     }
   });
@@ -160,7 +143,7 @@ describe("browser skill migration end-state", () => {
 
   test("all browser tools have default allow rules", () => {
     const templates = getDefaultRuleTemplates();
-    for (const tool of BROWSER_TOOLS) {
+    for (const tool of BROWSER_TOOL_NAMES) {
       const rule = templates.find(
         (t) => t.id === `default:allow-${tool}-global`,
       );
@@ -219,7 +202,7 @@ describe("browser skill migration end-state", () => {
     const content = fs.readFileSync(execPath, "utf-8");
     // browser_wait_for_download uses a standalone wrapper that calls
     // browserManager.waitForDownload() directly — no execute* function.
-    const TOOLS_WITH_EXECUTE_FN = BROWSER_TOOLS.filter(
+    const TOOLS_WITH_EXECUTE_FN = BROWSER_TOOL_NAMES.filter(
       (name) => name !== "browser_wait_for_download",
     );
     for (const name of TOOLS_WITH_EXECUTE_FN) {

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -200,8 +200,8 @@ describe("browser skill migration end-state", () => {
     );
     expect(fs.existsSync(execPath)).toBe(true);
     const content = fs.readFileSync(execPath, "utf-8");
-    // browser_wait_for_download uses a standalone wrapper that calls
-    // browserManager.waitForDownload() directly — no execute* function.
+    // browser_wait_for_download has no matching executeBrowser* function
+    // exported from browser-execution.ts — it is handled via operations.ts.
     const TOOLS_WITH_EXECUTE_FN = BROWSER_TOOL_NAMES.filter(
       (name) => name !== "browser_wait_for_download",
     );

--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -1,25 +1,9 @@
+import { BROWSER_TOOL_NAMES } from "../../browser/operations.js";
 import type { Message } from "../../providers/types.js";
 
-/** The browser tool names provided by the browser skill. */
-export const BROWSER_TOOL_NAMES = [
-  "browser_navigate",
-  "browser_snapshot",
-  "browser_screenshot",
-  "browser_close",
-  "browser_attach",
-  "browser_detach",
-  "browser_click",
-  "browser_type",
-  "browser_press_key",
-  "browser_scroll",
-  "browser_select_option",
-  "browser_hover",
-  "browser_wait_for",
-  "browser_extract",
-  "browser_wait_for_download",
-  "browser_fill_credential",
-  "browser_status",
-] as const;
+// Re-export BROWSER_TOOL_NAMES from the shared browser operations contract
+// so existing test imports continue to work.
+export { BROWSER_TOOL_NAMES };
 
 /** Number of browser tools provided by the skill. */
 export const BROWSER_TOOL_COUNT = BROWSER_TOOL_NAMES.length;

--- a/assistant/src/browser/__tests__/operations.test.ts
+++ b/assistant/src/browser/__tests__/operations.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BROWSER_OPERATION_META,
+  BROWSER_OPERATION_NAMES,
+  BROWSER_TOOL_NAMES,
+  browserOperationToToolName,
+  browserToolNameToOperation,
+  executeBrowserOperation,
+  getBrowserOperationMeta,
+} from "../operations.js";
+import { BROWSER_OPERATIONS, type BrowserOperation } from "../types.js";
+
+describe("browser operations contract", () => {
+  // ── Exactly 17 operations ──────────────────────────────────────────
+
+  test("defines exactly 17 operations", () => {
+    expect(BROWSER_OPERATION_NAMES).toHaveLength(17);
+    expect(BROWSER_TOOL_NAMES).toHaveLength(17);
+  });
+
+  // ── Bijective tool-name mapping ────────────────────────────────────
+
+  test("tool name -> operation is bijective", () => {
+    for (const op of BROWSER_OPERATIONS) {
+      const toolName = browserOperationToToolName(op);
+      expect(toolName).toBe(`browser_${op}`);
+      const roundTripped = browserToolNameToOperation(toolName!);
+      expect(roundTripped).toBe(op);
+    }
+  });
+
+  test("operation -> tool name is bijective", () => {
+    for (const toolName of BROWSER_TOOL_NAMES) {
+      const op = browserToolNameToOperation(toolName);
+      expect(op).toBeDefined();
+      const roundTripped = browserOperationToToolName(op!);
+      expect(roundTripped).toBe(toolName);
+    }
+  });
+
+  test("unknown tool name returns undefined", () => {
+    expect(browserToolNameToOperation("browser_unknown")).toBeUndefined();
+    expect(browserToolNameToOperation("not_browser")).toBeUndefined();
+    expect(browserToolNameToOperation("")).toBeUndefined();
+  });
+
+  test("unknown operation returns undefined", () => {
+    expect(browserOperationToToolName("unknown")).toBeUndefined();
+    expect(browserOperationToToolName("")).toBeUndefined();
+  });
+
+  // ── Every operation has metadata ───────────────────────────────────
+
+  test("every operation has command metadata", () => {
+    for (const op of BROWSER_OPERATIONS) {
+      const meta = getBrowserOperationMeta(op);
+      expect(meta).toBeDefined();
+      expect(meta!.operation).toBe(op);
+      expect(typeof meta!.description).toBe("string");
+      expect(meta!.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("metadata count matches operation count", () => {
+    expect(BROWSER_OPERATION_META).toHaveLength(BROWSER_OPERATIONS.length);
+  });
+
+  test("metadata operations match BROWSER_OPERATIONS", () => {
+    const metaOps = BROWSER_OPERATION_META.map((m) => m.operation).sort();
+    const declaredOps = [...BROWSER_OPERATIONS].sort();
+    expect(metaOps).toEqual(declaredOps);
+  });
+
+  // ── Every operation has a dispatch handler ─────────────────────────
+
+  test("every operation has a dispatch handler (rejects unknown)", async () => {
+    // We verify dispatch handlers exist by calling executeBrowserOperation
+    // with an invalid operation, which should return an error for unknown
+    // operations. For known operations, the handler itself exists (it would
+    // attempt real browser work, which we do not test here).
+    const result = await executeBrowserOperation(
+      "nonexistent" as BrowserOperation,
+      {},
+      {
+        workingDir: "/tmp",
+        conversationId: "test",
+        trustClass: "guardian",
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown browser operation");
+  });
+
+  // ── wait_for_download mode constraints ─────────────────────────────
+
+  test("wait_for_download metadata restricts modes to auto and local", () => {
+    const meta = getBrowserOperationMeta("wait_for_download");
+    expect(meta).toBeDefined();
+    expect(meta!.allowedModes).toBeDefined();
+    expect(meta!.allowedModes).toContain("auto");
+    expect(meta!.allowedModes).toContain("local");
+    expect(meta!.allowedModes).toHaveLength(2);
+  });
+
+  test("wait_for_download rejects extension mode", async () => {
+    const result = await executeBrowserOperation(
+      "wait_for_download",
+      { browser_mode: "extension" },
+      {
+        workingDir: "/tmp",
+        conversationId: "test",
+        trustClass: "guardian",
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("does not support browser_mode");
+    expect(result.content).toContain("extension");
+  });
+
+  test("wait_for_download rejects cdp-inspect mode", async () => {
+    const result = await executeBrowserOperation(
+      "wait_for_download",
+      { browser_mode: "cdp-inspect" },
+      {
+        workingDir: "/tmp",
+        conversationId: "test",
+        trustClass: "guardian",
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("does not support browser_mode");
+    expect(result.content).toContain("cdp-inspect");
+  });
+
+  // ── Metadata field constraints ─────────────────────────────────────
+
+  test("all metadata fields have valid types", () => {
+    const validTypes = new Set(["string", "number", "boolean"]);
+    for (const meta of BROWSER_OPERATION_META) {
+      for (const field of meta.fields) {
+        expect(validTypes.has(field.type)).toBe(true);
+        expect(typeof field.name).toBe("string");
+        expect(field.name.length).toBeGreaterThan(0);
+        expect(typeof field.description).toBe("string");
+        expect(typeof field.required).toBe("boolean");
+      }
+    }
+  });
+
+  test("required fields appear before optional fields in metadata", () => {
+    for (const meta of BROWSER_OPERATION_META) {
+      let seenOptional = false;
+      for (const field of meta.fields) {
+        if (!field.required) {
+          seenOptional = true;
+        } else if (seenOptional) {
+          throw new Error(
+            `Operation "${meta.operation}": required field "${field.name}" appears after optional fields`,
+          );
+        }
+      }
+    }
+  });
+
+  // ── No TOOLS.json dependency ───────────────────────────────────────
+
+  test("operations module does not depend on TOOLS.json", async () => {
+    // Verify by checking that the operations module source does not
+    // reference TOOLS.json. This is a static analysis guard.
+    const { readFileSync } = await import("node:fs");
+    const source = readFileSync(
+      new URL("../operations.ts", import.meta.url),
+      "utf-8",
+    );
+    expect(source).not.toContain("TOOLS.json");
+    expect(source).not.toContain("bundled-skills");
+  });
+});

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -196,7 +196,8 @@ const DISPATCH_HANDLERS: Record<BrowserOperation, OperationHandler> = {
  * @param input     - Flat input object matching the operation's field schema.
  * @param context   - Tool execution context (conversation ID, signal, etc.).
  * @returns The tool execution result from the underlying handler.
- * @throws If the operation identifier is not recognized.
+ *   If the operation identifier is not recognized, returns an error
+ *   result (`isError: true`) rather than throwing.
  */
 export async function executeBrowserOperation(
   operation: BrowserOperation,
@@ -220,8 +221,8 @@ export async function executeBrowserOperation(
  * constraints. Used by the CLI command builder to generate subcommands.
  *
  * The `browser_mode` and `activity` fields are omitted from per-operation
- * metadata because they are common to all operations and handled by the
- * CLI framework as global options.
+ * metadata because they are not exposed through the CLI. Operations
+ * invoked via the CLI always use the default browser mode.
  */
 export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
   {

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -227,12 +227,26 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Loads the given URL and waits for the page to reach a stable state.
+Returns the page title on success.
+
+Examples:
+  $ assistant browser navigate --url https://example.com
+  $ assistant browser navigate --url http://localhost:3000 --allow-private-network
+  $ assistant browser --session s1 navigate --url https://github.com`,
   },
   {
     operation: "snapshot",
     description:
       "List interactive elements on the current page with unique IDs.",
     fields: [],
+    helpText: `Returns a structured list of interactive elements (buttons, links,
+inputs, etc.) with stable element IDs that can be passed to click,
+type, and other element-targeting commands.
+
+Examples:
+  $ assistant browser snapshot
+  $ assistant browser --json snapshot`,
   },
   {
     operation: "screenshot",
@@ -246,6 +260,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Captures a JPEG screenshot. Use --output to save to a file, or
+--json to receive base64-encoded image data in the output.
+
+Examples:
+  $ assistant browser screenshot --output page.jpg
+  $ assistant browser screenshot --full-page --output full.jpg
+  $ assistant browser --json screenshot`,
   },
   {
     operation: "close",
@@ -258,16 +279,35 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Closes the browser page for the current session. Use --close-all-pages
+to tear down the entire browser context including all pages.
+
+Examples:
+  $ assistant browser close
+  $ assistant browser close --close-all-pages
+  $ assistant browser --session s1 close`,
   },
   {
     operation: "attach",
     description: "Attach the Chrome debugger to the active browser tab.",
     fields: [],
+    helpText: `Connects the assistant to a running Chrome instance via the Chrome
+DevTools Protocol. Required before interacting with Chrome-attached tabs.
+
+Examples:
+  $ assistant browser attach
+  $ assistant browser --session s1 attach`,
   },
   {
     operation: "detach",
     description: "Detach the Chrome debugger from the active browser tab.",
     fields: [],
+    helpText: `Disconnects the assistant from the Chrome DevTools Protocol session.
+The browser tab continues running but is no longer controlled.
+
+Examples:
+  $ assistant browser detach
+  $ assistant browser --session s1 detach`,
   },
   {
     operation: "click",
@@ -286,6 +326,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Clicks an element identified by element ID (from snapshot) or CSS
+selector. Provide at least one of --element-id or --selector.
+
+Examples:
+  $ assistant browser click --element-id e14
+  $ assistant browser click --selector "#login-button"
+  $ assistant browser click --selector "a.nav-link"`,
   },
   {
     operation: "type",
@@ -322,6 +369,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Types text into the focused or targeted element. By default, existing
+content is cleared first (--clear-first). Use --no-clear-first to
+append to existing content. Use --press-enter to submit after typing.
+
+Examples:
+  $ assistant browser type --text "hello world" --element-id e14
+  $ assistant browser type --text "search query" --selector "#search" --press-enter
+  $ assistant browser type --text "append this" --no-clear-first`,
   },
   {
     operation: "press_key",
@@ -347,6 +402,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Sends a keyboard key press. If --element-id or --selector is given,
+the key is dispatched to that element; otherwise to the focused element.
+
+Examples:
+  $ assistant browser press-key --key Enter
+  $ assistant browser press-key --key Tab --element-id e5
+  $ assistant browser press-key --key Escape`,
   },
   {
     operation: "scroll",
@@ -378,6 +440,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Scrolls the page or a specific scrollable element. Direction is
+required; amount defaults to 500 pixels.
+
+Examples:
+  $ assistant browser scroll --direction down
+  $ assistant browser scroll --direction up --amount 1000
+  $ assistant browser scroll --direction down --element-id e8`,
   },
   {
     operation: "select_option",
@@ -414,6 +483,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Selects an option in a <select> element by value, label, or index.
+Provide at least one of --value, --label, or --index to identify
+the option, and --element-id or --selector to identify the <select>.
+
+Examples:
+  $ assistant browser select-option --element-id e12 --label "United States"
+  $ assistant browser select-option --selector "#country" --value "us"
+  $ assistant browser select-option --element-id e12 --index 3`,
   },
   {
     operation: "hover",
@@ -432,6 +509,12 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Moves the mouse cursor over an element to trigger hover effects
+(tooltips, dropdowns, etc.). Provide --element-id or --selector.
+
+Examples:
+  $ assistant browser hover --element-id e7
+  $ assistant browser hover --selector ".dropdown-trigger"`,
   },
   {
     operation: "wait_for",
@@ -464,6 +547,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Blocks until a condition is met: an element appears (--selector),
+text appears (--text), or a fixed duration elapses (--duration).
+Provide exactly one condition. --timeout caps the overall wait.
+
+Examples:
+  $ assistant browser wait-for --selector ".results-loaded"
+  $ assistant browser wait-for --text "Success"
+  $ assistant browser wait-for --duration 2000`,
   },
   {
     operation: "extract",
@@ -476,6 +567,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Extracts the visible text content of the current page. Optionally
+includes a list of all links found on the page.
+
+Examples:
+  $ assistant browser extract
+  $ assistant browser extract --include-links
+  $ assistant browser --json extract`,
   },
   {
     operation: "wait_for_download",
@@ -490,6 +588,12 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Waits for an in-progress file download to complete and returns the
+filename and path. Only supported in "auto" and "local" browser modes.
+
+Examples:
+  $ assistant browser wait-for-download
+  $ assistant browser wait-for-download --timeout 60000`,
   },
   {
     operation: "fill_credential",
@@ -527,6 +631,13 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Fills a credential from the assistant's credential vault into a form
+field. The credential value is never exposed in CLI output. Use
+'assistant credentials list' to see available service:field pairs.
+
+Examples:
+  $ assistant browser fill-credential --service github --field token --element-id e9
+  $ assistant browser fill-credential --service github --field password --selector "#password" --press-enter`,
   },
   {
     operation: "status",
@@ -540,6 +651,14 @@ export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
         required: false,
       },
     ],
+    helpText: `Reports the readiness of available browser backends (local Playwright,
+Chrome extension). Includes remediation steps if a backend is not ready.
+Use --check-local-launch for an active Playwright launch probe (slower).
+
+Examples:
+  $ assistant browser status
+  $ assistant browser status --check-local-launch
+  $ assistant browser --json status`,
   },
 ];
 

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -1,0 +1,561 @@
+/**
+ * Shared browser operations contract.
+ *
+ * This module is the single execution entrypoint for all browser
+ * operations. Both the existing tool wrappers and the CLI command
+ * builder consume this contract. All metadata is defined inline —
+ * this module has no dependency on skill registration files.
+ *
+ * Responsibilities:
+ *   - Canonical operation <-> tool name mapping (bijective).
+ *   - Dispatch to existing browser-execution.ts implementations.
+ *   - Command-oriented metadata for CLI subcommand generation.
+ *   - `wait_for_download` mode-constraint enforcement.
+ */
+
+import {
+  executeBrowserAttach,
+  executeBrowserClick,
+  executeBrowserClose,
+  executeBrowserDetach,
+  executeBrowserExtract,
+  executeBrowserFillCredential,
+  executeBrowserHover,
+  executeBrowserNavigate,
+  executeBrowserPressKey,
+  executeBrowserScreenshot,
+  executeBrowserScroll,
+  executeBrowserSelectOption,
+  executeBrowserSnapshot,
+  executeBrowserStatus,
+  executeBrowserType,
+  executeBrowserWaitFor,
+} from "../tools/browser/browser-execution.js";
+import { browserManager } from "../tools/browser/browser-manager.js";
+import { normalizeBrowserMode } from "../tools/browser/browser-mode.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import {
+  BROWSER_OPERATIONS,
+  type BrowserOperation,
+  type BrowserOperationMeta,
+} from "./types.js";
+
+// ── Tool name constants ──────────────────────────────────────────────
+
+/**
+ * All canonical browser operation identifiers (re-exported from types).
+ */
+export const BROWSER_OPERATION_NAMES: readonly BrowserOperation[] =
+  BROWSER_OPERATIONS;
+
+/**
+ * All `browser_*` tool names derived from operation identifiers.
+ */
+export const BROWSER_TOOL_NAMES: readonly string[] = BROWSER_OPERATIONS.map(
+  (op) => `browser_${op}`,
+);
+
+// ── Bidirectional name mapping ───────────────────────────────────────
+
+/**
+ * Convert a `browser_*` tool name to its canonical operation ID.
+ * Returns `undefined` if the tool name does not match a known operation.
+ */
+export function browserToolNameToOperation(
+  toolName: string,
+): BrowserOperation | undefined {
+  if (!toolName.startsWith("browser_")) return undefined;
+  const candidate = toolName.slice("browser_".length);
+  if ((BROWSER_OPERATIONS as readonly string[]).includes(candidate)) {
+    return candidate as BrowserOperation;
+  }
+  return undefined;
+}
+
+/**
+ * Convert a canonical operation ID to its `browser_*` tool name.
+ * Returns `undefined` if the operation is not a known identifier.
+ */
+export function browserOperationToToolName(
+  operation: string,
+): string | undefined {
+  if ((BROWSER_OPERATIONS as readonly string[]).includes(operation)) {
+    return `browser_${operation}`;
+  }
+  return undefined;
+}
+
+// ── Dispatch handlers ────────────────────────────────────────────────
+
+/**
+ * Handler signature for a browser operation dispatcher.
+ */
+type OperationHandler = (
+  input: Record<string, unknown>,
+  context: ToolContext,
+) => Promise<ToolExecutionResult>;
+
+/**
+ * Inline `wait_for_download` handler. This logic currently lives in the
+ * tool wrapper (`browser-wait-for-download.ts`); it is replicated here
+ * so the shared contract can dispatch it without depending on the
+ * wrapper. The wrapper can be repointed to this contract in a later PR.
+ */
+async function executeWaitForDownload(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  // Validate browser_mode: only auto/local are supported for downloads.
+  const modeResult = normalizeBrowserMode(input.browser_mode);
+  if ("error" in modeResult) {
+    return { content: `Error: ${modeResult.error}`, isError: true };
+  }
+  const { mode } = modeResult;
+  if (mode !== "auto" && mode !== "local") {
+    return {
+      content:
+        `Error: wait_for_download does not support browser_mode "${mode}". ` +
+        `File downloads require the local Playwright backend. ` +
+        `Use browser_mode "auto" or "local" instead.`,
+      isError: true,
+    };
+  }
+
+  const timeout =
+    typeof input.timeout === "number"
+      ? Math.min(Math.max(input.timeout, 1000), 120_000)
+      : 30_000;
+
+  try {
+    const download = await browserManager.waitForDownload(
+      context.conversationId,
+      timeout,
+    );
+    return {
+      content: JSON.stringify({
+        filename: download.filename,
+        path: download.path,
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: ${msg}`, isError: true };
+  }
+}
+
+/**
+ * Registry mapping each operation to its dispatch handler.
+ * Every entry in BROWSER_OPERATIONS must have a corresponding handler.
+ */
+const DISPATCH_HANDLERS: Record<BrowserOperation, OperationHandler> = {
+  navigate: executeBrowserNavigate,
+  snapshot: executeBrowserSnapshot,
+  screenshot: executeBrowserScreenshot,
+  close: executeBrowserClose,
+  attach: executeBrowserAttach,
+  detach: executeBrowserDetach,
+  click: executeBrowserClick,
+  type: executeBrowserType,
+  press_key: executeBrowserPressKey,
+  scroll: executeBrowserScroll,
+  select_option: executeBrowserSelectOption,
+  hover: executeBrowserHover,
+  wait_for: executeBrowserWaitFor,
+  extract: executeBrowserExtract,
+  wait_for_download: executeWaitForDownload,
+  fill_credential: executeBrowserFillCredential,
+  status: executeBrowserStatus,
+};
+
+// ── Execute ──────────────────────────────────────────────────────────
+
+/**
+ * Execute a browser operation by its canonical identifier.
+ *
+ * This is the single execution entrypoint. Callers pass the operation
+ * name (e.g. `"navigate"`), a flat input object, and a {@link ToolContext}.
+ * The function looks up the handler in the dispatch registry and
+ * delegates to the existing browser-execution.ts implementation.
+ *
+ * @param operation - Canonical operation identifier (e.g. `"navigate"`).
+ * @param input     - Flat input object matching the operation's field schema.
+ * @param context   - Tool execution context (conversation ID, signal, etc.).
+ * @returns The tool execution result from the underlying handler.
+ * @throws If the operation identifier is not recognized.
+ */
+export async function executeBrowserOperation(
+  operation: BrowserOperation,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const handler = DISPATCH_HANDLERS[operation];
+  if (!handler) {
+    return {
+      content: `Error: Unknown browser operation "${operation}".`,
+      isError: true,
+    };
+  }
+  return handler(input, context);
+}
+
+// ── Command-oriented metadata ────────────────────────────────────────
+
+/**
+ * Metadata for every browser operation, describing fields, types, and
+ * constraints. Used by the CLI command builder to generate subcommands.
+ *
+ * The `browser_mode` and `activity` fields are omitted from per-operation
+ * metadata because they are common to all operations and handled by the
+ * CLI framework as global options.
+ */
+export const BROWSER_OPERATION_META: readonly BrowserOperationMeta[] = [
+  {
+    operation: "navigate",
+    description: "Navigate the browser to a URL and return the page title.",
+    fields: [
+      {
+        name: "url",
+        type: "string",
+        description: "The URL to navigate to.",
+        required: true,
+      },
+      {
+        name: "allow_private_network",
+        type: "boolean",
+        description: "Allow navigation to localhost/private-network hosts.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "snapshot",
+    description:
+      "List interactive elements on the current page with unique IDs.",
+    fields: [],
+  },
+  {
+    operation: "screenshot",
+    description: "Take a visual screenshot of the current page.",
+    fields: [
+      {
+        name: "full_page",
+        type: "boolean",
+        description:
+          "Capture the full scrollable page instead of just the viewport.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "close",
+    description: "Close the browser page for the current conversation.",
+    fields: [
+      {
+        name: "close_all_pages",
+        type: "boolean",
+        description: "Close all browser pages and the browser context.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "attach",
+    description: "Attach the Chrome debugger to the active browser tab.",
+    fields: [],
+  },
+  {
+    operation: "detach",
+    description: "Detach the Chrome debugger from the active browser tab.",
+    fields: [],
+  },
+  {
+    operation: "click",
+    description: "Click an element on the page.",
+    fields: [
+      {
+        name: "element_id",
+        type: "string",
+        description: "Element ID from a previous browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "CSS selector to target.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "type",
+    description: "Type text into an input element.",
+    fields: [
+      {
+        name: "text",
+        type: "string",
+        description: "The text to type into the element.",
+        required: true,
+      },
+      {
+        name: "element_id",
+        type: "string",
+        description: "Element ID from a previous browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "CSS selector to target.",
+        required: false,
+      },
+      {
+        name: "clear_first",
+        type: "boolean",
+        description: "Clear existing content before typing. Default: true.",
+        required: false,
+      },
+      {
+        name: "press_enter",
+        type: "boolean",
+        description: "Press Enter after typing the text.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "press_key",
+    description: "Press a keyboard key, optionally targeting an element.",
+    fields: [
+      {
+        name: "key",
+        type: "string",
+        description:
+          'The key to press (e.g. "Enter", "Escape", "Tab", "ArrowDown").',
+        required: true,
+      },
+      {
+        name: "element_id",
+        type: "string",
+        description: "Optional element ID from browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "Optional CSS selector to target.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "scroll",
+    description: "Scroll the page or a specific element.",
+    fields: [
+      {
+        name: "direction",
+        type: "string",
+        description: "The direction to scroll.",
+        required: true,
+        enum: ["up", "down", "left", "right"],
+      },
+      {
+        name: "amount",
+        type: "number",
+        description: "The number of pixels to scroll. Default: 500.",
+        required: false,
+      },
+      {
+        name: "element_id",
+        type: "string",
+        description: "Optional element ID to scroll within.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "Optional CSS selector of element to scroll within.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "select_option",
+    description: "Select an option from a native <select> element.",
+    fields: [
+      {
+        name: "element_id",
+        type: "string",
+        description: "Element ID of the <select> from browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "CSS selector for the <select> element.",
+        required: false,
+      },
+      {
+        name: "value",
+        type: "string",
+        description: "The value attribute of the <option> to select.",
+        required: false,
+      },
+      {
+        name: "label",
+        type: "string",
+        description: "The visible text of the <option> to select.",
+        required: false,
+      },
+      {
+        name: "index",
+        type: "number",
+        description: "The zero-based index of the <option> to select.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "hover",
+    description: "Hover over an element on the page.",
+    fields: [
+      {
+        name: "element_id",
+        type: "string",
+        description: "Element ID from a previous browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "CSS selector to target.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "wait_for",
+    description:
+      "Wait for a condition: a CSS selector, text, or fixed duration.",
+    fields: [
+      {
+        name: "selector",
+        type: "string",
+        description: "Wait for an element matching this CSS selector.",
+        required: false,
+      },
+      {
+        name: "text",
+        type: "string",
+        description: "Wait for this text to appear on the page.",
+        required: false,
+      },
+      {
+        name: "duration",
+        type: "number",
+        description: "Wait for this many milliseconds.",
+        required: false,
+      },
+      {
+        name: "timeout",
+        type: "number",
+        description:
+          "Maximum wait time in milliseconds. Default and max: 30000.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "extract",
+    description: "Extract the text content of the current page.",
+    fields: [
+      {
+        name: "include_links",
+        type: "boolean",
+        description: "Include a list of links found on the page.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "wait_for_download",
+    description: "Wait for a file download to complete on the current page.",
+    allowedModes: ["auto", "local"],
+    fields: [
+      {
+        name: "timeout",
+        type: "number",
+        description:
+          "Maximum wait time in milliseconds. Default: 30000, max: 120000.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "fill_credential",
+    description:
+      "Fill a stored credential into a form field without exposing the value.",
+    fields: [
+      {
+        name: "service",
+        type: "string",
+        description: "Credential vault service name.",
+        required: true,
+      },
+      {
+        name: "field",
+        type: "string",
+        description: "Credential vault field name.",
+        required: true,
+      },
+      {
+        name: "element_id",
+        type: "string",
+        description: "Element ID from browser snapshot.",
+        required: false,
+      },
+      {
+        name: "selector",
+        type: "string",
+        description: "CSS selector for target element.",
+        required: false,
+      },
+      {
+        name: "press_enter",
+        type: "boolean",
+        description: "Press Enter after filling.",
+        required: false,
+      },
+    ],
+  },
+  {
+    operation: "status",
+    description: "Check browser backend readiness and remediation guidance.",
+    fields: [
+      {
+        name: "check_local_launch",
+        type: "boolean",
+        description:
+          "Run an active local Playwright launch probe. Default: false.",
+        required: false,
+      },
+    ],
+  },
+];
+
+// ── Lookup helper ────────────────────────────────────────────────────
+
+/** Index for O(1) metadata lookups by operation. */
+const META_BY_OPERATION = new Map<BrowserOperation, BrowserOperationMeta>(
+  BROWSER_OPERATION_META.map((m) => [m.operation, m]),
+);
+
+/**
+ * Get metadata for a specific operation. Returns `undefined` if the
+ * operation is not recognized.
+ */
+export function getBrowserOperationMeta(
+  operation: BrowserOperation,
+): BrowserOperationMeta | undefined {
+  return META_BY_OPERATION.get(operation);
+}

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -50,6 +50,20 @@ export const BROWSER_OPERATION_NAMES: readonly BrowserOperation[] =
 
 /**
  * All `browser_*` tool names derived from operation identifiers.
+ *
+ * These names are the LLM-facing tool aliases registered by the browser
+ * skill wrappers. They are compatibility adapters: the canonical
+ * identifiers are the operation names in {@link BROWSER_OPERATIONS},
+ * and the `browser_*` prefix is a naming convention for the tool layer.
+ * When the `browser_*` tool wrappers are eventually removed, this
+ * derived list can be dropped — the CLI and operations layer only need
+ * {@link BROWSER_OPERATIONS} and {@link BROWSER_OPERATION_META}.
+ *
+ * Consumed by:
+ *   - Permission default rules (permissions/defaults.ts)
+ *   - Workspace policy classification (permissions/workspace-policy.ts)
+ *   - Side-effect tool classification (tools/side-effects.ts)
+ *   - Test harnesses and parity guards
  */
 export const BROWSER_TOOL_NAMES: readonly string[] = BROWSER_OPERATIONS.map(
   (op) => `browser_${op}`,

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -128,7 +128,7 @@ async function executeWaitForDownload(
   if (mode !== "auto" && mode !== "local") {
     return {
       content:
-        `Error: wait_for_download does not support browser_mode "${mode}". ` +
+        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
         `File downloads require the local Playwright backend. ` +
         `Use browser_mode "auto" or "local" instead.`,
       isError: true,

--- a/assistant/src/browser/operations.ts
+++ b/assistant/src/browser/operations.ts
@@ -110,10 +110,9 @@ type OperationHandler = (
 ) => Promise<ToolExecutionResult>;
 
 /**
- * Inline `wait_for_download` handler. This logic currently lives in the
- * tool wrapper (`browser-wait-for-download.ts`); it is replicated here
- * so the shared contract can dispatch it without depending on the
- * wrapper. The wrapper can be repointed to this contract in a later PR.
+ * Inline `wait_for_download` handler. Downloads are only supported
+ * on auto/local browser modes; the handler validates the mode and
+ * delegates to `browserManager.waitForDownload()`.
  */
 async function executeWaitForDownload(
   input: Record<string, unknown>,

--- a/assistant/src/browser/types.ts
+++ b/assistant/src/browser/types.ts
@@ -72,4 +72,10 @@ export interface BrowserOperationMeta {
    * `["auto", "local"]`.
    */
   allowedModes?: readonly string[];
+  /**
+   * Extended help text appended after the auto-generated options list.
+   * Should include behavioral notes and 2-3 concrete examples per
+   * CLI AGENTS.md Help Text Standards.
+   */
+  helpText?: string;
 }

--- a/assistant/src/browser/types.ts
+++ b/assistant/src/browser/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Canonical browser operation identifiers and typed metadata.
+ *
+ * This module defines the shared vocabulary for browser operations,
+ * independent of skill-tool registration or TOOLS.json. Both the
+ * tool wrappers and the CLI command builder consume these types.
+ */
+
+// ── Operation identifiers ────────────────────────────────────────────
+
+/**
+ * Canonical operation identifiers for every browser operation.
+ * Each maps 1:1 to a `browser_*` tool name via deterministic
+ * naming convention (`navigate` <-> `browser_navigate`).
+ */
+export const BROWSER_OPERATIONS = [
+  "navigate",
+  "snapshot",
+  "screenshot",
+  "close",
+  "attach",
+  "detach",
+  "click",
+  "type",
+  "press_key",
+  "scroll",
+  "select_option",
+  "hover",
+  "wait_for",
+  "extract",
+  "wait_for_download",
+  "fill_credential",
+  "status",
+] as const;
+
+export type BrowserOperation = (typeof BROWSER_OPERATIONS)[number];
+
+// ── Field metadata types ─────────────────────────────────────────────
+
+/** Scalar types that operation fields can have. */
+export type OperationFieldType = "string" | "number" | "boolean";
+
+/** Metadata for a single field on an operation. */
+export interface OperationField {
+  /** The field name as it appears in the input object. */
+  name: string;
+  /** The scalar type of the field. */
+  type: OperationFieldType;
+  /** Human-readable description for CLI help text. */
+  description: string;
+  /** Whether this field is required for the operation. */
+  required: boolean;
+  /** For string enums, the allowed values. */
+  enum?: readonly string[];
+}
+
+/**
+ * Command-oriented metadata for a single browser operation.
+ * Used by the CLI command builder to generate subcommands
+ * without reading TOOLS.json.
+ */
+export interface BrowserOperationMeta {
+  /** The canonical operation identifier. */
+  operation: BrowserOperation;
+  /** Human-readable summary for CLI help text. */
+  description: string;
+  /** Ordered list of fields (required first, then optional). */
+  fields: readonly OperationField[];
+  /**
+   * When set, the operation is restricted to these browser_mode
+   * values. For example, `wait_for_download` only supports
+   * `["auto", "local"]`.
+   */
+  allowedModes?: readonly string[];
+}

--- a/assistant/src/cli/commands/__tests__/browser.test.ts
+++ b/assistant/src/cli/commands/__tests__/browser.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Tests for the `assistant browser` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration count and names
+ *   - Required-argument enforcement (navigate, type, press-key, scroll, fill-credential)
+ *   - Correct IPC payload mapping (kebab-case CLI -> snake_case input)
+ *   - --json and error exit-code behavior
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import { BROWSER_OPERATION_META } from "../../../browser/operations.js";
+import { BROWSER_OPERATIONS } from "../../../browser/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { content: "ok", isError: false } };
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerBrowserCommand } = await import("../browser.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerBrowserCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: { content: "ok", isError: false },
+  };
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers exactly 17 subcommands", () => {
+    const program = new Command();
+    registerBrowserCommand(program);
+    const browser = program.commands.find((c) => c.name() === "browser");
+    expect(browser).toBeDefined();
+    const subcommands = browser!.commands;
+    expect(subcommands).toHaveLength(17);
+  });
+
+  test("subcommand names match kebab-cased BROWSER_OPERATIONS", () => {
+    const program = new Command();
+    registerBrowserCommand(program);
+    const browser = program.commands.find((c) => c.name() === "browser");
+    const subcommandNames = browser!.commands.map((c) => c.name()).sort();
+    const expectedNames = BROWSER_OPERATIONS.map((op) =>
+      op.replace(/_/g, "-"),
+    ).sort();
+    expect(subcommandNames).toEqual(expectedNames);
+  });
+
+  test("all 17 operations from BROWSER_OPERATIONS are covered", () => {
+    expect(BROWSER_OPERATIONS).toHaveLength(17);
+    expect(BROWSER_OPERATION_META).toHaveLength(17);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Required-argument enforcement
+// ---------------------------------------------------------------------------
+
+describe("required-argument enforcement", () => {
+  test("navigate requires --url", async () => {
+    const { exitCode } = await runCommand(["browser", "navigate"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("type requires --text", async () => {
+    const { exitCode } = await runCommand(["browser", "type"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("press-key requires --key", async () => {
+    const { exitCode } = await runCommand(["browser", "press-key"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("scroll requires --direction", async () => {
+    const { exitCode } = await runCommand(["browser", "scroll"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("fill-credential requires --service and --field", async () => {
+    // Missing both
+    const { exitCode: e1 } = await runCommand(["browser", "fill-credential"]);
+    expect(e1).not.toBe(0);
+
+    // Missing --field
+    const { exitCode: e2 } = await runCommand([
+      "browser",
+      "fill-credential",
+      "--service",
+      "github",
+    ]);
+    expect(e2).not.toBe(0);
+
+    // Missing --service
+    const { exitCode: e3 } = await runCommand([
+      "browser",
+      "fill-credential",
+      "--field",
+      "token",
+    ]);
+    expect(e3).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IPC payload mapping
+// ---------------------------------------------------------------------------
+
+describe("IPC payload mapping", () => {
+  test("navigate sends correct operation and input", async () => {
+    await runCommand(["browser", "navigate", "--url", "https://example.com"]);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("browser_execute");
+    expect(lastIpcCall!.params!.operation).toBe("navigate");
+    expect(lastIpcCall!.params!.input).toEqual({
+      url: "https://example.com",
+    });
+    expect(lastIpcCall!.params!.sessionId).toBe("default");
+  });
+
+  test("navigate with --allow-private-network maps to allow_private_network", async () => {
+    await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "http://localhost:3000",
+      "--allow-private-network",
+    ]);
+    expect(lastIpcCall!.params!.input).toEqual({
+      url: "http://localhost:3000",
+      allow_private_network: true,
+    });
+  });
+
+  test("type maps --text, --element-id, --clear-first", async () => {
+    await runCommand([
+      "browser",
+      "type",
+      "--text",
+      "hello world",
+      "--element-id",
+      "e14",
+      "--clear-first",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("type");
+    expect(lastIpcCall!.params!.input).toEqual({
+      text: "hello world",
+      element_id: "e14",
+      clear_first: true,
+    });
+  });
+
+  test("scroll maps --direction and --amount (number coercion)", async () => {
+    await runCommand([
+      "browser",
+      "scroll",
+      "--direction",
+      "down",
+      "--amount",
+      "300",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("scroll");
+    const input = lastIpcCall!.params!.input as Record<string, unknown>;
+    expect(input.direction).toBe("down");
+    expect(input.amount).toBe(300);
+    expect(typeof input.amount).toBe("number");
+  });
+
+  test("press-key maps --key", async () => {
+    await runCommand(["browser", "press-key", "--key", "Enter"]);
+    expect(lastIpcCall!.params!.operation).toBe("press_key");
+    expect(lastIpcCall!.params!.input).toEqual({ key: "Enter" });
+  });
+
+  test("fill-credential maps --service, --field, --press-enter", async () => {
+    await runCommand([
+      "browser",
+      "fill-credential",
+      "--service",
+      "github",
+      "--field",
+      "token",
+      "--press-enter",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("fill_credential");
+    expect(lastIpcCall!.params!.input).toEqual({
+      service: "github",
+      field: "token",
+      press_enter: true,
+    });
+  });
+
+  test("select-option maps to select_option operation", async () => {
+    await runCommand([
+      "browser",
+      "select-option",
+      "--value",
+      "us",
+      "--selector",
+      "#country",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("select_option");
+    expect(lastIpcCall!.params!.input).toEqual({
+      value: "us",
+      selector: "#country",
+    });
+  });
+
+  test("wait-for maps to wait_for operation", async () => {
+    await runCommand([
+      "browser",
+      "wait-for",
+      "--selector",
+      ".loaded",
+      "--timeout",
+      "5000",
+    ]);
+    expect(lastIpcCall!.params!.operation).toBe("wait_for");
+    const input = lastIpcCall!.params!.input as Record<string, unknown>;
+    expect(input.selector).toBe(".loaded");
+    expect(input.timeout).toBe(5000);
+  });
+
+  test("wait-for-download maps to wait_for_download operation", async () => {
+    await runCommand(["browser", "wait-for-download"]);
+    expect(lastIpcCall!.params!.operation).toBe("wait_for_download");
+  });
+
+  test("snapshot sends empty input", async () => {
+    await runCommand(["browser", "snapshot"]);
+    expect(lastIpcCall!.params!.operation).toBe("snapshot");
+    expect(lastIpcCall!.params!.input).toEqual({});
+  });
+
+  test("screenshot sends empty input by default", async () => {
+    await runCommand(["browser", "screenshot"]);
+    expect(lastIpcCall!.params!.operation).toBe("screenshot");
+    expect(lastIpcCall!.params!.input).toEqual({});
+  });
+
+  test("status maps --check-local-launch", async () => {
+    await runCommand(["browser", "status", "--check-local-launch"]);
+    expect(lastIpcCall!.params!.operation).toBe("status");
+    expect(lastIpcCall!.params!.input).toEqual({
+      check_local_launch: true,
+    });
+  });
+
+  test("--session flag is passed through as sessionId", async () => {
+    await runCommand([
+      "browser",
+      "--session",
+      "myflow",
+      "navigate",
+      "--url",
+      "https://example.com",
+    ]);
+    expect(lastIpcCall!.params!.sessionId).toBe("myflow");
+  });
+
+  test("default session is 'default'", async () => {
+    await runCommand(["browser", "snapshot"]);
+    expect(lastIpcCall!.params!.sessionId).toBe("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --json and error exit-code behavior
+// ---------------------------------------------------------------------------
+
+describe("--json output", () => {
+  test("--json outputs JSON with ok:true on success", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { content: "Page title: Example", isError: false },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "snapshot",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.content).toBe("Page title: Example");
+  });
+
+  test("--json includes screenshots when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Screenshot taken",
+        isError: false,
+        screenshots: [{ mediaType: "image/jpeg", data: "abc123base64" }],
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "screenshot",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.screenshots).toHaveLength(1);
+    expect(parsed.screenshots[0].mediaType).toBe("image/jpeg");
+    expect(parsed.screenshots[0].data).toBe("abc123base64");
+  });
+
+  test("--json outputs ok:false when IPC connection fails", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "Could not connect to assistant daemon. Is it running?",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "snapshot",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Could not connect");
+  });
+
+  test("--json outputs ok:false when operation returns isError:true", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Error: Element not found",
+        isError: true,
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "browser",
+      "--json",
+      "click",
+      "--selector",
+      "#missing",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Error: Element not found");
+  });
+});
+
+describe("error exit codes", () => {
+  test("exits with non-zero code when IPC fails", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "Connection refused",
+    };
+
+    const { exitCode } = await runCommand(["browser", "snapshot"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with non-zero code when operation returns error", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        content: "Error: Navigation failed",
+        isError: true,
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "https://broken.test",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with zero code on successful operation", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { content: "Done", isError: false },
+    };
+
+    const { exitCode } = await runCommand([
+      "browser",
+      "navigate",
+      "--url",
+      "https://example.com",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -1,0 +1,278 @@
+/**
+ * `assistant browser` CLI namespace.
+ *
+ * One subcommand per browser operation, driven from the shared
+ * browser operations contract ({@link BROWSER_OPERATION_META}).
+ * Each subcommand maps CLI kebab-case flags into snake_case input
+ * keys and calls `browser_execute` over the CLI IPC socket.
+ */
+
+import { writeFileSync } from "node:fs";
+
+import { type Command, Option } from "commander";
+
+import { BROWSER_OPERATION_META } from "../../browser/operations.js";
+import type {
+  BrowserOperationMeta,
+  OperationField,
+} from "../../browser/types.js";
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+// ── Naming helpers ───────────────────────────────────────────────────
+
+/**
+ * Convert a snake_case operation name to kebab-case for CLI subcommand
+ * names (e.g. `press_key` -> `press-key`).
+ */
+function toKebab(snakeCase: string): string {
+  return snakeCase.replace(/_/g, "-");
+}
+
+/**
+ * Convert a snake_case field name to a kebab-case CLI option flag
+ * (e.g. `allow_private_network` -> `--allow-private-network`).
+ *
+ * Boolean fields declare only `--flag`; Commander 13 auto-generates
+ * the `--no-flag` negation variant. Declaring both in a single spec
+ * string (e.g. `--flag, --no-flag`) breaks in Commander 13 because
+ * `--flag` still parses to `false`.
+ */
+function fieldToFlag(field: OperationField): string {
+  const kebab = toKebab(field.name);
+  if (field.type === "boolean") {
+    return `--${kebab}`;
+  }
+  return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
+}
+
+/**
+ * Convert a kebab-case option key back to snake_case for the IPC
+ * input object (e.g. `allowPrivateNetwork` -> `allow_private_network`).
+ *
+ * Commander camelCases option names, so we convert from camelCase
+ * to snake_case.
+ */
+function camelToSnake(camel: string): string {
+  return camel.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
+}
+
+/**
+ * Parse a CLI option value according to its field type.
+ */
+function parseFieldValue(
+  value: unknown,
+  field: OperationField,
+): string | number | boolean {
+  if (field.type === "boolean") return Boolean(value);
+  if (field.type === "number") {
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+      throw new Error(`Invalid number for --${toKebab(field.name)}: ${value}`);
+    }
+    return num;
+  }
+  return String(value);
+}
+
+// ── IPC response shape ───────────────────────────────────────────────
+
+interface BrowserExecuteResult {
+  content: string;
+  isError: boolean;
+  screenshots?: Array<{ mediaType: string; data: string }>;
+}
+
+// ── Subcommand builder ───────────────────────────────────────────────
+
+/**
+ * Build a Commander subcommand for a single browser operation.
+ */
+function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
+  const subcmd = parent
+    .command(toKebab(meta.operation))
+    .description(meta.description);
+
+  // Add per-operation field options
+  for (const field of meta.fields) {
+    const flag = fieldToFlag(field);
+
+    if (field.enum) {
+      // Use Commander's Option class with .choices() for enum-constrained
+      // fields so invalid values are rejected at the CLI level and
+      // --help lists the allowed values.
+      const opt = new Option(flag, field.description).choices([...field.enum]);
+      if (field.required) {
+        opt.makeOptionMandatory(true);
+      }
+      subcmd.addOption(opt);
+    } else if (field.required) {
+      subcmd.requiredOption(flag, field.description);
+    } else {
+      subcmd.option(flag, field.description);
+    }
+  }
+
+  // Append per-operation help text with behavioral notes and examples
+  if (meta.helpText) {
+    subcmd.addHelpText("after", `\n${meta.helpText}`);
+  }
+
+  // screenshot gets an --output <path> option for writing JPEG to disk
+  if (meta.operation === "screenshot") {
+    subcmd.option(
+      "--output <path>",
+      "Write the screenshot JPEG to a file path on disk.",
+    );
+  }
+
+  subcmd.action(async (opts: Record<string, unknown>) => {
+    const parentOpts = parent.opts() as {
+      session?: string;
+      json?: boolean;
+    };
+    const sessionId = parentOpts.session ?? "default";
+    const jsonMode = parentOpts.json ?? false;
+
+    // Map Commander camelCase options back to snake_case input keys,
+    // filtering out parent-level options (session, json) and screenshot
+    // ergonomics (output).
+    const input: Record<string, unknown> = {};
+    const excludeKeys = new Set(["session", "json", "output"]);
+
+    for (const [key, value] of Object.entries(opts)) {
+      if (excludeKeys.has(key)) continue;
+      if (value === undefined) continue;
+
+      const snakeKey = camelToSnake(key);
+      // Find the matching field for type coercion
+      const field = meta.fields.find((f) => f.name === snakeKey);
+      if (field) {
+        input[snakeKey] = parseFieldValue(value, field);
+      } else {
+        input[snakeKey] = value;
+      }
+    }
+
+    const ipcResult = await cliIpcCall<BrowserExecuteResult>(
+      "browser_execute",
+      {
+        operation: meta.operation,
+        input,
+        sessionId,
+      },
+    );
+
+    if (!ipcResult.ok) {
+      if (jsonMode) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+        );
+      } else {
+        log.error(`Error: ${ipcResult.error}`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = ipcResult.result!;
+
+    if (result.isError) {
+      if (jsonMode) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: result.content }) + "\n",
+        );
+      } else {
+        log.error(result.content);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    // Handle screenshot --output: write JPEG to disk
+    if (
+      meta.operation === "screenshot" &&
+      opts.output &&
+      result.screenshots?.length
+    ) {
+      const screenshot = result.screenshots[0];
+      const buffer = Buffer.from(screenshot.data, "base64");
+      try {
+        writeFileSync(String(opts.output), buffer);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (jsonMode) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: false,
+              error: `Failed to write screenshot to ${opts.output}: ${msg}`,
+            }) + "\n",
+          );
+        } else {
+          log.error(`Failed to write screenshot to ${opts.output}: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+      if (!jsonMode) {
+        log.info(`Screenshot saved to ${opts.output}`);
+      }
+    }
+
+    if (jsonMode) {
+      const payload: Record<string, unknown> = {
+        ok: true,
+        content: result.content,
+      };
+      // Include base64 screenshot data in JSON output
+      if (result.screenshots?.length) {
+        payload.screenshots = result.screenshots;
+      }
+      process.stdout.write(JSON.stringify(payload) + "\n");
+    } else {
+      if (result.content) {
+        log.info(result.content);
+      }
+    }
+  });
+}
+
+// ── Registration ─────────────────────────────────────────────────────
+
+export function registerBrowserCommand(program: Command): void {
+  const browser = program
+    .command("browser")
+    .description("Control the browser via the running assistant.")
+    .option(
+      "--session <id>",
+      "Session ID to preserve browser state across invocations.",
+      "default",
+    )
+    .option("--json", "Output results as machine-readable JSON.");
+
+  browser.addHelpText(
+    "after",
+    `
+Browser operations are executed through the running assistant.
+Each subcommand maps to a browser operation and communicates
+with the assistant process.
+
+The --session flag groups sequential commands so they share browser
+state (same page, cookies, etc.). Different session IDs create
+independent browser contexts.
+
+Examples:
+  $ assistant browser navigate --url https://example.com
+  $ assistant browser snapshot
+  $ assistant browser click --selector "#login"
+  $ assistant browser type --text "hello" --element-id e14
+  $ assistant browser screenshot --output page.jpg
+  $ assistant browser --session myflow navigate --url https://example.com
+  $ assistant browser --json screenshot`,
+  );
+
+  // Register one subcommand per browser operation
+  for (const meta of BROWSER_OPERATION_META) {
+    buildSubcommand(browser, meta);
+  }
+}

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -154,6 +154,9 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
       }
     }
 
+    // Browser operations can be long-running (page loads, auth
+    // challenges, downloads up to 120s, etc.), so use a generous
+    // IPC timeout that exceeds any server-side operation timeout.
     const ipcResult = await cliIpcCall<BrowserExecuteResult>(
       "browser_execute",
       {
@@ -161,6 +164,7 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
         input,
         sessionId,
       },
+      { timeoutMs: 180_000 },
     );
 
     if (!ipcResult.ok) {

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -14,6 +14,7 @@ import { registerAutonomyCommand } from "./commands/autonomy.js";
 import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBackupCommand } from "./commands/backup.js";
 import { registerBashCommand } from "./commands/bash.js";
+import { registerBrowserCommand } from "./commands/browser.js";
 import { registerChannelVerificationSessionsCommand } from "./commands/channel-verification-sessions.js";
 import { registerCompletionsCommand } from "./commands/completions.js";
 import { registerConfigCommand } from "./commands/config.js";
@@ -64,6 +65,7 @@ Examples:
   registerDefaultAction(program);
   registerBackupCommand(program);
   registerBashCommand(program);
+  registerBrowserCommand(program);
   registerConversationsCommand(program);
   registerConfigCommand(program);
   registerKeysCommand(program);

--- a/assistant/src/config/bundled-skills/browser/tools/__tests__/wrapper-adapters.test.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/__tests__/wrapper-adapters.test.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { BROWSER_OPERATIONS } from "../../../../../browser/types.js";
+
+const TOOLS_DIR = join(import.meta.dir, "..");
+
+describe("browser skill wrappers are thin adapters", () => {
+  // Collect all browser-*.ts wrapper files (excluding shared.ts and test dirs).
+  const wrapperFiles = readdirSync(TOOLS_DIR)
+    .filter((f) => f.startsWith("browser-") && f.endsWith(".ts"))
+    .sort();
+
+  test("has exactly 17 wrapper files matching BROWSER_OPERATIONS", () => {
+    expect(wrapperFiles).toHaveLength(17);
+    expect(wrapperFiles).toHaveLength(BROWSER_OPERATIONS.length);
+  });
+
+  test("every wrapper file maps to a valid browser_* tool name", () => {
+    for (const file of wrapperFiles) {
+      // browser-navigate.ts -> browser_navigate
+      const toolName = file.replace(".ts", "").replace(/-/g, "_");
+      const operation = toolName.replace("browser_", "");
+      expect(
+        (BROWSER_OPERATIONS as readonly string[]).includes(operation),
+      ).toBe(true);
+    }
+  });
+
+  test("every wrapper delegates through shared.ts runBrowserTool", () => {
+    for (const file of wrapperFiles) {
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      // Wrapper must import from shared.ts
+      expect(source).toContain("./shared.js");
+      expect(source).toContain("runBrowserTool");
+    }
+  });
+
+  test("no wrapper imports browser-execution, browser-manager, or browser-mode directly", () => {
+    for (const file of wrapperFiles) {
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      expect(source).not.toContain("browser-execution");
+      expect(source).not.toContain("browser-manager");
+      expect(source).not.toContain("browser-mode");
+    }
+  });
+
+  test("shared.ts exists and exports runBrowserTool", () => {
+    const sharedSource = readFileSync(join(TOOLS_DIR, "shared.ts"), "utf-8");
+    expect(sharedSource).toContain("export async function runBrowserTool");
+    expect(sharedSource).toContain("browserToolNameToOperation");
+    expect(sharedSource).toContain("executeBrowserOperation");
+  });
+
+  test("shared.ts does not depend on TOOLS.json or bundled-skills internals", () => {
+    const sharedSource = readFileSync(join(TOOLS_DIR, "shared.ts"), "utf-8");
+    expect(sharedSource).not.toContain("TOOLS.json");
+  });
+
+  test("each wrapper passes the correct tool name to runBrowserTool", () => {
+    for (const file of wrapperFiles) {
+      const toolName = file.replace(".ts", "").replace(/-/g, "_");
+      const source = readFileSync(join(TOOLS_DIR, file), "utf-8");
+      expect(source).toContain(`"${toolName}"`);
+    }
+  });
+});

--- a/assistant/src/config/bundled-skills/browser/tools/browser-attach.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-attach.ts
@@ -1,12 +1,12 @@
-import { executeBrowserAttach } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserAttach(input, context);
+  return runBrowserTool("browser_attach", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-click.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-click.ts
@@ -1,12 +1,12 @@
-import { executeBrowserClick } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserClick(input, context);
+  return runBrowserTool("browser_click", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-close.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-close.ts
@@ -1,12 +1,12 @@
-import { executeBrowserClose } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserClose(input, context);
+  return runBrowserTool("browser_close", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-detach.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-detach.ts
@@ -1,12 +1,12 @@
-import { executeBrowserDetach } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserDetach(input, context);
+  return runBrowserTool("browser_detach", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-extract.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-extract.ts
@@ -1,12 +1,12 @@
-import { executeBrowserExtract } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserExtract(input, context);
+  return runBrowserTool("browser_extract", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-fill-credential.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-fill-credential.ts
@@ -1,12 +1,12 @@
-import { executeBrowserFillCredential } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserFillCredential(input, context);
+  return runBrowserTool("browser_fill_credential", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-hover.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-hover.ts
@@ -1,12 +1,12 @@
-import { executeBrowserHover } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserHover(input, context);
+  return runBrowserTool("browser_hover", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-navigate.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-navigate.ts
@@ -1,12 +1,12 @@
-import { executeBrowserNavigate } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserNavigate(input, context);
+  return runBrowserTool("browser_navigate", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-press-key.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-press-key.ts
@@ -1,12 +1,12 @@
-import { executeBrowserPressKey } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserPressKey(input, context);
+  return runBrowserTool("browser_press_key", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-screenshot.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-screenshot.ts
@@ -1,12 +1,12 @@
-import { executeBrowserScreenshot } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserScreenshot(input, context);
+  return runBrowserTool("browser_screenshot", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-scroll.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-scroll.ts
@@ -1,12 +1,12 @@
-import { executeBrowserScroll } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserScroll(input, context);
+  return runBrowserTool("browser_scroll", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-select-option.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-select-option.ts
@@ -1,12 +1,12 @@
-import { executeBrowserSelectOption } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserSelectOption(input, context);
+  return runBrowserTool("browser_select_option", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-snapshot.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-snapshot.ts
@@ -1,12 +1,12 @@
-import { executeBrowserSnapshot } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserSnapshot(input, context);
+  return runBrowserTool("browser_snapshot", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-status.ts
@@ -1,12 +1,12 @@
-import { executeBrowserStatus } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserStatus(input, context);
+  return runBrowserTool("browser_status", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-type.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-type.ts
@@ -1,12 +1,12 @@
-import { executeBrowserType } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserType(input, context);
+  return runBrowserTool("browser_type", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for-download.ts
@@ -1,49 +1,12 @@
-import { browserManager } from "../../../../tools/browser/browser-manager.js";
-import { normalizeBrowserMode } from "../../../../tools/browser/browser-mode.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  // Validate browser_mode: only auto/local are supported for downloads.
-  const modeResult = normalizeBrowserMode(input.browser_mode);
-  if ("error" in modeResult) {
-    return { content: `Error: ${modeResult.error}`, isError: true };
-  }
-  const { mode } = modeResult;
-  if (mode !== "auto" && mode !== "local") {
-    return {
-      content:
-        `Error: browser_wait_for_download does not support browser_mode "${mode}". ` +
-        `File downloads require the local Playwright backend. ` +
-        `Use browser_mode "auto" or "local" instead.`,
-      isError: true,
-    };
-  }
-
-  const timeout =
-    typeof input.timeout === "number"
-      ? Math.min(Math.max(input.timeout, 1000), 120_000)
-      : 30_000;
-
-  try {
-    const download = await browserManager.waitForDownload(
-      context.conversationId,
-      timeout,
-    );
-    return {
-      content: JSON.stringify({
-        filename: download.filename,
-        path: download.path,
-      }),
-      isError: false,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { content: `Error: ${msg}`, isError: true };
-  }
+  return runBrowserTool("browser_wait_for_download", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/browser-wait-for.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/browser-wait-for.ts
@@ -1,12 +1,12 @@
-import { executeBrowserWaitFor } from "../../../../tools/browser/browser-execution.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { runBrowserTool } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeBrowserWaitFor(input, context);
+  return runBrowserTool("browser_wait_for", input, context);
 }

--- a/assistant/src/config/bundled-skills/browser/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/shared.ts
@@ -8,6 +8,13 @@
  * This keeps every wrapper as a thin adapter with no independent
  * execution logic — all behavior flows through the shared browser
  * operations contract.
+ *
+ * NOTE: The current `browser_*` skill tools are compatibility adapters
+ * over the canonical browser operations contract. They exist so the
+ * LLM-facing tool API remains stable while the CLI (`assistant browser`)
+ * consumes the same operations directly. Once the `browser_*` tool
+ * names are no longer referenced by clients or the LLM, these wrappers
+ * can be removed without changing the CLI or the operations layer.
  */
 
 import {

--- a/assistant/src/config/bundled-skills/browser/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/browser/tools/shared.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared adapter for browser skill wrappers.
+ *
+ * Each browser tool wrapper delegates to this helper, which maps
+ * the `browser_*` tool name to a canonical operation identifier
+ * and dispatches through {@link executeBrowserOperation}.
+ *
+ * This keeps every wrapper as a thin adapter with no independent
+ * execution logic — all behavior flows through the shared browser
+ * operations contract.
+ */
+
+import {
+  browserToolNameToOperation,
+  executeBrowserOperation,
+} from "../../../../browser/operations.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+/**
+ * Execute a browser tool by its `browser_*` tool name.
+ *
+ * Resolves the tool name to a canonical operation via
+ * {@link browserToolNameToOperation}, then dispatches through
+ * {@link executeBrowserOperation}. Returns an error result if the
+ * tool name does not map to a known operation.
+ *
+ * @param toolName - The `browser_*` tool name (e.g. `"browser_navigate"`).
+ * @param input    - Flat input object from the tool call.
+ * @param context  - Tool execution context.
+ */
+export async function runBrowserTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const operation = browserToolNameToOperation(toolName);
+  if (!operation) {
+    return {
+      content: `Error: "${toolName}" does not map to a known browser operation.`,
+      isError: true,
+    };
+  }
+  return executeBrowserOperation(operation, input, context);
+}

--- a/assistant/src/ipc/__tests__/browser-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/browser-ipc.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the `browser_execute` IPC route.
+ *
+ * Mocks executeBrowserOperation at the module boundary so the route
+ * handler can be exercised without spinning up real browser state.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolExecutionResult } from "../../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockOperationResult: ToolExecutionResult = {
+  content: "ok",
+  isError: false,
+};
+let mockOperationCalls: Array<{
+  operation: string;
+  input: Record<string, unknown>;
+  conversationId: string;
+}> = [];
+
+mock.module("../../browser/operations.js", () => ({
+  executeBrowserOperation: async (
+    operation: string,
+    input: Record<string, unknown>,
+    context: { conversationId: string },
+  ) => {
+    mockOperationCalls.push({
+      operation,
+      input,
+      conversationId: context.conversationId,
+    });
+    return mockOperationResult;
+  },
+}));
+
+// Import after mocking
+const { browserExecuteRoute, browserCliConversationKey } =
+  await import("../routes/browser.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  mockOperationResult = { content: "ok", isError: false };
+  mockOperationCalls = [];
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("browser_execute IPC route", () => {
+  test("method is browser_execute", () => {
+    expect(browserExecuteRoute.method).toBe("browser_execute");
+  });
+
+  // ── Successful dispatch ────────────────────────────────────────────
+
+  test("dispatches a valid operation and returns structured result", async () => {
+    mockOperationResult = {
+      content: "Navigated to https://example.com",
+      isError: false,
+    };
+
+    const result = await browserExecuteRoute.handler({
+      operation: "navigate",
+      input: { url: "https://example.com" },
+      sessionId: "test-session",
+    });
+
+    expect(result).toEqual({
+      content: "Navigated to https://example.com",
+      isError: false,
+    });
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].operation).toBe("navigate");
+    expect(mockOperationCalls[0].input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  // ── Unknown operation rejection ────────────────────────────────────
+
+  test("rejects unknown operation with a validation error", async () => {
+    await expect(
+      browserExecuteRoute.handler({
+        operation: "nonexistent_operation",
+        input: {},
+      }),
+    ).rejects.toThrow();
+
+    // Should never reach executeBrowserOperation
+    expect(mockOperationCalls).toHaveLength(0);
+  });
+
+  // ── Session ID mapping ─────────────────────────────────────────────
+
+  test("maps sessionId to deterministic conversation key", async () => {
+    await browserExecuteRoute.handler({
+      operation: "snapshot",
+      input: {},
+      sessionId: "my-session",
+    });
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].conversationId).toBe("browser-cli:my-session");
+  });
+
+  test("defaults sessionId to 'default' when omitted", async () => {
+    await browserExecuteRoute.handler({
+      operation: "snapshot",
+      input: {},
+    });
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].conversationId).toBe("browser-cli:default");
+  });
+
+  test("same sessionId produces same conversation key", () => {
+    const key1 = browserCliConversationKey("alpha");
+    const key2 = browserCliConversationKey("alpha");
+    expect(key1).toBe(key2);
+    expect(key1).toBe("browser-cli:alpha");
+  });
+
+  test("different sessionIds produce different conversation keys", () => {
+    const key1 = browserCliConversationKey("alpha");
+    const key2 = browserCliConversationKey("beta");
+    expect(key1).not.toBe(key2);
+  });
+
+  // ── Screenshot payload transport ───────────────────────────────────
+
+  test("extracts screenshot base64 payloads from content blocks", async () => {
+    mockOperationResult = {
+      content: "Screenshot taken",
+      isError: false,
+      contentBlocks: [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "iVBORw0KGgoAAAANS...",
+          },
+        },
+      ],
+    };
+
+    const result = (await browserExecuteRoute.handler({
+      operation: "screenshot",
+      input: {},
+      sessionId: "screenshot-test",
+    })) as {
+      content: string;
+      isError: boolean;
+      screenshots: Array<{ mediaType: string; data: string }>;
+    };
+
+    expect(result.content).toBe("Screenshot taken");
+    expect(result.isError).toBe(false);
+    expect(result.screenshots).toHaveLength(1);
+    expect(result.screenshots[0].mediaType).toBe("image/png");
+    expect(result.screenshots[0].data).toBe("iVBORw0KGgoAAAANS...");
+  });
+
+  test("omits screenshots field when no image blocks present", async () => {
+    mockOperationResult = {
+      content: "Snapshot taken",
+      isError: false,
+    };
+
+    const result = (await browserExecuteRoute.handler({
+      operation: "snapshot",
+      input: {},
+    })) as Record<string, unknown>;
+
+    expect(result.content).toBe("Snapshot taken");
+    expect(result.isError).toBe(false);
+    expect(result).not.toHaveProperty("screenshots");
+  });
+
+  test("handles multiple screenshot content blocks", async () => {
+    mockOperationResult = {
+      content: "Multiple screenshots",
+      isError: false,
+      contentBlocks: [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "first-screenshot-data",
+          },
+        },
+        {
+          type: "text",
+          text: "some text block",
+        },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/jpeg",
+            data: "second-screenshot-data",
+          },
+        },
+      ],
+    };
+
+    const result = (await browserExecuteRoute.handler({
+      operation: "screenshot",
+      input: { full_page: true },
+    })) as {
+      content: string;
+      isError: boolean;
+      screenshots: Array<{ mediaType: string; data: string }>;
+    };
+
+    expect(result.screenshots).toHaveLength(2);
+    expect(result.screenshots[0].data).toBe("first-screenshot-data");
+    expect(result.screenshots[1].data).toBe("second-screenshot-data");
+    expect(result.screenshots[1].mediaType).toBe("image/jpeg");
+  });
+
+  // ── Error propagation ──────────────────────────────────────────────
+
+  test("propagates isError from operation result", async () => {
+    mockOperationResult = {
+      content: "Error: page not found",
+      isError: true,
+    };
+
+    const result = await browserExecuteRoute.handler({
+      operation: "navigate",
+      input: { url: "https://404.example.com" },
+    });
+
+    expect(result).toEqual({
+      content: "Error: page not found",
+      isError: true,
+    });
+  });
+
+  // ── Input defaults ─────────────────────────────────────────────────
+
+  test("defaults input to empty object when omitted", async () => {
+    await browserExecuteRoute.handler({
+      operation: "snapshot",
+    });
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0].input).toEqual({});
+  });
+});

--- a/assistant/src/ipc/routes/browser.ts
+++ b/assistant/src/ipc/routes/browser.ts
@@ -1,0 +1,89 @@
+/**
+ * IPC route for browser operations.
+ *
+ * Exposes `browser_execute` so CLI commands and external processes can
+ * invoke browser operations without going through skill tool wrappers.
+ *
+ * The `sessionId` parameter (default `"default"`) is mapped to a
+ * deterministic conversation key `browser-cli:<sessionId>` so that
+ * sequential IPC calls with the same session reuse browser state.
+ */
+
+import { z } from "zod";
+
+import { executeBrowserOperation } from "../../browser/operations.js";
+import {
+  BROWSER_OPERATIONS,
+  type BrowserOperation,
+} from "../../browser/types.js";
+import type { ContentBlock } from "../../providers/types.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ── Param validation ─────────────────────────────────────────────────
+
+const BrowserExecuteParams = z.object({
+  operation: z.enum(BROWSER_OPERATIONS as unknown as [string, ...string[]]),
+  input: z.record(z.string(), z.unknown()).default({}),
+  sessionId: z.string().min(1).default("default"),
+});
+
+// ── Conversation key ─────────────────────────────────────────────────
+
+/**
+ * Build a deterministic conversation key from a session ID.
+ * All CLI browser calls with the same session share browser state.
+ */
+export function browserCliConversationKey(sessionId: string): string {
+  return `browser-cli:${sessionId}`;
+}
+
+// ── Screenshot extraction ────────────────────────────────────────────
+
+/**
+ * Extract base64 screenshot payloads from tool execution content blocks.
+ * Returns an array of `{ mediaType, data }` objects for each image found.
+ */
+function extractScreenshots(
+  contentBlocks?: ContentBlock[],
+): Array<{ mediaType: string; data: string }> {
+  if (!contentBlocks) return [];
+  const screenshots: Array<{ mediaType: string; data: string }> = [];
+  for (const block of contentBlocks) {
+    if (block.type === "image" && block.source.type === "base64") {
+      screenshots.push({
+        mediaType: block.source.media_type,
+        data: block.source.data,
+      });
+    }
+  }
+  return screenshots;
+}
+
+// ── Route definition ─────────────────────────────────────────────────
+
+export const browserExecuteRoute: IpcRoute = {
+  method: "browser_execute",
+  handler: async (params) => {
+    const { operation, input, sessionId } = BrowserExecuteParams.parse(params);
+
+    const conversationId = browserCliConversationKey(sessionId);
+
+    const result = await executeBrowserOperation(
+      operation as BrowserOperation,
+      input,
+      {
+        workingDir: process.cwd(),
+        conversationId,
+        trustClass: "guardian",
+      },
+    );
+
+    const screenshots = extractScreenshots(result.contentBlocks);
+
+    return {
+      content: result.content,
+      isError: result.isError,
+      ...(screenshots.length > 0 ? { screenshots } : {}),
+    };
+  },
+};

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,5 +1,9 @@
 import type { IpcRoute } from "../cli-server.js";
+import { browserExecuteRoute } from "./browser.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
 
 /** All built-in CLI IPC routes. */
-export const cliIpcRoutes: IpcRoute[] = [wakeConversationRoute];
+export const cliIpcRoutes: IpcRoute[] = [
+  browserExecuteRoute,
+  wakeConversationRoute,
+];

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { BROWSER_TOOL_NAMES } from "../browser/operations.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { getBundledSkillsDir } from "../config/skills.js";
@@ -275,43 +276,20 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Browser tools were previously core-registered with RiskLevel.Low (auto-allowed).
   // After migration to skill-provided tools, default allow rules preserve the
   // same frictionless UX so they don't trigger permission prompts.
+  //
   // browser_navigate candidates contain URLs with "/" (e.g.
   // "browser_navigate:https://example.com/path"), so it needs standalone
   // "**" globstar (same as host_bash / computer_use_*).  The tool field
   // already filters by tool name, so a prefix is unnecessary.
-  const browserNavigateRule: DefaultRuleTemplate = {
-    id: "default:allow-browser_navigate-global",
-    tool: "browser_navigate",
-    pattern: "**",
-    scope: "everywhere",
-    decision: "allow",
-    priority: 100,
-  };
-
-  const BROWSER_TOOLS_NO_SLASH = [
-    "browser_snapshot",
-    "browser_screenshot",
-    "browser_close",
-    "browser_attach",
-    "browser_detach",
-    "browser_click",
-    "browser_type",
-    "browser_press_key",
-    "browser_scroll",
-    "browser_select_option",
-    "browser_hover",
-    "browser_wait_for",
-    "browser_extract",
-    "browser_wait_for_download",
-    "browser_fill_credential",
-    "browser_status",
-  ] as const;
-
-  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOLS_NO_SLASH.map(
+  // All other browser tools use the standard "tool:*" pattern.
+  //
+  // The canonical set of browser tool names is sourced from BROWSER_TOOL_NAMES
+  // (browser/operations.ts) — the single source of truth for browser identifiers.
+  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOL_NAMES.map(
     (tool) => ({
       id: `default:allow-${tool}-global`,
       tool,
-      pattern: `${tool}:*`,
+      pattern: tool === "browser_navigate" ? "**" : `${tool}:*`,
       scope: "everywhere",
       decision: "allow" as const,
       priority: 100,
@@ -357,7 +335,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     skillLoadDynamicRule,
     skillLoadRule,
     skillExecuteRule,
-    browserNavigateRule,
     ...browserToolRules,
     ...uiSurfaceRules,
     memoryRecallRule,

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -1,6 +1,8 @@
 import { realpathSync } from "node:fs";
 import { basename, dirname, normalize, resolve } from "node:path";
 
+import { BROWSER_TOOL_NAMES } from "../browser/operations.js";
+
 /**
  * Resolve a path to its canonical form. When the target itself doesn't
  * exist (e.g. a new file being written), walk up to the nearest existing
@@ -53,21 +55,13 @@ export function isPathWithinWorkspaceRoot(
 /** File-path tools whose workspace-scoped-ness depends on the file_path input. */
 const PATH_SCOPED_TOOLS = new Set(["file_read", "file_write", "file_edit"]);
 
-/** Network-accessing tools — never workspace-scoped. */
+/** Network-accessing tools — never workspace-scoped.
+ * Browser tool names are sourced from the shared browser operations contract
+ * (BROWSER_TOOL_NAMES) to avoid maintaining a separate browser tool list. */
 const NETWORK_TOOLS = new Set([
   "web_search",
   "web_fetch",
-  "browser_navigate",
-  "browser_click",
-  "browser_type",
-  "browser_scroll",
-  "browser_select_option",
-  "browser_hover",
-  "browser_screenshot",
-  "browser_close",
-  "browser_attach",
-  "browser_detach",
-  "browser_status",
+  ...BROWSER_TOOL_NAMES,
   "network_request",
 ]);
 

--- a/assistant/src/tools/side-effects.ts
+++ b/assistant/src/tools/side-effects.ts
@@ -4,6 +4,23 @@
 // Used by private-conversation gating and permission simulation to decide
 // whether a tool invocation requires explicit approval.
 
+import { BROWSER_TOOL_NAMES } from "../browser/operations.js";
+
+/**
+ * Browser tools that are read-only / observational and do NOT have
+ * side effects. These are excluded from the side-effect set.
+ * The mutating browser tools (navigate, click, type, etc.) are derived
+ * from BROWSER_TOOL_NAMES by subtracting this set.
+ */
+const BROWSER_READONLY_TOOLS = new Set([
+  "browser_snapshot",
+  "browser_screenshot",
+  "browser_extract",
+  "browser_wait_for",
+  "browser_wait_for_download",
+  "browser_status",
+]);
+
 const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "file_write",
   "file_edit",
@@ -12,17 +29,7 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "bash",
   "host_bash",
   "web_fetch",
-  "browser_navigate",
-  "browser_click",
-  "browser_type",
-  "browser_press_key",
-  "browser_scroll",
-  "browser_select_option",
-  "browser_hover",
-  "browser_close",
-  "browser_attach",
-  "browser_detach",
-  "browser_fill_credential",
+  ...BROWSER_TOOL_NAMES.filter((name) => !BROWSER_READONLY_TOOLS.has(name)),
   "document_create",
   "document_update",
   "schedule_create",


### PR DESCRIPTION
## Summary
Introduces a first-class `assistant browser` command namespace with 17 subcommands (navigate, click, type, screenshot, etc.) that are fully decoupled from the existing `browser_*` skill tools. The implementation adds a shared browser operations contract that both tool wrappers and the CLI consume, creating a clean removal path for `browser_*` tools later.

## Self-review result
GAPS FOUND — 5 gaps fixed across 2 fix PRs

## PRs merged into feature branch
- #26193: refactor: add browser operations contract decoupled from tool wrappers
- #26199: refactor: make browser skill wrappers thin adapters over browser operations
- #26200: feat: add `browser_execute` CLI IPC route for daemon-side browser operations
- #26207: feat: add `assistant browser` command namespace with 17 browser subcommands
- #26223: refactor: centralize browser identifier sets across permissions and side-effects

### Fix PRs
- #26233: fix: IPC timeout for browser operations, JSDoc accuracy, and misleading comments
- #26234: fix: stale comment and error message wording for wait_for_download

Part of plan: assistant-browser-cli-decoupling.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
