### PR TITLE
refactor(gmail/outlook): back scan-result-store with shared skill cache

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _internals,
+  clearScanStore,
+  getSenderMessageIds,
+  getSenderMetadata,
+  storeScanResult,
+} from "../config/bundled-skills/gmail/tools/scan-result-store.js";
+import { clearCacheForTests } from "../skills/skill-cache-store.js";
+
+afterEach(() => {
+  clearScanStore();
+  clearCacheForTests();
+});
+
+describe("storeScanResult / getSenderMessageIds round-trip", () => {
+  test("stores senders and retrieves flattened message IDs", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1", "m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+      {
+        id: "sender-b",
+        messageIds: ["m3"],
+        newestMessageId: "m3",
+        newestUnsubscribableMessageId: "m3",
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["sender-a", "sender-b"]);
+    expect(ids).not.toBeNull();
+    expect(ids).toContain("m1");
+    expect(ids).toContain("m2");
+    expect(ids).toContain("m3");
+    expect(ids).toHaveLength(3);
+  });
+
+  test("returns only requested senders' message IDs", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+      {
+        id: "sender-b",
+        messageIds: ["m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["sender-a"]);
+    expect(ids).toEqual(["m1"]);
+  });
+
+  test("returns empty array when sender IDs do not match", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["nonexistent"]);
+    expect(ids).toEqual([]);
+  });
+});
+
+describe("missing scan ID returns null", () => {
+  test("getSenderMessageIds returns null for unknown scan ID", () => {
+    expect(getSenderMessageIds("no-such-scan", ["s1"])).toBeNull();
+  });
+
+  test("getSenderMetadata returns null for unknown scan ID", () => {
+    expect(getSenderMetadata("no-such-scan", "s1")).toBeNull();
+  });
+});
+
+describe("getSenderMetadata", () => {
+  test("returns metadata for a known sender", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-x",
+        messageIds: ["m1", "m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: "m1",
+      },
+    ]);
+
+    const meta = getSenderMetadata(scanId, "sender-x");
+    expect(meta).toEqual({
+      newestMessageId: "m2",
+      newestUnsubscribableMessageId: "m1",
+    });
+  });
+
+  test("returns null for unknown sender within a valid scan", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-x",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    expect(getSenderMetadata(scanId, "sender-unknown")).toBeNull();
+  });
+
+  test("returns null newestUnsubscribableMessageId when not present", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-y",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const meta = getSenderMetadata(scanId, "sender-y");
+    expect(meta).toEqual({
+      newestMessageId: "m1",
+      newestUnsubscribableMessageId: null,
+    });
+  });
+});
+
+describe("clearScanStore", () => {
+  test("clears all tracked scan entries from the shared cache", () => {
+    const scanId1 = storeScanResult([
+      {
+        id: "s1",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+    const scanId2 = storeScanResult([
+      {
+        id: "s2",
+        messageIds: ["m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    // Sanity: both are retrievable
+    expect(getSenderMessageIds(scanId1, ["s1"])).not.toBeNull();
+    expect(getSenderMessageIds(scanId2, ["s2"])).not.toBeNull();
+
+    clearScanStore();
+
+    // After clear, both should be gone
+    expect(getSenderMessageIds(scanId1, ["s1"])).toBeNull();
+    expect(getSenderMessageIds(scanId2, ["s2"])).toBeNull();
+  });
+
+  test("clears tracked scan IDs set", () => {
+    storeScanResult([
+      {
+        id: "s1",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    expect(_internals.trackedScanIds.size).toBe(1);
+    clearScanStore();
+    expect(_internals.trackedScanIds.size).toBe(0);
+  });
+});
+
+describe("_internals", () => {
+  test("TTL_MS is 30 minutes", () => {
+    expect(_internals.TTL_MS).toBe(30 * 60_000);
+  });
+});

--- a/assistant/src/__tests__/skill-cache-store.test.ts
+++ b/assistant/src/__tests__/skill-cache-store.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _internals,
+  clearCacheForTests,
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../skills/skill-cache-store.js";
+
+afterEach(() => {
+  clearCacheForTests();
+});
+
+describe("setCacheEntry", () => {
+  test("auto-generated key is a 16-char lowercase hex string", () => {
+    const { key } = setCacheEntry("hello");
+    expect(key).toHaveLength(16);
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("each auto-generated key is unique", () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      keys.add(setCacheEntry(i).key);
+    }
+    expect(keys.size).toBe(20);
+  });
+
+  test("explicit key stores and retrieves correctly", () => {
+    setCacheEntry({ foo: "bar" }, { key: "my-key" });
+    const result = getCacheEntry("my-key");
+    expect(result).toEqual({ data: { foo: "bar" } });
+  });
+
+  test("explicit key upsert overwrites existing value", () => {
+    setCacheEntry("v1", { key: "same" });
+    setCacheEntry("v2", { key: "same" });
+    const result = getCacheEntry("same");
+    expect(result).toEqual({ data: "v2" });
+    // Only one entry in the store for this key.
+    let count = 0;
+    for (const k of _internals.store.keys()) {
+      if (k === "same") count++;
+    }
+    expect(count).toBe(1);
+  });
+
+  test("upsert refreshes insertion order (LRU position)", () => {
+    setCacheEntry("a", { key: "first" });
+    setCacheEntry("b", { key: "second" });
+    // Upsert 'first' — it should move to the end.
+    setCacheEntry("a-updated", { key: "first" });
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["second", "first"]);
+  });
+
+  test("upsert resets expiry timestamp", () => {
+    setCacheEntry("v1", { key: "k", ttlMs: 1000 });
+    const expiryBefore = _internals.store.get("k")!.expiresAt;
+
+    // Small delay to ensure Date.now() advances.
+    const start = Date.now();
+    while (Date.now() === start) {
+      /* busy-wait for at least 1ms */
+    }
+
+    setCacheEntry("v2", { key: "k", ttlMs: 5000 });
+    const expiryAfter = _internals.store.get("k")!.expiresAt;
+    expect(expiryAfter).toBeGreaterThan(expiryBefore);
+  });
+});
+
+describe("getCacheEntry", () => {
+  test("returns data for a valid key", () => {
+    const { key } = setCacheEntry(42);
+    expect(getCacheEntry(key)).toEqual({ data: 42 });
+  });
+
+  test("returns null for an unknown key", () => {
+    expect(getCacheEntry("nonexistent")).toBeNull();
+  });
+
+  test("refreshes LRU position on access", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    setCacheEntry("c", { key: "k3" });
+
+    // Access k1 — should move to the end.
+    getCacheEntry("k1");
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["k2", "k3", "k1"]);
+  });
+});
+
+describe("TTL expiry (lazy eviction)", () => {
+  test("expired entry returns null and is removed from the store", () => {
+    setCacheEntry("ephemeral", { key: "ttl-test", ttlMs: 1 });
+
+    // Wait for the TTL to elapse.
+    const deadline = Date.now() + 2;
+    while (Date.now() < deadline) {
+      /* busy-wait */
+    }
+
+    expect(getCacheEntry("ttl-test")).toBeNull();
+    expect(_internals.store.has("ttl-test")).toBe(false);
+  });
+
+  test("non-expired entry is still accessible", () => {
+    setCacheEntry("durable", { key: "long-lived", ttlMs: 60_000 });
+    expect(getCacheEntry("long-lived")).toEqual({ data: "durable" });
+  });
+
+  test("default TTL is 30 minutes", () => {
+    expect(_internals.DEFAULT_TTL_MS).toBe(30 * 60_000);
+  });
+});
+
+describe("LRU eviction at capacity", () => {
+  test("evicts oldest entry when at max capacity", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES; // 64
+
+    // Fill the store to capacity.
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+    expect(_internals.store.size).toBe(maxEntries);
+
+    // One more insert should evict the oldest (entry-0).
+    setCacheEntry("overflow", { key: "new-entry" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toBeNull();
+    expect(getCacheEntry("new-entry")).toEqual({ data: "overflow" });
+  });
+
+  test("default max entries is 64", () => {
+    expect(_internals.DEFAULT_MAX_ENTRIES).toBe(64);
+  });
+
+  test("upsert at capacity does not evict (key already exists)", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES;
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+
+    // Upsert an existing key — should not evict anything.
+    setCacheEntry("updated", { key: "entry-0" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toEqual({ data: "updated" });
+    expect(getCacheEntry("entry-1")).toEqual({ data: 1 });
+  });
+});
+
+describe("deleteCacheEntry", () => {
+  test("returns true when deleting an existing key", () => {
+    setCacheEntry("x", { key: "del" });
+    expect(deleteCacheEntry("del")).toBe(true);
+    expect(getCacheEntry("del")).toBeNull();
+  });
+
+  test("returns false for an unknown key (idempotent)", () => {
+    expect(deleteCacheEntry("ghost")).toBe(false);
+  });
+
+  test("double delete is idempotent", () => {
+    setCacheEntry("x", { key: "once" });
+    expect(deleteCacheEntry("once")).toBe(true);
+    expect(deleteCacheEntry("once")).toBe(false);
+  });
+});
+
+describe("clearCacheForTests", () => {
+  test("empties the entire store", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    clearCacheForTests();
+    expect(_internals.store.size).toBe(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -1,4 +1,8 @@
-import { randomBytes } from "crypto";
+import {
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../../../../skills/skill-cache-store.js";
 
 interface SenderData {
   messageIds: string[];
@@ -6,15 +10,21 @@ interface SenderData {
   newestUnsubscribableMessageId: string | null;
 }
 
-interface ScanEntry {
-  senders: Map<string, SenderData>;
-  createdAt: number;
+/**
+ * Serializable payload stored in the shared cache.
+ * Uses a plain object (not a Map) so it round-trips through the cache cleanly.
+ */
+interface ScanPayload {
+  senders: Record<string, SenderData>;
 }
 
-const MAX_ENTRIES = 16;
 const TTL_MS = 30 * 60_000; // 30 minutes
 
-const _store = new Map<string, ScanEntry>();
+/**
+ * Local bookkeeping of scan IDs produced by this module so
+ * `clearScanStore()` can delete them from the shared cache.
+ */
+const _trackedScanIds = new Set<string>();
 
 /** Store scan results and return a unique scan ID. */
 export function storeScanResult(
@@ -25,24 +35,18 @@ export function storeScanResult(
     newestUnsubscribableMessageId: string | null;
   }>,
 ): string {
-  const scanId = randomBytes(8).toString("hex");
-
-  // LRU eviction: remove oldest if at capacity
-  if (_store.size >= MAX_ENTRIES) {
-    const oldest = _store.keys().next().value;
-    if (oldest !== undefined) _store.delete(oldest);
-  }
-
-  const senderMap = new Map<string, SenderData>();
+  const sendersObj: Record<string, SenderData> = {};
   for (const s of senders) {
-    senderMap.set(s.id, {
+    sendersObj[s.id] = {
       messageIds: s.messageIds,
       newestMessageId: s.newestMessageId,
       newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
-    });
+    };
   }
 
-  _store.set(scanId, { senders: senderMap, createdAt: Date.now() });
+  const payload: ScanPayload = { senders: sendersObj };
+  const { key: scanId } = setCacheEntry(payload, { ttlMs: TTL_MS });
+  _trackedScanIds.add(scanId);
   return scanId;
 }
 
@@ -51,19 +55,13 @@ export function getSenderMessageIds(
   scanId: string,
   senderIds: string[],
 ): string[] | null {
-  const entry = _store.get(scanId);
-  if (!entry) return null;
-  if (Date.now() - entry.createdAt > TTL_MS) {
-    _store.delete(scanId);
-    return null;
-  }
-  // LRU: move to end
-  _store.delete(scanId);
-  _store.set(scanId, entry);
+  const result = getCacheEntry(scanId);
+  if (!result) return null;
 
+  const payload = result.data as ScanPayload;
   const ids: string[] = [];
   for (const sid of senderIds) {
-    const data = entry.senders.get(sid);
+    const data = payload.senders[sid];
     if (data) ids.push(...data.messageIds);
   }
   return ids;
@@ -77,13 +75,11 @@ export function getSenderMetadata(
   newestMessageId: string;
   newestUnsubscribableMessageId: string | null;
 } | null {
-  const entry = _store.get(scanId);
-  if (!entry) return null;
-  if (Date.now() - entry.createdAt > TTL_MS) {
-    _store.delete(scanId);
-    return null;
-  }
-  const data = entry.senders.get(senderId);
+  const result = getCacheEntry(scanId);
+  if (!result) return null;
+
+  const payload = result.data as ScanPayload;
+  const data = payload.senders[senderId];
   if (!data) return null;
   return {
     newestMessageId: data.newestMessageId,
@@ -93,8 +89,11 @@ export function getSenderMetadata(
 
 /** Clear the store (for tests). */
 export function clearScanStore(): void {
-  _store.clear();
+  for (const scanId of _trackedScanIds) {
+    deleteCacheEntry(scanId);
+  }
+  _trackedScanIds.clear();
 }
 
-/** Visible for testing: override TTL check by returning internal store reference. */
-export const _internals = { store: _store, TTL_MS };
+/** Visible for testing. */
+export const _internals = { TTL_MS, trackedScanIds: _trackedScanIds };

--- a/assistant/src/skills/skill-cache-store.ts
+++ b/assistant/src/skills/skill-cache-store.ts
@@ -1,0 +1,97 @@
+import { randomBytes } from "crypto";
+
+/** Default time-to-live for cache entries: 30 minutes. */
+const DEFAULT_TTL_MS = 30 * 60_000;
+
+/** Default maximum number of entries before LRU eviction kicks in. */
+const DEFAULT_MAX_ENTRIES = 64;
+
+interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+/**
+ * Daemon-process singleton in-memory cache with TTL and LRU eviction.
+ *
+ * - Keys are auto-generated 16-char hex strings unless an explicit key is provided.
+ * - TTL defaults to 30 minutes; per-entry override via `ttlMs`.
+ * - Uses Map insertion order for LRU; `get` refreshes position.
+ * - At capacity, the oldest entry is evicted before a new insert.
+ * - Expired entries are lazily evicted on `get`.
+ */
+const _store = new Map<string, CacheEntry>();
+
+/**
+ * Store a value in the cache.
+ *
+ * If `options.key` is provided, the entry is upserted at that key
+ * (refreshing insertion order and resetting expiry).
+ * Otherwise a random 16-char hex key is generated.
+ */
+export function setCacheEntry(
+  data: unknown,
+  options?: { key?: string; ttlMs?: number },
+): { key: string } {
+  const key = options?.key ?? randomBytes(8).toString("hex");
+  const ttl = options?.ttlMs ?? DEFAULT_TTL_MS;
+
+  // Upsert: delete first so the re-insert moves to the end of the Map
+  // (refreshes LRU position).
+  if (_store.has(key)) {
+    _store.delete(key);
+  }
+
+  // LRU eviction: if at capacity after removing a potential existing key,
+  // drop the oldest entry (first key in Map iteration order).
+  if (_store.size >= DEFAULT_MAX_ENTRIES) {
+    const oldest = _store.keys().next().value;
+    if (oldest !== undefined) _store.delete(oldest);
+  }
+
+  _store.set(key, { data, expiresAt: Date.now() + ttl });
+  return { key };
+}
+
+/**
+ * Retrieve a value from the cache.
+ *
+ * Returns `null` if the key does not exist or the entry has expired.
+ * On a hit, the entry is moved to the end of the Map (LRU refresh).
+ */
+export function getCacheEntry(key: string): { data: unknown } | null {
+  const entry = _store.get(key);
+  if (!entry) return null;
+
+  // Lazy TTL eviction.
+  if (Date.now() >= entry.expiresAt) {
+    _store.delete(key);
+    return null;
+  }
+
+  // LRU refresh: delete + re-set moves the entry to the tail.
+  _store.delete(key);
+  _store.set(key, entry);
+
+  return { data: entry.data };
+}
+
+/**
+ * Remove a cache entry by key. Returns `true` if an entry was deleted,
+ * `false` if the key was not present (idempotent).
+ */
+export function deleteCacheEntry(key: string): boolean {
+  return _store.delete(key);
+}
+
+/** Clear all entries — exposed for test isolation only. */
+export function clearCacheForTests(): void {
+  _store.clear();
+}
+
+/** Visible-for-testing internals. */
+export const _internals = {
+  store: _store,
+  DEFAULT_TTL_MS,
+  DEFAULT_MAX_ENTRIES,
+};


### PR DESCRIPTION
## Summary
- Replace local Map-based scan result store with shared skill cache primitive
- Preserve all existing exports and behavioral compatibility
- Add focused tests for scan-result-store round-trip, missing IDs, metadata retrieval, and cleanup

Part of plan: skill-scoped-cache.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
