### PR TITLE
feat(cli): add assistant cache set/get/delete commands

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Tests for the `assistant cache` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration (set, get, delete)
+ *   - `set` payload parsing from stdin + IPC param mapping
+ *   - TTL parsing edge cases (ms, s, m, h, invalid)
+ *   - >1 MB payload warning path
+ *   - `get` success, miss, and error output
+ *   - `delete` success and error output
+ *   - JSON output shape and exit-code behavior on IPC errors
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { key: "test-key" } };
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+/** Whether to simulate stdin as a TTY (no piped input). */
+let mockStdinIsTTY: boolean = false;
+
+/** Captured stderr output for warning assertions. */
+let stderrChunks: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      stderrChunks.push(args.map(String).join(" "));
+    },
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      stderrChunks.push(args.map(String).join(" "));
+    },
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerCacheCommand } = await import("../cache.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const localStderrChunks: string[] = [];
+
+  // Save and mock isTTY
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: mockStdinIsTTY ? true : undefined,
+    configurable: true,
+  });
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    localStderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerCacheCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: localStderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: { key: "test-key" } };
+  mockStdinContent = null;
+  mockStdinIsTTY = false;
+  stderrChunks = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers set, get, delete subcommands under cache", () => {
+    const program = new Command();
+    registerCacheCommand(program);
+    const cache = program.commands.find((c) => c.name() === "cache");
+    expect(cache).toBeDefined();
+    const subcommandNames = cache!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual(["delete", "get", "set"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — payload parsing + IPC params
+// ---------------------------------------------------------------------------
+
+describe("cache set", () => {
+  test("parses JSON from stdin and sends cache/set IPC", async () => {
+    mockStdinContent = '{"scores":[98,85,72]}';
+    mockIpcResult = { ok: true, result: { key: "generated-key" } };
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("cache/set");
+    expect(lastIpcCall!.params!.data).toEqual({ scores: [98, 85, 72] });
+    expect(lastIpcCall!.params!.ttl_ms).toBeUndefined();
+    expect(lastIpcCall!.params!.key).toBeUndefined();
+  });
+
+  test("passes --key to IPC params", async () => {
+    mockStdinContent = '"hello"';
+    mockIpcResult = { ok: true, result: { key: "my-key" } };
+
+    await runCommand(["cache", "set", "--key", "my-key"]);
+
+    expect(lastIpcCall!.params!.key).toBe("my-key");
+  });
+
+  test("passes --ttl as ttl_ms in IPC params", async () => {
+    mockStdinContent = "42";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "5m"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(300_000);
+  });
+
+  test("--json outputs JSON with ok:true and key on success", async () => {
+    mockStdinContent = '{"a":1}';
+    mockIpcResult = { ok: true, result: { key: "abc-123" } };
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, key: "abc-123" });
+  });
+
+  test("errors on empty stdin", async () => {
+    mockStdinContent = "   ";
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on invalid JSON", async () => {
+    mockStdinContent = "{not json}";
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on TTY stdin (no pipe)", async () => {
+    mockStdinIsTTY = true;
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on invalid JSON stdin", async () => {
+    mockStdinContent = "{bad}";
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON");
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockStdinContent = '"data"';
+    mockIpcResult = {
+      ok: false,
+      error: "Could not connect to assistant daemon. Is it running?",
+    };
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Could not connect");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — TTL parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe("TTL parsing", () => {
+  test("parses milliseconds", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "500ms"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(500);
+  });
+
+  test("parses seconds", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "30s"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(30_000);
+  });
+
+  test("parses minutes", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "10m"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(600_000);
+  });
+
+  test("parses hours", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "2h"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(7_200_000);
+  });
+
+  test("rejects invalid TTL format", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "5days"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects TTL without unit", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "100"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on invalid TTL", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "bad",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --ttl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — >1 MB warning
+// ---------------------------------------------------------------------------
+
+describe(">1 MB warning", () => {
+  test("warns on payloads exceeding 1 MB but still succeeds", async () => {
+    // Create a payload larger than 1 MB
+    const largeString = "x".repeat(1_100_000);
+    mockStdinContent = JSON.stringify(largeString);
+    mockIpcResult = { ok: true, result: { key: "big-key" } };
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("cache/set");
+    // Check that the warning was logged (via our mock logger)
+    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(true);
+  });
+
+  test("does not warn on payloads under 1 MB", async () => {
+    mockStdinContent = '{"small": true}';
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set"]);
+
+    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get — success, miss, and error
+// ---------------------------------------------------------------------------
+
+describe("cache get", () => {
+  test("prints data on cache hit", async () => {
+    mockIpcResult = { ok: true, result: { data: { foo: "bar" } } };
+
+    const { exitCode } = await runCommand(["cache", "get", "my-key"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("cache/get");
+    expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("--json outputs { ok: true, data: ... } on hit", async () => {
+    mockIpcResult = { ok: true, result: { data: [1, 2, 3] } };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "my-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, data: [1, 2, 3] });
+  });
+
+  test("--json outputs { ok: true, data: null } on miss", async () => {
+    mockIpcResult = { ok: true, result: null };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "missing-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, data: null });
+  });
+
+  test("exits with error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand(["cache", "get", "some-key"]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "some-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Connection refused" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete — success and error
+// ---------------------------------------------------------------------------
+
+describe("cache delete", () => {
+  test("sends cache/delete IPC and succeeds", async () => {
+    mockIpcResult = { ok: true, result: {} };
+
+    const { exitCode } = await runCommand(["cache", "delete", "my-key"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("cache/delete");
+    expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("--json outputs { ok: true } on success", async () => {
+    mockIpcResult = { ok: true, result: {} };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "my-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  test("exits with error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand(["cache", "delete", "some-key"]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Timeout" };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "some-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Timeout" });
+  });
+});

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -1,0 +1,321 @@
+/**
+ * `assistant cache` CLI namespace.
+ *
+ * Subcommands: set, get, delete — thin wrappers over the daemon's
+ * cache IPC routes (`cache/set`, `cache/get`, `cache/delete`).
+ */
+
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/** Warn (stderr) when a raw payload exceeds this byte count. */
+const MAX_PAYLOAD_BYTES = 1_000_000; // 1 MB
+
+// ── TTL parsing ───────────────────────────────────────────────────────
+
+const TTL_PATTERN = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h)$/;
+
+const TTL_MULTIPLIERS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+/**
+ * Parse a human-friendly duration string (e.g. `"30s"`, `"5m"`, `"2h"`)
+ * into milliseconds. Returns `undefined` when the input is falsy.
+ * Throws on malformed input so the CLI can surface actionable errors.
+ */
+function parseTtl(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const match = TTL_PATTERN.exec(raw.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+    );
+  }
+  const value = Number(match[1]);
+  const unit = match[2] as keyof typeof TTL_MULTIPLIERS;
+  const ms = Math.round(value * TTL_MULTIPLIERS[unit]);
+  if (ms <= 0) {
+    throw new Error(`--ttl must resolve to a positive duration, got ${ms}ms.`);
+  }
+  return ms;
+}
+
+// ── Stdin helpers ─────────────────────────────────────────────────────
+
+/**
+ * Read JSON payload from stdin when piped. Returns `undefined` when stdin
+ * is a TTY (no piped input). Throws on invalid/missing JSON so the CLI
+ * can surface actionable parse errors.
+ */
+function readPayloadFromStdin(): unknown {
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "No input provided. Pipe JSON into stdin.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync("/dev/stdin", "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read stdin: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!raw.trim()) {
+    throw new Error(
+      "Empty input on stdin. Pipe valid JSON.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+
+  // Warn on large payloads (but do not fail)
+  const byteLength = Buffer.byteLength(raw, "utf-8");
+  if (byteLength > MAX_PAYLOAD_BYTES) {
+    const sizeMb = (byteLength / 1_000_000).toFixed(2);
+    log.warn(
+      `Payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "Invalid JSON on stdin. Provide a valid JSON value.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+}
+
+// ── Registration ──────────────────────────────────────────────────────
+
+export function registerCacheCommand(program: Command): void {
+  const cache = program
+    .command("cache")
+    .description("Interact with the assistant's in-memory key/value cache");
+
+  cache.addHelpText(
+    "after",
+    `
+The cache is a TTL-aware, LRU-evicting in-memory store managed by the
+running assistant. Data is scoped to the assistant process lifetime and
+is not persisted across restarts.
+
+Keys are opaque strings. If no key is provided on set, the assistant
+generates one and returns it. Values can be any JSON-serializable data.
+
+Examples:
+  $ echo '{"result": [1,2,3]}' | assistant cache set --ttl 5m
+  $ echo '{"result": [1,2,3]}' | assistant cache set --key my-key --ttl 1h
+  $ assistant cache get my-key
+  $ assistant cache delete my-key`,
+  );
+
+  // ── set ───────────────────────────────────────────────────────────
+
+  cache
+    .command("set")
+    .description("Store a JSON value in the cache (reads payload from stdin)")
+    .option(
+      "--key <key>",
+      "Cache key for idempotent upsert. Omit to auto-generate.",
+    )
+    .option(
+      "--ttl <duration>",
+      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Omit for no expiry.",
+    )
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Reads a JSON payload from stdin, stores it in the cache, and prints the
+assigned key. If --key is provided, the entry is upserted (created or
+replaced). If omitted, a new unique key is generated.
+
+Payloads exceeding 1 MB emit a warning to stderr but are still stored.
+
+Arguments:
+  (none — payload is read from stdin)
+
+Options:
+  --key <key>       Cache key string. Omit to auto-generate a UUID key.
+  --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
+                    Examples: 500ms, 30s, 5m, 2h. Omit for no TTL.
+  --json            Output as JSON: { "ok": true, "key": "..." }
+
+Examples:
+  $ echo '{"scores":[98,85,72]}' | assistant cache set
+  $ echo '{"scores":[98,85,72]}' | assistant cache set --key scores --ttl 10m
+  $ echo '"simple string"' | assistant cache set --ttl 1h --json`,
+    )
+    .action(async (opts: { key?: string; ttl?: string; json?: boolean }) => {
+      let data: unknown;
+      try {
+        data = readPayloadFromStdin();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      let ttl_ms: number | undefined;
+      try {
+        ttl_ms = parseTtl(opts.ttl);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const params: Record<string, unknown> = { data };
+      if (ttl_ms !== undefined) params.ttl_ms = ttl_ms;
+      if (opts.key) params.key = opts.key;
+
+      const result = await cliIpcCall<{ key: string }>("cache/set", params);
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, key: result.result!.key }) + "\n",
+        );
+      } else {
+        log.info(`Cached with key: ${result.result!.key}`);
+      }
+    });
+
+  // ── get ───────────────────────────────────────────────────────────
+
+  cache
+    .command("get <key>")
+    .description("Retrieve a cached value by key")
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key   The cache key to look up. Run 'assistant cache set' to store a
+        value and receive its key.
+
+Fetches the value associated with the given key. If the key does not
+exist or has expired, reports not-found. In --json mode, a miss returns
+{ "ok": true, "data": null }.
+
+Examples:
+  $ assistant cache get my-key
+  $ assistant cache get my-key --json`,
+    )
+    .action(async (key: string, opts: { json?: boolean }) => {
+      const result = await cliIpcCall<{ data: unknown } | null>("cache/get", {
+        key,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            data: result.result ? result.result.data : null,
+          }) + "\n",
+        );
+      } else {
+        if (result.result == null) {
+          log.info(`No cache entry found for key "${key}".`);
+        } else {
+          log.info(JSON.stringify(result.result.data, null, 2));
+        }
+      }
+    });
+
+  // ── delete ────────────────────────────────────────────────────────
+
+  cache
+    .command("delete <key>")
+    .description("Remove a cached entry by key")
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key   The cache key to remove. Run 'assistant cache get <key>' to
+        verify a key exists before deleting.
+
+Removes the entry from the cache. Succeeds silently if the key does not
+exist (idempotent).
+
+Examples:
+  $ assistant cache delete my-key
+  $ assistant cache delete my-key --json`,
+    )
+    .action(async (key: string, opts: { json?: boolean }) => {
+      const result = await cliIpcCall<Record<string, never>>("cache/delete", {
+        key,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ ok: true }) + "\n");
+      } else {
+        log.info(`Deleted cache entry "${key}".`);
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -15,6 +15,7 @@ import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBackupCommand } from "./commands/backup.js";
 import { registerBashCommand } from "./commands/bash.js";
 import { registerBrowserCommand } from "./commands/browser.js";
+import { registerCacheCommand } from "./commands/cache.js";
 import { registerChannelVerificationSessionsCommand } from "./commands/channel-verification-sessions.js";
 import { registerCompletionsCommand } from "./commands/completions.js";
 import { registerConfigCommand } from "./commands/config.js";
@@ -66,6 +67,7 @@ Examples:
   registerBackupCommand(program);
   registerBashCommand(program);
   registerBrowserCommand(program);
+  registerCacheCommand(program);
   registerConversationsCommand(program);
   registerConfigCommand(program);
   registerKeysCommand(program);


### PR DESCRIPTION
## Summary
- Add cache namespace with set, get, delete subcommands
- Support TTL duration parsing (ms/s/m/h), stdin JSON payload, optional key for upsert
- Warn on >1 MB payloads without failing
- Include CLI unit tests with mocked IPC

Part of plan: skill-scoped-cache.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
