### PR TITLE
fix(macos): use dedicated webURL for login redirect instead of platformURL

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -100,7 +100,7 @@ public final class AuthManager {
             guard let encodedReturnTo = returnTo.addingPercentEncoding(withAllowedCharacters: allowedReturnToChars) else {
                 throw AuthServiceError.invalidURL
             }
-            let loginURLString = "\(VellumEnvironment.resolvedPlatformURL)/account/login?returnTo=\(encodedReturnTo)"
+            let loginURLString = "\(VellumEnvironment.resolvedWebURL)/account/login?returnTo=\(encodedReturnTo)"
             guard let loginURL = URL(string: loginURLString) else {
                 throw AuthServiceError.invalidURL
             }

--- a/clients/shared/App/VellumEnvironment.swift
+++ b/clients/shared/App/VellumEnvironment.swift
@@ -116,6 +116,38 @@ public enum VellumEnvironment: String {
         return current.platformURL
     }
 
+    /// The canonical Vellum web app (Next.js) base URL for this environment.
+    /// This is where browser-facing pages like `/account/login` live.
+    public var webURL: String {
+        switch self {
+        case .local:
+            return "http://localhost:3000"
+        case .dev:
+            return "https://dev-assistant.vellum.ai"
+        case .test:
+            return "https://dev-assistant.vellum.ai"
+        case .staging:
+            return "https://staging-assistant.vellum.ai"
+        case .production:
+            return "https://www.vellum.ai"
+        }
+    }
+
+    /// The current resolved web app URL.
+    ///
+    /// Resolution order:
+    /// 1. `VELLUM_WEB_URL` environment variable (explicit override)
+    /// 2. `VELLUM_ENVIRONMENT`-based canonical URL
+    public static var resolvedWebURL: String {
+        let environment = ProcessInfo.processInfo.environment
+        if let raw = environment["VELLUM_WEB_URL"] {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalized = trimmed.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+            if !normalized.isEmpty { return normalized }
+        }
+        return current.webURL
+    }
+
     /// The platform URL to inject into containers (Docker, Apple Containers).
     /// For `local`, containers can't reach `localhost` on the host, so we
     /// fall back to the remote dev platform.


### PR DESCRIPTION
## Summary
- Add `webURL` and `resolvedWebURL` to `VellumEnvironment` pointing to the Next.js web app host (with `VELLUM_WEB_URL` env override)
- Update `AuthManager.loginURL` to use `resolvedWebURL` instead of `resolvedPlatformURL` so login redirects hit the correct host
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
