### PR TITLE
fix(meet): Dockerfile copies, CI filters, terminology, and guard tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,18 @@
 !packages/**
 !skills/
 !skills/meet-join/
+!skills/meet-join/package.json
+!skills/meet-join/bun.lock
+!skills/meet-join/config-schema.ts
+!skills/meet-join/meet-config.ts
 !skills/meet-join/contracts/
 !skills/meet-join/contracts/**
+!skills/meet-join/daemon/
+!skills/meet-join/daemon/**
+!skills/meet-join/tools/
+!skills/meet-join/tools/**
+!skills/meet-join/routes/
+!skills/meet-join/routes/**
 
 # Exclude local dependencies and build outputs from included directories.
 assistant/node_modules/
@@ -24,4 +34,7 @@ credential-executor/.env.*
 packages/*/node_modules/
 packages/*/.env
 packages/*/.env.*
+skills/meet-join/node_modules/
 skills/meet-join/contracts/node_modules/
+skills/meet-join/**/__tests__/
+skills/meet-join/**/*.test.ts

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -8,6 +8,7 @@ on:
       - 'assistant/**'
       - 'credential-executor/**'
       - 'packages/**'
+      - 'skills/meet-join/contracts/**'
       - 'meta/feature-flags/**'
       - '.github/workflows/ci-main-assistant.yaml'
 

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -7,6 +7,7 @@ on:
       - 'assistant/**'
       - 'credential-executor/**'
       - 'packages/**'
+      - 'skills/meet-join/contracts/**'
       - 'scripts/skills/**'
       - 'meta/feature-flags/**'
       - '.github/workflows/pr-assistant.yaml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1877,6 +1877,8 @@ jobs:
             echo "Installing dependencies in ${dir}"
             (cd "${dir}" && bun install --frozen-lockfile 2>/dev/null || bun install)
           done
+          # Meet-join skill needs node_modules for zod to resolve during bundle
+          (cd skills/meet-join && bun install --frozen-lockfile 2>/dev/null || bun install)
 
       - name: Build Bun binaries (x64)
         run: |

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -20,8 +20,16 @@ ENV PATH="/root/.bun/bin:${PATH}"
 COPY packages/ces-contracts ./packages/ces-contracts
 COPY packages/credential-storage ./packages/credential-storage
 COPY packages/egress-proxy ./packages/egress-proxy
+# Copy meet-join skill (contracts + daemon + config) needed at runtime
+COPY skills/meet-join/package.json skills/meet-join/bun.lock ./skills/meet-join/
+COPY skills/meet-join/contracts ./skills/meet-join/contracts
+COPY skills/meet-join/config-schema.ts skills/meet-join/meet-config.ts ./skills/meet-join/
+COPY skills/meet-join/daemon ./skills/meet-join/daemon
+COPY skills/meet-join/tools ./skills/meet-join/tools
+COPY skills/meet-join/routes ./skills/meet-join/routes
 # Install assistant dependencies first for cache reuse
 COPY assistant/package.json assistant/bun.lock ./assistant/
+RUN cd /app/skills/meet-join && bun install --frozen-lockfile 2>/dev/null || bun install
 RUN cd /app/assistant && bun install --frozen-lockfile
 
 # Copy source

--- a/skills/meet-join/contracts/__tests__/events.test.ts
+++ b/skills/meet-join/contracts/__tests__/events.test.ts
@@ -37,15 +37,17 @@ describe("contract independence", () => {
   const sourceFiles = ["../index.ts", "../events.ts", "../commands.ts"];
 
   for (const file of sourceFiles) {
-    test(`${file} does not import from assistant/ or skills/meet-join/bot/`, () => {
+    test(`${file} does not import from assistant/, bot/, or daemon/`, () => {
       const src = require("node:fs").readFileSync(
         require("node:path").resolve(__dirname, file),
         "utf-8",
       );
       expect(src).not.toMatch(/from\s+['"].*assistant\//);
       expect(src).not.toMatch(/from\s+['"].*meet-join\/bot\//);
+      expect(src).not.toMatch(/from\s+['"]\.\.\/(bot|daemon)\//);
       expect(src).not.toMatch(/require\(['"].*assistant\//);
       expect(src).not.toMatch(/require\(['"].*meet-join\/bot\//);
+      expect(src).not.toMatch(/require\(['"]\.\.\/(bot|daemon)\//);
     });
   }
 });

--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -616,10 +616,10 @@ describe("DockerRunner workspace-mount mode branching", () => {
     });
 
     const expected = dockerSocketUnreachableMessage(socketPath);
-    // Guard the exact Phase 1.10 wording so regressions to the old
-    // Phase 1.8 "host docker socket" message surface loudly.
+    // Guard the wording so regressions to the old "host docker socket"
+    // message surface loudly. Must use "assistant" not "daemon" per AGENTS.md.
     expect(expected).toContain("Inner dockerd is not running");
-    expect(expected).toContain("Phase 1.10 PR 2");
+    expect(expected).toContain("assistant container");
 
     await expect(
       runner.run({

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -214,7 +214,7 @@ export class DockerApiError extends Error {
  * operator overrides the default socket path).
  */
 export function dockerSocketUnreachableMessage(socketPath: string): string {
-  return `Inner dockerd is not running (socket ${socketPath}). The daemon container's init supervisor (Phase 1.10 PR 2) failed to start dockerd. Check daemon container logs.`;
+  return `Inner dockerd is not running (socket ${socketPath}). The assistant container's init supervisor failed to start dockerd. Check assistant container logs.`;
 }
 
 /**


### PR DESCRIPTION
Address consolidated review feedback from PRs #25823, #25890, #25893, #25894, #25896, #25898, #25907, #25913, #25914, #25919.

## Changes

- **Terminology**: User-facing error message in `dockerSocketUnreachableMessage()` now says "assistant container" instead of "daemon container" per AGENTS.md
- **CI filters**: `pr-assistant.yaml` and `ci-main-assistant.yaml` now trigger on `skills/meet-join/contracts/**` changes
- **Dockerfile**: Copies `skills/meet-join/` (contracts, daemon, tools, routes, config-schema) into the assistant container image
- **.dockerignore**: Whitelists the new skill paths and excludes test files / node_modules
- **release.yml**: x64 build now installs `skills/meet-join` deps (matching arm64 which uses `build.sh`)
- **Guard tests**: Contract independence guard catches relative `../bot/` and `../daemon/` imports, not just absolute `meet-join/bot/` paths
- **Test assertions**: docker-runner test now asserts "assistant container" wording instead of "Phase 1.10 PR 2"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
