### PR TITLE
fix(macos): add Anthropic models to OpenRouter seed catalog

### DIFF
--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -298,6 +298,11 @@ extension ProviderCatalogEntry {
             CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
         ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
         ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
+            // Anthropic
+            CatalogModel(id: "anthropic/claude-opus-4.7", displayName: "Claude Opus 4.7"),
+            CatalogModel(id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6"),
+            CatalogModel(id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6"),
+            CatalogModel(id: "anthropic/claude-haiku-4.5", displayName: "Claude Haiku 4.5"),
             // xAI
             CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
             CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),


### PR DESCRIPTION
## Summary
- The Swift inline seed (defaultCatalog in ChatMessageManager.swift) was missing the four Anthropic Claude entries under OpenRouter that the daemon's PROVIDER_CATALOG already exposes (fa30c524cf + 4911a6f330 updated the daemon but not the seed).
- Adds claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.6, claude-haiku-4.5 to the OpenRouter section of the Swift seed so the model picker shows them before the daemon fetch completes, and matches the order/IDs of the daemon catalog at assistant/src/providers/model-catalog.ts:82-85.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
