### PR TITLE
fix(chrome-extension): harden cloud auth fallback URL handling

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -153,6 +153,44 @@ describe('signInCloud', () => {
     expect(seenUrl).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
     expect(seenUrl).not.toContain('www.vellum.ai//accounts');
   });
+
+  test('retries without assistant_id when Chrome reports auth page load failure', async () => {
+    const seenUrls: string[] = [];
+    launchWebAuthFlowImpl = async (details) => {
+      seenUrls.push(details.url);
+      if (seenUrls.length === 1) {
+        throw new Error('Authorization page could not be loaded.');
+      }
+      return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
+    };
+
+    await signInCloud(ASSISTANT_A, config);
+
+    expect(seenUrls.length).toBe(2);
+    expect(seenUrls[0]).toContain(`assistant_id=${ASSISTANT_A}`);
+    expect(seenUrls[1]).not.toContain('assistant_id=');
+  });
+
+  test('retries against runtimeBaseUrl after webBaseUrl auth page load failures', async () => {
+    const seenUrls: string[] = [];
+    launchWebAuthFlowImpl = async (details) => {
+      seenUrls.push(details.url);
+      if (seenUrls.length < 3) {
+        throw new Error('Authorization page could not be loaded.');
+      }
+      return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
+    };
+
+    await signInCloud(ASSISTANT_A, {
+      ...config,
+      runtimeBaseUrl: 'https://platform.vellum.ai',
+    });
+
+    expect(seenUrls.length).toBe(3);
+    expect(seenUrls[0]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrls[1]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrls[2]).toContain('https://platform.vellum.ai/accounts/chrome-extension/start');
+  });
 });
 
 describe('getStoredToken', () => {

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -28,6 +28,13 @@
 export interface CloudAuthConfig {
   /** Web app base URL for browser-facing pages, e.g. https://www.vellum.ai */
   webBaseUrl: string;
+  /**
+   * Optional runtime/gateway origin for the selected assistant.
+   *
+   * Used only as a fallback when Chrome reports the primary authorization
+   * page could not be loaded.
+   */
+  runtimeBaseUrl?: string;
   /** OAuth client id registered for the chrome extension. */
   clientId: string;
 }
@@ -222,14 +229,104 @@ function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
   };
 }
 
-function buildAuthUrl(config: CloudAuthConfig, assistantId: string): string {
+function normalizeBaseUrl(raw: string): string {
+  return raw.trim().replace(/\/$/, '');
+}
+
+function buildAuthUrl(
+  config: CloudAuthConfig,
+  assistantId: string,
+  options: {
+    baseUrl?: string;
+    includeAssistantId?: boolean;
+  } = {},
+): string {
   const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
-  return (
-    `${config.webBaseUrl.replace(/\/$/, '')}/accounts/chrome-extension/start` +
+  const includeAssistantId = options.includeAssistantId ?? true;
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? config.webBaseUrl);
+  let url =
+    `${baseUrl}/accounts/chrome-extension/start` +
     `?client_id=${encodeURIComponent(config.clientId)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-    `&assistant_id=${encodeURIComponent(assistantId)}`
-  );
+    `&redirect_uri=${encodeURIComponent(redirectUri)}`;
+  if (includeAssistantId) {
+    url += `&assistant_id=${encodeURIComponent(assistantId)}`;
+  }
+  return url;
+}
+
+interface AuthUrlCandidate {
+  url: string;
+  baseUrl: string;
+  includeAssistantId: boolean;
+}
+
+function buildAuthUrlCandidates(config: CloudAuthConfig, assistantId: string): AuthUrlCandidate[] {
+  const baseCandidates = [config.webBaseUrl, config.runtimeBaseUrl]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => normalizeBaseUrl(value));
+  const baseUrls = Array.from(new Set(baseCandidates));
+
+  const seenUrls = new Set<string>();
+  const candidates: AuthUrlCandidate[] = [];
+  for (const baseUrl of baseUrls) {
+    for (const includeAssistantId of [true, false]) {
+      const url = buildAuthUrl(config, assistantId, { baseUrl, includeAssistantId });
+      if (seenUrls.has(url)) continue;
+      seenUrls.add(url);
+      candidates.push({ url, baseUrl, includeAssistantId });
+    }
+  }
+
+  if (candidates.length === 0) {
+    const baseUrl = normalizeBaseUrl(config.webBaseUrl);
+    candidates.push({
+      url: buildAuthUrl(config, assistantId, { baseUrl, includeAssistantId: true }),
+      baseUrl,
+      includeAssistantId: true,
+    });
+  }
+
+  return candidates;
+}
+
+function isAuthorizationPageLoadError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.toLowerCase().includes('authorization page could not be loaded');
+}
+
+async function launchWebAuthFlowWithFallback(
+  assistantId: string,
+  config: CloudAuthConfig,
+  interactive: boolean,
+): Promise<string | undefined> {
+  const candidates = buildAuthUrlCandidates(config, assistantId);
+  let lastError: unknown = null;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i]!;
+    try {
+      return await chrome.identity.launchWebAuthFlow({
+        url: candidate.url,
+        interactive,
+      });
+    } catch (err) {
+      lastError = err;
+      const hasNext = i < candidates.length - 1;
+      if (hasNext && isAuthorizationPageLoadError(err)) {
+        const next = candidates[i + 1]!;
+        console.warn(
+          `[vellum-cloud-auth] authorization page failed to load for ` +
+            `base=${candidate.baseUrl} includeAssistantId=${candidate.includeAssistantId}; ` +
+            `retrying with base=${next.baseUrl} includeAssistantId=${next.includeAssistantId}`,
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (lastError) throw lastError;
+  return undefined;
 }
 
 /**
@@ -237,9 +334,7 @@ function buildAuthUrl(config: CloudAuthConfig, assistantId: string): string {
  * The extension receives the token via the redirect URI fragment.
  */
 export async function signInCloud(assistantId: string, config: CloudAuthConfig): Promise<StoredCloudToken> {
-  const authUrl = buildAuthUrl(config, assistantId);
-
-  const responseUrl = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
+  const responseUrl = await launchWebAuthFlowWithFallback(assistantId, config, true);
   if (!responseUrl) throw new Error('cloud sign-in cancelled');
 
   const stored = parseAuthResponseUrl(responseUrl);
@@ -266,14 +361,9 @@ export async function refreshCloudToken(
   assistantId: string,
   config: CloudAuthConfig,
 ): Promise<StoredCloudToken | null> {
-  const authUrl = buildAuthUrl(config, assistantId);
-
   let responseUrl: string | undefined;
   try {
-    responseUrl = await chrome.identity.launchWebAuthFlow({
-      url: authUrl,
-      interactive: false,
-    });
+    responseUrl = await launchWebAuthFlowWithFallback(assistantId, config, false);
   } catch (err) {
     // Chrome rejects non-interactive flows with messages like
     // "OAuth2 not granted or revoked", "user interaction required",

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -1012,6 +1012,7 @@ async function connectPreflight(
       // Non-interactive: attempt a silent refresh first.
       const refreshed = await refreshCloudToken(assistantId, {
         webBaseUrl: CLOUD_WEB_BASE_URL,
+        runtimeBaseUrl: assistant?.runtimeUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
@@ -1030,6 +1031,7 @@ async function connectPreflight(
     // Interactive: launch the full OAuth sign-in flow.
     const stored = await signInCloud(assistantId, {
       webBaseUrl: CLOUD_WEB_BASE_URL,
+      runtimeBaseUrl: assistant?.runtimeUrl,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
     const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
@@ -1234,18 +1236,19 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     // Run the OAuth flow in the service worker — not the popup — so the
     // awaited promise survives the popup losing focus during the Chrome
     // identity window. The popup just awaits this message response.
-    const assistantId =
+    const requestedAssistantId =
       typeof message.assistantId === 'string' ? message.assistantId : null;
-    (assistantId
-      ? Promise.resolve(assistantId)
-      : loadSelectedAssistantId()
-    )
-      .then(async (resolvedId) => {
+    getAssistantCatalogAndSelection()
+      .then(async ({ assistants, selected }) => {
+        const resolvedId = requestedAssistantId ?? selected?.assistantId ?? null;
         if (!resolvedId) {
           throw new Error('No assistant selected. Fetch the assistant catalog first.');
         }
+        const descriptor =
+          assistants.find((assistant) => assistant.assistantId === resolvedId) ?? null;
         const config: CloudAuthConfig = {
           webBaseUrl: CLOUD_WEB_BASE_URL,
+          runtimeBaseUrl: descriptor?.runtimeUrl,
           clientId:
             typeof message.clientId === 'string' ? message.clientId : CLOUD_OAUTH_CLIENT_ID,
         };


### PR DESCRIPTION
## Summary
- add cloud auth URL fallback candidates for launchWebAuthFlow when Chrome reports the authorization page could not be loaded
- thread selected assistant runtime URL into cloud auth config so sign-in can retry against assistant-specific web origins
- cover the new fallback behavior with targeted cloud-auth tests to lock in retry order and assistant_id fallback behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
