### PR TITLE
fix(macos): keep scroll debug HUD live when scrolling stops

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -326,6 +326,16 @@ struct ScrollDebugMetrics {
         return recentAnchorShiftTimes.reduce(0) { $1 > cutoff ? $0 + 1 : $0 }
     }
 
+    /// Velocity to show in the HUD. Snaps to 0 once no snapshot has arrived
+    /// for `idleThreshold` seconds — without this, the EMA stays pinned at
+    /// its last value when scrolling stops and the reading looks stuck.
+    func displayedVelocity(at now: Date, idleThreshold: TimeInterval = 0.1) -> CGFloat {
+        guard let last = lastSnapshotTime, now.timeIntervalSince(last) <= idleThreshold else {
+            return 0
+        }
+        return velocityPtPerSec
+    }
+
     /// Keep a little slack past 1s so reads near a second boundary don't flap.
     /// `static` so the inout buffer access doesn't overlap with the caller's
     /// inout access to `self` via the mutating entry point.

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -35,11 +35,22 @@ struct ScrollDebugOverlayView: View {
     }
 
     private var hud: some View {
-        // Reading the observed version counter registers an invalidation
-        // dependency so the HUD re-renders on every debug-metric tick.
+        // `TimelineView(.animation)` drives a redraw every frame (display link
+        // cadence) while the HUD is mounted, so time-derived readings like
+        // updates/s, anchors/s, and the idle-snapped velocity stay current
+        // even when no scroll events are arriving. This is a dev-only debug
+        // panel, so the per-frame evaluation cost is deliberate.
+        TimelineView(.animation) { context in
+            hudContent(now: context.date)
+        }
+    }
+
+    private func hudContent(now: Date) -> some View {
+        // Reading the observed version counter still registers an
+        // invalidation dependency so metric writes that happen faster
+        // than the display cadence also trigger redraws.
         _ = scrollState.debugMetricsVersion
 
-        let now = Date()
         let metrics = scrollState.debugMetrics
         let pinnedEpsilon: CGFloat = 8
 
@@ -56,7 +67,7 @@ struct ScrollDebugOverlayView: View {
             row("pagInRange", bool(scrollState.wasPaginationTriggerInRange))
             row("ctaVisible", bool(scrollState.showScrollToLatest))
             row("updates/s", String(metrics.updatesPerSecond(at: now)))
-            row("velocity", "\(signed(metrics.velocityPtPerSec)) pt/s")
+            row("velocity", "\(signed(metrics.displayedVelocity(at: now))) pt/s")
             row("lastDeltaY", signed(metrics.lastDeltaY))
             row("anchors/s", String(metrics.anchorShiftsPerSecond(at: now)))
             row("anchorTotal", String(metrics.anchorShiftTotal))


### PR DESCRIPTION
## Summary
- Wrap the HUD body in `TimelineView(.animation)` so it redraws every frame while mounted — updates/s and anchors/s now tick down as their 1s rolling windows expire.
- Add `ScrollDebugMetrics.displayedVelocity(at:)` that snaps to 0 after 100ms of idle, so the EMA-smoothed velocity doesn't stay pinned at its last nonzero value when scrolling stops.

## Original prompt
Implement the approved plan at /Users/sidd/.claude/plans/the-scrolling-in-the-sunny-lagoon.md — scroll debug overlay as a dev setting in the macOS app.

(Follow-up: keep the HUD updating per-frame even when no scroll events are arriving.)