### PR TITLE
Fix extension-id-sync-guard test after canonical ID update

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -41,11 +41,15 @@ function parseCanonicalConfig(): AllowlistConfig {
   const parsed = JSON.parse(raw) as Partial<AllowlistConfig>;
 
   if (!Number.isInteger(parsed.version) || (parsed.version ?? 0) <= 0) {
-    throw new Error("Invalid canonical config: version must be a positive integer");
+    throw new Error(
+      "Invalid canonical config: version must be a positive integer",
+    );
   }
 
   if (!Array.isArray(parsed.allowedExtensionIds)) {
-    throw new Error("Invalid canonical config: allowedExtensionIds must be an array");
+    throw new Error(
+      "Invalid canonical config: allowedExtensionIds must be an array",
+    );
   }
 
   if (parsed.allowedExtensionIds.length === 0) {
@@ -95,6 +99,7 @@ function listTextFilesRecursively(root: string): string[] {
     ".turbo",
     ".idea",
     ".vscode",
+    ".codex-worktrees",
   ]);
 
   const allowedExtensions = new Set([
@@ -196,12 +201,20 @@ describe("Chrome extension allowlist guard", () => {
     expect(new Set(ALLOWED_EXTENSION_ORIGINS)).toEqual(expectedOrigins);
   });
 
-  test("concrete extension IDs appear only in canonical config", () => {
+  test("concrete extension IDs appear only in canonical config or CWS URLs", () => {
+    // The canonical extension ID may also appear in Chrome Web Store URLs
+    // (e.g. chromewebstore.google.com/detail/.../ID) or in documentation
+    // referencing the published extension. Those are acceptable — they
+    // reference the published extension, not duplicate config. We flag
+    // files where the ID appears outside of a CWS URL context.
     const config = parseCanonicalConfig();
     const allFiles = listTextFilesRecursively(repoRoot);
 
+    const CWS_URL_PATTERN =
+      /chromewebstore\.google\.com\/detail\/[^/]+\/[a-p]{32}/;
+
     for (const extensionId of config.allowedExtensionIds) {
-      const matches: string[] = [];
+      const unexpectedMatches: string[] = [];
       for (const absPath of allFiles) {
         const relPath = absPath.replace(`${repoRoot}/`, "");
         let content: string;
@@ -212,11 +225,17 @@ describe("Chrome extension allowlist guard", () => {
           if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
           throw err;
         }
-        if (content.includes(extensionId)) {
-          matches.push(relPath);
+        if (!content.includes(extensionId)) continue;
+        if (relPath === CANONICAL_CONFIG_REL_PATH) continue;
+
+        // Strip all CWS URLs and check if the ID still appears — if it
+        // does, the file is using the ID as a standalone config value.
+        const stripped = content.replace(CWS_URL_PATTERN, "");
+        if (stripped.includes(extensionId)) {
+          unexpectedMatches.push(relPath);
         }
       }
-      expect(matches).toEqual([CANONICAL_CONFIG_REL_PATH]);
+      expect(unexpectedMatches).toEqual([]);
     }
   });
 });

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -122,10 +122,10 @@ cd clients/chrome-extension/native-host
 bun install
 ```
 
-2. Export your extension ID(s). Include both the CWS ID and your dev ID if you want both to work:
+2. Export your extension ID(s). Include both the CWS ID (from the canonical allowlist) and your dev ID if you want both to work:
 
 ```bash
-export CWS_EXTENSION_ID=hphbdmpffeigpcdjkckleobjmhhokpne
+export CWS_EXTENSION_ID=$(cat ../../meta/browser-extension/chrome-extension-allowlist.json | grep -oE '[a-p]{32}')
 export DEV_EXTENSION_ID=<id from chrome://extensions>
 ```
 


### PR DESCRIPTION
## Summary
- Update guard test to allow canonical extension ID in CWS URLs (strip `chromewebstore.google.com` URLs before checking for bare ID duplication)
- Add `.codex-worktrees` to ignored dirs in the repo scanner
- Replace hardcoded CWS extension ID in README manual setup with a command that reads from the canonical config

## Original prompt
Follow-up to #26259 — Devin bot correctly flagged that the guard test would fail after the canonical ID was updated to match the published CWS extension ID.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
