### PR TITLE
feat: skill-scoped cache primitive with CLI surface and scan-store migration

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -183,4 +183,22 @@ describe("_internals", () => {
   test("TTL_MS is 30 minutes", () => {
     expect(_internals.TTL_MS).toBe(30 * 60_000);
   });
+
+  test("trackedScanIds stays bounded at MAX_TRACKED_SCAN_IDS", () => {
+    const limit = _internals.MAX_TRACKED_SCAN_IDS;
+
+    // Store more scan results than the cap allows.
+    for (let i = 0; i < limit + 10; i++) {
+      storeScanResult([
+        {
+          id: `sender-${i}`,
+          messageIds: [`m-${i}`],
+          newestMessageId: `m-${i}`,
+          newestUnsubscribableMessageId: null,
+        },
+      ]);
+    }
+
+    expect(_internals.trackedScanIds.size).toBe(limit);
+  });
 });

--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _internals,
+  clearScanStore,
+  getSenderMessageIds,
+  getSenderMetadata,
+  storeScanResult,
+} from "../config/bundled-skills/gmail/tools/scan-result-store.js";
+import { clearCacheForTests } from "../skills/skill-cache-store.js";
+
+afterEach(() => {
+  clearScanStore();
+  clearCacheForTests();
+});
+
+describe("storeScanResult / getSenderMessageIds round-trip", () => {
+  test("stores senders and retrieves flattened message IDs", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1", "m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+      {
+        id: "sender-b",
+        messageIds: ["m3"],
+        newestMessageId: "m3",
+        newestUnsubscribableMessageId: "m3",
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["sender-a", "sender-b"]);
+    expect(ids).not.toBeNull();
+    expect(ids).toContain("m1");
+    expect(ids).toContain("m2");
+    expect(ids).toContain("m3");
+    expect(ids).toHaveLength(3);
+  });
+
+  test("returns only requested senders' message IDs", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+      {
+        id: "sender-b",
+        messageIds: ["m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["sender-a"]);
+    expect(ids).toEqual(["m1"]);
+  });
+
+  test("returns empty array when sender IDs do not match", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-a",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const ids = getSenderMessageIds(scanId, ["nonexistent"]);
+    expect(ids).toEqual([]);
+  });
+});
+
+describe("missing scan ID returns null", () => {
+  test("getSenderMessageIds returns null for unknown scan ID", () => {
+    expect(getSenderMessageIds("no-such-scan", ["s1"])).toBeNull();
+  });
+
+  test("getSenderMetadata returns null for unknown scan ID", () => {
+    expect(getSenderMetadata("no-such-scan", "s1")).toBeNull();
+  });
+});
+
+describe("getSenderMetadata", () => {
+  test("returns metadata for a known sender", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-x",
+        messageIds: ["m1", "m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: "m1",
+      },
+    ]);
+
+    const meta = getSenderMetadata(scanId, "sender-x");
+    expect(meta).toEqual({
+      newestMessageId: "m2",
+      newestUnsubscribableMessageId: "m1",
+    });
+  });
+
+  test("returns null for unknown sender within a valid scan", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-x",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    expect(getSenderMetadata(scanId, "sender-unknown")).toBeNull();
+  });
+
+  test("returns null newestUnsubscribableMessageId when not present", () => {
+    const scanId = storeScanResult([
+      {
+        id: "sender-y",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    const meta = getSenderMetadata(scanId, "sender-y");
+    expect(meta).toEqual({
+      newestMessageId: "m1",
+      newestUnsubscribableMessageId: null,
+    });
+  });
+});
+
+describe("clearScanStore", () => {
+  test("clears all tracked scan entries from the shared cache", () => {
+    const scanId1 = storeScanResult([
+      {
+        id: "s1",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+    const scanId2 = storeScanResult([
+      {
+        id: "s2",
+        messageIds: ["m2"],
+        newestMessageId: "m2",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    // Sanity: both are retrievable
+    expect(getSenderMessageIds(scanId1, ["s1"])).not.toBeNull();
+    expect(getSenderMessageIds(scanId2, ["s2"])).not.toBeNull();
+
+    clearScanStore();
+
+    // After clear, both should be gone
+    expect(getSenderMessageIds(scanId1, ["s1"])).toBeNull();
+    expect(getSenderMessageIds(scanId2, ["s2"])).toBeNull();
+  });
+
+  test("clears tracked scan IDs set", () => {
+    storeScanResult([
+      {
+        id: "s1",
+        messageIds: ["m1"],
+        newestMessageId: "m1",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    expect(_internals.trackedScanIds.size).toBe(1);
+    clearScanStore();
+    expect(_internals.trackedScanIds.size).toBe(0);
+  });
+});
+
+describe("_internals", () => {
+  test("TTL_MS is 30 minutes", () => {
+    expect(_internals.TTL_MS).toBe(30 * 60_000);
+  });
+});

--- a/assistant/src/__tests__/skill-cache-store.test.ts
+++ b/assistant/src/__tests__/skill-cache-store.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _internals,
+  clearCacheForTests,
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../skills/skill-cache-store.js";
+
+afterEach(() => {
+  clearCacheForTests();
+});
+
+describe("setCacheEntry", () => {
+  test("auto-generated key is a 16-char lowercase hex string", () => {
+    const { key } = setCacheEntry("hello");
+    expect(key).toHaveLength(16);
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("each auto-generated key is unique", () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      keys.add(setCacheEntry(i).key);
+    }
+    expect(keys.size).toBe(20);
+  });
+
+  test("explicit key stores and retrieves correctly", () => {
+    setCacheEntry({ foo: "bar" }, { key: "my-key" });
+    const result = getCacheEntry("my-key");
+    expect(result).toEqual({ data: { foo: "bar" } });
+  });
+
+  test("explicit key upsert overwrites existing value", () => {
+    setCacheEntry("v1", { key: "same" });
+    setCacheEntry("v2", { key: "same" });
+    const result = getCacheEntry("same");
+    expect(result).toEqual({ data: "v2" });
+    // Only one entry in the store for this key.
+    let count = 0;
+    for (const k of _internals.store.keys()) {
+      if (k === "same") count++;
+    }
+    expect(count).toBe(1);
+  });
+
+  test("upsert refreshes insertion order (LRU position)", () => {
+    setCacheEntry("a", { key: "first" });
+    setCacheEntry("b", { key: "second" });
+    // Upsert 'first' — it should move to the end.
+    setCacheEntry("a-updated", { key: "first" });
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["second", "first"]);
+  });
+
+  test("upsert resets expiry timestamp", () => {
+    setCacheEntry("v1", { key: "k", ttlMs: 1000 });
+    const expiryBefore = _internals.store.get("k")!.expiresAt;
+
+    // Small delay to ensure Date.now() advances.
+    const start = Date.now();
+    while (Date.now() === start) {
+      /* busy-wait for at least 1ms */
+    }
+
+    setCacheEntry("v2", { key: "k", ttlMs: 5000 });
+    const expiryAfter = _internals.store.get("k")!.expiresAt;
+    expect(expiryAfter).toBeGreaterThan(expiryBefore);
+  });
+});
+
+describe("getCacheEntry", () => {
+  test("returns data for a valid key", () => {
+    const { key } = setCacheEntry(42);
+    expect(getCacheEntry(key)).toEqual({ data: 42 });
+  });
+
+  test("returns null for an unknown key", () => {
+    expect(getCacheEntry("nonexistent")).toBeNull();
+  });
+
+  test("refreshes LRU position on access", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    setCacheEntry("c", { key: "k3" });
+
+    // Access k1 — should move to the end.
+    getCacheEntry("k1");
+
+    const keys = [..._internals.store.keys()];
+    expect(keys).toEqual(["k2", "k3", "k1"]);
+  });
+});
+
+describe("TTL expiry (lazy eviction)", () => {
+  test("expired entry returns null and is removed from the store", () => {
+    setCacheEntry("ephemeral", { key: "ttl-test", ttlMs: 1 });
+
+    // Wait for the TTL to elapse.
+    const deadline = Date.now() + 2;
+    while (Date.now() < deadline) {
+      /* busy-wait */
+    }
+
+    expect(getCacheEntry("ttl-test")).toBeNull();
+    expect(_internals.store.has("ttl-test")).toBe(false);
+  });
+
+  test("non-expired entry is still accessible", () => {
+    setCacheEntry("durable", { key: "long-lived", ttlMs: 60_000 });
+    expect(getCacheEntry("long-lived")).toEqual({ data: "durable" });
+  });
+
+  test("default TTL is 30 minutes", () => {
+    expect(_internals.DEFAULT_TTL_MS).toBe(30 * 60_000);
+  });
+});
+
+describe("LRU eviction at capacity", () => {
+  test("evicts oldest entry when at max capacity", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES; // 64
+
+    // Fill the store to capacity.
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+    expect(_internals.store.size).toBe(maxEntries);
+
+    // One more insert should evict the oldest (entry-0).
+    setCacheEntry("overflow", { key: "new-entry" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toBeNull();
+    expect(getCacheEntry("new-entry")).toEqual({ data: "overflow" });
+  });
+
+  test("default max entries is 64", () => {
+    expect(_internals.DEFAULT_MAX_ENTRIES).toBe(64);
+  });
+
+  test("upsert at capacity does not evict (key already exists)", () => {
+    const maxEntries = _internals.DEFAULT_MAX_ENTRIES;
+    for (let i = 0; i < maxEntries; i++) {
+      setCacheEntry(i, { key: `entry-${i}` });
+    }
+
+    // Upsert an existing key — should not evict anything.
+    setCacheEntry("updated", { key: "entry-0" });
+    expect(_internals.store.size).toBe(maxEntries);
+    expect(getCacheEntry("entry-0")).toEqual({ data: "updated" });
+    expect(getCacheEntry("entry-1")).toEqual({ data: 1 });
+  });
+});
+
+describe("deleteCacheEntry", () => {
+  test("returns true when deleting an existing key", () => {
+    setCacheEntry("x", { key: "del" });
+    expect(deleteCacheEntry("del")).toBe(true);
+    expect(getCacheEntry("del")).toBeNull();
+  });
+
+  test("returns false for an unknown key (idempotent)", () => {
+    expect(deleteCacheEntry("ghost")).toBe(false);
+  });
+
+  test("double delete is idempotent", () => {
+    setCacheEntry("x", { key: "once" });
+    expect(deleteCacheEntry("once")).toBe(true);
+    expect(deleteCacheEntry("once")).toBe(false);
+  });
+});
+
+describe("clearCacheForTests", () => {
+  test("empties the entire store", () => {
+    setCacheEntry("a", { key: "k1" });
+    setCacheEntry("b", { key: "k2" });
+    clearCacheForTests();
+    expect(_internals.store.size).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Tests for the `assistant cache` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration (set, get, delete)
+ *   - `set` payload parsing from stdin + IPC param mapping
+ *   - TTL parsing edge cases (ms, s, m, h, invalid)
+ *   - >1 MB payload warning path
+ *   - `get` success, miss, and error output
+ *   - `delete` success and error output
+ *   - JSON output shape and exit-code behavior on IPC errors
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { key: "test-key" } };
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+/** Whether to simulate stdin as a TTY (no piped input). */
+let mockStdinIsTTY: boolean = false;
+
+/** Captured stderr output for warning assertions. */
+let stderrChunks: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      stderrChunks.push(args.map(String).join(" "));
+    },
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      stderrChunks.push(args.map(String).join(" "));
+    },
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerCacheCommand } = await import("../cache.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const localStderrChunks: string[] = [];
+
+  // Save and mock isTTY
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: mockStdinIsTTY ? true : undefined,
+    configurable: true,
+  });
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    localStderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerCacheCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: localStderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: { key: "test-key" } };
+  mockStdinContent = null;
+  mockStdinIsTTY = false;
+  stderrChunks = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers set, get, delete subcommands under cache", () => {
+    const program = new Command();
+    registerCacheCommand(program);
+    const cache = program.commands.find((c) => c.name() === "cache");
+    expect(cache).toBeDefined();
+    const subcommandNames = cache!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual(["delete", "get", "set"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — payload parsing + IPC params
+// ---------------------------------------------------------------------------
+
+describe("cache set", () => {
+  test("parses JSON from stdin and sends cache/set IPC", async () => {
+    mockStdinContent = '{"scores":[98,85,72]}';
+    mockIpcResult = { ok: true, result: { key: "generated-key" } };
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("cache/set");
+    expect(lastIpcCall!.params!.data).toEqual({ scores: [98, 85, 72] });
+    expect(lastIpcCall!.params!.ttl_ms).toBeUndefined();
+    expect(lastIpcCall!.params!.key).toBeUndefined();
+  });
+
+  test("passes --key to IPC params", async () => {
+    mockStdinContent = '"hello"';
+    mockIpcResult = { ok: true, result: { key: "my-key" } };
+
+    await runCommand(["cache", "set", "--key", "my-key"]);
+
+    expect(lastIpcCall!.params!.key).toBe("my-key");
+  });
+
+  test("passes --ttl as ttl_ms in IPC params", async () => {
+    mockStdinContent = "42";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "5m"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(300_000);
+  });
+
+  test("--json outputs JSON with ok:true and key on success", async () => {
+    mockStdinContent = '{"a":1}';
+    mockIpcResult = { ok: true, result: { key: "abc-123" } };
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, key: "abc-123" });
+  });
+
+  test("errors on empty stdin", async () => {
+    mockStdinContent = "   ";
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on invalid JSON", async () => {
+    mockStdinContent = "{not json}";
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on TTY stdin (no pipe)", async () => {
+    mockStdinIsTTY = true;
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on invalid JSON stdin", async () => {
+    mockStdinContent = "{bad}";
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON");
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockStdinContent = '"data"';
+    mockIpcResult = {
+      ok: false,
+      error: "Could not connect to assistant daemon. Is it running?",
+    };
+
+    const { exitCode, stdout } = await runCommand(["cache", "set", "--json"]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Could not connect");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — TTL parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe("TTL parsing", () => {
+  test("parses milliseconds", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "500ms"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(500);
+  });
+
+  test("parses seconds", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "30s"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(30_000);
+  });
+
+  test("parses minutes", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "10m"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(600_000);
+  });
+
+  test("parses hours", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set", "--ttl", "2h"]);
+
+    expect(lastIpcCall!.params!.ttl_ms).toBe(7_200_000);
+  });
+
+  test("rejects invalid TTL format", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "5days"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects TTL without unit", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "100"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on invalid TTL", async () => {
+    mockStdinContent = "1";
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "bad",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --ttl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set — >1 MB warning
+// ---------------------------------------------------------------------------
+
+describe(">1 MB warning", () => {
+  test("warns on payloads exceeding 1 MB but still succeeds", async () => {
+    // Create a payload larger than 1 MB
+    const largeString = "x".repeat(1_100_000);
+    mockStdinContent = JSON.stringify(largeString);
+    mockIpcResult = { ok: true, result: { key: "big-key" } };
+
+    const { exitCode } = await runCommand(["cache", "set"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("cache/set");
+    // Check that the warning was logged (via our mock logger)
+    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(true);
+  });
+
+  test("does not warn on payloads under 1 MB", async () => {
+    mockStdinContent = '{"small": true}';
+    mockIpcResult = { ok: true, result: { key: "k" } };
+
+    await runCommand(["cache", "set"]);
+
+    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get — success, miss, and error
+// ---------------------------------------------------------------------------
+
+describe("cache get", () => {
+  test("prints data on cache hit", async () => {
+    mockIpcResult = { ok: true, result: { data: { foo: "bar" } } };
+
+    const { exitCode } = await runCommand(["cache", "get", "my-key"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("cache/get");
+    expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("--json outputs { ok: true, data: ... } on hit", async () => {
+    mockIpcResult = { ok: true, result: { data: [1, 2, 3] } };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "my-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, data: [1, 2, 3] });
+  });
+
+  test("--json outputs { ok: true, data: null } on miss", async () => {
+    mockIpcResult = { ok: true, result: null };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "missing-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, data: null });
+  });
+
+  test("exits with error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand(["cache", "get", "some-key"]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "get",
+      "some-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Connection refused" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete — success and error
+// ---------------------------------------------------------------------------
+
+describe("cache delete", () => {
+  test("sends cache/delete IPC and succeeds", async () => {
+    mockIpcResult = { ok: true, result: {} };
+
+    const { exitCode } = await runCommand(["cache", "delete", "my-key"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.method).toBe("cache/delete");
+    expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("--json outputs { ok: true } on success", async () => {
+    mockIpcResult = { ok: true, result: {} };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "my-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  test("exits with error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand(["cache", "delete", "some-key"]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Timeout" };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "some-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Timeout" });
+  });
+});

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -373,22 +373,22 @@ describe(">1 MB warning", () => {
     mockStdinContent = JSON.stringify(largeString);
     mockIpcResult = { ok: true, result: { key: "big-key" } };
 
-    const { exitCode } = await runCommand(["cache", "set"]);
+    const { exitCode, stderr } = await runCommand(["cache", "set"]);
 
     expect(exitCode).toBe(0);
     expect(lastIpcCall).toBeDefined();
     expect(lastIpcCall!.method).toBe("cache/set");
-    // Check that the warning was logged (via our mock logger)
-    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(true);
+    // Warning is written directly to stderr (not through the logger)
+    expect(stderr).toContain("exceeds 1 MB");
   });
 
   test("does not warn on payloads under 1 MB", async () => {
     mockStdinContent = '{"small": true}';
     mockIpcResult = { ok: true, result: { key: "k" } };
 
-    await runCommand(["cache", "set"]);
+    const { stderr } = await runCommand(["cache", "set"]);
 
-    expect(stderrChunks.some((s) => s.includes("exceeds 1 MB"))).toBe(false);
+    expect(stderr).not.toContain("exceeds 1 MB");
   });
 });
 

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -81,12 +81,13 @@ function readPayloadFromStdin(): unknown {
     );
   }
 
-  // Warn on large payloads (but do not fail)
+  // Warn on large payloads (but do not fail).
+  // Write directly to stderr so --json stdout output stays clean.
   const byteLength = Buffer.byteLength(raw, "utf-8");
   if (byteLength > MAX_PAYLOAD_BYTES) {
     const sizeMb = (byteLength / 1_000_000).toFixed(2);
-    log.warn(
-      `Payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.`,
+    process.stderr.write(
+      `Warning: payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.\n`,
     );
   }
 

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -53,8 +53,8 @@ function parseTtl(raw: string | undefined): number | undefined {
 // ── Stdin helpers ─────────────────────────────────────────────────────
 
 /**
- * Read JSON payload from stdin when piped. Returns `undefined` when stdin
- * is a TTY (no piped input). Throws on invalid/missing JSON so the CLI
+ * Read JSON payload from stdin when piped. Throws when stdin is a TTY
+ * (no piped input) or when the input is empty/invalid JSON, so the CLI
  * can surface actionable parse errors.
  */
 function readPayloadFromStdin(): unknown {
@@ -152,7 +152,7 @@ Arguments:
   (none — payload is read from stdin)
 
 Options:
-  --key <key>       Cache key string. Omit to auto-generate a UUID key.
+  --key <key>       Cache key string. Omit to auto-generate a random hex key.
   --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
                     Examples: 500ms, 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -1,0 +1,321 @@
+/**
+ * `assistant cache` CLI namespace.
+ *
+ * Subcommands: set, get, delete — thin wrappers over the daemon's
+ * cache IPC routes (`cache/set`, `cache/get`, `cache/delete`).
+ */
+
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/** Warn (stderr) when a raw payload exceeds this byte count. */
+const MAX_PAYLOAD_BYTES = 1_000_000; // 1 MB
+
+// ── TTL parsing ───────────────────────────────────────────────────────
+
+const TTL_PATTERN = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h)$/;
+
+const TTL_MULTIPLIERS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+/**
+ * Parse a human-friendly duration string (e.g. `"30s"`, `"5m"`, `"2h"`)
+ * into milliseconds. Returns `undefined` when the input is falsy.
+ * Throws on malformed input so the CLI can surface actionable errors.
+ */
+function parseTtl(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const match = TTL_PATTERN.exec(raw.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+    );
+  }
+  const value = Number(match[1]);
+  const unit = match[2] as keyof typeof TTL_MULTIPLIERS;
+  const ms = Math.round(value * TTL_MULTIPLIERS[unit]);
+  if (ms <= 0) {
+    throw new Error(`--ttl must resolve to a positive duration, got ${ms}ms.`);
+  }
+  return ms;
+}
+
+// ── Stdin helpers ─────────────────────────────────────────────────────
+
+/**
+ * Read JSON payload from stdin when piped. Returns `undefined` when stdin
+ * is a TTY (no piped input). Throws on invalid/missing JSON so the CLI
+ * can surface actionable parse errors.
+ */
+function readPayloadFromStdin(): unknown {
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "No input provided. Pipe JSON into stdin.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync("/dev/stdin", "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read stdin: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!raw.trim()) {
+    throw new Error(
+      "Empty input on stdin. Pipe valid JSON.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+
+  // Warn on large payloads (but do not fail)
+  const byteLength = Buffer.byteLength(raw, "utf-8");
+  if (byteLength > MAX_PAYLOAD_BYTES) {
+    const sizeMb = (byteLength / 1_000_000).toFixed(2);
+    log.warn(
+      `Payload size (${sizeMb} MB) exceeds 1 MB. Large payloads may impact cache performance.`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "Invalid JSON on stdin. Provide a valid JSON value.\n" +
+        '  Example: echo \'{"key":"value"}\' | assistant cache set',
+    );
+  }
+}
+
+// ── Registration ──────────────────────────────────────────────────────
+
+export function registerCacheCommand(program: Command): void {
+  const cache = program
+    .command("cache")
+    .description("Interact with the assistant's in-memory key/value cache");
+
+  cache.addHelpText(
+    "after",
+    `
+The cache is a TTL-aware, LRU-evicting in-memory store managed by the
+running assistant. Data is scoped to the assistant process lifetime and
+is not persisted across restarts.
+
+Keys are opaque strings. If no key is provided on set, the assistant
+generates one and returns it. Values can be any JSON-serializable data.
+
+Examples:
+  $ echo '{"result": [1,2,3]}' | assistant cache set --ttl 5m
+  $ echo '{"result": [1,2,3]}' | assistant cache set --key my-key --ttl 1h
+  $ assistant cache get my-key
+  $ assistant cache delete my-key`,
+  );
+
+  // ── set ───────────────────────────────────────────────────────────
+
+  cache
+    .command("set")
+    .description("Store a JSON value in the cache (reads payload from stdin)")
+    .option(
+      "--key <key>",
+      "Cache key for idempotent upsert. Omit to auto-generate.",
+    )
+    .option(
+      "--ttl <duration>",
+      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Omit for no expiry.",
+    )
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Reads a JSON payload from stdin, stores it in the cache, and prints the
+assigned key. If --key is provided, the entry is upserted (created or
+replaced). If omitted, a new unique key is generated.
+
+Payloads exceeding 1 MB emit a warning to stderr but are still stored.
+
+Arguments:
+  (none — payload is read from stdin)
+
+Options:
+  --key <key>       Cache key string. Omit to auto-generate a UUID key.
+  --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
+                    Examples: 500ms, 30s, 5m, 2h. Omit for no TTL.
+  --json            Output as JSON: { "ok": true, "key": "..." }
+
+Examples:
+  $ echo '{"scores":[98,85,72]}' | assistant cache set
+  $ echo '{"scores":[98,85,72]}' | assistant cache set --key scores --ttl 10m
+  $ echo '"simple string"' | assistant cache set --ttl 1h --json`,
+    )
+    .action(async (opts: { key?: string; ttl?: string; json?: boolean }) => {
+      let data: unknown;
+      try {
+        data = readPayloadFromStdin();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      let ttl_ms: number | undefined;
+      try {
+        ttl_ms = parseTtl(opts.ttl);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const params: Record<string, unknown> = { data };
+      if (ttl_ms !== undefined) params.ttl_ms = ttl_ms;
+      if (opts.key) params.key = opts.key;
+
+      const result = await cliIpcCall<{ key: string }>("cache/set", params);
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, key: result.result!.key }) + "\n",
+        );
+      } else {
+        log.info(`Cached with key: ${result.result!.key}`);
+      }
+    });
+
+  // ── get ───────────────────────────────────────────────────────────
+
+  cache
+    .command("get <key>")
+    .description("Retrieve a cached value by key")
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key   The cache key to look up. Run 'assistant cache set' to store a
+        value and receive its key.
+
+Fetches the value associated with the given key. If the key does not
+exist or has expired, reports not-found. In --json mode, a miss returns
+{ "ok": true, "data": null }.
+
+Examples:
+  $ assistant cache get my-key
+  $ assistant cache get my-key --json`,
+    )
+    .action(async (key: string, opts: { json?: boolean }) => {
+      const result = await cliIpcCall<{ data: unknown } | null>("cache/get", {
+        key,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            data: result.result ? result.result.data : null,
+          }) + "\n",
+        );
+      } else {
+        if (result.result == null) {
+          log.info(`No cache entry found for key "${key}".`);
+        } else {
+          log.info(JSON.stringify(result.result.data, null, 2));
+        }
+      }
+    });
+
+  // ── delete ────────────────────────────────────────────────────────
+
+  cache
+    .command("delete <key>")
+    .description("Remove a cached entry by key")
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key   The cache key to remove. Run 'assistant cache get <key>' to
+        verify a key exists before deleting.
+
+Removes the entry from the cache. Succeeds silently if the key does not
+exist (idempotent).
+
+Examples:
+  $ assistant cache delete my-key
+  $ assistant cache delete my-key --json`,
+    )
+    .action(async (key: string, opts: { json?: boolean }) => {
+      const result = await cliIpcCall<Record<string, never>>("cache/delete", {
+        key,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ ok: true }) + "\n");
+      } else {
+        log.info(`Deleted cache entry "${key}".`);
+      }
+    });
+}

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -135,7 +135,7 @@ Examples:
     )
     .option(
       "--ttl <duration>",
-      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Omit for no expiry.",
+      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
     )
     .option("--json", "Output result as machine-readable JSON.")
     .addHelpText(
@@ -153,7 +153,7 @@ Arguments:
 Options:
   --key <key>       Cache key string. Omit to auto-generate a UUID key.
   --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
-                    Examples: 500ms, 30s, 5m, 2h. Omit for no TTL.
+                    Examples: 500ms, 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }
 
 Examples:

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -15,6 +15,7 @@ import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBackupCommand } from "./commands/backup.js";
 import { registerBashCommand } from "./commands/bash.js";
 import { registerBrowserCommand } from "./commands/browser.js";
+import { registerCacheCommand } from "./commands/cache.js";
 import { registerChannelVerificationSessionsCommand } from "./commands/channel-verification-sessions.js";
 import { registerCompletionsCommand } from "./commands/completions.js";
 import { registerConfigCommand } from "./commands/config.js";
@@ -66,6 +67,7 @@ Examples:
   registerBackupCommand(program);
   registerBashCommand(program);
   registerBrowserCommand(program);
+  registerCacheCommand(program);
   registerConversationsCommand(program);
   registerConfigCommand(program);
   registerKeysCommand(program);

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -21,8 +21,17 @@ interface ScanPayload {
 const TTL_MS = 30 * 60_000; // 30 minutes
 
 /**
+ * Maximum number of scan IDs to track. Matches the shared cache capacity
+ * so bookkeeping never grows beyond what the cache itself can hold.
+ */
+const MAX_TRACKED_SCAN_IDS = 64;
+
+/**
  * Local bookkeeping of scan IDs produced by this module so
  * `clearScanStore()` can delete them from the shared cache.
+ *
+ * Bounded to `MAX_TRACKED_SCAN_IDS` — when full, the oldest entry
+ * (first in Set iteration order) is evicted.
  */
 const _trackedScanIds = new Set<string>();
 
@@ -47,6 +56,13 @@ export function storeScanResult(
   const payload: ScanPayload = { senders: sendersObj };
   const { key: scanId } = setCacheEntry(payload, { ttlMs: TTL_MS });
   _trackedScanIds.add(scanId);
+
+  // Evict the oldest tracked ID when over capacity (Set preserves insertion order).
+  if (_trackedScanIds.size > MAX_TRACKED_SCAN_IDS) {
+    const oldest = _trackedScanIds.values().next().value;
+    if (oldest !== undefined) _trackedScanIds.delete(oldest);
+  }
+
   return scanId;
 }
 
@@ -96,4 +112,8 @@ export function clearScanStore(): void {
 }
 
 /** Visible for testing. */
-export const _internals = { TTL_MS, trackedScanIds: _trackedScanIds };
+export const _internals = {
+  TTL_MS,
+  MAX_TRACKED_SCAN_IDS,
+  trackedScanIds: _trackedScanIds,
+};

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -60,7 +60,10 @@ export function storeScanResult(
   // Evict the oldest tracked ID when over capacity (Set preserves insertion order).
   if (_trackedScanIds.size > MAX_TRACKED_SCAN_IDS) {
     const oldest = _trackedScanIds.values().next().value;
-    if (oldest !== undefined) _trackedScanIds.delete(oldest);
+    if (oldest !== undefined) {
+      _trackedScanIds.delete(oldest);
+      deleteCacheEntry(oldest);
+    }
   }
 
   return scanId;

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -1,4 +1,8 @@
-import { randomBytes } from "crypto";
+import {
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../../../../skills/skill-cache-store.js";
 
 interface SenderData {
   messageIds: string[];
@@ -6,15 +10,21 @@ interface SenderData {
   newestUnsubscribableMessageId: string | null;
 }
 
-interface ScanEntry {
-  senders: Map<string, SenderData>;
-  createdAt: number;
+/**
+ * Serializable payload stored in the shared cache.
+ * Uses a plain object (not a Map) so it round-trips through the cache cleanly.
+ */
+interface ScanPayload {
+  senders: Record<string, SenderData>;
 }
 
-const MAX_ENTRIES = 16;
 const TTL_MS = 30 * 60_000; // 30 minutes
 
-const _store = new Map<string, ScanEntry>();
+/**
+ * Local bookkeeping of scan IDs produced by this module so
+ * `clearScanStore()` can delete them from the shared cache.
+ */
+const _trackedScanIds = new Set<string>();
 
 /** Store scan results and return a unique scan ID. */
 export function storeScanResult(
@@ -25,24 +35,18 @@ export function storeScanResult(
     newestUnsubscribableMessageId: string | null;
   }>,
 ): string {
-  const scanId = randomBytes(8).toString("hex");
-
-  // LRU eviction: remove oldest if at capacity
-  if (_store.size >= MAX_ENTRIES) {
-    const oldest = _store.keys().next().value;
-    if (oldest !== undefined) _store.delete(oldest);
-  }
-
-  const senderMap = new Map<string, SenderData>();
+  const sendersObj: Record<string, SenderData> = {};
   for (const s of senders) {
-    senderMap.set(s.id, {
+    sendersObj[s.id] = {
       messageIds: s.messageIds,
       newestMessageId: s.newestMessageId,
       newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
-    });
+    };
   }
 
-  _store.set(scanId, { senders: senderMap, createdAt: Date.now() });
+  const payload: ScanPayload = { senders: sendersObj };
+  const { key: scanId } = setCacheEntry(payload, { ttlMs: TTL_MS });
+  _trackedScanIds.add(scanId);
   return scanId;
 }
 
@@ -51,19 +55,13 @@ export function getSenderMessageIds(
   scanId: string,
   senderIds: string[],
 ): string[] | null {
-  const entry = _store.get(scanId);
-  if (!entry) return null;
-  if (Date.now() - entry.createdAt > TTL_MS) {
-    _store.delete(scanId);
-    return null;
-  }
-  // LRU: move to end
-  _store.delete(scanId);
-  _store.set(scanId, entry);
+  const result = getCacheEntry(scanId);
+  if (!result) return null;
 
+  const payload = result.data as ScanPayload;
   const ids: string[] = [];
   for (const sid of senderIds) {
-    const data = entry.senders.get(sid);
+    const data = payload.senders[sid];
     if (data) ids.push(...data.messageIds);
   }
   return ids;
@@ -77,13 +75,11 @@ export function getSenderMetadata(
   newestMessageId: string;
   newestUnsubscribableMessageId: string | null;
 } | null {
-  const entry = _store.get(scanId);
-  if (!entry) return null;
-  if (Date.now() - entry.createdAt > TTL_MS) {
-    _store.delete(scanId);
-    return null;
-  }
-  const data = entry.senders.get(senderId);
+  const result = getCacheEntry(scanId);
+  if (!result) return null;
+
+  const payload = result.data as ScanPayload;
+  const data = payload.senders[senderId];
   if (!data) return null;
   return {
     newestMessageId: data.newestMessageId,
@@ -93,8 +89,11 @@ export function getSenderMetadata(
 
 /** Clear the store (for tests). */
 export function clearScanStore(): void {
-  _store.clear();
+  for (const scanId of _trackedScanIds) {
+    deleteCacheEntry(scanId);
+  }
+  _trackedScanIds.clear();
 }
 
-/** Visible for testing: override TTL check by returning internal store reference. */
-export const _internals = { store: _store, TTL_MS };
+/** Visible for testing. */
+export const _internals = { TTL_MS, trackedScanIds: _trackedScanIds };

--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -119,6 +119,12 @@ describe("cache IPC routes", () => {
 
   // ── Validation errors ─────────────────────────────────────────────
 
+  test("cache/set rejects missing data field", async () => {
+    const result = await cliIpcCall("cache/set", {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("data is required");
+  });
+
   test("cache/set rejects empty key", async () => {
     const result = await cliIpcCall("cache/set", {
       data: "value",

--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration tests for the cache IPC routes.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with the real in-memory cache store backing
+ * the route handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearCacheForTests } from "../../skills/skill-cache-store.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+
+beforeEach(async () => {
+  clearCacheForTests();
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  clearCacheForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cache IPC routes", () => {
+  // ── Set / Get round-trip ──────────────────────────────────────────
+
+  test("set then get returns stored data", async () => {
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: { greeting: "hello" },
+    });
+
+    expect(setResult.ok).toBe(true);
+    expect(setResult.result).toBeDefined();
+    const key = setResult.result!.key;
+    expect(typeof key).toBe("string");
+    expect(key.length).toBeGreaterThan(0);
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key,
+    });
+
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: { greeting: "hello" } });
+  });
+
+  // ── Explicit key upsert ───────────────────────────────────────────
+
+  test("set with explicit key upserts on second call", async () => {
+    const set1 = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "first",
+      key: "my-key",
+    });
+    expect(set1.ok).toBe(true);
+    expect(set1.result!.key).toBe("my-key");
+
+    const set2 = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "second",
+      key: "my-key",
+    });
+    expect(set2.ok).toBe(true);
+    expect(set2.result!.key).toBe("my-key");
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "my-key",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: "second" });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────
+
+  test("delete returns empty object and makes later get return null", async () => {
+    // Store an entry first.
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: 42,
+      key: "to-delete",
+    });
+    expect(setResult.ok).toBe(true);
+
+    // Delete it.
+    const delResult = await cliIpcCall<object>("cache/delete", {
+      key: "to-delete",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({});
+
+    // Get should now return null.
+    const getResult = await cliIpcCall<null>("cache/get", {
+      key: "to-delete",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Get for non-existent key returns null ─────────────────────────
+
+  test("get for non-existent key returns null", async () => {
+    const getResult = await cliIpcCall<null>("cache/get", {
+      key: "does-not-exist",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Validation errors ─────────────────────────────────────────────
+
+  test("cache/set rejects empty key", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      key: "",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects non-positive ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: 0,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects negative ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: -100,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/set rejects non-integer ttl_ms", async () => {
+    const result = await cliIpcCall("cache/set", {
+      data: "value",
+      ttl_ms: 1.5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/get rejects empty key", async () => {
+    const result = await cliIpcCall("cache/get", { key: "" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/get rejects missing key", async () => {
+    const result = await cliIpcCall("cache/get", {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("cache/delete rejects empty key", async () => {
+    const result = await cliIpcCall("cache/delete", { key: "" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // ── Method aliases ────────────────────────────────────────────────
+
+  test("cache_set alias works identically to cache/set", async () => {
+    const setResult = await cliIpcCall<{ key: string }>("cache_set", {
+      data: { alias: true },
+      key: "alias-test",
+    });
+    expect(setResult.ok).toBe(true);
+    expect(setResult.result!.key).toBe("alias-test");
+
+    // Retrieve via the canonical method to confirm storage.
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "alias-test",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: { alias: true } });
+  });
+
+  test("cache_get alias works identically to cache/get", async () => {
+    await cliIpcCall("cache/set", { data: "via-canonical", key: "cg-alias" });
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache_get", {
+      key: "cg-alias",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: "via-canonical" });
+  });
+
+  test("cache_delete alias works identically to cache/delete", async () => {
+    await cliIpcCall("cache/set", { data: "to-remove", key: "cd-alias" });
+
+    const delResult = await cliIpcCall<object>("cache_delete", {
+      key: "cd-alias",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({});
+
+    const getResult = await cliIpcCall<null>("cache/get", { key: "cd-alias" });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toBeNull();
+  });
+
+  // ── Structured payloads ───────────────────────────────────────────
+
+  test("supports nested structured data payloads", async () => {
+    const payload = {
+      results: [
+        { id: 1, name: "a", tags: ["x", "y"] },
+        { id: 2, name: "b", tags: [] },
+      ],
+      meta: { total: 2, page: 1 },
+    };
+
+    const setResult = await cliIpcCall<{ key: string }>("cache/set", {
+      data: payload,
+      key: "structured",
+    });
+    expect(setResult.ok).toBe(true);
+
+    const getResult = await cliIpcCall<{ data: unknown }>("cache/get", {
+      key: "structured",
+    });
+    expect(getResult.ok).toBe(true);
+    expect(getResult.result).toEqual({ data: payload });
+  });
+
+  // ── TTL parameter accepted ────────────────────────────────────────
+
+  test("set with valid ttl_ms succeeds", async () => {
+    const result = await cliIpcCall<{ key: string }>("cache/set", {
+      data: "ephemeral",
+      ttl_ms: 5000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.result!.key).toBeDefined();
+  });
+});

--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -20,7 +20,9 @@ import type { IpcRoute } from "../cli-server.js";
 // ── Param schemas ─────────────────────────────────────────────────────
 
 const CacheSetParams = z.object({
-  data: z.unknown(),
+  data: z.unknown().refine((v) => v !== undefined, {
+    message: "data is required",
+  }),
   key: z.string().min(1).optional(),
   ttl_ms: z.number().int().positive().optional(),
 });

--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -1,0 +1,92 @@
+/**
+ * IPC routes for the daemon-memory cache.
+ *
+ * Exposes set/get/delete operations so CLI commands and external processes
+ * can interact with the shared in-memory cache store.
+ *
+ * Each operation is registered under both a slash-style method name
+ * (e.g. `cache/set`) and an underscore alias (`cache_set`) for ergonomics.
+ */
+
+import { z } from "zod";
+
+import {
+  deleteCacheEntry,
+  getCacheEntry,
+  setCacheEntry,
+} from "../../skills/skill-cache-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ── Param schemas ─────────────────────────────────────────────────────
+
+const CacheSetParams = z.object({
+  data: z.unknown(),
+  key: z.string().min(1).optional(),
+  ttl_ms: z.number().int().positive().optional(),
+});
+
+const CacheKeyParams = z.object({
+  key: z.string().min(1),
+});
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+function handleCacheSet(params?: Record<string, unknown>): { key: string } {
+  const { data, key, ttl_ms } = CacheSetParams.parse(params);
+  return setCacheEntry(data, { key, ttlMs: ttl_ms });
+}
+
+function handleCacheGet(
+  params?: Record<string, unknown>,
+): { data: unknown } | null {
+  const { key } = CacheKeyParams.parse(params);
+  return getCacheEntry(key);
+}
+
+function handleCacheDelete(params?: Record<string, unknown>): object {
+  const { key } = CacheKeyParams.parse(params);
+  deleteCacheEntry(key);
+  return {};
+}
+
+// ── Route definitions ─────────────────────────────────────────────────
+
+export const cacheSetRoute: IpcRoute = {
+  method: "cache/set",
+  handler: handleCacheSet,
+};
+
+export const cacheSetAliasRoute: IpcRoute = {
+  method: "cache_set",
+  handler: handleCacheSet,
+};
+
+export const cacheGetRoute: IpcRoute = {
+  method: "cache/get",
+  handler: handleCacheGet,
+};
+
+export const cacheGetAliasRoute: IpcRoute = {
+  method: "cache_get",
+  handler: handleCacheGet,
+};
+
+export const cacheDeleteRoute: IpcRoute = {
+  method: "cache/delete",
+  handler: handleCacheDelete,
+};
+
+export const cacheDeleteAliasRoute: IpcRoute = {
+  method: "cache_delete",
+  handler: handleCacheDelete,
+};
+
+/** All cache IPC routes (canonical + aliases). */
+export const cacheRoutes: IpcRoute[] = [
+  cacheSetRoute,
+  cacheSetAliasRoute,
+  cacheGetRoute,
+  cacheGetAliasRoute,
+  cacheDeleteRoute,
+  cacheDeleteAliasRoute,
+];

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,9 +1,11 @@
 import type { IpcRoute } from "../cli-server.js";
 import { browserExecuteRoute } from "./browser.js";
+import { cacheRoutes } from "./cache.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
   browserExecuteRoute,
   wakeConversationRoute,
+  ...cacheRoutes,
 ];

--- a/assistant/src/skills/skill-cache-store.ts
+++ b/assistant/src/skills/skill-cache-store.ts
@@ -1,0 +1,97 @@
+import { randomBytes } from "crypto";
+
+/** Default time-to-live for cache entries: 30 minutes. */
+const DEFAULT_TTL_MS = 30 * 60_000;
+
+/** Default maximum number of entries before LRU eviction kicks in. */
+const DEFAULT_MAX_ENTRIES = 64;
+
+interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+/**
+ * Daemon-process singleton in-memory cache with TTL and LRU eviction.
+ *
+ * - Keys are auto-generated 16-char hex strings unless an explicit key is provided.
+ * - TTL defaults to 30 minutes; per-entry override via `ttlMs`.
+ * - Uses Map insertion order for LRU; `get` refreshes position.
+ * - At capacity, the oldest entry is evicted before a new insert.
+ * - Expired entries are lazily evicted on `get`.
+ */
+const _store = new Map<string, CacheEntry>();
+
+/**
+ * Store a value in the cache.
+ *
+ * If `options.key` is provided, the entry is upserted at that key
+ * (refreshing insertion order and resetting expiry).
+ * Otherwise a random 16-char hex key is generated.
+ */
+export function setCacheEntry(
+  data: unknown,
+  options?: { key?: string; ttlMs?: number },
+): { key: string } {
+  const key = options?.key ?? randomBytes(8).toString("hex");
+  const ttl = options?.ttlMs ?? DEFAULT_TTL_MS;
+
+  // Upsert: delete first so the re-insert moves to the end of the Map
+  // (refreshes LRU position).
+  if (_store.has(key)) {
+    _store.delete(key);
+  }
+
+  // LRU eviction: if at capacity after removing a potential existing key,
+  // drop the oldest entry (first key in Map iteration order).
+  if (_store.size >= DEFAULT_MAX_ENTRIES) {
+    const oldest = _store.keys().next().value;
+    if (oldest !== undefined) _store.delete(oldest);
+  }
+
+  _store.set(key, { data, expiresAt: Date.now() + ttl });
+  return { key };
+}
+
+/**
+ * Retrieve a value from the cache.
+ *
+ * Returns `null` if the key does not exist or the entry has expired.
+ * On a hit, the entry is moved to the end of the Map (LRU refresh).
+ */
+export function getCacheEntry(key: string): { data: unknown } | null {
+  const entry = _store.get(key);
+  if (!entry) return null;
+
+  // Lazy TTL eviction.
+  if (Date.now() >= entry.expiresAt) {
+    _store.delete(key);
+    return null;
+  }
+
+  // LRU refresh: delete + re-set moves the entry to the tail.
+  _store.delete(key);
+  _store.set(key, entry);
+
+  return { data: entry.data };
+}
+
+/**
+ * Remove a cache entry by key. Returns `true` if an entry was deleted,
+ * `false` if the key was not present (idempotent).
+ */
+export function deleteCacheEntry(key: string): boolean {
+  return _store.delete(key);
+}
+
+/** Clear all entries — exposed for test isolation only. */
+export function clearCacheForTests(): void {
+  _store.clear();
+}
+
+/** Visible-for-testing internals. */
+export const _internals = {
+  store: _store,
+  DEFAULT_TTL_MS,
+  DEFAULT_MAX_ENTRIES,
+};


### PR DESCRIPTION
## Summary
Add a daemon-memory cache primitive that workspace skill scripts can use via `assistant cache` without pushing large intermediate payloads through LLM context. Introduces a shared in-process cache store with TTL + LRU semantics, exposes it through CLI IPC, adds a first-class CLI command surface (`set/get/delete`), and migrates the existing Gmail/Outlook scan-result store to the new primitive.

## Self-review result
PASS after 2 rounds — 4 gaps found and fixed in round 1, 2 test coverage gaps fixed in round 2

## PRs merged into feature branch
- #26333: feat(skills): add in-memory skill cache store with TTL and LRU eviction
- #26334: feat(ipc): add cache set/get/delete CLI IPC methods
- #26336: feat(cli): add assistant cache set/get/delete commands
- #26335: refactor(gmail/outlook): back scan-result-store with shared skill cache

### Fix PRs
- #26337: fix: correct CLI help text for --ttl default (30m, not no expiry)
- #26338: fix: cap _trackedScanIds to prevent unbounded growth
- #26339: fix: require data field in cache/set IPC route
- #26340: fix: route >1 MB warning to stderr instead of log.warn
- #26343: test: add regression test for cache/set missing data validation
- #26344: test: add regression test for _trackedScanIds cap at 64

Part of plan: skill-scoped-cache.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
