### PR TITLE
fix(macos): persist selected provider in managed inference mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -488,7 +488,7 @@ struct InferenceServiceCard: View {
     }
 
     private func performSave() {
-        let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
+        let persistProvider = draftProvider
 
         // If the resolved provider ID is changing AND the user has any
         // per-call-site overrides pinned to the OLD provider, ask whether
@@ -552,7 +552,7 @@ struct InferenceServiceCard: View {
         // managed and your-own implies a provider change even if the
         // resolved provider ID happens to match initialProvider (ensures
         // config stays consistent).
-        let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
+        let persistProvider = draftProvider
         let providerChanged = persistProvider != initialProvider || modeChanged
         if providerChanged {
             initialProvider = draftProvider


### PR DESCRIPTION
## Summary
- Remove hardcoded `"anthropic"` override in `performSave()`/`performSaveCore()` that ignored the user's provider selection in managed mode
- Now persists `draftProvider` directly so selecting Gemini or OpenAI in managed mode actually takes effect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
