### PR TITLE
fix: route >1 MB warning to stderr instead of log.warn

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -373,22 +373,22 @@ describe(">1 MB warning", () => {
     mockStdinContent = JSON.stringify(largeString);
     mockIpcResult = { ok: true, result: { key: "big-key" } };
 
-    const { exitCode } = await runCommand(["cache", "set"]);
+    const { exitCode, stderr } = await runCommand(["cache", "set"]);
 
     expect(exitCode).toBe(0);
     expect(lastIpcCall).toBeDefined();
     expect(lastIpcCall!.method).toBe("cache/set");
-    // Check that the warning was logged (via our mock logger)
-    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(true);
+    // Warning is written directly to stderr (not through the logger)
+    expect(stderr).toContain("exceeds 1 MB");
   });
 
   test("does not warn on payloads under 1 MB", async () => {
     mockStdinContent = '{"small": true}';
     mockIpcResult = { ok: true, result: { key: "k" } };
 
-    await runCommand(["cache", "set"]);
+    const { stderr } = await runCommand(["cache", "set"]);
 
-    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(false);
+    expect(stderr).not.toContain("exceeds 1 MB");
   });
 });
 

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -81,12 +81,13 @@ function readPayloadFromStdin(): unknown {
     );
   }
 
-  // Warn on large payloads (but do not fail)
+  // Warn on large payloads (but do not fail).
+  // Write directly to stderr so --json stdout output stays clean.
   const byteLength = Buffer.byteLength(raw, "utf-8");
   if (byteLength > MAX_PAYLOAD_BYTES) {
     const sizeMb = (byteLength / 1_000_000).toFixed(2);
-    log.warn(
-      `Payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.`,
+    process.stderr.write(
+      `Warning: payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.\n`,
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-scoped-cache.md.

**Gap:** log.warn breaks --json output for >1 MB payloads
**What was expected:** Warning should go to stderr per plan spec
**What was found:** log.warn routes to stdout via CLI logger, breaking JSON output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
