### PR TITLE
fix(workspace-migration-038): preserve legacy provider/model when llm.default was injected by schema-default backfill

### DIFF
--- a/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
@@ -88,7 +88,11 @@ describe("038-unify-llm-callsite-configs migration", () => {
     expect(raw).toEqual([1, 2, 3]);
   });
 
-  test("idempotent: early-returns when llm.default is already present", () => {
+  test("idempotent: early-returns when llm.default is present and no legacy source remains", () => {
+    // True idempotency case: migration 039 has already stripped legacy
+    // source keys, leaving only `llm.default`. Re-running migration 038
+    // here must be a byte-identical no-op so daemon restarts don't churn
+    // the on-disk config.
     const original = {
       llm: {
         default: {
@@ -101,9 +105,8 @@ describe("038-unify-llm-callsite-configs migration", () => {
         },
       },
       services: {
-        inference: { provider: "anthropic", model: "claude-opus-4-6" },
+        inference: { mode: "your-own" },
       },
-      maxTokens: 64000,
     };
     writeConfig(original);
 
@@ -111,6 +114,108 @@ describe("038-unify-llm-callsite-configs migration", () => {
 
     const config = readConfig();
     expect(config).toEqual(original);
+  });
+
+  // ─── Schema-default-injection regression (the original bug) ────────────
+
+  test("legacy services.inference.{provider,model} win over schema-default-injected llm.default", () => {
+    // Reproduces the production bug: between PR #26095 (added
+    // `LLMSchema.default(LLMSchema.parse({}))` to AssistantConfigSchema)
+    // and PR #26101 (this migration), any daemon boot caused the loader's
+    // `backfillConfigDefaults()` to write a schema-default `llm.default`
+    // block to disk. Migration 038's old idempotency check (`return early
+    // if llm.default exists`) then silently skipped, and migration 039
+    // stripped `services.inference.{provider,model}` — losing the user's
+    // actual configuration. The fix prefers legacy source keys over the
+    // injected schema defaults whenever both are present.
+    writeConfig({
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "openrouter",
+          model: "anthropic/claude-opus-4.7",
+        },
+      },
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          maxTokens: 64000,
+          effort: "max",
+          speed: "standard",
+          temperature: null,
+          thinking: { enabled: true, streamThinking: true },
+          contextWindow: {
+            enabled: true,
+            maxInputTokens: 200000,
+            targetBudgetRatio: 0.3,
+            compactThreshold: 0.8,
+            summaryBudgetRatio: 0.05,
+            overflowRecovery: {
+              enabled: true,
+              safetyMarginRatio: 0.05,
+              maxAttempts: 3,
+              interactiveLatestTurnCompression: "summarize",
+              nonInteractiveLatestTurnCompression: "truncate",
+            },
+          },
+        },
+      },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, Record<string, unknown>>;
+    expect(llm.default.provider).toBe("openrouter");
+    expect(llm.default.model).toBe("anthropic/claude-opus-4.7");
+  });
+
+  test("user-set llm.default fields survive when no legacy source exists for that field", () => {
+    // Ensures the precedence rule (legacy → existing-default → fallback)
+    // doesn't clobber values a user has explicitly set under `llm.default`
+    // when there's no corresponding legacy key to migrate.
+    writeConfig({
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      },
+      llm: {
+        default: {
+          provider: "anthropic", // schema-default — overridden by services.inference below
+          model: "claude-opus-4-7", // schema-default — overridden by services.inference below
+          effort: "low", // user-set; no top-level `effort` legacy key, must survive
+          maxTokens: 8000, // user-set; no top-level `maxTokens` legacy key, must survive
+        },
+      },
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, Record<string, unknown>>;
+    // Legacy services.inference wins over existing llm.default
+    expect(llm.default.provider).toBe("openai");
+    expect(llm.default.model).toBe("gpt-5.4");
+    // Existing llm.default values for fields with no legacy source are kept
+    expect(llm.default.effort).toBe("low");
+    expect(llm.default.maxTokens).toBe(8000);
+  });
+
+  test("xhigh effort (added in main PR #26117 after this migration was authored) is preserved", () => {
+    // EFFORT_VALUES had to be widened to include `xhigh` so a legacy
+    // top-level `effort: "xhigh"` value isn't silently downgraded to "max"
+    // by `readEnum(...) ?? "max"`.
+    writeConfig({
+      services: { inference: { mode: "your-own", provider: "anthropic" } },
+      effort: "xhigh",
+    });
+
+    unifyLlmCallSiteConfigsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, Record<string, unknown>>;
+    expect(llm.default.effort).toBe("xhigh");
   });
 
   // ─── Defaults from schema (no scattered keys) ──────────────────────────

--- a/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
+++ b/assistant/src/workspace/migrations/038-unify-llm-callsite-configs.ts
@@ -60,14 +60,33 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
       return;
     }
 
-    // Idempotency: if `llm.default` already present, the workspace has
-    // already been migrated.
+    // Idempotency: skip only when `llm.default` is present AND no legacy
+    // source key remains on disk. The `&& !hasLegacyData` clause matters
+    // because `AssistantConfigSchema` wires `llm: LLMSchema.default(LLMSchema
+    // .parse({}))`, which makes `loadConfig()` inject a full schema-default
+    // `llm.default` block to disk on first daemon boot under the new schema.
+    // If that boot happened before this migration was added (or before the
+    // daemon binary that includes it landed on the user's machine),
+    // `llm.default` will be present BUT will hold schema defaults rather
+    // than the user's actual `services.inference.{provider, model}` values.
+    // Returning early here would let migration 039 strip the legacy keys
+    // silently, dropping the user's real configuration.
     const existingLlm = readObject(config.llm);
-    if (existingLlm !== null && readObject(existingLlm.default) !== null) {
+    const existingDefault = existingLlm
+      ? readObject(existingLlm.default)
+      : null;
+    const hasLegacyData =
+      hasLegacyLlmDefaultSource(config) || hasLegacyCallSiteSource(config);
+    if (existingDefault !== null && !hasLegacyData) {
       return;
     }
 
     // ── Build llm.default ──────────────────────────────────────────────
+    // Precedence (highest wins): legacy source key → existing `llm.default`
+    // value → migration fallback. Existing values come second so that on a
+    // re-run AFTER legacy keys are stripped, user-set `llm.default.*` values
+    // survive untouched (the early-return above handles the common no-op
+    // path; this ordering covers the partial-state case).
     const services = readObject(config.services) ?? {};
     const inference = readObject(services.inference) ?? {};
 
@@ -75,23 +94,42 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
       provider:
         readString(inference.provider) ??
         readString(config.provider) ??
+        readString(existingDefault?.provider) ??
         "anthropic",
       model:
         readString(inference.model) ??
         readString(config.model) ??
+        readString(existingDefault?.model) ??
         "claude-opus-4-6",
-      maxTokens: readPositiveInt(config.maxTokens) ?? 64000,
-      effort: readEnum(config.effort, EFFORT_VALUES) ?? "max",
-      speed: readEnum(config.speed, SPEED_VALUES) ?? "standard",
-      // No current config key maps to temperature — seed null to match
-      // `LLMConfigBase` defaults.
-      temperature: null,
+      maxTokens:
+        readPositiveInt(config.maxTokens) ??
+        readPositiveInt(existingDefault?.maxTokens) ??
+        64000,
+      effort:
+        readEnum(config.effort, EFFORT_VALUES) ??
+        readEnum(existingDefault?.effort, EFFORT_VALUES) ??
+        "max",
+      speed:
+        readEnum(config.speed, SPEED_VALUES) ??
+        readEnum(existingDefault?.speed, SPEED_VALUES) ??
+        "standard",
+      // No current legacy key maps to temperature; preserve existing
+      // `llm.default.temperature` if a user set one, else seed null to
+      // match `LLMConfigBase` defaults.
+      temperature:
+        existingDefault && "temperature" in existingDefault
+          ? (existingDefault.temperature as number | null)
+          : null,
     };
-    const thinking = readObject(config.thinking);
+    const thinking =
+      readObject(config.thinking) ??
+      (existingDefault ? readObject(existingDefault.thinking) : null);
     if (thinking !== null) {
       defaultBlock.thinking = thinking;
     }
-    const contextWindow = readObject(config.contextWindow);
+    const contextWindow =
+      readObject(config.contextWindow) ??
+      (existingDefault ? readObject(existingDefault.contextWindow) : null);
     if (contextWindow !== null) {
       defaultBlock.contextWindow = contextWindow;
     }
@@ -302,7 +340,12 @@ export const unifyLlmCallSiteConfigsMigration: WorkspaceMigration = {
 // Helpers — self-contained per workspace migrations AGENTS.md
 // ---------------------------------------------------------------------------
 
-const EFFORT_VALUES = new Set(["low", "medium", "high", "max"]);
+// `xhigh` was added to the runtime enum in main PR #26117 after this
+// migration was authored. Widening the validation set is safe (it can only
+// admit MORE legitimate values, never narrow them) and prevents an `effort:
+// "xhigh"` legacy value from being silently downgraded to "max" during the
+// consolidation below.
+const EFFORT_VALUES = new Set(["low", "medium", "high", "xhigh", "max"]);
 const SPEED_VALUES = new Set(["standard", "fast"]);
 const MODEL_INTENT_VALUES = new Set([
   "latency-optimized",
@@ -399,4 +442,75 @@ function readTemperature(value: unknown): number | undefined {
     value <= 2
     ? value
     : undefined;
+}
+
+/**
+ * Returns true if any source key that this migration consolidates into
+ * `llm.default` is still present on disk. The `provider`/`model`/etc. checks
+ * cover the `services.inference` and top-level legacy locations; their
+ * presence proves migration 039 hasn't yet stripped them, which means we
+ * MUST re-process even if `llm.default` already exists (it may have been
+ * injected by `loadConfig()`'s schema-default backfill rather than by a
+ * previous run of this migration).
+ */
+function hasLegacyLlmDefaultSource(config: Record<string, unknown>): boolean {
+  const services = readObject(config.services);
+  const inference = services ? readObject(services.inference) : null;
+  if (
+    inference &&
+    (readString(inference.provider) !== undefined ||
+      readString(inference.model) !== undefined)
+  ) {
+    return true;
+  }
+  for (const key of [
+    "provider",
+    "model",
+    "maxTokens",
+    "effort",
+    "speed",
+    "thinking",
+    "contextWindow",
+    "pricingOverrides",
+  ]) {
+    if (key in config) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true if any source key that this migration consolidates into
+ * `llm.callSites` is still present on disk. Same idempotency justification
+ * as `hasLegacyLlmDefaultSource`: their presence proves migration 039
+ * hasn't yet stripped them and re-processing is required.
+ */
+function hasLegacyCallSiteSource(config: Record<string, unknown>): boolean {
+  const heartbeat = readObject(config.heartbeat);
+  if (heartbeat && "speed" in heartbeat) return true;
+  const filing = readObject(config.filing);
+  if (filing && "speed" in filing) return true;
+  const analysis = readObject(config.analysis);
+  if (analysis && ("modelIntent" in analysis || "modelOverride" in analysis)) {
+    return true;
+  }
+  const memory = readObject(config.memory);
+  const summarization = memory ? readObject(memory.summarization) : null;
+  if (summarization && "modelIntent" in summarization) return true;
+  const notifications = readObject(config.notifications);
+  if (notifications && "decisionModelIntent" in notifications) return true;
+  const ui = readObject(config.ui);
+  if (ui && "greetingModelIntent" in ui) return true;
+  const calls = readObject(config.calls);
+  if (calls && "model" in calls) return true;
+  const workspaceGit = readObject(config.workspaceGit);
+  const commitMessageLLM = workspaceGit
+    ? readObject(workspaceGit.commitMessageLLM)
+    : null;
+  if (
+    commitMessageLLM &&
+    ("maxTokens" in commitMessageLLM || "temperature" in commitMessageLLM)
+  ) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

- Migration 038's idempotency check returned early as soon as \`llm.default\` existed, but \`AssistantConfigSchema\` wires \`llm: LLMSchema.default(LLMSchema.parse({}))\` so the loader's \`backfillConfigDefaults()\` injects a schema-default \`llm.default\` block to disk on first daemon boot under the new schema. If that boot happened before this migration was added, migration 038 silently skipped and migration 039 then stripped \`services.inference.{provider,model}\` — losing the user's actual provider configuration. Repro: workspace had \`services.inference.{provider:"openrouter", model:"anthropic/claude-opus-4.7"}\` pre-migration; post-migration \`llm.default.{provider,model}\` showed the schema defaults \`anthropic\`/\`claude-opus-4-7\` and the openrouter values were gone.
- Fix: skip only when \`llm.default\` is present AND no legacy source key remains. When a legacy key is still on disk (\`services.inference.{provider,model}\`, top-level \`maxTokens\`/\`effort\`/etc., \`heartbeat.speed\`, \`analysis.modelIntent\`, ...), re-run and let legacy values WIN over the existing \`llm.default\` (precedence: legacy → existing-default → fallback).
- Also widens \`EFFORT_VALUES\` to include \`xhigh\` (added to the runtime enum in main PR #26117 after this migration was authored) so a legacy \`effort: "xhigh"\` value isn't silently downgraded to \`max\`.
- Adds 3 regression tests: schema-default-injection scenario, user-set llm.default fields surviving when no legacy source exists, and xhigh effort preservation.

## Original prompt

The migration reset my LLM provider config instead of copying it over, can you fix that?