### PR TITLE
fix(chrome-ext): use dedicated web app URL for OAuth start page instead of gateway URL

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -79,6 +79,7 @@ afterEach(() => {
 
 const config: CloudAuthConfig = {
   gatewayBaseUrl: 'https://api.vellum.ai',
+  webBaseUrl: 'https://www.vellum.ai',
   clientId: 'test-client-id',
 };
 
@@ -94,7 +95,7 @@ describe('signInCloud', () => {
   test('happy path stores a token and returns it', async () => {
     launchWebAuthFlowImpl = async (details) => {
       // The redirect URL the gateway would send back.
-      expect(details.url).toContain('https://api.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
       expect(details.url).toContain('client_id=test-client-id');
       expect(details.interactive).toBe(true);
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc123&expires_in=3600&guardian_id=g-42';
@@ -142,15 +143,15 @@ describe('signInCloud', () => {
     expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
   });
 
-  test('trims trailing slash on gatewayBaseUrl', async () => {
+  test('trims trailing slash on webBaseUrl', async () => {
     let seenUrl = '';
     launchWebAuthFlowImpl = async (details) => {
       seenUrl = details.url;
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
     };
-    await signInCloud(ASSISTANT_A, { gatewayBaseUrl: 'https://api.vellum.ai/', clientId: 'cid' });
-    expect(seenUrl).toContain('https://api.vellum.ai/oauth/chrome-extension/start');
-    expect(seenUrl).not.toContain('api.vellum.ai//oauth');
+    await signInCloud(ASSISTANT_A, { gatewayBaseUrl: 'https://api.vellum.ai/', webBaseUrl: 'https://www.vellum.ai/', clientId: 'cid' });
+    expect(seenUrl).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
+    expect(seenUrl).not.toContain('www.vellum.ai//oauth');
   });
 });
 
@@ -301,7 +302,7 @@ describe('refreshCloudToken', () => {
     let seenInteractive: boolean | undefined;
     launchWebAuthFlowImpl = async (details) => {
       seenInteractive = details.interactive;
-      expect(details.url).toContain('https://api.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=fresh-jwt&expires_in=3600&guardian_id=g-99';
     };
 

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -69,13 +69,14 @@ function missingTokenMessage(profile: AssistantAuthProfile | null): string {
  */
 interface PreflightDeps {
   bootstrapLocalToken: (assistantId: string | null) => Promise<StoredLocalToken>;
-  signInCloud: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
-  refreshCloudToken: (assistantId: string, config: { gatewayBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
+  signInCloud: (assistantId: string, config: { gatewayBaseUrl: string; webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
+  refreshCloudToken: (assistantId: string, config: { gatewayBaseUrl: string; webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
   getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
   getRelayPort: () => Promise<number>;
 }
 
 const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
+const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 /**
@@ -125,6 +126,7 @@ async function connectPreflight(
       const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
       const refreshed = await deps.refreshCloudToken(assistantId, {
         gatewayBaseUrl,
+        webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
@@ -143,6 +145,7 @@ async function connectPreflight(
     const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
     const stored = await deps.signInCloud(assistantId, {
       gatewayBaseUrl,
+      webBaseUrl: CLOUD_WEB_BASE_URL,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
     const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -1,15 +1,19 @@
 /**
  * Cloud OAuth sign-in state machine for the Vellum chrome extension.
  *
- * Launches chrome.identity.launchWebAuthFlow against the Vellum gateway and
- * persists the guardian-bound JWT in chrome.storage.local. The token is used
- * to authenticate the browser-relay WebSocket against the cloud gateway.
+ * Launches chrome.identity.launchWebAuthFlow against the Vellum web app
+ * and persists the guardian-bound JWT in chrome.storage.local. The token
+ * is used to authenticate the browser-relay WebSocket against the cloud
+ * gateway.
  *
- * The gateway base URL is now resolved per-assistant: cloud-managed
- * assistants carry a `runtimeUrl` in their lockfile entry, which the
- * worker passes as `CloudAuthConfig.gatewayBaseUrl` when signing in or
- * refreshing. When no assistant-specific URL is available, the caller
- * falls back to the default cloud gateway (`https://api.vellum.ai`).
+ * Two base URLs are involved:
+ * - `webBaseUrl` — the Next.js web app that serves the browser-facing
+ *   OAuth start page (`/oauth/chrome-extension/start`). Always
+ *   `https://www.vellum.ai` in production.
+ * - `gatewayBaseUrl` — the API gateway / runtime that hosts the
+ *   WebSocket relay. Resolved per-assistant: cloud-managed assistants
+ *   carry a `runtimeUrl` in their lockfile entry, falling back to
+ *   `https://api.vellum.ai`.
  *
  * Also exposes {@link refreshCloudToken}, the non-interactive refresh helper
  * used by the relay reconnect path when the stored token has expired or the
@@ -27,6 +31,8 @@
 export interface CloudAuthConfig {
   /** Gateway base URL, e.g. https://api.vellum.ai */
   gatewayBaseUrl: string;
+  /** Web app base URL for browser-facing pages, e.g. https://www.vellum.ai */
+  webBaseUrl: string;
   /** OAuth client id registered for the chrome extension. */
   clientId: string;
 }
@@ -224,7 +230,7 @@ function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
 function buildAuthUrl(config: CloudAuthConfig): string {
   const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
   return (
-    `${config.gatewayBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
+    `${config.webBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
     `?client_id=${encodeURIComponent(config.clientId)}` +
     `&redirect_uri=${encodeURIComponent(redirectUri)}`
   );

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -89,6 +89,7 @@ import {
 // avoids the MV3 popup teardown race where closing the popup mid-auth kills
 // the awaited promise before the token is persisted.
 const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
+const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 const DEFAULT_RELAY_PORT = 7830;
@@ -768,6 +769,7 @@ async function cloudReconnectHook(
   const refreshed = selectedId
     ? await refreshCloudToken(selectedId, {
         gatewayBaseUrl,
+        webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       })
     : null;
@@ -1039,6 +1041,7 @@ async function connectPreflight(
       const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
       const refreshed = await refreshCloudToken(assistantId, {
         gatewayBaseUrl,
+        webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
@@ -1058,6 +1061,7 @@ async function connectPreflight(
     const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
     const stored = await signInCloud(assistantId, {
       gatewayBaseUrl,
+      webBaseUrl: CLOUD_WEB_BASE_URL,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
     const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
@@ -1288,6 +1292,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         const config: CloudAuthConfig = {
           gatewayBaseUrl:
             typeof message.gatewayBaseUrl === 'string' ? message.gatewayBaseUrl : gatewayBaseUrl,
+          webBaseUrl: CLOUD_WEB_BASE_URL,
           clientId:
             typeof message.clientId === 'string' ? message.clientId : CLOUD_OAUTH_CLIENT_ID,
         };


### PR DESCRIPTION
## Summary
- Add `webBaseUrl` field to `CloudAuthConfig` and `CLOUD_WEB_BASE_URL` constant (`https://www.vellum.ai`) to separate the browser-facing OAuth page URL from the API gateway URL
- Update `buildAuthUrl()` to use `webBaseUrl` instead of `gatewayBaseUrl` — fixes "Authorization page could not be loaded" error during cloud login
- Same class of bug as the macOS login fix in PR #26328: the OAuth start page lives on the web app, not the API gateway

## Release YAMLs
No changes needed — the Chrome extension hard-codes URL constants (same pattern as `CLOUD_GATEWAY_BASE_URL`), and is only built for production in `release.yml`. No URL env vars are injected at build time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
