### PR TITLE
fix: emit server_tool_start/complete events for OpenAI native web search

### DIFF
--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -175,6 +175,8 @@ export class OpenAIResponsesProvider implements Provider {
       >();
       // Maps item_id → callId so we can look up tool calls from delta events.
       const itemIdToCallId = new Map<string, string>();
+      // Track web search call item IDs so we can emit server_tool_complete.
+      const webSearchCallIds: string[] = [];
       let finishReason = "unknown";
       let responseModel = modelOverride ?? this.model;
       let inputTokens = 0;
@@ -218,6 +220,15 @@ export class OpenAIResponsesProvider implements Provider {
                   args: "",
                 });
                 itemIdToCallId.set(itemId, callId);
+              } else if (item?.type === "web_search_call") {
+                const toolUseId = item.id ?? "";
+                webSearchCallIds.push(toolUseId);
+                onEvent?.({
+                  type: "server_tool_start",
+                  name: "web_search",
+                  toolUseId,
+                  input: {},
+                });
               }
               break;
             }
@@ -270,6 +281,14 @@ export class OpenAIResponsesProvider implements Provider {
                     response.usage.output_tokens_details?.reasoning_tokens ?? 0;
                 }
                 finishReason = response.status ?? "completed";
+              }
+              // Emit server_tool_complete for any web search calls that were started.
+              for (const toolUseId of webSearchCallIds) {
+                onEvent?.({
+                  type: "server_tool_complete",
+                  toolUseId,
+                  isError: false,
+                });
               }
               break;
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-openai-native-web-search.md.

**Gap:** Missing web_search_call stream event handling
**What was expected:** Web search activity indicators should show in the UI for OpenAI native web search
**What was found:** web_search_call items from the Responses API stream were silently dropped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
