### PR TITLE
refactor(permissions): remove `browser_*` risk and allowlist branches; update trust contracts

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -104,7 +104,7 @@ import {
 } from "../permissions/trust-store.js";
 import type { TrustRule } from "../permissions/types.js";
 import { RiskLevel } from "../permissions/types.js";
-import { getTool, registerTool } from "../tools/registry.js";
+import { registerTool } from "../tools/registry.js";
 import type { Tool } from "../tools/types.js";
 
 // Register a mock skill-origin tool for testing default-ask policy.
@@ -2117,9 +2117,6 @@ describe("Permission Checker", () => {
     test("returns empty for non-scoped tools", () => {
       const workingDir = join(homedir(), "projects", "myapp");
       expect(generateScopeOptions(workingDir, "web_fetch")).toHaveLength(0);
-      expect(generateScopeOptions(workingDir, "browser_navigate")).toHaveLength(
-        0,
-      );
       expect(generateScopeOptions(workingDir, "skill_load")).toHaveLength(0);
       expect(generateScopeOptions(workingDir, "credential_store")).toHaveLength(
         0,
@@ -4529,78 +4526,6 @@ describe("Permission Checker", () => {
     });
   });
 
-  // ── browser tool permission baselines ─────────────────────────────
-  // Representative browser tools are RiskLevel.Low and auto-allowed by
-  // default rules in strict mode.
-
-  describe("browser tool permission baselines", () => {
-    const browserToolNames = [
-      "browser_navigate",
-      "browser_snapshot",
-      "browser_screenshot",
-      "browser_close",
-      "browser_attach",
-      "browser_detach",
-      "browser_click",
-      "browser_type",
-      "browser_press_key",
-      "browser_wait_for",
-      "browser_extract",
-      "browser_fill_credential",
-      "browser_status",
-    ] as const;
-
-    // Register mock browser tools with the correct metadata so classifyRisk
-    // resolves them without pulling in the full headless-browser module
-    // (which depends on playwright and browser-manager).
-    beforeAll(() => {
-      for (const name of browserToolNames) {
-        // Skip if already registered (e.g. via initializeTools)
-        if (getTool(name)) continue;
-
-        registerTool({
-          name,
-          description: `Mock ${name} for permission baseline`,
-          category: "browser",
-          defaultRiskLevel: RiskLevel.Low,
-          getDefinition: () => ({
-            name,
-            description: `Mock ${name}`,
-            input_schema: { type: "object" as const, properties: {} },
-          }),
-          execute: async () => ({ content: "ok", isError: false }),
-        });
-      }
-    });
-
-    for (const toolName of browserToolNames) {
-      test(`${toolName} has RiskLevel.Low default risk`, async () => {
-        const risk = await classifyRisk(toolName, {});
-        expect(risk).toBe(RiskLevel.Low);
-      });
-    }
-
-    test("browser tools are auto-allowed in workspace mode", async () => {
-      testConfig.permissions = { mode: "workspace" };
-      for (const toolName of browserToolNames) {
-        const result = await check(toolName, {}, "/tmp");
-        expect(result.decision).toBe("allow");
-      }
-    });
-
-    test("browser tools are auto-allowed in strict mode via default allow rules", async () => {
-      testConfig.permissions = { mode: "strict" };
-      try {
-        for (const toolName of browserToolNames) {
-          const result = await check(toolName, {}, "/tmp");
-          expect(result.decision).toBe("allow");
-        }
-      } finally {
-        testConfig.permissions = { mode: "workspace" };
-      }
-    });
-  });
-
   // ── default allow: skill_load ──────────────────────────────────
 
   describe("default allow: skill_load", () => {
@@ -4621,54 +4546,6 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(result.decision).toBe("allow");
-    });
-  });
-
-  // ── default allow: browser tools ──────────────────────────────
-
-  describe("default allow: browser tools", () => {
-    beforeEach(() => {
-      clearCache();
-      testConfig.permissions = { mode: "strict" };
-    });
-
-    test("all browser tools are allowed by default rules in strict mode", async () => {
-      const browserTools = [
-        "browser_navigate",
-        "browser_snapshot",
-        "browser_screenshot",
-        "browser_close",
-        "browser_attach",
-        "browser_detach",
-        "browser_click",
-        "browser_type",
-        "browser_press_key",
-        "browser_wait_for",
-        "browser_extract",
-        "browser_fill_credential",
-        "browser_status",
-      ];
-
-      for (const tool of browserTools) {
-        const result = await check(tool, {}, "/tmp");
-        expect(result.decision).toBe("allow");
-      }
-    });
-
-    test("browser_navigate with a real URL is allowed in strict mode", async () => {
-      const result = await check(
-        "browser_navigate",
-        { url: "https://example.com/path/to/page" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("allow");
-    });
-
-    test("non-browser skill tools are NOT auto-allowed", async () => {
-      // skill_test_tool is a registered skill-origin tool without a default
-      // allow rule — it should prompt in strict mode.
-      const result = await check("skill_test_tool", {}, "/tmp");
-      expect(result.decision).not.toBe("allow");
     });
   });
 });

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -273,16 +273,6 @@ describe("isVerificationControlPlaneInvocation", () => {
     });
   });
 
-  describe("browser_navigate tool with verification endpoint in url", () => {
-    test("detects verification endpoint", () => {
-      expect(
-        isVerificationControlPlaneInvocation("browser_navigate", {
-          url: "http://localhost:3000/v1/channel-verification-sessions/status",
-        }),
-      ).toBe(true);
-    });
-  });
-
   describe("unrelated tools are not flagged", () => {
     test("file_read is never a verification invocation", () => {
       expect(
@@ -671,17 +661,6 @@ describe("ToolExecutor verification control-plane policy gate", () => {
     const result = await executor.execute(
       "web_fetch",
       { url: "http://localhost:3000/v1/channel-verification-sessions/resend" },
-      makeContext({ trustClass: "trusted_contact" }),
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("restricted to guardian users");
-  });
-
-  test("non-guardian blocked from browser_navigate to verification endpoint", async () => {
-    const executor = new ToolExecutor(makePrompter());
-    const result = await executor.execute(
-      "browser_navigate",
-      { url: "http://localhost:3000/v1/channel-verification-sessions/status" },
       makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -582,11 +582,7 @@ async function buildCommandCandidates(
     return [`${toolName}:${skillId}`];
   }
 
-  if (
-    toolName === "web_fetch" ||
-    toolName === "browser_navigate" ||
-    toolName === "network_request"
-  ) {
+  if (toolName === "web_fetch" || toolName === "network_request") {
     const rawUrl = getStringField(input, "url").trim();
     const candidates: string[] = [];
 
@@ -760,13 +756,6 @@ async function classifyRiskUncached(
       ? RiskLevel.High
       : RiskLevel.Low;
   }
-  if (toolName === "browser_navigate") {
-    return input.allow_private_network === true
-      ? RiskLevel.High
-      : RiskLevel.Low;
-  }
-  // All other browser tools are low risk — the browser is sandboxed and user-visible.
-  if (toolName.startsWith("browser_")) return RiskLevel.Low;
   // Proxy-authenticated network requests are Medium risk — they carry injected
   // credentials and the user should approve the target host/origin.
   if (toolName === "network_request") return RiskLevel.Medium;
@@ -1120,9 +1109,7 @@ export async function check(
   }
 
   // Auto-allow low-risk bundled skill tools even without explicit trust rules.
-  // These are first-party tools with a vetted risk declaration — applying the
-  // same policy as the per-tool default allow rules for browser tools, but
-  // generically so every new bundled skill benefits automatically.
+  // These are first-party tools with a vetted risk declaration.
   // This block must come AFTER the strict mode check so that strict mode
   // still prompts for bundled skill tools without explicit rules.
   if (!matchedRule && risk === RiskLevel.Low) {
@@ -1157,7 +1144,6 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   host_file_write: "host file writes",
   host_file_edit: "host file edits",
   web_fetch: "URL fetches",
-  browser_navigate: "browser navigations",
   network_request: "network requests",
 };
 
@@ -1366,7 +1352,6 @@ const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
   host_file_write: fileAllowlistStrategy,
   host_file_edit: fileAllowlistStrategy,
   web_fetch: urlAllowlistStrategy,
-  browser_navigate: urlAllowlistStrategy,
   network_request: urlAllowlistStrategy,
   scaffold_managed_skill: managedSkillAllowlistStrategy,
   delete_managed_skill: managedSkillAllowlistStrategy,

--- a/assistant/src/tools/verification-control-plane-policy.ts
+++ b/assistant/src/tools/verification-control-plane-policy.ts
@@ -28,7 +28,7 @@ const VERIFICATION_PATH_REGEX = /\/v1\/channel-verification-sessions/;
 const COMMAND_TOOLS = new Set(["bash", "host_bash"]);
 
 /** Tools whose `input.url` (string) may contain verification endpoint paths. */
-const URL_TOOLS = new Set(["network_request", "web_fetch", "browser_navigate"]);
+const URL_TOOLS = new Set(["network_request", "web_fetch"]);
 
 /**
  * Normalize a string to defeat common URL obfuscation techniques before matching:

--- a/packages/ces-contracts/src/__tests__/trust-rules.test.ts
+++ b/packages/ces-contracts/src/__tests__/trust-rules.test.ts
@@ -114,7 +114,7 @@ describe("parseTrustRule — URL tools strip invalid fields", () => {
   });
 
   test("type guard isUrlRule narrows correctly", () => {
-    const { rule } = parseTrustRule(makeRaw({ tool: "browser_navigate" }));
+    const { rule } = parseTrustRule(makeRaw({ tool: "network_request" }));
     expect(isUrlRule(rule)).toBe(true);
     expect(isScopedRule(rule)).toBe(false);
   });

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -13,13 +13,13 @@
  *   `file_edit`, `host_file_read`, `host_file_write`, `host_file_edit`,
  *   `bash`, `host_bash`).
  * - **URL**: tools whose candidates include a URL (`web_fetch`,
- *   `browser_navigate`, `network_request`).
+ *   `network_request`).
  * - **Managed skill**: tools that manage first-party skill packages
  *   (`scaffold_managed_skill`, `delete_managed_skill`).
  * - **Skill load**: the `skill_load` tool, which uses a distinct candidate
  *   namespace (`skill_load:selector` or `skill_load_dynamic:selector`).
- * - **Generic**: everything else (computer-use tools, browser action tools,
- *   UI surface tools, recall, skill_execute, etc.).
+ * - **Generic**: everything else (computer-use tools, UI surface tools,
+ *   recall, skill_execute, etc.).
  */
 
 // ---------------------------------------------------------------------------
@@ -51,11 +51,7 @@ export const SCOPED_TOOLS = [
 /**
  * Tools whose permission candidates include a URL.
  */
-export const URL_TOOLS = [
-  "web_fetch",
-  "browser_navigate",
-  "network_request",
-] as const;
+export const URL_TOOLS = ["web_fetch", "network_request"] as const;
 
 /**
  * Tools that manage first-party skill packages (scaffold/delete).


### PR DESCRIPTION
## Summary
- Removes browser-specific risk handling and allowlist strategy branches from checker
- Removes browser_navigate from verification control-plane URL tool checks
- Updates CES trust-rule URL-family constants
- Updates all related tests

Part of plan: remove-browser-tools.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
