### PR TITLE
fix(macos): suppress Thinking row when no extended thinking occurred

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -106,8 +106,11 @@ struct AssistantProgressView: View {
             initialThinkingStart = latestEnd
             initialThinkingEnd = latestEnd.addingTimeInterval(duration)
         } else if model.allComplete && model.hasTools {
-            let phase = model.phase
-            if phase == .toolsCompleteThinking || phase == .processing {
+            // Only seed the thinking anchor when the daemon has explicitly
+            // signaled thinking-after-tools (.processing). .toolsCompleteThinking
+            // is pure phase inference and would mislabel post-tool latency as
+            // "Thinking" — see the synthetic ThinkingStepRow below.
+            if model.phase == .processing {
                 initialThinkingStart = model.latestCompletedAt ?? Date()
                 initialThinkingEnd = nil
             } else {
@@ -299,8 +302,15 @@ struct AssistantProgressView: View {
                 thinkingAfterToolsStartDate = nil
                 thinkingAfterToolsEndDate = nil
             }
-            // Track thinking phase start: all tools complete, card still active.
-            if (newPhase == .toolsCompleteThinking || newPhase == .processing)
+            // Track thinking phase start only when the daemon explicitly
+            // signaled thinking-after-tools. .processing fires only when
+            // isProcessing is true, which the daemon emits on the first
+            // thinking_delta following a tool completion (see
+            // handleThinkingDelta in conversation-agent-loop-handlers.ts).
+            // .toolsCompleteThinking is pure phase inference and does not
+            // imply real thinking happened — gating on it would mislabel
+            // post-tool network/first-token latency as "Thinking".
+            if newPhase == .processing
                 && model.allComplete && model.hasTools
                 && thinkingAfterToolsStartDate == nil {
                 thinkingAfterToolsStartDate = model.latestCompletedAt ?? Date()


### PR DESCRIPTION
## Summary

- The expanded step block in `AssistantProgressView` was rendering a synthetic \"Thinking\" row whenever the gap between the last tool completion and the card going `.complete` was \u2265 2s, regardless of whether any extended-thinking blocks were actually emitted. Plain post-tool latency (network round-trip, slow first token of the next LLM call) got mislabeled as thinking time.
- Gate the `thinkingAfterToolsStartDate` anchor on `.processing` only \u2014 that phase requires `isProcessing`, which the daemon sets via `assistant_activity_state \"thinking\"` on the first thinking-delta after a tool completes (see `handleThinkingDelta` in `conversation-agent-loop-handlers.ts`). `.toolsCompleteThinking` is pure phase inference and stays unchanged for the collapsed-card headline.
- True-positive case (real extended thinking) still renders the row with its actual duration.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
