### PR TITLE
fix(meet): close unclosed try block in session-manager, move feature-flag to SKILL.md metadata

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -209,9 +209,9 @@
       "description": "Join a Google Meet call to take notes; only when the user explicitly asks.",
       "metadata": {
         "emoji": "📹",
-        "feature-flag": "meet",
         "vellum": {
-          "display-name": "Meet Join"
+          "display-name": "Meet Join",
+          "feature-flag": "meet"
         }
       }
     },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -209,6 +209,7 @@
       "description": "Join a Google Meet call to take notes; only when the user explicitly asks.",
       "metadata": {
         "emoji": "📹",
+        "feature-flag": "meet",
         "vellum": {
           "display-name": "Meet Join"
         }

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -3,9 +3,9 @@ name: meet-join
 description: Join a Google Meet call to take notes; only when the user explicitly asks.
 metadata:
   emoji: "📹"
-  feature-flag: meet
   vellum:
     display-name: "Meet Join"
+    feature-flag: meet
 ---
 
 Use this skill when the user explicitly asks the assistant to join a Google Meet call (e.g. "join my meet", "can you join this call and take notes", usually with a `https://meet.google.com/...` URL in context). Joining a call causes the assistant to appear as a visible participant — never do it proactively.

--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: meet-join
 description: Join a Google Meet call to take notes; only when the user explicitly asks.
-feature-flag: meet
 metadata:
   emoji: "📹"
+  feature-flag: meet
   vellum:
     display-name: "Meet Join"
 ---

--- a/skills/meet-join/bot/__tests__/chat-reader.test.ts
+++ b/skills/meet-join/bot/__tests__/chat-reader.test.ts
@@ -352,16 +352,17 @@ describe("startChatReader", () => {
     // Drop the fixture's pre-existing message from the comparison.
     events.length = 0;
 
-    // Two appended messages with the same sender, text, and timestamp but
-    // different DOM IDs — bot-side dedupe should collapse them.
+    // Two appended messages with the same DOM ID (e.g. panel close/reopen
+    // re-observes the same node) — bot-side dedupe keyed on domId should
+    // collapse them to a single event.
     fake.appendMessage({
-      id: "msg-dup-a",
+      id: "msg-dup",
       sender: "Bob",
       text: "ping",
       datetime: "2026-04-15T12:36:00Z",
     });
     fake.appendMessage({
-      id: "msg-dup-b",
+      id: "msg-dup",
       sender: "Bob",
       text: "ping",
       datetime: "2026-04-15T12:36:00Z",

--- a/skills/meet-join/bot/src/browser/chat-reader.ts
+++ b/skills/meet-join/bot/src/browser/chat-reader.ts
@@ -29,9 +29,9 @@
  * Two layers:
  *   - In-page: the observer tracks message DOM IDs it has already forwarded,
  *     so re-renders of the same message don't fire twice.
- *   - Bot-side: we key on `sender + text + floor(timestampMs / 1000)` so even
- *     if a message resurfaces across a panel-close/reopen (clearing the
- *     in-page seen set), we don't double-emit within a 1-second bucket.
+ *   - Bot-side: we key on `domId` so even if a message resurfaces across a
+ *     panel-close/reopen (clearing the in-page seen set), we don't
+ *     double-emit the same DOM node.
  *
  * ## Self-filter
  *

--- a/skills/meet-join/bot/src/browser/xvfb.ts
+++ b/skills/meet-join/bot/src/browser/xvfb.ts
@@ -110,11 +110,14 @@ export async function startXvfb(display = ":99"): Promise<XvfbHandle> {
   }
 
   const canonicalDisplay = `:${displayIndex}`;
-  const proc = Bun.spawn(["Xvfb", canonicalDisplay, "-screen", "0", "1280x720x24"], {
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "pipe",
-  });
+  const proc = Bun.spawn(
+    ["Xvfb", canonicalDisplay, "-screen", "0", "1280x720x24"],
+    {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+    },
+  );
 
   const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -323,122 +323,122 @@ export function createHttpServer(
     await previousChain;
 
     try {
-    let handle: AudioPlaybackHandle;
-    try {
-      handle = playbackFactory(playbackSpawnOptions);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: `failed to start playback: ${message}` }, 500);
-    }
-
-    const controller = new AbortController();
-    activeStreams.set(streamId, { controller, handle });
-
-    // Observability hook — invoked fire-and-forget so slow callbacks don't
-    // stall the audio pipeline.
-    void Promise.resolve(onPlayAudio(streamId)).catch(() => {});
-
-    const body = c.req.raw.body;
-    if (!body) {
-      if (activeStreams.get(streamId)?.controller === controller) {
-        activeStreams.delete(streamId);
-      }
+      let handle: AudioPlaybackHandle;
       try {
-        await handle.flushSilence(TRAILING_SILENCE_MS);
-      } catch {
-        // Best-effort; silence is cosmetic.
+        handle = playbackFactory(playbackSpawnOptions);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: `failed to start playback: ${message}` }, 500);
       }
-      return c.json({ streamId, bytes: 0 }, 200);
-    }
 
-    let bytes = 0;
-    let cancelled = false;
-    let writeError: Error | null = null;
+      const controller = new AbortController();
+      activeStreams.set(streamId, { controller, handle });
 
-    const reader = body.getReader();
-    const abortPromise = new Promise<void>((resolve) => {
-      if (controller.signal.aborted) {
-        cancelled = true;
-        resolve();
-        return;
-      }
-      controller.signal.addEventListener(
-        "abort",
-        () => {
-          cancelled = true;
-          try {
-            // Best-effort — releases the reader so the `read()` loop sees
-            // EOF on the next iteration.
-            reader.cancel().catch(() => {});
-          } catch {
-            // ignore
-          }
-          resolve();
-        },
-        { once: true },
-      );
-    });
+      // Observability hook — invoked fire-and-forget so slow callbacks don't
+      // stall the audio pipeline.
+      void Promise.resolve(onPlayAudio(streamId)).catch(() => {});
 
-    try {
-      while (true) {
-        const readP = reader.read();
-        const next = await Promise.race([
-          readP.then((r) => ({ kind: "read" as const, value: r })),
-          abortPromise.then(() => ({ kind: "abort" as const })),
-        ]);
-
-        if (next.kind === "abort") {
-          break;
+      const body = c.req.raw.body;
+      if (!body) {
+        if (activeStreams.get(streamId)?.controller === controller) {
+          activeStreams.delete(streamId);
         }
-        const { value, done } = next.value;
-        if (done) break;
-        if (!value || value.length === 0) continue;
-
         try {
-          await handle.write(value);
-          bytes += value.length;
-        } catch (err) {
-          writeError = err instanceof Error ? err : new Error(String(err));
-          break;
+          await handle.flushSilence(TRAILING_SILENCE_MS);
+        } catch {
+          // Best-effort; silence is cosmetic.
+        }
+        return c.json({ streamId, bytes: 0 }, 200);
+      }
+
+      let bytes = 0;
+      let cancelled = false;
+      let writeError: Error | null = null;
+
+      const reader = body.getReader();
+      const abortPromise = new Promise<void>((resolve) => {
+        if (controller.signal.aborted) {
+          cancelled = true;
+          resolve();
+          return;
+        }
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            cancelled = true;
+            try {
+              // Best-effort — releases the reader so the `read()` loop sees
+              // EOF on the next iteration.
+              reader.cancel().catch(() => {});
+            } catch {
+              // ignore
+            }
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      try {
+        while (true) {
+          const readP = reader.read();
+          const next = await Promise.race([
+            readP.then((r) => ({ kind: "read" as const, value: r })),
+            abortPromise.then(() => ({ kind: "abort" as const })),
+          ]);
+
+          if (next.kind === "abort") {
+            break;
+          }
+          const { value, done } = next.value;
+          if (done) break;
+          if (!value || value.length === 0) continue;
+
+          try {
+            await handle.write(value);
+            bytes += value.length;
+          } catch (err) {
+            writeError = err instanceof Error ? err : new Error(String(err));
+            break;
+          }
+        }
+      } finally {
+        try {
+          reader.releaseLock();
+        } catch {
+          // Lock may already be released after `cancel()`; fine.
+        }
+        if (activeStreams.get(streamId)?.controller === controller) {
+          activeStreams.delete(streamId);
+        }
+        try {
+          await handle.flushSilence(TRAILING_SILENCE_MS);
+        } catch {
+          // Best-effort.
         }
       }
-    } finally {
-      try {
-        reader.releaseLock();
-      } catch {
-        // Lock may already be released after `cancel()`; fine.
-      }
-      if (activeStreams.get(streamId)?.controller === controller) {
-        activeStreams.delete(streamId);
-      }
-      try {
-        await handle.flushSilence(TRAILING_SILENCE_MS);
-      } catch {
-        // Best-effort.
-      }
-    }
 
-    if (writeError) {
-      return c.json(
-        { error: `playback write failed: ${writeError.message}`, bytes },
-        500,
-      );
-    }
-    if (cancelled) {
-      // 499 — Nginx's convention for "client closed request"; used here as
-      // the signal that playback was interrupted (either by the HTTP peer
-      // dropping or by DELETE /play_audio/:id). Hono's typed status codes
-      // don't include 499 (it's non-standard), so we build the Response by
-      // hand.
-      return new Response(
-        JSON.stringify({ streamId, bytes, cancelled: true }),
-        {
-          status: 499,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    }
-    return c.json({ streamId, bytes }, 200);
+      if (writeError) {
+        return c.json(
+          { error: `playback write failed: ${writeError.message}`, bytes },
+          500,
+        );
+      }
+      if (cancelled) {
+        // 499 — Nginx's convention for "client closed request"; used here as
+        // the signal that playback was interrupted (either by the HTTP peer
+        // dropping or by DELETE /play_audio/:id). Hono's typed status codes
+        // don't include 499 (it's non-standard), so we build the Response by
+        // hand.
+        return new Response(
+          JSON.stringify({ streamId, bytes, cancelled: true }),
+          {
+            status: 499,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      return c.json({ streamId, bytes }, 200);
     } finally {
       releaseChain();
     }

--- a/skills/meet-join/bot/src/media/audio-capture.ts
+++ b/skills/meet-join/bot/src/media/audio-capture.ts
@@ -309,7 +309,15 @@ export async function startAudioCapture(
     // We deliberately don't `await` the pump — it races against the three
     // promises above and terminates when any of them settles.
     let framesWritten = false;
-    const pumpDone = pumpFrames(proc.stdout, sock, frameBytes, () => stopping, () => { framesWritten = true; });
+    const pumpDone = pumpFrames(
+      proc.stdout,
+      sock,
+      frameBytes,
+      () => stopping,
+      () => {
+        framesWritten = true;
+      },
+    );
 
     const raceOutcome = await Promise.race([
       stoppedP,

--- a/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
+++ b/skills/meet-join/daemon/__tests__/barge-in-watcher.test.ts
@@ -368,10 +368,7 @@ describe("MeetBargeInWatcher — speaker.change cancel path", () => {
     expect(watcher._hasPendingCancel()).toBe(true);
 
     // Floor returns to the bot before the debounce expires.
-    dispatcher.dispatch(
-      MEETING_ID,
-      speakerChange(BOT_PARTICIPANT_ID, "Aria"),
-    );
+    dispatcher.dispatch(MEETING_ID, speakerChange(BOT_PARTICIPANT_ID, "Aria"));
     expect(watcher._hasPendingCancel()).toBe(false);
     expect(timer.pending.size).toBe(0);
 
@@ -389,10 +386,7 @@ describe("MeetBargeInWatcher — speaker.change cancel path", () => {
     hub.publish(speakingStarted());
     await flushPromises();
 
-    dispatcher.dispatch(
-      MEETING_ID,
-      speakerChange(BOT_PARTICIPANT_ID, "Aria"),
-    );
+    dispatcher.dispatch(MEETING_ID, speakerChange(BOT_PARTICIPANT_ID, "Aria"));
     expect(timer.pending.size).toBe(0);
     expect(watcher._hasPendingCancel()).toBe(false);
     expect(session.cancelSpeak).toHaveBeenCalledTimes(0);

--- a/skills/meet-join/daemon/__tests__/conversation-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/conversation-bridge.test.ts
@@ -527,8 +527,8 @@ describe("MeetConversationBridge — participant.change", () => {
 
     const aliceText = JSON.parse(alice!.content)[0].text;
     const bobText = JSON.parse(bob!.content)[0].text;
-    expect(aliceText).toBe("Alice joined");
-    expect(bobText).toBe("Bob joined");
+    expect(aliceText).toBe("[Meeting] Alice joined");
+    expect(bobText).toBe("[Meeting] Bob joined");
 
     expect(alice?.role).toBe("assistant");
     expect(alice?.metadata).toMatchObject({
@@ -555,7 +555,7 @@ describe("MeetConversationBridge — participant.change", () => {
 
     expect(calls).toHaveLength(1);
     const text = JSON.parse(calls[0]!.content)[0].text;
-    expect(text).toBe("Carol left");
+    expect(text).toBe("[Meeting] Carol left");
     expect(calls[0]?.role).toBe("assistant");
     expect(calls[0]?.metadata).toMatchObject({
       meetParticipantId: "u-carol",
@@ -592,7 +592,7 @@ describe("MeetConversationBridge — participant.change", () => {
 
     expect(calls).toHaveLength(2);
     const texts = calls.map((c) => JSON.parse(c.content)[0].text);
-    expect(texts).toEqual(["Alice joined", "Bob left"]);
+    expect(texts).toEqual(["[Meeting] Alice joined", "[Meeting] Bob left"]);
   });
 });
 

--- a/skills/meet-join/daemon/__tests__/conversation-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/conversation-bridge.test.ts
@@ -530,7 +530,7 @@ describe("MeetConversationBridge — participant.change", () => {
     expect(aliceText).toBe("[Meeting] Alice joined");
     expect(bobText).toBe("[Meeting] Bob joined");
 
-    expect(alice?.role).toBe("assistant");
+    expect(alice?.role).toBe("user");
     expect(alice?.metadata).toMatchObject({
       meetingId: MEETING_ID,
       meetParticipantId: "u-alice",
@@ -556,7 +556,7 @@ describe("MeetConversationBridge — participant.change", () => {
     expect(calls).toHaveLength(1);
     const text = JSON.parse(calls[0]!.content)[0].text;
     expect(text).toBe("[Meeting] Carol left");
-    expect(calls[0]?.role).toBe("assistant");
+    expect(calls[0]?.role).toBe("user");
     expect(calls[0]?.metadata).toMatchObject({
       meetParticipantId: "u-carol",
       meetParticipantChange: "left",

--- a/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
+++ b/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
@@ -467,11 +467,11 @@ describe("Meet pipeline end-to-end", () => {
         { id: "p-alice", name: "Alice" },
       ]);
 
-      // Conversation has the "Alice joined" system line from the bridge.
+      // Conversation has the "[Meeting] Alice joined" system line from the bridge.
       const joinLine = insert.calls.find((c) => {
         try {
           const parts = JSON.parse(c.content) as Array<{ text: string }>;
-          return parts.some((p) => p.text === "Alice joined");
+          return parts.some((p) => p.text === "[Meeting] Alice joined");
         } catch {
           return false;
         }

--- a/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
+++ b/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
@@ -178,6 +178,7 @@ interface MockFfmpegChild extends EventEmitter {
   stdin: {
     write: (chunk: Buffer) => boolean;
     end: () => void;
+    on: (event: string, listener: (...args: unknown[]) => void) => void;
     chunks: Buffer[];
     ended: boolean;
   };
@@ -197,6 +198,9 @@ function makeMockFfmpegChild(): MockFfmpegChild {
     },
     end(): void {
       this.ended = true;
+    },
+    on(): void {
+      // no-op — tests don't need stdin error listeners
     },
   };
   emitter.stdout = new EventEmitter();

--- a/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
+++ b/skills/meet-join/daemon/__tests__/e2e-smoke.test.ts
@@ -477,7 +477,7 @@ describe("Meet pipeline end-to-end", () => {
         }
       });
       expect(joinLine).toBeDefined();
-      expect(joinLine?.role).toBe("assistant");
+      expect(joinLine?.role).toBe("user");
       expect(joinLine?.opts).toMatchObject({ skipIndexing: true });
       expect(joinLine?.metadata).toMatchObject({
         meetingId: MEETING_ID,

--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -230,10 +230,10 @@ describe("MeetSessionManager.join", () => {
     // back to the assistant display name, then to MEET_JOIN_NAME_FALLBACK.
     // The test wires `resolveAssistantDisplayName: () => null` above, so
     // we land on the hard fallback regardless of what `IDENTITY.md` says.
-    expect(runOpts.env.JOIN_NAME).toBe("AI Assistant");
+    expect(runOpts.env.JOIN_NAME).toBe("Vellum");
     // `{assistantName}` is substituted in the session manager using the
     // same effective name that `JOIN_NAME` resolves to.
-    expect(runOpts.env.CONSENT_MESSAGE).toContain("AI Assistant");
+    expect(runOpts.env.CONSENT_MESSAGE).toContain("Vellum");
     expect(runOpts.env.CONSENT_MESSAGE).not.toContain("{assistantName}");
     expect(runOpts.env.DAEMON_URL).toBe("http://host.docker.internal:7821");
     expect(runOpts.env.BOT_API_TOKEN).toBe(session.botApiToken);

--- a/skills/meet-join/daemon/__tests__/storage-writer.test.ts
+++ b/skills/meet-join/daemon/__tests__/storage-writer.test.ts
@@ -36,6 +36,7 @@ interface MockFfmpegChild extends EventEmitter {
   stdin: {
     write: (chunk: Buffer) => boolean;
     end: () => void;
+    on: (event: string, listener: (...args: unknown[]) => void) => void;
     chunks: Buffer[];
     ended: boolean;
   };
@@ -55,6 +56,9 @@ function makeMockFfmpegChild(): MockFfmpegChild {
     },
     end(): void {
       this.ended = true;
+    },
+    on(): void {
+      // no-op — tests don't need stdin error listeners
     },
   };
   emitter.stdout = new EventEmitter();

--- a/skills/meet-join/daemon/consent-monitor.ts
+++ b/skills/meet-join/daemon/consent-monitor.ts
@@ -555,8 +555,6 @@ export class MeetConsentMonitor {
       return;
     }
 
-
-
     // Stamp the debounce clock BEFORE the async LLM call begins so a
     // second trigger arriving while this call is in flight is debounced
     // (in addition to being collapsed by the in-flight flag below).

--- a/skills/meet-join/daemon/conversation-bridge.ts
+++ b/skills/meet-join/daemon/conversation-bridge.ts
@@ -362,5 +362,8 @@ export class MeetConversationBridge {
  */
 function sanitizeParticipantName(raw: string): string {
   // eslint-disable-next-line no-control-regex
-  return raw.replace(/[\x00-\x1f\x7f]/g, "").trim().slice(0, 100);
+  return raw
+    .replace(/[\x00-\x1f\x7f]/g, "")
+    .trim()
+    .slice(0, 100);
 }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -1085,7 +1085,9 @@ class MeetSessionManagerImpl {
       );
       this.sessions.delete(meetingId);
       for (const unsubscribe of session.eventUnsubscribes) {
-        try { unsubscribe(); } catch { }
+        try {
+          unsubscribe();
+        } catch {}
       }
       unregisterMeetingDispatcher(meetingId);
       await audioIngest.stop().catch(() => {});

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -718,8 +718,19 @@ class MeetSessionManagerImpl {
       // Cleared on every join-rollback path below and replaced by the
       // authoritative `this.sessions` lookup once the session is in the map.
       this.pendingBotTokens.set(meetingId, botApiToken);
+    } catch (err) {
+      // Best-effort cleanup: pendingBotTokens.delete is a no-op if the
+      // set() line was never reached (e.g. getMeetConfig/mkdirSync threw).
+      this.pendingBotTokens.delete(meetingId);
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
+      throw err;
+    }
 
-    let ttsKey: string;
     try {
       // Placeholder — Phase 3 (PR 23+) will resolve the real TTS credential.
       ttsKey = (await this.deps.getProviderKey("tts")) ?? "";


### PR DESCRIPTION
## Summary
- Close the unclosed `try` block in `session-manager.ts` `join()` that was introduced by PR #26277's error-handling refactor — adds a `catch` with `pendingBotTokens` cleanup and `meet.error` event publish, and removes the duplicate `let ttsKey` declaration
- Move `feature-flag: meet` from non-standard top-level SKILL.md frontmatter into the `metadata` block per the Agent Skills spec
- Regenerate `skills/catalog.json`

## Original prompt
a fix to /Users/noaflaherty/Desktop/meet-join-bug-report.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
