### PR TITLE
feat(ipc): add cache set/get/delete CLI IPC methods

### DIFF
--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration tests for the cache IPC routes.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with the real in-memory cache store backing
+ * the route handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearCacheForTests } from "../../skills/skill-cache-store.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+
+beforeEach(async () => {
+  clearCacheForTests();
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  clearCacheForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cache IPC routes", () => {
+  // ── Set / Get round-trip ──────────────────────────────────────────
+
+  test("set then get returns stored data", async () => {
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: { greeting: "hello" },
+    });
+
+    expect(setResult.ok).toBe(true);
+    expect(setResult.result).toBeDefined();
+    const key = setResult.result!.key;
+    expect(typeof key).toBe("string");
+    expect(key.length).toBeGreaterThan(0);
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key,
+    });
+
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: { greeting: "hello" } });
+  });
+
+  // ── Explicit key upsert ───────────────────────────────────────────
+
+  test("set with explicit key upserts on second call", async () => {
+    const set1 = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "first",
+      key: "my-key",
+    });
+    expect(set1.ok).toBe(true);
+    expect(set1.result!.key).toBe("my-key");
+
+    const set2 = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "second",
+      key: "my-key",
+    });
+    expect(set2.ok).toBe(true);
+    expect(set2.result!.key).toBe("my-key");
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "my-key",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: "second" });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────
+
+  test("delete returns empty object and makes later get return null", async () => {
+    // Store an entry first.
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: 42,
+      key: "to-delete",
+    });
+    expect(setResult.ok).toBe(true);
+
+    // Delete it.
+    const delResult = await cliIpcCall<object>("cache/delete", {
+      key: "to-delete",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({});
+
+    // Get should now return null.
+    const getResult = await cliIpcCall<null>("cache/get", {
+      key: "to-delete",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Get for non-existent key returns null ─────────────────────────
+
+  test("get for non-existent key returns null", async () => {
+    const getResult = await cliIpcCall<null>("cache/get", {
+      key: "does-not-exist",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Validation errors ─────────────────────────────────────────────
+
+  test("cache/set rejects empty key", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      key: "",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects non-positive ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: 0,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects negative ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: -100,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects non-integer ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: 1.5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/get rejects empty key", async () => {
+    const result = await cliIpcCall("cache/get", { key: "" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/get rejects missing key", async () => {
+    const result = await cliIpcCall("cache/get", {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/delete rejects empty key", async () => {
+    const result = await cliIpcCall("cache/delete", { key: "" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // ── Method aliases ────────────────────────────────────────────────
+
+  test("cache_set alias works identically to cache/set", async () => {
+    const setResult = await cliIpcCall<{ key: string }>("cache_set", {
+      data: { alias: true },
+      key: "alias-test",
+    });
+    expect(setResult.ok).toBe(true);
+    expect(setResult.result!.key).toBe("alias-test");
+
+    // Retrieve via the canonical method to confirm storage.
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "alias-test",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: { alias: true } });
+  });
+
+  test("cache_get alias works identically to cache/get", async () => {
+    await cliIpcCall("cache/set", { data: "via-canonical", key: "cg-alias" });
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache_get", {
+      key: "cg-alias",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: "via-canonical" });
+  });
+
+  test("cache_delete alias works identically to cache/delete", async () => {
+    await cliIpcCall("cache/set", { data: "to-remove", key: "cd-alias" });
+
+    const delResult = await cliIpcCall<object>("cache_delete", {
+      key: "cd-alias",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({});
+
+    const getResult = await cliIpcCall<null>("cache/get", { key: "cd-alias" });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Structured payloads ───────────────────────────────────────────
+
+  test("supports nested structured data payloads", async () => {
+    const payload = {
+      results: [
+        { id: 1, name: "a", tags: ["x", "y"] },
+        { id: 2, name: "b", tags: [] },
+      ],
+      meta: { total: 2, page: 1 },
+    };
+
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: payload,
+      key: "structured",
+    });
+    expect(setResult.ok).toBe(true);
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "structured",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: payload });
+  });
+
+  // ── TTL parameter accepted ────────────────────────────────────────
+
+  test("set with valid ttl_ms succeeds", async () => {
+    const result = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "ephemeral",
+      ttl_ms: 5000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.result!.key).toBeDefined();
+  });
+});

--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -1,0 +1,92 @@
+/**
+ * IPC routes for the daemon-memory cache.
+ *
+ * Exposes set/get/delete operations so CLI commands and external processes
+ * can interact with the shared in-memory cache store.
+ *
+ * Each operation is registered under both a slash-style method name
+ * (e.g. `cache/set`) and an underscore alias (`cache_set`) for ergonomics.
+ */
+
+import { z } from "zod";
+
+import {
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../../skills/skill-cache-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ── Param schemas ─────────────────────────────────────────────────────
+
+const CacheSetParams = z.object({
+  data: z.unknown(),
+  key: z.string().min(1).optional(),
+  ttl_ms: z.number().int().positive().optional(),
+});
+
+const CacheKeyParams = z.object({
+  key: z.string().min(1),
+});
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+function handleCacheSet(params?: Record<string, unknown>): { key: string } {
+  const { data, key, ttl_ms } = CacheSetParams.parse(params);
+  return setCacheEntry(data, { key, ttlMs: ttl_ms });
+}
+
+function handleCacheGet(
+  params?: Record<string, unknown>,
+): { data: unknown } | null {
+  const { key } = CacheKeyParams.parse(params);
+  return getCacheEntry(key);
+}
+
+function handleCacheDelete(params?: Record<string, unknown>): object {
+  const { key } = CacheKeyParams.parse(params);
+  deleteCacheEntry(key);
+  return {};
+}
+
+// ── Route definitions ─────────────────────────────────────────────────
+
+export const cacheSetRoute: IpcRoute = {
+  method: "cache/set",
+  handler: handleCacheSet,
+};
+
+export const cacheSetAliasRoute: IpcRoute = {
+  method: "cache_set",
+  handler: handleCacheSet,
+};
+
+export const cacheGetRoute: IpcRoute = {
+  method: "cache/get",
+  handler: handleCacheGet,
+};
+
+export const cacheGetAliasRoute: IpcRoute = {
+  method: "cache_get",
+  handler: handleCacheGet,
+};
+
+export const cacheDeleteRoute: IpcRoute = {
+  method: "cache/delete",
+  handler: handleCacheDelete,
+};
+
+export const cacheDeleteAliasRoute: IpcRoute = {
+  method: "cache_delete",
+  handler: handleCacheDelete,
+};
+
+/** All cache IPC routes (canonical + aliases). */
+export const cacheRoutes: IpcRoute[] = [
+  cacheSetRoute,
+  cacheSetAliasRoute,
+  cacheGetRoute,
+  cacheGetAliasRoute,
+  cacheDeleteRoute,
+  cacheDeleteAliasRoute,
+];

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,9 +1,11 @@
 import type { IpcRoute } from "../cli-server.js";
 import { browserExecuteRoute } from "./browser.js";
+import { cacheRoutes } from "./cache.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
   browserExecuteRoute,
   wakeConversationRoute,
+  ...cacheRoutes,
 ];


### PR DESCRIPTION
## Summary
- Add cache/set, cache/get, cache/delete IPC routes with Zod validation
- Support method aliases (cache_set, cache_get, cache_delete)
- Include integration tests covering round-trip, upsert, delete, validation errors, and aliases

Part of plan: skill-scoped-cache.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
