### PR TITLE
fix(macos): clear composer undo stack on dismantle to prevent cmd+z crash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -332,6 +332,16 @@ struct ComposerTextEditor: NSViewRepresentable {
             coordinator.boundsObserver = nil
         }
         coordinator.cancelPendingMeasureHeight()
+
+        // NSTextView registers text-edit undo actions on the window's undo
+        // manager with the text view as an unsafe-unretained target — weak
+        // zeroing does not apply, so a later cmd+z after the view is torn
+        // down dereferences a freed pointer in `_undoRedoTextOperation:`.
+        // Purge our actions before the view dies.
+        if let textView = scrollView.documentView as? ComposerTextView {
+            textView.breakUndoCoalescing()
+            textView.undoManager?.removeAllActions(withTarget: textView)
+        }
     }
 
     // MARK: - Coordinator


### PR DESCRIPTION
## Summary
- Chat composer was crashing with EXC_BAD_ACCESS on cmd+z after the composer view was re-created (conversation switch, composer section replacement).
- NSTextView's built-in text undo registers actions on the window's `NSUndoManager` with the text view as an unsafe-unretained target, so freeing the view leaves dangling `_undoRedoTextOperation:` actions on the stack.
- `dismantleNSView` now calls `breakUndoCoalescing()` and `removeAllActions(withTarget: textView)` before the view is released, so the next cmd+z cannot dereference freed memory.

## Test plan
- [ ] Launch the macOS app, type in the chat composer, switch conversations, press cmd+z — no crash.
- [ ] Type, send, then cmd+z immediately — still no crash and no stray undo actions leak across conversations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
