### PR TITLE
fix(chrome-ext): include assistantId in OAuth start URL and use /accounts/ path

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -94,8 +94,9 @@ describe('signInCloud', () => {
   test('happy path stores a token and returns it', async () => {
     launchWebAuthFlowImpl = async (details) => {
       // The redirect URL the gateway would send back.
-      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
       expect(details.url).toContain('client_id=test-client-id');
+      expect(details.url).toContain(`assistant_id=${ASSISTANT_A}`);
       expect(details.interactive).toBe(true);
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc123&expires_in=3600&guardian_id=g-42';
     };
@@ -149,8 +150,8 @@ describe('signInCloud', () => {
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
     };
     await signInCloud(ASSISTANT_A, { webBaseUrl: 'https://www.vellum.ai/', clientId: 'cid' });
-    expect(seenUrl).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
-    expect(seenUrl).not.toContain('www.vellum.ai//oauth');
+    expect(seenUrl).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrl).not.toContain('www.vellum.ai//accounts');
   });
 });
 
@@ -301,7 +302,8 @@ describe('refreshCloudToken', () => {
     let seenInteractive: boolean | undefined;
     launchWebAuthFlowImpl = async (details) => {
       seenInteractive = details.interactive;
-      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+      expect(details.url).toContain(`assistant_id=${ASSISTANT_A}`);
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=fresh-jwt&expires_in=3600&guardian_id=g-99';
     };
 

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -8,7 +8,7 @@
  *
  * The `CloudAuthConfig.webBaseUrl` field points to the Next.js web app
  * that serves the browser-facing OAuth start page
- * (`/oauth/chrome-extension/start`). Always `https://www.vellum.ai` in
+ * (`/accounts/chrome-extension/start`). Always `https://www.vellum.ai` in
  * production. The gateway / relay URL is managed separately by the
  * caller (worker.ts) and is not part of the auth config.
  *
@@ -222,12 +222,13 @@ function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
   };
 }
 
-function buildAuthUrl(config: CloudAuthConfig): string {
+function buildAuthUrl(config: CloudAuthConfig, assistantId: string): string {
   const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
   return (
-    `${config.webBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
+    `${config.webBaseUrl.replace(/\/$/, '')}/accounts/chrome-extension/start` +
     `?client_id=${encodeURIComponent(config.clientId)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}`
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&assistant_id=${encodeURIComponent(assistantId)}`
   );
 }
 
@@ -236,7 +237,7 @@ function buildAuthUrl(config: CloudAuthConfig): string {
  * The extension receives the token via the redirect URI fragment.
  */
 export async function signInCloud(assistantId: string, config: CloudAuthConfig): Promise<StoredCloudToken> {
-  const authUrl = buildAuthUrl(config);
+  const authUrl = buildAuthUrl(config, assistantId);
 
   const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
   if (!responseUrl) throw new Error('cloud sign-in cancelled');
@@ -265,7 +266,7 @@ export async function refreshCloudToken(
   assistantId: string,
   config: CloudAuthConfig,
 ): Promise<StoredCloudToken | null> {
-  const authUrl = buildAuthUrl(config);
+  const authUrl = buildAuthUrl(config, assistantId);
 
   let responseUrl: string | undefined;
   try {


### PR DESCRIPTION
## Summary
- Update `buildAuthUrl()` to accept `assistantId` and include it as `assistant_id` query parameter in the OAuth start URL
- Change the OAuth start path from `/oauth/chrome-extension/start` to `/accounts/chrome-extension/start` (Django backend-owned namespace)
- Update `cloud-auth.test.ts` assertions for the new path and `assistant_id` parameter

Part of plan: chrome-ext-cloud-oauth.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
