### PR TITLE
fix(macos): keep chat text layout contiguous to prevent streaming gap/overlap

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -177,11 +177,19 @@ public struct VSelectableTextView: NSViewRepresentable {
         // Reference: https://developer.apple.com/documentation/appkit/nstextview/1449309-layoutmanager
         let textStorage = NSTextStorage()
         let layoutManager = NSLayoutManager()
-        // Confine glyph generation to the requested bounding rect so that
-        // attaching the text view to its hosting view does not force full
-        // document layout on the main thread.
-        // https://developer.apple.com/documentation/appkit/nslayoutmanager/allowsnoncontiguouslayout
-        layoutManager.allowsNonContiguousLayout = true
+        // Contiguous (default) layout: the measurement path uses
+        // `NSLayoutManager.ensureLayout(for:)` + `usedRect(for:)` on a separate
+        // TextKit stack that always lays out every glyph, so the frame we
+        // hand SwiftUI via `.frame(height:)` assumes the NSTextView will
+        // render every glyph in that same rect. Non-contiguous layout leaves
+        // glyphs pending until the view scrolls or draws them, which races
+        // with streaming updates — the NSTextView briefly paints a smaller
+        // laid-out region inside the (correctly-measured) larger frame,
+        // producing a visible gap; the next sibling then gets placed via
+        // the measured frame and the lazy glyphs later paint outside it,
+        // producing overlap. Keep this contiguous for correctness here.
+        // VCodeView / HighlightedTextView still opt in to non-contiguous
+        // layout independently for their own scroll-attachment perf fix.
         textStorage.addLayoutManager(layoutManager)
         let textContainer = NSTextContainer(size: NSSize(
             width: 0,


### PR DESCRIPTION
## Summary
- Remove `NSLayoutManager.allowsNonContiguousLayout = true` from `VSelectableTextView` (chat-bubble text). The measurement path uses a separate TextKit stack that lays out every glyph via `ensureLayout`, so the `.frame(height:)` we hand SwiftUI assumes the NSTextView will render every glyph in that rect. Non-contiguous layout races with streaming updates: the NSTextView briefly paints a smaller laid-out region inside the correctly-measured larger frame (visible gap between thinking block and text), and when the lazy glyphs eventually paint they can fall outside the frame into the sibling's space (interleaved-line overlap between paragraphs).
- Code-view paths (`VCodeView`, `HighlightedTextView`) keep their own `allowsNonContiguousLayout = true` — those solve a different scroll-view-attachment hang and don't participate in chat streaming, so the perf fix from #26242 is preserved there.
- Verified: the gap between thinking block and streaming response text goes away, and the paragraph-overlap during streaming stops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
