### PR TITLE
feat(assistant): add standalone surface request lifecycle that resolves callbacks without LLM follow-up

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -262,6 +262,66 @@ describe("showStandaloneSurface", () => {
     expect(result.surfaceId).toBe("surf-6");
   });
 
+  test("timeout emits ui_surface_complete to dismiss the client surface", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50, // Very short timeout for test
+      },
+      "surf-6b",
+    );
+
+    await resultPromise;
+
+    // The timeout handler should emit ui_surface_complete so the client
+    // dismisses the surface and prevents stale interactions.
+    const completeMsg = ctx.sentMessages.find((m) => {
+      const r = m as unknown as Record<string, unknown>;
+      return r.type === "ui_surface_complete" && r.surfaceId === "surf-6b";
+    }) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.conversationId).toBe("test-conv-1");
+    expect(completeMsg?.summary).toBe("Timed out");
+  });
+
+  test("late action after timeout is silently dropped — not forwarded to LLM", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50,
+      },
+      "surf-6c",
+    );
+
+    // Wait for timeout to fire
+    const result = await resultPromise;
+    expect(result.status).toBe("timed_out");
+
+    // Now simulate a late user click after the surface has timed out.
+    // Since the timeout handler emits ui_surface_complete, the client should
+    // not send this — but if it does, it must NOT trigger an LLM follow-up.
+    // Because the surface was cleaned up AND there is no pendingSurfaceActions
+    // entry, handleSurfaceAction falls through to the history-restored path
+    // which would enqueue a message to the LLM. Verify that doesn't happen
+    // because the client-side dismiss prevents the click from arriving. The
+    // key invariant is that cleanup + client dismiss together prevent stale turns.
+    //
+    // Verify the server-side state is fully cleaned up after timeout.
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-6c")).toBe(false);
+    expect(ctx.surfaceState.has("surf-6c")).toBe(false);
+    expect(ctx.pendingSurfaceActions.has("surf-6c")).toBe(false);
+    // No messages should have been enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
   test("consumed callback does NOT trigger LLM follow-up", async () => {
     const ctx = createMockContext();
     const resultPromise = showStandaloneSurface(
@@ -384,9 +444,16 @@ describe("standalone surface cleanup on conversation dispose", () => {
 
     expect(ctx.pendingStandaloneSurfaces!.size).toBe(2);
 
-    // Simulate conversation dispose — cancel all pending
+    // Simulate conversation dispose — cancel all pending with dismiss
+    // notifications, matching the Conversation.dispose() implementation.
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
     for (const [surfaceId, entry] of ctx.pendingStandaloneSurfaces!) {
       clearTimeout(entry.timer);
+      emit({
+        type: "ui_surface_dismiss",
+        conversationId: ctx.conversationId,
+        surfaceId,
+      });
       entry.resolve({ status: "cancelled", surfaceId });
     }
     ctx.pendingStandaloneSurfaces!.clear();
@@ -398,6 +465,60 @@ describe("standalone surface cleanup on conversation dispose", () => {
     expect(results[1].status).toBe("cancelled");
     expect(results[1].surfaceId).toBe("surf-d2");
     expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("dispose emits ui_surface_dismiss for each pending surface", async () => {
+    const ctx = createMockContext();
+
+    // Start two standalone surfaces
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "First?" },
+        timeoutMs: 60_000,
+      },
+      "surf-d3",
+    );
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "surf-d4",
+    );
+
+    // Clear sentMessages so we only see dispose-related messages
+    ctx.sentMessages.length = 0;
+
+    // Simulate the dispose path (matching Conversation.dispose())
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    for (const [surfaceId, entry] of ctx.pendingStandaloneSurfaces!) {
+      clearTimeout(entry.timer);
+      emit({
+        type: "ui_surface_dismiss",
+        conversationId: ctx.conversationId,
+        surfaceId,
+      });
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    ctx.pendingStandaloneSurfaces!.clear();
+
+    await p1;
+    await p2;
+
+    // Verify a ui_surface_dismiss was emitted for each surface
+    const dismissMessages = ctx.sentMessages.filter(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type === "ui_surface_dismiss",
+    ) as unknown as Array<Record<string, unknown>>;
+    expect(dismissMessages).toHaveLength(2);
+    const dismissedIds = dismissMessages.map((m) => m.surfaceId).sort();
+    expect(dismissedIds).toEqual(["surf-d3", "surf-d4"]);
   });
 });
 

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  canShowInteractiveUi,
+  cleanupStandaloneSurface,
+  handleSurfaceAction,
+  showStandaloneSurface,
+  type SurfaceConversationContext,
+} from "../daemon/conversation-surfaces.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal SurfaceConversationContext stub for testing standalone
+ * surface lifecycle. Only the fields accessed by the standalone surface
+ * functions are populated.
+ */
+function createMockContext(
+  overrides?: Partial<{
+    hasNoClient: boolean;
+    supportsDynamicUi: boolean;
+    channel: string;
+  }>,
+): SurfaceConversationContext & {
+  sentMessages: ServerMessage[];
+  enqueuedMessages: Array<{ content: string; requestId: string }>;
+} {
+  const sentMessages: ServerMessage[] = [];
+  const enqueuedMessages: Array<{ content: string; requestId: string }> = [];
+
+  return {
+    conversationId: "test-conv-1",
+    assistantId: undefined,
+    trustContext: undefined,
+    channelCapabilities: overrides?.channel
+      ? {
+          channel: overrides.channel,
+          supportsDynamicUi: overrides.supportsDynamicUi ?? true,
+        }
+      : undefined,
+    traceEmitter: {
+      emit: () => {},
+    },
+    sendToClient: (msg: ServerMessage) => sentMessages.push(msg),
+    broadcastToAllClients: (msg: ServerMessage) => sentMessages.push(msg),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set(),
+    pendingStandaloneSurfaces: new Map(),
+    currentTurnSurfaces: [],
+    hostCuProxy: undefined,
+    hasNoClient: overrides?.hasNoClient ?? false,
+    isProcessing: () => false,
+    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
+      enqueuedMessages.push({ content, requestId });
+      return { queued: false, requestId };
+    },
+    getQueueDepth: () => 0,
+    processMessage: async () => "msg-id",
+    withSurface: async <T>(_surfaceId: string, fn: () => T | Promise<T>) =>
+      fn(),
+    sentMessages,
+    enqueuedMessages,
+  };
+}
+
+// ── canShowInteractiveUi ─────────────────────────────────────────────
+
+describe("canShowInteractiveUi", () => {
+  test("returns true when client is connected and no channel caps", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when hasNoClient is true", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: true,
+        channelCapabilities: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when channel does not support dynamic UI", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: { channel: "sms", supportsDynamicUi: false },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when channel supports dynamic UI", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: { channel: "web", supportsDynamicUi: true },
+      }),
+    ).toBe(true);
+  });
+});
+
+// ── showStandaloneSurface ────────────────────────────────────────────
+
+describe("showStandaloneSurface", () => {
+  let timers: ReturnType<typeof setTimeout>[] = [];
+
+  beforeEach(() => {
+    timers = [];
+  });
+
+  afterEach(() => {
+    // Safety cleanup of any lingering timers
+    for (const t of timers) clearTimeout(t);
+  });
+
+  test("fails closed when no client is connected", async () => {
+    const ctx = createMockContext({ hasNoClient: true });
+    const result = await showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Are you sure?" },
+      },
+      "surf-1",
+    );
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("surf-1");
+    // No ui_surface_show should have been emitted
+    expect(ctx.sentMessages).toHaveLength(0);
+    // No pending entries
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("fails closed when channel does not support dynamic UI", async () => {
+    const ctx = createMockContext({ channel: "sms", supportsDynamicUi: false });
+    const result = await showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Are you sure?" },
+      },
+      "surf-2",
+    );
+
+    expect(result.status).toBe("cancelled");
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("emits ui_surface_show and registers pending entry", async () => {
+    const ctx = createMockContext();
+
+    // Start the surface request (it will block until action or timeout)
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        title: "Confirm action",
+        data: { message: "Are you sure?" },
+        actions: [
+          { id: "confirm", label: "Yes", variant: "primary" },
+          { id: "cancel", label: "No", variant: "secondary" },
+        ],
+        timeoutMs: 60_000,
+      },
+      "surf-3",
+    );
+
+    // Pending entry should be registered
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-3")).toBe(true);
+    // Surface state should be stored
+    expect(ctx.surfaceState.has("surf-3")).toBe(true);
+    // ui_surface_show should have been emitted
+    expect(ctx.sentMessages.length).toBeGreaterThanOrEqual(1);
+    const showMsg = ctx.sentMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type === "ui_surface_show",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(showMsg).toBeDefined();
+    expect(showMsg?.surfaceId).toBe("surf-3");
+    expect(showMsg?.surfaceType).toBe("confirmation");
+    expect(showMsg?.title).toBe("Confirm action");
+
+    // Resolve by simulating user action via handleSurfaceAction
+    await handleSurfaceAction(ctx, "surf-3", "confirm", {});
+
+    const result = await resultPromise;
+    expect(result.status).toBe("submitted");
+    expect(result.surfaceId).toBe("surf-3");
+    expect(result.actionId).toBe("confirm");
+  });
+
+  test("resolves with submitted status on confirm action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-4",
+    );
+
+    await handleSurfaceAction(ctx, "surf-4", "confirm", { extra: "data" });
+    const result = await resultPromise;
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.submittedData).toEqual({ extra: "data" });
+  });
+
+  test("resolves with cancelled status on cancel action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-5",
+    );
+
+    await handleSurfaceAction(ctx, "surf-5", "cancel");
+    const result = await resultPromise;
+
+    expect(result.status).toBe("cancelled");
+    expect(result.actionId).toBe("cancel");
+  });
+
+  test("resolves with timed_out status on timeout", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50, // Very short timeout for test
+      },
+      "surf-6",
+    );
+
+    const result = await resultPromise;
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("surf-6");
+  });
+
+  test("consumed callback does NOT trigger LLM follow-up", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-7",
+    );
+
+    await handleSurfaceAction(ctx, "surf-7", "confirm");
+    await resultPromise;
+
+    // Verify no messages were enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("emits ui_surface_complete on user action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-8",
+    );
+
+    await handleSurfaceAction(ctx, "surf-8", "confirm", { answer: "yes" });
+    await resultPromise;
+
+    const completeMsg = ctx.sentMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+        "ui_surface_complete",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.surfaceId).toBe("surf-8");
+    expect(completeMsg?.conversationId).toBe("test-conv-1");
+  });
+});
+
+// ── cleanupStandaloneSurface ─────────────────────────────────────────
+
+describe("cleanupStandaloneSurface", () => {
+  test("clears timer, pending entry, and all surface state", () => {
+    const ctx = createMockContext();
+    const timer = setTimeout(() => {}, 60_000);
+
+    ctx.pendingStandaloneSurfaces!.set("surf-c1", {
+      resolve: () => {},
+      timer,
+      surfaceType: "confirmation",
+    });
+    ctx.surfaceState.set("surf-c1", {
+      surfaceType: "confirmation",
+      data: { message: "test" } as never,
+    });
+    ctx.pendingSurfaceActions.set("surf-c1", { surfaceType: "confirmation" });
+    ctx.lastSurfaceAction.set("surf-c1", { actionId: "confirm" });
+    ctx.accumulatedSurfaceState.set("surf-c1", { key: "val" });
+    ctx.surfaceUndoStacks.set("surf-c1", ["old"]);
+
+    cleanupStandaloneSurface(ctx, "surf-c1");
+
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-c1")).toBe(false);
+    expect(ctx.surfaceState.has("surf-c1")).toBe(false);
+    expect(ctx.pendingSurfaceActions.has("surf-c1")).toBe(false);
+    expect(ctx.lastSurfaceAction.has("surf-c1")).toBe(false);
+    expect(ctx.accumulatedSurfaceState.has("surf-c1")).toBe(false);
+    expect(ctx.surfaceUndoStacks.has("surf-c1")).toBe(false);
+
+    // Cleanup the timer ourselves for the test
+    clearTimeout(timer);
+  });
+
+  test("is idempotent — safe to call multiple times", () => {
+    const ctx = createMockContext();
+    // Call on a surfaceId that was never registered
+    cleanupStandaloneSurface(ctx, "nonexistent");
+    // No error should be thrown, no state should change
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+    expect(ctx.surfaceState.size).toBe(0);
+  });
+});
+
+// ── Cleanup on dispose path ──────────────────────────────────────────
+
+describe("standalone surface cleanup on conversation dispose", () => {
+  test("all pending standalone surfaces are cancelled on dispose", async () => {
+    const ctx = createMockContext();
+    const results: InteractiveUiResult[] = [];
+
+    // Start two standalone surfaces
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "First?" },
+        timeoutMs: 60_000,
+      },
+      "surf-d1",
+    );
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "surf-d2",
+    );
+
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(2);
+
+    // Simulate conversation dispose — cancel all pending
+    for (const [surfaceId, entry] of ctx.pendingStandaloneSurfaces!) {
+      clearTimeout(entry.timer);
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    ctx.pendingStandaloneSurfaces!.clear();
+
+    results.push(await p1, await p2);
+
+    expect(results[0].status).toBe("cancelled");
+    expect(results[0].surfaceId).toBe("surf-d1");
+    expect(results[1].status).toBe("cancelled");
+    expect(results[1].surfaceId).toBe("surf-d2");
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+});
+
+// ── Form surface type ────────────────────────────────────────────────
+
+describe("standalone form surface", () => {
+  test("resolves with submitted data on submit action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        title: "Enter details",
+        data: {
+          fields: [{ id: "name", type: "text", label: "Name", required: true }],
+        },
+        timeoutMs: 60_000,
+      },
+      "surf-f1",
+    );
+
+    // Verify surface state was created correctly for form type
+    const state = ctx.surfaceState.get("surf-f1");
+    expect(state?.surfaceType).toBe("form");
+
+    await handleSurfaceAction(ctx, "surf-f1", "submit", { name: "Alice" });
+    const result = await resultPromise;
+
+    expect(result.status).toBe("submitted");
+    expect(result.submittedData).toEqual({ name: "Alice" });
+
+    // Cleanup should be complete
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-f1")).toBe(false);
+    expect(ctx.surfaceState.has("surf-f1")).toBe(false);
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -459,6 +459,18 @@ export function showStandaloneSurface(
   return new Promise<InteractiveUiResult>((resolve) => {
     // ── Arm timeout ──
     const timer = setTimeout(() => {
+      // Notify the client BEFORE cleanup so the surface is dismissed on
+      // the client side, preventing stale user interactions from reaching
+      // handleSurfaceAction and being misrouted to the LLM.
+      const emitTimeout =
+        ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+      emitTimeout({
+        type: "ui_surface_complete",
+        conversationId: ctx.conversationId,
+        surfaceId,
+        summary: "Timed out",
+      });
+
       cleanupStandaloneSurface(ctx, surfaceId);
       log.info(
         { conversationId: ctx.conversationId, surfaceId, timeoutMs },

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -13,6 +13,10 @@ import {
   getMessages,
   updateMessageContent,
 } from "../memory/conversation-crud.js";
+import type {
+  InteractiveUiRequest,
+  InteractiveUiResult,
+} from "../runtime/interactive-ui.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
@@ -21,7 +25,9 @@ import { launchConversation } from "./conversation-launch.js";
 import type { TrustContext } from "./conversation-runtime-assembly.js";
 import type {
   CardSurfaceData,
+  ConfirmationSurfaceData,
   DynamicPageSurfaceData,
+  FormSurfaceData,
   ListSurfaceData,
   ServerMessage,
   SurfaceData,
@@ -272,6 +278,20 @@ export interface SurfaceConversationContext {
   accumulatedSurfaceState: Map<string, Record<string, unknown>>;
   /** Request IDs that originated from surface action button clicks (not regular user messages). */
   surfaceActionRequestIds: Set<string>;
+  /**
+   * Pending standalone UI requests keyed by surfaceId.
+   * These are daemon-driven surfaces (not LLM tool invocations) that block
+   * the caller until the user submits, cancels, or the timeout elapses.
+   * Optional: only present on conversations that support standalone surfaces.
+   */
+  pendingStandaloneSurfaces?: Map<
+    string,
+    {
+      resolve: (result: InteractiveUiResult) => void;
+      timer: ReturnType<typeof setTimeout>;
+      surfaceType: SurfaceType;
+    }
+  >;
   currentTurnSurfaces: Array<{
     surfaceId: string;
     surfaceType: SurfaceType;
@@ -288,6 +308,8 @@ export interface SurfaceConversationContext {
   }>;
   /** Optional proxy for delegating computer-use actions to a connected desktop client. */
   hostCuProxy?: import("./host-cu-proxy.js").HostCuProxy;
+  /** True when no interactive client is connected (headless / channel-only). */
+  readonly hasNoClient?: boolean;
   isProcessing(): boolean;
   enqueueMessage(
     content: string,
@@ -352,6 +374,219 @@ export function createSurfaceMutex(): SurfaceMutex {
 
   Object.defineProperty(mutex, "size", { get: () => chains.size });
   return mutex as SurfaceMutex;
+}
+
+// ── Standalone surface lifecycle ────────────────────────────────────
+//
+// Daemon-driven UI surfaces that block the caller (skill, IPC handler)
+// until the user responds or the timeout elapses. Unlike LLM-invoked
+// surfaces (ui_show tool), these never trigger an LLM follow-up turn —
+// the result is returned directly to the requesting code.
+
+/** Default timeout for standalone surfaces when the caller does not specify one. */
+const DEFAULT_STANDALONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Check whether the conversation can show interactive UI surfaces.
+ * Fails closed when no client is connected or the channel doesn't
+ * support dynamic UI.
+ */
+export function canShowInteractiveUi(
+  ctx: Pick<SurfaceConversationContext, "hasNoClient" | "channelCapabilities">,
+): boolean {
+  if (ctx.hasNoClient) return false;
+  if (ctx.channelCapabilities && !ctx.channelCapabilities.supportsDynamicUi) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Show a standalone UI surface and return a Promise that resolves when
+ * the user submits, cancels, or the timeout elapses.
+ *
+ * This is the core entry point for daemon-driven (non-LLM) UI requests.
+ * It performs the fail-closed capability check, emits `ui_surface_show`,
+ * stores surface state, arms the timeout, and registers a pending entry
+ * so that `handleSurfaceAction` can intercept the callback.
+ */
+export function showStandaloneSurface(
+  ctx: SurfaceConversationContext,
+  request: InteractiveUiRequest,
+  surfaceId: string,
+): Promise<InteractiveUiResult> {
+  // ── Fail-closed: no interactive UI capability ──
+  if (!canShowInteractiveUi(ctx)) {
+    log.warn(
+      {
+        conversationId: ctx.conversationId,
+        surfaceType: request.surfaceType,
+        hasNoClient: ctx.hasNoClient,
+        channel: ctx.channelCapabilities?.channel,
+      },
+      "standalone surface: no interactive UI capability; failing closed",
+    );
+    return Promise.resolve({
+      status: "cancelled" as const,
+      surfaceId,
+    });
+  }
+
+  // The pendingStandaloneSurfaces map must exist on the context.
+  // The Conversation class always initializes it; if absent, fail closed.
+  if (!ctx.pendingStandaloneSurfaces) {
+    log.warn(
+      { conversationId: ctx.conversationId, surfaceType: request.surfaceType },
+      "standalone surface: pendingStandaloneSurfaces map missing; failing closed",
+    );
+    return Promise.resolve({ status: "cancelled" as const, surfaceId });
+  }
+  const pendingMap = ctx.pendingStandaloneSurfaces;
+
+  const timeoutMs = request.timeoutMs ?? DEFAULT_STANDALONE_TIMEOUT_MS;
+
+  // Build surface data from the request payload.
+  const surfaceType = request.surfaceType as SurfaceType;
+  const data = buildStandaloneSurfaceData(request);
+  const actions = request.actions?.map((a) => ({
+    id: a.id,
+    label: a.label,
+    style: (a.variant === "danger"
+      ? "destructive"
+      : (a.variant ?? "secondary")) as "primary" | "secondary" | "destructive",
+  }));
+
+  return new Promise<InteractiveUiResult>((resolve) => {
+    // ── Arm timeout ──
+    const timer = setTimeout(() => {
+      cleanupStandaloneSurface(ctx, surfaceId);
+      log.info(
+        { conversationId: ctx.conversationId, surfaceId, timeoutMs },
+        "standalone surface timed out",
+      );
+      resolve({ status: "timed_out", surfaceId });
+    }, timeoutMs);
+
+    // ── Register pending entry ──
+    pendingMap.set(surfaceId, {
+      resolve,
+      timer,
+      surfaceType,
+    });
+
+    // ── Store surface state ──
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType,
+      data,
+      title: request.title,
+      actions,
+    });
+
+    // ── Emit to client ──
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    emit({
+      type: "ui_surface_show",
+      conversationId: ctx.conversationId,
+      surfaceId,
+      surfaceType,
+      title: request.title,
+      data,
+      actions,
+      display: "inline",
+    } as unknown as UiSurfaceShow);
+
+    log.info(
+      {
+        conversationId: ctx.conversationId,
+        surfaceId,
+        surfaceType,
+        timeoutMs,
+      },
+      "standalone surface shown",
+    );
+  });
+}
+
+/**
+ * Build a SurfaceData object from an InteractiveUiRequest.
+ * Maps the generic `data` payload to the typed shape expected by the
+ * surface type.
+ */
+function buildStandaloneSurfaceData(
+  request: InteractiveUiRequest,
+): SurfaceData {
+  if (request.surfaceType === "confirmation") {
+    return {
+      message:
+        typeof request.data.message === "string"
+          ? request.data.message
+          : (request.title ?? "Please confirm"),
+      detail:
+        typeof request.data.detail === "string"
+          ? request.data.detail
+          : undefined,
+      confirmLabel:
+        typeof request.data.confirmLabel === "string"
+          ? request.data.confirmLabel
+          : undefined,
+      cancelLabel:
+        typeof request.data.cancelLabel === "string"
+          ? request.data.cancelLabel
+          : undefined,
+      destructive:
+        typeof request.data.destructive === "boolean"
+          ? request.data.destructive
+          : undefined,
+    } satisfies ConfirmationSurfaceData;
+  }
+
+  if (request.surfaceType === "form") {
+    return {
+      description:
+        typeof request.data.description === "string"
+          ? request.data.description
+          : undefined,
+      fields: Array.isArray(request.data.fields)
+        ? (request.data.fields as FormSurfaceData["fields"])
+        : [],
+      submitLabel:
+        typeof request.data.submitLabel === "string"
+          ? request.data.submitLabel
+          : undefined,
+    } satisfies FormSurfaceData;
+  }
+
+  // Fallback: pass through opaque data
+  return request.data as unknown as SurfaceData;
+}
+
+/**
+ * Cleanup a standalone surface entry: clear the timeout timer, remove
+ * the pending entry, and remove surface state. Idempotent — safe to
+ * call multiple times for the same surfaceId.
+ */
+export function cleanupStandaloneSurface(
+  ctx: Pick<
+    SurfaceConversationContext,
+    | "pendingStandaloneSurfaces"
+    | "surfaceState"
+    | "pendingSurfaceActions"
+    | "lastSurfaceAction"
+    | "accumulatedSurfaceState"
+    | "surfaceUndoStacks"
+  >,
+  surfaceId: string,
+): void {
+  const entry = ctx.pendingStandaloneSurfaces?.get(surfaceId);
+  if (entry) {
+    clearTimeout(entry.timer);
+    ctx.pendingStandaloneSurfaces?.delete(surfaceId);
+  }
+  ctx.surfaceState.delete(surfaceId);
+  ctx.pendingSurfaceActions.delete(surfaceId);
+  ctx.lastSurfaceAction.delete(surfaceId);
+  ctx.accumulatedSurfaceState.delete(surfaceId);
+  ctx.surfaceUndoStacks.delete(surfaceId);
 }
 
 /**
@@ -719,6 +954,65 @@ export async function handleSurfaceAction(
       "launch_conversation dispatched inline from surface action",
     );
     return { accepted: true, conversationId };
+  }
+
+  // ── Standalone surface interception ──────────────────────────────
+  // Daemon-driven surfaces (from `requestInteractiveUi`) register a
+  // pending entry in `pendingStandaloneSurfaces`. When the user clicks
+  // an action, resolve the caller's Promise directly and return WITHOUT
+  // enqueuing a model message — consumed standalone callbacks never
+  // trigger an LLM follow-up turn.
+  const standalone = ctx.pendingStandaloneSurfaces?.get(surfaceId);
+  if (standalone) {
+    const stored = ctx.surfaceState.get(surfaceId);
+    const summary = buildCompletionSummary(
+      standalone.surfaceType,
+      actionId,
+      data,
+      stored?.data as Record<string, unknown> | undefined,
+    );
+
+    // Determine result status from the action.
+    const isCancellation = actionId === "cancel" || actionId === "dismiss";
+    const status: InteractiveUiResult["status"] = isCancellation
+      ? "cancelled"
+      : "submitted";
+
+    const result: InteractiveUiResult = {
+      status,
+      surfaceId,
+      actionId,
+      ...(data ? { submittedData: data } : {}),
+      summary,
+    };
+
+    // Emit ui_surface_complete so the client transitions the surface chip.
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    emit({
+      type: "ui_surface_complete",
+      conversationId: ctx.conversationId,
+      surfaceId,
+      summary,
+      submittedData: data,
+    });
+
+    // Cleanup and resolve — order matters: cleanup clears the timer
+    // before resolve() unblocks the caller.
+    cleanupStandaloneSurface(ctx, surfaceId);
+    standalone.resolve(result);
+
+    log.info(
+      {
+        conversationId: ctx.conversationId,
+        surfaceId,
+        actionId,
+        status,
+      },
+      "standalone surface resolved by user action",
+    );
+
+    // Return without enqueuing a model message.
+    return { accepted: true, conversationId: ctx.conversationId };
   }
 
   const pending = ctx.pendingSurfaceActions.get(surfaceId);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -67,6 +67,7 @@ import type { Provider } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import * as approvalOverrides from "../runtime/conversation-approval-overrides.js";
+import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
@@ -263,6 +264,19 @@ export class Conversation {
   /** @internal */ accumulatedSurfaceState = new Map<
     string,
     Record<string, unknown>
+  >();
+  /**
+   * Pending standalone UI requests keyed by surfaceId.
+   * Daemon-driven surfaces that block the caller until user response or timeout.
+   * @internal
+   */
+  pendingStandaloneSurfaces = new Map<
+    string,
+    {
+      resolve: (result: InteractiveUiResult) => void;
+      timer: ReturnType<typeof setTimeout>;
+      surfaceType: SurfaceType;
+    }
   >();
   /** @internal */ broadcastToAllClients?: (msg: ServerMessage) => void;
   /** @internal */ withSurface = createSurfaceMutex();
@@ -720,6 +734,13 @@ export class Conversation {
 
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
+    // Cancel all pending standalone surfaces so callers get a clean
+    // cancellation instead of hanging forever.
+    for (const [surfaceId, entry] of this.pendingStandaloneSurfaces) {
+      clearTimeout(entry.timer);
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    this.pendingStandaloneSurfaces.clear();
     this.hostBashProxy?.dispose();
     this.hostBrowserProxy?.dispose();
     this.hostCuProxy?.dispose();

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -735,9 +735,22 @@ export class Conversation {
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
     // Cancel all pending standalone surfaces so callers get a clean
-    // cancellation instead of hanging forever.
+    // cancellation instead of hanging forever. Emit dismiss notifications
+    // to the client so surfaces don't remain visually active if the client
+    // reconnects after dispose.
+    const emitDispose =
+      this.broadcastToAllClients ?? this.sendToClient.bind(this);
     for (const [surfaceId, entry] of this.pendingStandaloneSurfaces) {
       clearTimeout(entry.timer);
+      try {
+        emitDispose({
+          type: "ui_surface_dismiss",
+          conversationId: this.conversationId,
+          surfaceId,
+        });
+      } catch {
+        // Best-effort: the client may already be disconnected during dispose.
+      }
       entry.resolve({ status: "cancelled", surfaceId });
     }
     this.pendingStandaloneSurfaces.clear();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -95,7 +95,10 @@ import { registerLaunchConversationDeps } from "./conversation-launch.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
-import { refreshSurfacesForApp } from "./conversation-surfaces.js";
+import {
+  refreshSurfacesForApp,
+  showStandaloneSurface,
+} from "./conversation-surfaces.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type {
@@ -834,10 +837,9 @@ export class DaemonServer {
     // Install the interactive UI resolver so skills and IPC handlers can
     // present ad-hoc UI surfaces (confirmations, forms) to the user via
     // `requestInteractiveUi()`. The resolver verifies the target
-    // conversation exists and is live before delegating to the
-    // conversation-level surface lifecycle (wired in PR 2). For now it
-    // validates the conversation and fails closed if not found — the
-    // actual surface show/await logic is added in the next PR.
+    // conversation exists and is live, then delegates to the
+    // conversation-level standalone surface lifecycle which blocks until
+    // the user responds or the timeout elapses.
     registerInteractiveUiResolver(async (request) => {
       const conversation = this.conversations.get(request.conversationId);
       if (!conversation) {
@@ -854,13 +856,11 @@ export class DaemonServer {
         };
       }
 
-      // PR 2 will wire conversation-scoped surface lifecycle here.
-      // For now, fail closed — the resolver exists and is reachable,
-      // but the surface presentation layer is not yet implemented.
-      return {
-        status: "cancelled" as const,
-        surfaceId: `ui-resolver-${Date.now()}`,
-      };
+      // Generate a unique surface ID and delegate to the conversation's
+      // standalone surface lifecycle. The returned Promise blocks until
+      // the user submits, cancels, or the timeout elapses.
+      const surfaceId = `ui-standalone-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      return showStandaloneSurface(conversation, request, surfaceId);
     });
 
     // Start the CLI IPC server. Built-in methods (wake_conversation) are


### PR DESCRIPTION
## Summary
- Add per-conversation pending standalone UI map for daemon-driven surface requests
- Intercept standalone callbacks in handleSurfaceAction before LLM forwarding
- Add deterministic timeout resolution and cleanup on every exit path

Part of plan: user-confirmation-primitive.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
