### PR TITLE
feat(assistant): add generic UI interaction request contract and daemon resolver hook

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -61,6 +61,7 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
+import { registerInteractiveUiResolver } from "../runtime/interactive-ui.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -828,6 +829,38 @@ export class DaemonServer {
         );
         return null;
       }
+    });
+
+    // Install the interactive UI resolver so skills and IPC handlers can
+    // present ad-hoc UI surfaces (confirmations, forms) to the user via
+    // `requestInteractiveUi()`. The resolver verifies the target
+    // conversation exists and is live before delegating to the
+    // conversation-level surface lifecycle (wired in PR 2). For now it
+    // validates the conversation and fails closed if not found — the
+    // actual surface show/await logic is added in the next PR.
+    registerInteractiveUiResolver(async (request) => {
+      const conversation = this.conversations.get(request.conversationId);
+      if (!conversation) {
+        log.warn(
+          {
+            conversationId: request.conversationId,
+            surfaceType: request.surfaceType,
+          },
+          "interactive-ui resolver: conversation not found; failing closed",
+        );
+        return {
+          status: "cancelled" as const,
+          surfaceId: `ui-resolver-${Date.now()}`,
+        };
+      }
+
+      // PR 2 will wire conversation-scoped surface lifecycle here.
+      // For now, fail closed — the resolver exists and is reachable,
+      // but the surface presentation layer is not yet implemented.
+      return {
+        status: "cancelled" as const,
+        surfaceId: `ui-resolver-${Date.now()}`,
+      };
     });
 
     // Start the CLI IPC server. Built-in methods (wake_conversation) are

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the interactive UI request primitive.
+ *
+ * Exercise strategy: the module exposes a register/request pattern with
+ * a module-level resolver, identical to `runtime/agent-wake.ts`. Tests
+ * exercise:
+ *   1. Contract validation — request/result shapes.
+ *   2. Missing resolver behavior (fail-closed).
+ *   3. Resolver registration + delegation.
+ *   4. Resolver error handling (fail-closed on throw).
+ *   5. Surface ID generation and consistency.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type InteractiveUiRequest,
+  type InteractiveUiResult,
+  registerInteractiveUiResolver,
+  requestInteractiveUi,
+  resetInteractiveUiResolverForTests,
+  resetSurfaceIdCounterForTests,
+} from "../interactive-ui.js";
+
+// ── Setup ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetInteractiveUiResolverForTests();
+  resetSurfaceIdCounterForTests();
+});
+
+// ── Missing resolver (fail-closed) ───────────────────────────────────
+
+describe("requestInteractiveUi without resolver", () => {
+  test("returns cancelled when no resolver is registered", async () => {
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: { message: "Are you sure?" },
+    };
+
+    const result = await requestInteractiveUi(request);
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+    expect(result.surfaceId.length).toBeGreaterThan(0);
+    expect(result.actionId).toBeUndefined();
+    expect(result.submittedData).toBeUndefined();
+  });
+
+  test("generates a unique surfaceId per call", async () => {
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+    };
+
+    const result1 = await requestInteractiveUi(request);
+    const result2 = await requestInteractiveUi(request);
+
+    expect(result1.surfaceId).not.toBe(result2.surfaceId);
+  });
+});
+
+// ── Resolver registration + delegation ──────────────────────────────
+
+describe("requestInteractiveUi with resolver", () => {
+  test("delegates to the registered resolver", async () => {
+    const receivedRequests: InteractiveUiRequest[] = [];
+
+    registerInteractiveUiResolver(async (req) => {
+      receivedRequests.push(req);
+      return {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "test-surface-1",
+      };
+    });
+
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-2",
+      surfaceType: "confirmation",
+      title: "Confirm deletion",
+      data: { itemName: "important-file.txt" },
+      actions: [
+        { id: "confirm", label: "Delete", variant: "danger" },
+        { id: "cancel", label: "Cancel", variant: "secondary" },
+      ],
+      timeoutMs: 30_000,
+    };
+
+    const result = await requestInteractiveUi(request);
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.surfaceId).toBe("test-surface-1");
+    expect(receivedRequests).toHaveLength(1);
+    expect(receivedRequests[0].conversationId).toBe("conv-2");
+    expect(receivedRequests[0].surfaceType).toBe("confirmation");
+    expect(receivedRequests[0].title).toBe("Confirm deletion");
+    expect(receivedRequests[0].data).toEqual({
+      itemName: "important-file.txt",
+    });
+    expect(receivedRequests[0].actions).toHaveLength(2);
+    expect(receivedRequests[0].timeoutMs).toBe(30_000);
+  });
+
+  test("passes through timed_out status from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "timeout-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-3",
+      surfaceType: "confirmation",
+      data: {},
+      timeoutMs: 100,
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("timeout-surface");
+  });
+
+  test("passes through cancelled status from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "cancelled-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-4",
+      surfaceType: "form",
+      data: { fields: ["name", "email"] },
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("cancelled-surface");
+  });
+
+  test("passes through submitted data from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "submit",
+      submittedData: { name: "Alice", email: "alice@example.com" },
+      summary: "Form submitted by user",
+      surfaceId: "form-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-5",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("submit");
+    expect(result.submittedData).toEqual({
+      name: "Alice",
+      email: "alice@example.com",
+    });
+    expect(result.summary).toBe("Form submitted by user");
+    expect(result.surfaceId).toBe("form-surface");
+  });
+
+  test("replaces resolver when registered a second time", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "first",
+      surfaceId: "first-resolver",
+    }));
+
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "second-resolver",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-6",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("second-resolver");
+  });
+});
+
+// ── Error handling (fail-closed on resolver throw) ──────────────────
+
+describe("resolver error handling", () => {
+  test("returns cancelled when resolver throws", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("Surface rendering failed");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-7",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+    expect(result.surfaceId.length).toBeGreaterThan(0);
+  });
+
+  test("returns cancelled when resolver rejects", async () => {
+    registerInteractiveUiResolver(() =>
+      Promise.reject(new Error("Connection lost")),
+    );
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-8",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+  });
+});
+
+// ── Surface ID consistency ──────────────────────────────────────────
+
+describe("surfaceId handling", () => {
+  test("uses resolver-provided surfaceId when present", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "resolver-provided-id",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-9",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.surfaceId).toBe("resolver-provided-id");
+  });
+
+  test("fills in surfaceId when resolver returns empty string", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-10",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    // Empty string is falsy, so the generated surfaceId should be used
+    expect(result.surfaceId).toStartWith("ui-interaction-");
+  });
+});
+
+// ── Contract shape validation ───────────────────────────────────────
+
+describe("contract shapes", () => {
+  test("request with minimal fields", async () => {
+    const received: InteractiveUiRequest[] = [];
+    registerInteractiveUiResolver(async (req) => {
+      received.push(req);
+      return { status: "cancelled", surfaceId: "min-surface" };
+    });
+
+    await requestInteractiveUi({
+      conversationId: "conv-minimal",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(received[0]).toEqual({
+      conversationId: "conv-minimal",
+      surfaceType: "confirmation",
+      data: {},
+    });
+    // Optional fields should be absent, not undefined
+    expect("title" in received[0]).toBe(false);
+    expect("actions" in received[0]).toBe(false);
+    expect("timeoutMs" in received[0]).toBe(false);
+  });
+
+  test("request with all fields populated", async () => {
+    const received: InteractiveUiRequest[] = [];
+    registerInteractiveUiResolver(async (req) => {
+      received.push(req);
+      return { status: "submitted", actionId: "ok", surfaceId: "full-surface" };
+    });
+
+    const fullRequest: InteractiveUiRequest = {
+      conversationId: "conv-full",
+      surfaceType: "form",
+      title: "Enter details",
+      data: { schema: { name: "string", age: "number" } },
+      actions: [
+        { id: "ok", label: "Submit", variant: "primary" },
+        { id: "skip", label: "Skip" },
+      ],
+      timeoutMs: 60_000,
+    };
+
+    await requestInteractiveUi(fullRequest);
+
+    expect(received[0].conversationId).toBe("conv-full");
+    expect(received[0].surfaceType).toBe("form");
+    expect(received[0].title).toBe("Enter details");
+    expect(received[0].actions).toHaveLength(2);
+    expect(received[0].actions![0].variant).toBe("primary");
+    expect(received[0].actions![1].variant).toBeUndefined();
+    expect(received[0].timeoutMs).toBe(60_000);
+  });
+
+  test("result contract — submitted with all optional fields", async () => {
+    const fullResult: InteractiveUiResult = {
+      status: "submitted",
+      actionId: "confirm",
+      submittedData: { choice: "yes" },
+      summary: "User confirmed the action",
+      surfaceId: "full-result-surface",
+    };
+
+    registerInteractiveUiResolver(async () => fullResult);
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-contract",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.submittedData).toEqual({ choice: "yes" });
+    expect(result.summary).toBe("User confirmed the action");
+    expect(result.surfaceId).toBe("full-result-surface");
+  });
+});

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -1,0 +1,229 @@
+/**
+ * Generic UI interaction request primitive.
+ *
+ * Provides a conversation-scoped mechanism for daemon-side code (skills,
+ * IPC handlers, CLI wrappers) to present an interactive UI surface to the
+ * user and await their response. This is intentionally decoupled from the
+ * confirmation_request / guardian approval pipeline — it serves a different
+ * purpose (ad-hoc UI prompts driven by skills or CLI commands, not
+ * tool-approval gates).
+ *
+ * Architecture:
+ *   - Typed {@link InteractiveUiRequest} / {@link InteractiveUiResult}
+ *     contracts define the wire shape for callers and resolvers.
+ *   - A module-level resolver ({@link registerInteractiveUiResolver}) is
+ *     installed once at daemon startup, following the same pattern as
+ *     {@link registerDefaultWakeResolver} in `runtime/agent-wake.ts`.
+ *   - {@link requestInteractiveUi} is the callable entry point. It
+ *     delegates to the registered resolver; when no resolver is present
+ *     (e.g. headless environments, test harnesses that don't install
+ *     one), it fails closed by returning a `"cancelled"` result.
+ *
+ * Concurrency:
+ *   - Requests are scoped to a single conversation and identified by a
+ *     unique `surfaceId` generated at request time.
+ *   - Multiple concurrent requests on different conversations are
+ *     independent.
+ *   - The resolver is responsible for lifecycle management of the
+ *     underlying surface (show, await action/timeout, dismiss).
+ *
+ * Fail-closed guarantee:
+ *   - If no resolver is registered, `requestInteractiveUi` returns
+ *     `{ status: "cancelled" }` immediately.
+ *   - If the request times out (per `timeoutMs`), the result status is
+ *     `"timed_out"`.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("interactive-ui");
+
+// ── Request / Result contracts ───────────────────────────────────────
+
+/**
+ * Describes a single action button/option presented to the user on the
+ * interactive surface.
+ */
+export interface InteractiveUiAction {
+  /** Unique identifier for this action within the request. */
+  id: string;
+  /** Human-readable label shown on the button/option. */
+  label: string;
+  /**
+   * Optional variant hint for the renderer.
+   * - `"primary"` — emphasized / default action
+   * - `"danger"` — destructive action (red styling)
+   * - `"secondary"` — de-emphasized / cancel-like action
+   */
+  variant?: "primary" | "danger" | "secondary";
+}
+
+/**
+ * A request to show an interactive UI surface to the user and await their
+ * response.
+ */
+export interface InteractiveUiRequest {
+  /** Conversation this interaction is scoped to. */
+  conversationId: string;
+  /**
+   * Surface type hint for the renderer.
+   * - `"confirmation"` — yes/no or approve/deny prompt
+   * - `"form"` — structured data entry (v1 placeholder)
+   */
+  surfaceType: "confirmation" | "form";
+  /** Optional title displayed at the top of the surface. */
+  title?: string;
+  /**
+   * Arbitrary payload describing the content of the surface. The shape
+   * depends on `surfaceType` — the runtime treats it as opaque and
+   * forwards it to the renderer.
+   */
+  data: Record<string, unknown>;
+  /** Actions (buttons) to present. When omitted, the renderer uses its default set. */
+  actions?: InteractiveUiAction[];
+  /**
+   * Maximum time (in milliseconds) to wait for a user response before
+   * the request resolves with `status: "timed_out"`. When omitted, the
+   * resolver uses its own default timeout (typically 5 minutes).
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * The result of an interactive UI request after the user has responded
+ * or the request has expired.
+ */
+export interface InteractiveUiResult {
+  /**
+   * Terminal status of the interaction.
+   * - `"submitted"` — the user selected an action / submitted data
+   * - `"cancelled"` — the user explicitly dismissed the surface, or the
+   *   surface could not be shown (fail-closed)
+   * - `"timed_out"` — the timeout elapsed without a user response
+   */
+  status: "submitted" | "cancelled" | "timed_out";
+  /** The `id` of the action the user selected (when `status === "submitted"`). */
+  actionId?: string;
+  /** Structured data submitted by the user (for `surfaceType: "form"`). */
+  submittedData?: Record<string, unknown>;
+  /** Optional human-readable summary of the user's response. */
+  summary?: string;
+  /** The surface identifier that was shown, for audit/correlation. */
+  surfaceId: string;
+}
+
+// ── Resolver type ────────────────────────────────────────────────────
+
+/**
+ * A function that presents an interactive UI surface and resolves when
+ * the user responds or the timeout elapses.
+ */
+export type InteractiveUiResolver = (
+  request: InteractiveUiRequest,
+) => Promise<InteractiveUiResult>;
+
+// ── Module-level resolver registration ───────────────────────────────
+//
+// Same pattern as `runtime/agent-wake.ts`: a module-level default
+// resolver that the daemon installs once at startup. Callers that use
+// `requestInteractiveUi()` get the daemon-wired resolver automatically.
+// Tests can register a mock resolver and reset via the test-only helper.
+
+let _resolver: InteractiveUiResolver | null = null;
+
+/**
+ * Install the process-wide interactive UI resolver. Called once at
+ * daemon startup (see `DaemonServer.start()`) with a function that
+ * knows how to show a surface on a live conversation and await the
+ * user's response.
+ *
+ * Calling this more than once replaces the prior resolver — the daemon
+ * startup path should call it exactly once.
+ */
+export function registerInteractiveUiResolver(
+  resolver: InteractiveUiResolver,
+): void {
+  _resolver = resolver;
+}
+
+/**
+ * Reset the process-wide resolver. Test-only.
+ *
+ * @internal
+ */
+export function resetInteractiveUiResolverForTests(): void {
+  _resolver = null;
+}
+
+// ── Surface ID generation ────────────────────────────────────────────
+
+let _surfaceIdCounter = 0;
+
+function generateSurfaceId(): string {
+  _surfaceIdCounter++;
+  return `ui-interaction-${Date.now()}-${_surfaceIdCounter}`;
+}
+
+/**
+ * Reset the surface ID counter. Test-only.
+ *
+ * @internal
+ */
+export function resetSurfaceIdCounterForTests(): void {
+  _surfaceIdCounter = 0;
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Present an interactive UI surface to the user and await their
+ * response.
+ *
+ * Fails closed: when no resolver is registered (headless, tests without
+ * setup), returns `{ status: "cancelled", surfaceId }` immediately.
+ *
+ * @param request - The interaction request describing the surface.
+ * @returns The user's response or a fail-closed cancellation.
+ */
+export async function requestInteractiveUi(
+  request: InteractiveUiRequest,
+): Promise<InteractiveUiResult> {
+  const surfaceId = generateSurfaceId();
+
+  if (!_resolver) {
+    log.warn(
+      {
+        conversationId: request.conversationId,
+        surfaceType: request.surfaceType,
+      },
+      "interactive-ui: no resolver registered; failing closed",
+    );
+    return {
+      status: "cancelled",
+      surfaceId,
+    };
+  }
+
+  try {
+    const result = await _resolver(request);
+    // Ensure the surfaceId is consistent — the resolver may or may not
+    // populate it, but the contract guarantees it is always present.
+    return {
+      ...result,
+      surfaceId: result.surfaceId || surfaceId,
+    };
+  } catch (err) {
+    log.error(
+      {
+        err,
+        conversationId: request.conversationId,
+        surfaceType: request.surfaceType,
+      },
+      "interactive-ui: resolver threw; failing closed",
+    );
+    return {
+      status: "cancelled",
+      surfaceId,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add typed request/result contracts for generic UI interaction requests
- Add module-level resolver registration pattern (same as agent-wake.ts)
- Wire resolver in daemon server startup with live conversation access

Part of plan: user-confirmation-primitive.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
