### PR TITLE
fix(macos): remove dead providerChanged/modeChanged in performSave

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -488,11 +488,7 @@ struct InferenceServiceCard: View {
     }
 
     private func performSave() {
-        // Detect mode change before persisting so downstream logic can
-        // force-persist provider/model even when IDs happen to match.
-        let modeChanged = draftMode != store.inferenceMode
         let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
-        let providerChanged = persistProvider != initialProvider || modeChanged
 
         // If the resolved provider ID is changing AND the user has any
         // per-call-site overrides pinned to the OLD provider, ask whether


### PR DESCRIPTION
## Summary
- `performSave()` computed `modeChanged` and `providerChanged` but neither was used — `performSaveCore()` recomputes them where they matter.
- Removes the dead bindings (and the stale comment that explained `modeChanged`) to silence the Swift 6 `#no-usage` warning.

## Original prompt
Fix this: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift:495:13: warning: initialization of immutable value 'providerChanged' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
493 |         let modeChanged = draftMode != store.inferenceMode
494 |         let persistProvider = draftMode == \"managed\" ? \"anthropic\" : draftProvider
495 |         let providerChanged = persistProvider != initialProvider || modeChanged
    |             \`- warning: initialization of immutable value 'providerChanged' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
