### PR TITLE
fix: robust timeout handler and deny label in completion summary

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -678,9 +678,26 @@ describe("buildCompletionSummary for standalone surfaces", () => {
     );
   });
 
-  test("unknown action ID is passed through", () => {
+  test("confirmation deny with custom cancelLabel uses the label", () => {
+    expect(
+      buildCompletionSummary(
+        "confirmation",
+        "deny",
+        {},
+        { cancelLabel: "Keep" },
+      ),
+    ).toBe('User chose: "Keep"');
+  });
+
+  test("confirmation deny without custom label returns Denied", () => {
     expect(buildCompletionSummary("confirmation", "deny", {}, {})).toBe(
-      "User selected: deny",
+      "Denied",
+    );
+  });
+
+  test("unknown action ID is passed through", () => {
+    expect(buildCompletionSummary("confirmation", "reject", {}, {})).toBe(
+      "User selected: reject",
     );
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -288,6 +288,43 @@ describe("showStandaloneSurface", () => {
     expect(completeMsg?.summary).toBe("Timed out");
   });
 
+  test("timeout still resolves when emit throws", async () => {
+    const ctx = createMockContext();
+    // Override broadcastToAllClients to throw on ui_surface_complete
+    let showEmitted = false;
+    ctx.broadcastToAllClients = (msg: ServerMessage) => {
+      const type = (msg as unknown as Record<string, unknown>).type;
+      if (type === "ui_surface_show") {
+        showEmitted = true;
+        ctx.sentMessages.push(msg);
+        return;
+      }
+      if (type === "ui_surface_complete") {
+        throw new Error("emit failed");
+      }
+    };
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50,
+      },
+      "surf-emit-err",
+    );
+
+    const result = await resultPromise;
+    expect(showEmitted).toBe(true);
+    // Despite the emit error, the promise should resolve with timed_out
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("surf-emit-err");
+    // Cleanup should still have happened
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-emit-err")).toBe(false);
+    expect(ctx.surfaceState.has("surf-emit-err")).toBe(false);
+  });
+
   test("late action after timeout is silently dropped — not forwarded to LLM", async () => {
     const ctx = createMockContext();
     const resultPromise = showStandaloneSurface(

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -462,14 +462,21 @@ export function showStandaloneSurface(
       // Notify the client BEFORE cleanup so the surface is dismissed on
       // the client side, preventing stale user interactions from reaching
       // handleSurfaceAction and being misrouted to the LLM.
-      const emitTimeout =
-        ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
-      emitTimeout({
-        type: "ui_surface_complete",
-        conversationId: ctx.conversationId,
-        surfaceId,
-        summary: "Timed out",
-      });
+      try {
+        const emitTimeout =
+          ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+        emitTimeout({
+          type: "ui_surface_complete",
+          conversationId: ctx.conversationId,
+          surfaceId,
+          summary: "Timed out",
+        });
+      } catch (err) {
+        log.warn(
+          { err, conversationId: ctx.conversationId, surfaceId },
+          "Failed to emit ui_surface_complete on timeout",
+        );
+      }
 
       cleanupStandaloneSurface(ctx, surfaceId);
       log.info(
@@ -1585,8 +1592,18 @@ export function buildCompletionSummary(
           : undefined;
       return confirmLabel ? `User chose: "${confirmLabel}"` : "Confirmed";
     }
+    if (actionId === "deny") {
+      // The deny button's custom label is passed as cancelLabel in the
+      // confirmation surface data (the deny action reuses the cancel label
+      // since both represent the "reject" path).
+      const denyLabel =
+        typeof surfaceData?.cancelLabel === "string"
+          ? surfaceData.cancelLabel
+          : undefined;
+      return denyLabel ? `User chose: "${denyLabel}"` : "Denied";
+    }
     // Preserve the actual action ID so the LLM knows the user's exact choice
-    // (e.g. "deny", "no", "reject") rather than misreporting it as confirmed.
+    // rather than misreporting it as confirmed.
     return `User selected: ${actionId}`;
   }
   if (surfaceType === "form") {
@@ -1637,6 +1654,13 @@ export function buildUserFacingLabel(
           ? surfaceData.confirmLabel
           : undefined;
       return confirmLabel ?? "Confirmed";
+    }
+    if (actionId === "deny") {
+      const denyLabel =
+        typeof surfaceData?.cancelLabel === "string"
+          ? surfaceData.cancelLabel
+          : undefined;
+      return denyLabel ?? "Denied";
     }
     return `Selected: ${actionId}`;
   }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for user-confirmation-primitive.md.

**Gap 1:** Timeout handler emit wrapped in try/catch to prevent hanging promise
**Gap 2:** buildCompletionSummary uses custom label for deny action
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
