### PR TITLE
fix(gemini): remove unsupported 'id' field from function_call/function_response

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -422,7 +422,6 @@ describe("GeminiProvider", () => {
     expect(contents[1].role).toBe("model");
     expect(contents[1].parts[0]).toEqual({
       functionCall: {
-        id: "call_abc",
         name: "file_read",
         args: { path: "/tmp/test" },
       },
@@ -430,7 +429,6 @@ describe("GeminiProvider", () => {
     expect(contents[2].role).toBe("user");
     expect(contents[2].parts[0]).toEqual({
       functionResponse: {
-        id: "call_abc",
         name: "file_read",
         response: { output: "file content here" },
       },
@@ -464,7 +462,6 @@ describe("GeminiProvider", () => {
     }>;
     expect(contents[0].parts[0]).toEqual({
       functionResponse: {
-        id: "unknown_id",
         name: "unknown_id",
         response: { output: "some result" },
       },

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -330,7 +330,6 @@ export class GeminiProvider implements Provider {
         case "tool_use":
           parts.push({
             functionCall: {
-              id: block.id,
               name: block.name,
               args: block.input,
             },
@@ -363,7 +362,6 @@ export class GeminiProvider implements Provider {
           }
           parts.push({
             functionResponse: {
-              id: block.tool_use_id,
               name: toolCallNames.get(block.tool_use_id) ?? block.tool_use_id,
               response: { output: outputText },
             },


### PR DESCRIPTION
## Summary
- Remove the `id` field from `functionCall` and `functionResponse` parts in the Gemini provider's `toGeminiParts()` method
- Gemini's API rejects unknown fields on these parts, causing 400 errors when tool use is involved
- Gemini uses `name` matching (not `id`) to correlate function calls with responses
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
