### PR TITLE
refactor(skill): rewrite bundled browser skill around `assistant browser` CLI contract

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -545,7 +545,7 @@ describe("bundled browser skill", () => {
     const browserSkill = catalog.find((s) => s.id === "browser");
     expect(browserSkill).toBeDefined();
     expect(browserSkill!.description).toBe(
-      "Navigate and interact with web pages using a headless browser",
+      "Browse the web using `assistant browser` CLI commands",
     );
   });
 

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser
-description: Navigate and interact with web pages using a headless browser
+description: Browse the web using `assistant browser` CLI commands
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🌐"
@@ -8,81 +8,131 @@ metadata:
     display-name: "Browser"
     feature-flag: "browser"
     activation-hints:
-      - "Load first if you need browser_* tools (navigating, clicking, extracting web content)"
+      - "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
 ---
 
-Use this skill to browse the web. After loading this skill, the following browser tools become available:
+Use this skill to browse the web. All browser operations are executed through the `assistant browser` CLI, invoked via `bash` or `host_bash`. Each operation is a subcommand:
 
-- `browser_attach` - Attach the Chrome debugger to the active tab
-- `browser_navigate` - Navigate to a URL
-- `browser_snapshot` - List interactive elements on the current page
-- `browser_screenshot` - Take a visual screenshot
-- `browser_close` - Close the browser page
-- `browser_detach` - Detach the Chrome debugger from the active tab
-- `browser_click` - Click an element
-- `browser_type` - Type text into an input
-- `browser_press_key` - Press a keyboard key
-- `browser_scroll` - Scroll the page or a specific element
-- `browser_select_option` - Select an option from a native `<select>` element
-- `browser_hover` - Hover over an element to reveal menus/tooltips
-- `browser_wait_for` - Wait for a condition
-- `browser_extract` - Extract page text content
-- `browser_wait_for_download` - Wait for a file download to complete
-- `browser_fill_credential` - Fill a stored credential into a form field
-- `browser_status` - Diagnose browser backend readiness and setup steps
+| Command | Description |
+|---|---|
+| `assistant browser navigate` | Navigate to a URL |
+| `assistant browser snapshot` | List interactive elements on the current page |
+| `assistant browser screenshot` | Take a visual screenshot |
+| `assistant browser click` | Click an element |
+| `assistant browser type` | Type text into an input |
+| `assistant browser press-key` | Press a keyboard key |
+| `assistant browser scroll` | Scroll the page or a specific element |
+| `assistant browser select-option` | Select an option from a native `<select>` element |
+| `assistant browser hover` | Hover over an element to reveal menus/tooltips |
+| `assistant browser wait-for` | Wait for a condition |
+| `assistant browser extract` | Extract page text content |
+| `assistant browser wait-for-download` | Wait for a file download to complete |
+| `assistant browser fill-credential` | Fill a stored credential into a form field |
+| `assistant browser attach` | Attach the Chrome debugger to the active tab |
+| `assistant browser detach` | Detach the Chrome debugger from the active tab |
+| `assistant browser close` | Close the browser page |
+| `assistant browser status` | Diagnose browser backend readiness and setup steps |
 
 ## Capabilities
 
 This browser runs **full Chromium with JavaScript enabled**. It can handle SPAs, React/Vue/Angular apps, dynamic content, date pickers, booking systems, reservation flows, and any JavaScript-heavy interactive site. Never tell the user you "can't handle interactive JavaScript" - you can.
 
+## Session Management
+
+Use `--session <id>` on the `assistant browser` parent command to group sequential operations so they share browser state (same page, cookies, etc.). Different session IDs create independent browser contexts.
+
+```bash
+assistant browser --session myflow navigate --url https://example.com
+assistant browser --session myflow snapshot
+assistant browser --session myflow click --element-id e3
+```
+
+Omitting `--session` uses the `default` session.
+
+## Machine-Readable Output
+
+Use `--json` on the `assistant browser` parent command to get structured JSON output suitable for parsing in scripts:
+
+```bash
+assistant browser --json navigate --url https://example.com
+# {"ok":true,"content":"Page title: Example Domain"}
+
+assistant browser --json snapshot
+# {"ok":true,"content":"...element list..."}
+
+assistant browser --json screenshot
+# {"ok":true,"content":"...","screenshots":[{"mediaType":"image/jpeg","data":"<base64>"}]}
+```
+
+Error responses use `{"ok":false,"error":"..."}`.
+
+## Screenshots
+
+To save a screenshot to disk, use `--output <path>`:
+
+```bash
+assistant browser screenshot --output page.jpg
+assistant browser screenshot --full-page --output full.jpg
+```
+
+To receive base64 screenshot data in JSON output:
+
+```bash
+assistant browser --json screenshot
+```
+
+The response includes a `screenshots` array with `mediaType` and `data` (base64) fields.
+
 ## Browser Mode
 
-Every browser tool accepts an optional `browser_mode` parameter that controls which backend executes the command:
+Use `--browser-mode <mode>` on the `assistant browser` parent command to pin the browser backend:
 
 | Value | Backend | Description |
 |---|---|---|
-| `auto` | Automatic | Default. The assistant picks the best available backend based on context (extension > cdp-inspect > local). |
+| `auto` | Automatic | Default. Picks the best available backend based on context. |
 | `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
-| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via the DevTools protocol. Alias: `cdp-debugger`. |
-| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. Alias: `playwright`. |
+| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via DevTools Protocol. |
+| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. |
 
-**When to use `auto`**: Prefer `auto` (or omit `browser_mode` entirely) unless you have a specific reason to pin. The automatic backend selection handles extension availability, fallback, and session reuse.
+```bash
+assistant browser --browser-mode local navigate --url http://localhost:3000
+```
+
+**When to use `auto`**: Prefer `auto` (or omit `--browser-mode` entirely) unless you have a specific reason to pin. The automatic backend selection handles extension availability, fallback, and session reuse.
 
 **When to pin a mode**: Pin explicitly when:
 - The user requests interaction with their own browser (use `extension` or `cdp-inspect`).
-- A tool only works on a specific backend (e.g. `browser_wait_for_download` requires `local`).
+- A command only works on a specific backend (e.g. `wait-for-download` requires `local`).
 - You want to avoid fallback behavior for diagnostic clarity.
-
-**Unsupported mode errors**: Some tools restrict which modes they support. For example, `browser_wait_for_download` only supports `auto` and `local` because file downloads require the Playwright backend. Passing an unsupported mode returns a clear error with the accepted alternatives.
 
 ## Typical Workflow
 
-1. (Optional) `browser_status` to diagnose backend availability and remediation when setup is unclear
-2. `browser_attach` to establish the debugger session (extension path; optional on other backends)
-3. `browser_navigate` to load a page
-4. `browser_snapshot` to discover interactive elements
-5. Use `browser_click`, `browser_type`, `browser_press_key`, `browser_scroll`, `browser_select_option`, or `browser_hover` to interact
-6. `browser_extract` or `browser_screenshot` to capture results
-7. `browser_detach` to end the debugger session, or `browser_close` to close the page entirely
+1. (Optional) `assistant browser status` to diagnose backend availability
+2. (Optional) `assistant browser attach` to establish the debugger session (extension path)
+3. `assistant browser navigate --url <url>` to load a page
+4. `assistant browser snapshot` to discover interactive elements
+5. Use `click`, `type`, `press-key`, `scroll`, `select-option`, or `hover` to interact
+6. `assistant browser extract` or `assistant browser screenshot --output <path>` to capture results
+7. `assistant browser detach` to end the session, or `assistant browser close` to close the page
 
 ## Interaction Strategies
 
-**Date pickers / calendars:** Click the date input to open the picker, re-snapshot to see calendar controls, click month navigation arrows to reach the target month, then click the target date. For `<input type="date">`, use `browser_type` with `YYYY-MM-DD` format.
+**Date pickers / calendars:** Click the date input to open the picker, re-snapshot to see calendar controls, click month navigation arrows to reach the target month, then click the target date. For `<input type="date">`, use `type` with `YYYY-MM-DD` format.
 
-**Native `<select>` elements:** Use `browser_select_option` with `value`, `label`, or `index`. Do not try to click individual `<option>` elements.
+**Native `<select>` elements:** Use `select-option` with `--value`, `--label`, or `--index`. Do not try to click individual `<option>` elements.
 
-**ARIA / custom dropdowns:** Click to open, take a new `browser_snapshot`, then click the desired option by `element_id`.
+**ARIA / custom dropdowns:** Click to open, take a new `snapshot`, then click the desired option by `--element-id`.
 
-**Autocomplete inputs:** Type the search text, wait 500–1000ms (`browser_wait_for` with duration), re-snapshot for suggestions, then click the suggestion or use ArrowDown + Enter.
+**Autocomplete inputs:** Type the search text, wait 500-1000ms (`wait-for --duration`), re-snapshot for suggestions, then click the suggestion or use `press-key --key ArrowDown` + `press-key --key Enter`.
 
 **Multi-step forms:** Complete each step, wait for the next section to load, re-snapshot to discover new elements, then proceed.
 
-**Dynamic content:** After interactions that change the page, use `browser_wait_for` (selector or text) or re-snapshot to see updated elements before continuing.
+**Dynamic content:** After interactions that change the page, use `wait-for` (with `--selector` or `--text`) or re-snapshot to see updated elements before continuing.
 
-**Scrolling:** Use `browser_scroll` to reveal below-the-fold content before snapshotting. Long pages may require multiple scrolls.
+**Scrolling:** Use `scroll --direction down` to reveal below-the-fold content before snapshotting. Long pages may require multiple scrolls.
 
-**Hover menus / tooltips:** Use `browser_hover` to reveal hidden menus or tooltips, then re-snapshot to see newly revealed elements.
+**Hover menus / tooltips:** Use `hover` to reveal hidden menus or tooltips, then re-snapshot to see newly revealed elements.
 
 ## Verification
 
-Use `browser_screenshot` after critical actions (form submission, booking confirmation, checkout) to visually verify results before reporting success to the user.
+Use `assistant browser screenshot --output <path>` after critical actions (form submission, booking confirmation, checkout) to visually verify results before reporting success to the user.

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -135,4 +135,10 @@ assistant browser --browser-mode local navigate --url http://localhost:3000
 
 ## Verification
 
-Use `assistant browser screenshot --output <path>` after critical actions (form submission, booking confirmation, checkout) to visually verify results before reporting success to the user.
+After critical actions (form submission, booking confirmation, checkout), take a screenshot and read the saved image to visually verify results before reporting success to the user:
+
+```bash
+assistant browser screenshot --output /tmp/verify.jpg
+# then read the image to see its contents
+read_file /tmp/verify.jpg
+```

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -141,4 +141,4 @@ After critical actions (form submission, booking confirmation, checkout), take a
 assistant browser screenshot --output /tmp/verify.jpg
 ```
 
-Then use `file_read` to inspect the saved image before reporting success.
+Then read the saved image to inspect it before reporting success. Use `file_read` if the screenshot was taken via `bash`, or `host_file_read` if it was taken via `host_bash`.

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -135,10 +135,10 @@ assistant browser --browser-mode local navigate --url http://localhost:3000
 
 ## Verification
 
-After critical actions (form submission, booking confirmation, checkout), take a screenshot and read the saved image to visually verify results before reporting success to the user:
+After critical actions (form submission, booking confirmation, checkout), take a screenshot and then read the saved image to visually verify results before reporting success to the user:
 
 ```bash
 assistant browser screenshot --output /tmp/verify.jpg
-# then read the image to see its contents
-read_file /tmp/verify.jpg
 ```
+
+Then use `file_read` to inspect the saved image before reporting success.


### PR DESCRIPTION
## Summary
- Rewrites bundled browser SKILL.md to use `assistant browser` CLI commands instead of `browser_*` tool calls
- Documents --session, --json, and screenshot --output invocation patterns
- Preserves browser skill identity/metadata for capability routing

Part of plan: remove-browser-tools.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
