### PR TITLE
test: add regression test for _trackedScanIds cap at 64

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -183,4 +183,22 @@ describe("_internals", () => {
   test("TTL_MS is 30 minutes", () => {
     expect(_internals.TTL_MS).toBe(30 * 60_000);
   });
+
+  test("trackedScanIds stays bounded at MAX_TRACKED_SCAN_IDS", () => {
+    const limit = _internals.MAX_TRACKED_SCAN_IDS;
+
+    // Store more scan results than the cap allows.
+    for (let i = 0; i < limit + 10; i++) {
+      storeScanResult([
+        {
+          id: `sender-${i}`,
+          messageIds: [`m-${i}`],
+          newestMessageId: `m-${i}`,
+          newestUnsubscribableMessageId: null,
+        },
+      ]);
+    }
+
+    expect(_internals.trackedScanIds.size).toBe(limit);
+  });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-scoped-cache.md.

**Gap:** No test for _trackedScanIds cap at 64
**What was expected:** Regression test for the bounded tracking set
**What was found:** No test verifying the cap on _trackedScanIds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
