### PR TITLE
fix(platform/status): read stored credentials via daemon

### DIFF
--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -78,7 +78,9 @@ Examples:
     )
     .action(async (_opts: Record<string, unknown>, cmd: Command) => {
       try {
-        const context = await resolvePlatformCallbackRegistrationContext();
+        const context = await resolvePlatformCallbackRegistrationContext(
+          getSecureKeyViaDaemon,
+        );
 
         const storedBaseUrl =
           (await getSecureKeyViaDaemon(
@@ -234,7 +236,9 @@ Examples:
     )
     .action(async (opts: { path: string; type: string }, cmd: Command) => {
       try {
-        const context = await resolvePlatformCallbackRegistrationContext();
+        const context = await resolvePlatformCallbackRegistrationContext(
+          getSecureKeyViaDaemon,
+        );
         if (!context.enabled) {
           writeOutput(cmd, {
             ok: false,
@@ -286,7 +290,9 @@ Examples:
     )
     .action(async (_opts: Record<string, unknown>, cmd: Command) => {
       try {
-        const context = await resolvePlatformCallbackRegistrationContext();
+        const context = await resolvePlatformCallbackRegistrationContext(
+          getSecureKeyViaDaemon,
+        );
         if (!context.platformBaseUrl || !context.authHeader) {
           writeOutput(cmd, {
             ok: false,

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -54,13 +54,23 @@ export function shouldUsePlatformCallbacks(): boolean {
   );
 }
 
-export async function resolvePlatformCallbackRegistrationContext(): Promise<PlatformCallbackRegistrationContext> {
+/**
+ * Read a secret by storage-key account. The default uses the in-process CES
+ * client. CLI-invoked commands run in a separate process without an
+ * in-process CES client and should pass `getSecureKeyViaDaemon` so reads
+ * hit the running assistant's `/v1/secrets/read` endpoint instead.
+ */
+export type SecretReader = (account: string) => Promise<string | undefined>;
+
+export async function resolvePlatformCallbackRegistrationContext(
+  read: SecretReader = getSecureKeyAsync,
+): Promise<PlatformCallbackRegistrationContext> {
   const platform = getIsPlatform();
   const [storedBaseUrlRaw, storedAssistantIdRaw, storedAssistantApiKeyRaw] =
     await Promise.all([
-      getSecureKeyAsync(credentialKey("vellum", "platform_base_url")),
-      getSecureKeyAsync(credentialKey("vellum", "platform_assistant_id")),
-      getSecureKeyAsync(credentialKey("vellum", "assistant_api_key")),
+      read(credentialKey("vellum", "platform_base_url")),
+      read(credentialKey("vellum", "platform_assistant_id")),
+      read(credentialKey("vellum", "assistant_api_key")),
     ]);
 
   const storedBaseUrl = storedBaseUrlRaw?.trim();


### PR DESCRIPTION
## Summary
- `resolvePlatformCallbackRegistrationContext` read stored secrets via `getSecureKeyAsync` (in-process CES client). That works from the assistant process but returns `undefined` from the CLI, which runs in a separate process with no CES client attached — so `assistant platform status` would fall back to `getPlatformBaseUrl()` and display the env/config default even after `vellum login` had correctly stored `vellum:platform_base_url` in the vault.
- Add an optional `SecretReader` argument to `resolvePlatformCallbackRegistrationContext` (defaulting to `getSecureKeyAsync` so in-process callers behave identically). The three CLI callers (`status`, `connect`, `disconnect`) now pass `getSecureKeyViaDaemon`, which reads over the running assistant's `/v1/secrets/read` endpoint and returns the real stored values.

## Related
Companion to #26248 (CLI bootstrap fix). #26248 corrects the write path; this PR corrects the CLI read path so `assistant platform status` reflects what was actually stored.

## Test plan
- [ ] `cd assistant && bun test src/__tests__/platform-callback-registration.test.ts` — context tests still pass (default reader unchanged)
- [ ] Run `vellum login` against a local assistant, then `assistant platform status` — Base URL, Assistant ID, and Assistant API key now show as set (instead of defaults / "not set") when the vault contains them
- [ ] From the running assistant process, exercise `registerCallbackRoute` to confirm in-process reads still work (default `getSecureKeyAsync` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
