### PR TITLE
Fix assistant browser IPC socket path overflow on macOS

### DIFF
--- a/assistant/src/ipc/__tests__/socket-path.test.ts
+++ b/assistant/src/ipc/__tests__/socket-path.test.ts
@@ -1,0 +1,73 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveIpcSocketPath } from "../socket-path.js";
+
+const LONG_WORKSPACE_DIR =
+  "/Users/noaflaherty/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+
+let savedWorkspaceDir: string | undefined;
+let savedBaseDataDir: string | undefined;
+
+beforeEach(() => {
+  savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  savedBaseDataDir = process.env.BASE_DATA_DIR;
+});
+
+afterEach(() => {
+  if (savedWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+  }
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+});
+
+describe("resolveIpcSocketPath", () => {
+  test("uses workspace path when it is within the platform limit", () => {
+    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
+
+    expect(resolved.source).toBe("workspace");
+    expect(resolved.path).toBe("/tmp/vellum-workspace-test/assistant-cli.sock");
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to BASE_DATA_DIR/ipc when workspace path is too long", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    process.env.BASE_DATA_DIR = "/tmp/vellum-instance-test";
+
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
+
+    expect(resolved.source).toBe("base-data-dir");
+    expect(resolved.path).toBe(
+      "/tmp/vellum-instance-test/ipc/assistant-cli.sock",
+    );
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to tmpdir hash path when workspace path is too long and BASE_DATA_DIR is absent", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("assistant-cli.sock");
+
+    expect(resolved.source).toBe("tmp-hash");
+    expect(resolved.path.startsWith(join(tmpdir(), "vellum-ipc"))).toBe(true);
+    expect(resolved.path.endsWith("assistant-cli.sock")).toBe(true);
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+});

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -5,7 +5,8 @@
  * Returns a typed result object so callers can distinguish success
  * from connection failures and method errors.
  *
- * The socket lives at `{workspaceDir}/assistant-cli.sock`.
+ * The preferred socket path is `{workspaceDir}/assistant-cli.sock`, with a
+ * deterministic fallback for long AF_UNIX paths.
  */
 
 import { connect, type Socket } from "node:net";

--- a/assistant/src/ipc/cli-server.ts
+++ b/assistant/src/ipc/cli-server.ts
@@ -10,17 +10,18 @@
  * - Request:  { "id": string, "method": string, "params"?: Record<string, unknown> }
  * - Response: { "id": string, "result"?: unknown, "error"?: string }
  *
- * The socket lives at `{workspaceDir}/assistant-cli.sock` on the workspace
- * volume so CLI commands running in the same container can connect to it.
+ * The preferred socket path is `{workspaceDir}/assistant-cli.sock`. On
+ * platforms with strict AF_UNIX path limits (notably macOS), the server falls
+ * back to a shorter deterministic path so CLI commands can still connect.
  */
 
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
-import { join } from "node:path";
+import { dirname } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
 import { cliIpcRoutes } from "./routes/index.js";
+import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("cli-ipc-server");
 
@@ -61,7 +62,19 @@ export class CliIpcServer {
   private socketPath: string;
 
   constructor() {
-    this.socketPath = getCliSocketPath();
+    const socketResolution = resolveIpcSocketPath("assistant-cli.sock");
+    this.socketPath = socketResolution.path;
+    if (socketResolution.source !== "workspace") {
+      log.warn(
+        {
+          source: socketResolution.source,
+          workspacePath: socketResolution.workspacePath,
+          resolvedPath: socketResolution.path,
+          maxPathBytes: socketResolution.maxPathBytes,
+        },
+        "CLI IPC socket path exceeded platform limit; using fallback path",
+      );
+    }
     for (const route of cliIpcRoutes) {
       this.methods.set(route.method, route.handler);
     }
@@ -74,6 +87,12 @@ export class CliIpcServer {
 
   /** Start listening on the Unix domain socket. */
   start(): void {
+    // Ensure the parent directory exists before listening.
+    const socketDir = dirname(this.socketPath);
+    if (!existsSync(socketDir)) {
+      mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+    }
+
     // Clean up stale socket file from a previous run
     if (existsSync(this.socketPath)) {
       try {
@@ -229,6 +248,5 @@ export class CliIpcServer {
 // ---------------------------------------------------------------------------
 
 export function getCliSocketPath(): string {
-  return join(getWorkspaceDir(), "assistant-cli.sock");
+  return resolveIpcSocketPath("assistant-cli.sock").path;
 }
-

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -5,14 +5,14 @@
  * for reading gateway-owned data. Protocol: newline-delimited JSON
  * (same as gateway/src/ipc/server.ts).
  *
- * The socket lives at `{workspaceDir}/gateway.sock` on the shared volume.
+ * The preferred socket path is `{workspaceDir}/gateway.sock`, with a
+ * deterministic fallback for long AF_UNIX paths.
  */
 
 import { connect, type Socket } from "node:net";
-import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("gateway-ipc-client");
 
@@ -176,5 +176,5 @@ export async function ipcGetFeatureFlags(): Promise<Record<string, boolean>> {
 // ---------------------------------------------------------------------------
 
 function getGatewaySocketPath(): string {
-  return join(getWorkspaceDir(), "gateway.sock");
+  return resolveIpcSocketPath("gateway.sock").path;
 }

--- a/assistant/src/ipc/socket-path.ts
+++ b/assistant/src/ipc/socket-path.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../util/platform.js";
+
+const DARWIN_UNIX_SOCKET_MAX_PATH_BYTES = 103;
+const DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES = 107;
+const IPC_TMP_DIR_NAME = "vellum-ipc";
+const IPC_BASE_DATA_DIR_NAME = "ipc";
+
+export type IpcSocketPathSource =
+  | "workspace"
+  | "base-data-dir"
+  | "tmp-hash"
+  | "tmp-short-hash";
+
+export interface IpcSocketPathResolution {
+  path: string;
+  source: IpcSocketPathSource;
+  workspacePath: string;
+  maxPathBytes: number;
+}
+
+function getUnixSocketMaxPathBytes(): number {
+  return process.platform === "darwin"
+    ? DARWIN_UNIX_SOCKET_MAX_PATH_BYTES
+    : DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES;
+}
+
+function isPathWithinSocketLimit(path: string, maxPathBytes: number): boolean {
+  return Buffer.byteLength(path, "utf8") <= maxPathBytes;
+}
+
+function buildBaseDataDirCandidate(socketFileName: string): string | null {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+  if (!baseDataDir) return null;
+  return join(baseDataDir, IPC_BASE_DATA_DIR_NAME, socketFileName);
+}
+
+function buildTmpCandidate(
+  workspacePath: string,
+  socketFileName: string,
+): { hashedPath: string; shortPath: string } {
+  const hash = createHash("sha256")
+    .update(workspacePath)
+    .digest("hex")
+    .slice(0, 12);
+  return {
+    hashedPath: join(tmpdir(), IPC_TMP_DIR_NAME, `${hash}-${socketFileName}`),
+    shortPath: join(tmpdir(), `v-${hash}.sock`),
+  };
+}
+
+export function resolveIpcSocketPath(
+  socketFileName: string,
+  workspaceDir: string = getWorkspaceDir(),
+): IpcSocketPathResolution {
+  const maxPathBytes = getUnixSocketMaxPathBytes();
+  const workspacePath = join(workspaceDir, socketFileName);
+
+  if (isPathWithinSocketLimit(workspacePath, maxPathBytes)) {
+    return {
+      path: workspacePath,
+      source: "workspace",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const baseDataDirCandidate = buildBaseDataDirCandidate(socketFileName);
+  if (
+    baseDataDirCandidate &&
+    isPathWithinSocketLimit(baseDataDirCandidate, maxPathBytes)
+  ) {
+    return {
+      path: baseDataDirCandidate,
+      source: "base-data-dir",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const tmpCandidate = buildTmpCandidate(workspacePath, socketFileName);
+  if (isPathWithinSocketLimit(tmpCandidate.hashedPath, maxPathBytes)) {
+    return {
+      path: tmpCandidate.hashedPath,
+      source: "tmp-hash",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  return {
+    path: tmpCandidate.shortPath,
+    source: "tmp-short-hash",
+    workspacePath,
+    maxPathBytes,
+  };
+}

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1076,6 +1076,7 @@ export async function startGateway(
     // (mirrors the daemon env setup).
     ...(resources
       ? {
+          BASE_DATA_DIR: resources.instanceDir,
           VELLUM_WORKSPACE_DIR: join(
             resources.instanceDir,
             ".vellum",

--- a/gateway/src/__tests__/ipc-socket-path.test.ts
+++ b/gateway/src/__tests__/ipc-socket-path.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveIpcSocketPath } from "../ipc/socket-path.js";
+
+const LONG_WORKSPACE_DIR =
+  "/Users/noaflaherty/.local/share/vellum-dev/assistants/vellum-safe-dace-8hrt6e/.vellum/workspace";
+
+let savedWorkspaceDir: string | undefined;
+let savedBaseDataDir: string | undefined;
+
+beforeEach(() => {
+  savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  savedBaseDataDir = process.env.BASE_DATA_DIR;
+});
+
+afterEach(() => {
+  if (savedWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+  }
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+});
+
+describe("resolveIpcSocketPath", () => {
+  test("uses workspace path when it is within the platform limit", () => {
+    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
+
+    expect(resolved.source).toBe("workspace");
+    expect(resolved.path).toBe("/tmp/vellum-workspace-test/gateway.sock");
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to BASE_DATA_DIR/ipc when workspace path is too long", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    process.env.BASE_DATA_DIR = "/tmp/vellum-instance-test";
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
+
+    expect(resolved.source).toBe("base-data-dir");
+    expect(resolved.path).toBe("/tmp/vellum-instance-test/ipc/gateway.sock");
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+
+  test("falls back to tmpdir hash path when workspace path is too long and BASE_DATA_DIR is absent", () => {
+    process.env.VELLUM_WORKSPACE_DIR = LONG_WORKSPACE_DIR;
+    delete process.env.BASE_DATA_DIR;
+
+    const resolved = resolveIpcSocketPath("gateway.sock");
+
+    expect(resolved.source).toBe("tmp-hash");
+    expect(resolved.path.startsWith(join(tmpdir(), "vellum-ipc"))).toBe(true);
+    expect(resolved.path.endsWith("gateway.sock")).toBe(true);
+    expect(Buffer.byteLength(resolved.path, "utf8")).toBeLessThanOrEqual(
+      resolved.maxPathBytes,
+    );
+  });
+});

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -7,18 +7,19 @@
  * - Response: { "id": string, "result"?: unknown, "error"?: string }
  * - Event:    { "event": string, "data"?: unknown }  (server → client push, no id)
  *
- * The socket lives at `{workspaceDir}/gateway.sock` on the shared volume so
- * the assistant container can connect to it.
+ * The preferred socket path is `{workspaceDir}/gateway.sock` on the shared
+ * volume. On platforms with strict AF_UNIX path limits, the server falls back
+ * to a shorter deterministic path.
  */
 
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 
 import type { z } from "zod";
 
-import { getWorkspaceDir } from "../credential-reader.js";
 import { getLogger } from "../logger.js";
+import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("ipc-server");
 
@@ -66,7 +67,19 @@ export class GatewayIpcServer {
   private socketPath: string;
 
   constructor(routes?: IpcRoute[]) {
-    this.socketPath = getDefaultSocketPath();
+    const socketResolution = resolveIpcSocketPath("gateway.sock");
+    this.socketPath = socketResolution.path;
+    if (socketResolution.source !== "workspace") {
+      log.warn(
+        {
+          source: socketResolution.source,
+          workspacePath: socketResolution.workspacePath,
+          resolvedPath: socketResolution.path,
+          maxPathBytes: socketResolution.maxPathBytes,
+        },
+        "Gateway IPC socket path exceeded platform limit; using fallback path",
+      );
+    }
     if (routes) {
       for (const route of routes) {
         this.methods.set(route.method, route.handler);
@@ -275,5 +288,5 @@ export class GatewayIpcServer {
 // ---------------------------------------------------------------------------
 
 export function getDefaultSocketPath(): string {
-  return join(getWorkspaceDir(), "gateway.sock");
+  return resolveIpcSocketPath("gateway.sock").path;
 }

--- a/gateway/src/ipc/socket-path.ts
+++ b/gateway/src/ipc/socket-path.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../paths.js";
+
+const DARWIN_UNIX_SOCKET_MAX_PATH_BYTES = 103;
+const DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES = 107;
+const IPC_TMP_DIR_NAME = "vellum-ipc";
+const IPC_BASE_DATA_DIR_NAME = "ipc";
+
+export type IpcSocketPathSource =
+  | "workspace"
+  | "base-data-dir"
+  | "tmp-hash"
+  | "tmp-short-hash";
+
+export interface IpcSocketPathResolution {
+  path: string;
+  source: IpcSocketPathSource;
+  workspacePath: string;
+  maxPathBytes: number;
+}
+
+function getUnixSocketMaxPathBytes(): number {
+  return process.platform === "darwin"
+    ? DARWIN_UNIX_SOCKET_MAX_PATH_BYTES
+    : DEFAULT_UNIX_SOCKET_MAX_PATH_BYTES;
+}
+
+function isPathWithinSocketLimit(path: string, maxPathBytes: number): boolean {
+  return Buffer.byteLength(path, "utf8") <= maxPathBytes;
+}
+
+function buildBaseDataDirCandidate(socketFileName: string): string | null {
+  const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+  if (!baseDataDir) return null;
+  return join(baseDataDir, IPC_BASE_DATA_DIR_NAME, socketFileName);
+}
+
+function buildTmpCandidate(
+  workspacePath: string,
+  socketFileName: string,
+): { hashedPath: string; shortPath: string } {
+  const hash = createHash("sha256")
+    .update(workspacePath)
+    .digest("hex")
+    .slice(0, 12);
+  return {
+    hashedPath: join(tmpdir(), IPC_TMP_DIR_NAME, `${hash}-${socketFileName}`),
+    shortPath: join(tmpdir(), `v-${hash}.sock`),
+  };
+}
+
+export function resolveIpcSocketPath(
+  socketFileName: string,
+  workspaceDir: string = getWorkspaceDir(),
+): IpcSocketPathResolution {
+  const maxPathBytes = getUnixSocketMaxPathBytes();
+  const workspacePath = join(workspaceDir, socketFileName);
+
+  if (isPathWithinSocketLimit(workspacePath, maxPathBytes)) {
+    return {
+      path: workspacePath,
+      source: "workspace",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const baseDataDirCandidate = buildBaseDataDirCandidate(socketFileName);
+  if (
+    baseDataDirCandidate &&
+    isPathWithinSocketLimit(baseDataDirCandidate, maxPathBytes)
+  ) {
+    return {
+      path: baseDataDirCandidate,
+      source: "base-data-dir",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  const tmpCandidate = buildTmpCandidate(workspacePath, socketFileName);
+  if (isPathWithinSocketLimit(tmpCandidate.hashedPath, maxPathBytes)) {
+    return {
+      path: tmpCandidate.hashedPath,
+      source: "tmp-hash",
+      workspacePath,
+      maxPathBytes,
+    };
+  }
+
+  return {
+    path: tmpCandidate.shortPath,
+    source: "tmp-short-hash",
+    workspacePath,
+    maxPathBytes,
+  };
+}


### PR DESCRIPTION
## Summary
- add deterministic IPC socket-path resolution with fallback when workspace socket paths exceed AF_UNIX limits
- apply the resolver to assistant CLI IPC and gateway IPC (server + client), and pass `BASE_DATA_DIR` to gateway startup so both processes resolve the same fallback path
- add focused unit tests for assistant and gateway socket path resolution behavior under long workspace paths

## Original prompt
the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
