### PR TITLE
feat(assistant): add script-facing assistant ui request and assistant ui confirm commands

### DIFF
--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Tests for the `assistant ui confirm` CLI command.
+ *
+ * Validates:
+ *   - Confirmation surface shape (actions, surfaceType)
+ *   - Exit code: 0 on confirm, 1 on deny/cancel/timeout
+ *   - --title, --message, --confirm-label, --deny-label mapping
+ *   - --json output contract: { ok, confirmed, status, actionId, surfaceId }
+ *   - Conversation ID resolution (same as ui request)
+ *   - IPC error handling
+ */
+
+import { existsSync as actualExistsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: { timeoutMs?: number };
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = {
+  ok: true,
+  result: {
+    status: "submitted",
+    actionId: "confirm",
+    surfaceId: "test-surface-1",
+  },
+};
+
+/** Saved env for restoration. */
+let savedEnv: Record<string, string | undefined> = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: () => {
+    throw new Error("ui confirm should not read stdin");
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerUiCommand } = await import("../ui.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerUiCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: {
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "test-surface-1",
+    },
+  };
+  process.exitCode = 0;
+
+  savedEnv = {
+    __SKILL_CONTEXT_JSON: process.env.__SKILL_CONTEXT_JSON,
+  };
+  // Set a default skill context so tests don't need to repeat it
+  process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+    conversationId: "conv-default",
+  });
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Confirmation surface shape
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — surface shape", () => {
+  test("sends confirmation surfaceType with confirm/deny actions", async () => {
+    await runCommand(["ui", "confirm", "--message", "Delete?"]);
+
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("ui_request");
+    expect(lastIpcCall!.params!.surfaceType).toBe("confirmation");
+    expect(lastIpcCall!.params!.actions).toEqual([
+      { id: "confirm", label: "Confirm", variant: "primary" },
+      { id: "deny", label: "Deny", variant: "secondary" },
+    ]);
+  });
+
+  test("maps --message to data.message", async () => {
+    await runCommand(["ui", "confirm", "--message", "Are you sure?"]);
+
+    expect(lastIpcCall!.params!.data).toEqual({ message: "Are you sure?" });
+  });
+
+  test("maps --title to IPC title param", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--title",
+      "Danger",
+      "--message",
+      "Really?",
+    ]);
+
+    expect(lastIpcCall!.params!.title).toBe("Danger");
+  });
+
+  test("uses custom --confirm-label and --deny-label", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "Continue?",
+      "--confirm-label",
+      "Yes",
+      "--deny-label",
+      "No",
+    ]);
+
+    expect(lastIpcCall!.params!.actions).toEqual([
+      { id: "confirm", label: "Yes", variant: "primary" },
+      { id: "deny", label: "No", variant: "secondary" },
+    ]);
+  });
+
+  test("sends empty data when --message is omitted", async () => {
+    await runCommand(["ui", "confirm"]);
+
+    expect(lastIpcCall!.params!.data).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit code behavior
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — exit codes", () => {
+  test("exits 0 when user confirms", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-1",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 when user denies", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "deny",
+        surfaceId: "s-2",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when request is cancelled", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "cancelled",
+        surfaceId: "s-3",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when request times out", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "timed_out",
+        surfaceId: "s-4",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 on IPC error", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — JSON output", () => {
+  test("outputs { ok: true, confirmed: true } on confirm", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-1",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({
+      ok: true,
+      confirmed: true,
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "s-1",
+    });
+  });
+
+  test("outputs { ok: true, confirmed: false } on deny", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "deny",
+        surfaceId: "s-2",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.confirmed).toBe(false);
+    expect(parsed.status).toBe("submitted");
+    expect(parsed.actionId).toBe("deny");
+  });
+
+  test("outputs { ok: true, confirmed: false } on timeout", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "timed_out",
+        surfaceId: "s-3",
+      },
+    };
+
+    const { stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.confirmed).toBe(false);
+    expect(parsed.status).toBe("timed_out");
+  });
+
+  test("outputs { ok: false, error } on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Daemon not running" };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Daemon not running" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation ID resolution
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — conversation ID", () => {
+  test("uses explicit --conversation-id", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--conversation-id",
+      "explicit-conv",
+    ]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("explicit-conv");
+  });
+
+  test("falls back to __SKILL_CONTEXT_JSON", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("conv-default");
+  });
+
+  test("errors when no conversation ID is available", async () => {
+    delete process.env.__SKILL_CONTEXT_JSON;
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout configuration
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — timeout", () => {
+  test("passes --timeout to IPC params", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "30000",
+    ]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(30_000);
+    expect(lastIpcCall!.options!.timeoutMs).toBe(40_000); // +10s buffer
+  });
+
+  test("uses default timeout when --timeout is omitted", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(300_000);
+    expect(lastIpcCall!.options!.timeoutMs).toBe(310_000);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -182,7 +182,11 @@ describe("ui confirm — surface shape", () => {
   test("maps --message to data.message", async () => {
     await runCommand(["ui", "confirm", "--message", "Are you sure?"]);
 
-    expect(lastIpcCall!.params!.data).toEqual({ message: "Are you sure?" });
+    expect(lastIpcCall!.params!.data).toEqual({
+      message: "Are you sure?",
+      confirmLabel: "Confirm",
+      cancelLabel: "Deny",
+    });
   });
 
   test("maps --title to IPC title param", async () => {

--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -198,7 +198,7 @@ describe("ui confirm — surface shape", () => {
     expect(lastIpcCall!.params!.title).toBe("Danger");
   });
 
-  test("uses custom --confirm-label and --deny-label", async () => {
+  test("uses custom --confirm-label and --deny-label in actions", async () => {
     await runCommand([
       "ui",
       "confirm",
@@ -216,10 +216,37 @@ describe("ui confirm — surface shape", () => {
     ]);
   });
 
-  test("sends empty data when --message is omitted", async () => {
+  test("passes custom labels in data.confirmLabel and data.cancelLabel", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "Continue?",
+      "--confirm-label",
+      "Yes",
+      "--deny-label",
+      "No",
+    ]);
+
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Yes");
+    expect(data.cancelLabel).toBe("No");
+  });
+
+  test("passes default labels in data.confirmLabel and data.cancelLabel", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Confirm");
+    expect(data.cancelLabel).toBe("Deny");
+  });
+
+  test("includes confirmLabel and cancelLabel in data even when --message is omitted", async () => {
     await runCommand(["ui", "confirm"]);
 
-    expect(lastIpcCall!.params!.data).toEqual({});
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Confirm");
+    expect(data.cancelLabel).toBe("Deny");
   });
 });
 
@@ -486,5 +513,61 @@ describe("ui confirm — timeout", () => {
 
     expect(lastIpcCall!.params!.timeoutMs).toBe(300_000);
     expect(lastIpcCall!.options!.timeoutMs).toBe(310_000);
+  });
+
+  test("rejects --timeout with trailing non-digit characters like '30s'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "30s",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with scientific notation like '1e3'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "1e3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation ID discovery hint
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — conversation ID discovery hint", () => {
+  test("error message mentions 'assistant conversations list'", async () => {
+    delete process.env.__SKILL_CONTEXT_JSON;
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("assistant conversations list");
   });
 });

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -1,0 +1,615 @@
+/**
+ * Tests for the `assistant ui request` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration (request, confirm)
+ *   - Payload parsing from --payload flag and stdin
+ *   - Conversation ID resolution (explicit, __SKILL_CONTEXT_JSON, missing)
+ *   - IPC param mapping (surfaceType, title, timeoutMs)
+ *   - IPC timeout budget (request timeout + buffer)
+ *   - JSON output shape for success and error
+ *   - Exit code behavior on IPC errors
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: { timeoutMs?: number };
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = {
+  ok: true,
+  result: {
+    status: "submitted",
+    actionId: "confirm",
+    surfaceId: "test-surface-1",
+  },
+};
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+/** Whether to simulate stdin as a TTY (no piped input). */
+let mockStdinIsTTY: boolean = false;
+
+/** Saved env for restoration. */
+let savedEnv: Record<string, string | undefined> = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerUiCommand } = await import("../ui.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const localStderrChunks: string[] = [];
+
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: mockStdinIsTTY ? true : undefined,
+    configurable: true,
+  });
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    localStderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerUiCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: localStderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: {
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "test-surface-1",
+    },
+  };
+  mockStdinContent = null;
+  mockStdinIsTTY = false;
+  process.exitCode = 0;
+
+  // Save and clear env
+  savedEnv = {
+    __SKILL_CONTEXT_JSON: process.env.__SKILL_CONTEXT_JSON,
+  };
+  delete process.env.__SKILL_CONTEXT_JSON;
+});
+
+// Restore env after each test
+import { afterEach } from "bun:test";
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers request and confirm subcommands under ui", () => {
+    const program = new Command();
+    registerUiCommand(program);
+    const ui = program.commands.find((c) => c.name() === "ui");
+    expect(ui).toBeDefined();
+    const subcommandNames = ui!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual(["confirm", "request"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — payload parsing
+// ---------------------------------------------------------------------------
+
+describe("ui request — payload parsing", () => {
+  test("parses --payload flag and sends ui_request IPC", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"message":"Proceed?"}',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("ui_request");
+    expect(lastIpcCall!.params!.data).toEqual({ message: "Proceed?" });
+  });
+
+  test("parses JSON from stdin when no --payload flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinContent = '{"message":"From stdin"}';
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.data).toEqual({ message: "From stdin" });
+  });
+
+  test("errors on invalid JSON in --payload", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      "{bad json}",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(
+      (await runCommand(["ui", "request", "--payload", "{bad}", "--json"]))
+        .stdout,
+    );
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON");
+  });
+
+  test("errors on non-object --payload (array)", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      "[1,2,3]",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("JSON object");
+  });
+
+  test("errors on TTY stdin with no --payload", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinIsTTY = true;
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on empty stdin", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinContent = "   ";
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — conversation ID resolution
+// ---------------------------------------------------------------------------
+
+describe("ui request — conversation ID resolution", () => {
+  test("uses explicit --conversation-id over env", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "from-env",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--conversation-id",
+      "explicit-id",
+    ]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("explicit-id");
+  });
+
+  test("falls back to __SKILL_CONTEXT_JSON.conversationId", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "skill-conv-42",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("skill-conv-42");
+  });
+
+  test("errors when no conversation ID is available", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+
+  test("errors when __SKILL_CONTEXT_JSON is invalid JSON", async () => {
+    process.env.__SKILL_CONTEXT_JSON = "not-valid-json";
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+
+  test("errors when __SKILL_CONTEXT_JSON has no conversationId field", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({ workingDir: "/tmp" });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — IPC param mapping
+// ---------------------------------------------------------------------------
+
+describe("ui request — IPC param mapping", () => {
+  test("passes surfaceType from --surface-type flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"fields":[]}',
+      "--surface-type",
+      "form",
+    ]);
+
+    expect(lastIpcCall!.params!.surfaceType).toBe("form");
+  });
+
+  test("defaults surfaceType to confirmation", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.surfaceType).toBe("confirmation");
+  });
+
+  test("passes title from --title flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--title",
+      "Important",
+    ]);
+
+    expect(lastIpcCall!.params!.title).toBe("Important");
+  });
+
+  test("does not include title when --title is omitted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.title).toBeUndefined();
+  });
+
+  test("passes timeoutMs from --timeout flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "60000",
+    ]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(60_000);
+  });
+
+  test("uses default timeoutMs when --timeout is omitted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(300_000);
+  });
+
+  test("IPC call timeout = request timeout + 10s buffer", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "60000",
+    ]);
+
+    expect(lastIpcCall!.options!.timeoutMs).toBe(70_000);
+  });
+
+  test("errors on invalid --timeout value", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "abc",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — output
+// ---------------------------------------------------------------------------
+
+describe("ui request — output", () => {
+  test("--json outputs full result on success", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "surface-abc",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.status).toBe("submitted");
+    expect(parsed.actionId).toBe("confirm");
+    expect(parsed.surfaceId).toBe("surface-abc");
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Connection refused");
+  });
+
+  test("exits 0 on successful IPC result", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = {
+      ok: true,
+      result: { status: "cancelled", surfaceId: "s-1" },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    // ui request exits 0 on any successful IPC result (even cancelled/timed_out),
+    // because it reports the status — it's ui confirm that gates on actionId
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 on IPC error", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = { ok: false, error: "timeout" };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -520,6 +520,69 @@ describe("ui request — IPC param mapping", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --timeout");
   });
+
+  test("rejects --timeout with trailing non-digit characters like '30s'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "30s",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with scientific notation like '1e3'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "1e3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with decimal like '12.5'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "12.5",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -611,5 +674,25 @@ describe("ui request — output", () => {
     ]);
 
     expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — conversation ID discovery hint
+// ---------------------------------------------------------------------------
+
+describe("ui request — conversation ID discovery hint", () => {
+  test("error message mentions 'assistant conversations list'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("assistant conversations list");
   });
 });

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -61,8 +61,8 @@ function resolveConversationId(explicit?: string): string {
 
   throw new Error(
     "No conversation ID available.\n" +
-      "Provide --conversation-id explicitly, or run this command from a skill " +
-      "context where __SKILL_CONTEXT_JSON is set.",
+      "Provide --conversation-id explicitly (run 'assistant conversations list' to find it),\n" +
+      "or run this command from a skill context where __SKILL_CONTEXT_JSON is set.",
   );
 }
 
@@ -144,6 +144,18 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
   }
 }
 
+// ── Strict integer parsing ────────────────────────────────────────────
+
+/**
+ * Parse a string as a strict positive integer. Rejects inputs like
+ * `"1e3"`, `"30s"`, `"12.5"` that `parseInt` would silently truncate.
+ * Returns the parsed integer or `NaN` on any non-pure-integer input.
+ */
+function parseStrictPositiveInt(value: string): number {
+  if (!/^\d+$/.test(value)) return NaN;
+  return Number(value);
+}
+
 // ── Registration ──────────────────────────────────────────────────────
 
 export function registerUiCommand(program: Command): void {
@@ -182,7 +194,7 @@ Examples:
     .option("--title <title>", "Title displayed on the surface")
     .option(
       "--conversation-id <id>",
-      "Conversation ID (auto-resolved from skill context if omitted)",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
     )
     .option(
       "--timeout <ms>",
@@ -260,10 +272,8 @@ Examples:
         }
 
         // Parse timeout
-        const requestTimeoutMs = parseInt(
-          opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
-          10,
-        );
+        const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+        const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
         if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
           const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
           if (opts.json) {
@@ -352,7 +362,7 @@ Examples:
     )
     .option(
       "--conversation-id <id>",
-      "Conversation ID (auto-resolved from skill context if omitted)",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
     )
     .option(
       "--timeout <ms>",
@@ -415,10 +425,8 @@ Examples:
         }
 
         // Parse timeout
-        const requestTimeoutMs = parseInt(
-          opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
-          10,
-        );
+        const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+        const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
         if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
           const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
           if (opts.json) {
@@ -433,8 +441,14 @@ Examples:
         }
 
         // Build confirmation surface data
+        const confirmLabel = opts.confirmLabel ?? "Confirm";
+        const denyLabel = opts.denyLabel ?? "Deny";
         const data: Record<string, unknown> = {};
         if (opts.message) data.message = opts.message;
+        // Pass custom labels via data payload so the renderer reads them
+        // from ConfirmationSurfaceData.confirmLabel / .cancelLabel.
+        data.confirmLabel = confirmLabel;
+        data.cancelLabel = denyLabel;
 
         // Build IPC params
         const ipcParams: Record<string, unknown> = {
@@ -444,12 +458,12 @@ Examples:
           actions: [
             {
               id: "confirm",
-              label: opts.confirmLabel ?? "Confirm",
+              label: confirmLabel,
               variant: "primary",
             },
             {
               id: "deny",
-              label: opts.denyLabel ?? "Deny",
+              label: denyLabel,
               variant: "secondary",
             },
           ],

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -1,0 +1,514 @@
+/**
+ * `assistant ui` CLI namespace.
+ *
+ * Subcommands:
+ *   - `assistant ui request`  — Present an arbitrary interactive surface to
+ *     the user and block until they respond. Input is a JSON payload
+ *     describing the surface (via `--payload` or stdin).
+ *   - `assistant ui confirm`  — Convenience wrapper that presents a yes/no
+ *     confirmation prompt and exits 0 on confirm, 1 on deny/cancel/timeout.
+ *
+ * Both commands delegate to the daemon's `ui_request` IPC method, which
+ * manages the surface lifecycle on the active conversation.
+ */
+
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { InteractiveUiResult } from "../../runtime/interactive-ui.js";
+import { log } from "../logger.js";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/**
+ * Default request timeout in milliseconds (5 minutes). This is the time
+ * the daemon will wait for the user to respond before the surface
+ * auto-cancels with `status: "timed_out"`.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
+
+/**
+ * Extra buffer added to the IPC call timeout beyond the request timeout
+ * so the IPC socket stays open long enough for the daemon to resolve the
+ * surface and send the response.
+ */
+const IPC_TIMEOUT_BUFFER_MS = 10_000; // 10s
+
+// ── Conversation ID resolution ────────────────────────────────────────
+
+/**
+ * Resolve the conversation ID by precedence:
+ *   1. Explicit `--conversation-id` flag
+ *   2. `__SKILL_CONTEXT_JSON` env var (set by skill sandbox runner)
+ *   3. Fail with an actionable error
+ */
+function resolveConversationId(explicit?: string): string {
+  if (explicit) return explicit;
+
+  const contextJson = process.env.__SKILL_CONTEXT_JSON;
+  if (contextJson) {
+    try {
+      const parsed = JSON.parse(contextJson);
+      if (parsed.conversationId && typeof parsed.conversationId === "string") {
+        return parsed.conversationId;
+      }
+    } catch {
+      // Fall through to the error below.
+    }
+  }
+
+  throw new Error(
+    "No conversation ID available.\n" +
+      "Provide --conversation-id explicitly, or run this command from a skill " +
+      "context where __SKILL_CONTEXT_JSON is set.",
+  );
+}
+
+// ── Payload parsing ───────────────────────────────────────────────────
+
+/**
+ * Read a JSON payload from either the `--payload` flag or stdin.
+ * Returns the parsed object. Throws on invalid input.
+ */
+function readPayload(payloadFlag?: string): Record<string, unknown> {
+  if (payloadFlag) {
+    try {
+      const parsed = JSON.parse(payloadFlag);
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error(
+          "--payload must be a JSON object (not array or primitive).",
+        );
+      }
+      return parsed as Record<string, unknown>;
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(
+          `Invalid JSON in --payload: ${err.message}\n` +
+            '  Example: --payload \'{"message":"Are you sure?"}\'',
+        );
+      }
+      throw err;
+    }
+  }
+
+  // Read from stdin
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "No payload provided. Use --payload <json> or pipe JSON into stdin.\n" +
+        '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync("/dev/stdin", "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read stdin: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!raw.trim()) {
+    throw new Error(
+      "Empty input on stdin. Provide a valid JSON object.\n" +
+        '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error(
+        "Stdin payload must be a JSON object (not array or primitive).",
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(
+        `Invalid JSON on stdin: ${err.message}\n` +
+          '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+      );
+    }
+    throw err;
+  }
+}
+
+// ── Registration ──────────────────────────────────────────────────────
+
+export function registerUiCommand(program: Command): void {
+  const ui = program
+    .command("ui")
+    .description("Present interactive UI surfaces to the user");
+
+  ui.addHelpText(
+    "after",
+    `
+Script-facing commands that present interactive surfaces (confirmations,
+forms) to the user via the running assistant and block until the user
+responds or the request times out.
+
+The conversation ID is resolved automatically when running inside a skill
+context (__SKILL_CONTEXT_JSON). Override with --conversation-id if needed.
+
+Examples:
+  $ echo '{"message":"Delete all logs?"}' | assistant ui request --json
+  $ assistant ui confirm --title "Deploy to production?" --message "This will push to prod."
+  $ assistant ui confirm --message "Are you sure?" --json`,
+  );
+
+  // ── ui request ───────────────────────────────────────────────────
+
+  ui.command("request")
+    .description(
+      "Present an interactive surface and block until the user responds",
+    )
+    .option("--payload <json>", "JSON object describing the surface data")
+    .option(
+      "--surface-type <type>",
+      'Surface type: "confirmation" or "form"',
+      "confirmation",
+    )
+    .option("--title <title>", "Title displayed on the surface")
+    .option(
+      "--conversation-id <id>",
+      "Conversation ID (auto-resolved from skill context if omitted)",
+    )
+    .option(
+      "--timeout <ms>",
+      "Request timeout in milliseconds",
+      String(DEFAULT_REQUEST_TIMEOUT_MS),
+    )
+    .option("--json", "Output result as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+Sends a UI interaction request to the running assistant and blocks until
+the user responds or the timeout elapses. The payload describes the
+surface content and can be provided via --payload or piped through stdin.
+
+The response includes the user's action (submitted, cancelled, timed_out)
+and any submitted data.
+
+Arguments:
+  (none — payload via --payload flag or stdin)
+
+Options:
+  --payload <json>         JSON object with surface data
+  --surface-type <type>    "confirmation" (default) or "form"
+  --title <title>          Surface title
+  --conversation-id <id>   Explicit conversation ID
+  --timeout <ms>           Request timeout in milliseconds (default: 300000)
+  --json                   Output as JSON
+
+Examples:
+  $ echo '{"message":"Proceed?"}' | assistant ui request
+  $ assistant ui request --payload '{"message":"Proceed?"}' --json
+  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json`,
+    )
+    .action(
+      async (opts: {
+        payload?: string;
+        surfaceType?: string;
+        title?: string;
+        conversationId?: string;
+        timeout?: string;
+        json?: boolean;
+      }) => {
+        // Parse payload
+        let data: Record<string, unknown>;
+        try {
+          data = readPayload(opts.payload);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Resolve conversation ID
+        let conversationId: string;
+        try {
+          conversationId = resolveConversationId(opts.conversationId);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Parse timeout
+        const requestTimeoutMs = parseInt(
+          opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
+          10,
+        );
+        if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+          const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Build IPC params
+        const ipcParams: Record<string, unknown> = {
+          conversationId,
+          surfaceType: opts.surfaceType ?? "confirmation",
+          data,
+          timeoutMs: requestTimeoutMs,
+        };
+        if (opts.title) {
+          ipcParams.title = opts.title;
+        }
+
+        // Call IPC with timeout budget = request timeout + buffer
+        const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+        const result = await cliIpcCall<InteractiveUiResult>(
+          "ui_request",
+          ipcParams,
+          {
+            timeoutMs: ipcTimeoutMs,
+          },
+        );
+
+        if (!result.ok) {
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: result.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: true, ...result.result }) + "\n",
+          );
+        } else {
+          const r = result.result!;
+          if (r.status === "submitted") {
+            log.info(
+              `User responded: ${r.actionId ?? "submitted"}${r.summary ? ` — ${r.summary}` : ""}`,
+            );
+          } else if (r.status === "timed_out") {
+            log.info("Request timed out without a response.");
+          } else {
+            log.info("Request was cancelled.");
+          }
+        }
+      },
+    );
+
+  // ── ui confirm ──────────────────────────────────────────────────
+
+  ui.command("confirm")
+    .description(
+      "Present a yes/no confirmation prompt; exits 0 on confirm, 1 on deny/cancel/timeout",
+    )
+    .option("--title <title>", "Title displayed on the confirmation prompt")
+    .option(
+      "--message <message>",
+      "Message body shown in the confirmation prompt",
+    )
+    .option(
+      "--confirm-label <label>",
+      'Label for the confirm button (default: "Confirm")',
+      "Confirm",
+    )
+    .option(
+      "--deny-label <label>",
+      'Label for the deny button (default: "Deny")',
+      "Deny",
+    )
+    .option(
+      "--conversation-id <id>",
+      "Conversation ID (auto-resolved from skill context if omitted)",
+    )
+    .option(
+      "--timeout <ms>",
+      "Request timeout in milliseconds",
+      String(DEFAULT_REQUEST_TIMEOUT_MS),
+    )
+    .option("--json", "Output result as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+Ergonomic wrapper around "ui request" for binary yes/no gating. Presents
+a confirmation surface to the user and blocks until they respond.
+
+Exit codes:
+  0  — User confirmed
+  1  — User denied, cancelled, or the request timed out
+
+The --json flag outputs the full interaction result for scripts that need
+to inspect the response details.
+
+Options:
+  --title <title>            Prompt title
+  --message <message>        Prompt body text
+  --confirm-label <label>    Confirm button label (default: "Confirm")
+  --deny-label <label>       Deny button label (default: "Deny")
+  --conversation-id <id>     Explicit conversation ID
+  --timeout <ms>             Request timeout in ms (default: 300000)
+  --json                     Output as JSON
+
+Examples:
+  $ assistant ui confirm --message "Delete all data?"
+  $ assistant ui confirm --title "Deploy" --message "Push to prod?" --json
+  $ assistant ui confirm --message "Proceed?" --confirm-label "Yes" --deny-label "No"`,
+    )
+    .action(
+      async (opts: {
+        title?: string;
+        message?: string;
+        confirmLabel?: string;
+        denyLabel?: string;
+        conversationId?: string;
+        timeout?: string;
+        json?: boolean;
+      }) => {
+        // Resolve conversation ID
+        let conversationId: string;
+        try {
+          conversationId = resolveConversationId(opts.conversationId);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Parse timeout
+        const requestTimeoutMs = parseInt(
+          opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
+          10,
+        );
+        if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+          const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Build confirmation surface data
+        const data: Record<string, unknown> = {};
+        if (opts.message) data.message = opts.message;
+
+        // Build IPC params
+        const ipcParams: Record<string, unknown> = {
+          conversationId,
+          surfaceType: "confirmation",
+          data,
+          actions: [
+            {
+              id: "confirm",
+              label: opts.confirmLabel ?? "Confirm",
+              variant: "primary",
+            },
+            {
+              id: "deny",
+              label: opts.denyLabel ?? "Deny",
+              variant: "secondary",
+            },
+          ],
+          timeoutMs: requestTimeoutMs,
+        };
+        if (opts.title) {
+          ipcParams.title = opts.title;
+        }
+
+        // Call IPC with timeout budget
+        const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+        const result = await cliIpcCall<InteractiveUiResult>(
+          "ui_request",
+          ipcParams,
+          {
+            timeoutMs: ipcTimeoutMs,
+          },
+        );
+
+        if (!result.ok) {
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: result.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const r = result.result!;
+        const confirmed = r.status === "submitted" && r.actionId === "confirm";
+
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              confirmed,
+              status: r.status,
+              actionId: r.actionId,
+              surfaceId: r.surfaceId,
+            }) + "\n",
+          );
+        } else {
+          if (confirmed) {
+            log.info("Confirmed.");
+          } else if (r.status === "timed_out") {
+            log.info("Confirmation timed out.");
+          } else if (r.status === "cancelled") {
+            log.info("Confirmation cancelled.");
+          } else {
+            log.info("Denied.");
+          }
+        }
+
+        if (!confirmed) {
+          process.exitCode = 1;
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -37,6 +37,7 @@ import { registerSequenceCommand } from "./commands/sequence.js";
 import { registerShotgunCommand } from "./commands/shotgun.js";
 import { registerSkillsCommand } from "./commands/skills.js";
 import { registerTrustCommand } from "./commands/trust.js";
+import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { log } from "./logger.js";
 
@@ -94,6 +95,8 @@ Examples:
   registerRoutesCommand(program);
   registerSkillsCommand(program);
   registerUsageCommand(program);
+
+  registerUiCommand(program);
 
   registerShotgunCommand(program);
   registerSequenceCommand(program);


### PR DESCRIPTION
## Summary
- Add assistant ui request subcommand with JSON payload input and conversation ID resolution
- Add assistant ui confirm convenience wrapper for yes/no gating
- Both commands call IPC ui_request and support --json output for scripts

Part of plan: user-confirmation-primitive.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
