### PR TITLE
feat(gallery): register Home detail panel components + side-by-side composite demo

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -372,6 +372,10 @@ struct HomeGallerySection: View {
 /// body, and a single attachment). Kept private to the gallery so it can
 /// own the `@State` bindings required by the editor's field text.
 private struct _HomeEmailEditorDemo: View {
+    private static let sampleAttachments: [HomeEmailEditor.Attachment] = [
+        .init(id: UUID(), fileName: "nba-2025-invoice-224468.pdf", fileSize: "24 kb"),
+    ]
+
     @State private var toAddress: String = "john@johnstown.com"
     @State private var subject: String = "looking for a basketball scholarship"
     @State private var bodyText: String = """
@@ -396,13 +400,7 @@ private struct _HomeEmailEditorDemo: View {
                 toAddress: $toAddress,
                 subject: $subject,
                 bodyText: $bodyText,
-                attachments: [
-                    .init(
-                        id: UUID(),
-                        fileName: "nba-2025-invoice-224468.pdf",
-                        fileSize: "24 kb"
-                    ),
-                ],
+                attachments: Self.sampleAttachments,
                 onAttachmentTap: { _ in }
             )
         }
@@ -418,6 +416,10 @@ private struct _HomeEmailEditorDemo: View {
 /// placeholder. The intent is to show the visual relationship between the
 /// two columns, not to exercise the real home page.
 private struct _HomeSplitLayoutDemo: View {
+    private static let sampleAttachments: [HomeEmailEditor.Attachment] = [
+        .init(id: UUID(), fileName: "nba-2025-invoice-224468.pdf", fileSize: "24 kb"),
+    ]
+
     @State private var toAddress: String = "john@johnstown.com"
     @State private var subject: String = "looking for a basketball scholarship"
     @State private var bodyText: String = """
@@ -451,13 +453,7 @@ private struct _HomeSplitLayoutDemo: View {
                     toAddress: $toAddress,
                     subject: $subject,
                     bodyText: $bodyText,
-                    attachments: [
-                        .init(
-                            id: UUID(),
-                            fileName: "nba-2025-invoice-224468.pdf",
-                            fileSize: "24 kb"
-                        ),
-                    ],
+                    attachments: Self.sampleAttachments,
                     onAttachmentTap: { _ in }
                 )
             }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -274,7 +274,196 @@ struct HomeGallerySection: View {
                     )
                 }
             }
+
+            // MARK: - HomeDetailPanel
+
+            if filter == nil || filter == "homeDetailPanel" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeDetailPanel",
+                    description: "Reusable white right-side panel container with standardized header (icon + title + primary/secondary actions + dismiss)."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    HomeDetailPanel(
+                        icon: .file,
+                        title: "Panel title",
+                        primaryAction: .init(label: "Primary", action: {}),
+                        secondaryAction: .init(label: "Secondary", style: .danger, action: {}),
+                        onDismiss: {}
+                    ) {
+                        Text("Detail content goes here.")
+                            .padding(VSpacing.lg)
+                    }
+                    .frame(height: 520)
+                }
+            }
+
+            // MARK: - HomeEmailEditor
+
+            if filter == nil || filter == "homeEmailEditor" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeEmailEditor",
+                    description: "Pure body content for the email editor variant of the Home detail panel."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    _HomeEmailEditorDemo()
+                }
+            }
+
+            // MARK: - HomeInvoicePreview
+
+            if filter == nil || filter == "homeInvoicePreview" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeInvoicePreview",
+                    description: "Pure body content showing a document / invoice image in the Home detail panel."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    HomeDetailPanel(
+                        icon: .file,
+                        title: "Authorise Payment to Slack",
+                        primaryAction: .init(label: "Authorise", action: {}),
+                        secondaryAction: .init(label: "Deny", style: .danger, action: {}),
+                        onDismiss: {}
+                    ) {
+                        HomeInvoicePreview(image: nil, placeholderCaption: "Sample invoice")
+                    }
+                    .frame(height: 520)
+                }
+            }
+
+            // MARK: - HomeSplitLayout
+
+            if filter == nil || filter == "homeSplitLayout" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+
+                GallerySectionHeader(
+                    title: "HomeSplitLayout",
+                    description: "Composite demo: home + right-side HomeDetailPanel showing the side-by-side layout."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    _HomeSplitLayoutDemo()
+                }
+            }
         }
+    }
+}
+
+// MARK: - Demo helpers
+
+/// Demo wrapper that hosts `HomeEmailEditor` inside a `HomeDetailPanel` with
+/// sample content matching the Figma mock (thread name, recipient, subject,
+/// body, and a single attachment). Kept private to the gallery so it can
+/// own the `@State` bindings required by the editor's field text.
+private struct _HomeEmailEditorDemo: View {
+    @State private var toAddress: String = "john@johnstown.com"
+    @State private var subject: String = "looking for a basketball scholarship"
+    @State private var bodyText: String = """
+    Dear Whatsyourface,
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+    Best,
+    Rok
+    """
+
+    var body: some View {
+        HomeDetailPanel(
+            icon: nil,
+            title: "Thread Name Here",
+            primaryAction: .init(label: "Send", action: {}),
+            onDismiss: {}
+        ) {
+            HomeEmailEditor(
+                toAddress: $toAddress,
+                subject: $subject,
+                bodyText: $bodyText,
+                attachments: [
+                    .init(
+                        id: UUID(),
+                        fileName: "nba-2025-invoice-224468.pdf",
+                        fileSize: "24 kb"
+                    ),
+                ],
+                onAttachmentTap: { _ in }
+            )
+        }
+        .frame(height: 640)
+    }
+}
+
+/// Demo wrapper that renders the side-by-side layout from the Figma mocks
+/// — a placeholder home column on the leading side and the email editor
+/// detail panel on the trailing side. `HomePageView` requires far too much
+/// setup (`HomeStore`, `HomeFeedStore`, etc.) to make a realistic full
+/// demo worthwhile here, so the leading column is intentionally a minimal
+/// placeholder. The intent is to show the visual relationship between the
+/// two columns, not to exercise the real home page.
+private struct _HomeSplitLayoutDemo: View {
+    @State private var toAddress: String = "john@johnstown.com"
+    @State private var subject: String = "looking for a basketball scholarship"
+    @State private var bodyText: String = """
+    Dear Whatsyourface,
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+    Best,
+    Rok
+    """
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VSpacing.lg) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Home placeholder")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(VSpacing.xxl)
+
+            HomeDetailPanel(
+                icon: nil,
+                title: "Thread Name Here",
+                primaryAction: .init(label: "Send", action: {}),
+                onDismiss: {}
+            ) {
+                HomeEmailEditor(
+                    toAddress: $toAddress,
+                    subject: $subject,
+                    bodyText: $bodyText,
+                    attachments: [
+                        .init(
+                            id: UUID(),
+                            fileName: "nba-2025-invoice-224468.pdf",
+                            fileSize: "24 kb"
+                        ),
+                    ],
+                    onAttachmentTap: { _ in }
+                )
+            }
+        }
+        .frame(width: 1200, height: 640)
+        .padding(VSpacing.lg)
     }
 }
 
@@ -293,6 +482,10 @@ extension HomeGallerySection {
         case "homeImageCard": HomeGallerySection(filter: "homeImageCard")
         case "homeFileCard": HomeGallerySection(filter: "homeFileCard")
         case "homeUpdatesListCard": HomeGallerySection(filter: "homeUpdatesListCard")
+        case "homeDetailPanel": HomeGallerySection(filter: "homeDetailPanel")
+        case "homeEmailEditor": HomeGallerySection(filter: "homeEmailEditor")
+        case "homeInvoicePreview": HomeGallerySection(filter: "homeInvoicePreview")
+        case "homeSplitLayout": HomeGallerySection(filter: "homeSplitLayout")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -110,6 +110,30 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("homeImageCard", "HomeImageCard", keywords: ["image", "photo", "preview"], description: "Image preview card"),
                 GalleryComponent("homeFileCard", "HomeFileCard", keywords: ["file", "document", "attachment"], description: "File reference card"),
                 GalleryComponent("homeUpdatesListCard", "HomeUpdatesListCard", keywords: ["updates", "list", "grouped"], description: "Grouped update notifications card"),
+                GalleryComponent(
+                    "homeDetailPanel",
+                    "HomeDetailPanel",
+                    keywords: ["detail panel", "side panel", "home", "container"],
+                    description: "Reusable white right-side panel container with standardized header (icon + title + primary/secondary actions + dismiss)."
+                ),
+                GalleryComponent(
+                    "homeEmailEditor",
+                    "HomeEmailEditor",
+                    keywords: ["email editor", "compose", "side panel", "detail"],
+                    description: "Pure body content for the email editor variant of the Home detail panel."
+                ),
+                GalleryComponent(
+                    "homeInvoicePreview",
+                    "HomeInvoicePreview",
+                    keywords: ["invoice", "document", "preview", "detail"],
+                    description: "Pure body content showing a document / invoice image in the Home detail panel."
+                ),
+                GalleryComponent(
+                    "homeSplitLayout",
+                    "HomeSplitLayout",
+                    keywords: ["home", "split", "side by side", "layout"],
+                    description: "Composite demo: home + right-side HomeDetailPanel showing the side-by-side layout."
+                ),
             ]
         case .icons:
             return [


### PR DESCRIPTION
## Summary
- Register `HomeDetailPanel`, `HomeEmailEditor`, `HomeInvoicePreview` and `HomeSplitLayout` in the Home category of the component gallery.
- `HomeSplitLayout` demos the side-by-side layout from the Figma mocks (placeholder home column + detail panel on the right).

Part of plan: home-detail-panel.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
