### PR TITLE
fix: correct CLI help text for --ttl default (30m, not no expiry)

### DIFF
--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -135,7 +135,7 @@ Examples:
     )
     .option(
       "--ttl <duration>",
-      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Omit for no expiry.",
+      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
     )
     .option("--json", "Output result as machine-readable JSON.")
     .addHelpText(
@@ -153,7 +153,7 @@ Arguments:
 Options:
   --key <key>       Cache key string. Omit to auto-generate a UUID key.
   --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
-                    Examples: 500ms, 30s, 5m, 2h. Omit for no TTL.
+                    Examples: 500ms, 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }
 
 Examples:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-scoped-cache.md.

**Gap:** CLI help text says no expiry when --ttl is omitted
**What was expected:** Help text should reflect 30-minute default TTL
**What was found:** Help text said 'Omit for no expiry'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
