### PR TITLE
feat(macos): record anchor-preserver decisions in scroll debug HUD

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -22,12 +22,19 @@ struct MessageListScrollObserver: NSViewRepresentable {
     /// growth). Used only by the scroll-debug overlay to count anchor
     /// activations. `nil` when no observer cares.
     var onAnchorShift: (@MainActor () -> Void)? = nil
+    /// Fired for every anchor-preserver decision where the content height
+    /// actually changed, regardless of whether the shift was applied or
+    /// skipped. Used by the scroll-debug recorder to attribute missed
+    /// compensations (content shrinks, live-scroll gates, first-layout).
+    /// `nil` when no observer cares.
+    var onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             onGeometryChange: onGeometryChange,
             shouldPreserveScrollAnchor: shouldPreserveScrollAnchor,
-            onAnchorShift: onAnchorShift
+            onAnchorShift: onAnchorShift,
+            onAnchorDecision: onAnchorDecision
         )
     }
 
@@ -45,6 +52,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
         context.coordinator.onGeometryChange = onGeometryChange
         context.coordinator.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
         context.coordinator.onAnchorShift = onAnchorShift
+        context.coordinator.onAnchorDecision = onAnchorDecision
         DispatchQueue.main.async { [weak nsView] in
             guard let nsView else { return }
             context.coordinator.attachIfNeeded(to: nsView)
@@ -65,6 +73,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
         var onGeometryChange: @MainActor (ScrollGeometrySnapshot) -> Void
         var shouldPreserveScrollAnchor: @MainActor () -> Bool
         var onAnchorShift: (@MainActor () -> Void)?
+        var onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)?
         private var observers: [NSObjectProtocol] = []
         private var lastSnapshot: ScrollGeometrySnapshot?
         /// Last observed `documentView.frame.height`. Used to compute the
@@ -89,11 +98,13 @@ struct MessageListScrollObserver: NSViewRepresentable {
         init(
             onGeometryChange: @escaping @MainActor (ScrollGeometrySnapshot) -> Void,
             shouldPreserveScrollAnchor: @escaping @MainActor () -> Bool,
-            onAnchorShift: (@MainActor () -> Void)? = nil
+            onAnchorShift: (@MainActor () -> Void)? = nil,
+            onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)? = nil
         ) {
             self.onGeometryChange = onGeometryChange
             self.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
             self.onAnchorShift = onAnchorShift
+            self.onAnchorDecision = onAnchorDecision
         }
 
         func attachIfNeeded(to hostView: NSView) {
@@ -136,6 +147,8 @@ struct MessageListScrollObserver: NSViewRepresentable {
 
             let clipView = scrollView.contentView
             let currentContentHeight = documentView.frame.height
+            let preOffsetY = clipView.bounds.origin.y
+            let contentHDelta = currentContentHeight - lastContentHeight
 
             // Anchor preservation: when the streaming assistant response
             // grows and the user is reading older content above the visual
@@ -146,21 +159,34 @@ struct MessageListScrollObserver: NSViewRepresentable {
             // clip view by the height delta so the visible content stays
             // put. The decision lives in `ScrollAnchorPreserver` so the
             // logic is unit-testable without an NSScrollView.
-            if let delta = ScrollAnchorPreserver.offsetDelta(
+            let decision = ScrollAnchorPreserver.decide(
                 currentContentHeight: currentContentHeight,
                 lastContentHeight: lastContentHeight,
-                contentOffsetY: clipView.bounds.origin.y,
+                contentOffsetY: preOffsetY,
                 shouldPreserveAnchor: shouldPreserveScrollAnchor(),
                 isUserLiveScrolling: isLiveScrolling,
                 pinnedToLatestEpsilon: Self.pinnedToLatestEpsilon
-            ) {
+            )
+            if case .applied(let delta) = decision {
                 let newOrigin = NSPoint(
                     x: clipView.bounds.origin.x,
-                    y: clipView.bounds.origin.y + delta
+                    y: preOffsetY + delta
                 )
                 clipView.setBoundsOrigin(newOrigin)
                 scrollView.reflectScrolledClipView(clipView)
                 onAnchorShift?()
+            }
+            // Telemetry: only fire when content height actually changed so
+            // the recorder isn't spammed with no-op decisions from bounds
+            // notifications that didn't involve a layout change.
+            if contentHDelta != 0, let onAnchorDecision {
+                onAnchorDecision(ScrollAnchorDecisionEvent(
+                    outcome: decision,
+                    contentHDelta: contentHDelta,
+                    preOffsetY: preOffsetY,
+                    postOffsetY: clipView.bounds.origin.y,
+                    at: Date()
+                ))
             }
             lastContentHeight = currentContentHeight
 
@@ -282,9 +308,25 @@ struct MessageListScrollObserver: NSViewRepresentable {
 /// decision tree can be exercised in unit tests without standing up a real
 /// `NSScrollView`.
 enum ScrollAnchorPreserver {
-    /// Returns the offset delta to add to `contentOffsetY` so the visible
-    /// content stays anchored when the document grows, or `nil` if no
-    /// adjustment is needed.
+    /// Reason the preserver chose not to shift the offset. Used by the
+    /// scroll-debug telemetry so each skipped decision is attributable.
+    enum SkipReason: String {
+        case anchorPreservationDisabled
+        case userLiveScrolling
+        case firstLayout
+        case notGrowth
+        case pinnedToLatest
+    }
+
+    /// Outcome of a single `decide(...)` call.
+    enum Decision {
+        case applied(delta: CGFloat)
+        case skipped(SkipReason)
+    }
+
+    /// Rich decision for a single layout-change notification. `offsetDelta`
+    /// is a thin convenience over this, kept for tests and simple callers
+    /// that only need the CGFloat?.
     ///
     /// In the inverted scroll, `contentOffsetY = 0` is the visual bottom
     /// (latest messages). The streaming assistant response lives at the
@@ -293,6 +335,26 @@ enum ScrollAnchorPreserver {
     /// content (positive `contentOffsetY`) sees that content scroll upward
     /// off the top of the viewport unless the offset is shifted by the
     /// growth amount.
+    static func decide(
+        currentContentHeight: CGFloat,
+        lastContentHeight: CGFloat,
+        contentOffsetY: CGFloat,
+        shouldPreserveAnchor: Bool,
+        isUserLiveScrolling: Bool,
+        pinnedToLatestEpsilon: CGFloat
+    ) -> Decision {
+        if !shouldPreserveAnchor { return .skipped(.anchorPreservationDisabled) }
+        if isUserLiveScrolling { return .skipped(.userLiveScrolling) }
+        if lastContentHeight <= 0 { return .skipped(.firstLayout) }
+        if currentContentHeight <= lastContentHeight { return .skipped(.notGrowth) }
+        if contentOffsetY <= pinnedToLatestEpsilon { return .skipped(.pinnedToLatest) }
+        return .applied(delta: currentContentHeight - lastContentHeight)
+    }
+
+    /// Returns the offset delta to add to `contentOffsetY` so the visible
+    /// content stays anchored when the document grows, or `nil` if no
+    /// adjustment is needed. Kept for tests and simple callers — see
+    /// `decide(...)` for the richer outcome.
     static func offsetDelta(
         currentContentHeight: CGFloat,
         lastContentHeight: CGFloat,
@@ -301,12 +363,28 @@ enum ScrollAnchorPreserver {
         isUserLiveScrolling: Bool,
         pinnedToLatestEpsilon: CGFloat
     ) -> CGFloat? {
-        guard shouldPreserveAnchor,
-              !isUserLiveScrolling,
-              lastContentHeight > 0,
-              currentContentHeight > lastContentHeight,
-              contentOffsetY > pinnedToLatestEpsilon
-        else { return nil }
-        return currentContentHeight - lastContentHeight
+        switch decide(
+            currentContentHeight: currentContentHeight,
+            lastContentHeight: lastContentHeight,
+            contentOffsetY: contentOffsetY,
+            shouldPreserveAnchor: shouldPreserveAnchor,
+            isUserLiveScrolling: isUserLiveScrolling,
+            pinnedToLatestEpsilon: pinnedToLatestEpsilon
+        ) {
+        case .applied(let delta): return delta
+        case .skipped: return nil
+        }
     }
+}
+
+/// Single anchor-preserver decision captured for the debug HUD / recorder.
+/// Fired on every call where `contentHDelta` is non-zero, including skips
+/// so we can attribute missed compensations (shrinks, live-scroll blocks,
+/// first-layout).
+struct ScrollAnchorDecisionEvent {
+    let outcome: ScrollAnchorPreserver.Decision
+    let contentHDelta: CGFloat
+    let preOffsetY: CGFloat
+    let postOffsetY: CGFloat
+    let at: Date
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -255,6 +255,14 @@ final class MessageListScrollState {
         debugMetricsVersion &+= 1
     }
 
+    /// Record a full anchor-preserver decision (applied or skipped) with
+    /// pre/post offsets and the content-height delta. Only called when the
+    /// `scroll-debug-overlay` flag is on.
+    func recordAnchorDecision(_ event: ScrollAnchorDecisionEvent) {
+        debugMetrics.recordAnchorDecision(event)
+        debugMetricsVersion &+= 1
+    }
+
     /// Reset debug metrics (e.g. on conversation switch) so counters start
     /// fresh and don't carry stale data across conversations.
     func resetDebugMetrics() {
@@ -289,6 +297,11 @@ struct ScrollDebugMetrics {
     /// Rolling buffer of anchor-shift timestamps — read once per render by the
     /// overlay to compute an anchor-shifts-per-second counter.
     var recentAnchorShiftTimes: [Date] = []
+    /// Most recent anchor-preserver decision (applied or skipped). Refreshed
+    /// on every call where the content height changed, so the HUD / CSV can
+    /// show what the preserver last decided and how long ago. `nil` until
+    /// the first such decision lands.
+    var lastAnchorDecision: ScrollAnchorDecisionEvent?
 
     private var lastSnapshotTime: Date?
     private var lastSnapshotOffsetY: CGFloat = 0
@@ -323,6 +336,10 @@ struct ScrollDebugMetrics {
         anchorShiftTotal += 1
         recentAnchorShiftTimes.append(now)
         Self.trim(&recentAnchorShiftTimes, at: now)
+    }
+
+    mutating func recordAnchorDecision(_ event: ScrollAnchorDecisionEvent) {
+        lastAnchorDecision = event
     }
 
     func updatesPerSecond(at now: Date = Date()) -> Int {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -152,6 +152,13 @@ struct MessageListView: View {
                                     // pays nothing when the overlay is off.
                                     guard MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") else { return }
                                     scrollState.recordDebugAnchorShift()
+                                },
+                                onAnchorDecision: { [scrollState] event in
+                                    // Debug-only full-decision log. Captures
+                                    // skips (shrinks, live-scroll gate, etc.)
+                                    // plus applies, with pre/post offsets.
+                                    guard MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") else { return }
+                                    scrollState.recordAnchorDecision(event)
                                 }
                             )
                         )

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -60,6 +60,14 @@ struct ScrollDebugOverlayView: View {
         let velocity = metrics.displayedVelocity(at: now)
         let anchorsPerSec = metrics.anchorShiftsPerSecond(at: now)
 
+        let lastAnchor = metrics.lastAnchorDecision
+        let anchorAgeMs: Int? = lastAnchor.map { Int(max(0, now.timeIntervalSince($0.at)) * 1000) }
+        let anchorOutcome: String = lastAnchor.map(Self.outcomeLabel) ?? ""
+        let anchorDelta: CGFloat = {
+            guard case .applied(let d) = lastAnchor?.outcome else { return 0 }
+            return d
+        }()
+
         if recorder.isRecording {
             recorder.capture(ScrollDebugRecorder.Frame(
                 timestamp: now,
@@ -80,6 +88,12 @@ struct ScrollDebugOverlayView: View {
                 lastContentHDelta: metrics.lastContentHDelta,
                 anchorsPerSecond: anchorsPerSec,
                 anchorTotal: metrics.anchorShiftTotal,
+                anchorOutcome: anchorOutcome,
+                anchorDelta: anchorDelta,
+                anchorContentHDelta: lastAnchor?.contentHDelta ?? 0,
+                anchorPreOffsetY: lastAnchor?.preOffsetY ?? 0,
+                anchorPostOffsetY: lastAnchor?.postOffsetY ?? 0,
+                anchorAgeMs: anchorAgeMs ?? -1,
                 conversationId: scrollState.currentConversationId
             ))
         }
@@ -109,6 +123,14 @@ struct ScrollDebugOverlayView: View {
             )
             row("anchors/s", String(anchorsPerSec))
             row("anchorTotal", String(metrics.anchorShiftTotal))
+            // Most recent anchor decision, tagged in red when it was a skip
+            // accompanying a non-zero content change (i.e. a compensation we
+            // missed). Applied events show the delta and age directly.
+            row(
+                "lastAnchor",
+                anchorDecisionLabel(lastAnchor, ageMs: anchorAgeMs),
+                valueColor: Self.isMissedCompensation(lastAnchor) ? VColor.systemNegativeStrong : nil
+            )
             if let id = scrollState.currentConversationId {
                 row("conv", String(id.uuidString.prefix(8)))
             }
@@ -216,6 +238,33 @@ struct ScrollDebugOverlayView: View {
     }
 
     private func bool(_ v: Bool) -> String { v ? "yes" : "no" }
+
+    private func anchorDecisionLabel(_ event: ScrollAnchorDecisionEvent?, ageMs: Int?) -> String {
+        guard let event, let ageMs else { return "—" }
+        let prefix: String
+        switch event.outcome {
+        case .applied(let delta):
+            prefix = "applied \(String(format: "%+.0f", delta))"
+        case .skipped(let reason):
+            prefix = "skip:\(reason.rawValue)"
+        }
+        return "\(prefix) @ \(ageMs)ms"
+    }
+
+    static func outcomeLabel(_ event: ScrollAnchorDecisionEvent) -> String {
+        switch event.outcome {
+        case .applied: return "applied"
+        case .skipped(let reason): return reason.rawValue
+        }
+    }
+
+    /// A skip that accompanied a real content-height change is a compensation
+    /// we missed — this is the class of event the telemetry is meant to flag.
+    static func isMissedCompensation(_ event: ScrollAnchorDecisionEvent?) -> Bool {
+        guard let event else { return false }
+        if case .skipped = event.outcome, event.contentHDelta != 0 { return true }
+        return false
+    }
 }
 
 // MARK: - ScrollDebugRecorder
@@ -256,6 +305,22 @@ final class ScrollDebugRecorder {
         let lastContentHDelta: CGFloat
         let anchorsPerSecond: Int
         let anchorTotal: Int
+        /// Outcome string of the most recent anchor decision: `"applied"` or
+        /// the skip reason (`"notGrowth"`, `"pinnedToLatest"`, etc.). Empty
+        /// before the first decision fires.
+        let anchorOutcome: String
+        /// Delta applied by the anchor preserver on the most recent decision.
+        /// `0` for skips.
+        let anchorDelta: CGFloat
+        /// Content-height delta the preserver saw on the most recent decision.
+        /// Negative values mean content shrunk — the preserver currently does
+        /// not compensate for shrinks.
+        let anchorContentHDelta: CGFloat
+        let anchorPreOffsetY: CGFloat
+        let anchorPostOffsetY: CGFloat
+        /// Milliseconds since the most recent anchor decision. `-1` before the
+        /// first decision fires.
+        let anchorAgeMs: Int
         let conversationId: UUID?
     }
 
@@ -302,8 +367,8 @@ final class ScrollDebugRecorder {
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
-        var csv = "elapsedSec,timestamp,offsetY,contentH,containerH,viewportH,distBottom,distTop,pinnedLatest,liveScrolling,paginating,paginationInRange,ctaVisible,updatesPerSecond,velocity,lastDeltaY,lastContentHDelta,anchorsPerSecond,anchorTotal,conversationId\n"
-        csv.reserveCapacity(frames.count * 190)
+        var csv = "elapsedSec,timestamp,offsetY,contentH,containerH,viewportH,distBottom,distTop,pinnedLatest,liveScrolling,paginating,paginationInRange,ctaVisible,updatesPerSecond,velocity,lastDeltaY,lastContentHDelta,anchorsPerSecond,anchorTotal,anchorOutcome,anchorDelta,anchorContentHDelta,anchorPreOffsetY,anchorPostOffsetY,anchorAgeMs,conversationId\n"
+        csv.reserveCapacity(frames.count * 240)
         for frame in frames {
             let elapsed = frame.timestamp.timeIntervalSince(start)
             let cols: [String] = [
@@ -326,6 +391,12 @@ final class ScrollDebugRecorder {
                 String(format: "%.2f", frame.lastContentHDelta),
                 String(frame.anchorsPerSecond),
                 String(frame.anchorTotal),
+                frame.anchorOutcome,
+                String(format: "%.2f", frame.anchorDelta),
+                String(format: "%.2f", frame.anchorContentHDelta),
+                String(format: "%.2f", frame.anchorPreOffsetY),
+                String(format: "%.2f", frame.anchorPostOffsetY),
+                String(frame.anchorAgeMs),
                 frame.conversationId?.uuidString ?? "",
             ]
             csv.append(cols.joined(separator: ","))


### PR DESCRIPTION
## Summary
- Replace `ScrollAnchorPreserver.offsetDelta` internals with a richer `decide(...)` returning `Decision.applied(delta:)` / `Decision.skipped(reason)`. `offsetDelta` is now a thin shim so existing unit tests pass unchanged.
- Add `onAnchorDecision` callback on `MessageListScrollObserver` that fires on every layout-notification where `contentH` actually changed — including skips — with pre/post clipView offsets.
- HUD gains a `lastAnchor` row showing the last decision + age. Highlighted red when a content change coincided with a skip (the missed-compensation class — e.g. the 2402pt shrink with no anchor fire we saw in the previous recording).
- CSV recorder gains six new columns: `anchorOutcome`, `anchorDelta`, `anchorContentHDelta`, `anchorPreOffsetY`, `anchorPostOffsetY`, `anchorAgeMs`.

## Original prompt
Instrument the anchor preserver call site to record pre- and post-shift offsets within the same layout pass, plus whether the call was a no-op (growth guard failed, shrink ignored, etc.).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
