### PR TITLE
fix(macos): emojis no longer inherit italic slant in rendered markdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -802,6 +802,20 @@ struct MarkdownSegmentView: View, Equatable {
             }
         }
 
+        // Core Text honors .obliqueness on every glyph in the range, including
+        // Apple Color Emoji substitutions. Strip it from emoji grapheme clusters
+        // so they render upright inside italic runs.
+        let swiftString = ns.string
+        var cursor = swiftString.startIndex
+        while cursor < swiftString.endIndex {
+            let next = swiftString.index(after: cursor)
+            if swiftString[cursor].rendersAsEmoji {
+                let charRange = NSRange(cursor..<next, in: swiftString)
+                ns.removeAttribute(.obliqueness, range: charRange)
+            }
+            cursor = next
+        }
+
         let hasUnresolvedEmphasis = unresolvedEmphasisCount > 0
         if hasUnresolvedEmphasis {
             mdConvertLog.warning(
@@ -967,5 +981,17 @@ private extension View {
         } else {
             self
         }
+    }
+}
+
+fileprivate extension Character {
+    /// True iff this grapheme cluster renders as emoji — either default emoji
+    /// presentation, or text-default codepoints forced into emoji presentation
+    /// via U+FE0F (VS16). Excludes text-presentation characters like digits
+    /// and `#`/`*` that carry the bare Emoji property but not Emoji_Presentation.
+    var rendersAsEmoji: Bool {
+        let scalars = unicodeScalars
+        if scalars.contains(where: { $0.value == 0xFE0F }) { return true }
+        return scalars.contains(where: { $0.properties.isEmojiPresentation })
     }
 }

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -162,6 +162,75 @@ final class MarkdownSegmentViewTests: XCTestCase {
         XCTAssertGreaterThan(abs(CGFloat(truncating: obliqueness!)), 0.01)
     }
 
+    func testItalicEmojiHasNoObliqueness() throws {
+        let input = "*harder than the 🥺 did*"
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown(input)
+        XCTAssertFalse(hasUnresolvedEmphasis)
+
+        // Surrounding italic text keeps obliqueness.
+        let textObliqueness = rendered.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+        XCTAssertNotNil(textObliqueness)
+        XCTAssertGreaterThan(abs(CGFloat(truncating: try XCTUnwrap(textObliqueness))), 0.01)
+
+        // The emoji grapheme cluster has obliqueness stripped.
+        let emojiOffset = try XCTUnwrap(utf16Offset(of: "🥺", in: rendered.string))
+        let emojiObliqueness = rendered.attribute(.obliqueness, at: emojiOffset, effectiveRange: nil) as? NSNumber
+        if let emojiObliqueness {
+            XCTAssertLessThan(abs(CGFloat(truncating: emojiObliqueness)), 0.01, "Emoji inside italic runs must not be skewed")
+        }
+    }
+
+    func testBoldItalicEmojiHasNoObliqueness() throws {
+        let input = "***oof 🥺***"
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown(input)
+        XCTAssertFalse(hasUnresolvedEmphasis)
+
+        let textObliqueness = rendered.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+        XCTAssertNotNil(textObliqueness)
+        XCTAssertGreaterThan(abs(CGFloat(truncating: try XCTUnwrap(textObliqueness))), 0.01)
+
+        let emojiOffset = try XCTUnwrap(utf16Offset(of: "🥺", in: rendered.string))
+        let emojiObliqueness = rendered.attribute(.obliqueness, at: emojiOffset, effectiveRange: nil) as? NSNumber
+        if let emojiObliqueness {
+            XCTAssertLessThan(abs(CGFloat(truncating: emojiObliqueness)), 0.01)
+        }
+    }
+
+    func testCompoundZWJEmojiHasNoObliqueness() throws {
+        // Family emoji is a multi-scalar ZWJ sequence — must be treated as one
+        // grapheme cluster so obliqueness is stripped across the whole sequence.
+        let input = "*family 👨‍👩‍👧 time*"
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown(input)
+        XCTAssertFalse(hasUnresolvedEmphasis)
+
+        let emojiOffset = try XCTUnwrap(utf16Offset(of: "👨\u{200D}👩\u{200D}👧", in: rendered.string))
+        let emojiObliqueness = rendered.attribute(.obliqueness, at: emojiOffset, effectiveRange: nil) as? NSNumber
+        if let emojiObliqueness {
+            XCTAssertLessThan(abs(CGFloat(truncating: emojiObliqueness)), 0.01)
+        }
+    }
+
+    func testTextPresentationDigitKeepsObliqueness() throws {
+        // Digits have the Emoji property but not Emoji_Presentation, and no VS16.
+        // They must remain italicized inside an italic run.
+        let input = "*round 1 ends*"
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown(input)
+        XCTAssertFalse(hasUnresolvedEmphasis)
+
+        let digitOffset = try XCTUnwrap(utf16Offset(of: "1", in: rendered.string))
+        let digitObliqueness = rendered.attribute(.obliqueness, at: digitOffset, effectiveRange: nil) as? NSNumber
+        XCTAssertNotNil(digitObliqueness, "Text-presentation digits must keep italic obliqueness")
+        XCTAssertGreaterThan(abs(CGFloat(truncating: try XCTUnwrap(digitObliqueness))), 0.01)
+    }
+
+    func testNonItalicEmojiRendersWithoutObliqueness() throws {
+        // Sanity check: when nothing applied obliqueness, the strip pass is a no-op.
+        let (rendered, _) = makeRenderedMarkdown("plain 🥺 text")
+        let emojiOffset = try XCTUnwrap(utf16Offset(of: "🥺", in: rendered.string))
+        let emojiObliqueness = rendered.attribute(.obliqueness, at: emojiOffset, effectiveRange: nil) as? NSNumber
+        XCTAssertNil(emojiObliqueness)
+    }
+
     func testInvalidEmphasisFontsSkipMeasurementCaching() throws {
         #if DEBUG
         VFont._chatMarkdownFontSetOverride = { size in
@@ -374,6 +443,11 @@ final class MarkdownSegmentViewTests: XCTestCase {
 
     private func renderedObliqueness(from rendered: NSAttributedString) -> NSNumber? {
         rendered.attribute(.obliqueness, at: 0, effectiveRange: nil) as? NSNumber
+    }
+
+    private func utf16Offset(of needle: String, in haystack: String) -> Int? {
+        guard let range = haystack.range(of: needle) else { return nil }
+        return haystack.utf16.distance(from: haystack.utf16.startIndex, to: range.lowerBound.samePosition(in: haystack.utf16)!)
     }
 
     private func familyName(for font: NSFont) -> String {


### PR DESCRIPTION
## Summary
- Strip `.obliqueness` from emoji grapheme clusters after the emphasis application pass in `convertToNSAttributedString`, so Apple Color Emoji glyphs render upright inside italic markdown instead of being sheared along with the synthesized DM Sans slant.
- Add a `Character.rendersAsEmoji` helper that treats a cluster as emoji when any scalar has `Emoji_Presentation` or when the cluster carries `U+FE0F` (VS16); digits, `#`, and `*` — Emoji-property but text-default — stay italicized.
- Regression tests cover italic, bold-italic, ZWJ sequences, text-presentation digits (must stay italic), and plain-text emoji (no-op).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
