### PR TITLE
fix(macos): mark computeTransparencyFromCGImage nonisolated for Swift 6

### DIFF
--- a/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
+++ b/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
@@ -41,12 +41,12 @@ public struct VAvatarImage: View {
 
     /// Alpha byte value at or above which a pixel is considered opaque.
     /// Derived from `ceil(0.95 * 255) = 243`.
-    static let alphaOpaqueThreshold: UInt8 = 243
+    nonisolated static let alphaOpaqueThreshold: UInt8 = 243
 
     /// Maximum dimension for the sampling CGContext. Images larger than this
     /// are downsampled before pixel inspection — we only need 8 sample points,
     /// so full-resolution rendering is unnecessary.
-    static let maxSamplingDimension = 64
+    nonisolated static let maxSamplingDimension = 64
 
     public init(image: NSImage, size: CGFloat, borderColor: Color = VColor.borderBase, showBorder: Bool = true) {
         self.image = image

--- a/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
+++ b/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
@@ -174,7 +174,10 @@ public struct VAvatarImage: View {
     /// - Returns `false` in O(1) when the pixel format has no alpha channel.
     /// - Otherwise draws into a downsampled 32-bit BGRA context and checks
     ///   the alpha byte at the 4 corners + 4 edge midpoints (8 points total).
-    private static func computeTransparencyFromCGImage(_ cgImage: CGImage) -> Bool {
+    ///
+    /// `nonisolated` so it can be called from `Task.detached` — the function
+    /// touches no instance state and `CGImage` is thread-safe.
+    nonisolated private static func computeTransparencyFromCGImage(_ cgImage: CGImage) -> Bool {
         let alphaInfo = cgImage.alphaInfo
         switch alphaInfo {
         case .none, .noneSkipFirst, .noneSkipLast:


### PR DESCRIPTION
## Summary

- Mark \`computeTransparencyFromCGImage\` as \`nonisolated\` so it can be called from the \`Task.detached\` block in \`refreshTransparencyOffMain\` without tripping Swift 6's main-actor-isolation check.
- The function is pure, touches no instance state, and only operates on a thread-safe \`CGImage\`, so lifting it out of the struct's implicit \`@MainActor\` isolation is safe and matches the existing intent (it was already designed to run off the main thread).

## Original prompt

Fix: Swift 6 warning in VAvatarImage.swift line 127 — main actor-isolated static method 'computeTransparencyFromCGImage' cannot be called from outside of the actor (inside Task.detached)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
