### PR TITLE
fix: model default fallback, empty-response nudge scan

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -70,9 +70,9 @@ describe("model intents", () => {
   });
 
   test("falls back to provider default for unknown providers", () => {
-    expect(getProviderDefaultModel("unknown-provider")).toBe("claude-opus-4-6");
+    expect(getProviderDefaultModel("unknown-provider")).toBe("claude-opus-4-7");
     expect(resolveModelIntent("unknown-provider", "quality-optimized")).toBe(
-      "claude-opus-4-6",
+      "claude-opus-4-7",
     );
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -425,12 +425,13 @@ export class AgentLoop {
           for (let i = history.length - 1; i >= 0; i--) {
             const msg = history[i];
             if (msg.role !== "assistant") continue;
-            return msg.content.some(
+            const hasText = msg.content.some(
               (block) =>
                 block.type === "text" &&
                 typeof (block as { text?: unknown }).text === "string" &&
                 (block as { text: string }).text.trim().length > 0,
             );
+            if (hasText) return true;
           }
           return false;
         })();

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -43,7 +43,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
 };
 
-const FALLBACK_DEFAULT_MODEL = "claude-opus-4-6";
+const FALLBACK_DEFAULT_MODEL = "claude-opus-4-7";
 
 const MODEL_INTENTS = new Set<ModelIntent>([
   "latency-optimized",

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -7,6 +7,7 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "./managed-proxy/context.js";
+import { isModelInCatalog } from "./model-catalog.js";
 import { getProviderDefaultModel } from "./model-intents.js";
 import { OllamaProvider } from "./ollama/client.js";
 import { OpenAIResponsesProvider } from "./openai/client.js";
@@ -71,11 +72,15 @@ function resolveModel(config: ProvidersConfig, providerName: string): string {
   const inferenceProvider = config.services.inference.provider;
   const inferenceModel = config.services.inference.model;
   if (inferenceProvider === providerName) {
-    // If a non-Anthropic provider is selected with the untouched global default
-    // model, use a provider-appropriate fallback instead.
+    // If a non-Anthropic provider is selected but the configured model is
+    // still an Anthropic catalog model (current or previous default), use a
+    // provider-appropriate fallback instead. Checking the full Anthropic
+    // catalog rather than only the current default prevents stale persisted
+    // defaults (e.g. claude-opus-4-6) from being sent to non-Anthropic APIs
+    // after the catalog default changes.
     if (
       providerName !== "anthropic" &&
-      inferenceModel === getProviderDefaultModel("anthropic")
+      isModelInCatalog("anthropic", inferenceModel)
     ) {
       return getProviderDefaultModel(providerName);
     }


### PR DESCRIPTION
## Summary
- **Model default migration** (PR #26247 feedback): Update `FALLBACK_DEFAULT_MODEL` to `claude-opus-4-7`. Fix `resolveModel` to check the full Anthropic catalog instead of only the current default, preventing stale persisted defaults from being sent to non-Anthropic APIs.
- **Empty-response nudge** (PR #26164 feedback): Fix `priorAssistantHadVisibleText` backward scan to check ALL prior assistant messages instead of returning early on the first one found. Previously, a tool-use-only assistant message would mask earlier text-bearing messages.
- **OpenAPI CI** (PR #25923): Already fixed in #25991.
- **Sidebar sentinel** (PR #25998): Already fixed in #25999.
- **Speed override** (PR #26254): Code is on feature branch `siddseethepalli/unify-llm-callsites`, not main — will be addressed when that branch lands.

## Test plan
- [ ] `bun test src/__tests__/model-intents.test.ts` passes with updated expectations
- [ ] Verify `resolveModel` falls back to provider default for any Anthropic catalog model, not just the current default
- [ ] Verify empty-response nudge fires when no prior assistant turn has visible text across multi-step tool chains
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
