### PR TITLE
fix: require data field in cache/set IPC route

### DIFF
--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -20,7 +20,9 @@ import type { IpcRoute } from "../cli-server.js";
 // ── Param schemas ─────────────────────────────────────────────────────
 
 const CacheSetParams = z.object({
-  data: z.unknown(),
+  data: z.unknown().refine((v) => v !== undefined, {
+    message: "data is required",
+  }),
   key: z.string().min(1).optional(),
   ttl_ms: z.number().int().positive().optional(),
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-scoped-cache.md.

**Gap:** IPC cache/set accepts calls without data field
**What was expected:** data field should be required
**What was found:** z.unknown() accepts undefined, silently storing it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
