### PR TITLE
refactor(credentials): switch browser fill policy key to operation capability with legacy alias support

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -56,6 +56,7 @@ import {
   _setMetadataPath,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { BROWSER_FILL_CAPABILITY } from "../tools/credentials/tool-policy.js";
 
 afterAll(() => {
   mock.restore();
@@ -594,6 +595,115 @@ describe("CredentialBroker.browserFill", () => {
       });
       expect(r3.success).toBe(true);
       expect(filled3).toBe("gl_tok");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Canonical capability key and legacy alias regression
+  // ---------------------------------------------------------------------------
+
+  describe("canonical capability key and legacy alias", () => {
+    test("credential restricted to canonical key authorizes browser fill", async () => {
+      upsertCredentialMetadata("github", "token", {
+        allowedTools: [BROWSER_FILL_CAPABILITY],
+      });
+      await setSecureKeyAsync(
+        credentialKey("github", "token"),
+        "ghp_canonical",
+      );
+
+      let filledValue: string | undefined;
+      const result = await broker.browserFill({
+        service: "github",
+        field: "token",
+        toolName: BROWSER_FILL_CAPABILITY,
+        fill: async (v) => {
+          filledValue = v;
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(filledValue).toBe("ghp_canonical");
+    });
+
+    test("legacy browser_fill_credential metadata authorizes canonical capability key", async () => {
+      // Stored with legacy tool name — simulates existing metadata on disk
+      upsertCredentialMetadata("github", "pat", {
+        allowedTools: ["browser_fill_credential"],
+      });
+      await setSecureKeyAsync(credentialKey("github", "pat"), "ghp_legacy");
+
+      let filledValue: string | undefined;
+      const result = await broker.browserFill({
+        service: "github",
+        field: "pat",
+        toolName: BROWSER_FILL_CAPABILITY,
+        fill: async (v) => {
+          filledValue = v;
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(filledValue).toBe("ghp_legacy");
+    });
+
+    test("canonical key in metadata authorizes legacy browser_fill_credential requests", async () => {
+      upsertCredentialMetadata("gitlab", "token", {
+        allowedTools: [BROWSER_FILL_CAPABILITY],
+      });
+      await setSecureKeyAsync(credentialKey("gitlab", "token"), "gl_mixed");
+
+      let filledValue: string | undefined;
+      const result = await broker.browserFill({
+        service: "gitlab",
+        field: "token",
+        toolName: "browser_fill_credential",
+        fill: async (v) => {
+          filledValue = v;
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(filledValue).toBe("gl_mixed");
+    });
+
+    test("empty allowedTools still fails closed with canonical key", async () => {
+      upsertCredentialMetadata("github", "token", { allowedTools: [] });
+      await setSecureKeyAsync(credentialKey("github", "token"), "ghp_no_tools");
+
+      const result = await broker.browserFill({
+        service: "github",
+        field: "token",
+        toolName: BROWSER_FILL_CAPABILITY,
+        fill: async () => {
+          throw new Error("should not be called");
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain("No tools are currently allowed");
+    });
+
+    test("incorrect allowlist denies canonical key (fail closed)", async () => {
+      upsertCredentialMetadata("github", "token", {
+        allowedTools: ["some_other_tool"],
+      });
+      await setSecureKeyAsync(
+        credentialKey("github", "token"),
+        "ghp_wrong_tool",
+      );
+
+      const result = await broker.browserFill({
+        service: "github",
+        field: "token",
+        toolName: BROWSER_FILL_CAPABILITY,
+        fill: async () => {
+          throw new Error("should not be called");
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain("not allowed");
     });
   });
 });

--- a/assistant/src/__tests__/credential-storage-static-compat.test.ts
+++ b/assistant/src/__tests__/credential-storage-static-compat.test.ts
@@ -371,6 +371,34 @@ describe("static credential storage compatibility", () => {
     });
   });
 
+  describe("canonical capability key storage", () => {
+    test("stores credential with canonical assistant_browser_fill_credential key", () => {
+      const created = store.upsert("github", "token", {
+        allowedTools: ["assistant_browser_fill_credential"],
+      });
+
+      const result = store.getByServiceField("github", "token");
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
+      expect(result!.allowedTools).toEqual([
+        "assistant_browser_fill_credential",
+      ]);
+    });
+
+    test("legacy browser_fill_credential metadata is preserved on read", () => {
+      const created = store.upsert("github", "pat", {
+        allowedTools: ["browser_fill_credential"],
+      });
+
+      const result = store.getByServiceField("github", "pat");
+      expect(result).toBeDefined();
+      expect(result!.credentialId).toBe(created.credentialId);
+      // The raw stored value is returned unchanged — alias resolution
+      // happens at policy-check time, not at storage time.
+      expect(result!.allowedTools).toEqual(["browser_fill_credential"]);
+    });
+  });
+
   describe("path management", () => {
     test("setPath changes the metadata file location", () => {
       store.upsert("github", "token");

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -204,12 +204,10 @@ mock.module("../daemon/handlers/config-slack-channel.js", () => ({
     clearSlackUserTokenCalls++;
 
     const { credentialKey } = await import("../security/credential-key.js");
-    const { deleteSecureKeyAsync, getSecureKeyAsync } = await import(
-      "../security/secure-keys.js"
-    );
-    const { deleteCredentialMetadata } = await import(
-      "../tools/credentials/metadata-store.js"
-    );
+    const { deleteSecureKeyAsync, getSecureKeyAsync } =
+      await import("../security/secure-keys.js");
+    const { deleteCredentialMetadata } =
+      await import("../tools/credentials/metadata-store.js");
 
     await deleteSecureKeyAsync(credentialKey("slack_channel", "user_token"));
     deleteCredentialMetadata("slack_channel", "user_token");
@@ -248,6 +246,7 @@ import {
   _setMetadataPath,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { BROWSER_FILL_CAPABILITY } from "../tools/credentials/tool-policy.js";
 import { credentialStoreTool } from "../tools/credentials/vault.js";
 import type { ToolContext } from "../tools/types.js";
 
@@ -775,7 +774,11 @@ describe("credential_store tool — prompt action", () => {
     expect(result.isError).toBe(false);
     // Routed to handler as third positional argument.
     expect(slackChannelConfigCalls).toEqual([
-      { botToken: undefined, appToken: undefined, userToken: "xoxp-valid-user-token" },
+      {
+        botToken: undefined,
+        appToken: undefined,
+        userToken: "xoxp-valid-user-token",
+      },
     ]);
     // Stored via the handler's mock, NOT via the generic setSecureKeyAsync path.
     expect(
@@ -867,7 +870,11 @@ describe("credential_store tool — slack_channel store routing", () => {
     expect(result.isError).toBe(false);
     // Exactly one handler call with (undefined, undefined, token).
     expect(slackChannelConfigCalls).toEqual([
-      { botToken: undefined, appToken: undefined, userToken: "xoxp-valid-user-token" },
+      {
+        botToken: undefined,
+        appToken: undefined,
+        userToken: "xoxp-valid-user-token",
+      },
     ]);
     // Stored through the handler's mock path, not the generic setSecureKeyAsync path.
     expect(
@@ -911,7 +918,11 @@ describe("credential_store tool — slack_channel store routing", () => {
 
     expect(result.isError).toBe(false);
     expect(slackChannelConfigCalls).toEqual([
-      { botToken: "xoxb-valid-bot-token", appToken: undefined, userToken: undefined },
+      {
+        botToken: "xoxb-valid-bot-token",
+        appToken: undefined,
+        userToken: undefined,
+      },
     ]);
   });
 
@@ -928,7 +939,11 @@ describe("credential_store tool — slack_channel store routing", () => {
 
     expect(result.isError).toBe(false);
     expect(slackChannelConfigCalls).toEqual([
-      { botToken: undefined, appToken: "xapp-valid-app-token", userToken: undefined },
+      {
+        botToken: undefined,
+        appToken: "xapp-valid-app-token",
+        userToken: undefined,
+      },
     ]);
   });
 });
@@ -1157,9 +1172,8 @@ describe("credential_store tool — slack_channel delete routing", () => {
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "user_token")),
     ).toBeUndefined();
-    const { getCredentialMetadata } = await import(
-      "../tools/credentials/metadata-store.js"
-    );
+    const { getCredentialMetadata } =
+      await import("../tools/credentials/metadata-store.js");
     expect(
       getCredentialMetadata("slack_channel", "user_token"),
     ).toBeUndefined();
@@ -1206,12 +1220,9 @@ describe("credential_store tool — slack_channel delete routing", () => {
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
     ).toBeUndefined();
-    const { getCredentialMetadata } = await import(
-      "../tools/credentials/metadata-store.js"
-    );
-    expect(
-      getCredentialMetadata("slack_channel", "bot_token"),
-    ).toBeUndefined();
+    const { getCredentialMetadata } =
+      await import("../tools/credentials/metadata-store.js");
+    expect(getCredentialMetadata("slack_channel", "bot_token")).toBeUndefined();
   });
 
   test("delete with app_token still tears down the oauth connection (regression guard)", async () => {
@@ -1408,5 +1419,110 @@ describe("CredentialBroker — revokeAll", () => {
     expect(broker.activeTokenCount).toBe(0);
     broker.revokeAll();
     expect(broker.activeTokenCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Broker — canonical capability key and legacy alias
+// ---------------------------------------------------------------------------
+
+describe("CredentialBroker — canonical capability key", () => {
+  let broker: CredentialBroker;
+
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+    _setMetadataPath(join(TEST_DIR, "metadata.json"));
+    broker = new CredentialBroker();
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    _setStorePath(null);
+    _resetBackend();
+  });
+
+  test("authorize succeeds with canonical key when metadata has canonical key", () => {
+    upsertCredentialMetadata("github", "token", {
+      allowedTools: [BROWSER_FILL_CAPABILITY],
+    });
+
+    const result = broker.authorize({
+      service: "github",
+      field: "token",
+      toolName: BROWSER_FILL_CAPABILITY,
+    });
+    expect(result.authorized).toBe(true);
+  });
+
+  test("authorize succeeds with canonical key when metadata has legacy alias", () => {
+    upsertCredentialMetadata("github", "token", {
+      allowedTools: ["browser_fill_credential"],
+    });
+
+    const result = broker.authorize({
+      service: "github",
+      field: "token",
+      toolName: BROWSER_FILL_CAPABILITY,
+    });
+    expect(result.authorized).toBe(true);
+  });
+
+  test("authorize succeeds with legacy alias when metadata has canonical key", () => {
+    upsertCredentialMetadata("github", "token", {
+      allowedTools: [BROWSER_FILL_CAPABILITY],
+    });
+
+    const result = broker.authorize({
+      service: "github",
+      field: "token",
+      toolName: "browser_fill_credential",
+    });
+    expect(result.authorized).toBe(true);
+  });
+
+  test("serverUse with canonical key works when metadata has legacy alias", async () => {
+    upsertCredentialMetadata("vercel", "api_token", {
+      allowedTools: ["browser_fill_credential"],
+    });
+    await setSecureKeyAsync(credentialKey("vercel", "api_token"), "vercel-tok");
+
+    const result = await broker.serverUse({
+      service: "vercel",
+      field: "api_token",
+      toolName: BROWSER_FILL_CAPABILITY,
+      execute: async (v) => v,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("vercel-tok");
+  });
+
+  test("non-aliased tool names are unaffected by alias resolution", () => {
+    upsertCredentialMetadata("svc", "key", {
+      allowedTools: ["custom_tool"],
+    });
+
+    const result = broker.authorize({
+      service: "svc",
+      field: "key",
+      toolName: "custom_tool",
+    });
+    expect(result.authorized).toBe(true);
+  });
+
+  test("non-aliased tool denied when only canonical key is allowed", () => {
+    upsertCredentialMetadata("svc", "key", {
+      allowedTools: [BROWSER_FILL_CAPABILITY],
+    });
+
+    const result = broker.authorize({
+      service: "svc",
+      field: "key",
+      toolName: "unrelated_tool",
+    });
+    expect(result.authorized).toBe(false);
   });
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -4,6 +4,7 @@ import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
 import { safeStringSlice } from "../../util/unicode.js";
 import { credentialBroker } from "../credentials/broker.js";
+import { BROWSER_FILL_CAPABILITY } from "../credentials/tool-policy.js";
 import {
   isPrivateOrLocalHost,
   parseUrl,
@@ -927,7 +928,7 @@ export async function executeBrowserNavigate(
                 "1. Use browser_snapshot to find the sign-in form elements",
               );
               lines.push(
-                "2. Use browser_fill_credential to fill email/password from credential_store",
+                "2. Use the browser credential fill to enter email/password from credential_store",
               );
               lines.push(
                 "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
@@ -958,7 +959,7 @@ export async function executeBrowserNavigate(
             "1. Use browser_snapshot to find the sign-in form elements",
           );
           lines.push(
-            "2. Use browser_fill_credential to fill email/password from credential_store",
+            "2. Use the browser credential fill to enter email/password from credential_store",
           );
           lines.push(
             "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
@@ -1941,7 +1942,7 @@ export async function executeBrowserExtract(
   }
 }
 
-// ── browser_fill_credential ──────────────────────────────────────────
+// ── browser credential fill ──────────────────────────────────────────
 
 export async function executeBrowserFillCredential(
   input: Record<string, unknown>,
@@ -1999,7 +2000,7 @@ export async function executeBrowserFillCredential(
     const result = await credentialBroker.browserFill({
       service,
       field,
-      toolName: "browser_fill_credential",
+      toolName: BROWSER_FILL_CAPABILITY,
       domain: pageDomain,
       fill: async (value) => {
         // Clear-then-focus-then-insert via the shared helper. We

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -6,16 +6,47 @@
  */
 
 /**
+ * Canonical capability key for browser-based credential fills.
+ *
+ * This decouples credential policy from any specific tool name so that
+ * browser fill operations work regardless of whether a
+ * `browser_fill_credential` tool is registered in the manifest.
+ */
+export const BROWSER_FILL_CAPABILITY = "assistant_browser_fill_credential";
+
+/**
+ * Legacy tool names that map to canonical capability keys.
+ *
+ * Credentials stored with `browser_fill_credential` in their
+ * `allowedTools` metadata continue to authorize browser fills
+ * without requiring a manual migration.
+ */
+const LEGACY_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["browser_fill_credential", BROWSER_FILL_CAPABILITY],
+]);
+
+/**
+ * Resolve a tool/capability name to its canonical form.
+ *
+ * If the name is a known legacy alias, returns the canonical key.
+ * Otherwise returns the name unchanged.
+ */
+function resolveCanonical(name: string): string {
+  return LEGACY_ALIASES.get(name) ?? name;
+}
+
+/**
  * Check whether a tool is allowed to use a credential.
  *
  * @param toolName - The name of the tool requesting credential use
  * @param allowedTools - The credential's allowed tools list
- * @returns true if the tool is explicitly listed in allowedTools
+ * @returns true if the tool is authorized after alias resolution
  *
  * Semantics:
- * 1. Explicit allowlist - tool must be listed by exact name
- * 2. No wildcard support in v1
- * 3. Fail-closed on empty or missing list
+ * 1. Both the requesting `toolName` and every entry in `allowedTools`
+ *    are resolved through the legacy-alias map before comparison.
+ * 2. No wildcard support in v1.
+ * 3. Fail-closed on empty or missing list.
  */
 export function isToolAllowed(
   toolName: string,
@@ -24,5 +55,8 @@ export function isToolAllowed(
   if (!Array.isArray(allowedTools) || allowedTools.length === 0) return false;
   if (!toolName || typeof toolName !== "string") return false;
 
-  return allowedTools.includes(toolName);
+  const canonical = resolveCanonical(toolName);
+  return allowedTools.some(
+    (allowed) => resolveCanonical(allowed) === canonical,
+  );
 }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -41,9 +41,7 @@ function isSlackChannelCredential(
 ): field is "bot_token" | "app_token" | "user_token" {
   return (
     service === "slack_channel" &&
-    (field === "bot_token" ||
-      field === "app_token" ||
-      field === "user_token")
+    (field === "bot_token" || field === "app_token" || field === "user_token")
   );
 }
 
@@ -128,7 +126,7 @@ class CredentialStoreTool implements Tool {
             type: "array",
             items: { type: "string" },
             description:
-              'Tools allowed to use this credential (for store/prompt actions), e.g. ["browser_fill_credential"]. Empty = deny all.',
+              'Tools/capabilities allowed to use this credential (for store/prompt actions), e.g. ["assistant_browser_fill_credential"]. Empty = deny all.',
           },
           allowed_domains: {
             type: "array",


### PR DESCRIPTION
## Summary
- Introduces canonical `assistant_browser_fill_credential` capability key for browser credential fills
- Updates credential tool-policy to treat legacy `browser_fill_credential` as alias for the canonical key
- Updates `credential_store` schema examples to reference the canonical key
- Adds regression tests for canonical key, legacy alias, and fail-closed behavior

Part of plan: remove-browser-tools.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
