### PR TITLE
fix(macos): clear queue drawer when dequeue requestId mapping is missing

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -751,6 +751,82 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].status, .processing)
     }
 
+    /// When a queued message is dequeued, it should leave the queue drawer
+    /// (`queuedMessages`) immediately — the drawer filters by `.queued` status,
+    /// and the dequeue transitions the message to `.processing`.
+    func testMessageDequeuedRemovesMessageFromQueuedMessagesDrawer() {
+        viewModel.conversationId = "sess-1"
+        viewModel.isSending = true
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(
+            MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 0)
+        ))
+        XCTAssertEqual(viewModel.queuedMessages.count, 1, "Message should be in the queue drawer before dequeue")
+
+        viewModel.handleServerMessage(.messageDequeued(
+            MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-1")
+        ))
+        XCTAssertTrue(viewModel.queuedMessages.isEmpty, "Message should leave the queue drawer after dequeue")
+        XCTAssertEqual(viewModel.messages.count, 1, "Message should still be in the transcript")
+        XCTAssertEqual(viewModel.messages[0].status, .processing)
+    }
+
+    /// Regression test for the reconnect case: when the daemon reconnects, it
+    /// clears `requestIdToMessageId` and `pendingMessageIds`, but local queued
+    /// messages remain. The next `message_dequeued` event carries a requestId
+    /// that no longer has a mapping, so the old fallback left the message
+    /// stuck with `.queued` status and it persisted in the queue drawer. The
+    /// head-of-queue fallback transitions it to `.processing` instead.
+    func testMessageDequeuedClearsQueueDrawerWhenMappingIsMissing() {
+        viewModel.conversationId = "sess-1"
+        viewModel.isSending = true
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(
+            MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 0)
+        ))
+        XCTAssertEqual(viewModel.queuedMessages.count, 1)
+
+        // Simulate the reconnect clearing the requestId mapping while leaving
+        // the local queued message intact.
+        viewModel.requestIdToMessageId.removeAll()
+        viewModel.pendingMessageIds.removeAll()
+
+        viewModel.handleServerMessage(.messageDequeued(
+            MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-1")
+        ))
+
+        XCTAssertTrue(viewModel.queuedMessages.isEmpty, "Queue drawer must clear even when the requestId mapping is missing")
+        XCTAssertEqual(viewModel.messages[0].status, .processing, "Head-of-queue message should transition to .processing")
+    }
+
+    /// Head-of-queue fallback must pick the lowest-position queued user
+    /// message, not simply the first in chronological order.
+    func testMessageDequeuedFallbackPicksLowestPositionQueuedMessage() {
+        viewModel.conversationId = "sess-1"
+
+        let older = ChatMessage(role: .user, text: "Older msg (higher pos)", status: .queued(position: 1))
+        let head = ChatMessage(role: .user, text: "Head of queue", status: .queued(position: 0))
+        viewModel.messages = [older, head]
+
+        // No requestId mapping — exercise the fallback branch.
+        viewModel.handleServerMessage(.messageDequeued(
+            MessageDequeuedMessage(conversationId: "sess-1", requestId: "unmapped-req")
+        ))
+
+        let headAfter = viewModel.messages.first { $0.text == "Head of queue" }
+        let olderAfter = viewModel.messages.first { $0.text == "Older msg (higher pos)" }
+        XCTAssertEqual(headAfter?.status, .processing, "Lowest-position message should be transitioned to .processing")
+        if case .queued(let p) = olderAfter?.status {
+            XCTAssertEqual(p, 0, "Remaining queued message should have its position decremented")
+        } else {
+            XCTFail("Remaining message should still be .queued")
+        }
+    }
+
     func testMessageDequeuedKeepsMessagePositionInTranscript() {
         viewModel.bootstrapCorrelationId = "test-correlation-id"
         viewModel.handleServerMessage(.conversationInfo(ConversationInfoMessage(conversationId: "sess-1", title: "Chat", correlationId: "test-correlation-id")))

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -783,6 +783,21 @@ final class ChatActionHandler {
         }
     }
 
+    /// Returns the index of the queued user message with the lowest position.
+    /// Ties break on the earlier-appended message (chronological order).
+    private static func headOfQueueIndex(in msgs: [ChatMessage]) -> Int? {
+        var minPos = Int.max
+        var headIdx: Int?
+        for (i, msg) in msgs.enumerated() {
+            guard msg.role == .user else { continue }
+            if case .queued(let p) = msg.status, p < minPos {
+                minPos = p
+                headIdx = i
+            }
+        }
+        return headIdx
+    }
+
     private func handleMessageDequeued(_ msg: MessageDequeuedMessage, vm: ChatViewModel) {
         guard belongsToConversation(msg.conversationId) else { return }
         vm.pendingQueuedCount = max(0, vm.pendingQueuedCount - 1)
@@ -824,14 +839,18 @@ final class ChatActionHandler {
                 vm.currentTurnUserText = text
             }
         } else {
-            // No matching messageId — still recompute queued positions and
-            // reconcile any false "Failed to send" state: the daemon is
-            // processing a queued message, so if a user message is marked as
-            // sendFailed, the send actually succeeded (transient HTTP error
-            // between enqueue and 202 response).
+            // No matching messageId — the requestId mapping was likely cleared
+            // by a daemon reconnect or sendingWatchdog. Reconcile any false
+            // "Failed to send" state, or transition the head-of-queue user
+            // message to .processing so the queue drawer doesn't hold onto a
+            // stale row while the daemon processes it. Then decrement the
+            // remaining queued positions.
             var reconciledId: UUID?
             vm.messageManager.batchUpdateMessages { msgs in
                 if let idx = msgs.lastIndex(where: { $0.role == .user && $0.status == .sendFailed }) {
+                    msgs[idx].status = .processing
+                    reconciledId = msgs[idx].id
+                } else if let idx = Self.headOfQueueIndex(in: msgs) {
                     msgs[idx].status = .processing
                     reconciledId = msgs[idx].id
                 }


### PR DESCRIPTION
## Summary
- Add a head-of-queue fallback in `handleMessageDequeued` so local queued messages transition to `.processing` even when `requestIdToMessageId` was cleared (daemon reconnect, sendingWatchdog).
- Without this, a message_dequeued event with an unknown requestId left the message stuck as `.queued`, keeping it in the queue drawer UI while the daemon was already processing it.
- Covered by three new `ChatViewModelTests` cases — normal-flow regression, missing-mapping fallback, and lowest-position selection.

## Original prompt
in the Vellum desktop app chat, when a queued message gets added to the chat it should get removed from the queue UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
