### PR TITLE
fix(daemon): strip Anthropic placeholder sentinels from persisted assistant messages

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -284,6 +284,33 @@ describe("cleanAssistantContent", () => {
     expect(result.warnings).toHaveLength(0);
     expect(result.cleanedContent).toHaveLength(1);
   });
+
+  test("drops Anthropic placeholder sentinel text blocks", () => {
+    const content = [
+      { type: "text", text: "\x00__PLACEHOLDER__[empty assistant turn]" },
+      { type: "text", text: "\x00__PLACEHOLDER__[internal blocks omitted]" },
+      { type: "text", text: "real text" },
+      { type: "tool_use", id: "t1", name: "read", input: {} },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.cleanedContent).toHaveLength(2);
+    expect((result.cleanedContent[0] as { text: string }).text).toBe(
+      "real text",
+    );
+    expect((result.cleanedContent[1] as { type: string }).type).toBe(
+      "tool_use",
+    );
+  });
+
+  test("returns empty array when all text blocks are placeholder sentinels", () => {
+    const content = [
+      { type: "text", text: "\x00__PLACEHOLDER__[empty assistant turn]" },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.cleanedContent).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -8,6 +8,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { basename } from "node:path";
 
+import { isPlaceholderSentinelText } from "../providers/anthropic/client.js";
 import {
   hostPolicy,
   sandboxPolicy,
@@ -692,19 +693,29 @@ export function cleanAssistantContent(content: readonly unknown[]): {
   const directives: DirectiveRequest[] = [];
   const warnings: string[] = [];
 
-  const cleanedContent = content.map((block) => {
-    const b = block as Record<string, unknown>;
-    if (b.type !== "text") return block;
-    const text = b.text as string;
-    // Only run the directive parser when the text actually contains a
-    // potential tag. This avoids unintentional whitespace normalisation
-    // (parseDirectives trims and collapses blank lines) on plain messages.
-    if (!text.includes("<vellum-attachment")) return block;
-    const result = parseDirectives(text);
-    directives.push(...result.directiveRequests);
-    warnings.push(...result.parseWarnings);
-    return { ...b, text: result.cleanText };
-  });
+  const cleanedContent = content
+    .filter((block) => {
+      // Drop placeholder sentinel text blocks. These are injected by the
+      // Anthropic provider to preserve role alternation in outbound requests
+      // and must never be persisted or rendered to users.
+      const b = block as Record<string, unknown>;
+      if (b.type !== "text") return true;
+      const text = b.text;
+      return typeof text !== "string" || !isPlaceholderSentinelText(text);
+    })
+    .map((block) => {
+      const b = block as Record<string, unknown>;
+      if (b.type !== "text") return block;
+      const text = b.text as string;
+      // Only run the directive parser when the text actually contains a
+      // potential tag. This avoids unintentional whitespace normalisation
+      // (parseDirectives trims and collapses blank lines) on plain messages.
+      if (!text.includes("<vellum-attachment")) return block;
+      const result = parseDirectives(text);
+      directives.push(...result.directiveRequests);
+      warnings.push(...result.parseWarnings);
+      return { ...b, text: result.cleanText };
+    });
 
   return { cleanedContent, directives, warnings };
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -146,6 +146,7 @@ import {
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateStripIntegrationPrefixFromProviderKeys,
+  migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
@@ -370,6 +371,7 @@ export function initializeDb(): void {
     migrateOAuthProvidersTokenExchangeBodyFormat,
     migrateNormalizeUserFileByPrincipal,
     migrateConversationsArchivedAt,
+    migrateStripPlaceholderSentinelsFromMessages,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
+++ b/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
@@ -1,0 +1,88 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Strip Anthropic provider placeholder sentinel text blocks from persisted
+ * assistant messages.
+ *
+ * PLACEHOLDER_EMPTY_TURN and PLACEHOLDER_BLOCKS_OMITTED are injected into
+ * outbound Anthropic request bodies to preserve role alternation when an
+ * assistant turn would otherwise be empty. They are never supposed to be
+ * persisted, but a leak path caused them to be stored in the messages table
+ * where they render in chat bubbles as bold "PLACEHOLDER[...]" (markdown
+ * interprets the double-underscore surround as bold).
+ *
+ * This migration walks every assistant message, parses its content blocks,
+ * and drops text blocks whose text matches either sentinel (with or without
+ * the null-byte prefix, to cover rows that round-tripped through tools that
+ * stripped null bytes). If stripping leaves the message empty, stores [].
+ *
+ * Idempotent — safe to re-run.
+ */
+export function migrateStripPlaceholderSentinelsFromMessages(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_strip_placeholder_sentinels_from_messages_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      const BATCH_SIZE = 100;
+      let lastRowid = 0;
+
+      for (;;) {
+        const rows = raw
+          .query(
+            `SELECT rowid, id, content FROM messages
+             WHERE role = 'assistant'
+               AND content LIKE '%__PLACEHOLDER__%'
+               AND rowid > ?
+             ORDER BY rowid
+             LIMIT ?`,
+          )
+          .all(lastRowid, BATCH_SIZE) as Array<{
+          rowid: number;
+          id: string;
+          content: string;
+        }>;
+
+        if (rows.length === 0) break;
+
+        for (const row of rows) {
+          lastRowid = row.rowid;
+
+          let blocks: Array<Record<string, unknown>>;
+          try {
+            const parsed = JSON.parse(row.content);
+            if (!Array.isArray(parsed)) continue;
+            blocks = parsed;
+          } catch {
+            continue;
+          }
+
+          const stripped = blocks.filter((b) => {
+            if (b.type !== "text") return true;
+            const text = typeof b.text === "string" ? b.text : "";
+            return !isSentinelText(text);
+          });
+
+          if (stripped.length === blocks.length) continue;
+
+          raw
+            .query(`UPDATE messages SET content = ? WHERE id = ?`)
+            .run(JSON.stringify(stripped), row.id);
+        }
+      }
+    },
+  );
+}
+
+function isSentinelText(text: string): boolean {
+  const normalized = text.startsWith("\x00") ? text.slice(1) : text;
+  return (
+    normalized === "__PLACEHOLDER__[empty assistant turn]" ||
+    normalized === "__PLACEHOLDER__[internal blocks omitted]"
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -166,6 +166,7 @@ export {
   migrateNormalizeUserFileByPrincipal,
 } from "./220-normalize-user-file-by-principal.js";
 export { migrateConversationsArchivedAt } from "./221-conversations-archived-at.js";
+export { migrateStripPlaceholderSentinelsFromMessages } from "./222-strip-placeholder-sentinels-from-messages.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -132,6 +132,20 @@ export const PLACEHOLDER_EMPTY_TURN =
 export const PLACEHOLDER_BLOCKS_OMITTED =
   "\x00__PLACEHOLDER__[internal blocks omitted]";
 
+const PLACEHOLDER_SENTINEL_TEXTS: ReadonlySet<string> = new Set([
+  PLACEHOLDER_EMPTY_TURN,
+  PLACEHOLDER_BLOCKS_OMITTED,
+]);
+
+/**
+ * True when the text is one of the provider's internal alternation-preserving
+ * sentinels. These must never be persisted or rendered to users — they exist
+ * only in outbound Anthropic API request bodies.
+ */
+export function isPlaceholderSentinelText(text: string): boolean {
+  return PLACEHOLDER_SENTINEL_TEXTS.has(text);
+}
+
 /**
  * Synthetic placeholder injected as user-message content when Anthropic API
  * alternation requires a user turn but no real user content exists. Uses the


### PR DESCRIPTION
## Summary
- Export `isPlaceholderSentinelText()` from the Anthropic provider and filter placeholder-only text blocks in `cleanAssistantContent`, preventing `PLACEHOLDER_EMPTY_TURN` / `PLACEHOLDER_BLOCKS_OMITTED` sentinels from being persisted to the `messages` table.
- Add migration 222 to scrub any existing sentinel text blocks from persisted assistant messages.
- Extend `cleanAssistantContent` tests to cover the new filter.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
