### PR TITLE
test(macos): use placeholder ID in Chrome extension allowlist tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ChromeExtensionAllowlistTests.swift
+++ b/clients/macos/vellum-assistantTests/ChromeExtensionAllowlistTests.swift
@@ -24,7 +24,7 @@ final class ChromeExtensionAllowlistTests: XCTestCase {
         try writeAllowlist(
             at: canonicalPath,
             ids: [
-                "hphbdmpffeigpcdjkckleobjmhhokpne",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "invalid",
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             ]
@@ -33,7 +33,7 @@ final class ChromeExtensionAllowlistTests: XCTestCase {
             at: localPath,
             ids: [
                 "cccccccccccccccccccccccccccccccc",
-                "hphbdmpffeigpcdjkckleobjmhhokpne",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ]
         )
 
@@ -49,7 +49,7 @@ final class ChromeExtensionAllowlistTests: XCTestCase {
         XCTAssertEqual(
             merged,
             [
-                "hphbdmpffeigpcdjkckleobjmhhokpne",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 "cccccccccccccccccccccccccccccccc",
                 "dddddddddddddddddddddddddddddddd",


### PR DESCRIPTION
## Summary
- Swap the real canonical Chrome extension ID in `ChromeExtensionAllowlistTests.swift` for a placeholder (`aaaa...`), so the canonical-vs-local dedup path still gets coverage without duplicating the canonical ID outside `meta/browser-extension/chrome-extension-allowlist.json`.
- Fixes the `extension-id-sync-guard.test.ts` guard ("concrete extension IDs appear only in canonical config or CWS URLs") that started failing on main after #26298.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24596179535/job/71926517876
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
