### PR TITLE
feat(openrouter): enable Anthropic native web search for anthropic/* models

### DIFF
--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -11,6 +11,7 @@ export interface OpenRouterProviderOptions {
   apiKey?: string;
   baseURL?: string;
   streamTimeoutMs?: number;
+  useNativeWebSearch?: boolean;
 }
 
 const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
@@ -36,6 +37,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   private readonly defaultModel: string;
   private readonly resolvedBaseURL: string;
   private readonly providerStreamTimeoutMs: number | undefined;
+  private readonly useNativeWebSearch: boolean;
   private anthropicInner: AnthropicProvider | undefined;
 
   constructor(
@@ -54,6 +56,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
     this.defaultModel = model;
     this.resolvedBaseURL = baseURL;
     this.providerStreamTimeoutMs = options.streamTimeoutMs;
+    this.useNativeWebSearch = options.useNativeWebSearch ?? false;
   }
 
   // When routing to an `anthropic/*` model, actual API calls hit the Anthropic
@@ -114,6 +117,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
           baseURL: toAnthropicMessagesBaseURL(this.resolvedBaseURL),
           streamTimeoutMs: this.providerStreamTimeoutMs,
           authToken: this.openRouterApiKey,
+          useNativeWebSearch: this.useNativeWebSearch,
         },
       );
     }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -250,6 +250,7 @@ export async function initializeProviders(
       "openrouter",
       new RetryProvider(
         new OpenRouterProvider(openrouterKey, model, {
+          useNativeWebSearch,
           streamTimeoutMs,
         }),
       ),

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -81,7 +81,7 @@ struct InferenceServiceCard: View {
         // only invalidate when the resulting provider cannot support native web search.
         // Skip when web search is in managed mode (webSearchProvider is stale).
         if draftMode == "managed" && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
-            if !store.isNativeWebSearchCapable(draftProvider) {
+            if !store.isNativeWebSearchCapable(draftProvider, model: draftModel) {
                 return true
             }
         }
@@ -89,7 +89,7 @@ struct InferenceServiceCard: View {
         // when the new provider cannot support native web search.
         // Skip when web search is in managed mode (webSearchProvider is stale).
         if providerChanging && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
-            if !store.isNativeWebSearchCapable(draftProvider) {
+            if !store.isNativeWebSearchCapable(draftProvider, model: draftModel) {
                 return true
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1101,9 +1101,17 @@ public final class SettingsStore: ObservableObject {
         Self.managedCapableProviderIds.contains(provider)
     }
 
-    /// Whether a given provider supports native web search.
-    func isNativeWebSearchCapable(_ provider: String) -> Bool {
-        Self.nativeWebSearchCapableProviderIds.contains(provider)
+    /// Whether the current inference selection supports native web search.
+    /// OpenRouter routes `anthropic/*` models through the Anthropic-compat
+    /// endpoint, which accepts Anthropic's native `web_search_20250305` tool.
+    func isNativeWebSearchCapable(_ provider: String, model: String) -> Bool {
+        if Self.nativeWebSearchCapableProviderIds.contains(provider) {
+            return true
+        }
+        if provider == "openrouter" && model.hasPrefix("anthropic/") {
+            return true
+        }
+        return false
     }
 
     // MARK: - Embedding Config Actions

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -45,11 +45,12 @@ struct WebSearchServiceCard: View {
         authManager.isAuthenticated
     }
 
-    /// The available providers depend on the current inference provider's capabilities.
+    /// The available providers depend on the current inference selection's capabilities.
     /// Provider Native is available whenever the inference provider supports native web search
-    /// (e.g. Anthropic, OpenAI), regardless of whether inference is managed or your-own.
+    /// (e.g. Anthropic, OpenAI, or OpenRouter routing to an `anthropic/*` model),
+    /// regardless of whether inference is managed or your-own.
     private var availableProviders: [String] {
-        store.isNativeWebSearchCapable(store.selectedInferenceProvider)
+        store.isNativeWebSearchCapable(store.selectedInferenceProvider, model: store.selectedModel)
             ? ["inference-provider-native", "perplexity", "brave"]
             : ["perplexity", "brave"]
     }
@@ -159,7 +160,7 @@ struct WebSearchServiceCard: View {
             }
             if newValue == "managed" && draftProvider == "inference-provider-native" {
                 // Only auto-correct when the managed provider lacks native web search support.
-                if !store.isNativeWebSearchCapable(store.selectedInferenceProvider) {
+                if !store.isNativeWebSearchCapable(store.selectedInferenceProvider, model: store.selectedModel) {
                     draftProvider = "perplexity"
                 }
             }
@@ -167,7 +168,14 @@ struct WebSearchServiceCard: View {
         .onChange(of: store.selectedInferenceProvider) { _, newProvider in
             // Auto-correct when the inference provider changes to one that
             // does not support native web search while provider-native is selected.
-            if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(newProvider) {
+            if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(newProvider, model: store.selectedModel) {
+                draftProvider = "perplexity"
+            }
+        }
+        .onChange(of: store.selectedModel) { _, newModel in
+            // Auto-correct when the model changes to one that breaks native web search
+            // for the current provider (e.g. OpenRouter switching off an `anthropic/*` model).
+            if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(store.selectedInferenceProvider, model: newModel) {
                 draftProvider = "perplexity"
             }
         }

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
@@ -52,19 +52,32 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
     // MARK: - isNativeWebSearchCapable
 
     func testAnthropicIsNativeWebSearchCapable() {
-        XCTAssertTrue(store.isNativeWebSearchCapable("anthropic"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("anthropic", model: "claude-opus-4.7"))
     }
 
     func testOpenAIIsNativeWebSearchCapable() {
-        XCTAssertTrue(store.isNativeWebSearchCapable("openai"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("openai", model: "gpt-5"))
     }
 
     func testGeminiIsNotNativeWebSearchCapable() {
-        XCTAssertFalse(store.isNativeWebSearchCapable("gemini"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("gemini", model: "gemini-2.5-pro"))
     }
 
     func testOllamaIsNotNativeWebSearchCapable() {
-        XCTAssertFalse(store.isNativeWebSearchCapable("ollama"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("ollama", model: "llama3"))
+    }
+
+    func testOpenRouterWithAnthropicModelIsNativeWebSearchCapable() {
+        // OpenRouter routes `anthropic/*` models through the Anthropic-compat
+        // endpoint, which supports Anthropic's native web_search tool.
+        XCTAssertTrue(store.isNativeWebSearchCapable("openrouter", model: "anthropic/claude-opus-4.7"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("openrouter", model: "anthropic/claude-sonnet-4.6"))
+    }
+
+    func testOpenRouterWithNonAnthropicModelIsNotNativeWebSearchCapable() {
+        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter", model: "openai/gpt-5"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter", model: "x-ai/grok-4"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter", model: ""))
     }
 
     // MARK: - managedCapableProviders
@@ -164,20 +177,20 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
         // OpenAI is both managed-capable and native-web-search-capable,
         // so managed inference + inference-provider-native should be allowed.
         XCTAssertTrue(store.isManagedCapable("openai"))
-        XCTAssertTrue(store.isNativeWebSearchCapable("openai"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("openai", model: "gpt-5"))
     }
 
     func testManagedAnthropicPlusProviderNativeIsValid() {
         // Anthropic is both managed-capable and native-web-search-capable.
         XCTAssertTrue(store.isManagedCapable("anthropic"))
-        XCTAssertTrue(store.isNativeWebSearchCapable("anthropic"))
+        XCTAssertTrue(store.isNativeWebSearchCapable("anthropic", model: "claude-opus-4.7"))
     }
 
     func testManagedGeminiPlusProviderNativeIsInvalid() {
         // Gemini is managed-capable but NOT native-web-search-capable,
         // so managed Gemini + inference-provider-native should be rejected.
         XCTAssertTrue(store.isManagedCapable("gemini"))
-        XCTAssertFalse(store.isNativeWebSearchCapable("gemini"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("gemini", model: "gemini-2.5-pro"))
     }
 
     func testManagedOpenAIProviderNativeWebSearchCanBePersisted() {
@@ -216,10 +229,11 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
         // When the inference provider doesn't support native web search,
         // isNativeWebSearchCapable should return false, indicating the UI
         // should enforce fallback to perplexity or brave.
-        XCTAssertFalse(store.isNativeWebSearchCapable("gemini"))
-        XCTAssertFalse(store.isNativeWebSearchCapable("ollama"))
-        XCTAssertFalse(store.isNativeWebSearchCapable("fireworks"))
-        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("gemini", model: "gemini-2.5-pro"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("ollama", model: "llama3"))
+        XCTAssertFalse(store.isNativeWebSearchCapable("fireworks", model: "accounts/fireworks/models/kimi-k2"))
+        // OpenRouter with a non-anthropic model is not native-web-search-capable.
+        XCTAssertFalse(store.isNativeWebSearchCapable("openrouter", model: "openai/gpt-5"))
     }
 
     // MARK: - Model Validation Against Selected Provider


### PR DESCRIPTION
## Summary

- Makes the **Provider Native** web search option appear in Settings when the inference provider is **OpenRouter** and the active model is an `anthropic/*` model (previously only visible for direct Anthropic / OpenAI).
- Forwards `useNativeWebSearch` through `OpenRouterProvider` into the inner `AnthropicProvider` so requests actually include Anthropic's native `web_search_20250305` tool when routing to `anthropic/*` on OpenRouter. Model-gating is automatic — non-`anthropic/*` routes stay on the OpenAI-compat path and ignore the flag.
- Auto-corrects the web-search provider back to Perplexity when the model is switched away from `anthropic/*` on OpenRouter, so stale `inference-provider-native` selections can't get stuck.

## Original prompt

> When using Anthropic models from OpenRouter, the provider native web search option should be available
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
