### PR TITLE
fix: diagnostics polish — web_search_call tests, tool count fix, loop consistency

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1601,4 +1601,125 @@ describe("normalizeLlmContextPayloads", () => {
 
     expect(normalized).toEqual({});
   });
+
+  test("normalizes Responses API web_search_call output as a tool_use section", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_030,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Search the web when needed.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "What is the weather?" }],
+            type: "message",
+          },
+        ],
+        tools: [{ type: "web_search_preview" }],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "web_search_call",
+            id: "ws_abc",
+            status: "completed",
+          },
+          {
+            type: "message",
+            role: "assistant",
+            content: [
+              { type: "output_text", text: "It is sunny in Boston today." },
+            ],
+          },
+        ],
+        usage: { input_tokens: 30, output_tokens: 15 },
+        status: "completed",
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: 30,
+      outputTokens: 15,
+      stopReason: "stop",
+      requestMessageCount: 1,
+      requestToolCount: 1,
+      responseMessageCount: 1,
+      responseToolCallCount: 1,
+      responsePreview: "It is sunny in Boston today.",
+      toolCallNames: ["web_search"],
+    });
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "tool_use",
+        label: "Response tool call 1",
+        role: "assistant",
+        toolName: "web_search",
+        data: { id: "ws_abc", status: "completed" },
+        text: "[Web search: completed]",
+      },
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "It is sunny in Boston today.",
+      },
+    ]);
+  });
+
+  test("normalizes Responses API response with only web_search_call (no message)", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_031,
+      requestPayload: {
+        model: "gpt-5.4",
+        instructions: "Search the web.",
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Find latest news" }],
+            type: "message",
+          },
+        ],
+        tools: [{ type: "web_search_preview" }],
+      },
+      responsePayload: {
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "web_search_call",
+            id: "ws_only",
+            status: "searching",
+          },
+        ],
+        usage: { input_tokens: 20, output_tokens: 5 },
+        status: "incomplete",
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      inputTokens: 20,
+      outputTokens: 5,
+      stopReason: "incomplete",
+      requestMessageCount: 1,
+      requestToolCount: 1,
+      responseMessageCount: 1,
+      responseToolCallCount: 1,
+      responsePreview: undefined,
+      toolCallNames: ["web_search"],
+    });
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "tool_use",
+        label: "Response tool call 1",
+        role: "assistant",
+        toolName: "web_search",
+        data: { id: "ws_only", status: "searching" },
+        text: "[Web search: searching]",
+      },
+    ]);
+  });
 });

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -461,6 +461,7 @@ function normalizeOpenAiResponsesResponsePayload(
       };
       toolCallSections.push(section);
       responseSections.push(section);
+      continue;
     }
   }
 
@@ -1053,6 +1054,10 @@ function extractOpenAiResponsesRequestToolNames(tools: unknown): string[] {
       // Responses shape: { type: "function", name: "...", ... }
       if (asString(tool.type) === "function" && asString(tool.name)) {
         return asString(tool.name);
+      }
+      // Native web search tool: { type: "web_search_preview" }
+      if (asString(tool.type) === "web_search_preview") {
+        return "web_search";
       }
       return undefined;
     })


### PR DESCRIPTION
## Summary
Fixes three minor gaps from plan review for managed-openai-native-web-search.md.

- Add tests for web_search_call diagnostics normalization
- Fix requestToolCount to include web_search_preview tools
- Add missing continue after web_search_call handler for loop consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
