### PR TITLE
test(extension-id-guard): allow CWS URL matches; mirrors main PR #26263

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -95,6 +95,7 @@ function listTextFilesRecursively(root: string): string[] {
     ".turbo",
     ".idea",
     ".vscode",
+    ".codex-worktrees",
   ]);
 
   const allowedExtensions = new Set([
@@ -196,12 +197,20 @@ describe("Chrome extension allowlist guard", () => {
     expect(new Set(ALLOWED_EXTENSION_ORIGINS)).toEqual(expectedOrigins);
   });
 
-  test("concrete extension IDs appear only in canonical config", () => {
+  test("concrete extension IDs appear only in canonical config or CWS URLs", () => {
+    // The canonical extension ID may also appear in Chrome Web Store URLs
+    // (e.g. chromewebstore.google.com/detail/.../ID) or in documentation
+    // referencing the published extension. Those are acceptable — they
+    // reference the published extension, not duplicate config. We flag
+    // files where the ID appears outside of a CWS URL context.
     const config = parseCanonicalConfig();
     const allFiles = listTextFilesRecursively(repoRoot);
 
+    const CWS_URL_PATTERN =
+      /chromewebstore\.google\.com\/detail\/[^/]+\/[a-p]{32}/;
+
     for (const extensionId of config.allowedExtensionIds) {
-      const matches: string[] = [];
+      const unexpectedMatches: string[] = [];
       for (const absPath of allFiles) {
         const relPath = absPath.replace(`${repoRoot}/`, "");
         let content: string;
@@ -212,11 +221,17 @@ describe("Chrome extension allowlist guard", () => {
           if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
           throw err;
         }
-        if (content.includes(extensionId)) {
-          matches.push(relPath);
+        if (!content.includes(extensionId)) continue;
+        if (relPath === CANONICAL_CONFIG_REL_PATH) continue;
+
+        // Strip all CWS URLs and check if the ID still appears — if it
+        // does, the file is using the ID as a standalone config value.
+        const stripped = content.replace(CWS_URL_PATTERN, "");
+        if (stripped.includes(extensionId)) {
+          unexpectedMatches.push(relPath);
         }
       }
-      expect(matches).toEqual([CANONICAL_CONFIG_REL_PATH]);
+      expect(unexpectedMatches).toEqual([]);
     }
   });
 });


### PR DESCRIPTION
## Summary
- The canonical extension ID also legitimately appears in Chrome Web Store URLs (README install link, browser-execution.ts setup hint). The strict guard rejected these and broke CI on this PR after main's PR #26249/#26259 added the URL references.
- Mirror main's pending fix (PR #26263) on the feature branch so test CI passes. Strip CWS URL substrings before checking for the bare ID; rename the test to clarify the new contract.
- Also adds \`.codex-worktrees\` to ignored directories (matches main PR #26263).

Part of plan: unify-llm-callsites.md (CI hot-fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
