### PR TITLE
Default Anthropic provider to Claude Opus 4.7

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -82,7 +82,7 @@ describe("AssistantConfigSchema", () => {
   test("parses empty object with full defaults", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.services.inference.provider).toBe("anthropic");
-    expect(result.services.inference.model).toBe("claude-opus-4-6");
+    expect(result.services.inference.model).toBe("claude-opus-4-7");
     expect(result.services.inference.mode).toBe("your-own");
     expect(result.services["image-generation"].provider).toBe("gemini");
     expect(result.services["image-generation"].model).toBe(
@@ -1953,7 +1953,7 @@ describe("loadConfig with schema validation", () => {
     writeConfig({});
     const config = loadConfig();
     expect(config.services.inference.provider).toBe("anthropic");
-    expect(config.services.inference.model).toBe("claude-opus-4-6");
+    expect(config.services.inference.model).toBe("claude-opus-4-7");
     expect(config.maxTokens).toBe(64000);
     expect(config.thinking).toEqual({
       enabled: true,

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -30,7 +30,7 @@ export type BaseService = z.infer<typeof BaseServiceSchema>;
 
 export const InferenceServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_INFERENCE_PROVIDERS).default("anthropic"),
-  model: z.string().default("claude-opus-4-6"),
+  model: z.string().default("claude-opus-4-7"),
 });
 export type InferenceService = z.infer<typeof InferenceServiceSchema>;
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -23,7 +23,7 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
       { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
     ],
-    defaultModel: "claude-opus-4-6",
+    defaultModel: "claude-opus-4-7",
     apiKeyUrl: "https://console.anthropic.com/settings/keys",
     apiKeyPlaceholder: "sk-ant-api03-...",
   },


### PR DESCRIPTION
## Summary
- \`PROVIDER_CATALOG\` Anthropic entry now defaults to \`claude-opus-4-7\`, so switching the provider dropdown to Anthropic in the inference settings selects Opus 4.7 instead of 4.6.
- \`InferenceServiceSchema\` schema default bumped to \`claude-opus-4-7\` so fresh configs pick up the new default; updated two \`config-schema.test.ts\` assertions accordingly.

## Original prompt
[Image #1] the default when switching to the Anthropic provider here should be Claude Opus 4.7 not 4.6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
