### PR TITLE
feat(skills): add in-memory skill cache store with TTL and LRU eviction

### DIFF
--- a/assistant/src/__tests__/skill-cache-store.test.ts
+++ b/assistant/src/__tests__/skill-cache-store.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _internals,
+  clearCacheForTests,
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../skills/skill-cache-store.js";
+
+afterEach(() => {
+  clearCacheForTests();
+});
+
+describe("setCacheEntry", () => {
+  test("auto-generated key is a 16-char lowercase hex string", () => {
+    const { key } = setCacheEntry("hello");
+    expect(key).toHaveLength(16);
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("each auto-generated key is unique", () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      keys.add(setCacheEntry(i).key);
+    }
+    expect(keys.size).toBe(20);
+  });
+
+  test("explicit key stores and retrieves correctly", () => {
+    setCacheEntry({ foo: "bar" }, { key: "my-key" });
+    const result = getCacheEntry("my-key");
+    expect(result).toEqual({ data: { foo: "bar" } });
+  });
+
+  test("explicit key upsert overwrites existing value", () => {
+    setCacheEntry("v1", { key: "same" });
+    setCacheEntry("v2", { key: "same" });
+    const result = getCacheEntry("same");
+    expect(result).toEqual({ data: "v2" });
+    // Only one entry in the store for this key.
+    let count = 0;
+    for (const k of _internals.store.keys()) {
+      if (k === "same") count++;
+    }
+    expect(count).toBe(1);
+  });
+
+  test("upsert refreshes insertion order (LRU position)", () => {
+    setCacheEntry("a", { key: "first" });
+    setCacheEntry("b", { key: "second" });
+    // Upsert 'first' — it should move to the end.
+    setCacheEntry("a-updated", { key: "first" });
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["second", "first"]);
+  });
+
+  test("upsert resets expiry timestamp", () => {
+    setCacheEntry("v1", { key: "k", ttlMs: 1000 });
+    const expiryBefore = _internals.store.get("k")!.expiresAt;
+
+    // Small delay to ensure Date.now() advances.
+    const start = Date.now();
+    while (Date.now() === start) {
+      /* busy-wait for at least 1ms */
+    }
+
+    setCacheEntry("v2", { key: "k", ttlMs: 5000 });
+    const expiryAfter = _internals.store.get("k")!.expiresAt;
+    expect(expiryAfter).toBeGreaterThan(expiryBefore);
+  });
+});
+
+describe("getCacheEntry", () => {
+  test("returns data for a valid key", () => {
+    const { key } = setCacheEntry(42);
+    expect(getCacheEntry(key)).toEqual({ data: 42 });
+  });
+
+  test("returns null for an unknown key", () => {
+    expect(getCacheEntry("nonexistent")).toBeNull();
+  });
+
+  test("refreshes LRU position on access", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    setCacheEntry("c", { key: "k3" });
+
+    // Access k1 — should move to the end.
+    getCacheEntry("k1");
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["k2", "k3", "k1"]);
+  });
+});
+
+describe("TTL expiry (lazy eviction)", () => {
+  test("expired entry returns null and is removed from the store", () => {
+    setCacheEntry("ephemeral", { key: "ttl-test", ttlMs: 1 });
+
+    // Wait for the TTL to elapse.
+    const deadline = Date.now() + 2;
+    while (Date.now() < deadline) {
+      /* busy-wait */
+    }
+
+    expect(getCacheEntry("ttl-test")).toBeNull();
+    expect(_internals.store.has("ttl-test")).toBe(false);
+  });
+
+  test("non-expired entry is still accessible", () => {
+    setCacheEntry("durable", { key: "long-lived", ttlMs: 60_000 });
+    expect(getCacheEntry("long-lived")).toEqual({ data: "durable" });
+  });
+
+  test("default TTL is 30 minutes", () => {
+    expect(_internals.DEFAULT_TTL_MS).toBe(30 * 60_000);
+  });
+});
+
+describe("LRU eviction at capacity", () => {
+  test("evicts oldest entry when at max capacity", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES; // 64
+
+    // Fill the store to capacity.
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+    expect(_internals.store.size).toBe(maxEntries);
+
+    // One more insert should evict the oldest (entry-0).
+    setCacheEntry("overflow", { key: "new-entry" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toBeNull();
+    expect(getCacheEntry("new-entry")).toEqual({ data: "overflow" });
+  });
+
+  test("default max entries is 64", () => {
+    expect(_internals.DEFAULT_MAX_ENTRIES).toBe(64);
+  });
+
+  test("upsert at capacity does not evict (key already exists)", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES;
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+
+    // Upsert an existing key — should not evict anything.
+    setCacheEntry("updated", { key: "entry-0" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toEqual({ data: "updated" });
+    expect(getCacheEntry("entry-1")).toEqual({ data: 1 });
+  });
+});
+
+describe("deleteCacheEntry", () => {
+  test("returns true when deleting an existing key", () => {
+    setCacheEntry("x", { key: "del" });
+    expect(deleteCacheEntry("del")).toBe(true);
+    expect(getCacheEntry("del")).toBeNull();
+  });
+
+  test("returns false for an unknown key (idempotent)", () => {
+    expect(deleteCacheEntry("ghost")).toBe(false);
+  });
+
+  test("double delete is idempotent", () => {
+    setCacheEntry("x", { key: "once" });
+    expect(deleteCacheEntry("once")).toBe(true);
+    expect(deleteCacheEntry("once")).toBe(false);
+  });
+});
+
+describe("clearCacheForTests", () => {
+  test("empties the entire store", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    clearCacheForTests();
+    expect(_internals.store.size).toBe(0);
+  });
+});

--- a/assistant/src/skills/skill-cache-store.ts
+++ b/assistant/src/skills/skill-cache-store.ts
@@ -1,0 +1,97 @@
+import { randomBytes } from "crypto";
+
+/** Default time-to-live for cache entries: 30 minutes. */
+const DEFAULT_TTL_MS = 30 * 60_000;
+
+/** Default maximum number of entries before LRU eviction kicks in. */
+const DEFAULT_MAX_ENTRIES = 64;
+
+interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+/**
+ * Daemon-process singleton in-memory cache with TTL and LRU eviction.
+ *
+ * - Keys are auto-generated 16-char hex strings unless an explicit key is provided.
+ * - TTL defaults to 30 minutes; per-entry override via `ttlMs`.
+ * - Uses Map insertion order for LRU; `get` refreshes position.
+ * - At capacity, the oldest entry is evicted before a new insert.
+ * - Expired entries are lazily evicted on `get`.
+ */
+const _store = new Map<string, CacheEntry>();
+
+/**
+ * Store a value in the cache.
+ *
+ * If `options.key` is provided, the entry is upserted at that key
+ * (refreshing insertion order and resetting expiry).
+ * Otherwise a random 16-char hex key is generated.
+ */
+export function setCacheEntry(
+  data: unknown,
+  options?: { key?: string; ttlMs?: number },
+): { key: string } {
+  const key = options?.key ?? randomBytes(8).toString("hex");
+  const ttl = options?.ttlMs ?? DEFAULT_TTL_MS;
+
+  // Upsert: delete first so the re-insert moves to the end of the Map
+  // (refreshes LRU position).
+  if (_store.has(key)) {
+    _store.delete(key);
+  }
+
+  // LRU eviction: if at capacity after removing a potential existing key,
+  // drop the oldest entry (first key in Map iteration order).
+  if (_store.size >= DEFAULT_MAX_ENTRIES) {
+    const oldest = _store.keys().next().value;
+    if (oldest !== undefined) _store.delete(oldest);
+  }
+
+  _store.set(key, { data, expiresAt: Date.now() + ttl });
+  return { key };
+}
+
+/**
+ * Retrieve a value from the cache.
+ *
+ * Returns `null` if the key does not exist or the entry has expired.
+ * On a hit, the entry is moved to the end of the Map (LRU refresh).
+ */
+export function getCacheEntry(key: string): { data: unknown } | null {
+  const entry = _store.get(key);
+  if (!entry) return null;
+
+  // Lazy TTL eviction.
+  if (Date.now() >= entry.expiresAt) {
+    _store.delete(key);
+    return null;
+  }
+
+  // LRU refresh: delete + re-set moves the entry to the tail.
+  _store.delete(key);
+  _store.set(key, entry);
+
+  return { data: entry.data };
+}
+
+/**
+ * Remove a cache entry by key. Returns `true` if an entry was deleted,
+ * `false` if the key was not present (idempotent).
+ */
+export function deleteCacheEntry(key: string): boolean {
+  return _store.delete(key);
+}
+
+/** Clear all entries — exposed for test isolation only. */
+export function clearCacheForTests(): void {
+  _store.clear();
+}
+
+/** Visible-for-testing internals. */
+export const _internals = {
+  store: _store,
+  DEFAULT_TTL_MS,
+  DEFAULT_MAX_ENTRIES,
+};


### PR DESCRIPTION
## Summary
- Add daemon-process singleton cache store with set/get/delete API
- Support TTL (default 30min) with lazy eviction and LRU (max 64 entries)
- Include comprehensive unit tests for all cache behaviors

Part of plan: skill-scoped-cache.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
