### PR TITLE
Fix README allowlist path and guard test regex flag

### DIFF
--- a/assistant/src/__tests__/extension-id-sync-guard.test.ts
+++ b/assistant/src/__tests__/extension-id-sync-guard.test.ts
@@ -211,7 +211,7 @@ describe("Chrome extension allowlist guard", () => {
     const allFiles = listTextFilesRecursively(repoRoot);
 
     const CWS_URL_PATTERN =
-      /chromewebstore\.google\.com\/detail\/[^/]+\/[a-p]{32}/;
+      /chromewebstore\.google\.com\/detail\/[^/]+\/[a-p]{32}/g;
 
     for (const extensionId of config.allowedExtensionIds) {
       const unexpectedMatches: string[] = [];

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -125,7 +125,7 @@ bun install
 2. Export your extension ID(s). Include both the CWS ID (from the canonical allowlist) and your dev ID if you want both to work:
 
 ```bash
-export CWS_EXTENSION_ID=$(cat ../../meta/browser-extension/chrome-extension-allowlist.json | grep -oE '[a-p]{32}')
+export CWS_EXTENSION_ID=$(cat ../../../meta/browser-extension/chrome-extension-allowlist.json | grep -oE '[a-p]{32}')
 export DEV_EXTENSION_ID=<id from chrome://extensions>
 ```
 


### PR DESCRIPTION
## Summary
- Fix relative path in README manual setup: `../../meta/...` -> `../../../meta/...` (the snippet runs from `clients/chrome-extension/native-host/`)
- Add `g` flag to CWS URL regex in guard test so `replaceAll` strips every occurrence
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
