### PR TITLE
refactor(chrome-ext): remove dead gatewayBaseUrl from CloudAuthConfig

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -78,7 +78,6 @@ afterEach(() => {
 });
 
 const config: CloudAuthConfig = {
-  gatewayBaseUrl: 'https://api.vellum.ai',
   webBaseUrl: 'https://www.vellum.ai',
   clientId: 'test-client-id',
 };
@@ -149,7 +148,7 @@ describe('signInCloud', () => {
       seenUrl = details.url;
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
     };
-    await signInCloud(ASSISTANT_A, { gatewayBaseUrl: 'https://api.vellum.ai/', webBaseUrl: 'https://www.vellum.ai/', clientId: 'cid' });
+    await signInCloud(ASSISTANT_A, { webBaseUrl: 'https://www.vellum.ai/', clientId: 'cid' });
     expect(seenUrl).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
     expect(seenUrl).not.toContain('www.vellum.ai//oauth');
   });

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -69,8 +69,8 @@ function missingTokenMessage(profile: AssistantAuthProfile | null): string {
  */
 interface PreflightDeps {
   bootstrapLocalToken: (assistantId: string | null) => Promise<StoredLocalToken>;
-  signInCloud: (assistantId: string, config: { gatewayBaseUrl: string; webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
-  refreshCloudToken: (assistantId: string, config: { gatewayBaseUrl: string; webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
+  signInCloud: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
+  refreshCloudToken: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
   getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
   getRelayPort: () => Promise<number>;
 }
@@ -123,9 +123,7 @@ async function connectPreflight(
     }
 
     if (!options.interactive) {
-      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
       const refreshed = await deps.refreshCloudToken(assistantId, {
-        gatewayBaseUrl,
         webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
@@ -142,9 +140,7 @@ async function connectPreflight(
       throw new MissingTokenError(missingTokenMessage('cloud-oauth'));
     }
 
-    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
     const stored = await deps.signInCloud(assistantId, {
-      gatewayBaseUrl,
       webBaseUrl: CLOUD_WEB_BASE_URL,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
@@ -340,10 +336,10 @@ describe('connectPreflight — cloud-oauth topology', () => {
       token: null,
     };
     const signedIn = makeStoredCloudToken({ token: 'fresh-cloud-jwt' });
-    let signInCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    let signInCalledWith: { assistantId: string } | null = null;
     const deps = makeDeps({
-      signInCloud: async (id, config) => {
-        signInCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+      signInCloud: async (id, _config) => {
+        signInCalledWith = { assistantId: id };
         return signedIn;
       },
     });
@@ -358,7 +354,6 @@ describe('connectPreflight — cloud-oauth topology', () => {
 
     expect(signInCalledWith).not.toBeNull();
     expect(signInCalledWith!.assistantId).toBe('cloud-1');
-    expect(signInCalledWith!.gatewayBaseUrl).toBe('https://rt.vellum.cloud');
     expect(result.kind).toBe('cloud');
     expect(result.token).toBe('fresh-cloud-jwt');
     expect(result.baseUrl).toBe('https://rt.vellum.cloud');
@@ -402,10 +397,10 @@ describe('connectPreflight — cloud-oauth topology', () => {
       token: null,
     };
     const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
-    let refreshCalledWith: { assistantId: string; gatewayBaseUrl: string } | null = null;
+    let refreshCalledWith: { assistantId: string } | null = null;
     const deps = makeDeps({
-      refreshCloudToken: async (id, config) => {
-        refreshCalledWith = { assistantId: id, gatewayBaseUrl: config.gatewayBaseUrl };
+      refreshCloudToken: async (id, _config) => {
+        refreshCalledWith = { assistantId: id };
         return refreshed;
       },
     });
@@ -528,7 +523,7 @@ describe('connectPreflight — cloud-oauth topology', () => {
     expect(result.token).toBe('existing-jwt');
   });
 
-  test('non-interactive: uses runtimeUrl from assistant for refresh', async () => {
+  test('non-interactive: relay baseUrl uses runtimeUrl from assistant', async () => {
     const assistant = makeCloudAssistant({
       runtimeUrl: 'https://custom-gateway.vellum.cloud',
     });
@@ -538,12 +533,8 @@ describe('connectPreflight — cloud-oauth topology', () => {
       token: null,
     };
     const refreshed = makeStoredCloudToken({ token: 'refreshed-jwt' });
-    let refreshCalledWith: { gatewayBaseUrl: string } | null = null;
     const deps = makeDeps({
-      refreshCloudToken: async (_id, config) => {
-        refreshCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
-        return refreshed;
-      },
+      refreshCloudToken: async () => refreshed,
     });
 
     const result = await connectPreflight(
@@ -554,7 +545,6 @@ describe('connectPreflight — cloud-oauth topology', () => {
       deps,
     );
 
-    expect(refreshCalledWith!.gatewayBaseUrl).toBe('https://custom-gateway.vellum.cloud');
     expect(result.baseUrl).toBe('https://custom-gateway.vellum.cloud');
   });
 });
@@ -631,7 +621,7 @@ describe('connectPreflight — edge cases', () => {
     }
   });
 
-  test('cloud interactive falls back to default gateway when no runtimeUrl', async () => {
+  test('cloud interactive falls back to default gateway for relay baseUrl when no runtimeUrl', async () => {
     const assistant = makeCloudAssistant({ runtimeUrl: '' });
     const mode: RelayMode = {
       kind: 'cloud',
@@ -639,12 +629,8 @@ describe('connectPreflight — edge cases', () => {
       token: null,
     };
     const signedIn = makeStoredCloudToken({ token: 'fallback-jwt' });
-    let signInCalledWith: { gatewayBaseUrl: string } | null = null;
     const deps = makeDeps({
-      signInCloud: async (_id, config) => {
-        signInCalledWith = { gatewayBaseUrl: config.gatewayBaseUrl };
-        return signedIn;
-      },
+      signInCloud: async () => signedIn,
     });
 
     const result = await connectPreflight(
@@ -655,7 +641,6 @@ describe('connectPreflight — edge cases', () => {
       deps,
     );
 
-    expect(signInCalledWith!.gatewayBaseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
     expect(result.baseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
     expect(result.token).toBe('fallback-jwt');
   });

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -6,14 +6,11 @@
  * is used to authenticate the browser-relay WebSocket against the cloud
  * gateway.
  *
- * Two base URLs are involved:
- * - `webBaseUrl` — the Next.js web app that serves the browser-facing
- *   OAuth start page (`/oauth/chrome-extension/start`). Always
- *   `https://www.vellum.ai` in production.
- * - `gatewayBaseUrl` — the API gateway / runtime that hosts the
- *   WebSocket relay. Resolved per-assistant: cloud-managed assistants
- *   carry a `runtimeUrl` in their lockfile entry, falling back to
- *   `https://api.vellum.ai`.
+ * The `CloudAuthConfig.webBaseUrl` field points to the Next.js web app
+ * that serves the browser-facing OAuth start page
+ * (`/oauth/chrome-extension/start`). Always `https://www.vellum.ai` in
+ * production. The gateway / relay URL is managed separately by the
+ * caller (worker.ts) and is not part of the auth config.
  *
  * Also exposes {@link refreshCloudToken}, the non-interactive refresh helper
  * used by the relay reconnect path when the stored token has expired or the
@@ -29,8 +26,6 @@
  */
 
 export interface CloudAuthConfig {
-  /** Gateway base URL, e.g. https://api.vellum.ai */
-  gatewayBaseUrl: string;
   /** Web app base URL for browser-facing pages, e.g. https://www.vellum.ai */
   webBaseUrl: string;
   /** OAuth client id registered for the chrome extension. */

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -695,29 +695,6 @@ function resetCloudRefreshAttempts(): void {
 }
 
 /**
- * Resolve the gateway base URL for the cloud reconnect hook. When a
- * selected assistant has a runtime URL, use it as the OAuth/gateway
- * base. Otherwise fall back to the default cloud gateway.
- */
-async function resolveCloudGatewayBase(): Promise<string> {
-  const selectedId = await loadSelectedAssistantId();
-  if (!selectedId) return CLOUD_GATEWAY_BASE_URL;
-
-  // Re-resolve the assistant catalog to get the runtime URL. This is
-  // cheap (native messaging round-trip) and ensures we get the latest
-  // lockfile state.
-  try {
-    const catalog = await listAssistants();
-    const match = catalog.assistants.find((a) => a.assistantId === selectedId);
-    if (match?.runtimeUrl) return match.runtimeUrl;
-  } catch {
-    // Fall back to the default gateway if the native host is
-    // unreachable during a reconnect attempt.
-  }
-  return CLOUD_GATEWAY_BASE_URL;
-}
-
-/**
  * Reconnect hook for cloud mode. Called by {@link RelayConnection} when
  * the WebSocket closes unexpectedly — responsible for deciding whether
  * to reuse the existing token, swap in a freshly refreshed one, or
@@ -758,17 +735,12 @@ async function cloudReconnectHook(
 
   // action.kind === 'refresh'
   cloudRefreshAttempts += 1;
-  // Resolve the gateway base URL from the selected assistant's runtime
-  // URL when available. This ensures refresh requests go to the correct
-  // gateway for the assistant's topology.
-  const gatewayBaseUrl = await resolveCloudGatewayBase();
   // refreshCloudToken requires an assistantId to persist the refreshed
   // token under the correct scoped key. When no assistant is selected
   // we can't scope the refresh, so we skip it — the user will be
   // prompted to sign in again (abort path on the next reconnect).
   const refreshed = selectedId
     ? await refreshCloudToken(selectedId, {
-        gatewayBaseUrl,
         webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       })
@@ -1038,9 +1010,7 @@ async function connectPreflight(
 
     if (!options.interactive) {
       // Non-interactive: attempt a silent refresh first.
-      const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
       const refreshed = await refreshCloudToken(assistantId, {
-        gatewayBaseUrl,
         webBaseUrl: CLOUD_WEB_BASE_URL,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
@@ -1058,9 +1028,7 @@ async function connectPreflight(
     }
 
     // Interactive: launch the full OAuth sign-in flow.
-    const gatewayBaseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
     const stored = await signInCloud(assistantId, {
-      gatewayBaseUrl,
       webBaseUrl: CLOUD_WEB_BASE_URL,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
@@ -1276,22 +1244,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         if (!resolvedId) {
           throw new Error('No assistant selected. Fetch the assistant catalog first.');
         }
-        // Resolve the gateway base URL from the assistant's runtime URL
-        // when available. This scopes the OAuth flow to the correct
-        // gateway for cloud-managed assistants.
-        let gatewayBaseUrl = CLOUD_GATEWAY_BASE_URL;
-        try {
-          const catalog = await listAssistants();
-          const match = catalog.assistants.find((a) => a.assistantId === resolvedId);
-          if (match?.runtimeUrl) {
-            gatewayBaseUrl = match.runtimeUrl;
-          }
-        } catch {
-          // Fall back to default gateway if native host unreachable.
-        }
         const config: CloudAuthConfig = {
-          gatewayBaseUrl:
-            typeof message.gatewayBaseUrl === 'string' ? message.gatewayBaseUrl : gatewayBaseUrl,
           webBaseUrl: CLOUD_WEB_BASE_URL,
           clientId:
             typeof message.clientId === 'string' ? message.clientId : CLOUD_OAUTH_CLIENT_ID,


### PR DESCRIPTION
## Summary
- Remove `gatewayBaseUrl` from `CloudAuthConfig` — nothing in the auth module reads it after PR #26331 switched `buildAuthUrl()` to use `webBaseUrl`
- Remove the now-unused `resolveCloudGatewayBase()` helper and dead gateway URL resolution in the popup sign-in handler
- Simplify test assertions that were capturing/verifying the removed field

## Original prompt
Remove `gatewayBaseUrl` from `CloudAuthConfig` in `clients/chrome-extension/background/cloud-auth.ts` since nothing in the auth module reads it after PR #26331. The callers already have the value in local variables for relay URL resolution. Update all call sites in `worker.ts` and test files to stop passing `gatewayBaseUrl` in the config object. Update the `PreflightDeps` type signatures in `worker-connect-preflight.test.ts` accordingly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
