### PR TITLE
Fix cost tracking for Anthropic models on OpenRouter

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -484,6 +484,53 @@ describe("Anthropic models on OpenRouter", () => {
     expect(result.estimatedCostUsd).toBe(5 + 25);
   });
 
+  test("prices version-first anthropic/claude-4.7-opus-<date> at Opus 4.7 rates", () => {
+    // OpenRouter's response.model for Anthropic calls comes back in the form
+    // `anthropic/claude-<version>-<family>-<date>`, which previously failed
+    // the catalog prefix match (catalog keys are `claude-<family>-<version>`).
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-4.7-opus-20260416",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("prices version-first dash-form anthropic/claude-4-7-opus-<date>", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-4-7-opus-20260416",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("prices version-first anthropic/claude-4.6-sonnet", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-4.6-sonnet",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test("prices version-first anthropic/claude-4.5-haiku", () => {
+    const result = resolvePricing(
+      "openrouter",
+      "anthropic/claude-4.5-haiku",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(0.8 + 4);
+  });
+
   test("returns unpriced for unknown anthropic model on OpenRouter", () => {
     const result = resolvePricing(
       "openrouter",

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -67,15 +67,25 @@ function isAnthropicModelId(model: string): boolean {
 
 /**
  * Normalize an OpenRouter-style Anthropic model ID for lookup against the
- * Anthropic catalog: strip the `anthropic/` prefix and convert OpenRouter's
+ * Anthropic catalog: strip the `anthropic/` prefix, convert OpenRouter's
  * dot-separated version tokens (`claude-opus-4.6`) to the dash form Anthropic
- * uses natively (`claude-opus-4-6`).
+ * uses natively (`claude-opus-4-6`), and swap OpenRouter's version-first
+ * response form (`claude-4-7-opus-20260416`) into Anthropic's model-first
+ * catalog form (`claude-opus-4-7-20260416`) so the prefix match succeeds.
  */
 function normalizeAnthropicModelId(model: string): string {
   const bare = model.startsWith("anthropic/")
     ? model.slice("anthropic/".length)
     : model;
-  return bare.replace(/\./g, "-");
+  const dashed = bare.replace(/\./g, "-");
+  const versionFirst = dashed.match(
+    /^claude-(\d+(?:-\d+)*)-(opus|sonnet|haiku)(-.+)?$/,
+  );
+  if (versionFirst) {
+    const [, version, family, suffix] = versionFirst;
+    return `claude-${family}-${version}${suffix ?? ""}`;
+  }
+  return dashed;
 }
 
 /**


### PR DESCRIPTION
## Summary

- OpenRouter's Anthropic response returns the version-first form `anthropic/claude-<version>-<family>-<date>` (e.g. `anthropic/claude-4.7-opus-20260416`), which didn't prefix-match the model-first catalog keys (`claude-opus-4-7`), so `resolvePricingForUsage` returned `unpriced` and the LLM Context Inspector showed "Estimated cost: Unavailable".
- `normalizeAnthropicModelId` now swaps `claude-<version>-<family>(-<date>)?` into `claude-<family>-<version>(-<date>)?` before the catalog lookup, covering opus/sonnet/haiku and both dot and dash variants.
- Added regression tests for the exact failing shape from the screenshot plus the other families and the dash form.

## Original prompt

Fix cost tracking for Anthropic models on OpenRouter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
