### PR TITLE
Fix Chrome extension ID and clarify dev setup in README

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -71,9 +71,49 @@ That's it. The extension auto-reconnects on browser restarts, network drops, and
 - **Service worker logs:** `chrome://extensions` > extension card > **Service worker** link
 - **Popup logs:** Open popup > right-click > **Inspect**
 
+## Extension ID & Allowlisting
+
+Chrome assigns each extension a unique 32-character ID. The assistant needs to know your extension's ID so it can accept connections from it. Three sources are merged at startup (duplicates are deduplicated):
+
+| Source | Purpose |
+|---|---|
+| `meta/browser-extension/chrome-extension-allowlist.json` | Committed canonical config (contains the published CWS extension ID) |
+| `~/.vellum/chrome-extension-allowlist.local.json` | Per-machine overrides — add your unpacked dev extension ID here |
+| `VELLUM_CHROME_EXTENSION_IDS` env var | Comma-separated IDs, useful for CI or one-off testing |
+
+This means the CWS extension and your local dev build work side-by-side with no conflict. You just need to add your dev ID to the local allowlist.
+
+### Adding your dev extension ID
+
+1. Open `chrome://extensions` and find the **ID** shown on your unpacked extension's card.
+
+2. Create (or edit) the local allowlist:
+
+```bash
+mkdir -p "$HOME/.vellum"
+cat > "$HOME/.vellum/chrome-extension-allowlist.local.json" <<JSON
+{
+  "version": 1,
+  "allowedExtensionIds": ["<id from chrome://extensions>"]
+}
+JSON
+```
+
+3. Restart the assistant — the allowlist is cached at startup.
+
+The IDs are public Chrome extension identifiers, so no special file permissions are needed. Your local allowlist is gitignored and stays on your machine.
+
 ## Native Messaging Host Setup
 
-The macOS app installs the native messaging host automatically. If pairing fails, set it up manually:
+The native messaging host lets the extension discover running assistants via the local lockfile.
+
+### With the macOS app (recommended)
+
+The macOS app installs the native messaging host automatically on every launch. It reads all merged allowlist IDs and writes them into the manifest's `allowed_origins`, so both the CWS extension and your dev build are accepted. After adding your dev ID to the local allowlist (see above), just restart the macOS app and Chrome.
+
+### Manual setup (without the macOS app)
+
+If you're not using the macOS app, set up the native messaging host manually:
 
 1. Install the helper's dependencies (no build step — the dev wrapper runs `bun` against `src/index.ts` directly, so the `dist/` directory is only needed for tests and release builds):
 
@@ -82,27 +122,14 @@ cd clients/chrome-extension/native-host
 bun install
 ```
 
-2. Find your extension ID in `chrome://extensions` and export it. Chrome assigns this ID the first time you **Load unpacked**, so the snippet below needs it as an env var:
+2. Export your extension ID(s). Include both the CWS ID and your dev ID if you want both to work:
 
 ```bash
-export EXTENSION_ID=<id from chrome://extensions>
+export CWS_EXTENSION_ID=hphbdmpffeigpcdjkckleobjmhhokpne
+export DEV_EXTENSION_ID=<id from chrome://extensions>
 ```
 
-3. Register the ID locally so the assistant accepts pair requests from your unpacked build. Create `~/.vellum/chrome-extension-allowlist.local.json` — this file is merged with the committed allowlist at assistant startup and stays local to your machine:
-
-```bash
-mkdir -p "$HOME/.vellum"
-cat > "$HOME/.vellum/chrome-extension-allowlist.local.json" <<JSON
-{
-  "version": 1,
-  "allowedExtensionIds": ["$EXTENSION_ID"]
-}
-JSON
-```
-
-Restart the assistant after creating or editing this file — the allowlist is cached at startup. The IDs are public Chrome extension identifiers, so no special file permissions are needed.
-
-4. Install the Chrome native messaging manifest. **Run this from the same `native-host/` directory as step 1** — the snippet reads `$(pwd)/src/index.ts`:
+3. Install the Chrome native messaging manifest. **Run this from the same `native-host/` directory as step 1** — the snippet reads `$(pwd)/src/index.ts`:
 
 ```bash
 NATIVE_HOST_ENTRY="$(pwd)/src/index.ts"
@@ -110,7 +137,6 @@ BUN_BIN="$(command -v bun)"
 NATIVE_HOSTS_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
 
 if [ -z "$BUN_BIN" ]; then echo "bun not found on PATH" >&2; exit 1; fi
-if [ -z "$EXTENSION_ID" ]; then echo "Set EXTENSION_ID=<id from chrome://extensions> first" >&2; exit 1; fi
 
 mkdir -p "$NATIVE_HOSTS_DIR"
 
@@ -126,7 +152,10 @@ cat > "$NATIVE_HOSTS_DIR/com.vellum.daemon.json" <<JSON
   "description": "Vellum assistant native messaging host",
   "path": "$NATIVE_HOSTS_DIR/com.vellum.daemon.sh",
   "type": "stdio",
-  "allowed_origins": ["chrome-extension://$EXTENSION_ID/"]
+  "allowed_origins": [
+    "chrome-extension://$CWS_EXTENSION_ID/",
+    "chrome-extension://$DEV_EXTENSION_ID/"
+  ]
 }
 JSON
 chmod 644 "$NATIVE_HOSTS_DIR/com.vellum.daemon.json"
@@ -136,7 +165,7 @@ chmod 644 "$NATIVE_HOSTS_DIR/com.vellum.daemon.json"
 >
 > Pointing the wrapper at `src/index.ts` (rather than `dist/index.js`) means the helper always runs the current source — no stale-`dist/` failures after editing `src/`. Bun executes TypeScript natively.
 
-5. Fully quit and relaunch Chrome.
+4. Fully quit and relaunch Chrome.
 
 ## Troubleshooting
 
@@ -150,9 +179,9 @@ chmod 644 "$NATIVE_HOSTS_DIR/com.vellum.daemon.json"
 
 | Error | Cause / Fix |
 |---|---|
-| `Access to the specified native messaging host is forbidden` | Manifest missing/invalid, or extension ID not in the allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` (see Native Messaging Host Setup, step 3). |
+| `Access to the specified native messaging host is forbidden` | Manifest missing/invalid, or extension ID not in the allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` (see Extension ID & Allowlisting above). |
 | `Native host has exited` | Chrome couldn't launch Bun. Use a wrapper script with an absolute Bun path in the manifest. |
-| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` and restart the assistant (the allowlist is cached at assistant startup). |
+| `assistant pair request failed with HTTP 401` | Extension ID not in allowlist. Add it to `~/.vellum/chrome-extension-allowlist.local.json` and restart the assistant (see Extension ID & Allowlisting above). |
 | `failed to reach assistant at http://127.0.0.1:<port>/...` | Assistant not running, wrong port, or firewall blocking. |
 | `Automatic cloud sign-in failed` | Use "Re-sign in" in the popup's Troubleshooting section, then click Connect. |
 | `Automatic local pairing failed` | Use "Re-pair" in the popup's Troubleshooting section, then click Connect. |

--- a/meta/browser-extension/chrome-extension-allowlist.json
+++ b/meta/browser-extension/chrome-extension-allowlist.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "allowedExtensionIds": [
-    "ccfbbgpdcnnfnnnodmkjkcpnbkmbjecp"
+    "hphbdmpffeigpcdjkckleobjmhhokpne"
   ]
 }


### PR DESCRIPTION
## Summary
- Update canonical allowlist (`meta/browser-extension/chrome-extension-allowlist.json`) from stale extension ID to the correct published CWS ID (`hphbdmpffeigpcdjkckleobjmhhokpne`)
- Restructure Chrome extension README: add "Extension ID & Allowlisting" section explaining the 3-source merge strategy, split native messaging setup into "with macOS app" (automatic) vs "manual" paths
- Update manual setup script to include both CWS and dev extension IDs in `allowed_origins`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
