### PR TITLE
feat(macos): scroll HUD rec appends, add clear button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -125,37 +125,50 @@ struct ScrollDebugOverlayView: View {
 
     private func recordControl(now: Date) -> some View {
         let elapsed: String = {
-            guard recorder.isRecording, let start = recorder.startTime else { return "" }
+            guard recorder.isRecording, let start = recorder.sessionStartTime else { return "" }
             return String(format: "%.1fs", now.timeIntervalSince(start))
         }()
         let frameCount = recorder.frames.count
 
-        return Button(action: toggleRecording) {
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(recorder.isRecording ? Color.red : Color.clear)
-                    .overlay(
-                        Circle().strokeBorder(
-                            recorder.isRecording ? Color.red : VColor.contentSecondary,
-                            lineWidth: 1
+        return HStack(spacing: 6) {
+            Button(action: toggleRecording) {
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(recorder.isRecording ? Color.red : Color.clear)
+                        .overlay(
+                            Circle().strokeBorder(
+                                recorder.isRecording ? Color.red : VColor.contentSecondary,
+                                lineWidth: 1
+                            )
                         )
-                    )
-                    .frame(width: 7, height: 7)
-                Text(recorder.isRecording ? "stop" : "rec")
-                    .foregroundStyle(VColor.contentDefault)
-                if recorder.isRecording {
-                    Text(elapsed)
-                        .foregroundStyle(VColor.contentSecondary)
-                    Spacer(minLength: 4)
-                    Text("\(frameCount)f")
-                        .foregroundStyle(VColor.contentSecondary)
+                        .frame(width: 7, height: 7)
+                    Text(recorder.isRecording ? "stop" : "rec")
+                        .foregroundStyle(VColor.contentDefault)
+                    if recorder.isRecording {
+                        Text(elapsed)
+                            .foregroundStyle(VColor.contentSecondary)
+                    }
                 }
+                .contentShape(Rectangle())
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .help(recorder.isRecording ? "Stop recording and save CSV to ~/Downloads" : "Start/resume recording per-frame scroll data (appends to existing buffer)")
+
+            Spacer(minLength: 4)
+
+            if frameCount > 0 {
+                Text("\(frameCount)f")
+                    .foregroundStyle(VColor.contentSecondary)
+
+                Button(action: clearFrames) {
+                    Text("clear")
+                        .foregroundStyle(VColor.contentSecondary)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Discard the recording buffer")
+            }
         }
-        .buttonStyle(.plain)
-        .help(recorder.isRecording ? "Stop recording and save CSV to ~/Downloads" : "Start recording per-frame scroll data")
     }
 
     private func toggleRecording() {
@@ -166,6 +179,10 @@ struct ScrollDebugOverlayView: View {
         } else {
             recorder.start()
         }
+    }
+
+    private func clearFrames() {
+        recorder.clear()
     }
 
     private func row(_ label: String, _ value: String) -> some View {
@@ -201,11 +218,14 @@ struct ScrollDebugOverlayView: View {
 @MainActor
 final class ScrollDebugRecorder {
     /// Observed so the record button's label/indicator update when recording
-    /// toggles. The frame buffer and start time are `@ObservationIgnored` —
+    /// toggles. The frame buffer and session start are `@ObservationIgnored` —
     /// appending to them inside the HUD's body would otherwise invalidate
     /// the view and cause "modifying state during view update" warnings.
     var isRecording: Bool = false
-    @ObservationIgnored var startTime: Date?
+    /// Set on each `start()` and cleared on `stop()` — drives the "3.2s"
+    /// elapsed readout next to the stop button. Separate from CSV elapsed
+    /// time, which is computed off the first frame's timestamp.
+    @ObservationIgnored var sessionStartTime: Date?
     @ObservationIgnored var frames: [Frame] = []
 
     struct Frame {
@@ -229,9 +249,10 @@ final class ScrollDebugRecorder {
         let conversationId: UUID?
     }
 
+    /// Begin (or resume) recording. Appends to the existing buffer — call
+    /// `clear()` first for a fresh recording.
     func start() {
-        frames.removeAll(keepingCapacity: true)
-        startTime = Date()
+        sessionStartTime = Date()
         isRecording = true
     }
 
@@ -243,20 +264,31 @@ final class ScrollDebugRecorder {
         frames.append(frame)
     }
 
-    /// Stop recording and write frames to `~/Downloads/vellum-scroll-debug-<timestamp>.csv`.
-    /// Returns the written URL, or `nil` if there was nothing to write or the
-    /// write failed.
+    /// Stop recording and write the accumulated buffer to
+    /// `~/Downloads/vellum-scroll-debug-<timestamp>.csv`. Frames are kept so
+    /// a subsequent `start()` appends to the same buffer; call `clear()` to
+    /// reset. Returns the written URL, or `nil` if the buffer was empty or
+    /// the write failed.
     func stop() -> URL? {
-        let captured = frames
-        let start = startTime
         isRecording = false
-        startTime = nil
-        frames.removeAll(keepingCapacity: true)
-        guard !captured.isEmpty, let start else { return nil }
-        return writeCSV(frames: captured, start: start)
+        sessionStartTime = nil
+        guard !frames.isEmpty else { return nil }
+        return writeCSV(frames: frames)
     }
 
-    private func writeCSV(frames: [Frame], start: Date) -> URL? {
+    /// Discard the buffer. Safe to call while recording — the next captured
+    /// frame becomes the new anchor, and the HUD's elapsed readout restarts.
+    func clear() {
+        frames.removeAll(keepingCapacity: true)
+        if isRecording {
+            sessionStartTime = Date()
+        } else {
+            sessionStartTime = nil
+        }
+    }
+
+    private func writeCSV(frames: [Frame]) -> URL? {
+        guard let start = frames.first?.timestamp else { return nil }
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 


### PR DESCRIPTION
## Summary
- `rec` now appends to the existing recording buffer instead of wiping it, so successive rec/stop cycles accumulate into one growing CSV.
- New `clear` button next to the frame count (visible whenever `frames > 0`) explicitly discards the buffer. Safe during recording — the elapsed readout restarts when the next frame is captured.
- CSV `elapsedSec` and the output filename are now anchored to the first frame's timestamp, so pauses between rec/stop cycles show up as time gaps in the data.

## Original prompt
Does starting a new recording delete the existing one or append to it? Can we add a "clear" button that deletes the existing and make "rec" append?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
