### PR TITLE
fix(meet): speaker attribution, watermark restoration, and docs updates

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -939,6 +939,10 @@ export class WorkspaceGitService {
   /**
    * Write a git note to a specific commit.
    * Uses the 'vellum' notes ref to avoid conflicts with default notes.
+   *
+   * Retries once on `index.lock` errors — `git notes add` briefly holds
+   * a ref lock that can collide with concurrent git operations (e.g. a
+   * heartbeat commit racing with fire-and-forget enrichment).
    */
   async writeNote(
     commitHash: string,
@@ -946,10 +950,25 @@ export class WorkspaceGitService {
     signal?: AbortSignal,
   ): Promise<void> {
     await this.mutex.withLock(async () => {
-      await this.execGit(
-        ["notes", "--ref=vellum", "add", "-f", "-m", noteContent, commitHash],
-        { signal },
-      );
+      const args = [
+        "notes",
+        "--ref=vellum",
+        "add",
+        "-f",
+        "-m",
+        noteContent,
+        commitHash,
+      ];
+      try {
+        await this.execGit(args, { signal });
+      } catch (err) {
+        const msg = (err as Error).message ?? "";
+        if (!msg.includes("index.lock") && !msg.includes("Unable to create")) {
+          throw err;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+        await this.execGit(args, { signal });
+      }
     });
   }
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -732,12 +732,12 @@ STTStreamingClient  ──WSS──>  stt-stream-websocket.ts  ──WS──>  
                                                          ┌──────────────┼──────────────┐
                                                          │              │              │
                                                   DeepgramRealtime  GoogleGemini   OpenAIWhisper
-                                                  Transcriber       Streaming      Streaming
+                                                  Transcriber       Live Stream    Streaming
                                                   (realtime-ws)     Transcriber    Transcriber
-                                                                    (incr-batch)   (incr-batch)
+                                                                    (realtime-ws)  (incr-batch)
                                                          │              │              │
-                                                  WSS to Deepgram  HTTP polling   HTTP polling
-                                                  /v1/listen       to Gemini API  to Whisper API
+                                                  WSS to Deepgram  WSS to Gemini  HTTP polling
+                                                  /v1/listen       Live API       to Whisper API
 ```
 
 **Provider support matrix:**

--- a/skills/meet-join/bot/README.md
+++ b/skills/meet-join/bot/README.md
@@ -93,8 +93,8 @@ the meet subsystem, run this manual verification loop.
   meeting-start time; the bot itself does not see STT credentials.
 - The `meet` feature flag enabled. Either:
   - **Local override** — set `meet` to `true` in
-    `$VELLUM_WORKSPACE_DIR/config.json` under the assistant feature flags
-    block, OR
+    `~/.vellum/workspace/config.json` (or `$VELLUM_WORKSPACE_DIR/config.json`
+    in Docker mode) under the assistant feature flags block, OR
   - **LaunchDarkly** — flip the `meet` flag on for your platform user.
 - A throwaway Google Meet URL with at least one other human participant so
   you can watch the bot behavior live.
@@ -125,7 +125,7 @@ the meet subsystem, run this manual verification loop.
 5. **Inspect on-disk artifacts.** After the bot leaves, the workspace
    directory should contain the meeting's artifact tree:
    ```bash
-   ls -la $VELLUM_WORKSPACE_DIR/meets/<meetingId>/
+   ls -la ~/.vellum/workspace/meets/<meetingId>/
    ```
    Expected files:
    - `audio.opus` — Opus-encoded audio, non-empty.

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -171,6 +171,14 @@ export interface MeetAudioIngestDeps {
   listen?: UnixSocketListenFn;
   /** Override the bot-connect timeout (tests). */
   botConnectTimeoutMs?: number;
+  /**
+   * Whether speaker diarization is enabled for this session. When `false`,
+   * `speakerLabel` is stripped from emitted {@link TranscriptChunkEvent}s
+   * even if the provider happens to include one — downstream consumers
+   * (speaker resolver, storage writer) should not attempt label-based
+   * attribution when diarization was not requested. Defaults to `true`.
+   */
+  diarize?: boolean;
 }
 
 /** Callback invoked for each PCM chunk received from the bot. */
@@ -185,6 +193,7 @@ export class MeetAudioIngest {
   private readonly createTranscriber: StreamingTranscriberFactory;
   private readonly listen: UnixSocketListenFn;
   private readonly botConnectTimeoutMs: number;
+  private readonly diarize: boolean;
 
   /** Stored only for teardown — set in `start()`. */
   private socketPath: string | null = null;
@@ -207,6 +216,7 @@ export class MeetAudioIngest {
     this.listen = deps.listen ?? defaultListen;
     this.botConnectTimeoutMs =
       deps.botConnectTimeoutMs ?? BOT_CONNECT_TIMEOUT_MS;
+    this.diarize = deps.diarize ?? true;
   }
 
   /**
@@ -475,11 +485,12 @@ export class MeetAudioIngest {
    * non-transcript events are ignored — the session manager owns the
    * provider's lifecycle, not the ingest.
    *
-   * When the provider emits a `speakerLabel` (Deepgram diarization is
-   * enabled for Meet audio), forward it on the transcript chunk so
-   * {@link MeetSpeakerResolver} can bind the opaque ASR label to a real
-   * participant identity. `confidence` rides along when the provider
-   * surfaces it.
+   * When diarization is enabled and the provider emits a `speakerLabel`,
+   * forward it on the transcript chunk so {@link MeetSpeakerResolver}
+   * can bind the opaque ASR label to a real participant identity.
+   * `confidence` rides along when the provider surfaces it.
+   * When `this.diarize` is false, `speakerLabel` is stripped even if
+   * the provider happens to include one.
    */
   private handleTranscriberEvent(
     meetingId: string,
@@ -491,20 +502,13 @@ export class MeetAudioIngest {
       return;
     }
 
-    // `speakerLabel` is populated by provider adapters that support
-    // diarization (currently Deepgram). Non-diarizing providers leave it
-    // undefined — downstream consumers treat that as "unknown speaker".
-    // Stable `speakerId` remains unset; the speaker resolver (PR 7)
-    // derives it by cross-checking the label against Meet's DOM-sourced
-    // active-speaker signal. `confidence` rides through when the
-    // provider surfaces it so observers can weight low-confidence chunks.
     const transcript: TranscriptChunkEvent = {
       type: "transcript.chunk",
       meetingId,
       timestamp: new Date().toISOString(),
       isFinal: event.type === "final",
       text: event.text,
-      ...(event.speakerLabel !== undefined
+      ...(this.diarize && event.speakerLabel !== undefined
         ? { speakerLabel: String(event.speakerLabel) }
         : {}),
       ...(event.confidence !== undefined

--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -557,6 +557,7 @@ export class MeetConsentMonitor {
     // keyword-driven. (The keyword path still fires whenever it hits,
     // because the watermark check is tick-only; the debounce above is
     // what rate-limits keyword-triggered calls.)
+    const prevLlmCheckContentTimestamp = this.lastLlmCheckContentTimestamp;
     this.lastLlmCheckContentTimestamp = this.lastContentTimestamp;
 
     // Stamp the debounce clock BEFORE the async LLM call begins so a
@@ -610,10 +611,13 @@ export class MeetConsentMonitor {
         }
       }
     } catch (err) {
-      // Restore the debounce clock on failure so the next trigger is
-      // not silently suppressed for the remainder of the 8s window.
-      // The `prev` value may be `null` (first-ever call) — that's fine.
+      // Restore both the debounce clock and the content watermark on
+      // failure so the next trigger is not silently suppressed. Without
+      // restoring the watermark, the next tick would see "no new content"
+      // and skip the LLM call even though the previous call never ran to
+      // completion. The `prev` values may be `null` (first-ever call).
       this.lastLlmCheckAt = prevLlmCheckAt;
+      this.lastLlmCheckContentTimestamp = prevLlmCheckContentTimestamp;
       log.warn(
         { err, meetingId: this.meetingId, trigger },
         "MeetConsentMonitor: LLM call failed — staying in the meeting",

--- a/skills/meet-join/daemon/speaker-resolver.ts
+++ b/skills/meet-join/daemon/speaker-resolver.ts
@@ -195,12 +195,18 @@ interface ActiveSpeakerSnapshot {
  * fresh DOM snapshot within the correlation window confirms the mapping.
  * `consecutiveDisagreements` is reset on agreement and grows on a DOM
  * conflict; crossing {@link MAPPING_REPLACE_THRESHOLD} replaces the mapping.
+ *
+ * `lastDisagreeSpeakerId` tracks which DOM speaker drove the current
+ * disagreement streak. If a *different* DOM speaker disagrees, the counter
+ * resets to 1 with the new challenger — random flicker from multiple
+ * speakers should not accumulate toward a mapping replacement.
  */
 interface LabelMapping {
   participantId: string;
   participantName: string;
   agreementCount: number;
   consecutiveDisagreements: number;
+  lastDisagreeSpeakerId: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +359,7 @@ export class MeetSpeakerResolver {
         participantName: domMatch.speakerName,
         agreementCount: 1,
         consecutiveDisagreements: 0,
+        lastDisagreeSpeakerId: null,
       });
       return this.emit({
         speakerId: domMatch.speakerId,
@@ -368,6 +375,7 @@ export class MeetSpeakerResolver {
     if (agrees) {
       existing.agreementCount += 1;
       existing.consecutiveDisagreements = 0;
+      existing.lastDisagreeSpeakerId = null;
       return this.emit({
         speakerId: domMatch.speakerId,
         speakerName: domMatch.speakerName,
@@ -375,7 +383,15 @@ export class MeetSpeakerResolver {
       });
     }
 
-    // Disagreement — log and decide whether to replace.
+    // Disagreement — only count consecutive disagreements from the SAME
+    // DOM speaker. A different challenger resets the streak to 1 so random
+    // flicker from multiple speakers can't accumulate toward replacement.
+    const sameChallenger =
+      existing.lastDisagreeSpeakerId === domMatch.speakerId;
+    const newDisagreements = sameChallenger
+      ? existing.consecutiveDisagreements + 1
+      : 1;
+
     this.conflictCount += 1;
     log.warn(
       {
@@ -391,19 +407,19 @@ export class MeetSpeakerResolver {
           speakerId: domMatch.speakerId,
           speakerName: domMatch.speakerName,
         },
-        consecutiveDisagreements: existing.consecutiveDisagreements + 1,
+        consecutiveDisagreements: newDisagreements,
       },
       "Meet speaker resolver: provider-label mapping disagrees with DOM",
     );
 
-    existing.consecutiveDisagreements += 1;
+    existing.consecutiveDisagreements = newDisagreements;
+    existing.lastDisagreeSpeakerId = domMatch.speakerId;
     if (existing.consecutiveDisagreements >= MAPPING_REPLACE_THRESHOLD) {
-      // Mapping has been wrong too many times in a row — replace it and
-      // emit the new DOM speaker authoritatively.
       existing.participantId = domMatch.speakerId;
       existing.participantName = domMatch.speakerName;
       existing.agreementCount = 1;
       existing.consecutiveDisagreements = 0;
+      existing.lastDisagreeSpeakerId = null;
       return this.emit({
         speakerId: domMatch.speakerId,
         speakerName: domMatch.speakerName,


### PR DESCRIPTION
Address consolidated review feedback from PRs #25786, #25789, #25793, #25798, #25802, #25811, #25813, #25824.

## Changes

- **Speaker label gating**: Add `diarize` flag to `MeetAudioIngestDeps`; skip `speakerLabel` forwarding when diarization is disabled
- **Disagreement counter fix**: Track challenger speaker ID in label mappings so consecutive disagreements only count from the same DOM speaker — random flicker from multiple speakers no longer falsely triggers mapping replacement
- **Content watermark restoration**: Restore `lastLlmCheckContentTimestamp` on LLM failure (alongside `lastLlmCheckAt`), preventing the next tick from silently skipping when the previous check never completed
- **Architecture diagram**: Update google-gemini from `(incr-batch) / HTTP polling` to `(realtime-ws) / WSS to Gemini Live API` in internal-reference.md
- **README local mode**: Replace `$VELLUM_WORKSPACE_DIR` with `~/.vellum/workspace` in bot README shell commands
- **Git notes race**: Add index.lock retry in `writeNote()` so fire-and-forget enrichment doesn't break subsequent commits
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
