### PR TITLE
soften PKB system reminder language

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -609,10 +609,8 @@ const MAX_BUFFER_LINES = 50;
 
 const PKB_SYSTEM_REMINDER =
   "<system_reminder>" +
-  "\n**CRITICAL:** you MUST read any PKB files that might be relevant to this conversation — " +
-  "INDEX.md is your table of contents. Don't wait to be asked. " +
-  "Use `remember` OFTEN for EVERY new fact you learn IMMEDIATELY, don't wait for the next turn. " +
-  "Corrections to things you had wrong are the highest-priority remembers — never skip them." +
+  "\nRead any unread PKB files that might be even partially relevant to this conversation" +
+  "\nUse `remember` for anything you learn immediately" +
   "\n</system_reminder>";
 
 /**


### PR DESCRIPTION
## Summary
- Replace aggressive directives (\`CRITICAL\`, \`MUST\`, \`IMMEDIATELY\`, \`OFTEN\`, \`never skip\`) in the PKB system reminder with calmer, shorter guidance.
- Drop the explicit INDEX.md and corrections framing; keep the core asks (read potentially relevant PKB files, call \`remember\` on new info).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
