### PR TITLE
fix(macos): suppress scroll anchor shift during live-scroll gestures

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -10,8 +10,12 @@ struct MessageListScrollObserver: NSViewRepresentable {
     /// grows. Re-evaluated on every potential compensation point — return
     /// `false` during pagination (where the explicit scroll-to-anchor is
     /// the source of truth). Compensation is additionally gated on the
-    /// user being above the visual bottom; when pinned to latest, growth
-    /// auto-follows naturally in the inverted scroll.
+    /// user being above the visual bottom (when pinned to latest, growth
+    /// auto-follows naturally in the inverted scroll) and on the user
+    /// not being in an active live-scroll gesture (tracked internally
+    /// via `NSScrollView.willStart/didEndLiveScrollNotification`, so
+    /// mid-gesture height growth — most often `LazyVStack` lazy cell
+    /// materialization — never fights the user's scroll).
     let shouldPreserveScrollAnchor: @MainActor () -> Bool
 
     func makeCoordinator() -> Coordinator {
@@ -60,6 +64,14 @@ struct MessageListScrollObserver: NSViewRepresentable {
         /// so a stale baseline from a previous conversation cannot apply
         /// a phantom delta on the first emit of a new ScrollView.
         private var lastContentHeight: CGFloat = 0
+        /// Tracks whether an AppKit live scroll (trackpad/wheel gesture plus
+        /// momentum decay) is currently in progress. Bracketed by
+        /// `willStartLiveScrollNotification` / `didEndLiveScrollNotification`
+        /// on the `NSScrollView`. Anchor preservation is suppressed while
+        /// this is true so content-height growth from `LazyVStack` lazy cell
+        /// materialization — or any other concurrent source — cannot fight
+        /// the user's gesture with a mid-gesture `setBoundsOrigin` shift.
+        private var isLiveScrolling: Bool = false
         /// In inverted-scroll coords, `contentOffsetY ≈ 0` means the user is
         /// pinned to the visual bottom (latest messages). Below this small
         /// epsilon we treat the user as pinned and let streaming growth
@@ -104,6 +116,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
             documentView = nil
             lastSnapshot = nil
             lastContentHeight = 0
+            isLiveScrolling = false
         }
 
         func emitCurrentSnapshotIfPossible() {
@@ -128,6 +141,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 lastContentHeight: lastContentHeight,
                 contentOffsetY: clipView.bounds.origin.y,
                 shouldPreserveAnchor: shouldPreserveScrollAnchor(),
+                isUserLiveScrolling: isLiveScrolling,
                 pinnedToLatestEpsilon: Self.pinnedToLatestEpsilon
             ) {
                 let newOrigin = NSPoint(
@@ -198,6 +212,40 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 })
             }
 
+            // Bracket the user's gesture (and its momentum decay) so anchor
+            // preservation doesn't call `setBoundsOrigin` while the user is
+            // actively scrolling. Without this, any content-height growth
+            // between scroll ticks — most often `LazyVStack` lazy cell
+            // materialization as new cells come into view — produces an
+            // upward `clipView` shift that cancels the user's input and
+            // traps them in the current region.
+            observers.append(center.addObserver(
+                forName: NSScrollView.willStartLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.isLiveScrolling = true
+                }
+            })
+            observers.append(center.addObserver(
+                forName: NSScrollView.didEndLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.isLiveScrolling = false
+                    // Re-baseline without applying a delta: any growth
+                    // that accumulated during the gesture has already
+                    // been absorbed into the user's new scroll position,
+                    // so we must not retroactively compensate for it on
+                    // the next passive emit.
+                    self.lastContentHeight = self.documentView?.frame.height ?? 0
+                    self.emitCurrentSnapshotIfPossible()
+                }
+            })
+
             emitCurrentSnapshotIfPossible()
         }
 
@@ -232,9 +280,11 @@ enum ScrollAnchorPreserver {
         lastContentHeight: CGFloat,
         contentOffsetY: CGFloat,
         shouldPreserveAnchor: Bool,
+        isUserLiveScrolling: Bool,
         pinnedToLatestEpsilon: CGFloat
     ) -> CGFloat? {
         guard shouldPreserveAnchor,
+              !isUserLiveScrolling,
               lastContentHeight > 0,
               currentContentHeight > lastContentHeight,
               contentOffsetY > pinnedToLatestEpsilon

--- a/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
@@ -19,6 +19,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         )
         XCTAssertEqual(delta, 50)
@@ -32,6 +33,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 800,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         )
         XCTAssertEqual(delta, 4000)
@@ -48,6 +50,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 0,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
     }
@@ -58,6 +61,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
     }
@@ -70,6 +74,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
     }
@@ -83,6 +88,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 5,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
     }
@@ -94,6 +100,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 8,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
     }
@@ -104,6 +111,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 9,
             shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         )
         XCTAssertEqual(delta, 100)
@@ -118,7 +126,43 @@ final class ScrollAnchorPreserverTests: XCTestCase {
             lastContentHeight: 1000,
             contentOffsetY: 200,
             shouldPreserveAnchor: false,
+            isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon
         ))
+    }
+
+    // MARK: - Live-scroll gate
+
+    func testSkipsWhenUserIsLiveScrolling() {
+        // The user is actively scrolling (trackpad, wheel, or momentum
+        // decay). Any content-height growth during the gesture — most
+        // often LazyVStack lazy cell materialization — must not trigger
+        // a clipView origin shift, because calling setBoundsOrigin
+        // mid-gesture cancels the user's scroll input and traps them in
+        // the current region. The original streaming-bug inputs would
+        // otherwise compensate; the live-scroll gate must override.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1050,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: true,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testCompensatesOnceLiveScrollEnds() {
+        // After didEndLiveScrollNotification fires, isUserLiveScrolling
+        // flips back to false and subsequent passive growth (e.g., a
+        // streaming response continuing to arrive) compensates normally.
+        let delta = ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 1050,
+            lastContentHeight: 1000,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, 50)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes jerky/"trapped" scrolling in the macOS chat where slow scrolls in either direction bounce back to a stuck region and only fast flicks escape. Happens both during and after streaming.
- Root cause: the scroll anchor preservation added in #26318 runs on every `emitCurrentSnapshotIfPossible()` — including those triggered by `clipView.boundsDidChangeNotification`, which fires on every user scroll tick. Any concurrent content-height growth (most often `LazyVStack` lazy cell materialization as new cells come into view) triggers a `setBoundsOrigin` shift mid-gesture that cancels the user's scroll input and traps them in the current region.
- Adds an `NSScrollView.willStart/didEndLiveScrollNotification`-bracketed gate in `MessageListScrollObserver.Coordinator`, plumbed through the pure `ScrollAnchorPreserver.offsetDelta` helper via a new `isUserLiveScrolling` parameter. On gesture end, re-baselines `lastContentHeight` so growth that landed during the gesture doesn't retroactively jolt the viewport on the next passive emit.
- Preserves the #26318 streaming-anchor fix: when the user is scrolled up and NOT touching the trackpad, streaming growth still shifts the clip view so the user's reading position stays anchored.
- Adds 2 new unit tests (live-scroll gate on/off) and threads `isUserLiveScrolling: false` through the existing 8 cases.

## Original prompt
Implement the approved plan at /Users/sidd/.claude/plans/the-scrolling-in-the-staged-spring.md — fix jerky scroll / upward-jump bug in the macOS chat by gating ScrollAnchorPreserver compensation on NSScrollView live-scroll state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
