### PR TITLE
docs(skills): standardize interactive script gating patterns with ui request + confirm wrapper

### DIFF
--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -99,7 +99,7 @@ These indicate infrastructure or configuration problems, not user decisions:
 - **IPC unavailable**: The daemon is not running or the socket is unreachable. The CLI exits non-zero with an error message.
 - **No conversation context**: Neither `--conversation-id` nor `__SKILL_CONTEXT_JSON` provided a valid conversation ID.
 - **Invalid payload**: Malformed JSON in `--payload` or stdin.
-- **No interactive surface**: The active channel does not support interactive UI (headless/API mode).
+- **No interactive surface**: The active channel does not support interactive UI (headless/API mode). Note: the runtime fails closed to `{ status: "cancelled" }` (a normal result with `ok: true`), not an IPC error. Scripts should check `status` to detect this case.
 
 In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
 

--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -79,12 +79,16 @@ The `assistant ui` commands present blocking interactive surfaces (confirmations
 
 User decisions — including declining — are normal operational results:
 
+**`assistant ui confirm`** maps outcomes to exit codes for simple shell branching:
+
 | Status                              | Exit code | Meaning                                                                  |
 | ----------------------------------- | --------- | ------------------------------------------------------------------------ |
 | `submitted` (confirmed)             | 0         | User completed the interaction. Proceed with the gated action.           |
 | `submitted` (denied via `actionId`) | 1         | User explicitly chose the deny/secondary action. Abort gracefully.       |
 | `cancelled`                         | 1         | User dismissed the surface without choosing an action. Abort gracefully. |
 | `timed_out`                         | 1         | No user response within the timeout window. Abort safely.                |
+
+**`assistant ui request`** always exits 0 on successful IPC (regardless of user action). Use `--json` and check the `status` field to branch on user decisions.
 
 Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
 

--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -69,3 +69,82 @@ Returning `undefined` is acceptable only for **lookup functions** where "not fou
 | Memory retriever (`memory/retriever.ts`)              | Result object (`MemoryRecallResult`) with degraded/reason fields                | Graceful degradation — embedding failures, search failures degrade quality without crashing                                    |
 | Filesystem tools (`path-policy.ts`, `edit-engine.ts`) | Discriminated union (`{ ok, reason }`)                                          | Validation outcomes that the caller must handle (out of bounds, not found, ambiguous)                                          |
 | Subagent manager (`subagent/manager.ts`)              | Throws for precondition violations, string literal unions for expected outcomes | Depth limit exceeded is a bug; `sendMessage` returns `'not_found' \| 'terminal' \| 'queue_full'` as expected states            |
+| Interactive UI (`cli/commands/ui.ts`)                 | Result object (`InteractiveUiResult`) with `status` + exit codes                | User cancel and timeout are expected operational outcomes, not errors. IPC failures are exceptional.                           |
+
+## 4. Interactive UI interactions (`assistant ui confirm` / `assistant ui request`)
+
+The `assistant ui` commands present blocking interactive surfaces (confirmations, forms) to the user and wait for a response. Their error model distinguishes three categories:
+
+### Expected outcomes (not errors)
+
+User decisions — including declining — are normal operational results:
+
+| Status                              | Exit code | Meaning                                                                  |
+| ----------------------------------- | --------- | ------------------------------------------------------------------------ |
+| `submitted` (confirmed)             | 0         | User completed the interaction. Proceed with the gated action.           |
+| `submitted` (denied via `actionId`) | 1         | User explicitly chose the deny/secondary action. Abort gracefully.       |
+| `cancelled`                         | 1         | User dismissed the surface without choosing an action. Abort gracefully. |
+| `timed_out`                         | 1         | No user response within the timeout window. Abort safely.                |
+
+Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
+
+### Operational errors (exceptional)
+
+These indicate infrastructure or configuration problems, not user decisions:
+
+- **IPC unavailable**: The daemon is not running or the socket is unreachable. The CLI exits non-zero with an error message.
+- **No conversation context**: Neither `--conversation-id` nor `__SKILL_CONTEXT_JSON` provided a valid conversation ID.
+- **Invalid payload**: Malformed JSON in `--payload` or stdin.
+- **No interactive surface**: The active channel does not support interactive UI (headless/API mode).
+
+In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
+
+### Branching pattern
+
+```typescript
+const proc = Bun.spawn(
+  [
+    "assistant",
+    "ui",
+    "confirm",
+    "--title",
+    "Send email",
+    "--message",
+    `Send to ${recipient}?`,
+    "--confirm-label",
+    "Send",
+    "--deny-label",
+    "Cancel",
+    "--json",
+  ],
+  { stdout: "pipe" },
+);
+
+const raw = await new Response(proc.stdout).text();
+const result = JSON.parse(raw);
+
+if (!result.ok) {
+  // Operational error — IPC failure, no conversation, etc.
+  throw new Error(`UI request failed: ${result.error}`);
+}
+
+switch (result.status) {
+  case "submitted":
+    if (result.confirmed) {
+      // User confirmed — proceed with the action
+      await sendEmail(draftId);
+    } else {
+      // User denied — abort gracefully
+      return { sent: false, reason: "User declined" };
+    }
+    break;
+  case "cancelled":
+    // User dismissed — abort gracefully
+    return { sent: false, reason: "User cancelled" };
+  case "timed_out":
+    // No response — abort safely
+    return { sent: false, reason: "Timed out" };
+}
+```
+
+The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs or environment issues** (throw or log as errors).

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -110,7 +110,7 @@
 
   if [ "$STATUS" = "submitted" ]; then
     # Extract user-submitted data and proceed
-    ACCOUNTS=$(echo "$RESULT" | jq -r '.data.accounts')
+    ACCOUNTS=$(echo "$RESULT" | jq -r '.submittedData.accounts')
     archive_accounts "$ACCOUNTS"
   elif [ "$STATUS" = "cancelled" ]; then
     echo "User cancelled."
@@ -126,8 +126,8 @@
 
   | Status | Meaning | Typical action |
   |--------|---------|----------------|
-  | `submitted` | User completed the interaction (confirmed, submitted form) | Proceed with the gated action. Check `actionId` or `data` for specifics. |
-  | `cancelled` | User explicitly dismissed or denied | Abort gracefully. Inform the user the action was skipped. |
+  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | Check `actionId` to determine the action taken — e.g. `"confirm"` or `"deny"` for confirmations. For `ui confirm`, exit code 0 = confirmed, 1 = denied. |
+  | `cancelled` | User dismissed the surface without choosing an action (e.g. closed the dialog) | Abort gracefully. Inform the user the action was skipped. |
   | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
 
   **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -34,5 +34,111 @@
   - The `inline-skill-commands` feature flag must be enabled for inline expansions to work. When the flag is off, skills containing expansion tokens fail closed at load time
   - Inline command expansions are only supported for `bundled`, `managed`, and `workspace` skill sources. Skills distributed as `extra` sources cannot use this syntax
 
+- **User-gated actions (interactive confirmation/input)**
+
+  Scripts that perform irreversible or high-risk operations (sending emails, deleting data, unsubscribing, making purchases) **must** gate execution on explicit user confirmation. Prose-only instructions in SKILL.md ("always ask the user first") are not sufficient — they rely on the LLM following the instruction, which is not guaranteed.
+
+  Use the `assistant ui` CLI commands to present a blocking interactive surface and branch on the result. Two commands are available:
+
+  ### `assistant ui confirm` — binary yes/no gate
+
+  Use this for irreversible actions that need a simple go/no-go decision. The command exits `0` on confirm, `1` on deny/cancel/timeout.
+
+  ```bash
+  # Gate on user confirmation before sending an email
+  if assistant ui confirm \
+    --title "Send email" \
+    --message "Send draft to jane@example.com — Subject: Q2 Report" \
+    --confirm-label "Send" \
+    --deny-label "Cancel"; then
+    # User confirmed — proceed with the action
+    assistant oauth request POST "/v1.0/me/messages/${DRAFT_ID}/send" \
+      --provider microsoft-graph
+  else
+    echo "Send cancelled by user."
+    exit 0
+  fi
+  ```
+
+  For scripts that need to inspect the result (e.g. distinguish deny from timeout):
+
+  ```bash
+  RESULT=$(assistant ui confirm \
+    --title "Delete records" \
+    --message "Permanently delete 42 records from the archive?" \
+    --confirm-label "Delete" \
+    --deny-label "Keep" \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  CONFIRMED=$(echo "$RESULT" | jq -r '.confirmed')
+
+  case "$STATUS" in
+    submitted)
+      if [ "$CONFIRMED" = "true" ]; then
+        # User clicked "Delete" — proceed
+        perform_deletion
+      else
+        echo "User denied the action."
+      fi
+      ;;
+    cancelled)
+      echo "User dismissed the prompt."
+      ;;
+    timed_out)
+      echo "No response — timed out. Aborting."
+      ;;
+    *)
+      echo "Unexpected status: $STATUS" >&2
+      exit 1
+      ;;
+  esac
+  ```
+
+  ### `assistant ui request` — structured input/data collection
+
+  Use this when you need more than a yes/no — e.g. collecting form data, presenting choices, or gathering parameters before executing an operation. Returns full JSON with user-submitted data.
+
+  ```bash
+  RESULT=$(assistant ui request \
+    --payload '{"message":"Select accounts to archive","fields":[{"name":"accounts","type":"multi-select"}]}' \
+    --surface-type form \
+    --title "Archive accounts" \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+
+  if [ "$STATUS" = "submitted" ]; then
+    # Extract user-submitted data and proceed
+    ACCOUNTS=$(echo "$RESULT" | jq -r '.data.accounts')
+    archive_accounts "$ACCOUNTS"
+  elif [ "$STATUS" = "cancelled" ]; then
+    echo "User cancelled."
+  else
+    echo "Request failed or timed out: $STATUS"
+    exit 1
+  fi
+  ```
+
+  ### Status branching reference
+
+  Every `assistant ui` response includes a `status` field. Handle all three terminal states:
+
+  | Status | Meaning | Typical action |
+  |--------|---------|----------------|
+  | `submitted` | User completed the interaction (confirmed, submitted form) | Proceed with the gated action. Check `actionId` or `data` for specifics. |
+  | `cancelled` | User explicitly dismissed or denied | Abort gracefully. Inform the user the action was skipped. |
+  | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
+
+  **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
+
+  ### Conversation ID resolution
+
+  Inside a skill context, the conversation ID is auto-resolved from `__SKILL_CONTEXT_JSON` (set by the skill sandbox runner). Override with `--conversation-id <id>` if needed — run `assistant conversations list` to find available IDs.
+
+  ### Timeouts
+
+  Both commands accept `--timeout <ms>` (default: 300000ms / 5 minutes). Choose a timeout appropriate to the operation — shorter for simple confirmations, longer for complex forms. On timeout, the surface auto-cancels and the CLI exits with `status: "timed_out"`.
+
 - **Vellum-specific extensions**
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -34,7 +34,24 @@ For details on how to use this command, run:
 assistant oauth request --help
 ```
 
-You should err towards asking your user for permission to make the request, especially if it performs side-effects (e.g. updates data, sends an email, etc.)
+**Side-effect requests require explicit user confirmation.** If the request performs a side-effect (updates data, sends an email, deletes a record, etc.), gate it with `assistant ui confirm` so the user has a hard runtime veto — do not rely solely on SKILL.md prose instructions.
+
+```bash
+# Example: gate a destructive OAuth request on user confirmation
+if assistant ui confirm \
+  --title "Send email" \
+  --message "Send draft to jane@example.com — Subject: Q2 Report" \
+  --confirm-label "Send" \
+  --deny-label "Cancel"; then
+  assistant oauth request POST "/v1.0/me/messages/${DRAFT_ID}/send" \
+    --provider microsoft-graph
+else
+  echo "Cancelled — email not sent."
+  exit 0
+fi
+```
+
+For read-only requests (fetching data, listing resources), no confirmation gate is needed.
 
 ### OAuth Token Escape Hatch
 


### PR DESCRIPTION
## Summary
- Update skill authoring docs with canonical ui confirm and ui request patterns
- Add concrete CLI gating examples for irreversible actions
- Document status branching (submitted/cancelled/timed_out)

Part of plan: user-confirmation-primitive.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
