### PR TITLE
fix: update stale OIDC comment in DeveloperSettingsSection

### DIFF
--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -221,7 +221,7 @@ private struct DeveloperSettingsSectionContent: View {
         _ = APIKeyManager.shared.deleteAPIKey(provider: "runtime-bearer-token")
 
         // Invalidate auth state so LoginView doesn't see a stale
-        // .authenticated value if the user cancels the OIDC flow.
+        // .authenticated value if the user cancels the login flow.
         authManager.state = .unauthenticated
 
         // Rebuild the client so it picks up the cleared state.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for native-auth-flow.md.

**Gap:** Stale OIDC comment in DeveloperSettingsSection.swift
**What was expected:** References to old OIDC flow should be updated
**What was found:** Comment still references 'OIDC flow' which is now misleading
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
