### PR TITLE
feat: Chrome extension cloud OAuth login (gateway + extension)

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -94,8 +94,9 @@ describe('signInCloud', () => {
   test('happy path stores a token and returns it', async () => {
     launchWebAuthFlowImpl = async (details) => {
       // The redirect URL the gateway would send back.
-      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
       expect(details.url).toContain('client_id=test-client-id');
+      expect(details.url).toContain(`assistant_id=${ASSISTANT_A}`);
       expect(details.interactive).toBe(true);
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc123&expires_in=3600&guardian_id=g-42';
     };
@@ -149,8 +150,8 @@ describe('signInCloud', () => {
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
     };
     await signInCloud(ASSISTANT_A, { webBaseUrl: 'https://www.vellum.ai/', clientId: 'cid' });
-    expect(seenUrl).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
-    expect(seenUrl).not.toContain('www.vellum.ai//oauth');
+    expect(seenUrl).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrl).not.toContain('www.vellum.ai//accounts');
   });
 });
 
@@ -301,7 +302,8 @@ describe('refreshCloudToken', () => {
     let seenInteractive: boolean | undefined;
     launchWebAuthFlowImpl = async (details) => {
       seenInteractive = details.interactive;
-      expect(details.url).toContain('https://www.vellum.ai/oauth/chrome-extension/start');
+      expect(details.url).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+      expect(details.url).toContain(`assistant_id=${ASSISTANT_A}`);
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=fresh-jwt&expires_in=3600&guardian_id=g-99';
     };
 

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -8,7 +8,7 @@
  *
  * The `CloudAuthConfig.webBaseUrl` field points to the Next.js web app
  * that serves the browser-facing OAuth start page
- * (`/oauth/chrome-extension/start`). Always `https://www.vellum.ai` in
+ * (`/accounts/chrome-extension/start`). Always `https://www.vellum.ai` in
  * production. The gateway / relay URL is managed separately by the
  * caller (worker.ts) and is not part of the auth config.
  *
@@ -222,12 +222,13 @@ function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
   };
 }
 
-function buildAuthUrl(config: CloudAuthConfig): string {
+function buildAuthUrl(config: CloudAuthConfig, assistantId: string): string {
   const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
   return (
-    `${config.webBaseUrl.replace(/\/$/, '')}/oauth/chrome-extension/start` +
+    `${config.webBaseUrl.replace(/\/$/, '')}/accounts/chrome-extension/start` +
     `?client_id=${encodeURIComponent(config.clientId)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}`
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&assistant_id=${encodeURIComponent(assistantId)}`
   );
 }
 
@@ -236,7 +237,7 @@ function buildAuthUrl(config: CloudAuthConfig): string {
  * The extension receives the token via the redirect URI fragment.
  */
 export async function signInCloud(assistantId: string, config: CloudAuthConfig): Promise<StoredCloudToken> {
-  const authUrl = buildAuthUrl(config);
+  const authUrl = buildAuthUrl(config, assistantId);
 
   const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
   if (!responseUrl) throw new Error('cloud sign-in cancelled');
@@ -265,7 +266,7 @@ export async function refreshCloudToken(
   assistantId: string,
   config: CloudAuthConfig,
 ): Promise<StoredCloudToken | null> {
-  const authUrl = buildAuthUrl(config);
+  const authUrl = buildAuthUrl(config, assistantId);
 
   let responseUrl: string | undefined;
   try {

--- a/gateway/src/__tests__/cloud-oauth-token.test.ts
+++ b/gateway/src/__tests__/cloud-oauth-token.test.ts
@@ -4,30 +4,47 @@ import "./test-preload.js";
 import {
   initSigningKey,
   loadOrCreateSigningKey,
+  mintToken,
+  verifyToken,
 } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import { createCloudOAuthTokenHandler } from "../http/routes/cloud-oauth-token.js";
-import { verifyToken } from "../auth/token-service.js";
+
+let serviceToken: string;
 
 beforeAll(() => {
   initSigningKey(loadOrCreateSigningKey());
+  // Mint a service token (svc:gateway:self) that the handler accepts.
+  serviceToken = mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 60,
+  });
 });
 
 const handler = createCloudOAuthTokenHandler();
 
+/** Build a POST request with the service-token Authorization header. */
+function makeRequest(body: unknown): Request {
+  return new Request(
+    "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${serviceToken}`,
+      },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+}
+
 describe("POST /v1/internal/oauth/chrome-extension/token", () => {
   test("happy path: valid body returns 200 with token, expiresIn, and guardianId", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: "asst-123",
-            actorPrincipalId: "user-456",
-          }),
-        },
-      ),
+      makeRequest({ assistantId: "asst-123", actorPrincipalId: "user-456" }),
     );
 
     expect(res.status).toBe(200);
@@ -54,18 +71,8 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("missing assistantId returns 400", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            actorPrincipalId: "user-456",
-          }),
-        },
-      ),
+      makeRequest({ actorPrincipalId: "user-456" }),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("assistantId");
@@ -73,18 +80,8 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("missing actorPrincipalId returns 400", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: "asst-123",
-          }),
-        },
-      ),
+      makeRequest({ assistantId: "asst-123" }),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("actorPrincipalId");
@@ -92,19 +89,8 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("empty assistantId string returns 400", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: "",
-            actorPrincipalId: "user-456",
-          }),
-        },
-      ),
+      makeRequest({ assistantId: "", actorPrincipalId: "user-456" }),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("assistantId");
@@ -112,19 +98,8 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("empty actorPrincipalId string returns 400", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: "asst-123",
-            actorPrincipalId: "",
-          }),
-        },
-      ),
+      makeRequest({ assistantId: "asst-123", actorPrincipalId: "" }),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("actorPrincipalId");
@@ -132,19 +107,8 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("whitespace-only strings return 400", async () => {
     const res = await handler.handleMintToken(
-      new Request(
-        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            assistantId: "   ",
-            actorPrincipalId: "user-456",
-          }),
-        },
-      ),
+      makeRequest({ assistantId: "   ", actorPrincipalId: "user-456" }),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("assistantId");
@@ -156,12 +120,14 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
         "http://gateway.test/v1/internal/oauth/chrome-extension/token",
         {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${serviceToken}`,
+          },
           body: "not-json",
         },
       ),
     );
-
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("JSON");
@@ -169,21 +135,72 @@ describe("POST /v1/internal/oauth/chrome-extension/token", () => {
 
   test("non-string assistantId returns 400", async () => {
     const res = await handler.handleMintToken(
+      makeRequest({ assistantId: 123, actorPrincipalId: "user-456" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("colon in assistantId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      makeRequest({ assistantId: "asst:123", actorPrincipalId: "user-456" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("colon");
+  });
+
+  test("colon in actorPrincipalId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      makeRequest({ assistantId: "asst-123", actorPrincipalId: "user:456" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("colon");
+  });
+
+  test("request without authorization header returns 403", async () => {
+    const res = await handler.handleMintToken(
       new Request(
         "http://gateway.test/v1/internal/oauth/chrome-extension/token",
         {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            assistantId: 123,
+            assistantId: "asst-123",
             actorPrincipalId: "user-456",
           }),
         },
       ),
     );
+    expect(res.status).toBe(403);
+  });
 
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("assistantId");
+  test("request with actor token (not service) returns 403", async () => {
+    const actorToken = mintToken({
+      aud: "vellum-gateway",
+      sub: "actor:asst-123:some-user",
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 60,
+    });
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${actorToken}`,
+          },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+    expect(res.status).toBe(403);
   });
 });

--- a/gateway/src/__tests__/cloud-oauth-token.test.ts
+++ b/gateway/src/__tests__/cloud-oauth-token.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import "./test-preload.js";
+
+import {
+  initSigningKey,
+  loadOrCreateSigningKey,
+} from "../auth/token-service.js";
+import { createCloudOAuthTokenHandler } from "../http/routes/cloud-oauth-token.js";
+import { verifyToken } from "../auth/token-service.js";
+
+beforeAll(() => {
+  initSigningKey(loadOrCreateSigningKey());
+});
+
+const handler = createCloudOAuthTokenHandler();
+
+describe("POST /v1/internal/oauth/chrome-extension/token", () => {
+  test("happy path: valid body returns 200 with token, expiresIn, and guardianId", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      token: string;
+      expiresIn: number;
+      guardianId: string;
+    };
+
+    expect(typeof body.token).toBe("string");
+    expect(body.token.split(".").length).toBe(3); // JWT format
+    expect(body.expiresIn).toBe(3600);
+    expect(body.guardianId).toBe("user-456");
+
+    // Verify the minted token has the correct claims
+    const result = verifyToken(body.token, "vellum-gateway");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.sub).toBe("actor:asst-123:user-456");
+      expect(result.claims.aud).toBe("vellum-gateway");
+      expect(result.claims.scope_profile).toBe("actor_client_v1");
+    }
+  });
+
+  test("missing assistantId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("missing actorPrincipalId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("actorPrincipalId");
+  });
+
+  test("empty assistantId string returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("empty actorPrincipalId string returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "asst-123",
+            actorPrincipalId: "",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("actorPrincipalId");
+  });
+
+  test("whitespace-only strings return 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: "   ",
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+
+  test("invalid JSON body returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not-json",
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("JSON");
+  });
+
+  test("non-string assistantId returns 400", async () => {
+    const res = await handler.handleMintToken(
+      new Request(
+        "http://gateway.test/v1/internal/oauth/chrome-extension/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assistantId: 123,
+            actorPrincipalId: "user-456",
+          }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("assistantId");
+  });
+});

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -131,6 +131,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   // Runtime proxy catch-all — documented as /{path} in the schema
   "catch-all",
 
+  // Internal-only endpoint called by the platform via vembda — not public API
+  "/v1/internal/oauth/chrome-extension/token",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -1,0 +1,95 @@
+/**
+ * Cloud OAuth token-minting endpoint for the Chrome extension.
+ *
+ * Called by the platform (via vembda) after a user authenticates through
+ * WorkOS. Mints a guardian-bound JWT that the Chrome extension uses to
+ * communicate with the gateway as a guardian client.
+ *
+ * POST /v1/internal/oauth/chrome-extension/token
+ *   Body: { assistantId: string, actorPrincipalId: string }
+ *   Auth: edge (service-token — only the platform calls this)
+ *   Returns: { token: string, expiresIn: number, guardianId: string }
+ */
+
+import { getLogger } from "../../logger.js";
+import { mintToken } from "../../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
+
+const log = getLogger("cloud-oauth-token");
+
+/** TTL for minted guardian tokens — 1 hour. */
+const GUARDIAN_TOKEN_TTL_SECONDS = 3600;
+
+export function createCloudOAuthTokenHandler() {
+  return {
+    async handleMintToken(req: Request): Promise<Response> {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json(
+          { error: "Request body must be valid JSON" },
+          { status: 400 },
+        );
+      }
+
+      if (!body || typeof body !== "object") {
+        return Response.json(
+          { error: "Request body must be a JSON object" },
+          { status: 400 },
+        );
+      }
+
+      const { assistantId, actorPrincipalId } = body as Record<string, unknown>;
+
+      if (typeof assistantId !== "string" || assistantId.trim() === "") {
+        return Response.json(
+          { error: "assistantId is required and must be a non-empty string" },
+          { status: 400 },
+        );
+      }
+
+      if (
+        typeof actorPrincipalId !== "string" ||
+        actorPrincipalId.trim() === ""
+      ) {
+        return Response.json(
+          {
+            error:
+              "actorPrincipalId is required and must be a non-empty string",
+          },
+          { status: 400 },
+        );
+      }
+
+      const sub = `actor:${assistantId}:${actorPrincipalId}`;
+
+      try {
+        const token = mintToken({
+          aud: "vellum-gateway",
+          sub,
+          scope_profile: "actor_client_v1",
+          policy_epoch: CURRENT_POLICY_EPOCH,
+          ttlSeconds: GUARDIAN_TOKEN_TTL_SECONDS,
+        });
+
+        log.info(
+          { assistantId, actorPrincipalId },
+          "Minted cloud OAuth guardian token",
+        );
+
+        return Response.json({
+          token,
+          expiresIn: GUARDIAN_TOKEN_TTL_SECONDS,
+          guardianId: actorPrincipalId,
+        });
+      } catch (err) {
+        log.error({ err }, "Failed to mint cloud OAuth guardian token");
+        return Response.json(
+          { error: "Failed to mint token" },
+          { status: 500 },
+        );
+      }
+    },
+  };
+}

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -27,18 +27,21 @@ export function createCloudOAuthTokenHandler() {
     async handleMintToken(req: Request): Promise<Response> {
       // Restrict to service tokens only — the platform calls this via vembda.
       // Actor tokens from regular users must not be able to mint arbitrary
-      // guardian JWTs (would allow impersonation).
+      // guardian JWTs (would allow impersonation). Fail closed: reject
+      // unless we can positively confirm the caller is svc_gateway.
       const authHeader = req.headers.get("authorization");
-      if (authHeader) {
-        const token = authHeader.replace(/^Bearer\s+/i, "");
-        const result = validateEdgeToken(token);
-        if (result.ok) {
-          const sub = parseSub(result.claims.sub);
-          if (!sub.ok || sub.principalType !== "svc_gateway") {
-            log.warn("Cloud OAuth token request rejected: not a service token");
-            return Response.json({ error: "Forbidden" }, { status: 403 });
-          }
-        }
+      const bearerToken = authHeader?.replace(/^Bearer\s+/i, "");
+      if (!bearerToken) {
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+      }
+      const tokenResult = validateEdgeToken(bearerToken);
+      if (!tokenResult.ok) {
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+      }
+      const sub = parseSub(tokenResult.claims.sub);
+      if (!sub.ok || sub.principalType !== "svc_gateway") {
+        log.warn("Cloud OAuth token request rejected: not a service token");
+        return Response.json({ error: "Forbidden" }, { status: 403 });
       }
 
       let body: unknown;

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -13,6 +13,8 @@
 
 import { getLogger } from "../../logger.js";
 import { mintToken } from "../../auth/token-service.js";
+import { validateEdgeToken } from "../../auth/token-exchange.js";
+import { parseSub } from "../../auth/subject.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 
 const log = getLogger("cloud-oauth-token");
@@ -23,6 +25,22 @@ const GUARDIAN_TOKEN_TTL_SECONDS = 3600;
 export function createCloudOAuthTokenHandler() {
   return {
     async handleMintToken(req: Request): Promise<Response> {
+      // Restrict to service tokens only — the platform calls this via vembda.
+      // Actor tokens from regular users must not be able to mint arbitrary
+      // guardian JWTs (would allow impersonation).
+      const authHeader = req.headers.get("authorization");
+      if (authHeader) {
+        const token = authHeader.replace(/^Bearer\s+/i, "");
+        const result = validateEdgeToken(token);
+        if (result.ok) {
+          const sub = parseSub(result.claims.sub);
+          if (!sub.ok || sub.principalType !== "svc_gateway") {
+            log.warn("Cloud OAuth token request rejected: not a service token");
+            return Response.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+
       let body: unknown;
       try {
         body = await req.json();
@@ -49,6 +67,13 @@ export function createCloudOAuthTokenHandler() {
         );
       }
 
+      if (assistantId.includes(":")) {
+        return Response.json(
+          { error: "assistantId must not contain colon characters" },
+          { status: 400 },
+        );
+      }
+
       if (
         typeof actorPrincipalId !== "string" ||
         actorPrincipalId.trim() === ""
@@ -58,6 +83,13 @@ export function createCloudOAuthTokenHandler() {
             error:
               "actorPrincipalId is required and must be a non-empty string",
           },
+          { status: 400 },
+        );
+      }
+
+      if (actorPrincipalId.includes(":")) {
+        return Response.json(
+          { error: "actorPrincipalId must not contain colon characters" },
           { status: 400 },
         );
       }

--- a/gateway/src/http/routes/cloud-oauth-token.ts
+++ b/gateway/src/http/routes/cloud-oauth-token.ts
@@ -38,8 +38,8 @@ export function createCloudOAuthTokenHandler() {
       if (!tokenResult.ok) {
         return Response.json({ error: "Forbidden" }, { status: 403 });
       }
-      const sub = parseSub(tokenResult.claims.sub);
-      if (!sub.ok || sub.principalType !== "svc_gateway") {
+      const callerSub = parseSub(tokenResult.claims.sub);
+      if (!callerSub.ok || callerSub.principalType !== "svc_gateway") {
         log.warn("Cloud OAuth token request rejected: not a service token");
         return Response.json({ error: "Forbidden" }, { status: 403 });
       }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -59,6 +59,7 @@ import {
   createPrivacyConfigPatchHandler,
 } from "./http/routes/privacy-config.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
+import { createCloudOAuthTokenHandler } from "./http/routes/cloud-oauth-token.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
 import { createVercelControlPlaneProxyHandler } from "./http/routes/vercel-control-plane-proxy.js";
@@ -328,6 +329,7 @@ async function main() {
   const pairingProxy = createPairingProxyHandler(config);
   const channelVerificationSessionProxy =
     createChannelVerificationSessionProxyHandler(config);
+  const cloudOAuthTokenHandler = createCloudOAuthTokenHandler();
   const telegramControlPlaneProxy =
     createTelegramControlPlaneProxyHandler(config);
   const vercelControlPlaneProxy = createVercelControlPlaneProxyHandler(config);
@@ -632,6 +634,14 @@ async function main() {
       auth: "edge",
       handler: (req, params) =>
         contactsControlPlaneProxy.handleGetContact(req, params[0]),
+    },
+
+    // ── Cloud OAuth token minting (Chrome extension) ──
+    {
+      path: "/v1/internal/oauth/chrome-extension/token",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => cloudOAuthTokenHandler.handleMintToken(req),
     },
 
     // ── Channel verification sessions ──


### PR DESCRIPTION
## Summary
Implements the gateway-side and Chrome extension-side components of the cloud OAuth login flow for the Chrome extension. The Chrome extension's cloud login has never worked because the endpoint it navigates to didn't exist.

- Add gateway endpoint `POST /v1/internal/oauth/chrome-extension/token` that mints guardian-bound JWTs for the platform to issue during the OAuth callback
- Update Chrome extension `buildAuthUrl()` to include `assistantId` in the auth URL and use `/accounts/chrome-extension/start` path (Django's backend-owned namespace)

## Self-review result
PASS — both plan faithfulness and repo integration reviews passed with no gaps.

## PRs merged into feature branch
- #26352: feat(gateway): add cloud OAuth token-minting endpoint for Chrome extension
- #26351: fix(chrome-ext): include assistantId in OAuth start URL and use /accounts/ path

## Remaining work
PR 3 (Django callback view in vellum-assistant-platform) is needed to complete the flow end-to-end. See `.private/plans/chrome-ext-cloud-oauth.md` for details.

Part of plan: chrome-ext-cloud-oauth.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
