### PR TITLE
feat(remember): add optional finish_turn to end assistant turn

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -249,6 +249,7 @@ async function handleArchiveRecall(
 
 export interface RememberInput {
   content: string;
+  finish_turn?: boolean;
 }
 
 export interface RememberResult {

--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -91,6 +91,11 @@ export const graphRememberDefinition: ToolDefinition = {
         description:
           "The fact to remember. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.",
       },
+      finish_turn: {
+        type: "boolean",
+        description:
+          "Set to true ONLY on the final `remember` call when you have nothing else to say and want to hand control back to the user. When true, the assistant turn ends after this tool call and no further LLM call is made. Do NOT set true on intermediate `remember` calls. Default: false.",
+      },
     },
     required: ["content"],
   },

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import type { ToolContext } from "../types.js";
+
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "remember-tool-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+// Import after the env var is set so getWorkspaceDir() resolves to the tmpdir.
+const { rememberTool } = await import("./register.js");
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: tmpWorkspace,
+    conversationId: "test-conversation",
+    trustClass: "guardian",
+  };
+}
+
+describe("rememberTool.execute — finish_turn", () => {
+  test("omits yieldToUser when finish_turn is not provided", async () => {
+    const result = await rememberTool.execute(
+      { content: "no finish_turn provided" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+  });
+
+  test("omits yieldToUser when finish_turn is false", async () => {
+    const result = await rememberTool.execute(
+      { content: "finish_turn=false", finish_turn: false },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+  });
+
+  test("sets yieldToUser=true when finish_turn is true", async () => {
+    const result = await rememberTool.execute(
+      { content: "finish_turn=true", finish_turn: true },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBe(true);
+  });
+
+  test("sets yieldToUser=true even when the write fails (empty content)", async () => {
+    const result = await rememberTool.execute(
+      { content: "", finish_turn: true },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.yieldToUser).toBe(true);
+  });
+});

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -29,14 +29,16 @@ class RememberTool implements Tool {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
+    const typedInput = input as unknown as RememberInput;
     const result = handleRemember(
-      input as unknown as RememberInput,
+      typedInput,
       context.conversationId,
       context.memoryScopeId ?? "default",
     );
     return {
       content: result.message,
       isError: !result.success,
+      ...(typedInput.finish_turn ? { yieldToUser: true } : {}),
     };
   }
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -228,9 +228,12 @@ export interface ToolExecutionResult {
   sensitiveBindings?: SensitiveOutputBinding[];
   /**
    * When true, the agent loop should yield control back to the user after
-   * returning this result. Used by interactive surfaces (tables with action
-   * buttons, file uploads) to force-stop the loop so the LLM cannot bypass
-   * the "wait for user action" instruction.
+   * returning this result — tool results are pushed to history and the loop
+   * breaks without another LLM call. Two callers set this: interactive
+   * surfaces (tables with action buttons, file uploads) that force-stop the
+   * loop so the LLM cannot bypass the "wait for user action" instruction,
+   * and tools like `remember` that expose a `finish_turn` parameter letting
+   * the LLM voluntarily end its turn.
    */
   yieldToUser?: boolean;
   /**


### PR DESCRIPTION
## Summary
- Add optional `finish_turn: boolean` (default false) to the `remember` tool's input schema. When true on any `remember` call in a tool block, the assistant turn ends after the tools run and no additional LLM call is made.
- Wired via the existing `ToolExecutionResult.yieldToUser` mechanism — the agent loop already supports "push tool results to history and break" when any tool in a batch sets that flag (`agent/loop.ts:651-656`). Zero changes to the loop; only the `RememberTool.execute()` wrapper and the tool schema/input interface change.
- Updated the `yieldToUser` doc comment to note both existing (interactive surfaces) and new (LLM-initiated via `finish_turn`) callers.
- Added `register.test.ts` covering: no flag, flag=false, flag=true, and flag=true with an error (we still yield — LLM intent wins over retry-nudge).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
