### PR TITLE
fix(macos): stop zero-width measurements from poisoning chat cell caches

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -443,8 +443,15 @@ struct MarkdownSegmentView: View, Equatable {
         // the next render will rebuild from scratch, which may succeed.
         // Also skip caching while this is the streaming tail: the value is
         // for an intermediate state that may not match the final content.
+        // And never cache a collapsed (zero-height) measurement: the
+        // environment can briefly deliver a zero `effectiveMaxWidth` during
+        // the first LazyVStack layout, and persisting that result would
+        // leave the cell collapsed and stacked under its neighbor.
         let textLen = Self.segmentTextLength(runSegments)
-        if !isStreamingTail && !hasUnresolvedEmphasis && textLen <= Self.maxCacheableTextLength {
+        if size.height > 0
+            && !isStreamingTail
+            && !hasUnresolvedEmphasis
+            && textLen <= Self.maxCacheableTextLength {
             Self.measuredTextCache.setObject(
                 MeasuredTextCacheEntry(nsAttributedString: nsAttributed, size: size),
                 forKey: keyNS,

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -208,6 +208,36 @@ final class MarkdownSegmentViewTests: XCTestCase {
         )
     }
 
+    /// `bubbleMaxWidth` is 0 during the first LazyVStack pass, before the
+    /// chat column's width resolves. A collapsed measurement must NOT be
+    /// cached at either the `measuredTextCache` or
+    /// `VSelectableTextView.measurementSizeCache` layer — caching (0,0)
+    /// would leave the cell stacked under its neighbor and cause the
+    /// multi-message overlap seen in practice.
+    func testZeroWidthReturnsZeroSizeWithoutPoisoningCaches() {
+        let segments = parseMarkdownSegments("a long enough run of text to wrap")
+        let view = MarkdownSegmentView(segments: segments, maxContentWidth: 0)
+        let result = view.resolveSelectableRunMeasurementResult(segments)
+
+        XCTAssertEqual(result.size.height, 0)
+        XCTAssertEqual(
+            MarkdownSegmentView._measuredTextCacheInsertCount,
+            0,
+            "Zero-height measurement must not populate the measured text cache"
+        )
+
+        // Now re-measure at a real width. Because nothing poisoned the
+        // caches, this must produce a non-zero height and populate the
+        // measured text cache exactly once.
+        let resolvedView = MarkdownSegmentView(
+            segments: segments,
+            maxContentWidth: VSpacing.chatBubbleMaxWidth
+        )
+        let resolved = resolvedView.resolveSelectableRunMeasurementResult(segments)
+        XCTAssertGreaterThan(resolved.size.height, 0)
+        XCTAssertEqual(MarkdownSegmentView._measuredTextCacheInsertCount, 1)
+    }
+
     func testWarmupRefreshClearsRenderCachesAndForcesRebuild() {
         let segments = parseMarkdownSegments("*warmup cache reset*")
         let key = "*warmup cache reset*" as NSString

--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -129,6 +129,15 @@ public struct VSelectableTextView: NSViewRepresentable {
         lineSpacing: CGFloat,
         maxWidth: CGFloat
     ) -> CGSize {
+        // `bubbleMaxWidth` can be 0 during the first LazyVStack layout pass
+        // before GeometryReader resolves the chat column width. Refuse
+        // degenerate inputs and do not cache — caching (0,0) would collapse
+        // the frame and, via the sibling measuredTextCache in
+        // MarkdownSegmentView, keep the cell collapsed on subsequent passes.
+        guard maxWidth > 0, attributedString.length > 0 else {
+            return .zero
+        }
+
         let key = MeasurementKey(
             attributedString: attributedString,
             maxWidth: maxWidth,
@@ -161,10 +170,14 @@ public struct VSelectableTextView: NSViewRepresentable {
             height: ceil(usedRect.height)
         )
 
-        if measurementSizeCache.count >= measurementCacheLimit {
-            measurementSizeCache.removeAll(keepingCapacity: true)
+        // Skip persisting a collapsed measurement so a transient bad input
+        // cannot poison later queries at the same key.
+        if size.height > 0 {
+            if measurementSizeCache.count >= measurementCacheLimit {
+                measurementSizeCache.removeAll(keepingCapacity: true)
+            }
+            measurementSizeCache[key] = size
         }
-        measurementSizeCache[key] = size
         return size
     }
 


### PR DESCRIPTION
## Summary

- Fixes the chat UI regression where multiple assistant message bodies render stacked on top of each other at the same vertical position.
- Root cause: `MessageListLayoutMetrics` (`clients/macos/vellum-assistant/Features/Chat/MessageListLayoutMetrics.swift:14-32`) reports `bubbleMaxWidth = 0` until `GeometryReader` resolves the chat column width. That zero cascades through `MarkdownSegmentView.effectiveMaxWidth` (line 404 uses `??` which only fires on `nil`, not on `0`) into `VSelectableTextView.measureSize(maxWidth: 0)`, where `ensureLayout` returns a `usedRect` with `height == 0`. `.frame(width: 0, height: 0)` applied by `SelectableRunView` collapses the cell — all visible assistant messages stack at the same y.
- Before #26170's caching, this self-healed on the next body pass. After #26170, two caches (`VSelectableTextView.measurementSizeCache` and `MarkdownSegmentView.measuredTextCache`) persisted the `(0,0)` result at the 0-width cache key, so the cell stayed collapsed.
- Fix keeps all perf wins from #26170 and #26242 — no revert.

## Changes

- `VSelectableTextView.measureSize` guards `maxWidth > 0 && attributedString.length > 0` and returns `.zero` without writing the cache. Also only persists non-zero heights in `measurementSizeCache`.
- `MarkdownSegmentView.resolveSelectableRunMeasurementResult` adds `size.height > 0 &&` to the `measuredTextCache` insertion guard.
- Adds `testZeroWidthReturnsZeroSizeWithoutPoisoningCaches` regression test.

## Test plan

- [ ] Build and run the macOS app (`clients/macos/build.sh`), open a long multi-message conversation, confirm each assistant body renders at a distinct y with no overlap.
- [ ] Resize window narrow → wide → narrow; no transient zero-height flash.
- [ ] Stream a fresh assistant reply; streaming-tail path still bypasses the cache as before.
- [ ] Run `xcodebuild test` for `MarkdownSegmentViewTests` — new regression test passes, existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
