### PR TITLE
feat(gateway): add cloud OAuth token-minting endpoint for Chrome extension

### DIFF
--- a/gateway/src/__tests__/cloud-oauth-token.test.ts
+++ b/gateway/src/__tests__/cloud-oauth-token.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import "./test-preload.js";
+
+import {
+  initSigningKey,
+  loadOrCreateSigningKey,
+} from "../auth/token-service.js";
+import { createCloudOAuthTokenHandler } from "../http/routes/cloud-oauth-token.js";
+import { verifyToken } from "../auth/token-service.js";
+
+beforeAll(() => {
+  initSigningKey(loadOrCreateSigningKey());
+});
+
+const handler = createCloudOAuthTokenHandler();
+
+describe("POST /v1/internal/oauth/chrome-extension/token", () => {
+  test("happy path: valid body returns 200 with token, expiresIn, and guardianId", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      token: string;
+      expiresIn: number;
+      guardianId: string;
+    };
+
+    expect(typeof body.token).toBe("string");
+    expect(body.token.split(".").length).toBe(3); // JWT format
+    expect(body.expiresIn).toBe(3600);
+    expect(body.guardianId).toBe("user-456");
+
+    // Verify the minted token has the correct claims
+    const result = verifyToken(body.token, "vellum-gateway");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.sub).toBe("actor:asst-123:user-456");
+      expect(result.claims.aud).toBe("vellum-gateway");
+      expect(result.claims.scope_profile).toBe("actor_client_v1");
+    }
+  });
+
+  test("missing assistantId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("missing actorPrincipalId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("actorPrincipalId");
+  });
+
+  test("empty assistantId string returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("empty actorPrincipalId string returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+            actorPrincipalId: "",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("actorPrincipalId");
+  });
+
+  test("whitespace-only strings return 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "   ",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("invalid JSON body returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not-json",
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("JSON");
+  });
+
+  test("non-string assistantId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: 123,
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+});

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -131,6 +131,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   // Runtime proxy catch-all — documented as /{path} in the schema
   "catch-all",
 
+  // Internal-only endpoint called by the platform via vembda — not public API
+  "/v1/internal/oauth/chrome-extension/token",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -1,0 +1,95 @@
+/**
+ * Cloud OAuth token-minting endpoint for the Chrome extension.
+ *
+ * Called by the platform (via vembda) after a user authenticates through
+ * WorkOS. Mints a guardian-bound JWT that the Chrome extension uses to
+ * communicate with the gateway as a guardian client.
+ *
+ * POST /v1/internal/oauth/chrome-extension/token
+ *   Body: { assistantId: string, actorPrincipalId: string }
+ *   Auth: edge (service-token — only the platform calls this)
+ *   Returns: { token: string, expiresIn: number, guardianId: string }
+ */
+
+import { getLogger } from "../../logger.js";
+import { mintToken } from "../../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
+
+const log = getLogger("cloud-oauth-token");
+
+/** TTL for minted guardian tokens — 1 hour. */
+const GUARDIAN_TOKEN_TTL_SECONDS = 3600;
+
+export function createCloudOAuthTokenHandler() {
+  return {
+    async handleMintToken(req: Request): Promise<Response> {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json(
+          { error: "Request body must be valid JSON" },
+          { status: 400 },
+        );
+      }
+
+      if (!body || typeof body !== "object") {
+        return Response.json(
+          { error: "Request body must be a JSON object" },
+          { status: 400 },
+        );
+      }
+
+      const { assistantId, actorPrincipalId } = body as Record<string, unknown>;
+
+      if (typeof assistantId !== "string" || assistantId.trim() === "") {
+        return Response.json(
+          { error: "assistantId is required and must be a non-empty string" },
+          { status: 400 },
+        );
+      }
+
+      if (
+        typeof actorPrincipalId !== "string" ||
+        actorPrincipalId.trim() === ""
+      ) {
+        return Response.json(
+          {
+            error:
+              "actorPrincipalId is required and must be a non-empty string",
+          },
+          { status: 400 },
+        );
+      }
+
+      const sub = `actor:${assistantId}:${actorPrincipalId}`;
+
+      try {
+        const token = mintToken({
+          aud: "vellum-gateway",
+          sub,
+          scope_profile: "actor_client_v1",
+          policy_epoch: CURRENT_POLICY_EPOCH,
+          ttlSeconds: GUARDIAN_TOKEN_TTL_SECONDS,
+        });
+
+        log.info(
+          { assistantId, actorPrincipalId },
+          "Minted cloud OAuth guardian token",
+        );
+
+        return Response.json({
+          token,
+          expiresIn: GUARDIAN_TOKEN_TTL_SECONDS,
+          guardianId: actorPrincipalId,
+        });
+      } catch (err) {
+        log.error({ err }, "Failed to mint cloud OAuth guardian token");
+        return Response.json(
+          { error: "Failed to mint token" },
+          { status: 500 },
+        );
+      }
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -59,6 +59,7 @@ import {
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
+import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
 import { createVercelControlPlaneProxyHandler } from "./http/routes/vercel-control-plane-proxy.js";
@@ -328,6 +329,7 @@ async function main() {
   const pairingProxy = createPairingProxyHandler(config);
   const channelVerificationSessionProxy =
     createChannelVerificationSessionProxyHandler(config);
+  const cloudOAuthTokenHandler = createCloudOAuthTokenHandler();
   const telegramControlPlaneProxy =
     createTelegramControlPlaneProxyHandler(config);
   const vercelControlPlaneProxy = createVercelControlPlaneProxyHandler(config);
@@ -632,6 +634,14 @@ async function main() {
       auth: "edge",
       handler: (req, params) =>
         contactsControlPlaneProxy.handleGetContact(req, params[0]),
+    },
+
+    // ── Cloud OAuth token minting (Chrome extension) ──
+    {
+      path: "/v1/internal/oauth/chrome-extension/token",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => cloudOAuthTokenHandler.handleMintToken(req),
     },
 
     // ── Channel verification sessions ──


### PR DESCRIPTION
## Summary
- Add `POST /v1/internal/oauth/chrome-extension/token` endpoint to mint guardian-bound JWTs for the Chrome extension cloud OAuth flow
- The platform calls this endpoint after WorkOS authentication to issue a 1-hour gateway access token with `actor_client_v1` scope
- Includes validation for required fields (`assistantId`, `actorPrincipalId`) and comprehensive test coverage

Part of plan: chrome-ext-cloud-oauth.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
