### PR TITLE
test(pricing): fix gemini-2.0-flash -> gemini-2.5-flash-lite to match catalog

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -116,15 +116,15 @@ describe("resolvePricing", () => {
       expect(result.estimatedCostUsd).toBe(0.15 + 0.6);
     });
 
-    test("returns priced for gemini-2.0-flash", () => {
+    test("returns priced for gemini-2.5-flash-lite", () => {
       const result = resolvePricing(
         "gemini",
-        "gemini-2.0-flash",
+        "gemini-2.5-flash-lite",
         1_000_000,
         1_000_000,
       );
       expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(0.1 + 0.4);
+      expect(result.estimatedCostUsd).toBe(0.02 + 0.1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Commit e35012514f (chore(gemini): update model catalog to Gemini 2.5 family) removed `gemini-2.0-flash` from `PROVIDER_PRICING` in `assistant/src/util/pricing.ts` but left the matching test case in `pricing.test.ts` expecting `gemini-2.0-flash` to be priced. The Test job on main has been failing as a result ([run](https://github.com/vellum-ai/vellum-assistant/actions/runs/24595267342/job/71923906744)).
- Update the test to assert pricing for `gemini-2.5-flash-lite` (the new latency-optimized Gemini model that replaced `gemini-2.0-flash` in the catalog), with the correct cost of $0.02 input + $0.1 output per 1M tokens.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24595267342/job/71923906744
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
