### PR TITLE
feat(assistant): add optional informational decision token and structured audit logs

### DIFF
--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -9,10 +9,14 @@
  *   3. Resolver registration + delegation.
  *   4. Resolver error handling (fail-closed on throw).
  *   5. Surface ID generation and consistency.
+ *   6. Decision token minting for submitted confirmation requests.
+ *   7. Decision token absence for non-confirmation or non-submitted.
+ *   8. Structured audit log emission for all outcomes.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { decodeDecisionToken } from "../decision-token.js";
 import {
   type InteractiveUiRequest,
   type InteractiveUiResult,
@@ -59,6 +63,17 @@ describe("requestInteractiveUi without resolver", () => {
     const result2 = await requestInteractiveUi(request);
 
     expect(result1.surfaceId).not.toBe(result2.surfaceId);
+  });
+
+  test("does not mint decision token on fail-closed cancel", async () => {
+    const result = await requestInteractiveUi({
+      conversationId: "conv-failclosed",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
   });
 });
 
@@ -219,6 +234,21 @@ describe("resolver error handling", () => {
     expect(result.status).toBe("cancelled");
     expect(result.surfaceId).toBeString();
   });
+
+  test("does not mint decision token on resolver error", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("kaboom");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-err-token",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
+  });
 });
 
 // ── Surface ID consistency ──────────────────────────────────────────
@@ -253,6 +283,165 @@ describe("surfaceId handling", () => {
 
     // Empty string is falsy, so the generated surfaceId should be used
     expect(result.surfaceId).toStartWith("ui-interaction-");
+  });
+});
+
+// ── Decision token minting ──────────────────────────────────────────
+
+describe("decision token", () => {
+  test("mints token for submitted confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "approve",
+      surfaceId: "confirm-surface-1",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-1",
+      surfaceType: "confirmation",
+      data: { message: "Deploy to production?" },
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeString();
+    expect(result.decisionToken!.length).toBeGreaterThan(0);
+
+    // Token should be decodable and contain correct metadata
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload).not.toBeNull();
+    expect(payload!.conversationId).toBe("conv-token-1");
+    expect(payload!.surfaceId).toBe("confirm-surface-1");
+    expect(payload!.action).toBe("approve");
+    expect(payload!.issuedAt).toBeString();
+    expect(payload!.expiresAt).toBeString();
+  });
+
+  test("token encodes actionId when present", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "deny",
+      surfaceId: "deny-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-action",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload!.action).toBe("deny");
+  });
+
+  test("token uses 'submitted' as action when actionId is absent", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "no-action-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-noaction",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload!.action).toBe("submitted");
+  });
+
+  test("token has expiry in the future", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "ok",
+      surfaceId: "expiry-surface",
+    }));
+
+    const before = Date.now();
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-expiry",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    const expiresAt = new Date(payload!.expiresAt).getTime();
+    // Should expire ~5 minutes in the future
+    expect(expiresAt).toBeGreaterThan(before);
+    expect(expiresAt).toBeGreaterThan(before + 4 * 60 * 1000);
+    expect(expiresAt).toBeLessThanOrEqual(before + 6 * 60 * 1000);
+  });
+
+  test("does not mint token for submitted form request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "submit",
+      submittedData: { name: "Bob" },
+      surfaceId: "form-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-form-notoken",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for cancelled confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "cancel-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-cancel-notoken",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for timed_out confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "timeout-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-timeout-notoken",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("each minted token is unique", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "ok",
+      surfaceId: "unique-surface",
+    }));
+
+    const result1 = await requestInteractiveUi({
+      conversationId: "conv-unique-1",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const result2 = await requestInteractiveUi({
+      conversationId: "conv-unique-1",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    // Tokens differ due to nonce even with same conversation/action
+    expect(result1.decisionToken).not.toBe(result2.decisionToken);
   });
 });
 
@@ -335,5 +524,7 @@ describe("contract shapes", () => {
     expect(result.submittedData).toEqual({ choice: "yes" });
     expect(result.summary).toBe("User confirmed the action");
     expect(result.surfaceId).toBe("full-result-surface");
+    // Confirmation + submitted → token should be present
+    expect(result.decisionToken).toBeString();
   });
 });

--- a/assistant/src/runtime/decision-token.ts
+++ b/assistant/src/runtime/decision-token.ts
@@ -1,0 +1,116 @@
+/**
+ * Lightweight informational decision token for interactive UI outcomes.
+ *
+ * Minted when a confirmation-style surface is `submitted`. The token is
+ * **non-authoritative** — it carries metadata about the decision for
+ * audit and correlation purposes only. It does not grant any capability
+ * and must not be used for enforcement or replay protection (that is
+ * explicitly out of scope for v1).
+ *
+ * Format: base64url-encoded JSON payload + `.` + random nonce.
+ * The nonce makes tokens unique even for identical payloads; the
+ * payload is readable by any consumer without a secret.
+ *
+ * This module is intentionally decoupled from the existing auth/token
+ * infrastructure in `runtime/auth/` — it serves a different purpose
+ * and should remain independent.
+ */
+
+import { randomBytes } from "node:crypto";
+
+// ── Token shape ──────────────────────────────────────────────────────
+
+export interface DecisionTokenPayload {
+  /** Conversation the decision belongs to. */
+  conversationId: string;
+  /** Surface identifier that was displayed. */
+  surfaceId: string;
+  /** Action the user took (`submitted`, `cancelled`, `timed_out`). */
+  action: string;
+  /** ISO-8601 timestamp when the decision was recorded. */
+  issuedAt: string;
+  /** ISO-8601 timestamp after which the token should be considered stale. */
+  expiresAt: string;
+}
+
+/** Default token lifetime: 5 minutes. */
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+// ── Minting ──────────────────────────────────────────────────────────
+
+/**
+ * Mint an informational decision token.
+ *
+ * The returned string is `<base64url-payload>.<random-nonce>`. It is
+ * short-lived (default 5 minutes) and non-authoritative.
+ *
+ * @param opts - Decision metadata.
+ * @param opts.conversationId - Conversation scope.
+ * @param opts.surfaceId - Surface that was displayed.
+ * @param opts.action - Terminal action taken by the user.
+ * @param opts.ttlMs - Token lifetime in milliseconds (default 5 min).
+ * @returns The minted token string.
+ */
+export function mintDecisionToken(opts: {
+  conversationId: string;
+  surfaceId: string;
+  action: string;
+  ttlMs?: number;
+}): string {
+  const now = new Date();
+  const ttl = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const expiresAt = new Date(now.getTime() + ttl);
+
+  const payload: DecisionTokenPayload = {
+    conversationId: opts.conversationId,
+    surfaceId: opts.surfaceId,
+    action: opts.action,
+    issuedAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  };
+
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const nonce = randomBytes(12).toString("hex");
+
+  return `${encoded}.${nonce}`;
+}
+
+// ── Decoding (informational only) ────────────────────────────────────
+
+/**
+ * Decode a decision token's payload.
+ *
+ * This is a pure decoding step — there is no signature verification
+ * because the token is non-authoritative. Consumers should treat the
+ * payload as informational metadata, not a trust assertion.
+ *
+ * @param token - The token string produced by {@link mintDecisionToken}.
+ * @returns The decoded payload, or `null` if the token is malformed.
+ */
+export function decodeDecisionToken(
+  token: string,
+): DecisionTokenPayload | null {
+  const dotIdx = token.indexOf(".");
+  if (dotIdx < 0) return null;
+
+  const encodedPayload = token.slice(0, dotIdx);
+  try {
+    const json = Buffer.from(encodedPayload, "base64url").toString("utf-8");
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+
+    // Minimal structural validation
+    if (
+      typeof parsed.conversationId !== "string" ||
+      typeof parsed.surfaceId !== "string" ||
+      typeof parsed.action !== "string" ||
+      typeof parsed.issuedAt !== "string" ||
+      typeof parsed.expiresAt !== "string"
+    ) {
+      return null;
+    }
+
+    return parsed as unknown as DecisionTokenPayload;
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -35,6 +35,7 @@
  */
 
 import { getLogger } from "../util/logger.js";
+import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
@@ -110,6 +111,15 @@ export interface InteractiveUiResult {
   summary?: string;
   /** The surface identifier that was shown, for audit/correlation. */
   surfaceId: string;
+  /**
+   * Short-lived informational decision token, present when
+   * `status === "submitted"` and `surfaceType === "confirmation"`.
+   *
+   * Non-authoritative — carries metadata about the decision for audit
+   * and correlation purposes only. Does not grant any capability.
+   * Verification/replay enforcement is out of scope for v1.
+   */
+  decisionToken?: string;
 }
 
 // ── Resolver type ────────────────────────────────────────────────────
@@ -173,6 +183,31 @@ export function resetSurfaceIdCounterForTests(): void {
   _surfaceIdCounter = 0;
 }
 
+// ── Audit logging ────────────────────────────────────────────────────
+
+/**
+ * Emit a structured audit log entry for an interactive UI decision.
+ * Keyed by conversation/surface/request IDs so downstream consumers
+ * can correlate decisions across the system.
+ */
+function emitAuditLog(
+  request: InteractiveUiRequest,
+  result: InteractiveUiResult,
+): void {
+  log.info(
+    {
+      event: "interactive_ui_decision",
+      conversationId: request.conversationId,
+      surfaceId: result.surfaceId,
+      surfaceType: request.surfaceType,
+      status: result.status,
+      actionId: result.actionId,
+      timestamp: new Date().toISOString(),
+    },
+    "interactive-ui: decision recorded",
+  );
+}
+
 // ── Public API ───────────────────────────────────────────────────────
 
 /**
@@ -181,6 +216,14 @@ export function resetSurfaceIdCounterForTests(): void {
  *
  * Fails closed: when no resolver is registered (headless, tests without
  * setup), returns `{ status: "cancelled", surfaceId }` immediately.
+ *
+ * When the surface type is `"confirmation"` and the user submits, a
+ * short-lived informational decision token is minted and attached to
+ * the result. The token is non-authoritative — see
+ * {@link mintDecisionToken} for details.
+ *
+ * Structured audit logs are emitted for all terminal outcomes
+ * (`submitted`, `cancelled`, `timed_out`).
  *
  * @param request - The interaction request describing the surface.
  * @returns The user's response or a fail-closed cancellation.
@@ -198,20 +241,41 @@ export async function requestInteractiveUi(
       },
       "interactive-ui: no resolver registered; failing closed",
     );
-    return {
+    const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
     };
+    emitAuditLog(request, failResult);
+    return failResult;
   }
 
   try {
-    const result = await _resolver(request);
+    const resolverResult = await _resolver(request);
     // Ensure the surfaceId is consistent — the resolver may or may not
     // populate it, but the contract guarantees it is always present.
-    return {
-      ...result,
-      surfaceId: result.surfaceId || surfaceId,
+    const finalSurfaceId = resolverResult.surfaceId || surfaceId;
+
+    const result: InteractiveUiResult = {
+      ...resolverResult,
+      surfaceId: finalSurfaceId,
     };
+
+    // Mint an informational decision token for submitted confirmation
+    // requests. The token encodes the decision metadata and is
+    // short-lived (5 minutes). It is non-authoritative in v1.
+    if (
+      result.status === "submitted" &&
+      request.surfaceType === "confirmation"
+    ) {
+      result.decisionToken = mintDecisionToken({
+        conversationId: request.conversationId,
+        surfaceId: finalSurfaceId,
+        action: result.actionId ?? "submitted",
+      });
+    }
+
+    emitAuditLog(request, result);
+    return result;
   } catch (err) {
     log.error(
       {
@@ -221,9 +285,11 @@ export async function requestInteractiveUi(
       },
       "interactive-ui: resolver threw; failing closed",
     );
-    return {
+    const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
     };
+    emitAuditLog(request, failResult);
+    return failResult;
   }
 }


### PR DESCRIPTION
## Summary
- Mint short-lived informational token on submitted confirmation-style requests
- Emit structured audit logs for all interactive UI decision outcomes
- Token is non-authoritative (informational only for v1)

Part of plan: user-confirmation-primitive.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
