### PR TITLE
fix(llm-callsite): pass CI + address subagent/thinking/temperature review comments

### DIFF
--- a/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
+++ b/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
@@ -33,8 +33,8 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => ({ llm: mockLlmConfig }),
 }));
 
-import { AgentLoop } from "../agent/loop.js";
 import type { ResolvedSystemPrompt } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 import { RetryProvider } from "../providers/retry.js";
 import type {
@@ -94,7 +94,11 @@ function makePipeline(providerName: string): {
 describe("AgentLoop — call-site precedence", () => {
   test("call-site maxTokens wins over conversation default when callSite is set", async () => {
     setLlmConfig({
-      default: { provider: "anthropic", model: "claude-default", maxTokens: 64000 },
+      default: {
+        provider: "anthropic",
+        model: "claude-default",
+        maxTokens: 64000,
+      },
       callSites: { mainAgent: { maxTokens: 4096 } },
     });
 
@@ -115,7 +119,11 @@ describe("AgentLoop — call-site precedence", () => {
 
   test("call-site effort wins over conversation default when callSite is set", async () => {
     setLlmConfig({
-      default: { provider: "anthropic", model: "claude-default", effort: "high" },
+      default: {
+        provider: "anthropic",
+        model: "claude-default",
+        effort: "high",
+      },
       callSites: { mainAgent: { effort: "low" } },
     });
 
@@ -139,7 +147,11 @@ describe("AgentLoop — call-site precedence", () => {
 
   test("call-site speed wins over conversation default when callSite is set", async () => {
     setLlmConfig({
-      default: { provider: "anthropic", model: "claude-default", speed: "standard" },
+      default: {
+        provider: "anthropic",
+        model: "claude-default",
+        speed: "standard",
+      },
       callSites: { mainAgent: { speed: "fast" } },
     });
 
@@ -197,15 +209,41 @@ describe("AgentLoop — call-site precedence", () => {
       "mainAgent",
     );
 
-    const thinking = lastConfig()!.thinking as
-      | { enabled?: boolean; type?: string }
-      | undefined;
-    // The resolver fills the schema-shaped object, not the wire-format
-    // `{ type: "adaptive" }`. The important assertion is that the call-site
-    // value reached the provider intact.
-    expect(thinking).toBeDefined();
-    expect(thinking!.enabled).toBe(false);
-    expect(thinking!.type).not.toBe("adaptive");
+    // Call-site override resolves `thinking.enabled: false`, so the
+    // RetryProvider normalizer must omit `thinking` entirely (matching the
+    // legacy non-callSite path which only sets `providerConfig.thinking`
+    // when enabled). Without the fix at agent/loop.ts, the conversation
+    // default's `thinking: { type: "adaptive" }` would be pre-set and mask
+    // the call-site override.
+    expect(lastConfig()!.thinking).toBeUndefined();
+  });
+
+  test("call-site thinking is converted to Anthropic wire-format when enabled", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-default",
+        thinking: { enabled: true, streamThinking: true },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    const { provider, lastConfig } = makePipeline("anthropic");
+    const loop = new AgentLoop(provider, "system", { maxTokens: 64000 });
+
+    await loop.run(
+      [userMessage],
+      () => {},
+      undefined,
+      undefined,
+      undefined,
+      "mainAgent",
+    );
+
+    // Must be wire-format `{ type: "adaptive" }` so the Anthropic SDK's
+    // `ThinkingConfigParam` accepts it. The schema-shape `{ enabled,
+    // streamThinking }` would be a runtime API error.
+    expect(lastConfig()!.thinking).toEqual({ type: "adaptive" });
   });
 
   test("conversation defaults still apply when callSite is absent", async () => {

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -27,11 +27,39 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        maxTokens: 64000,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
     services: {
       inference: {
         mode: "your-own",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
       },
       "image-generation": {
         mode: "your-own",

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -82,8 +82,11 @@ import { getSchemaAtPath } from "../config/schema-utils.js";
 // ---------------------------------------------------------------------------
 
 describe("getSchemaAtPath", () => {
-  test("returns full schema for a top-level key (maxTokens → number schema)", () => {
-    const result = getSchemaAtPath(AssistantConfigSchema, "maxTokens");
+  test("returns full schema for a leaf key (llm.default.maxTokens → number schema)", () => {
+    const result = getSchemaAtPath(
+      AssistantConfigSchema,
+      "llm.default.maxTokens",
+    );
     expect(result).not.toBeNull();
     // maxTokens has a default, so it should be parseable
     const parsed = (result as z.ZodType).parse(undefined);
@@ -184,7 +187,7 @@ describe("z.toJSONSchema integration", () => {
     expect(properties).toBeDefined();
     // Check that top-level keys are present
     expect(properties.services).toBeDefined();
-    expect(properties.maxTokens).toBeDefined();
+    expect(properties.llm).toBeDefined();
     expect(properties.calls).toBeDefined();
     expect(properties.memory).toBeDefined();
     expect(properties.timeouts).toBeDefined();
@@ -222,8 +225,11 @@ describe("z.toJSONSchema integration", () => {
     expect(properties!.safety).toBeDefined();
   });
 
-  test("sub-schema at a leaf like maxTokens produces integer schema", () => {
-    const maxTokensSchema = getSchemaAtPath(AssistantConfigSchema, "maxTokens");
+  test("sub-schema at a leaf like llm.default.maxTokens produces integer schema", () => {
+    const maxTokensSchema = getSchemaAtPath(
+      AssistantConfigSchema,
+      "llm.default.maxTokens",
+    );
     expect(maxTokensSchema).not.toBeNull();
     const jsonSchema = z.toJSONSchema(maxTokensSchema!, {
       unrepresentable: "any",

--- a/assistant/src/__tests__/conversation-routes-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-routes-disk-view.test.ts
@@ -49,11 +49,39 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        maxTokens: 64000,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
     services: {
       inference: {
         mode: "your-own",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
       },
       "image-generation": {
         mode: "your-own",

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -26,17 +26,45 @@ mock.module("../daemon/conversation-slash.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    model: "claude-opus-4-6",
+    model: "claude-opus-4-7",
     provider: "anthropic",
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        maxTokens: 64000,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
     services: {
       inference: {
         mode: "your-own",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
       },
       "image-generation": {
         mode: "your-own",
@@ -347,7 +375,7 @@ describe("handleSendMessage slash command interception", () => {
       inputTokens: 1000,
       outputTokens: 500,
       estimatedCost: 0.05,
-      model: "claude-opus-4-6",
+      model: "claude-opus-4-7",
       provider: "anthropic",
       maxInputTokens: 200000,
     });

--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -16,7 +16,9 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    pricingOverrides: [],
+    llm: {
+      pricingOverrides: [],
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -130,11 +130,39 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     contextWindow: { maxInputTokens: 200000 },
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        maxTokens: 64000,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
     services: {
       inference: {
         mode: "your-own",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
       },
       "image-generation": {
         mode: "your-own",

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -70,7 +70,7 @@ describe("LLMSchema", () => {
     const parsed = LLMSchema.parse({});
     expect(parsed.default).toEqual({
       provider: "anthropic",
-      model: "claude-opus-4-6",
+      model: "claude-opus-4-7",
       maxTokens: 64000,
       effort: "max",
       speed: "standard",

--- a/assistant/src/__tests__/secret-ingress-http.test.ts
+++ b/assistant/src/__tests__/secret-ingress-http.test.ts
@@ -7,6 +7,34 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const BASE_CONFIG = {
   contextWindow: { maxInputTokens: 100000 },
   services: { inference: { model: "test-model", provider: "test-provider" } },
+  llm: {
+    default: {
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      maxTokens: 64000,
+      effort: "max" as const,
+      speed: "standard" as const,
+      temperature: null,
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        enabled: true,
+        maxInputTokens: 200000,
+        targetBudgetRatio: 0.3,
+        compactThreshold: 0.8,
+        summaryBudgetRatio: 0.05,
+        overflowRecovery: {
+          enabled: true,
+          safetyMarginRatio: 0.05,
+          maxAttempts: 3,
+          interactiveLatestTurnCompression: "summarize",
+          nonInteractiveLatestTurnCompression: "truncate",
+        },
+      },
+    },
+    profiles: {},
+    callSites: {},
+    pricingOverrides: [],
+  },
 };
 
 let mockConfig: Record<string, unknown> = {

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -39,11 +39,39 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    llm: {
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        maxTokens: 64000,
+        effort: "max" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: true, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 200000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
     services: {
       inference: {
         mode: "your-own",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
       },
       "image-generation": {
         mode: "your-own",

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Regression test for the subagent provider routing fix.
+ *
+ * Before the fix, `SubagentManager.spawn()` constructed the Conversation with
+ * `getProvider(appConfig.llm.default.provider)` directly, which meant per-call
+ * `llm.callSites.subagentSpawn.provider` overrides only changed the request
+ * *metadata* the downstream client saw — the actual HTTP transport still
+ * belonged to `llm.default.provider`. After the fix, the provider is wrapped
+ * in `CallSiteRoutingProvider`, which consults the resolver per call and
+ * routes to the resolved provider's transport when it differs from the
+ * default.
+ *
+ * This test stubs the `Conversation` constructor and the provider registry
+ * so we can capture the provider that `SubagentManager` passes into
+ * `Conversation`, then verify it's a `CallSiteRoutingProvider` that selects
+ * the right transport for the `subagentSpawn` callSite.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+// Capture the provider passed to Conversation.
+let capturedProvider: unknown = undefined;
+
+// Stub Conversation so spawn() doesn't try to actually run an agent loop —
+// we only care about what provider it was constructed with.
+class FakeConversation {
+  constructor(
+    _id: string,
+    provider: unknown,
+    _systemPrompt: string,
+    _maxTokens: number,
+    _sendToClient: (msg: ServerMessage) => void,
+  ) {
+    capturedProvider = provider;
+  }
+  updateClient() {}
+  setIsSubagent() {}
+  hasSystemPromptOverride = false;
+  setSubagentAllowedTools() {}
+  preactivateSkills() {}
+  preactivateSkillsAsync() {}
+  setSpawnHints() {}
+  injectInheritedContext() {}
+  setActiveBranchId() {}
+  setBranchTag() {}
+  setForkPolicy() {}
+  setForkParentMessageCount() {}
+  setForkParentSystemPrompt() {}
+  enqueueMessage() {
+    return { rejected: false, queued: true };
+  }
+  abort() {}
+  dispose() {}
+  messages = [];
+  usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+  sendToClient() {}
+  loadFromDb() {
+    return Promise.resolve();
+  }
+  persistUserMessage() {
+    return "msg-id";
+  }
+  runAgentLoop() {
+    return Promise.resolve();
+  }
+  getCurrentSystemPrompt() {
+    return "system";
+  }
+}
+
+mock.module("../daemon/conversation.js", () => ({
+  Conversation: FakeConversation,
+}));
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: () => ({ id: "conv-id" }),
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+  buildSubagentSystemPrompt: () => "subagent system",
+}));
+
+// Provider registry — return distinct stubs so we can verify the selection.
+const anthropicStub = { name: "anthropic" };
+const openaiStub = { name: "openai" };
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: (name: string) => {
+    if (name === "anthropic") return anthropicStub;
+    if (name === "openai") return openaiStub;
+    throw new Error(`unknown provider: ${name}`);
+  },
+}));
+
+// Mutable LLM config — tests rewrite this per-case.
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: mockLlmConfig,
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
+import { SubagentManager } from "../subagent/manager.js";
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+describe("SubagentManager — provider call-site routing", () => {
+  test("wraps the default provider in CallSiteRoutingProvider", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+    });
+
+    capturedProvider = undefined;
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-1",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    expect(capturedProvider).toBeInstanceOf(CallSiteRoutingProvider);
+  });
+
+  test("the wrapped provider exposes the default provider's name (stable identity for outer wrappers)", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        subagentSpawn: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    capturedProvider = undefined;
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-2",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    // The wrapper exposes the *default* provider's name (so wrappers further
+    // out — e.g. RateLimitProvider — see a stable identity), but routes the
+    // actual sendMessage to the resolved provider. The routing behavior
+    // itself is exercised in the next describe block with a fully-stubbed
+    // provider pair.
+    expect(capturedProvider).toBeInstanceOf(CallSiteRoutingProvider);
+    const wrapper = capturedProvider as CallSiteRoutingProvider;
+    expect(wrapper.name).toBe("anthropic");
+  });
+
+  test("falls back to default provider when subagentSpawn callSite is absent", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      // No subagentSpawn override.
+    });
+
+    capturedProvider = undefined;
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-3",
+        label: "test",
+        objective: "test objective",
+      },
+      () => {},
+    );
+
+    expect(capturedProvider).toBeInstanceOf(CallSiteRoutingProvider);
+    // Default provider's name surfaces.
+    expect((capturedProvider as { name: string }).name).toBe("anthropic");
+  });
+});
+
+// ── Direct unit test for CallSiteRoutingProvider's selection logic ─────────
+
+describe("CallSiteRoutingProvider — selectProvider behavior", () => {
+  test("routes to the resolved provider when callSite.provider differs from default", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        subagentSpawn: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    let calledOnDefault = false;
+    let calledOnAlternative = false;
+
+    const defaultProvider = {
+      name: "anthropic",
+      sendMessage: async () => {
+        calledOnDefault = true;
+        return {
+          content: [],
+          model: "anthropic",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "end_turn" as const,
+        };
+      },
+    };
+    const altProvider = {
+      name: "openai",
+      sendMessage: async () => {
+        calledOnAlternative = true;
+        return {
+          content: [],
+          model: "openai",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "end_turn" as const,
+        };
+      },
+    };
+
+    const wrapper = new CallSiteRoutingProvider(defaultProvider, (name) => {
+      if (name === "openai") return altProvider;
+      return undefined;
+    });
+
+    await wrapper.sendMessage([], undefined, undefined, {
+      config: { callSite: "subagentSpawn" },
+    });
+
+    expect(calledOnAlternative).toBe(true);
+    expect(calledOnDefault).toBe(false);
+  });
+
+  test("routes to default when no callSite provided", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        subagentSpawn: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    let calledOnDefault = false;
+
+    const defaultProvider = {
+      name: "anthropic",
+      sendMessage: async () => {
+        calledOnDefault = true;
+        return {
+          content: [],
+          model: "anthropic",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "end_turn" as const,
+        };
+      },
+    };
+
+    const wrapper = new CallSiteRoutingProvider(
+      defaultProvider,
+      () => undefined,
+    );
+
+    await wrapper.sendMessage([], undefined, undefined, {
+      config: {},
+    });
+
+    expect(calledOnDefault).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
+++ b/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
@@ -16,7 +16,9 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    pricingOverrides: mockPricingOverrides,
+    llm: {
+      pricingOverrides: mockPricingOverrides,
+    },
   }),
 }));
 

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -148,7 +148,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.max_tokens).toBe(32000);
   });
 
-  test("propagates resolved effort/speed/temperature/thinking/contextWindow", async () => {
+  test("propagates resolved effort/speed/temperature/contextWindow", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -179,10 +179,123 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.effort).toBe("high");
     expect(config.speed).toBe("fast");
     expect(config.temperature).toBe(0.7);
-    // Deep-merged: enabled overridden by callSite, streamThinking inherited.
-    expect(config.thinking).toEqual({ enabled: false, streamThinking: true });
+    // Disabled thinking is omitted entirely so providers fall back to their
+    // default behavior — matches the legacy non-callSite path which only sets
+    // `providerConfig.thinking` when `enabled === true`.
+    expect(config.thinking).toBeUndefined();
     // contextWindow comes through from the resolved default.
     expect(config.contextWindow).toBeDefined();
+  });
+
+  test("converts resolved thinking config to Anthropic wire-format `{ type: 'adaptive' }` when enabled", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: true, streamThinking: true },
+      },
+      callSites: {
+        // Inherits `thinking.enabled: true` from default.
+        mainAgent: {},
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    // Must be the Anthropic SDK's `ThinkingConfigAdaptive` shape, NOT the
+    // schema-shape `{ enabled, streamThinking }`. The Anthropic client spreads
+    // `restConfig` directly into `Anthropic.MessageStreamParams` and the SDK
+    // only accepts the `{ type: ... }` discriminator.
+    expect(config.thinking).toEqual({ type: "adaptive" });
+  });
+
+  test("omits thinking when resolved config has thinking.enabled: false", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: {
+        mainAgent: {},
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toBeUndefined();
+  });
+
+  test("does NOT propagate temperature when resolved value is null (schema default)", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        // `temperature` defaults to null — "let provider pick".
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    // Must NOT be set — null would either trigger a wire error or override
+    // sensible provider defaults. Mirrors the legacy non-callSite path which
+    // never sets `temperature` on `providerConfig`.
+    expect(config.temperature).toBeUndefined();
+    expect("temperature" in config).toBe(false);
+  });
+
+  test("propagates temperature when explicitly set in resolved config", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        mainAgent: { temperature: 0.5 },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.temperature).toBe(0.5);
   });
 
   test("strips effort/speed/thinking for providers that don't support them", async () => {
@@ -302,5 +415,4 @@ describe("getConfiguredProvider — callSite routing", () => {
     const provider = await getConfiguredProvider("heartbeatAgent");
     expect(provider?.name).toBe("anthropic");
   });
-
 });

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -119,11 +119,31 @@ function normalizeSendMessageOptions(
     if (nextConfig.speed === undefined) {
       nextConfig.speed = resolved.speed;
     }
-    if (nextConfig.temperature === undefined) {
+    // `temperature` defaults to `null` in the LLM schema (meaning "no opinion
+    // — let the provider pick its own default"). Only forward when the
+    // resolved value is an actual number; passing `temperature: null` to
+    // provider clients would either be a wire error or silently override
+    // sensible provider defaults. Mirrors the legacy non-callSite path which
+    // never set `temperature` on `providerConfig`.
+    if (
+      nextConfig.temperature === undefined &&
+      resolved.temperature !== null &&
+      resolved.temperature !== undefined
+    ) {
       nextConfig.temperature = resolved.temperature;
     }
     if (nextConfig.thinking === undefined) {
-      nextConfig.thinking = resolved.thinking;
+      // Convert the schema-shape `{ enabled, streamThinking }` into the
+      // Anthropic wire-format `{ type: "adaptive" }` (or omit when disabled).
+      // Mirrors the non-callSite path in `agent/loop.ts` which sets
+      // `providerConfig.thinking = { type: "adaptive" }` only when enabled.
+      // Without this conversion, `thinking` arrives at `AnthropicProvider`
+      // with a shape the SDK doesn't accept (`ThinkingConfigParam` requires
+      // a `type` discriminator), and OpenRouter's truthy check would treat
+      // a disabled config as enabled.
+      if (resolved.thinking?.enabled === true) {
+        nextConfig.thinking = { type: "adaptive" };
+      }
     }
     if (nextConfig.contextWindow === undefined) {
       nextConfig.contextWindow = resolved.contextWindow;

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -17,6 +17,7 @@ import {
 } from "../daemon/conversation.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { getProvider } from "../providers/registry.js";
 import { createAbortReason } from "../util/abort-reasons.js";
@@ -155,7 +156,9 @@ export class SubagentManager {
    * `onSubagentFinished`.  Used by fork spawn to resolve the parent's
    * system prompt when `config.parentSystemPrompt` is not provided.
    */
-  resolveParentConversation?: (conversationId: string) => Conversation | undefined;
+  resolveParentConversation?: (
+    conversationId: string,
+  ) => Conversation | undefined;
 
   // ── Spawn ───────────────────────────────────────────────────────────
 
@@ -212,6 +215,18 @@ export class SubagentManager {
     // ── Build conversation dependencies ─────────────────────────────
     const appConfig = getConfig();
     let provider = getProvider(appConfig.llm.default.provider);
+    // Per-call `options.config.callSite` (e.g. `subagentSpawn`) can resolve
+    // to a provider name that differs from `llm.default.provider`. Wrap the
+    // default provider so the actual transport routes correctly per call,
+    // rather than only forwarding metadata to the default's HTTP client.
+    // See `providers/call-site-routing.ts`.
+    provider = new CallSiteRoutingProvider(provider, (name) => {
+      try {
+        return getProvider(name);
+      } catch {
+        return undefined;
+      }
+    });
     const { rateLimit } = appConfig;
     if (rateLimit.maxRequestsPerMinute > 0) {
       provider = new RateLimitProvider(
@@ -227,19 +242,21 @@ export class SubagentManager {
       if (config.parentSystemPrompt) {
         systemPrompt = config.parentSystemPrompt;
       } else if (this.resolveParentConversation) {
-        const parentConv = this.resolveParentConversation(config.parentConversationId);
+        const parentConv = this.resolveParentConversation(
+          config.parentConversationId,
+        );
         const resolved = parentConv?.getCurrentSystemPrompt();
         if (!resolved) {
           throw new Error(
             "Fork spawn requires a parent system prompt but neither config.parentSystemPrompt " +
-            "nor resolveParentConversation yielded one.",
+              "nor resolveParentConversation yielded one.",
           );
         }
         systemPrompt = resolved;
       } else {
         throw new Error(
           "Fork spawn requires a parent system prompt but neither config.parentSystemPrompt " +
-          "is set nor resolveParentConversation callback is wired.",
+            "is set nor resolveParentConversation callback is wired.",
         );
       }
     } else {
@@ -266,10 +283,16 @@ export class SubagentManager {
     const now = Date.now();
     // For forks, default sendResultToUser to false (silent) unless explicitly true.
     const resolvedSendResultToUser = isFork
-      ? (config.sendResultToUser === true ? true : false)
+      ? config.sendResultToUser === true
+        ? true
+        : false
       : config.sendResultToUser;
     const state: SubagentState = {
-      config: { ...config, id: subagentId, sendResultToUser: resolvedSendResultToUser },
+      config: {
+        ...config,
+        id: subagentId,
+        sendResultToUser: resolvedSendResultToUser,
+      },
       status: "pending",
       conversationId: conversationRecord.id,
       isFork,
@@ -413,7 +436,9 @@ export class SubagentManager {
       // This prepends the inherited context so the fork has full conversational
       // awareness while the objective becomes the latest user turn.
       if (managed.state.isFork && managed.state.config.parentMessages) {
-        conversation.injectInheritedContext(managed.state.config.parentMessages);
+        conversation.injectInheritedContext(
+          managed.state.config.parentMessages,
+        );
         // Release the parent message arrays now that they've been injected — holding
         // them in SubagentState.config would retain significant memory until the TTL
         // sweep disposes this entry (up to 30 minutes for terminal subagents).
@@ -904,8 +929,7 @@ export class SubagentManager {
     const prefix = managed.state.isFork ? "Fork" : "Subagent";
     let notificationString = `[${prefix} "${info.label}" — ${urgency}] ${message}`;
     if (urgency === "blocked") {
-      notificationString +=
-        `\nUse subagent_message to send guidance to this ${prefix.toLowerCase()}.`;
+      notificationString += `\nUse subagent_message to send guidance to this ${prefix.toLowerCase()}.`;
     }
 
     try {

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -1702,8 +1702,9 @@ const CHAT_OPPORTUNITY_TOOL: ToolDefinition = {
 async function defaultCallDetectorLLM(
   prompt: string,
 ): Promise<ChatOpportunityDecision> {
-  const provider: Provider | null =
-    await getConfiguredProvider("meetChatOpportunity");
+  const provider: Provider | null = await getConfiguredProvider(
+    "meetChatOpportunity",
+  );
   if (!provider) {
     return { shouldRespond: false, reason: "" };
   }

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -10,47 +10,47 @@ If the user switches models mid-session via the UI, the skill will reflect the u
 
 All known models by provider, so you can interpret model IDs from config:
 
-| Provider | Model ID | Display Name |
-|----------|----------|--------------|
-| Anthropic | `claude-opus-4-7` | Claude Opus 4.7 |
-| Anthropic | `claude-opus-4-6` | Claude Opus 4.6 |
-| Anthropic | `claude-sonnet-4-6` | Claude Sonnet 4.6 |
-| Anthropic | `claude-haiku-4-5-20251001` | Claude Haiku 4.5 |
-| OpenAI | `gpt-5.2` | GPT-5.2 |
-| OpenAI | `gpt-5.4` | GPT-5.4 |
-| OpenAI | `gpt-5.4-nano` | GPT-5.4 Nano |
-| Google Gemini | `gemini-3-flash` | Gemini 3 Flash |
-| Google Gemini | `gemini-3-pro` | Gemini 3 Pro |
-| Ollama | `llama3.2` | Llama 3.2 |
-| Ollama | `mistral` | Mistral |
-| Fireworks | `accounts/fireworks/models/kimi-k2p5` | Kimi K2.5 |
-| OpenRouter | `x-ai/grok-4` | Grok 4 |
-| OpenRouter | `x-ai/grok-4.20-beta` | Grok 4.20 Beta |
-| OpenRouter | `deepseek/deepseek-r1-0528` | DeepSeek R1 |
-| OpenRouter | `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 |
-| OpenRouter | `qwen/qwen3.5-plus-02-15` | Qwen 3.5 Plus |
-| OpenRouter | `qwen/qwen3.5-397b-a17b` | Qwen 3.5 397B |
-| OpenRouter | `qwen/qwen3.5-flash-02-23` | Qwen 3.5 Flash |
-| OpenRouter | `qwen/qwen3-coder-next` | Qwen 3 Coder |
-| OpenRouter | `moonshotai/kimi-k2.5` | Kimi K2.5 |
-| OpenRouter | `mistralai/mistral-medium-3` | Mistral Medium 3 |
-| OpenRouter | `mistralai/mistral-small-2603` | Mistral Small 4 |
-| OpenRouter | `mistralai/devstral-2512` | Devstral 2 |
-| OpenRouter | `meta-llama/llama-4-maverick` | Llama 4 Maverick |
-| OpenRouter | `meta-llama/llama-4-scout` | Llama 4 Scout |
-| OpenRouter | `amazon/nova-pro-v1` | Amazon Nova Pro |
+| Provider      | Model ID                              | Display Name      |
+| ------------- | ------------------------------------- | ----------------- |
+| Anthropic     | `claude-opus-4-7`                     | Claude Opus 4.7   |
+| Anthropic     | `claude-opus-4-6`                     | Claude Opus 4.6   |
+| Anthropic     | `claude-sonnet-4-6`                   | Claude Sonnet 4.6 |
+| Anthropic     | `claude-haiku-4-5-20251001`           | Claude Haiku 4.5  |
+| OpenAI        | `gpt-5.2`                             | GPT-5.2           |
+| OpenAI        | `gpt-5.4`                             | GPT-5.4           |
+| OpenAI        | `gpt-5.4-nano`                        | GPT-5.4 Nano      |
+| Google Gemini | `gemini-3-flash`                      | Gemini 3 Flash    |
+| Google Gemini | `gemini-3-pro`                        | Gemini 3 Pro      |
+| Ollama        | `llama3.2`                            | Llama 3.2         |
+| Ollama        | `mistral`                             | Mistral           |
+| Fireworks     | `accounts/fireworks/models/kimi-k2p5` | Kimi K2.5         |
+| OpenRouter    | `x-ai/grok-4`                         | Grok 4            |
+| OpenRouter    | `x-ai/grok-4.20-beta`                 | Grok 4.20 Beta    |
+| OpenRouter    | `deepseek/deepseek-r1-0528`           | DeepSeek R1       |
+| OpenRouter    | `deepseek/deepseek-chat-v3-0324`      | DeepSeek V3       |
+| OpenRouter    | `qwen/qwen3.5-plus-02-15`             | Qwen 3.5 Plus     |
+| OpenRouter    | `qwen/qwen3.5-397b-a17b`              | Qwen 3.5 397B     |
+| OpenRouter    | `qwen/qwen3.5-flash-02-23`            | Qwen 3.5 Flash    |
+| OpenRouter    | `qwen/qwen3-coder-next`               | Qwen 3 Coder      |
+| OpenRouter    | `moonshotai/kimi-k2.5`                | Kimi K2.5         |
+| OpenRouter    | `mistralai/mistral-medium-3`          | Mistral Medium 3  |
+| OpenRouter    | `mistralai/mistral-small-2603`        | Mistral Small 4   |
+| OpenRouter    | `mistralai/devstral-2512`             | Devstral 2        |
+| OpenRouter    | `meta-llama/llama-4-maverick`         | Llama 4 Maverick  |
+| OpenRouter    | `meta-llama/llama-4-scout`            | Llama 4 Scout     |
+| OpenRouter    | `amazon/nova-pro-v1`                  | Amazon Nova Pro   |
 
 ## Inference Configuration
 
 Relevant config paths and what they control:
 
-| Config Path | Description |
-|-------------|-------------|
-| `llm.default.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
-| `llm.default.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
-| `services.inference.mode` | `"your-own"` (user's API key) vs `"managed"` (platform proxy) |
-| `llm.default.effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` (`xhigh` sits between `high` and `max`, for models that support it — e.g. Opus 4.7) |
-| `llm.default.thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
+| Config Path                    | Description                                                                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `llm.default.model`            | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`)                                                                                                       |
+| `llm.default.provider`         | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter`                                                                     |
+| `services.inference.mode`      | `"your-own"` (user's API key) vs `"managed"` (platform proxy)                                                                                                 |
+| `llm.default.effort`           | Inference effort level: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` (`xhigh` sits between `high` and `max`, for models that support it — e.g. Opus 4.7) |
+| `llm.default.thinking.enabled` | Whether extended thinking (chain-of-thought) is active                                                                                                        |
 
 Read any of these with `assistant config get <path>`, e.g.:
 

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -75,10 +75,13 @@ async function main(): Promise<void> {
   const jsonMode = process.argv.includes("--json");
 
   try {
-    const proc = Bun.spawn(["assistant", "config", "get", "services.inference"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const proc = Bun.spawn(
+      ["assistant", "config", "get", "services.inference"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
 
     const stdout = await new Response(proc.stdout).text();
     const stderr = await new Response(proc.stderr).text();
@@ -120,9 +123,15 @@ async function main(): Promise<void> {
     const mode = config.mode ?? "unknown";
 
     const modelDisplayName = MODEL_DISPLAY_NAMES[modelId] ?? modelId;
-    const providerDisplayName = PROVIDER_DISPLAY_NAMES[providerId] ?? providerId;
+    const providerDisplayName =
+      PROVIDER_DISPLAY_NAMES[providerId] ?? providerId;
 
-    const modeLabel = mode === "your-own" ? "your-own API key" : mode === "managed" ? "managed platform proxy" : mode;
+    const modeLabel =
+      mode === "your-own"
+        ? "your-own API key"
+        : mode === "managed"
+          ? "managed platform proxy"
+          : mode;
 
     const summary = `You are running as ${modelDisplayName} via ${providerDisplayName} (${modeLabel}).`;
 


### PR DESCRIPTION
## Summary
- Lint/prettier: sort imports in agent-loop-callsite-precedence.test.ts; reformat session-manager.ts, inference.md, self-info.ts.
- Test mocks: extend ~10 test `getConfig` mocks to include the new `llm.{default,profiles,callSites,pricingOverrides}` block now that production code reads `config.llm.default.*` directly.
- Update default-model assertions from claude-opus-4-6 → claude-opus-4-7 in config-schema-cmd and llm-schema tests (matches main's PR #26247 bump).
- Wrap subagent provider in CallSiteRoutingProvider so `llm.callSites.subagentSpawn.provider` actually swaps transport (Devin flag).
- Normalize thinking config shape so callSite-routed requests reach the Anthropic client in the same wire format as legacy requests (Devin flag).
- Skip propagating `temperature: null` to provider clients for callSite-routed requests; only forward when explicitly set (Devin flag).

Part of plan: unify-llm-callsites.md (post-self-review CI fixes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
