### PR TITLE
feat(macos): track contentH delta in scroll debug HUD

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -243,8 +243,8 @@ final class MessageListScrollState {
 
     /// Fold a fresh scroll snapshot into the debug metrics. Only called when
     /// the `scroll-debug-overlay` flag is on — the hot path otherwise skips this.
-    func recordDebugSnapshot(offsetY: CGFloat, isLiveScrolling: Bool, at now: Date = Date()) {
-        debugMetrics.recordSnapshot(offsetY: offsetY, isLiveScrolling: isLiveScrolling, at: now)
+    func recordDebugSnapshot(offsetY: CGFloat, contentH: CGFloat, isLiveScrolling: Bool, at now: Date = Date()) {
+        debugMetrics.recordSnapshot(offsetY: offsetY, contentH: contentH, isLiveScrolling: isLiveScrolling, at: now)
         debugMetricsVersion &+= 1
     }
 
@@ -271,6 +271,10 @@ final class MessageListScrollState {
 /// hot path pays nothing when the overlay is off.
 struct ScrollDebugMetrics {
     var lastDeltaY: CGFloat = 0
+    /// Per-frame delta of `scrollContentHeight`. Large single-frame changes
+    /// here — particularly drops — point at LazyVStack height-estimate
+    /// corrections that manifest as jerky scroll at the top of history.
+    var lastContentHDelta: CGFloat = 0
     /// Signed scroll velocity in points per second, smoothed across recent
     /// samples via an EMA to damp per-tick jitter.
     var velocityPtPerSec: CGFloat = 0
@@ -288,12 +292,13 @@ struct ScrollDebugMetrics {
 
     private var lastSnapshotTime: Date?
     private var lastSnapshotOffsetY: CGFloat = 0
+    private var lastSnapshotContentH: CGFloat?
     /// EMA smoothing factor for velocity. Higher = more responsive, lower =
     /// smoother. 0.35 keeps the reading stable during momentum scroll while
     /// still reacting to direction flips.
     private static let velocitySmoothing: CGFloat = 0.35
 
-    mutating func recordSnapshot(offsetY: CGFloat, isLiveScrolling: Bool, at now: Date) {
+    mutating func recordSnapshot(offsetY: CGFloat, contentH: CGFloat, isLiveScrolling: Bool, at now: Date) {
         if let prev = lastSnapshotTime {
             let dt = now.timeIntervalSince(prev)
             let delta = offsetY - lastSnapshotOffsetY
@@ -303,8 +308,12 @@ struct ScrollDebugMetrics {
                 velocityPtPerSec += (instantaneous - velocityPtPerSec) * Self.velocitySmoothing
             }
         }
+        if let prevH = lastSnapshotContentH {
+            lastContentHDelta = contentH - prevH
+        }
         lastSnapshotTime = now
         lastSnapshotOffsetY = offsetY
+        lastSnapshotContentH = contentH
         self.isLiveScrolling = isLiveScrolling
         recentUpdateTimes.append(now)
         Self.trim(&recentUpdateTimes, at: now)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -41,6 +41,7 @@ extension MessageListView {
         if MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") {
             scrollState.recordDebugSnapshot(
                 offsetY: newState.contentOffsetY,
+                contentH: newState.contentHeight,
                 isLiveScrolling: newState.isLiveScrolling
             )
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -77,6 +77,7 @@ struct ScrollDebugOverlayView: View {
                 updatesPerSecond: updatesPerSec,
                 velocity: velocity,
                 lastDeltaY: metrics.lastDeltaY,
+                lastContentHDelta: metrics.lastContentHDelta,
                 anchorsPerSecond: anchorsPerSec,
                 anchorTotal: metrics.anchorShiftTotal,
                 conversationId: scrollState.currentConversationId
@@ -98,6 +99,14 @@ struct ScrollDebugOverlayView: View {
             row("updates/s", String(updatesPerSec))
             row("velocity", "\(signed(velocity)) pt/s")
             row("lastDeltaY", signed(metrics.lastDeltaY))
+            // Highlight large single-frame contentH swings in red — these are
+            // the LazyVStack height-estimate corrections we care about for
+            // jerky-scroll investigation.
+            row(
+                "ΔcontentH",
+                signed(metrics.lastContentHDelta),
+                valueColor: abs(metrics.lastContentHDelta) > 100 ? VColor.systemNegativeStrong : nil
+            )
             row("anchors/s", String(anchorsPerSec))
             row("anchorTotal", String(metrics.anchorShiftTotal))
             if let id = scrollState.currentConversationId {
@@ -185,13 +194,13 @@ struct ScrollDebugOverlayView: View {
         recorder.clear()
     }
 
-    private func row(_ label: String, _ value: String) -> some View {
+    private func row(_ label: String, _ value: String, valueColor: Color? = nil) -> some View {
         HStack(spacing: 6) {
             Text(label)
                 .foregroundStyle(VColor.contentSecondary)
                 .frame(width: 84, alignment: .trailing)
             Text(value)
-                .foregroundStyle(VColor.contentDefault)
+                .foregroundStyle(valueColor ?? VColor.contentDefault)
                 .frame(minWidth: 60, alignment: .leading)
         }
     }
@@ -244,6 +253,7 @@ final class ScrollDebugRecorder {
         let updatesPerSecond: Int
         let velocity: CGFloat
         let lastDeltaY: CGFloat
+        let lastContentHDelta: CGFloat
         let anchorsPerSecond: Int
         let anchorTotal: Int
         let conversationId: UUID?
@@ -292,8 +302,8 @@ final class ScrollDebugRecorder {
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
-        var csv = "elapsedSec,timestamp,offsetY,contentH,containerH,viewportH,distBottom,distTop,pinnedLatest,liveScrolling,paginating,paginationInRange,ctaVisible,updatesPerSecond,velocity,lastDeltaY,anchorsPerSecond,anchorTotal,conversationId\n"
-        csv.reserveCapacity(frames.count * 180)
+        var csv = "elapsedSec,timestamp,offsetY,contentH,containerH,viewportH,distBottom,distTop,pinnedLatest,liveScrolling,paginating,paginationInRange,ctaVisible,updatesPerSecond,velocity,lastDeltaY,lastContentHDelta,anchorsPerSecond,anchorTotal,conversationId\n"
+        csv.reserveCapacity(frames.count * 190)
         for frame in frames {
             let elapsed = frame.timestamp.timeIntervalSince(start)
             let cols: [String] = [
@@ -313,6 +323,7 @@ final class ScrollDebugRecorder {
                 String(frame.updatesPerSecond),
                 String(format: "%.3f", frame.velocity),
                 String(format: "%.3f", frame.lastDeltaY),
+                String(format: "%.2f", frame.lastContentHDelta),
                 String(frame.anchorsPerSecond),
                 String(frame.anchorTotal),
                 frame.conversationId?.uuidString ?? "",


### PR DESCRIPTION
## Summary
- New `lastContentHDelta` metric in `ScrollDebugMetrics` — per-frame change in `scrollContentHeight`, updated from the existing geometry callback alongside `lastDeltaY`.
- HUD gets a `ΔcontentH` row that highlights red when `|delta| > 100pt`, so large single-frame content-height swings are visible during a live reproduction.
- Recorder CSV gains a `lastContentHDelta` column, making it straightforward to grep recordings for the estimation corrections we suspect cause jerky scroll at the top of long conversations.

## Original prompt
[Follow-up from scroll debug investigation] yeah [confirm the LazyVStack-estimation hypothesis by instrumenting contentH delta]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
