### PR TITLE
fix: render web_search_call output items in LLM context diagnostics

### DIFF
--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -400,7 +400,8 @@ function normalizeOpenAiResponsesResponsePayload(
     output.some(
       (item) =>
         asString(item.type) === "message" ||
-        asString(item.type) === "function_call",
+        asString(item.type) === "function_call" ||
+        asString(item.type) === "web_search_call",
     );
   if (!hasResponsesSignal) {
     return null;
@@ -441,6 +442,22 @@ function normalizeOpenAiResponsesResponsePayload(
         toolName: name,
         data: args,
         text: previewStructuredValue(args),
+      };
+      toolCallSections.push(section);
+      responseSections.push(section);
+      continue;
+    }
+
+    if (itemType === "web_search_call") {
+      toolCallIndex++;
+      const status = asString(item.status);
+      const section: LlmContextSection = {
+        kind: "tool_use",
+        label: `Response tool call ${toolCallIndex}`,
+        role: "assistant",
+        toolName: "web_search",
+        data: omitRecordKeys(item, ["type"]) ?? undefined,
+        text: status ? `[Web search: ${status}]` : "[Web search]",
       };
       toolCallSections.push(section);
       responseSections.push(section);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-openai-native-web-search.md.

**Gap:** normalizeOpenAiResponsesResponsePayload silently skips web_search_call items in response output, making native web search invisible in diagnostics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
