### PR TITLE
fix(macos,ios): exclude background conversations from dock badge count

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -31,6 +31,11 @@ struct IOSConversation: Identifiable {
     /// The source that created this conversation (e.g. "heartbeat", "task", "schedule", "reminder", "notification").
     /// Immutable after creation — pinning/moving a conversation changes groupId but never source.
     var source: String?
+    /// The daemon-side conversation classification: "standard", "private", "background", "scheduled".
+    /// Canonical signal for unread-suppression of automated threads. `nil` for rows written by
+    /// older daemons or for locally-created conversations that have not yet round-tripped to the
+    /// server; callers should treat `nil` as non-suppressed.
+    var conversationType: String?
     var hasUnseenLatestAssistantMessage: Bool
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
@@ -47,14 +52,16 @@ struct IOSConversation: Identifiable {
     /// indicators should only reflect content requiring user attention — system-generated
     /// messages from automated threads do not qualify.
     ///
-    /// Schedule detection uses `scheduleJobId` / title prefix (via `isScheduleConversation`).
-    /// Background detection uses `source` (immutable) rather than `groupId` (mutable on
-    /// pin/move) so suppression is stable regardless of group changes.
+    /// Primary signal is `conversationType` (the daemon's canonical classification) so any
+    /// server-created `background` or `scheduled` conversation is suppressed regardless of source.
+    /// The source/title fallbacks cover locally-created conversations and older daemons that
+    /// don't return the field.
     var shouldSuppressUnreadIndicator: Bool {
-        isScheduleConversation || source == "heartbeat" || source == "task"
+        conversationType == "background" || conversationType == "scheduled"
+            || isScheduleConversation || source == "heartbeat" || source == "task" || source == "auto-analysis"
     }
 
-    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, displayOrder: Int? = nil, isPrivate: Bool = false, scheduleJobId: String? = nil, forkParent: ConversationForkParent? = nil, groupId: String? = nil, source: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
+    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, displayOrder: Int? = nil, isPrivate: Bool = false, scheduleJobId: String? = nil, forkParent: ConversationForkParent? = nil, groupId: String? = nil, source: String? = nil, conversationType: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -68,6 +75,7 @@ struct IOSConversation: Identifiable {
         self.forkParent = forkParent
         self.groupId = groupId
         self.source = source
+        self.conversationType = conversationType
         self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
         self.latestAssistantMessageAt = latestAssistantMessageAt
         self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
@@ -90,6 +98,7 @@ private struct PersistedConversation: Codable {
     var scheduleJobId: String?
     var forkParent: ConversationForkParent?
     var source: String?
+    var conversationType: String?
     var hasUnseenLatestAssistantMessage: Bool?
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
@@ -100,7 +109,7 @@ private struct PersistedConversation: Codable {
     enum CodingKeys: String, CodingKey {
         case id, title, createdAt, lastActivityAt, isArchived, isPinned, displayOrder, isPrivate
         case conversationId
-        case scheduleJobId, forkParent, source, hasUnseenLatestAssistantMessage, latestAssistantMessageAt, lastSeenAssistantMessageAt
+        case scheduleJobId, forkParent, source, conversationType, hasUnseenLatestAssistantMessage, latestAssistantMessageAt, lastSeenAssistantMessageAt
         // Legacy key used before the session-to-conversation rename.
         case legacySessionId = "sessionId"
     }
@@ -126,6 +135,7 @@ extension PersistedConversation {
         scheduleJobId = try container.decodeIfPresent(String.self, forKey: .scheduleJobId)
         forkParent = try container.decodeIfPresent(ConversationForkParent.self, forKey: .forkParent)
         source = try container.decodeIfPresent(String.self, forKey: .source)
+        conversationType = try container.decodeIfPresent(String.self, forKey: .conversationType)
         hasUnseenLatestAssistantMessage = try container.decodeIfPresent(Bool.self, forKey: .hasUnseenLatestAssistantMessage)
         latestAssistantMessageAt = try container.decodeIfPresent(Date.self, forKey: .latestAssistantMessageAt)
         lastSeenAssistantMessageAt = try container.decodeIfPresent(Date.self, forKey: .lastSeenAssistantMessageAt)
@@ -146,6 +156,7 @@ extension PersistedConversation {
         try container.encodeIfPresent(scheduleJobId, forKey: .scheduleJobId)
         try container.encodeIfPresent(forkParent, forKey: .forkParent)
         try container.encodeIfPresent(source, forKey: .source)
+        try container.encodeIfPresent(conversationType, forKey: .conversationType)
         try container.encodeIfPresent(hasUnseenLatestAssistantMessage, forKey: .hasUnseenLatestAssistantMessage)
         try container.encodeIfPresent(latestAssistantMessageAt, forKey: .latestAssistantMessageAt)
         try container.encodeIfPresent(lastSeenAssistantMessageAt, forKey: .lastSeenAssistantMessageAt)
@@ -278,6 +289,7 @@ class IOSConversationStore: ObservableObject {
         conversation.displayOrder = item.displayOrder.map { Int($0) }
         conversation.groupId = item.groupId
         conversation.source = item.source
+        conversation.conversationType = item.conversationType
         let serverUnseen = item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
         conversation.hasUnseenLatestAssistantMessage =
             conversation.shouldSuppressUnreadIndicator ? false : serverUnseen
@@ -319,6 +331,7 @@ class IOSConversationStore: ObservableObject {
         conversation.conversationId = restored.conversationId ?? conversation.conversationId
         conversation.scheduleJobId = restored.scheduleJobId ?? conversation.scheduleJobId
         conversation.source = restored.source ?? conversation.source
+        conversation.conversationType = restored.conversationType ?? conversation.conversationType
         conversation.forkParent = restored.forkParent
         let hasLocalPinEdit = conversation.conversationId.map { locallyEditedPinConversationIds.contains($0) } ?? false
         if !hasLocalPinEdit {
@@ -412,7 +425,8 @@ class IOSConversationStore: ObservableObject {
             isPrivate: item.conversationType == "private",
             scheduleJobId: item.scheduleJobId,
             forkParent: item.forkParent,
-            source: item.source
+            source: item.source,
+            conversationType: item.conversationType
         )
         applyConversationMetadata(item, to: &conversation)
         return conversation
@@ -863,6 +877,7 @@ class IOSConversationStore: ObservableObject {
                             forkParent: restored.forkParent,
                             groupId: restored.groupId,
                             source: restored.source,
+                            conversationType: restored.conversationType,
                             hasUnseenLatestAssistantMessage: restored.hasUnseenLatestAssistantMessage,
                             latestAssistantMessageAt: restored.latestAssistantMessageAt,
                             lastSeenAssistantMessageAt: restored.lastSeenAssistantMessageAt
@@ -1546,6 +1561,7 @@ class IOSConversationStore: ObservableObject {
                 scheduleJobId: $0.scheduleJobId,
                 forkParent: $0.forkParent,
                 source: $0.source,
+                conversationType: $0.conversationType,
                 hasUnseenLatestAssistantMessage: $0.hasUnseenLatestAssistantMessage,
                 latestAssistantMessageAt: $0.latestAssistantMessageAt,
                 lastSeenAssistantMessageAt: $0.lastSeenAssistantMessageAt
@@ -1576,6 +1592,7 @@ class IOSConversationStore: ObservableObject {
                 scheduleJobId: p.scheduleJobId,
                 forkParent: p.forkParent,
                 source: p.source,
+                conversationType: p.conversationType,
                 hasUnseenLatestAssistantMessage: p.hasUnseenLatestAssistantMessage ?? false,
                 latestAssistantMessageAt: p.latestAssistantMessageAt,
                 lastSeenAssistantMessageAt: p.lastSeenAssistantMessageAt
@@ -1601,7 +1618,8 @@ class IOSConversationStore: ObservableObject {
                 conversationId: $0.conversationId,
                 scheduleJobId: $0.scheduleJobId,
                 forkParent: $0.forkParent,
-                source: $0.source
+                source: $0.source,
+                conversationType: $0.conversationType
             )
         }
         if let data = try? JSONEncoder().encode(persisted) {
@@ -1625,7 +1643,8 @@ class IOSConversationStore: ObservableObject {
                 isPrivate: $0.isPrivate ?? false,
                 scheduleJobId: $0.scheduleJobId,
                 forkParent: $0.forkParent,
-                source: $0.source
+                source: $0.source,
+                conversationType: $0.conversationType
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -459,6 +459,7 @@ final class ConversationListStore {
             lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(item.lastMessageAt ?? item.updatedAt) / 1000.0),
             kind: item.conversationType == "private" ? .private : .standard,
             source: item.source,
+            conversationType: item.conversationType,
             hostAccess: item.hostAccess ?? false,
             scheduleJobId: item.scheduleJobId,
             hasUnseenLatestAssistantMessage: (item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false),

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -40,6 +40,12 @@ struct ConversationModel: Identifiable, Hashable {
     var lastInteractedAt: Date
     var kind: ConversationKind
     var source: String?
+    /// The daemon-side conversation classification: "standard", "private", "background", "scheduled".
+    /// This is the canonical signal for unread-suppression of automated threads — keys off the
+    /// `conversationType` column the daemon sets at creation time, and is stable across pin/move
+    /// operations (which can mutate `groupId` but never `conversationType`). `nil` for rows returned
+    /// by older daemons that predate the field; callers should treat `nil` as non-suppressed.
+    var conversationType: String?
     var hostAccess: Bool
     /// The schedule job ID that created this conversation, if any.
     /// Conversations sharing the same scheduleJobId belong to the same schedule group.
@@ -50,7 +56,7 @@ struct ConversationModel: Identifiable, Hashable {
     var forkParent: ConversationForkParent?
     var originChannel: String?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, hostAccess: Bool = false, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, conversationType: String? = nil, hostAccess: Bool = false, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -61,6 +67,7 @@ struct ConversationModel: Identifiable, Hashable {
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
         self.source = source
+        self.conversationType = conversationType
         self.hostAccess = hostAccess
         self.scheduleJobId = scheduleJobId
         self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
@@ -97,9 +104,17 @@ struct ConversationModel: Identifiable, Hashable {
     }
 
     /// Whether this conversation is automated (heartbeat, schedule, background/task,
-    /// auto-analysis) and should never show unread indicators on individual rows.
+    /// auto-analysis, watcher, filing, and any future daemon-classified background thread)
+    /// and should never show unread indicators on individual rows.
+    ///
+    /// Primary signal is `conversationType` — the daemon's canonical field — so any
+    /// server-created background/scheduled conversation is suppressed regardless of its
+    /// `source`. The source-based fallbacks cover locally-created conversations (before
+    /// the server round-trip sets `conversationType`) and older daemons that don't return
+    /// the field.
     var shouldSuppressUnreadIndicator: Bool {
-        isScheduleConversation || shouldReturnToBackgroundOnUnpin
+        conversationType == "background" || conversationType == "scheduled"
+            || isScheduleConversation || shouldReturnToBackgroundOnUnpin
     }
 
     /// Whether this conversation should be excluded from *global* unread
@@ -148,6 +163,7 @@ struct ConversationModel: Identifiable, Hashable {
             lhs.lastInteractedAt == rhs.lastInteractedAt &&
             lhs.kind == rhs.kind &&
             lhs.source == rhs.source &&
+            lhs.conversationType == rhs.conversationType &&
             lhs.hostAccess == rhs.hostAccess &&
             lhs.scheduleJobId == rhs.scheduleJobId &&
             lhs.hasUnseenLatestAssistantMessage == rhs.hasUnseenLatestAssistantMessage &&
@@ -170,6 +186,7 @@ struct ConversationModel: Identifiable, Hashable {
         hasher.combine(lastInteractedAt)
         hasher.combine(kind)
         hasher.combine(source)
+        hasher.combine(conversationType)
         hasher.combine(hostAccess)
         hasher.combine(scheduleJobId)
         hasher.combine(hasUnseenLatestAssistantMessage)

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -925,6 +925,104 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                        "Deferred history request should target the correct conversation")
     }
 
+    // MARK: - conversationType-based suppression
+
+    /// Server-created background conversations (e.g. watcher, filing) can carry any `source`,
+    /// including `nil`. The hardcoded source allowlist misses these, so we rely on
+    /// `conversationType == "background"` from the daemon to suppress their unread indicator
+    /// and exclude them from the dock badge count.
+    func testBackgroundConversationTypeFromServerSuppressesUnreadIndicator() {
+        // Filing-style background: conversationType="background", source="filing"
+        let filingModel = ConversationModel(
+            title: "Filing run",
+            conversationId: "bg-filing",
+            source: "filing",
+            conversationType: "background",
+            hasUnseenLatestAssistantMessage: true
+        )
+        XCTAssertTrue(filingModel.shouldSuppressUnreadIndicator,
+                      "Filing background conversations (source=filing, conversationType=background) must suppress unread indicator")
+        XCTAssertTrue(filingModel.shouldSuppressGlobalUnreadAggregations,
+                      "Filing background conversations must be excluded from the dock badge")
+
+        // Watcher-style background: conversationType="background", source=nil
+        let watcherModel = ConversationModel(
+            title: "Watcher tick",
+            conversationId: "bg-watcher",
+            source: nil,
+            conversationType: "background",
+            hasUnseenLatestAssistantMessage: true
+        )
+        XCTAssertTrue(watcherModel.shouldSuppressUnreadIndicator,
+                      "Watcher background conversations (source=nil, conversationType=background) must suppress unread indicator")
+        XCTAssertTrue(watcherModel.shouldSuppressGlobalUnreadAggregations,
+                      "Watcher background conversations must be excluded from the dock badge")
+    }
+
+    /// Scheduled `conversationType` from the server should also suppress unread indicators
+    /// regardless of the `source` column — keeps the filter robust to new automation sources.
+    func testScheduledConversationTypeFromServerSuppressesUnreadIndicator() {
+        let scheduledModel = ConversationModel(
+            title: "Scheduled run",
+            conversationId: "sched-type",
+            source: nil,
+            conversationType: "scheduled",
+            hasUnseenLatestAssistantMessage: true
+        )
+        XCTAssertTrue(scheduledModel.shouldSuppressUnreadIndicator)
+        XCTAssertTrue(scheduledModel.shouldSuppressGlobalUnreadAggregations)
+    }
+
+    /// Regression guard: a standard conversation with an unseen assistant message must still
+    /// contribute to the badge count even if its source is nil (the common user case).
+    func testStandardConversationTypeWithUnseenMessageIsNotSuppressed() {
+        let standardModel = ConversationModel(
+            title: "Regular chat",
+            conversationId: "std-1",
+            source: nil,
+            conversationType: "standard",
+            hasUnseenLatestAssistantMessage: true
+        )
+        XCTAssertFalse(standardModel.shouldSuppressUnreadIndicator,
+                       "Standard user conversations must continue to show unread indicators")
+        XCTAssertFalse(standardModel.shouldSuppressGlobalUnreadAggregations,
+                       "Standard user conversations must continue to contribute to the dock badge")
+    }
+
+    /// End-to-end through the conversation-list response: a server-provided background
+    /// conversation with an unseen flag must land in the store with unread cleared so the
+    /// dock-badge aggregator (`unseenVisibleConversationCount`) skips it.
+    func testBackgroundConversationFromListResponseNotCountedInBadge() {
+        let response = makeConversationListResponse(
+            conversations: [[
+                "id": "bg-watcher-list",
+                "title": "Watcher",
+                "createdAt": 5_000,
+                "updatedAt": 6_000,
+                "conversationType": "background",
+                "assistantAttention": [
+                    "hasUnseenLatestAssistantMessage": true,
+                    "latestAssistantMessageAt": 9_000,
+                ],
+            ]],
+            hasMore: false
+        )
+
+        let unseenBefore = conversationManager.unseenVisibleConversationCount
+        conversationManager.appendConversations(from: response)
+
+        guard let appended = conversationManager.conversations.first(where: { $0.conversationId == "bg-watcher-list" }) else {
+            XCTFail("Expected background conversation to be appended")
+            return
+        }
+
+        XCTAssertEqual(appended.conversationType, "background")
+        XCTAssertFalse(appended.hasUnseenLatestAssistantMessage,
+                       "Server-reported unseen flag should be stripped for background conversations")
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, unseenBefore,
+                       "Appending a background conversation must not increment the dock badge count")
+    }
+
     private func waitForPropagation() {
         let exp = expectation(description: "combine propagation")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {


### PR DESCRIPTION
## Summary
- Dock badge counted heartbeat/task/auto-analysis via a hardcoded source allowlist but silently included other daemon-created background conversations (watcher has `source: nil`, filing has `source: "filing"`) that the server tags with `conversationType: "background"` — those were contributing to the dock badge despite being automated.
- Plumb `conversationType` through `ConversationModel` (macOS) and `IOSConversation` + `PersistedConversation` (iOS) and widen `shouldSuppressUnreadIndicator` to check `conversationType == "background" || conversationType == "scheduled"` ahead of the existing source/title heuristics, so any automation thread the server marks is excluded regardless of its `source`.
- Add regression tests exercising filing (source="filing"), watcher (source=nil) and scheduled cases through the conversation-list response; keep a guard that a standard user conversation with an unseen assistant message still contributes to the badge.

## Original prompt
it

Unread background conversations shouldn't contribute to the notification badge count