### PR TITLE
fix(macos): preserve scroll anchor when streaming response grows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -5,9 +5,20 @@ import SwiftUI
 /// without relying on SwiftUI's `onScrollGeometryChange` modifier.
 struct MessageListScrollObserver: NSViewRepresentable {
     let onGeometryChange: @MainActor (ScrollGeometrySnapshot) -> Void
+    /// Whether to absorb content-height growth by shifting the clip view
+    /// so the visible content stays anchored as the streaming response
+    /// grows. Re-evaluated on every potential compensation point — return
+    /// `false` during pagination (where the explicit scroll-to-anchor is
+    /// the source of truth). Compensation is additionally gated on the
+    /// user being above the visual bottom; when pinned to latest, growth
+    /// auto-follows naturally in the inverted scroll.
+    let shouldPreserveScrollAnchor: @MainActor () -> Bool
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onGeometryChange: onGeometryChange)
+        Coordinator(
+            onGeometryChange: onGeometryChange,
+            shouldPreserveScrollAnchor: shouldPreserveScrollAnchor
+        )
     }
 
     func makeNSView(context: Context) -> NSView {
@@ -22,6 +33,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         context.coordinator.onGeometryChange = onGeometryChange
+        context.coordinator.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
         DispatchQueue.main.async { [weak nsView] in
             guard let nsView else { return }
             context.coordinator.attachIfNeeded(to: nsView)
@@ -40,11 +52,26 @@ struct MessageListScrollObserver: NSViewRepresentable {
         weak var clipView: NSClipView?
         weak var documentView: NSView?
         var onGeometryChange: @MainActor (ScrollGeometrySnapshot) -> Void
+        var shouldPreserveScrollAnchor: @MainActor () -> Bool
         private var observers: [NSObjectProtocol] = []
         private var lastSnapshot: ScrollGeometrySnapshot?
+        /// Last observed `documentView.frame.height`. Used to compute the
+        /// growth delta for anchor preservation. Reset to 0 on attach/detach
+        /// so a stale baseline from a previous conversation cannot apply
+        /// a phantom delta on the first emit of a new ScrollView.
+        private var lastContentHeight: CGFloat = 0
+        /// In inverted-scroll coords, `contentOffsetY ≈ 0` means the user is
+        /// pinned to the visual bottom (latest messages). Below this small
+        /// epsilon we treat the user as pinned and let streaming growth
+        /// auto-follow naturally instead of compensating.
+        static let pinnedToLatestEpsilon: CGFloat = 8
 
-        init(onGeometryChange: @escaping @MainActor (ScrollGeometrySnapshot) -> Void) {
+        init(
+            onGeometryChange: @escaping @MainActor (ScrollGeometrySnapshot) -> Void,
+            shouldPreserveScrollAnchor: @escaping @MainActor () -> Bool
+        ) {
             self.onGeometryChange = onGeometryChange
+            self.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
         }
 
         func attachIfNeeded(to hostView: NSView) {
@@ -62,6 +89,10 @@ struct MessageListScrollObserver: NSViewRepresentable {
             self.scrollView = scrollView
             self.clipView = clipView
             self.documentView = documentView
+            // Reset the baseline so the first emit after a re-attach (e.g.
+            // conversation switch destroys + recreates the ScrollView) does
+            // not treat the new content height as a delta over the old.
+            self.lastContentHeight = 0
             installObservers()
         }
 
@@ -72,6 +103,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
             clipView = nil
             documentView = nil
             lastSnapshot = nil
+            lastContentHeight = 0
         }
 
         func emitCurrentSnapshotIfPossible() {
@@ -80,9 +112,36 @@ struct MessageListScrollObserver: NSViewRepresentable {
             else { return }
 
             let clipView = scrollView.contentView
+            let currentContentHeight = documentView.frame.height
+
+            // Anchor preservation: when the streaming assistant response
+            // grows and the user is reading older content above the visual
+            // bottom, leaving the offset alone lets the new content push
+            // the visible region upward off the top of the viewport (the
+            // streaming message lives at doc Y=0; growing it shifts every
+            // higher-Y item further from the visual bottom). Shift the
+            // clip view by the height delta so the visible content stays
+            // put. The decision lives in `ScrollAnchorPreserver` so the
+            // logic is unit-testable without an NSScrollView.
+            if let delta = ScrollAnchorPreserver.offsetDelta(
+                currentContentHeight: currentContentHeight,
+                lastContentHeight: lastContentHeight,
+                contentOffsetY: clipView.bounds.origin.y,
+                shouldPreserveAnchor: shouldPreserveScrollAnchor(),
+                pinnedToLatestEpsilon: Self.pinnedToLatestEpsilon
+            ) {
+                let newOrigin = NSPoint(
+                    x: clipView.bounds.origin.x,
+                    y: clipView.bounds.origin.y + delta
+                )
+                clipView.setBoundsOrigin(newOrigin)
+                scrollView.reflectScrolledClipView(clipView)
+            }
+            lastContentHeight = currentContentHeight
+
             let snapshot = ScrollGeometrySnapshot(
                 contentOffsetY: clipView.bounds.origin.y,
-                contentHeight: documentView.frame.height,
+                contentHeight: currentContentHeight,
                 containerHeight: clipView.bounds.height,
                 visibleRectHeight: scrollView.documentVisibleRect.height
             )
@@ -149,5 +208,37 @@ struct MessageListScrollObserver: NSViewRepresentable {
             }
             observers.removeAll()
         }
+    }
+}
+
+/// Pure decision logic for inverted-scroll anchor preservation. Extracted
+/// from `MessageListScrollObserver.Coordinator` so the streaming-vs-pinned
+/// decision tree can be exercised in unit tests without standing up a real
+/// `NSScrollView`.
+enum ScrollAnchorPreserver {
+    /// Returns the offset delta to add to `contentOffsetY` so the visible
+    /// content stays anchored when the document grows, or `nil` if no
+    /// adjustment is needed.
+    ///
+    /// In the inverted scroll, `contentOffsetY = 0` is the visual bottom
+    /// (latest messages). The streaming assistant response lives at the
+    /// low end of the document (doc Y near 0), so its growth pushes every
+    /// higher-Y item further from the visual bottom. A user reading older
+    /// content (positive `contentOffsetY`) sees that content scroll upward
+    /// off the top of the viewport unless the offset is shifted by the
+    /// growth amount.
+    static func offsetDelta(
+        currentContentHeight: CGFloat,
+        lastContentHeight: CGFloat,
+        contentOffsetY: CGFloat,
+        shouldPreserveAnchor: Bool,
+        pinnedToLatestEpsilon: CGFloat
+    ) -> CGFloat? {
+        guard shouldPreserveAnchor,
+              lastContentHeight > 0,
+              currentContentHeight > lastContentHeight,
+              contentOffsetY > pinnedToLatestEpsilon
+        else { return nil }
+        return currentContentHeight - lastContentHeight
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -134,9 +134,19 @@ struct MessageListView: View {
                     scrollViewContent
                         .frame(width: widths.chatColumnWidth)
                         .background(
-                            MessageListScrollObserver { newState in
-                                enqueueScrollGeometryUpdate(newState)
-                            }
+                            MessageListScrollObserver(
+                                onGeometryChange: { newState in
+                                    enqueueScrollGeometryUpdate(newState)
+                                },
+                                shouldPreserveScrollAnchor: { [scrollState] in
+                                    // Skip during pagination — the explicit
+                                    // scroll-to-anchor in `handlePaginationSentinel`
+                                    // is the source of truth for that flow, and
+                                    // shifting the offset to absorb the older
+                                    // page's height would race the snap.
+                                    !scrollState.isPaginationInFlight
+                                }
+                            )
                         )
                     Spacer(minLength: 0)
                 }

--- a/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ScrollAnchorPreserverTests: XCTestCase {
+
+    private static let epsilon: CGFloat = 8
+
+    // MARK: - The streaming bug case
+
+    func testStreamingGrowthShiftsOffsetByDelta() {
+        // User is reading older content 200pt above the visual bottom while
+        // a streaming assistant response (lives at doc Y=0 in the inverted
+        // scroll) grows by 50pt. Without compensation, the user's visible
+        // content scrolls upward off the viewport. Compensation must add
+        // 50pt to the offset so the same content stays in view.
+        let delta = ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1050,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, 50)
+    }
+
+    func testStreamingGrowthCompensatesByExactDeltaForLargeJump() {
+        // A multi-token batch can land in a single layout pass. The delta
+        // must equal the actual height growth, not be capped or rounded.
+        let delta = ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 5000,
+            lastContentHeight: 1000,
+            contentOffsetY: 800,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, 4000)
+    }
+
+    // MARK: - Skip cases
+
+    func testSkipsOnFirstMeasurement() {
+        // Initial attach has lastContentHeight == 0. Compensating against
+        // 0 would treat the entire first emit as a delta and shove the
+        // user far off the visual bottom on first paint.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1000,
+            lastContentHeight: 0,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsWhenContentDidNotGrow() {
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1000,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsWhenContentShrunk() {
+        // A collapse (e.g., thinking-block dismissal) reduces height. We
+        // do not pull the user toward the streaming edge in that case.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 900,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsWhenPinnedToVisualBottom() {
+        // User is at the visual bottom (offset ≤ epsilon). Inverted scroll
+        // already auto-follows new content there — adding a delta would
+        // push them off the bottom they intentionally stayed at.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1100,
+            lastContentHeight: 1000,
+            contentOffsetY: 5,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsWhenAtExactlyEpsilon() {
+        // Boundary: offset == epsilon counts as pinned (strict > check).
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1100,
+            lastContentHeight: 1000,
+            contentOffsetY: 8,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testCompensatesJustAboveEpsilon() {
+        let delta = ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1100,
+            lastContentHeight: 1000,
+            contentOffsetY: 9,
+            shouldPreserveAnchor: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, 100)
+    }
+
+    func testSkipsWhenPreservationDisabled() {
+        // Pagination flow opts out: the explicit scroll-to-anchor in
+        // `handlePaginationSentinel` is the source of truth and shifting
+        // the offset to absorb the older page would race the snap.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1100,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- The inverted-scroll chat view kept `contentOffsetY` constant as the streaming assistant response grew, so the visible content scrolled upward off the top of the viewport every time new tokens arrived (the streaming message lives at doc Y=0 in the inverted scroll, and growing it shifts every higher-Y item further from the visual bottom).
- `MessageListScrollObserver.Coordinator` now compares the previous and current `documentView.frame.height`, and when content grows while the user is above the visual bottom (and not in pagination) it shifts `clipView.bounds.origin.y` by the delta — keeping whatever the user was reading anchored in place.
- Decision logic is extracted into a pure `ScrollAnchorPreserver.offsetDelta` helper with nine unit tests covering the streaming case plus every skip branch (initial measurement, no growth, shrink, pinned-to-bottom, exactly-at-epsilon boundary, just-above-epsilon boundary, large multi-token jump, pagination opt-out).

## Original prompt

> Fix chat view auto-scrolling upward during response streaming.
>
> **Bug:** When an assistant response is generating, the chat view scrolls upward — content the user is reading gets pushed off the top of the screen as new tokens arrive at the bottom. This is the opposite of correct behavior.
>
> **Expected behavior:** When the user is NOT at the bottom (scroll-to-latest button visible), the visible content should stay anchored in place as new content is appended below. Only auto-scroll if the user is pinned to the bottom.
>
> **Evidence:** User attached 7 sequential screenshots from 1:51:27 AM through 1:51:34 AM showing the same conversation ("Velissa System Architecture"). The "Scroll to latest" button is visible in every screenshot (so the user is not at the bottom), yet the visible content scrolls upward as new draft tokens stream in. For example, at 1:51:27 the content starts with "He validated me (good good)" and by 1:51:34 that text is gone — replaced by content that was further down at the start.
>
> **Context:**
> - This is the macOS client (clients/macos/, with shared code in clients/shared/).
> - Current branch is \`do/fix-chat-cell-zero-width-overlap\` and the most recent commit is \`aa2f61e4bd fix(macos): stop zero-width measurements from poisoning chat cell caches\` — there's a modified file \`clients/shared/DesignSystem/Components/Display/SelectableTextView.swift\` already in the working tree. The scroll bug is likely in the chat list / scroll-anchor logic, possibly interacting with how cell heights are recomputed during streaming.
> - Relevant area to investigate first: the SwiftUI/AppKit chat list view that hosts assistant message cells in the macOS client. Look for scroll position management, content-height-change handlers, and any "stick to bottom" logic. Pay special attention to how cell height changes during streaming might be inadvertently shifting the scroll offset.
>
> Investigate root cause (likely a height-change handler that shifts the contentOffset incorrectly when cells above the viewport grow), fix it, and verify the fix in the running macOS app (\`/update\` after the fix) by streaming a long response and confirming the visible content stays anchored when the user has scrolled up. Open a PR.

## Test plan

- [x] \`swift build --target VellumAssistantLib\` succeeds in the worktree
- [x] All 9 \`ScrollAnchorPreserverTests\` pass
- [ ] Verify in the running macOS app via \`/update\`: stream a long assistant response, scroll up to see older content while it's generating, and confirm the visible content stays anchored instead of scrolling upward off the top of the viewport
- [ ] Verify pagination still snaps cleanly to the anchor message when scrolling past the visual top of loaded history (compensation should opt out via \`isPaginationInFlight\`)
- [ ] Verify auto-follow still works when the user is pinned to the visual bottom (offset \`≤ 8pt\` — compensation should not fire)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
