### PR TITLE
feat: GA managed X/Twitter OAuth integration

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -244,7 +244,6 @@ export const PROVIDER_SEED_DATA: Record<
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17335,
     managedServiceConfigKey: "twitter-oauth",
-    featureFlag: "managed-x-oauth-integration",
     injectionTemplates: [
       {
         hostPattern: "api.x.com",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -322,14 +322,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "managed-x-oauth-integration",
-      "scope": "assistant",
-      "key": "managed-x-oauth-integration",
-      "label": "Managed X/Twitter OAuth",
-      "description": "Enable platform-managed X/Twitter OAuth integration in Models & Services settings",
-      "defaultEnabled": false
-    },
-    {
       "id": "onboarding-pre-chat",
       "scope": "macos",
       "key": "onboarding-pre-chat",


### PR DESCRIPTION
## Summary
- Remove the `managed-x-oauth-integration` feature flag from the registry and the Twitter OAuth provider seed data
- The Twitter/X OAuth provider is now visible to all users by default without any feature flag gating

## Original prompt
GA the Managed Twitter/X OAuth feature flag - remove the feature flag gating so that the managed Twitter/X OAuth functionality is available to all users by default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
