### PR TITLE
fix(retry): stop forwarding contextWindow/provider to provider request body

### DIFF
--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -148,7 +148,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.max_tokens).toBe(32000);
   });
 
-  test("propagates resolved effort/speed/temperature/contextWindow", async () => {
+  test("propagates resolved effort/speed/temperature; omits server-side fields", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -183,8 +183,14 @@ describe("RetryProvider — callSite resolution", () => {
     // default behavior — matches the legacy non-callSite path which only sets
     // `providerConfig.thinking` when `enabled === true`.
     expect(config.thinking).toBeUndefined();
-    // contextWindow comes through from the resolved default.
-    expect(config.contextWindow).toBeDefined();
+    // `contextWindow` and `provider` are server-side concerns and must NOT
+    // leak into the per-call provider config — Anthropic rejects unknown
+    // fields with `{type:"invalid_request_error", message:"contextWindow:
+    // Extra inputs are not permitted"}`. Provider routing is handled by
+    // CallSiteRoutingProvider; contextWindow is consumed by the agent loop
+    // directly from `config.llm.default.contextWindow.*`.
+    expect(config.contextWindow).toBeUndefined();
+    expect(config.provider).toBeUndefined();
   });
 
   test("converts resolved thinking config to Anthropic wire-format `{ type: 'adaptive' }` when enabled", async () => {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -145,16 +145,14 @@ function normalizeSendMessageOptions(
         nextConfig.thinking = { type: "adaptive" };
       }
     }
-    if (nextConfig.contextWindow === undefined) {
-      nextConfig.contextWindow = resolved.contextWindow;
-    }
-    // Provider name from the resolver — informational; the wrapped provider
-    // is the actual transport. Downstream consumers may inspect this for
-    // diagnostics or wire-format decisions, but the request still routes
-    // through the inner provider that this RetryProvider wraps.
-    if (nextConfig.provider === undefined) {
-      nextConfig.provider = resolved.provider;
-    }
+    // `contextWindow` and `provider` are server-side concerns, not provider
+    // request parameters: `contextWindow` is consumed by the agent loop's
+    // overflow recovery and the conversation manager directly from
+    // `config.llm.default.contextWindow.*`; `provider` selection is handled
+    // by `CallSiteRoutingProvider` upstream. Forwarding them as per-call
+    // config leaks unknown fields into provider request bodies — Anthropic
+    // (and other strict-schema clients) reject the request with
+    // "Extra inputs are not permitted".
   }
 
   // thinking is Anthropic-specific on the wire; OpenRouter reads it as a


### PR DESCRIPTION
## Summary

Live bug surfaced when the daemon picked up the new \`llm.callSites\` config: every callSite-routed request crashed with \`Anthropic API error (400): contextWindow: Extra inputs are not permitted\`.

\`RetryProvider.normalizeSendMessageOptions\` was writing \`nextConfig.contextWindow = resolved.contextWindow\` (and \`nextConfig.provider = resolved.provider\`) onto the per-call config, which then arrived at \`AnthropicProvider.sendMessage\` and got serialized into the request body. Anthropic's strict schema rejects unknown fields.

Both fields are server-side concerns:
- \`contextWindow\` is consumed by the agent loop's overflow recovery and the conversation manager directly from \`config.llm.default.contextWindow.*\`.
- \`provider\` selection is already handled by \`CallSiteRoutingProvider\` upstream; the value here was only "informational" and never read by any provider client.

Stop forwarding both. Test \`propagates resolved effort/speed/temperature/contextWindow\` rewritten to assert \`contextWindow\` and \`provider\` are NOT on the per-call config.

Part of plan: unify-llm-callsites.md (live-traffic hot-fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
