### PR TITLE
feat: add portable outlook Graph API client and shared script utilities

### DIFF
--- a/skills/outlook/scripts/lib/common.ts
+++ b/skills/outlook/scripts/lib/common.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+
+/**
+ * Shared utilities for outlook scripts.
+ * Provides CLI argument parsing, JSON output helpers, and common patterns.
+ */
+
+/** Parse `--key value` and `--flag` CLI arguments. */
+export function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      result[key] = true;
+    } else {
+      result[key] = next;
+      i++;
+    }
+  }
+  return result;
+}
+
+/** Write JSON to stdout. */
+export function printJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data) + "\n");
+}
+
+/** Write `{ ok: false, error: message }` to stdout and exit. */
+export function printError(message: string): void {
+  printJson({ ok: false, error: message });
+  process.exit(1);
+}
+
+/** Write `{ ok: true, data }` to stdout. */
+export function ok(data: unknown): void {
+  printJson({ ok: true, data });
+}
+
+/** Extract a required string argument or call `printError`. */
+export function requireArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    printError(`Missing required argument: --${name}`);
+    // printError calls process.exit(1), but TypeScript doesn't know that
+    throw new Error("unreachable");
+  }
+  return value;
+}
+
+/** Extract an optional string argument. */
+export function optionalArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Split comma-separated values, trim whitespace. */
+export function parseCsv(value: string): string[] {
+  return value.split(",").map((s) => s.trim());
+}

--- a/skills/outlook/scripts/lib/graph-client.ts
+++ b/skills/outlook/scripts/lib/graph-client.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+
+/**
+ * Authenticated Microsoft Graph API client.
+ * Uses `assistant oauth request` under the hood for portable OAuth.
+ */
+
+export interface GraphRequestOptions {
+  method?: string;
+  path: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  account?: string;
+  headers?: Record<string, string>;
+}
+
+export interface GraphResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+/**
+ * Execute an authenticated Microsoft Graph API request via `assistant oauth request`.
+ */
+export async function graphRequest<T = unknown>(
+  opts: GraphRequestOptions,
+): Promise<GraphResponse<T>> {
+  const args: string[] = [
+    "assistant",
+    "oauth",
+    "request",
+    "--provider",
+    "outlook",
+  ];
+
+  const method = opts.method ?? "GET";
+  args.push("-X", method);
+
+  if (opts.body !== undefined) {
+    args.push("-d", JSON.stringify(opts.body));
+    args.push("-H", "Content-Type: application/json");
+  }
+
+  if (opts.headers) {
+    for (const [key, value] of Object.entries(opts.headers)) {
+      args.push("-H", `${key}: ${value}`);
+    }
+  }
+
+  if (opts.account) {
+    args.push("--account", opts.account);
+  }
+
+  let path = opts.path;
+  if (opts.query && Object.keys(opts.query).length > 0) {
+    path += "?" + new URLSearchParams(opts.query).toString();
+  }
+
+  args.push(path);
+  args.push("--json");
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+  } catch (err) {
+    throw new Error(
+      `Failed to spawn assistant oauth request: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `assistant oauth request failed (exit ${exitCode}): ${stderr || stdout}`,
+    );
+  }
+
+  let result: { ok: boolean; status: number; headers: unknown; body: unknown };
+  try {
+    result = JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse assistant oauth request output: ${err instanceof Error ? err.message : String(err)}. stdout: ${stdout}`,
+    );
+  }
+
+  return {
+    ok: result.ok,
+    status: result.status,
+    data: result.body as T,
+  };
+}
+
+/** Convenience wrapper for GET requests. */
+export async function graphGet<T = unknown>(
+  path: string,
+  query?: Record<string, string>,
+  account?: string,
+): Promise<GraphResponse<T>> {
+  return graphRequest<T>({ method: "GET", path, query, account });
+}
+
+/** Convenience wrapper for POST requests. */
+export async function graphPost<T = unknown>(
+  path: string,
+  body: unknown,
+  account?: string,
+): Promise<GraphResponse<T>> {
+  return graphRequest<T>({ method: "POST", path, body, account });
+}
+
+/** Convenience wrapper for PATCH requests. */
+export async function graphPatch<T = unknown>(
+  path: string,
+  body: unknown,
+  account?: string,
+): Promise<GraphResponse<T>> {
+  return graphRequest<T>({ method: "PATCH", path, body, account });
+}
+
+/** Convenience wrapper for DELETE requests. */
+export async function graphDelete(
+  path: string,
+  account?: string,
+): Promise<GraphResponse<void>> {
+  return graphRequest<void>({ method: "DELETE", path, account });
+}
+
+export type { GraphResponse, GraphRequestOptions };


### PR DESCRIPTION
## Summary
- Add shared CLI argument parsing, JSON output, and error handling utilities for outlook scripts
- Add authenticated Microsoft Graph API client that uses `assistant oauth request` for portable OAuth

Part of plan: migrate-outlook-skill.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
