### PR TITLE
fix(llm-callsite): refresh stale docstring, restore overflow budget, restore SettingsStore fallback

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -40,7 +40,7 @@ mock.module("../config/loader.js", () => ({
         thinking: { enabled: false, streamThinking: true },
         contextWindow: {
           enabled: true,
-          maxInputTokens: 100000,
+          maxInputTokens: 200_000,
           targetBudgetRatio: 0.3,
           compactThreshold: 0.8,
           summaryBudgetRatio: 0.05,

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -3,14 +3,10 @@ import { z } from "zod";
 /**
  * Unified LLM configuration schema.
  *
- * Defines the shape of the new top-level `llm` config block that consolidates
+ * Defines the shape of the top-level `llm` config block that consolidates
  * provider/model/effort/speed/thinking/contextWindow/pricingOverrides for all
- * call sites in the assistant.
- *
- * This file only defines the schema — it is not yet wired into the master
- * `AssistantConfigSchema` (PR 3) and is not yet consumed by any resolver
- * (PR 2). Downstream PRs handle migration, provider abstraction, and
- * call-site adoption.
+ * call sites in the assistant. Wired into `AssistantConfigSchema` as the `llm`
+ * field and consumed by `resolveCallSiteConfig` in `llm-resolver.ts`.
  */
 
 // ---------------------------------------------------------------------------

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2169,12 +2169,17 @@ public final class SettingsStore: ObservableObject {
 
     /// Loads service modes (inference, image-generation) from workspace config.
     /// Called during init and when the daemon reconnects.
+    ///
+    /// Inference provider/model are resolved from `llm.default.*` first
+    /// (the canonical unified-LLM location), falling back per-field to
+    /// `services.inference.{provider,model}` when the corresponding
+    /// `llm.default.*` field is absent. The fallback covers unmigrated
+    /// configs and early-return cases (missing config.json, malformed JSON,
+    /// fresh installs that pre-date the workspace migration). The
+    /// `services.inference.mode` field stays under `services` because it
+    /// is an inference-delivery setting (managed vs. your-own), orthogonal
+    /// to model selection.
     func loadServiceModes(config: [String: Any]) {
-        // Resolve inference provider/model from `llm.default.*` — the unified
-        // LLM config block is the only source of truth. The
-        // `services.inference.mode` field stays under `services` because it is
-        // an inference-delivery setting (managed vs. your-own), orthogonal to
-        // model selection.
         let services = config["services"] as? [String: Any]
         let llmDefault = (config["llm"] as? [String: Any])?["default"] as? [String: Any]
         let inference = services?["inference"] as? [String: Any]
@@ -2189,8 +2194,12 @@ public final class SettingsStore: ObservableObject {
         if lastDaemonProvider == nil {
             if let provider = llmDefault?["provider"] as? String {
                 self.selectedInferenceProvider = provider
+            } else if let provider = inference?["provider"] as? String {
+                self.selectedInferenceProvider = provider
             }
             if let model = llmDefault?["model"] as? String {
+                self.selectedModel = model
+            } else if let model = inference?["model"] as? String {
                 self.selectedModel = model
             }
         }


### PR DESCRIPTION
## Summary
- Replace stale `llm.ts` file docstring (was 'not yet wired'; the schema is wired and consumed). Per-AGENTS.md rule against history-narrating comments.
- Restore `maxInputTokens: 200_000` in the conversation-agent-loop overflow test mock — was silently halved during the config refactor and weakened the test's fidelity to production defaults.
- Restore `services.inference.{provider,model}` fallback in macOS `SettingsStore.loadServiceModes` so `testLoadServiceModesFallsBackToServicesInferenceWhenLLMDefaultAbsent` passes for the right reason rather than coinciding with the default "anthropic" provider value.

Part of plan: unify-llm-callsites.md (post-self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
