### PR TITLE
feat(macos): scroll debug HUD behind dev setting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -17,11 +17,17 @@ struct MessageListScrollObserver: NSViewRepresentable {
     /// mid-gesture height growth — most often `LazyVStack` lazy cell
     /// materialization — never fights the user's scroll).
     let shouldPreserveScrollAnchor: @MainActor () -> Bool
+    /// Fired whenever `ScrollAnchorPreserver.offsetDelta(...)` returns a
+    /// non-nil value (the clip view was shifted to absorb content-height
+    /// growth). Used only by the scroll-debug overlay to count anchor
+    /// activations. `nil` when no observer cares.
+    var onAnchorShift: (@MainActor () -> Void)? = nil
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             onGeometryChange: onGeometryChange,
-            shouldPreserveScrollAnchor: shouldPreserveScrollAnchor
+            shouldPreserveScrollAnchor: shouldPreserveScrollAnchor,
+            onAnchorShift: onAnchorShift
         )
     }
 
@@ -38,6 +44,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         context.coordinator.onGeometryChange = onGeometryChange
         context.coordinator.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
+        context.coordinator.onAnchorShift = onAnchorShift
         DispatchQueue.main.async { [weak nsView] in
             guard let nsView else { return }
             context.coordinator.attachIfNeeded(to: nsView)
@@ -57,6 +64,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
         weak var documentView: NSView?
         var onGeometryChange: @MainActor (ScrollGeometrySnapshot) -> Void
         var shouldPreserveScrollAnchor: @MainActor () -> Bool
+        var onAnchorShift: (@MainActor () -> Void)?
         private var observers: [NSObjectProtocol] = []
         private var lastSnapshot: ScrollGeometrySnapshot?
         /// Last observed `documentView.frame.height`. Used to compute the
@@ -80,10 +88,12 @@ struct MessageListScrollObserver: NSViewRepresentable {
 
         init(
             onGeometryChange: @escaping @MainActor (ScrollGeometrySnapshot) -> Void,
-            shouldPreserveScrollAnchor: @escaping @MainActor () -> Bool
+            shouldPreserveScrollAnchor: @escaping @MainActor () -> Bool,
+            onAnchorShift: (@MainActor () -> Void)? = nil
         ) {
             self.onGeometryChange = onGeometryChange
             self.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
+            self.onAnchorShift = onAnchorShift
         }
 
         func attachIfNeeded(to hostView: NSView) {
@@ -150,6 +160,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 )
                 clipView.setBoundsOrigin(newOrigin)
                 scrollView.reflectScrolledClipView(clipView)
+                onAnchorShift?()
             }
             lastContentHeight = currentContentHeight
 
@@ -157,7 +168,8 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 contentOffsetY: clipView.bounds.origin.y,
                 contentHeight: currentContentHeight,
                 containerHeight: clipView.bounds.height,
-                visibleRectHeight: scrollView.documentVisibleRect.height
+                visibleRectHeight: scrollView.documentVisibleRect.height,
+                isLiveScrolling: isLiveScrolling
             )
             guard snapshot != lastSnapshot else { return }
             lastSnapshot = snapshot
@@ -225,7 +237,13 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 queue: .main
             ) { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    self?.isLiveScrolling = true
+                    guard let self else { return }
+                    self.isLiveScrolling = true
+                    // Emit so downstream observers (e.g. the debug overlay)
+                    // see `isLiveScrolling` flip immediately on gesture start
+                    // rather than waiting for the first scroll tick to carry
+                    // the new flag through.
+                    self.emitCurrentSnapshotIfPossible()
                 }
             })
             observers.append(center.addObserver(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -195,6 +195,8 @@ final class MessageListScrollState {
         highlightDismissTask?.cancel()
         highlightDismissTask = nil
 
+        resetDebugMetrics()
+
         // Briefly hide scroll indicators during switch
         hideScrollIndicatorsBriefly()
     }
@@ -229,4 +231,108 @@ final class MessageListScrollState {
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
 
+    // MARK: - Debug metrics (populated only when scroll-debug-overlay is on)
+
+    /// Incremented on every debug-metric write so the overlay's isolated
+    /// observation boundary re-renders as metrics update. Kept observed; the
+    /// underlying struct stays `@ObservationIgnored` so geometry ticks do not
+    /// invalidate the rest of `MessageListView`.
+    private(set) var debugMetricsVersion: Int = 0
+
+    @ObservationIgnored var debugMetrics = ScrollDebugMetrics()
+
+    /// Fold a fresh scroll snapshot into the debug metrics. Only called when
+    /// the `scroll-debug-overlay` flag is on — the hot path otherwise skips this.
+    func recordDebugSnapshot(offsetY: CGFloat, isLiveScrolling: Bool, at now: Date = Date()) {
+        debugMetrics.recordSnapshot(offsetY: offsetY, isLiveScrolling: isLiveScrolling, at: now)
+        debugMetricsVersion &+= 1
+    }
+
+    /// Record that the anchor preserver applied a non-nil offset delta. Only
+    /// called when the `scroll-debug-overlay` flag is on.
+    func recordDebugAnchorShift(at now: Date = Date()) {
+        debugMetrics.recordAnchorShift(at: now)
+        debugMetricsVersion &+= 1
+    }
+
+    /// Reset debug metrics (e.g. on conversation switch) so counters start
+    /// fresh and don't carry stale data across conversations.
+    func resetDebugMetrics() {
+        debugMetrics = ScrollDebugMetrics()
+        debugMetricsVersion &+= 1
+    }
+
+}
+
+// MARK: - ScrollDebugMetrics
+
+/// Live metrics surfaced by the scroll-debug overlay. Populated in the scroll
+/// geometry handler only when the `scroll-debug-overlay` flag is on, so the
+/// hot path pays nothing when the overlay is off.
+struct ScrollDebugMetrics {
+    var lastDeltaY: CGFloat = 0
+    /// Signed scroll velocity in points per second, smoothed across recent
+    /// samples via an EMA to damp per-tick jitter.
+    var velocityPtPerSec: CGFloat = 0
+    /// Mirrors `MessageListScrollObserver.Coordinator.isLiveScrolling`.
+    var isLiveScrolling: Bool = false
+    /// Cumulative count of non-nil `ScrollAnchorPreserver.offsetDelta(...)`
+    /// returns since the last reset.
+    var anchorShiftTotal: Int = 0
+    /// Rolling buffer of geometry-snapshot timestamps — read once per render
+    /// by the overlay to compute an updates-per-second counter.
+    var recentUpdateTimes: [Date] = []
+    /// Rolling buffer of anchor-shift timestamps — read once per render by the
+    /// overlay to compute an anchor-shifts-per-second counter.
+    var recentAnchorShiftTimes: [Date] = []
+
+    private var lastSnapshotTime: Date?
+    private var lastSnapshotOffsetY: CGFloat = 0
+    /// EMA smoothing factor for velocity. Higher = more responsive, lower =
+    /// smoother. 0.35 keeps the reading stable during momentum scroll while
+    /// still reacting to direction flips.
+    private static let velocitySmoothing: CGFloat = 0.35
+
+    mutating func recordSnapshot(offsetY: CGFloat, isLiveScrolling: Bool, at now: Date) {
+        if let prev = lastSnapshotTime {
+            let dt = now.timeIntervalSince(prev)
+            let delta = offsetY - lastSnapshotOffsetY
+            lastDeltaY = delta
+            if dt > 0.001 {
+                let instantaneous = delta / CGFloat(dt)
+                velocityPtPerSec += (instantaneous - velocityPtPerSec) * Self.velocitySmoothing
+            }
+        }
+        lastSnapshotTime = now
+        lastSnapshotOffsetY = offsetY
+        self.isLiveScrolling = isLiveScrolling
+        recentUpdateTimes.append(now)
+        Self.trim(&recentUpdateTimes, at: now)
+    }
+
+    mutating func recordAnchorShift(at now: Date) {
+        anchorShiftTotal += 1
+        recentAnchorShiftTimes.append(now)
+        Self.trim(&recentAnchorShiftTimes, at: now)
+    }
+
+    func updatesPerSecond(at now: Date = Date()) -> Int {
+        let cutoff = now.addingTimeInterval(-1)
+        return recentUpdateTimes.reduce(0) { $1 > cutoff ? $0 + 1 : $0 }
+    }
+
+    func anchorShiftsPerSecond(at now: Date = Date()) -> Int {
+        let cutoff = now.addingTimeInterval(-1)
+        return recentAnchorShiftTimes.reduce(0) { $1 > cutoff ? $0 + 1 : $0 }
+    }
+
+    /// Keep a little slack past 1s so reads near a second boundary don't flap.
+    /// `static` so the inout buffer access doesn't overlap with the caller's
+    /// inout access to `self` via the mutating entry point.
+    private static func trim(_ buffer: inout [Date], at now: Date) {
+        let cutoff = now.addingTimeInterval(-1.5)
+        while let first = buffer.first, first < cutoff {
+            buffer.removeFirst()
+        }
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -37,6 +37,10 @@ struct ScrollGeometrySnapshot: Equatable {
     let contentHeight: CGFloat
     let containerHeight: CGFloat
     let visibleRectHeight: CGFloat
+    /// Tracks whether an AppKit live scroll gesture (trackpad/wheel + momentum)
+    /// is currently in progress. Exposed to the debug overlay; the scroll hot
+    /// path does not consume it.
+    var isLiveScrolling: Bool = false
 }
 
 // MARK: - Scroll Geometry Dispatcher

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -37,6 +37,14 @@ extension MessageListView {
             viewportHeight = accepted
         }
 
+        // --- Debug metrics (flag-gated — hot path pays nothing when off) ---
+        if MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") {
+            scrollState.recordDebugSnapshot(
+                offsetY: newState.contentOffsetY,
+                isLiveScrolling: newState.isLiveScrolling
+            )
+        }
+
         // --- Distance-based scroll-to-latest CTA ---
         scrollState.updateScrollToLatest()
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -145,6 +145,13 @@ struct MessageListView: View {
                                     // shifting the offset to absorb the older
                                     // page's height would race the snap.
                                     !scrollState.isPaginationInFlight
+                                },
+                                onAnchorShift: { [scrollState] in
+                                    // Debug-only counter for anchor-preserver
+                                    // activations. Flag-gated so the hot path
+                                    // pays nothing when the overlay is off.
+                                    guard MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") else { return }
+                                    scrollState.recordDebugAnchorShift()
                                 }
                             )
                         )
@@ -180,6 +187,11 @@ struct MessageListView: View {
                     onSnapWindowToLatest?()
                     scrollPosition = ScrollPosition(edge: .top)
                 })
+            }
+            .overlay(alignment: .topTrailing) {
+                ScrollDebugOverlayView(scrollState: scrollState)
+                    .padding(.top, VSpacing.sm)
+                    .padding(.trailing, VSpacing.md)
             }
             .onAppear {
                 handleAppear()

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Developer HUD that displays live scroll metrics in the top-right of the
+/// conversation. Hidden unless the `scroll-debug-overlay` macOS feature flag
+/// is enabled from Settings → Developer.
+///
+/// Isolated observation boundary: reading `scrollState.debugMetricsVersion`
+/// in the hud body registers this view for invalidation on every metric
+/// tick without invalidating `MessageListView.body`. All other geometry
+/// fields on `MessageListScrollState` are `@ObservationIgnored`, so the
+/// version counter is what drives re-renders.
+struct ScrollDebugOverlayView: View {
+    let scrollState: MessageListScrollState
+
+    /// Seeded from the flag manager on first appear, then kept in sync via
+    /// `.assistantFeatureFlagDidChange`. Starting at `false` and deferring the
+    /// lookup to `.onAppear` avoids paying the flag-manager lock cost on every
+    /// re-render of the parent `MessageListView`.
+    @State private var isEnabled: Bool = false
+
+    var body: some View {
+        Group {
+            if isEnabled {
+                hud
+            }
+        }
+        .onAppear {
+            isEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
+            guard let key = notification.userInfo?["key"] as? String, key == "scroll-debug-overlay" else { return }
+            isEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+        }
+    }
+
+    private var hud: some View {
+        // Reading the observed version counter registers an invalidation
+        // dependency so the HUD re-renders on every debug-metric tick.
+        _ = scrollState.debugMetricsVersion
+
+        let now = Date()
+        let metrics = scrollState.debugMetrics
+        let pinnedEpsilon: CGFloat = 8
+
+        return VStack(alignment: .leading, spacing: 1) {
+            row("offsetY", pt(scrollState.lastContentOffsetY))
+            row("contentH", pt(scrollState.scrollContentHeight))
+            row("containerH", pt(scrollState.scrollContainerHeight))
+            row("viewportH", pt(scrollState.viewportHeight))
+            row("distBottom", pt(scrollState.distanceFromBottom))
+            row("distTop", pt(scrollState.distanceFromTop))
+            row("pinnedLatest", bool(scrollState.lastContentOffsetY.magnitude < pinnedEpsilon))
+            row("liveScrolling", bool(metrics.isLiveScrolling))
+            row("paginating", bool(scrollState.isPaginationInFlight))
+            row("pagInRange", bool(scrollState.wasPaginationTriggerInRange))
+            row("ctaVisible", bool(scrollState.showScrollToLatest))
+            row("updates/s", String(metrics.updatesPerSecond(at: now)))
+            row("velocity", "\(signed(metrics.velocityPtPerSec)) pt/s")
+            row("lastDeltaY", signed(metrics.lastDeltaY))
+            row("anchors/s", String(metrics.anchorShiftsPerSecond(at: now)))
+            row("anchorTotal", String(metrics.anchorShiftTotal))
+            if let id = scrollState.currentConversationId {
+                row("conv", String(id.uuidString.prefix(8)))
+            }
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .font(.system(size: 10, design: .monospaced))
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(VColor.borderBase, lineWidth: 0.5)
+                )
+        )
+        .fixedSize()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .foregroundStyle(VColor.contentSecondary)
+                .frame(width: 84, alignment: .trailing)
+            Text(value)
+                .foregroundStyle(VColor.contentDefault)
+                .frame(minWidth: 60, alignment: .leading)
+        }
+    }
+
+    private func pt(_ v: CGFloat) -> String {
+        guard v.isFinite else { return "∞" }
+        return String(format: "%.1f", v)
+    }
+
+    private func signed(_ v: CGFloat) -> String {
+        guard v.isFinite else { return "∞" }
+        return String(format: "%+.1f", v)
+    }
+
+    private func bool(_ v: Bool) -> String { v ? "yes" : "no" }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -352,6 +352,14 @@
       "label": "Google Meet",
       "description": "Enables the Google Meet joining bot and the meet-join skill.",
       "defaultEnabled": false
+    },
+    {
+      "id": "scroll-debug-overlay",
+      "scope": "macos",
+      "key": "scroll-debug-overlay",
+      "label": "Scroll Debug Overlay",
+      "description": "Show a live HUD in the top-right of the conversation with scroll geometry, velocity, update rate, and anchor-preserver activity. Developer diagnostic for investigating scroll jank.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New macOS-scoped feature flag `scroll-debug-overlay` (defaults off) shows up automatically in Settings → Developer.
- Adds a compact live HUD in the top-right of the conversation with offsets, heights, distances, velocity, updates/sec, anchor-preserver shifts/sec, pagination state, live-scroll flag, and conversation ID prefix.
- Zero overhead when off — isolated observation boundary so the HUD re-renders independently of `MessageListView`, and all instrumentation is flag-gated.

## Why
We've been seeing jerky scrolling in the conversation view. Before changing scroll behavior, this lands the diagnostic surface so the jank can be observed in numbers (update rate vs. offset oscillation, anchor-preserver activations while live-scrolling, etc.) and the fix can be targeted.

## Original prompt
Implement the approved plan at /Users/sidd/.claude/plans/the-scrolling-in-the-sunny-lagoon.md — scroll debug overlay as a dev setting in the macOS app.