### PR TITLE
feat: support local chrome extension allowlist override and surface forbidden errors

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -335,18 +335,20 @@ function updateAuthSections(authProfile: AssistantAuthProfile | null): void {
 /**
  * Load the assistant catalog from the worker and render the selector.
  */
-function isNativeHostUnavailable(error: string | undefined): boolean {
+function isNativeHostMissing(error: string | undefined): boolean {
   if (!error) return false;
   const lower = error.toLowerCase();
-  // Match only Chrome's specific host-not-installed error messages:
+  // Match only Chrome's host-not-installed error message:
   //   "Specified native messaging host not found."
-  //   "Access to the specified native messaging host is forbidden."
-  // Recoverable errors like timeouts, generic helper errors, and
-  // disconnect-before-response must NOT trigger the no-native-host phase.
-  return (
-    (lower.includes('native messaging host') && lower.includes('not found')) ||
-    (lower.includes('native messaging host') && lower.includes('forbidden'))
-  );
+  // Recoverable errors, allowlist errors ("forbidden"), generic helper
+  // errors, and disconnect-before-response must NOT trigger no-native-host.
+  return lower.includes('native messaging host') && lower.includes('not found');
+}
+
+function isNativeHostForbidden(error: string | undefined): boolean {
+  if (!error) return false;
+  const lower = error.toLowerCase();
+  return lower.includes('native messaging host') && lower.includes('forbidden');
 }
 
 function loadAssistantCatalog(): void {
@@ -354,8 +356,15 @@ function loadAssistantCatalog(): void {
     if (chrome.runtime.lastError || !response?.ok) {
       const errMsg = response?.error ?? chrome.runtime.lastError?.message ?? 'Failed to load assistants';
 
-      if (isNativeHostUnavailable(errMsg)) {
+      if (isNativeHostMissing(errMsg)) {
         setPhase('no-native-host');
+        return;
+      }
+
+      if (isNativeHostForbidden(errMsg)) {
+        showError(
+          'Native host access is blocked for this extension ID. Add the ID to ~/.vellum/chrome-extension-allowlist.local.json, restart the assistant, then reload Chrome.',
+        );
         return;
       }
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1102,6 +1102,12 @@ fi
 _LSE_ENTRIES+="
         <key>VELLUM_ENVIRONMENT</key>
         <string>$VELLUM_ENVIRONMENT</string>"
+if [ -n "${CHROME_EXTENSION_IDS_CSV:-}" ]; then
+    echo "Embedding VELLUM_CHROME_EXTENSION_IDS"
+    _LSE_ENTRIES+="
+        <key>VELLUM_CHROME_EXTENSION_IDS</key>
+        <string>$CHROME_EXTENSION_IDS_CSV</string>"
+fi
 if [ -n "${SENTRY_DSN_MACOS:-}" ]; then
     echo "Embedding SENTRY_DSN_MACOS"
     _LSE_ENTRIES+="

--- a/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
@@ -92,46 +92,120 @@ extension AppDelegate {
 }
 
 /// Chrome extension IDs used when writing the native messaging manifest's
-/// `allowed_origins` entries. Resolved from the canonical config at
-/// `meta/browser-extension/chrome-extension-allowlist.json` when available.
+/// `allowed_origins` entries. Resolved from merged allowlist sources:
+/// canonical config, local override, and environment overrides.
 ///
 /// Kept in a standalone enum so unit tests can reference it without
 /// instantiating `AppDelegate`.
 enum ChromeExtensionAllowlist {
     private static let fallbackPlaceholderId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     private static let extensionIdRegex = try! NSRegularExpression(pattern: "^[a-p]{32}$")
+    private static let localOverrideFilename = "chrome-extension-allowlist.local.json"
 
-    /// All valid extension IDs from the canonical config. Used to populate
-    /// the native messaging manifest's `allowed_origins` array so both the
-    /// development (sideloaded) and CWS-published extension are accepted.
+    /// All valid extension IDs merged from:
+    /// 1. Canonical repo allowlist config.
+    /// 2. Per-machine local override under `~/.vellum/`.
+    /// 3. Environment overrides (`VELLUM_CHROME_EXTENSION_IDS` /
+    ///    `VELLUM_CHROME_EXTENSION_ID`).
+    ///
+    /// Used to populate the native messaging manifest's `allowed_origins`
+    /// array so both the published extension and local unpacked builds can
+    /// connect when explicitly allowlisted.
     static var allIds: [String] {
-        if let fromEnv = ProcessInfo.processInfo.environment["VELLUM_CHROME_EXTENSION_IDS"] {
-            let ids = fromEnv.components(separatedBy: CharacterSet(charactersIn: ", "))
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .filter { isValidExtensionId($0) }
-            if !ids.isEmpty { return ids }
+        let ids = mergedIds(
+            canonicalCandidates: canonicalConfigPathCandidates(),
+            localOverridePath: localOverridePath(),
+            environment: ProcessInfo.processInfo.environment
+        )
+        if !ids.isEmpty {
+            return ids
         }
-
-        if let fromConfig = loadAllIdsFromCanonicalConfig() {
-            return fromConfig
-        }
-
         return [fallbackPlaceholderId]
     }
 
     /// The first valid extension ID — used when a single ID is needed.
     static var primaryId: String {
-        if let fromEnv = ProcessInfo.processInfo.environment["VELLUM_CHROME_EXTENSION_ID"],
-           isValidExtensionId(fromEnv)
-        {
-            return fromEnv
+        allIds.first ?? fallbackPlaceholderId
+    }
+
+    /// Testable helper: merge IDs from canonical/local/env sources.
+    ///
+    /// Canonical config uses first-valid-candidate-wins semantics so source
+    /// and cwd path candidates are treated as one logical source.
+    static func mergedIds(
+        canonicalCandidates: [URL],
+        localOverridePath: URL,
+        environment: [String: String]
+    ) -> [String] {
+        var merged: [String] = []
+        var seen = Set<String>()
+
+        for candidate in canonicalCandidates {
+            guard let canonicalIds = readIdsFromAllowlistFile(candidate) else {
+                continue
+            }
+            appendUnique(canonicalIds, into: &merged, seen: &seen)
+            break
         }
 
-        if let fromCanonicalConfig = loadPrimaryIdFromCanonicalConfig() {
-            return fromCanonicalConfig
+        if let localIds = readIdsFromAllowlistFile(localOverridePath, allowEmpty: true) {
+            appendUnique(localIds, into: &merged, seen: &seen)
         }
 
-        return fallbackPlaceholderId
+        appendUnique(
+            parseIdsFromEnvironmentList(environment["VELLUM_CHROME_EXTENSION_IDS"]),
+            into: &merged,
+            seen: &seen
+        )
+        if let singleEnvId = parseSingleIdFromEnvironment(environment["VELLUM_CHROME_EXTENSION_ID"]) {
+            appendUnique([singleEnvId], into: &merged, seen: &seen)
+        }
+
+        return merged
+    }
+
+    private static func appendUnique(
+        _ ids: [String],
+        into merged: inout [String],
+        seen: inout Set<String>
+    ) {
+        for id in ids where !seen.contains(id) {
+            seen.insert(id)
+            merged.append(id)
+        }
+    }
+
+    private static func parseIdsFromEnvironmentList(_ raw: String?) -> [String] {
+        guard let raw else { return [] }
+        let tokens = raw
+            .components(separatedBy: CharacterSet(charactersIn: ",").union(.whitespacesAndNewlines))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return tokens.filter { isValidExtensionId($0) }
+    }
+
+    private static func parseSingleIdFromEnvironment(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return isValidExtensionId(trimmed) ? trimmed : nil
+    }
+
+    private static func readIdsFromAllowlistFile(
+        _ path: URL,
+        allowEmpty: Bool = false
+    ) -> [String]? {
+        guard let data = try? Data(contentsOf: path),
+              let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ids = raw["allowedExtensionIds"] as? [String]
+        else {
+            return nil
+        }
+
+        let valid = ids.filter { isValidExtensionId($0) }
+        if valid.isEmpty && !allowEmpty {
+            return nil
+        }
+        return valid
     }
 
     private static func isValidExtensionId(_ value: String) -> Bool {
@@ -140,33 +214,10 @@ enum ChromeExtensionAllowlist {
         return match != nil
     }
 
-    private static func loadAllIdsFromCanonicalConfig() -> [String]? {
-        for candidate in canonicalConfigPathCandidates() {
-            guard let data = try? Data(contentsOf: candidate),
-                  let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let ids = raw["allowedExtensionIds"] as? [String]
-            else {
-                continue
-            }
-            let valid = ids.filter { isValidExtensionId($0) }
-            if !valid.isEmpty { return valid }
-        }
-        return nil
-    }
-
-    private static func loadPrimaryIdFromCanonicalConfig() -> String? {
-        for candidate in canonicalConfigPathCandidates() {
-            guard let data = try? Data(contentsOf: candidate),
-                  let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let ids = raw["allowedExtensionIds"] as? [String],
-                  let first = ids.first,
-                  isValidExtensionId(first)
-            else {
-                continue
-            }
-            return first
-        }
-        return nil
+    private static func localOverridePath() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum", isDirectory: true)
+            .appendingPathComponent(localOverrideFilename, isDirectory: false)
     }
 
     private static func canonicalConfigPathCandidates() -> [URL] {

--- a/clients/macos/vellum-assistantTests/ChromeExtensionAllowlistTests.swift
+++ b/clients/macos/vellum-assistantTests/ChromeExtensionAllowlistTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+
+final class ChromeExtensionAllowlistTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChromeExtensionAllowlistTests-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testMergedIdsCombinesCanonicalLocalAndEnvironmentInStableOrder() throws {
+        let canonicalPath = tempDir.appendingPathComponent("canonical.json")
+        let localPath = tempDir.appendingPathComponent("local.json")
+
+        try writeAllowlist(
+            at: canonicalPath,
+            ids: [
+                "hphbdmpffeigpcdjkckleobjmhhokpne",
+                "invalid",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ]
+        )
+        try writeAllowlist(
+            at: localPath,
+            ids: [
+                "cccccccccccccccccccccccccccccccc",
+                "hphbdmpffeigpcdjkckleobjmhhokpne",
+            ]
+        )
+
+        let merged = ChromeExtensionAllowlist.mergedIds(
+            canonicalCandidates: [canonicalPath],
+            localOverridePath: localPath,
+            environment: [
+                "VELLUM_CHROME_EXTENSION_IDS": "dddddddddddddddddddddddddddddddd cccccccccccccccccccccccccccccccc bad-id",
+                "VELLUM_CHROME_EXTENSION_ID": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            ]
+        )
+
+        XCTAssertEqual(
+            merged,
+            [
+                "hphbdmpffeigpcdjkckleobjmhhokpne",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "cccccccccccccccccccccccccccccccc",
+                "dddddddddddddddddddddddddddddddd",
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            ]
+        )
+    }
+
+    func testMergedIdsFallsBackToLaterCanonicalCandidateWhenFirstMissing() throws {
+        let missingCanonicalPath = tempDir.appendingPathComponent("missing.json")
+        let canonicalPath = tempDir.appendingPathComponent("canonical.json")
+        let localPath = tempDir.appendingPathComponent("local.json")
+
+        try writeAllowlist(
+            at: canonicalPath,
+            ids: ["ffffffffffffffffffffffffffffffff"]
+        )
+        try writeAllowlist(at: localPath, ids: [])
+
+        let merged = ChromeExtensionAllowlist.mergedIds(
+            canonicalCandidates: [missingCanonicalPath, canonicalPath],
+            localOverridePath: localPath,
+            environment: [:]
+        )
+
+        XCTAssertEqual(merged, ["ffffffffffffffffffffffffffffffff"])
+    }
+
+    func testMergedIdsReturnsEmptyWhenNoSourceProvidesValidIds() throws {
+        let missingCanonicalPath = tempDir.appendingPathComponent("missing.json")
+        let localPath = tempDir.appendingPathComponent("local.json")
+
+        try writeAllowlist(at: localPath, ids: ["not-valid"])
+
+        let merged = ChromeExtensionAllowlist.mergedIds(
+            canonicalCandidates: [missingCanonicalPath],
+            localOverridePath: localPath,
+            environment: [
+                "VELLUM_CHROME_EXTENSION_IDS": "still-invalid",
+                "VELLUM_CHROME_EXTENSION_ID": "also-invalid",
+            ]
+        )
+
+        XCTAssertEqual(merged, [])
+    }
+
+    private func writeAllowlist(at url: URL, ids: [String]) throws {
+        let object: [String: Any] = [
+            "version": 1,
+            "allowedExtensionIds": ids,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor `ChromeExtensionAllowlist` to merge IDs from canonical config, a per-machine local override file (`~/.vellum/chrome-extension-allowlist.local.json`), and environment variables — with deduplication and stable ordering. Adds unit tests.
- Split `isNativeHostUnavailable` into `isNativeHostMissing` / `isNativeHostForbidden` so Chrome "forbidden" errors surface an actionable allowlist fix message instead of incorrectly triggering the "no native host" install phase.
- Embed `VELLUM_CHROME_EXTENSION_IDS` into the macOS app environment at build time when the env var is set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
