### PR TITLE
fix(gateway): include ces-contracts in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 !assistant/**
 !credential-executor/
 !credential-executor/**
+!gateway/
+!gateway/**
 !packages/
 !packages/**
 !skills/
@@ -31,6 +33,9 @@ assistant/.env.*
 credential-executor/node_modules/
 credential-executor/.env
 credential-executor/.env.*
+gateway/node_modules/
+gateway/.env
+gateway/.env.*
 packages/*/node_modules/
 packages/*/.env
 packages/*/.env.*

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -516,8 +516,8 @@ function serviceImageConfigs(
       tag: imageTags["credential-executor"],
     },
     gateway: {
-      context: join(repoRoot, "gateway"),
-      dockerfile: "Dockerfile",
+      context: repoRoot,
+      dockerfile: "gateway/Dockerfile",
       tag: imageTags.gateway,
     },
   };

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -8,10 +8,15 @@ WORKDIR /app
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
-COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
+# Copy shared packages needed by gateway's repo-local dependencies
+COPY packages/ces-contracts ./packages/ces-contracts
 
-COPY . .
+# Install gateway dependencies first for cache reuse
+COPY gateway/package.json gateway/bun.lock ./gateway/
+RUN cd /app/gateway && bun install --frozen-lockfile --production
+
+# Copy source
+COPY gateway ./gateway
 
 # Runtime stage
 FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS runner
@@ -30,7 +35,7 @@ COPY --from=builder /usr/local/bin/bun /usr/local/bin/bun
 RUN groupadd --system --gid 1001 gateway && \
     useradd --system --uid 1001 --gid gateway --create-home gateway
 
-COPY --from=builder --chown=gateway:gateway /app /app
+COPY --from=builder --chown=gateway:gateway /app/gateway /app
 
 RUN mkdir -p /gateway-security && chown gateway:gateway /gateway-security
 


### PR DESCRIPTION
## Summary
- Changed gateway Docker build context from `gateway/` to the repo root, matching assistant-server and credential-executor
- Updated gateway Dockerfile to copy `packages/ces-contracts` before `bun install` so the `file:../packages/ces-contracts` dependency resolves
- Added `gateway/` to `.dockerignore` allowlist with node_modules/env exclusions

## Original prompt
these fixes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
