### PR TITLE
fix(gateway): update trust-rules-routes test after browser_navigate removal

### DIFF
--- a/gateway/src/__tests__/trust-rules-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-routes.test.ts
@@ -173,7 +173,7 @@ describe("POST /v1/trust-rules — canonicalization", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        tool: "browser_navigate",
+        tool: "network_request",
         pattern: "https://example.com/**",
         scope: "everywhere",
         decision: "allow",


### PR DESCRIPTION
## Problem

The `ci-gateway` test job is failing on `main` at `trust-rules-routes.test.ts:193`:

```
Expected: false
Received: true
```

## Root Cause

PR #26309 (part of #26315 — browser_* tool removal) removed `browser_navigate` from the `URL_TOOLS` array in `ces-contracts/src/trust-rules.ts`. The contracts-level unit test was updated (`browser_navigate` → `network_request`), but the **gateway route test** was missed.

The legacy-payload canonicalization test at line 169 creates a rule with `tool: "browser_navigate"` and expects `executionTarget` to be stripped (URL-family behavior). Since `browser_navigate` is no longer a URL-family tool, it falls through to the generic family in `parseTrustRule`, which **preserves** `executionTarget` — causing the assertion to fail.

## Fix

Swap `browser_navigate` → `network_request` (still a URL-family tool) so the test correctly validates URL-family normalization behavior.

One-line change, zero behavior change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
