### PR TITLE
test(meet-join): replace personal names in test fixtures with generic 'Aria'

### DIFF
--- a/skills/meet-join/bot/__tests__/participant-scraper.test.ts
+++ b/skills/meet-join/bot/__tests__/participant-scraper.test.ts
@@ -386,7 +386,7 @@ describe("startParticipantScraper", () => {
     // deliberately unique display name.
     const page = makeFakePage([
       { id: "p-alice", name: "Alice", isSelfByDom: false },
-      { id: "p-bot", name: "Velissa (Sidd's assistant)", isSelfByDom: false },
+      { id: "p-bot", name: "Aria", isSelfByDom: false },
     ]);
     const handle = startParticipantScraper(
       page as unknown as Parameters<typeof startParticipantScraper>[0],
@@ -394,7 +394,7 @@ describe("startParticipantScraper", () => {
       {
         meetingId: "m-1",
         pollMs: 50,
-        selfName: "Velissa (Sidd's assistant)",
+        selfName: "Aria",
       },
     );
     handles.push(handle);
@@ -403,7 +403,7 @@ describe("startParticipantScraper", () => {
 
     expect(events.length).toBe(1);
     const joined = events[0]!.joined;
-    const bot = joined.find((p) => p.name === "Velissa (Sidd's assistant)");
+    const bot = joined.find((p) => p.name === "Aria");
     expect(bot?.isSelf).toBe(true);
     const alice = joined.find((p) => p.id === "p-alice");
     expect(alice?.isSelf).toBeUndefined();

--- a/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
+++ b/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
@@ -174,7 +174,7 @@ function participantChangeWithSelf(): MeetBotEvent {
     type: "participant.change",
     meetingId: MEETING_ID,
     timestamp: "2024-01-01T00:00:00.000Z",
-    joined: [{ id: BOT_PARTICIPANT_ID, name: "Velissa", isSelf: true }],
+    joined: [{ id: BOT_PARTICIPANT_ID, name: "Aria", isSelf: true }],
     left: [],
   };
 }
@@ -370,7 +370,7 @@ describe("MeetBargeInWatcher — speaker.change cancel path", () => {
     // Floor returns to the bot before the debounce expires.
     dispatcher.dispatch(
       MEETING_ID,
-      speakerChange(BOT_PARTICIPANT_ID, "Velissa"),
+      speakerChange(BOT_PARTICIPANT_ID, "Aria"),
     );
     expect(watcher._hasPendingCancel()).toBe(false);
     expect(timer.pending.size).toBe(0);
@@ -391,7 +391,7 @@ describe("MeetBargeInWatcher — speaker.change cancel path", () => {
 
     dispatcher.dispatch(
       MEETING_ID,
-      speakerChange(BOT_PARTICIPANT_ID, "Velissa"),
+      speakerChange(BOT_PARTICIPANT_ID, "Aria"),
     );
     expect(timer.pending.size).toBe(0);
     expect(watcher._hasPendingCancel()).toBe(false);

--- a/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
+++ b/skills/meet-join/daemon/__tests__/chat-opportunity-detector.test.ts
@@ -155,7 +155,7 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig(),
       callDetectorLLM: llm,
       onOpportunity,
@@ -200,7 +200,7 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig(),
       callDetectorLLM: llm,
       onOpportunity,
@@ -245,7 +245,7 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig(),
       callDetectorLLM: llm,
       onOpportunity,
@@ -295,7 +295,7 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig(),
       callDetectorLLM: llm,
       onOpportunity,
@@ -309,7 +309,7 @@ describe("MeetChatOpportunityDetector — Tier 1 fast filter", () => {
       transcriptChunk(
         "m1",
         "2024-01-01T00:00:00.000Z",
-        "I was chatting with Velissa earlier.",
+        "I was chatting with Aria earlier.",
       ),
     );
 
@@ -335,7 +335,7 @@ describe("MeetChatOpportunityDetector — debounce + cooldown", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig({ tier2DebounceMs: 5_000 }),
       callDetectorLLM: llm,
       onOpportunity,
@@ -399,7 +399,7 @@ describe("MeetChatOpportunityDetector — debounce + cooldown", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       // Use a short debounce so the second hit actually reaches Tier 2,
       // letting us exercise the escalation cooldown rather than the
       // debounce guard above it.
@@ -474,7 +474,7 @@ describe("MeetChatOpportunityDetector — enabled=false", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig({ enabled: false }),
       callDetectorLLM: llm,
       onOpportunity,
@@ -488,7 +488,7 @@ describe("MeetChatOpportunityDetector — enabled=false", () => {
       transcriptChunk(
         "m1",
         "2024-01-01T00:00:00.000Z",
-        "Hey Velissa, can you send the deck?",
+        "Hey Aria, can you send the deck?",
       ),
     );
     dispatcher.dispatch(
@@ -528,7 +528,7 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
 
     const detector = new MeetChatOpportunityDetector({
       meetingId: "m1",
-      assistantDisplayName: "Velissa",
+      assistantDisplayName: "Aria",
       config: defaultConfig({
         // Only this custom pattern — none of the defaults are present.
         detectorKeywords: ["\\bblue\\s+monkey\\b"],
@@ -551,8 +551,8 @@ describe("MeetChatOpportunityDetector — custom keywords", () => {
       ),
     );
     await flushPromises();
-    // Still matches the assistant-name pattern if name is "Velissa"?
-    // This phrase doesn't mention Velissa, so Tier 1 should not hit.
+    // Still matches the assistant-name pattern if name is "Aria"?
+    // This phrase doesn't mention Aria, so Tier 1 should not hit.
     expect(detector.getStats().tier1Hits).toBe(0);
     expect(llm).toHaveBeenCalledTimes(0);
 

--- a/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
+++ b/skills/meet-join/daemon/__tests__/voice-e2e.test.ts
@@ -479,7 +479,7 @@ function participantChangeWithSelf(): ParticipantChangeEvent {
     type: "participant.change",
     meetingId: MEETING_ID,
     timestamp: "2024-01-01T00:00:00.000Z",
-    joined: [{ id: BOT_PARTICIPANT_ID, name: "Velissa", isSelf: true }],
+    joined: [{ id: BOT_PARTICIPANT_ID, name: "Aria", isSelf: true }],
     left: [],
   };
 }
@@ -773,7 +773,7 @@ describe("Meet voice E2E (bridge + watcher + real assistant-event-hub)", () => {
       await new Promise((r) => setTimeout(r, 80));
       dispatcher.dispatch(
         MEETING_ID,
-        speakerChange(BOT_PARTICIPANT_ID, "Velissa"),
+        speakerChange(BOT_PARTICIPANT_ID, "Aria"),
       );
 
       // The pending cancel must have been cleared by the return-to-bot

--- a/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-join-tool.test.ts
@@ -236,7 +236,7 @@ describe("meet_join input validation", () => {
 
 describe("meet_join session-manager delegation", () => {
   test("substitutes {assistantName} into the consent message before joining", async () => {
-    assistantNameValue = "Velissa";
+    assistantNameValue = "Aria";
     const result = await meetJoinTool.execute(
       { url: "https://meet.google.com/abc-defg-hij" },
       makeContext({ conversationId: "conv-123" }),
@@ -249,7 +249,7 @@ describe("meet_join session-manager delegation", () => {
     expect(call.conversationId).toBe("conv-123");
     expect(call.consentMessage).toBeDefined();
     expect(call.consentMessage).not.toContain("{assistantName}");
-    expect(call.consentMessage).toContain("Velissa");
+    expect(call.consentMessage).toContain("Aria");
     expect(call.meetingId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );


### PR DESCRIPTION
## Summary

- Replace hardcoded \`Velissa\` and \`Velissa (Sidd's assistant)\` references in meet-join test fixtures with the neutral placeholder \`Aria\`.
- Keeps tests self-consistent: both the \`assistantDisplayName\` config and the in-message assistant-name mentions are updated in lockstep so Tier 1 keyword matching still fires where expected.
- Test-only change — no production behavior affected.

## Original prompt

Remove these mentions of Velissa and Sidd from the codebase (\`rg velissa\` across \`skills/meet-join/**/__tests__/\`).