### PR TITLE
fix(daemon): catch placeholder sentinels that lost their null-byte prefix

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -77,6 +77,7 @@ mock.module("@anthropic-ai/sdk", () => ({
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../prompts/system-prompt.js";
 import {
   AnthropicProvider,
+  isPlaceholderSentinelText,
   PLACEHOLDER_BLOCKS_OMITTED,
   PLACEHOLDER_EMPTY_TURN,
 } from "../providers/anthropic/client.js";
@@ -1252,6 +1253,29 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     for (let i = 1; i < sent.length; i++) {
       expect(sent[i].role).not.toBe(sent[i - 1].role);
     }
+  });
+
+  test("isPlaceholderSentinelText matches sentinel with and without the null-byte prefix", () => {
+    // The runtime filter must be lenient enough to catch sentinel text that
+    // lost its `\x00` prefix in transit (e.g. a model echoing it back from
+    // input history without reproducing the control character). Migration 222
+    // handles the same two variants.
+    expect(isPlaceholderSentinelText(PLACEHOLDER_EMPTY_TURN)).toBe(true);
+    expect(isPlaceholderSentinelText(PLACEHOLDER_BLOCKS_OMITTED)).toBe(true);
+    expect(
+      isPlaceholderSentinelText("__PLACEHOLDER__[empty assistant turn]"),
+    ).toBe(true);
+    expect(
+      isPlaceholderSentinelText("__PLACEHOLDER__[internal blocks omitted]"),
+    ).toBe(true);
+    // Nearby strings must NOT match — guard against over-broad matching.
+    expect(isPlaceholderSentinelText("")).toBe(false);
+    expect(isPlaceholderSentinelText("__PLACEHOLDER__")).toBe(false);
+    expect(
+      isPlaceholderSentinelText(
+        "prefix __PLACEHOLDER__[empty assistant turn]",
+      ),
+    ).toBe(false);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -311,6 +311,23 @@ describe("cleanAssistantContent", () => {
 
     expect(result.cleanedContent).toHaveLength(0);
   });
+
+  test("drops placeholder sentinels even when the null-byte prefix is missing", () => {
+    // Models sometimes echo the sentinel from input history without reproducing
+    // the \x00 control character. The filter must catch both variants so
+    // stripped-prefix echoes don't leak into persisted messages.
+    const content = [
+      { type: "text", text: "__PLACEHOLDER__[empty assistant turn]" },
+      { type: "text", text: "__PLACEHOLDER__[internal blocks omitted]" },
+      { type: "text", text: "real text" },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.cleanedContent).toHaveLength(1);
+    expect((result.cleanedContent[0] as { text: string }).text).toBe(
+      "real text",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
+++ b/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
@@ -1,3 +1,4 @@
+import { isPlaceholderSentinelText } from "../../providers/anthropic/client.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
@@ -65,7 +66,7 @@ export function migrateStripPlaceholderSentinelsFromMessages(
           const stripped = blocks.filter((b) => {
             if (b.type !== "text") return true;
             const text = typeof b.text === "string" ? b.text : "";
-            return !isSentinelText(text);
+            return !isPlaceholderSentinelText(text);
           });
 
           if (stripped.length === blocks.length) continue;
@@ -76,13 +77,5 @@ export function migrateStripPlaceholderSentinelsFromMessages(
         }
       }
     },
-  );
-}
-
-function isSentinelText(text: string): boolean {
-  const normalized = text.startsWith("\x00") ? text.slice(1) : text;
-  return (
-    normalized === "__PLACEHOLDER__[empty assistant turn]" ||
-    normalized === "__PLACEHOLDER__[internal blocks omitted]"
   );
 }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -132,18 +132,24 @@ export const PLACEHOLDER_EMPTY_TURN =
 export const PLACEHOLDER_BLOCKS_OMITTED =
   "\x00__PLACEHOLDER__[internal blocks omitted]";
 
-const PLACEHOLDER_SENTINEL_TEXTS: ReadonlySet<string> = new Set([
-  PLACEHOLDER_EMPTY_TURN,
-  PLACEHOLDER_BLOCKS_OMITTED,
+// Compared against the payload with any leading `\x00` stripped, so the check
+// matches both the prefixed sentinel we emit and any bare variant that lost
+// the null byte in transit (e.g. the model echoing the text back without
+// reproducing the control character).
+const PLACEHOLDER_SENTINEL_BARE: ReadonlySet<string> = new Set([
+  PLACEHOLDER_EMPTY_TURN.slice(1),
+  PLACEHOLDER_BLOCKS_OMITTED.slice(1),
 ]);
 
 /**
  * True when the text is one of the provider's internal alternation-preserving
- * sentinels. These must never be persisted or rendered to users — they exist
- * only in outbound Anthropic API request bodies.
+ * sentinels, with or without the null-byte prefix. These must never be
+ * persisted or rendered to users — they exist only in outbound Anthropic API
+ * request bodies.
  */
 export function isPlaceholderSentinelText(text: string): boolean {
-  return PLACEHOLDER_SENTINEL_TEXTS.has(text);
+  const normalized = text.startsWith("\x00") ? text.slice(1) : text;
+  return PLACEHOLDER_SENTINEL_BARE.has(normalized);
 }
 
 /**
@@ -734,10 +740,7 @@ export class AnthropicProvider implements Provider {
             )
               return false;
             const text = (c[0] as { text?: string }).text;
-            return (
-              text === PLACEHOLDER_EMPTY_TURN ||
-              text === PLACEHOLDER_BLOCKS_OMITTED
-            );
+            return typeof text === "string" && isPlaceholderSentinelText(text);
           };
           if (isPlaceholder(iContent)) {
             formatted.splice(i, 1);


### PR DESCRIPTION
## Summary
- Make \`isPlaceholderSentinelText\` match the sentinel payload with or without its leading \`\x00\`, so the runtime filter catches model echoes that drop the control character — stops \`__PLACEHOLDER__[empty assistant turn]\` from persisting and rendering as bold text in chat bubbles.
- Route the formatter's inline \`isPlaceholder\` dedupe helper and migration 222's local \`isSentinelText\` through the shared function so detection stays in one place and can't drift again.
- Add targeted tests covering bare (no-prefix) and prefixed sentinel variants, plus regression coverage that nearby strings aren't over-matched.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
