### PR TITLE
fix: resolve scan-result-store eviction and malformed-payload handling

### DIFF
--- a/assistant/src/__tests__/scan-result-store.test.ts
+++ b/assistant/src/__tests__/scan-result-store.test.ts
@@ -7,7 +7,11 @@ import {
   getSenderMetadata,
   storeScanResult,
 } from "../config/bundled-skills/gmail/tools/scan-result-store.js";
-import { clearCacheForTests } from "../skills/skill-cache-store.js";
+import {
+  _internals as cacheInternals,
+  clearCacheForTests,
+  setCacheEntry,
+} from "../skills/skill-cache-store.js";
 
 afterEach(() => {
   clearScanStore();
@@ -81,6 +85,35 @@ describe("missing scan ID returns null", () => {
 
   test("getSenderMetadata returns null for unknown scan ID", () => {
     expect(getSenderMetadata("no-such-scan", "s1")).toBeNull();
+  });
+});
+
+describe("malformed cache payloads", () => {
+  test("getSenderMessageIds returns null for non-scan payload", () => {
+    const { key } = setCacheEntry({ foo: "bar" });
+    expect(getSenderMessageIds(key, ["sender-a"])).toBeNull();
+  });
+
+  test("getSenderMetadata returns null for non-scan payload", () => {
+    const { key } = setCacheEntry(["not", "a", "scan"]);
+    expect(getSenderMetadata(key, "sender-a")).toBeNull();
+  });
+
+  test("getSenderMessageIds skips malformed sender payloads without throwing", () => {
+    const { key } = setCacheEntry({
+      senders: {
+        "sender-good": {
+          messageIds: ["m1"],
+          newestMessageId: "m1",
+          newestUnsubscribableMessageId: null,
+        },
+        "sender-bad": { messageIds: "oops-not-an-array" },
+      },
+    });
+
+    expect(getSenderMessageIds(key, ["sender-good", "sender-bad"])).toEqual([
+      "m1",
+    ]);
   });
 });
 
@@ -176,6 +209,41 @@ describe("clearScanStore", () => {
     expect(_internals.trackedScanIds.size).toBe(1);
     clearScanStore();
     expect(_internals.trackedScanIds.size).toBe(0);
+  });
+});
+
+describe("tracked scan ID bounds", () => {
+  test("capping tracked IDs does not delete active shared-cache entries", () => {
+    const limit = _internals.MAX_TRACKED_SCAN_IDS;
+    const scanIds: string[] = [];
+
+    for (let i = 0; i < limit; i++) {
+      scanIds.push(
+        storeScanResult([
+          {
+            id: `sender-${i}`,
+            messageIds: [`m-${i}`],
+            newestMessageId: `m-${i}`,
+            newestUnsubscribableMessageId: null,
+          },
+        ]),
+      );
+    }
+
+    // Refresh the first entry so shared-cache LRU keeps it hot.
+    expect(getSenderMessageIds(scanIds[0], ["sender-0"])).toEqual(["m-0"]);
+
+    storeScanResult([
+      {
+        id: "sender-overflow",
+        messageIds: ["m-overflow"],
+        newestMessageId: "m-overflow",
+        newestUnsubscribableMessageId: null,
+      },
+    ]);
+
+    expect(cacheInternals.store.size).toBe(cacheInternals.DEFAULT_MAX_ENTRIES);
+    expect(getSenderMessageIds(scanIds[0], ["sender-0"])).toEqual(["m-0"]);
   });
 });
 

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -35,6 +35,31 @@ const MAX_TRACKED_SCAN_IDS = 64;
  */
 const _trackedScanIds = new Set<string>();
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSenderData(value: unknown): value is SenderData {
+  if (!isRecord(value)) return false;
+  const messageIds = value.messageIds;
+  return (
+    Array.isArray(messageIds) &&
+    messageIds.every((id) => typeof id === "string") &&
+    typeof value.newestMessageId === "string" &&
+    (typeof value.newestUnsubscribableMessageId === "string" ||
+      value.newestUnsubscribableMessageId === null)
+  );
+}
+
+function parseScanPayload(
+  data: unknown,
+): { senders: Record<string, unknown> } | null {
+  if (!isRecord(data)) return null;
+  const senders = data.senders;
+  if (!isRecord(senders)) return null;
+  return { senders };
+}
+
 /** Store scan results and return a unique scan ID. */
 export function storeScanResult(
   senders: Array<{
@@ -57,12 +82,11 @@ export function storeScanResult(
   const { key: scanId } = setCacheEntry(payload, { ttlMs: TTL_MS });
   _trackedScanIds.add(scanId);
 
-  // Evict the oldest tracked ID when over capacity (Set preserves insertion order).
+  // Keep bookkeeping bounded without mutating shared cache contents.
   if (_trackedScanIds.size > MAX_TRACKED_SCAN_IDS) {
     const oldest = _trackedScanIds.values().next().value;
     if (oldest !== undefined) {
       _trackedScanIds.delete(oldest);
-      deleteCacheEntry(oldest);
     }
   }
 
@@ -77,11 +101,12 @@ export function getSenderMessageIds(
   const result = getCacheEntry(scanId);
   if (!result) return null;
 
-  const payload = result.data as ScanPayload;
+  const payload = parseScanPayload(result.data);
+  if (!payload) return null;
   const ids: string[] = [];
   for (const sid of senderIds) {
     const data = payload.senders[sid];
-    if (data) ids.push(...data.messageIds);
+    if (isSenderData(data)) ids.push(...data.messageIds);
   }
   return ids;
 }
@@ -97,9 +122,10 @@ export function getSenderMetadata(
   const result = getCacheEntry(scanId);
   if (!result) return null;
 
-  const payload = result.data as ScanPayload;
+  const payload = parseScanPayload(result.data);
+  if (!payload) return null;
   const data = payload.senders[senderId];
-  if (!data) return null;
+  if (!isSenderData(data)) return null;
   return {
     newestMessageId: data.newestMessageId,
     newestUnsubscribableMessageId: data.newestUnsubscribableMessageId,


### PR DESCRIPTION
## Summary
- Remove the scan-store tracked-ID overflow path that deleted shared cache entries, preventing unintended eviction of active scan data and preserving effective cache capacity.
- Harden getSenderMessageIds/getSenderMetadata with runtime payload-shape guards so non-scan or malformed cache payloads return safe misses instead of throwing.
- Add regression coverage for both fixes, including a bounded-tracking test that ensures no extra cache deletion and malformed-payload tests for global cache-key collisions.

## Original prompt
Can you /do a PR with fixes for both findings?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
