### PR TITLE
fix(tests): restore heartbeat dual-emit and update analyze-job test

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -43,16 +43,22 @@ export const HeartbeatConfigSchema = z
     const startNull = config.activeHoursStart == null;
     const endNull = config.activeHoursEnd == null;
     if (startNull !== endNull) {
-      // Emit only on the null side so validateWithSchema's delete-and-retry
-      // preserves the explicit non-null value. Dual-emit would delete both
-      // keys, losing valid explicit values for mixed-null configs like
-      // { activeHoursStart: null, activeHoursEnd: 20 } → (8, 22) instead of
-      // retaining the explicit 20.
+      // Emit on both fields so validateWithSchema's delete-and-retry strips
+      // both sides in one pass. Single-emit on the null side can cascade when
+      // the explicit value happens to equal the opposite default (e.g.
+      // { start: null, end: 8 } → strip start → default 8 → equal check fires
+      // → loader falls back to full defaults, wiping unrelated keys like
+      // maxTokens).
       const message =
         "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be null";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
+        path: ["activeHoursStart"],
+        message,
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursEnd"],
         message,
       });
       return;
@@ -62,11 +68,17 @@ export const HeartbeatConfigSchema = z
       config.activeHoursEnd != null &&
       config.activeHoursStart === config.activeHoursEnd
     ) {
-      // Emit only on activeHoursEnd so the explicit start value is preserved.
-      // Dual-emit would delete both keys, e.g. { start: 5, end: 5 } → (8, 22)
-      // instead of preserving the explicit 5 as start → (5, 22).
+      // Emit on both fields. Single-emit would strip one side and the default
+      // for that side could recreate a new mismatch (e.g. { start: 22, end: 22 }
+      // → strip end → default 22 → equal again), cascading to a full defaults
+      // reset that wipes unrelated fields.
       const message =
         "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must not be equal (would create an empty window)";
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursStart"],
+        message,
+      });
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["activeHoursEnd"],

--- a/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
+++ b/assistant/src/memory/__tests__/conversation-analyze-job.test.ts
@@ -64,6 +64,7 @@ mock.module("../auto-analysis-enqueue.js", () => ({
 
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
+import { BackendUnavailableError } from "../../util/errors.js";
 import { conversationAnalyzeJob } from "../conversation-analyze-job.js";
 import type { MemoryJob } from "../jobs-store.js";
 
@@ -121,20 +122,20 @@ describe("conversationAnalyzeJob", () => {
     expect(mockGetAnalysisDeps).not.toHaveBeenCalled();
   });
 
-  test("returns without calling the service when deps singleton is not yet initialized", async () => {
-    // Deps singleton is unset during slow daemon startup. The handler must
-    // NOT throw — a plain Error here is classified as fatal by
-    // classifyError() and the worker would mark the job permanently failed
-    // (failMemoryJob with maxAttempts: 1). Returning lets the next batch /
-    // idle / lifecycle trigger from enqueueAutoAnalysisIfEnabled() produce
-    // a fresh job once the daemon has fully started.
+  test("throws BackendUnavailableError when deps singleton is not yet initialized", async () => {
+    // Deps singleton is unset during slow daemon startup. The handler throws
+    // BackendUnavailableError so handleJobError() in the worker defers the
+    // job with exponential backoff (via deferMemoryJob) instead of completing
+    // it. Returning success here would permanently drop the job via
+    // completeMemoryJob — conversations with a pre-existing queued job
+    // during startup and no subsequent activity would never be analyzed.
     mockGetAnalysisDeps.mockImplementation(() => null);
     await expect(
       conversationAnalyzeJob(
         makeJob({ conversationId: "conv-1" }),
         TEST_CONFIG,
       ),
-    ).resolves.toBeUndefined();
+    ).rejects.toBeInstanceOf(BackendUnavailableError);
     expect(analyzeCalls).toHaveLength(0);
     expect(mockGetAnalysisDeps).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Revert \`heartbeat.ts\` superRefine to dual-emit. Single-emit (introduced by #26266) cascades in edge cases where the explicit value equals the opposite default, causing \`validateWithSchema\`'s delete-and-retry to fall back to full defaults and wipe unrelated user config (e.g. \`maxTokens\`). Filing already uses dual-emit; this restores symmetry.
- Update \`conversation-analyze-job.test.ts\` to expect \`BackendUnavailableError\`. The handler already throws (also from #26266) so \`handleJobError()\` defers the job via \`deferMemoryJob\` — the old test's "must NOT throw" rationale was incorrect because \`BackendUnavailableError\` has special non-fatal handling in \`jobs-worker.ts\`.

Fixes the three \`config-schema.test.ts\` failures and the one \`conversation-analyze-job.test.ts\` failure seen in [CI run 24591555165](https://github.com/vellum-ai/vellum-assistant/actions/runs/24591555165/job/71913156040).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24591555165/job/71913156040
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
