### PR TITLE
fix(meet): address review feedback — resource leaks, consent monitor, security gaps

### DIFF
--- a/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
+++ b/assistant/src/providers/speech-to-text/google-gemini-live-stream.ts
@@ -250,10 +250,9 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
     let timedOut = false;
     connectPromise
       .then((session) => {
-        if (timedOut) {
-          // Never assign a session after the start() timeout: if we did,
-          // `this.session` would persist past the failed start() and a
-          // retry would incorrectly trip the "start() called twice" guard.
+        if (timedOut || this.closed || this.stopping) {
+          // Never assign a session after shutdown or timeout: if we did,
+          // `this.session` would persist as an orphaned live WebSocket.
           try {
             session.close();
           } catch {
@@ -398,6 +397,7 @@ export class GoogleGeminiLiveStreamingTranscriber implements StreamingTranscribe
       serverContent.turnComplete === true;
 
     if (isComplete) {
+      if (this.finalEmittedForCurrentTurn) return;
       const finalText = this.currentTurnText;
       this.currentTurnText = "";
       this.lastEmittedPartial = "";

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -207,6 +207,7 @@
       "id": "meet-join",
       "name": "meet-join",
       "description": "Join a Google Meet call to take notes; only when the user explicitly asks.",
+      "feature-flag": "meet",
       "metadata": {
         "emoji": "📹",
         "vellum": {

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: meet-join
 description: Join a Google Meet call to take notes; only when the user explicitly asks.
+feature-flag: meet
 metadata:
   emoji: "📹"
   vellum:

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -506,7 +506,6 @@ export async function runBot(deps: BotDeps): Promise<void> {
     } catch (err) {
       const msg = errMsg(err);
       deps.logError(`meet-bot: join flow failed: ${msg}`);
-      publishLifecycle(subsystems.daemonClient, meetingId, "error", deps, msg);
       await shutdown("error", msg);
       detachSigterm();
       detachSigint();
@@ -585,7 +584,6 @@ export async function runBot(deps: BotDeps): Promise<void> {
   } catch (err) {
     const msg = errMsg(err);
     deps.logError(`meet-bot: boot failed: ${msg}`);
-    publishLifecycle(subsystems.daemonClient, meetingId, "error", deps, msg);
     await shutdown("error", msg);
     detachSigterm();
     detachSigint();

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -28,8 +28,7 @@
  *     catalog. Meet transcription therefore honors the same provider
  *     selection as the rest of the assistant.
  *   - Provider-specific options (e.g. Deepgram's `smartFormatting` /
- *     `interimResults`) are now owned by the individual provider's config
- *     schema; this module no longer threads them through.
+ *     `interimResults`) are owned by each provider's config schema.
  *   - All external dependencies (transcriber factory, socket listener) are
  *     swapped via constructor-level factories so tests can drive the class
  *     without touching real sockets or a real STT provider account.
@@ -271,6 +270,7 @@ export class MeetAudioIngest {
       this.socketPath = null;
       throw err;
     }
+    if (this.stopped) return;
     this.transcriber = transcriber;
 
     try {
@@ -283,6 +283,7 @@ export class MeetAudioIngest {
       this.socketPath = null;
       throw err;
     }
+    if (this.stopped) return;
 
     // Open the Unix-socket server. The bot will dial this path from inside
     // its container as soon as it boots.

--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -202,6 +202,9 @@ export class MeetConsentMonitor {
   /** Flips to true after the first positive objection verdict. */
   private decided = false;
 
+  /** Flips to true when `stop()` is called so in-flight LLM verdicts are discarded. */
+  private stopped = false;
+
   /** In-flight flag so overlapping keyword hits don't fan out LLM calls. */
   private llmInFlight = false;
 
@@ -293,6 +296,7 @@ export class MeetConsentMonitor {
    * Tear down the subscription and timer. Idempotent.
    */
   stop(): void {
+    this.stopped = true;
     if (this.unsubscribe) {
       try {
         this.unsubscribe();
@@ -500,7 +504,7 @@ export class MeetConsentMonitor {
    * checks (there shouldn't be any, but defense-in-depth).
    */
   private async maybeRunLLMCheck(trigger: string): Promise<void> {
-    if (this.decided || this.llmInFlight) return;
+    if (this.decided || this.llmInFlight || this.stopped) return;
     // Don't call the LLM on the tick path when both buffers are empty.
     if (
       trigger === "tick" &&
@@ -550,15 +554,6 @@ export class MeetConsentMonitor {
       return;
     }
 
-    // Advance the content watermark to the current content timestamp
-    // before firing. Every LLM call that actually fires advances the
-    // watermark so the next tick will correctly skip if no new content
-    // has arrived since the call — whether this call was tick-driven or
-    // keyword-driven. (The keyword path still fires whenever it hits,
-    // because the watermark check is tick-only; the debounce above is
-    // what rate-limits keyword-triggered calls.)
-    this.lastLlmCheckContentTimestamp = this.lastContentTimestamp;
-
     // Stamp the debounce clock BEFORE the async LLM call begins so a
     // second trigger arriving while this call is in flight is debounced
     // (in addition to being collapsed by the in-flight flag below).
@@ -569,10 +564,22 @@ export class MeetConsentMonitor {
     const prevLlmCheckAt = this.lastLlmCheckAt;
     this.lastLlmCheckAt = now;
 
+    // Capture the content timestamp we're about to check so we can
+    // advance the watermark only after a successful LLM call. Advancing
+    // before the call would prevent retry on failure.
+    const contentTimestampAtCheck = this.lastContentTimestamp;
+
+    this.trimTranscriptBuffer();
     const prompt = this.buildPrompt();
     this.llmInFlight = true;
     try {
       const decision = await this.llmAsk(prompt);
+      if (this.stopped) return;
+
+      // Advance the content watermark only after a successful LLM call
+      // so that a failed call doesn't prevent the next tick from retrying.
+      this.lastLlmCheckContentTimestamp = contentTimestampAtCheck;
+
       if (!decision.objected) {
         log.debug(
           {

--- a/skills/meet-join/daemon/conversation-bridge.ts
+++ b/skills/meet-join/daemon/conversation-bridge.ts
@@ -4,7 +4,7 @@
  *
  * The bridge subscribes to a meeting's bot-event stream via
  * {@link subscribeToMeetingEvents} (the PR 19 fan-out dispatcher). It fans
- * incoming {@link MeetBotEvent}s into three sinks:
+ * incoming {@link MeetBotEvent}s into four sinks:
  *
  *   1. **Final transcripts** (`transcript.chunk` with `isFinal === true`)
  *      are run through {@link MeetSpeakerResolver} to arbitrate Deepgram
@@ -314,11 +314,14 @@ export class MeetConversationBridge {
   ): Promise<void> {
     // Emit one short status line per join/leave so the conversation
     // stays readable — one batched summary would hide concurrent moves.
+    // Persisted as "user" with `automated: true` so untrusted participant
+    // names never carry assistant-level authority in model context.
     for (const participant of event.joined) {
-      const line = `${participant.name} joined`;
+      const safeName = sanitizeParticipantName(participant.name);
+      const line = `[Meeting] ${safeName} joined`;
       await this.insertMessage(
         this.conversationId,
-        "assistant",
+        "user",
         JSON.stringify([{ type: "text", text: line }]),
         {
           meetingId: this.meetingId,
@@ -332,10 +335,11 @@ export class MeetConversationBridge {
     }
 
     for (const participant of event.left) {
-      const line = `${participant.name} left`;
+      const safeName = sanitizeParticipantName(participant.name);
+      const line = `[Meeting] ${safeName} left`;
       await this.insertMessage(
         this.conversationId,
-        "assistant",
+        "user",
         JSON.stringify([{ type: "text", text: line }]),
         {
           meetingId: this.meetingId,
@@ -348,4 +352,15 @@ export class MeetConversationBridge {
       );
     }
   }
+}
+
+/**
+ * Strip control characters and collapse whitespace in a participant display
+ * name so it can't inject newlines, tabs, or other formatting tricks when
+ * persisted as message content. Truncated to 100 chars to bound the attack
+ * surface of absurdly long names.
+ */
+function sanitizeParticipantName(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/[\x00-\x1f\x7f]/g, "").trim().slice(0, 100);
 }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -8,9 +8,7 @@
  *     workspace volume.
  *   - Resolve a placeholder TTS key reserved for Phase 3 via the
  *     secure-keys abstraction. STT credentials are resolved inside the
- *     audio-ingest via the configured `services.stt.provider` — the
- *     session manager no longer needs to know which STT provider is in
- *     use or how to fetch its key.
+ *     audio-ingest via the configured `services.stt.provider`.
  *   - Drive `DockerRunner` to create + start the Meet-bot container with the
  *     right env/workspaceMounts/port mappings.
  *   - Register the per-meeting handler with `MeetSessionEventRouter` via
@@ -157,7 +155,7 @@ export const CHAT_OPPORTUNITY_LLM_MAX_TOKENS = 256;
  * before `IDENTITY.md` has been written. Matches the tool-side fallback
  * in `skills/meet-join/tools/meet-join-tool.ts`.
  */
-export const MEET_JOIN_NAME_FALLBACK = "AI Assistant";
+export const MEET_JOIN_NAME_FALLBACK = "Vellum";
 
 // ---------------------------------------------------------------------------
 // Domain errors
@@ -550,6 +548,8 @@ export interface MeetSessionManagerDeps {
 
 class MeetSessionManagerImpl {
   private sessions = new Map<string, ActiveSession>();
+  /** True while {@link shutdownAll} is in progress — blocks new joins. */
+  private shuttingDown = false;
   /**
    * Bot API tokens for sessions whose container has been spawned but whose
    * full {@link ActiveSession} record has not yet been inserted into
@@ -669,6 +669,12 @@ class MeetSessionManagerImpl {
   async join(input: JoinInput): Promise<MeetSession> {
     const { url, meetingId, conversationId, consentMessage } = input;
 
+    if (this.shuttingDown) {
+      throw new Error(
+        "MeetSessionManager is shutting down — new joins are not accepted",
+      );
+    }
+
     if (this.sessions.has(meetingId)) {
       throw new Error(
         `MeetSession already exists for meetingId=${meetingId}; leave the existing session before re-joining`,
@@ -686,26 +692,46 @@ class MeetSessionManagerImpl {
       { url },
     );
 
-    const meet = getMeetConfig();
+    let meet: ReturnType<typeof getMeetConfig>;
+    let workspaceDir: string;
+    let meetingDir: string;
+    let socketsDir: string;
+    let outDir: string;
+    let botApiToken: string;
+    let ttsKey: string;
+    try {
+      meet = getMeetConfig();
 
-    const workspaceDir = this.deps.getWorkspaceDir();
-    const meetingDir = join(workspaceDir, "meets", meetingId);
-    const socketsDir = join(meetingDir, "sockets");
-    const outDir = join(meetingDir, "out");
-    mkdirSync(socketsDir, { recursive: true });
-    mkdirSync(outDir, { recursive: true });
+      workspaceDir = this.deps.getWorkspaceDir();
+      meetingDir = join(workspaceDir, "meets", meetingId);
+      socketsDir = join(meetingDir, "sockets");
+      outDir = join(meetingDir, "out");
+      mkdirSync(socketsDir, { recursive: true });
+      mkdirSync(outDir, { recursive: true });
 
-    const botApiToken = generateBotApiToken();
-    // Pre-register the token so `/v1/internal/meet/:id/events` can
-    // authenticate the bot's earliest `lifecycle:joining` POST — which
-    // fires before the `ActiveSession` record lands in `this.sessions`
-    // (that happens only after the audio-ingest handshake completes).
-    // Cleared on every join-rollback path below and replaced by the
-    // authoritative `this.sessions` lookup once the session is in the map.
-    this.pendingBotTokens.set(meetingId, botApiToken);
+      botApiToken = generateBotApiToken();
+      // Pre-register the token so `/v1/internal/meet/:id/events` can
+      // authenticate the bot's earliest `lifecycle:joining` POST — which
+      // fires before the `ActiveSession` record lands in `this.sessions`
+      // (that happens only after the audio-ingest handshake completes).
+      // Cleared on every join-rollback path below and replaced by the
+      // authoritative `this.sessions` lookup once the session is in the map.
+      this.pendingBotTokens.set(meetingId, botApiToken);
 
-    // Placeholder — Phase 3 (PR 23+) will resolve the real TTS credential.
-    const ttsKey = (await this.deps.getProviderKey("tts")) ?? "";
+      // Placeholder — Phase 3 (PR 23+) will resolve the real TTS credential.
+      ttsKey = (await this.deps.getProviderKey("tts")) ?? "";
+    } catch (err) {
+      // Pre-container setup failed — emit a terminal `meet.error` so clients
+      // that observed `meet.joining` don't get stuck in that state forever.
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
+      this.pendingBotTokens.delete(meetingId);
+      throw err;
+    }
 
     const daemonUrl = this.deps.resolveDaemonUrl();
 
@@ -757,6 +783,13 @@ class MeetSessionManagerImpl {
     const audioSocketPath = join(socketsDir, "audio.sock");
     const audioIngest = this.deps.audioIngestFactory();
     const audioIngestPromise = audioIngest.start(meetingId, audioSocketPath);
+    // Guard the ingest promise immediately so a rejection between here and
+    // the first explicit `await audioIngestPromise` (after `runner.run()`)
+    // does not surface as an unhandled rejection. The global handler in
+    // `shutdown-handlers.ts` calls `process.exit(1)` on unhandled
+    // rejections, so without this guard a transient STT failure during
+    // container spawn would crash the entire daemon.
+    audioIngestPromise.catch(() => {});
 
     const env: Record<string, string> = {
       MEET_URL: url,
@@ -813,9 +846,6 @@ class MeetSessionManagerImpl {
       );
       // Tear down the concurrently-started audio ingest so we don't leak
       // a listening socket or a streaming STT session on the spawn-failure path.
-      // Swallow its in-flight promise before stopping to prevent unhandled
-      // rejections from surfacing in the caller's context.
-      audioIngestPromise.catch(() => {});
       await audioIngest.stop().catch(() => {});
       unregisterMeetingDispatcher(meetingId);
       this.pendingBotTokens.delete(meetingId);
@@ -836,7 +866,6 @@ class MeetSessionManagerImpl {
       // bot. Best-effort — surface the original error either way.
       await captureBotLogs(runner, runResult.containerId, meetingDir);
       await runner.remove(runResult.containerId).catch(() => {});
-      audioIngestPromise.catch(() => {});
       await audioIngest.stop().catch(() => {});
       unregisterMeetingDispatcher(meetingId);
       this.pendingBotTokens.delete(meetingId);
@@ -1024,11 +1053,33 @@ class MeetSessionManagerImpl {
     );
 
     // Subscribe the conversation bridge + start the storage writer now
-    // that the session record is in place. The writer subscribes to the
-    // dispatcher via its own `start()`; it reads live PCM off the audio
-    // ingest's tee once the source adapter is wired in.
-    conversationBridge.subscribe();
-    storageWriter.start();
+    // that the session record is in place. If either throws, roll back the
+    // container and audio ingest so we don't leak a running bot.
+    try {
+      conversationBridge.subscribe();
+      storageWriter.start();
+    } catch (err) {
+      log.error(
+        { err, meetingId, containerId: runResult.containerId },
+        "Bridge/writer subscribe failed — rolling back container and audio ingest",
+      );
+      this.sessions.delete(meetingId);
+      for (const unsubscribe of session.eventUnsubscribes) {
+        try { unsubscribe(); } catch { }
+      }
+      unregisterMeetingDispatcher(meetingId);
+      await audioIngest.stop().catch(() => {});
+      await runner.stop(runResult.containerId).catch(() => {});
+      await captureBotLogs(runner, runResult.containerId, meetingDir);
+      await runner.remove(runResult.containerId).catch(() => {});
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
+      throw err;
+    }
     const pcmSource: PcmSource = {
       subscribe: (cb) => audioIngest.subscribePcm(cb),
     };
@@ -1467,6 +1518,7 @@ class MeetSessionManagerImpl {
     reason: string,
     totalDeadlineMs = MEET_SHUTDOWN_DEADLINE_MS,
   ): Promise<void> {
+    this.shuttingDown = true;
     // Snapshot what we need for the straggler path BEFORE launching the
     // leaves, since `leave()` drops sessions from the map early.
     const snapshot = Array.from(this.sessions.values()).map((session) => ({
@@ -1498,13 +1550,15 @@ class MeetSessionManagerImpl {
           resolved.add(entry.meetingId);
         }),
     );
-    const deadline = new Promise<"timeout">((resolve) =>
-      setTimeout(() => resolve("timeout"), totalDeadlineMs),
-    );
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const deadline = new Promise<"timeout">((resolve) => {
+      deadlineTimer = setTimeout(() => resolve("timeout"), totalDeadlineMs);
+    });
     const outcome = await Promise.race([
       Promise.all(leaves).then(() => "completed" as const),
       deadline,
     ]);
+    if (deadlineTimer !== null) clearTimeout(deadlineTimer);
 
     if (outcome === "timeout") {
       const stragglers = snapshot.filter((s) => !resolved.has(s.meetingId));

--- a/skills/meet-join/daemon/speaker-resolver.ts
+++ b/skills/meet-join/daemon/speaker-resolver.ts
@@ -329,6 +329,7 @@ export class MeetSpeakerResolver {
 
   private onSpeakerChange(event: SpeakerChangeEvent): void {
     const timestampMs = parseTimestamp(event.timestamp);
+    if (!Number.isFinite(timestampMs)) return;
     this.activeSpeaker = {
       speakerId: event.speakerId,
       speakerName: event.speakerName,


### PR DESCRIPTION
## Summary

Consolidated fixes from review feedback across 16 merged Meet PRs (#25761, #25762, #25767, #25770, #25772, #25773, #25774, #25775, #25776, #25778, #25780, #25781, #25782, #25800, #25801, #25804).

### Crashes & security
- **Unhandled rejection crash**: Guard `audioIngestPromise` immediately after `start()` so a rejection between start and the first explicit `await` doesn't crash the daemon via `unhandledRejection`
- **Prompt injection**: Participant join/leave messages now use `"user"` role (not `"assistant"`) with name sanitization (control chars stripped, length capped)
- **Pre-container failures**: Setup steps wrapped in try/catch that emits `meet.error` so clients aren't left stuck

### Resource leaks
- **Deadline timer leak**: Capture timer handle from `shutdownAll` deadline and clear after race
- **Bridge/writer rollback**: If `conversationBridge.subscribe()` or `storageWriter.start()` throws after container + audio ingest are running, roll back both to prevent orphaned bot containers
- **Shutdown admission control**: Reject new `join()` calls once `shutdownAll` begins
- **Audio-ingest stopped guards**: Check `stopped` flag after async boundaries (`createTranscriber`, `transcriber.start`) to prevent work on a stopped instance
- **Gemini adapter**: Close orphaned sessions on late connect; deduplicate final events

### Consent monitor correctness
- **Stale verdicts**: `stopped` flag checked at entry and after async LLM call
- **Untrimmed buffer**: Call `trimTranscriptBuffer()` before `buildPrompt()`
- **Watermark race**: Advance `lastLlmCheckContentTimestamp` only after successful LLM call

### Other
- **NaN timestamp bypass**: Finite check in speaker resolver `onSpeakerChange`
- **JOIN_NAME fallback**: `"AI Assistant"` → `"Vellum"` to match `DEFAULT_ASSISTANT_NAME`
- **Duplicate lifecycle:error**: Removed from meet-bot (shutdown already publishes)
- **Feature flag**: Added `feature-flag: meet` to SKILL.md frontmatter and catalog.json
- Removed narrating-history comments

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Existing meet tests pass
- [ ] Join a Meet call → verify bot joins, transcribes, leaves cleanly
- [ ] Kill daemon mid-meeting → verify no orphaned containers
- [ ] Verify meet tools only appear when `meet` feature flag is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
