### PR TITLE
refactor(permissions): drop `browser_*` default trust/workspace/side-effect classification

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -108,18 +108,13 @@ describe("browser skill migration end-state", () => {
     expect(rule!.decision).toBe("allow");
   });
 
-  test("all browser tools have default allow rules", () => {
+  test("browser tools do not have default allow rules", () => {
     const templates = getDefaultRuleTemplates();
     for (const tool of BROWSER_TOOL_NAMES) {
       const rule = templates.find(
         (t) => t.id === `default:allow-${tool}-global`,
       );
-      expect(rule).toBeDefined();
-      expect(rule!.decision).toBe("allow");
-      // browser_navigate uses standalone "**" globstar because navigate
-      // candidates contain URLs with "/" (e.g. "browser_navigate:https://example.com/path").
-      const expectedPattern = tool === "browser_navigate" ? "**" : `${tool}:*`;
-      expect(rule!.pattern).toBe(expectedPattern);
+      expect(rule).toBeUndefined();
     }
   });
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4530,8 +4530,8 @@ describe("Permission Checker", () => {
   });
 
   // ── browser tool permission baselines ─────────────────────────────
-  // Representative browser tools are RiskLevel.Low and auto-allowed by
-  // default rules in strict mode.
+  // Browser tools are RiskLevel.Low and prompt in strict mode (no
+  // default allow rules).
 
   describe("browser tool permission baselines", () => {
     const browserToolNames = [
@@ -4588,12 +4588,12 @@ describe("Permission Checker", () => {
       }
     });
 
-    test("browser tools are auto-allowed in strict mode via default allow rules", async () => {
+    test("browser tools prompt in strict mode (no default allow rules)", async () => {
       testConfig.permissions = { mode: "strict" };
       try {
         for (const toolName of browserToolNames) {
           const result = await check(toolName, {}, "/tmp");
-          expect(result.decision).toBe("allow");
+          expect(result.decision).toBe("prompt");
         }
       } finally {
         testConfig.permissions = { mode: "workspace" };
@@ -4624,15 +4624,15 @@ describe("Permission Checker", () => {
     });
   });
 
-  // ── default allow: browser tools ──────────────────────────────
+  // ── browser tools: no default allow ──────────────────────────────
 
-  describe("default allow: browser tools", () => {
+  describe("browser tools: no default allow", () => {
     beforeEach(() => {
       clearCache();
       testConfig.permissions = { mode: "strict" };
     });
 
-    test("all browser tools are allowed by default rules in strict mode", async () => {
+    test("browser tools prompt in strict mode (no default allow rules)", async () => {
       const browserTools = [
         "browser_navigate",
         "browser_snapshot",
@@ -4651,22 +4651,22 @@ describe("Permission Checker", () => {
 
       for (const tool of browserTools) {
         const result = await check(tool, {}, "/tmp");
-        expect(result.decision).toBe("allow");
+        expect(result.decision).toBe("prompt");
       }
     });
 
-    test("browser_navigate with a real URL is allowed in strict mode", async () => {
+    test("browser_navigate with a real URL prompts in strict mode", async () => {
       const result = await check(
         "browser_navigate",
         { url: "https://example.com/path/to/page" },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
+      expect(result.decision).toBe("prompt");
     });
 
     test("non-browser skill tools are NOT auto-allowed", async () => {
       // skill_test_tool is a registered skill-origin tool without a default
-      // allow rule — it should prompt in strict mode.
+      // allow rule -- it should prompt in strict mode.
       const result = await check("skill_test_tool", {}, "/tmp");
       expect(result.decision).not.toBe("allow");
     });

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1147,14 +1147,6 @@ describe("isSideEffectTool", () => {
       "bash",
       "host_bash",
       "web_fetch",
-      "browser_navigate",
-      "browser_click",
-      "browser_type",
-      "browser_press_key",
-      "browser_close",
-      "browser_attach",
-      "browser_detach",
-      "browser_fill_credential",
       "document_create",
       "document_update",
       "schedule_create",
@@ -1175,6 +1167,14 @@ describe("isSideEffectTool", () => {
       "memory_recall",
       "memory_manage",
       "web_search",
+      "browser_navigate",
+      "browser_click",
+      "browser_type",
+      "browser_press_key",
+      "browser_close",
+      "browser_attach",
+      "browser_detach",
+      "browser_fill_credential",
       "browser_snapshot",
       "browser_screenshot",
       "browser_wait_for",
@@ -1582,51 +1582,6 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
     expect(result.isError).toBe(false);
     expect(promptCalled).toBe(true);
-  });
-
-  // ── Browser action tools as side-effect tools (PR fix2) ──────────
-
-  test("browser_click forces prompt in private conversation", async () => {
-    checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
-
-    const executor = new ToolExecutor(makeTrackingPrompter());
-    const result = await executor.execute(
-      "browser_click",
-      { selector: "#submit-btn" },
-      makeContext({ forcePromptSideEffects: true }),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(promptCalled).toBe(true);
-  });
-
-  test("browser_type forces prompt in private conversation", async () => {
-    checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
-
-    const executor = new ToolExecutor(makeTrackingPrompter());
-    const result = await executor.execute(
-      "browser_type",
-      { selector: "#search-input", text: "query" },
-      makeContext({ forcePromptSideEffects: true }),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(promptCalled).toBe(true);
-  });
-
-  test("browser_snapshot does NOT force prompt in private conversation", async () => {
-    checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
-
-    const executor = new ToolExecutor(makeTrackingPrompter());
-    const result = await executor.execute(
-      "browser_snapshot",
-      {},
-      makeContext({ forcePromptSideEffects: true }),
-    );
-
-    expect(result.isError).toBe(false);
-    // browser_snapshot is read-only — must NOT trigger forced prompting
-    expect(promptCalled).toBe(false);
   });
 
   // ── Always-mutating document tools (PR fix5) ──────────

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -740,23 +740,6 @@ describe("Trust Store", () => {
       ].sort();
       expect(defaultTools).toEqual([
         "bash",
-        "browser_attach",
-        "browser_click",
-        "browser_close",
-        "browser_detach",
-        "browser_extract",
-        "browser_fill_credential",
-        "browser_hover",
-        "browser_navigate",
-        "browser_press_key",
-        "browser_screenshot",
-        "browser_scroll",
-        "browser_select_option",
-        "browser_snapshot",
-        "browser_status",
-        "browser_type",
-        "browser_wait_for",
-        "browser_wait_for_download",
         "computer_use_click",
         "computer_use_drag",
         "computer_use_key",
@@ -1077,58 +1060,6 @@ describe("Trust Store", () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:allow-skill_load-global");
       expect(match!.decision).toBe("allow");
-    });
-
-    // ── default allow: browser tools ────────────────────────────
-
-    test("all browser tools have default allow rules", () => {
-      const templates = getDefaultRuleTemplates();
-      const browserTools = [
-        "browser_navigate",
-        "browser_snapshot",
-        "browser_screenshot",
-        "browser_close",
-        "browser_attach",
-        "browser_detach",
-        "browser_click",
-        "browser_type",
-        "browser_press_key",
-        "browser_scroll",
-        "browser_select_option",
-        "browser_hover",
-        "browser_wait_for",
-        "browser_extract",
-        "browser_wait_for_download",
-        "browser_fill_credential",
-        "browser_status",
-      ];
-
-      for (const tool of browserTools) {
-        const rule = templates.find(
-          (t) => t.id === `default:allow-${tool}-global`,
-        );
-        expect(rule).toBeDefined();
-        expect(rule!.tool).toBe(tool);
-        // browser_navigate uses standalone "**" because its candidates
-        // contain URLs with "/" that single "*" cannot match.
-        const expectedPattern =
-          tool === "browser_navigate" ? "**" : `${tool}:*`;
-        expect(rule!.pattern).toBe(expectedPattern);
-        expect(rule!.decision).toBe("allow");
-        expect(rule!.scope).toBe("everywhere");
-      }
-    });
-
-    test("browser tool default rules match via findHighestPriorityRule", () => {
-      // Use a candidate without slashes so the `browser_snapshot:*` pattern
-      // matches (minimatch `*` does not cross `/` boundaries).
-      const result = findHighestPriorityRule(
-        "browser_snapshot",
-        ["browser_snapshot:"],
-        "/tmp",
-      );
-      expect(result).toBeDefined();
-      expect(result!.decision).toBe("allow");
     });
 
     test("no default ask rules exist for file_read on skill source paths", () => {
@@ -1528,7 +1459,7 @@ describe("Trust Store", () => {
 
     test("single-star wildcard matches flat candidates only", () => {
       // "network_request:*" won't match URLs with slashes — consistent
-      // with the behavior of web_fetch:* and browser_navigate:* patterns.
+      // with the behavior of web_fetch:* patterns.
       addRule("network_request", "network_request:*", "everywhere");
       const noSlashMatch = findHighestPriorityRule(
         "network_request",
@@ -1738,7 +1669,7 @@ describe("canonical parser normalization-on-load", () => {
         rules: [
           {
             id: "url-rule-with-ahr",
-            tool: "browser_navigate",
+            tool: "web_fetch",
             pattern: "**",
             scope: "everywhere",
             decision: "allow",

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -212,19 +212,7 @@ describe("isWorkspaceScopedInvocation", () => {
   // ── Network tools ──────────────────────────────────────────────────
 
   describe("network tools", () => {
-    const networkTools = [
-      "web_search",
-      "web_fetch",
-      "browser_navigate",
-      "browser_click",
-      "browser_type",
-      "browser_scroll",
-      "browser_screenshot",
-      "browser_close",
-      "browser_attach",
-      "browser_detach",
-      "network_request",
-    ];
+    const networkTools = ["web_search", "web_fetch", "network_request"];
 
     for (const tool of networkTools) {
       test(`${tool} is NOT workspace-scoped`, () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 
-import { BROWSER_TOOL_NAMES } from "../browser/identifiers.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { getBundledSkillsDir } from "../config/skills.js";
@@ -273,29 +272,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
-  // Browser tools were previously core-registered with RiskLevel.Low (auto-allowed).
-  // After migration to skill-provided tools, default allow rules preserve the
-  // same frictionless UX so they don't trigger permission prompts.
-  //
-  // browser_navigate candidates contain URLs with "/" (e.g.
-  // "browser_navigate:https://example.com/path"), so it needs standalone
-  // "**" globstar (same as host_bash / computer_use_*).  The tool field
-  // already filters by tool name, so a prefix is unnecessary.
-  // All other browser tools use the standard "tool:*" pattern.
-  //
-  // The canonical set of browser tool names is sourced from BROWSER_TOOL_NAMES
-  // (browser/operations.ts) — the single source of truth for browser identifiers.
-  const browserToolRules: DefaultRuleTemplate[] = BROWSER_TOOL_NAMES.map(
-    (tool) => ({
-      id: `default:allow-${tool}-global`,
-      tool,
-      pattern: tool === "browser_navigate" ? "**" : `${tool}:*`,
-      scope: "everywhere",
-      decision: "allow" as const,
-      priority: 100,
-    }),
-  );
-
   // All three UI surface tools are passive, user-visible operations. ui_show
   // creates surfaces (cards, forms, tables) but user input is voluntary and
   // user-controlled — safe to auto-approve like ui_update and ui_dismiss.
@@ -335,7 +311,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     skillLoadDynamicRule,
     skillLoadRule,
     skillExecuteRule,
-    ...browserToolRules,
     ...uiSurfaceRules,
     memoryRecallRule,
   ];

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -1,8 +1,6 @@
 import { realpathSync } from "node:fs";
 import { basename, dirname, normalize, resolve } from "node:path";
 
-import { BROWSER_TOOL_NAMES } from "../browser/identifiers.js";
-
 /**
  * Resolve a path to its canonical form. When the target itself doesn't
  * exist (e.g. a new file being written), walk up to the nearest existing
@@ -55,15 +53,8 @@ export function isPathWithinWorkspaceRoot(
 /** File-path tools whose workspace-scoped-ness depends on the file_path input. */
 const PATH_SCOPED_TOOLS = new Set(["file_read", "file_write", "file_edit"]);
 
-/** Network-accessing tools — never workspace-scoped.
- * Browser tool names are sourced from the shared browser operations contract
- * (BROWSER_TOOL_NAMES) to avoid maintaining a separate browser tool list. */
-const NETWORK_TOOLS = new Set([
-  "web_search",
-  "web_fetch",
-  ...BROWSER_TOOL_NAMES,
-  "network_request",
-]);
+/** Network-accessing tools — never workspace-scoped. */
+const NETWORK_TOOLS = new Set(["web_search", "web_fetch", "network_request"]);
 
 /** Host-level tools — operate outside the sandbox, never workspace-scoped. */
 const HOST_TOOLS = new Set([

--- a/assistant/src/tools/side-effects.ts
+++ b/assistant/src/tools/side-effects.ts
@@ -4,23 +4,6 @@
 // Used by private-conversation gating and permission simulation to decide
 // whether a tool invocation requires explicit approval.
 
-import { BROWSER_TOOL_NAMES } from "../browser/identifiers.js";
-
-/**
- * Browser tools that are read-only / observational and do NOT have
- * side effects. These are excluded from the side-effect set.
- * The mutating browser tools (navigate, click, type, etc.) are derived
- * from BROWSER_TOOL_NAMES by subtracting this set.
- */
-const BROWSER_READONLY_TOOLS = new Set([
-  "browser_snapshot",
-  "browser_screenshot",
-  "browser_extract",
-  "browser_wait_for",
-  "browser_wait_for_download",
-  "browser_status",
-]);
-
 const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "file_write",
   "file_edit",
@@ -29,7 +12,6 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "bash",
   "host_bash",
   "web_fetch",
-  ...BROWSER_TOOL_NAMES.filter((name) => !BROWSER_READONLY_TOOLS.has(name)),
   "document_create",
   "document_update",
   "schedule_create",


### PR DESCRIPTION
## Summary
- Removes BROWSER_TOOL_NAMES-driven default trust rule seeding
- Removes browser tool workspace scope classification
- Removes browser tool side-effect sets
- Updates permission tests accordingly

Part of plan: remove-browser-tools.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
