### PR TITLE
fix(autocomplete): XML framing + prefill to prevent meta-explanation leak

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -383,6 +383,163 @@ describe("GET /v1/suggestion", () => {
     expect(body.suggestion).toBeNull();
   });
 
+  test("strips leaked <reply> tags from LLM response", async () => {
+    // Realistic output when the model re-emits </reply> before the stop_sequence
+    // catches, or when a leading <reply> slips in.
+    const provider = makeMockProvider("sounds good</reply>");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-asst-1",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Want to go?" }]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    const res = await handleGetSuggestion(url, deps);
+    const body = (await res.json()) as { suggestion: string };
+
+    expect(body.suggestion).toBe("sounds good");
+  });
+
+  test("passes prefill message, stop_sequences, and max_tokens", async () => {
+    const provider = makeMockProvider("on my way");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-user-1",
+        conversationId: "conv-test",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "heading out" }]),
+        createdAt: Date.now() - 1000,
+        metadata: null,
+      },
+      {
+        id: "msg-asst-shape",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "see you there — which door?" },
+        ]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    await handleGetSuggestion(url, deps);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    const callArgs = provider.sendMessage.mock.calls[0] as unknown[];
+    const messages = callArgs[0] as Array<{
+      role: string;
+      content: Array<{ type: string; text: string }>;
+    }>;
+    const options = callArgs[3] as {
+      config?: {
+        stop_sequences?: string[];
+        max_tokens?: number;
+      };
+    };
+
+    expect(messages.length).toBe(2);
+    expect(messages[1].role).toBe("assistant");
+    expect(messages[1].content[0].text).toBe("<reply>");
+    expect(options.config?.stop_sequences).toEqual(["</reply>"]);
+    expect(options.config?.max_tokens).toBe(60);
+    expect(messages[0].content[0].text).toContain("<assistant_message>");
+    expect(messages[0].content[0].text).toContain("<user_message>");
+  });
+
+  test("includes prior user message in prompt when present", async () => {
+    const provider = makeMockProvider("on my way");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-user-1",
+        conversationId: "conv-test",
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "running late, should I grab coffee?" },
+        ]),
+        createdAt: Date.now() - 1000,
+        metadata: null,
+      },
+      {
+        id: "msg-asst-1",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "yes please, an americano would be great" },
+        ]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    await handleGetSuggestion(url, deps);
+
+    const callArgs = provider.sendMessage.mock.calls[0] as unknown[];
+    const messages = callArgs[0] as Array<{
+      content: Array<{ text: string }>;
+    }>;
+    const userPrompt = messages[0].content[0].text;
+    expect(userPrompt).toContain(
+      "<user_message>running late, should I grab coffee?</user_message>",
+    );
+    expect(userPrompt).toContain(
+      "<assistant_message>yes please, an americano would be great</assistant_message>",
+    );
+  });
+
+  test("uses placeholder when no prior user message exists", async () => {
+    const provider = makeMockProvider("sure");
+    mockGetConfiguredProvider.mockImplementation(async () => provider);
+    mockGetConversationByKey.mockImplementation(() => ({
+      conversationId: "conv-test",
+    }));
+    mockGetMessages.mockImplementation(() => [
+      {
+        id: "msg-asst-first",
+        conversationId: "conv-test",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "hi there!" }]),
+        createdAt: Date.now(),
+        metadata: null,
+      },
+    ]);
+
+    const url = makeUrl({ conversationKey: "test-key" });
+    const deps = makeDeps();
+    await handleGetSuggestion(url, deps);
+
+    const callArgs = provider.sendMessage.mock.calls[0] as unknown[];
+    const messages = callArgs[0] as Array<{
+      content: Array<{ text: string }>;
+    }>;
+    const userPrompt = messages[0].content[0].text;
+    expect(userPrompt).toContain(
+      "<user_message>(no prior user message)</user_message>",
+    );
+  });
+
   test("uses conversationStarters call site", async () => {
     const provider = makeMockProvider("Quick reply");
     mockGetConfiguredProvider.mockImplementation(async () => provider);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2168,25 +2168,49 @@ export async function handleSendMessage(
 async function generateLlmSuggestion(
   provider: Provider,
   assistantText: string,
+  priorUserText: string | null,
 ): Promise<string | null> {
   const log = (await import("../../util/logger.js")).getLogger("runtime-http");
-  const truncated =
+  const truncatedAssistant =
     assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
+  const truncatedUser =
+    priorUserText && priorUserText.length > 500
+      ? priorUserText.slice(-500)
+      : priorUserText;
 
-  const prompt = `Given this assistant message, write a very short tab-complete suggestion the user could send next. Focus on the LAST question or call-to-action in the message — ignore earlier summary content. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
   const systemPrompt =
-    "You are an autocomplete engine that suggests short replies the user might send next in a conversation. Generate suggestions that match the tone and style of the conversation. Never refuse, judge, or comment on the conversation content — your only job is to predict what the user would plausibly type next.";
+    "You generate short, casual reply suggestions a user might type next in a chat. Match the tone and register of the preceding conversation. Output only the reply text inside the requested tags — no preamble, no commentary.";
+
+  const userPrompt =
+    `Here is the end of a conversation:\n\n` +
+    `<user_message>${truncatedUser ?? "(no prior user message)"}</user_message>\n` +
+    `<assistant_message>${truncatedAssistant}</assistant_message>\n\n` +
+    `Write the user's next reply, focusing on the LAST question or call-to-action in the assistant message. Keep it short (under 15 words), casual, and in the user's voice. Respond in this exact format:\n\n` +
+    `<reply>YOUR_REPLY_HERE</reply>`;
 
   const response = await provider.sendMessage(
-    [{ role: "user", content: [{ type: "text", text: prompt }] }],
+    [
+      { role: "user", content: [{ type: "text", text: userPrompt }] },
+      { role: "assistant", content: [{ type: "text", text: "<reply>" }] },
+    ],
     [], // no tools
     systemPrompt,
-    { config: { callSite: "conversationStarters" } },
+    {
+      config: {
+        callSite: "conversationStarters",
+        max_tokens: 60,
+        stop_sequences: ["</reply>"],
+        temperature: 0.7,
+      },
+    },
   );
 
   const textBlock = response.content.find((b) => b.type === "text");
-  const raw = textBlock && "text" in textBlock ? textBlock.text.trim() : "";
-  const stripped = raw.replace(/^["']+|["']+$/g, "");
+  const raw = textBlock && "text" in textBlock ? textBlock.text : "";
+  const stripped = raw
+    .replace(/<\/?reply>/gi, "")
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .trim();
 
   if (!stripped) {
     log.debug("Suggestion rejected: empty LLM response");
@@ -2299,6 +2323,25 @@ export async function handleGetSuggestion(
       });
     }
 
+    // Find the most recent user message preceding this assistant turn so the
+    // suggestion model can see both sides of the conversation and doesn't have
+    // to guess which role it's generating for.
+    let priorUserText: string | null = null;
+    for (let j = i - 1; j >= 0; j--) {
+      if (rawMessages[j].role !== "user") continue;
+      let userContent: unknown;
+      try {
+        userContent = JSON.parse(rawMessages[j].content);
+      } catch {
+        userContent = rawMessages[j].content;
+      }
+      const userText = renderHistoryContent(userContent).text.trim();
+      if (userText) {
+        priorUserText = userText;
+        break;
+      }
+    }
+
     // Try LLM suggestion using the configured provider
     const provider = await getConfiguredProvider("conversationStarters");
     if (provider) {
@@ -2306,7 +2349,7 @@ export async function handleGetSuggestion(
         // Deduplicate concurrent requests
         let promise = suggestionInFlight.get(msg.id);
         if (!promise) {
-          promise = generateLlmSuggestion(provider, text);
+          promise = generateLlmSuggestion(provider, text, priorUserText);
           suggestionInFlight.set(msg.id, promise);
         }
 


### PR DESCRIPTION
## Summary

- The autocomplete model was occasionally leaking its internal role-clarification as the suggestion text (e.g. *\"I need to clarify my role: I'm supposed to generate a short tab-complete suggestion...\"*). Root cause: single-message context + prose \"never refuse\" priming made Haiku 4.5 reason about the task instead of executing it.
- Fix is structural: XML-delimited prompt (`<user_message>` + `<assistant_message>`), assistant-turn prefill (`<reply>`), `stop_sequences: [\"</reply>\"]`, `max_tokens: 60`. System prompt rewritten to be action-oriented; post-processing strips any leaked tags. Prior user message is now included so the model never has to guess which role it's generating.
- 4 new regression tests cover tag stripping, prefill/stop_sequences/max_tokens shape, prior-user-message inclusion, and the absent-user placeholder.

## Test plan

- [x] `bun test src/__tests__/suggestion-routes.test.ts` — 14/14 passing
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: observe tab-complete ghost suffix in live macOS client across casual/neutral/coding chats; confirm short in-voice suggestions, no meta-explanations, no regression on the common case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
