### PR TITLE
feat: add outlook email composition scripts (draft, send-draft, forward, trash)

### DIFF
--- a/skills/outlook/scripts/outlook-email.ts
+++ b/skills/outlook/scripts/outlook-email.ts
@@ -13,7 +13,7 @@ import {
   optionalArg,
   parseCsv,
 } from "./lib/common.js";
-import { graphPost, graphPatch } from "./lib/graph-client.js";
+import { graphRequest, graphPost, graphPatch } from "./lib/graph-client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -87,7 +87,7 @@ Options:
   if (inReplyTo) {
     // Create a reply draft from an existing message
     const replyResponse = await graphPost<DraftMessageResponse>(
-      `/v1.0/me/messages/${inReplyTo}/createReply`,
+      `/v1.0/me/messages/${encodeURIComponent(inReplyTo)}/createReply`,
       { comment: body },
       account,
     );
@@ -107,7 +107,7 @@ Options:
     if (bccRecipientsList) patchBody.bccRecipients = bccRecipientsList;
 
     const patchResponse = await graphPatch<DraftMessageResponse>(
-      `/v1.0/me/messages/${draftId}`,
+      `/v1.0/me/messages/${encodeURIComponent(draftId)}`,
       patchBody,
       account,
     );
@@ -171,11 +171,11 @@ Options:
   const draftId = requireArg(args, "draft-id");
   const account = optionalArg(args, "account");
 
-  const response = await graphPost(
-    `/v1.0/me/messages/${draftId}/send`,
-    {},
+  const response = await graphRequest({
+    method: "POST",
+    path: `/v1.0/me/messages/${encodeURIComponent(draftId)}/send`,
     account,
-  );
+  });
 
   if (!response.ok) {
     printError(`Failed to send draft: status ${response.status}`);
@@ -212,14 +212,16 @@ Options:
   const comment = optionalArg(args, "comment");
   const account = optionalArg(args, "account");
 
-  const toRecipientsList = toRecipients(parseCsv(to));
+  const recipients = toRecipients(parseCsv(to));
 
-  // Create a forward draft
-  const forwardBody: Record<string, unknown> = {};
+  // Create a forward draft with recipients included
+  const forwardBody: Record<string, unknown> = {
+    toRecipients: recipients,
+  };
   if (comment) forwardBody.comment = comment;
 
   const response = await graphPost<ForwardResponse>(
-    `/v1.0/me/messages/${messageId}/createForward`,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}/createForward`,
     forwardBody,
     account,
   );
@@ -230,18 +232,6 @@ Options:
   }
 
   const draftId = response.data.id;
-
-  // Patch the draft to add recipients
-  const patchResponse = await graphPatch(
-    `/v1.0/me/messages/${draftId}`,
-    { toRecipients: toRecipientsList },
-    account,
-  );
-
-  if (!patchResponse.ok) {
-    printError(`Failed to update forward recipients: status ${patchResponse.status}`);
-    return;
-  }
 
   ok({ draftId });
 }
@@ -266,7 +256,7 @@ Options:
   const account = optionalArg(args, "account");
 
   const response = await graphPost(
-    `/v1.0/me/messages/${messageId}/move`,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}/move`,
     { destinationId: "deleteditems" },
     account,
   );

--- a/skills/outlook/scripts/outlook-email.ts
+++ b/skills/outlook/scripts/outlook-email.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env bun
+
+/**
+ * Outlook email composition and sending operations.
+ * Subcommands: draft, send-draft, forward, trash
+ */
+
+import {
+  parseArgs,
+  printError,
+  ok,
+  requireArg,
+  optionalArg,
+  parseCsv,
+} from "./lib/common.js";
+import { graphPost, graphPatch } from "./lib/graph-client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getCommand(): string | undefined {
+  return process.argv[2];
+}
+
+interface Recipient {
+  emailAddress: { address: string };
+}
+
+function toRecipients(emails: string[]): Recipient[] {
+  return emails.map((email) => ({
+    emailAddress: { address: email.trim() },
+  }));
+}
+
+function printUsage(): void {
+  console.log(`Usage: outlook-email.ts <subcommand> [options]
+
+Subcommands:
+  draft        Create an email draft
+  send-draft   Send an existing draft
+  forward      Forward a message
+  trash        Move a message to trash
+
+Run with <subcommand> --help for subcommand-specific options.`);
+}
+
+// ---------------------------------------------------------------------------
+// draft
+// ---------------------------------------------------------------------------
+
+interface DraftMessageResponse {
+  id: string;
+  subject?: string;
+  webLink?: string;
+}
+
+async function draft(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  if (args["help"]) {
+    console.log(`Usage: outlook-email.ts draft --to <emails> --subject <text> --body <html>
+
+Options:
+  --to          Comma-separated recipient emails (required)
+  --subject     Email subject (required)
+  --body        Email body as HTML (required)
+  --cc          Comma-separated CC emails
+  --bcc         Comma-separated BCC emails
+  --in-reply-to Message ID to reply to
+  --account     Outlook account to use`);
+    return;
+  }
+
+  const to = requireArg(args, "to");
+  const subject = requireArg(args, "subject");
+  const body = requireArg(args, "body");
+  const cc = optionalArg(args, "cc");
+  const bcc = optionalArg(args, "bcc");
+  const inReplyTo = optionalArg(args, "in-reply-to");
+  const account = optionalArg(args, "account");
+
+  const toRecipientsList = toRecipients(parseCsv(to));
+  const ccRecipientsList = cc ? toRecipients(parseCsv(cc)) : undefined;
+  const bccRecipientsList = bcc ? toRecipients(parseCsv(bcc)) : undefined;
+
+  if (inReplyTo) {
+    // Create a reply draft from an existing message
+    const replyResponse = await graphPost<DraftMessageResponse>(
+      `/v1.0/me/messages/${inReplyTo}/createReply`,
+      { comment: body },
+      account,
+    );
+
+    if (!replyResponse.ok) {
+      printError(`Failed to create reply draft: status ${replyResponse.status}`);
+      return;
+    }
+
+    const draftId = replyResponse.data.id;
+
+    // Patch the draft to update subject and recipients if specified
+    const patchBody: Record<string, unknown> = {};
+    patchBody.subject = subject;
+    patchBody.toRecipients = toRecipientsList;
+    if (ccRecipientsList) patchBody.ccRecipients = ccRecipientsList;
+    if (bccRecipientsList) patchBody.bccRecipients = bccRecipientsList;
+
+    const patchResponse = await graphPatch<DraftMessageResponse>(
+      `/v1.0/me/messages/${draftId}`,
+      patchBody,
+      account,
+    );
+
+    if (!patchResponse.ok) {
+      printError(`Failed to update reply draft: status ${patchResponse.status}`);
+      return;
+    }
+
+    ok({
+      draftId,
+      subject,
+      webLink: patchResponse.data.webLink,
+    });
+  } else {
+    // Create a new draft message
+    const messageBody: Record<string, unknown> = {
+      subject,
+      body: { contentType: "HTML", content: body },
+      toRecipients: toRecipientsList,
+      isDraft: true,
+    };
+    if (ccRecipientsList) messageBody.ccRecipients = ccRecipientsList;
+    if (bccRecipientsList) messageBody.bccRecipients = bccRecipientsList;
+
+    const response = await graphPost<DraftMessageResponse>(
+      "/v1.0/me/messages",
+      messageBody,
+      account,
+    );
+
+    if (!response.ok) {
+      printError(`Failed to create draft: status ${response.status}`);
+      return;
+    }
+
+    ok({
+      draftId: response.data.id,
+      subject,
+      webLink: response.data.webLink,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// send-draft
+// ---------------------------------------------------------------------------
+
+async function sendDraft(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  if (args["help"]) {
+    console.log(`Usage: outlook-email.ts send-draft --draft-id <id>
+
+Options:
+  --draft-id    ID of the draft to send (required)
+  --account     Outlook account to use`);
+    return;
+  }
+
+  const draftId = requireArg(args, "draft-id");
+  const account = optionalArg(args, "account");
+
+  const response = await graphPost(
+    `/v1.0/me/messages/${draftId}/send`,
+    {},
+    account,
+  );
+
+  if (!response.ok) {
+    printError(`Failed to send draft: status ${response.status}`);
+    return;
+  }
+
+  ok({ sent: true, draftId });
+}
+
+// ---------------------------------------------------------------------------
+// forward
+// ---------------------------------------------------------------------------
+
+interface ForwardResponse {
+  id: string;
+}
+
+async function forward(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  if (args["help"]) {
+    console.log(`Usage: outlook-email.ts forward --message-id <id> --to <emails>
+
+Options:
+  --message-id  ID of the message to forward (required)
+  --to          Comma-separated recipient emails (required)
+  --comment     Optional comment to include
+  --account     Outlook account to use`);
+    return;
+  }
+
+  const messageId = requireArg(args, "message-id");
+  const to = requireArg(args, "to");
+  const comment = optionalArg(args, "comment");
+  const account = optionalArg(args, "account");
+
+  const toRecipientsList = toRecipients(parseCsv(to));
+
+  // Create a forward draft
+  const forwardBody: Record<string, unknown> = {};
+  if (comment) forwardBody.comment = comment;
+
+  const response = await graphPost<ForwardResponse>(
+    `/v1.0/me/messages/${messageId}/createForward`,
+    forwardBody,
+    account,
+  );
+
+  if (!response.ok) {
+    printError(`Failed to create forward draft: status ${response.status}`);
+    return;
+  }
+
+  const draftId = response.data.id;
+
+  // Patch the draft to add recipients
+  const patchResponse = await graphPatch(
+    `/v1.0/me/messages/${draftId}`,
+    { toRecipients: toRecipientsList },
+    account,
+  );
+
+  if (!patchResponse.ok) {
+    printError(`Failed to update forward recipients: status ${patchResponse.status}`);
+    return;
+  }
+
+  ok({ draftId });
+}
+
+// ---------------------------------------------------------------------------
+// trash
+// ---------------------------------------------------------------------------
+
+async function trash(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  if (args["help"]) {
+    console.log(`Usage: outlook-email.ts trash --message-id <id>
+
+Options:
+  --message-id  ID of the message to trash (required)
+  --account     Outlook account to use`);
+    return;
+  }
+
+  const messageId = requireArg(args, "message-id");
+  const account = optionalArg(args, "account");
+
+  const response = await graphPost(
+    `/v1.0/me/messages/${messageId}/move`,
+    { destinationId: "deleteditems" },
+    account,
+  );
+
+  if (!response.ok) {
+    printError(`Failed to trash message: status ${response.status}`);
+    return;
+  }
+
+  ok({ trashed: true, messageId });
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const command = getCommand();
+
+  if (!command || command === "--help" || command === "-h") {
+    printUsage();
+    return;
+  }
+
+  switch (command) {
+    case "draft":
+      await draft(process.argv.slice(3));
+      break;
+    case "send-draft":
+      await sendDraft(process.argv.slice(3));
+      break;
+    case "forward":
+      await forward(process.argv.slice(3));
+      break;
+    case "trash":
+      await trash(process.argv.slice(3));
+      break;
+    default:
+      printError(`Unknown subcommand: ${command}. Use --help for usage.`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    printError(err instanceof Error ? err.message : String(err));
+  });
+}


### PR DESCRIPTION
## Summary
- Add outlook-email.ts with draft, send-draft, forward, and trash subcommands
- Uses portable Graph API client for OAuth-authenticated requests

Part of plan: migrate-outlook-skill.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
