### PR TITLE
fix(config): restore heartbeat dual-emit and empty llm.callSites default

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -38,16 +38,22 @@ export const HeartbeatConfigSchema = z
     const startNull = config.activeHoursStart == null;
     const endNull = config.activeHoursEnd == null;
     if (startNull !== endNull) {
-      // Emit only on the null side so validateWithSchema's delete-and-retry
-      // preserves the explicit non-null value. Dual-emit would delete both
-      // keys, losing valid explicit values for mixed-null configs like
-      // { activeHoursStart: null, activeHoursEnd: 20 } → (8, 22) instead of
-      // retaining the explicit 20.
+      // Emit on both fields so validateWithSchema's delete-and-retry strips
+      // both sides in one pass. Single-emit on the null side can cascade when
+      // the explicit value happens to equal the opposite default (e.g.
+      // { start: null, end: 8 } → strip start → default 8 → equal check fires
+      // → loader falls back to full defaults, wiping unrelated keys like
+      // maxTokens).
       const message =
         "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be null";
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
+        path: ["activeHoursStart"],
+        message,
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursEnd"],
         message,
       });
       return;
@@ -57,11 +63,17 @@ export const HeartbeatConfigSchema = z
       config.activeHoursEnd != null &&
       config.activeHoursStart === config.activeHoursEnd
     ) {
-      // Emit only on activeHoursEnd so the explicit start value is preserved.
-      // Dual-emit would delete both keys, e.g. { start: 5, end: 5 } → (8, 22)
-      // instead of preserving the explicit 5 as start → (5, 22).
+      // Emit on both fields. Single-emit would strip one side and the default
+      // for that side could recreate a new mismatch (e.g. { start: 22, end: 22 }
+      // → strip end → default 22 → equal again), cascading to a full defaults
+      // reset that wipes unrelated fields.
       const message =
         "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must not be equal (would create an empty window)";
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursStart"],
+        message,
+      });
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["activeHoursEnd"],

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -258,38 +258,6 @@ export const LLMCallSiteConfig = LLMConfigFragment.extend({
 export type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
 
 // ---------------------------------------------------------------------------
-// Latency-optimized call-site defaults
-//
-// Call sites that previously used `modelIntent: "latency-optimized"` need a
-// fast model, disabled thinking, and low effort so they don't fall through to
-// the expensive `llm.default` (opus with max effort). These defaults match the
-// Anthropic provider; users on other providers override via config.
-// ---------------------------------------------------------------------------
-
-const LATENCY_OPTIMIZED_FRAGMENT = {
-  model: "claude-haiku-4-5-20251001",
-  effort: "low" as const,
-  thinking: { enabled: false },
-};
-
-export const LATENCY_OPTIMIZED_CALLSITE_DEFAULTS: Partial<
-  Record<LLMCallSite, z.input<typeof LLMCallSiteConfig>>
-> = {
-  guardianQuestionCopy: LATENCY_OPTIMIZED_FRAGMENT,
-  watchCommentary: LATENCY_OPTIMIZED_FRAGMENT,
-  interactionClassifier: LATENCY_OPTIMIZED_FRAGMENT,
-  skillCategoryInference: LATENCY_OPTIMIZED_FRAGMENT,
-  inviteInstructionGenerator: LATENCY_OPTIMIZED_FRAGMENT,
-  notificationDecision: LATENCY_OPTIMIZED_FRAGMENT,
-  preferenceExtraction: LATENCY_OPTIMIZED_FRAGMENT,
-  commitMessage: {
-    ...LATENCY_OPTIMIZED_FRAGMENT,
-    maxTokens: 120,
-    temperature: 0.2,
-  },
-};
-
-// ---------------------------------------------------------------------------
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
 
@@ -300,10 +268,12 @@ export const LLMSchema = z
     // `partialRecord` (vs `record`) makes call-site keys optional while still
     // rejecting keys that aren't members of `LLMCallSiteEnum` — exactly the
     // behavior we want (typo detection without requiring callers to declare
-    // every call site).
+    // every call site). Latency-optimized defaults for background call sites
+    // are seeded into the user's on-disk config by migration 040, not at
+    // schema level, so `LLMSchema.parse({})` yields an empty map.
     callSites: z
       .partialRecord(LLMCallSiteEnum, LLMCallSiteConfig)
-      .default(LATENCY_OPTIMIZED_CALLSITE_DEFAULTS),
+      .default({}),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {


### PR DESCRIPTION
## Summary

- Restores heartbeat \`superRefine\` dual-emit (from #26278) so \`validateWithSchema\` strips both \`activeHoursStart\` and \`activeHoursEnd\` in one pass, preventing the cascade where a single-side strip + defaulting recreates an equal/mismatch error and forces a full-defaults fallback that wipes unrelated fields like \`llm.default.maxTokens\`.
- Changes \`LLMSchema.callSites\` default from \`LATENCY_OPTIMIZED_CALLSITE_DEFAULTS\` to \`{}\`. Latency-optimized call-site defaults are owned by workspace migration 040, not the schema — the schema default was polluting parsed configs with unrequested entries. Removes the now-unused \`LATENCY_OPTIMIZED_FRAGMENT\` / \`LATENCY_OPTIMIZED_CALLSITE_DEFAULTS\` constants.
- Both regressions were introduced when PR #26159 was squash-merged from a branch based on a pre-#26278 \`main\`. Restores the \`config-schema.test.ts\` and \`llm-schema.test.ts\` invariants they enforce.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24594653268/job/71922239048
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
