### PR TITLE
fix: add tombstone guard for late standalone surface callbacks

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -52,6 +52,7 @@ function createMockContext(
     accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set(),
     pendingStandaloneSurfaces: new Map(),
+    recentlyCompletedStandaloneSurfaces: new Map(),
     currentTurnSurfaces: [],
     hostCuProxy: undefined,
     hasNoClient: overrides?.hasNoClient ?? false,
@@ -305,19 +306,47 @@ describe("showStandaloneSurface", () => {
     const result = await resultPromise;
     expect(result.status).toBe("timed_out");
 
-    // Now simulate a late user click after the surface has timed out.
-    // Since the timeout handler emits ui_surface_complete, the client should
-    // not send this — but if it does, it must NOT trigger an LLM follow-up.
-    // Because the surface was cleaned up AND there is no pendingSurfaceActions
-    // entry, handleSurfaceAction falls through to the history-restored path
-    // which would enqueue a message to the LLM. Verify that doesn't happen
-    // because the client-side dismiss prevents the click from arriving. The
-    // key invariant is that cleanup + client dismiss together prevent stale turns.
-    //
     // Verify the server-side state is fully cleaned up after timeout.
     expect(ctx.pendingStandaloneSurfaces!.has("surf-6c")).toBe(false);
     expect(ctx.surfaceState.has("surf-6c")).toBe(false);
     expect(ctx.pendingSurfaceActions.has("surf-6c")).toBe(false);
+
+    // The surfaceId should now be in the tombstone set.
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-6c")).toBe(true);
+
+    // Now simulate a late user click after the surface has timed out.
+    // Without the tombstone guard, this would fall through to the
+    // history-restored path and enqueue a message to the LLM.
+    await handleSurfaceAction(ctx, "surf-6c", "confirm", {});
+
+    // No messages should have been enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("late action after user-resolved surface is silently dropped", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-6d",
+    );
+
+    // User confirms — resolves the surface
+    await handleSurfaceAction(ctx, "surf-6d", "confirm");
+    const result = await resultPromise;
+    expect(result.status).toBe("submitted");
+
+    // Tombstone should be recorded
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-6d")).toBe(true);
+
+    // A duplicate/late click arrives — must be silently dropped
+    await handleSurfaceAction(ctx, "surf-6d", "confirm", {});
+
     // No messages should have been enqueued to the LLM
     expect(ctx.enqueuedMessages).toHaveLength(0);
   });
@@ -399,8 +428,14 @@ describe("cleanupStandaloneSurface", () => {
     expect(ctx.accumulatedSurfaceState.has("surf-c1")).toBe(false);
     expect(ctx.surfaceUndoStacks.has("surf-c1")).toBe(false);
 
-    // Cleanup the timer ourselves for the test
+    // Tombstone should be recorded for the completed surface
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-c1")).toBe(true);
+
+    // Cleanup the timer and tombstone timer ourselves for the test
     clearTimeout(timer);
+    const tombstoneTimer =
+      ctx.recentlyCompletedStandaloneSurfaces!.get("surf-c1");
+    if (tombstoneTimer) clearTimeout(tombstoneTimer);
   });
 
   test("is idempotent — safe to call multiple times", () => {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -292,6 +292,16 @@ export interface SurfaceConversationContext {
       surfaceType: SurfaceType;
     }
   >;
+  /**
+   * Short-lived tombstone set of recently-completed standalone surface IDs.
+   * Prevents late client actions (arriving after timeout/resolution) from
+   * falling through to the history-restored path and triggering an
+   * unintended LLM turn. Entries are auto-removed after a TTL.
+   */
+  recentlyCompletedStandaloneSurfaces?: Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >;
   currentTurnSurfaces: Array<{
     surfaceId: string;
     surfaceType: SurfaceType;
@@ -385,6 +395,12 @@ export function createSurfaceMutex(): SurfaceMutex {
 
 /** Default timeout for standalone surfaces when the caller does not specify one. */
 const DEFAULT_STANDALONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * How long a tombstone entry persists after a standalone surface is completed.
+ * Late client actions arriving within this window are silently dropped.
+ */
+const STANDALONE_TOMBSTONE_TTL_MS = 30_000; // 30 seconds
 
 /**
  * Check whether the conversation can show interactive UI surfaces.
@@ -574,13 +590,16 @@ function buildStandaloneSurfaceData(
 
 /**
  * Cleanup a standalone surface entry: clear the timeout timer, remove
- * the pending entry, and remove surface state. Idempotent — safe to
- * call multiple times for the same surfaceId.
+ * the pending entry, remove surface state, and record a short-lived
+ * tombstone so late client actions are silently dropped instead of
+ * falling through to the LLM path. Idempotent — safe to call multiple
+ * times for the same surfaceId.
  */
 export function cleanupStandaloneSurface(
   ctx: Pick<
     SurfaceConversationContext,
     | "pendingStandaloneSurfaces"
+    | "recentlyCompletedStandaloneSurfaces"
     | "surfaceState"
     | "pendingSurfaceActions"
     | "lastSurfaceAction"
@@ -599,6 +618,19 @@ export function cleanupStandaloneSurface(
   ctx.lastSurfaceAction.delete(surfaceId);
   ctx.accumulatedSurfaceState.delete(surfaceId);
   ctx.surfaceUndoStacks.delete(surfaceId);
+
+  // Record a tombstone so late client actions are silently dropped.
+  if (ctx.recentlyCompletedStandaloneSurfaces) {
+    // Clear any existing tombstone timer for this surfaceId (idempotency).
+    const existingTimer =
+      ctx.recentlyCompletedStandaloneSurfaces.get(surfaceId);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    const tombstoneTimer = setTimeout(() => {
+      ctx.recentlyCompletedStandaloneSurfaces?.delete(surfaceId);
+    }, STANDALONE_TOMBSTONE_TTL_MS);
+    ctx.recentlyCompletedStandaloneSurfaces.set(surfaceId, tombstoneTimer);
+  }
 }
 
 /**
@@ -1024,6 +1056,18 @@ export async function handleSurfaceAction(
     );
 
     // Return without enqueuing a model message.
+    return { accepted: true, conversationId: ctx.conversationId };
+  }
+
+  // ── Tombstone guard for recently-completed standalone surfaces ────
+  // After a standalone surface times out or is resolved, cleanup removes
+  // all state. Without this guard a late client action would fall through
+  // to the history-restored path below and enqueue a message to the LLM.
+  if (ctx.recentlyCompletedStandaloneSurfaces?.has(surfaceId)) {
+    log.debug(
+      { conversationId: ctx.conversationId, surfaceId, actionId },
+      "Dropping late action for recently-completed standalone surface",
+    );
     return { accepted: true, conversationId: ctx.conversationId };
   }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -278,6 +278,15 @@ export class Conversation {
       surfaceType: SurfaceType;
     }
   >();
+  /**
+   * Short-lived tombstone set of recently-completed standalone surface IDs.
+   * Prevents late client actions from falling through to the LLM path.
+   * @internal
+   */
+  recentlyCompletedStandaloneSurfaces = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   /** @internal */ broadcastToAllClients?: (msg: ServerMessage) => void;
   /** @internal */ withSurface = createSurfaceMutex();
   /** @internal */ currentTurnSurfaces: Array<{
@@ -754,6 +763,11 @@ export class Conversation {
       entry.resolve({ status: "cancelled", surfaceId });
     }
     this.pendingStandaloneSurfaces.clear();
+    // Clear tombstone timers to prevent dangling references after dispose.
+    for (const timer of this.recentlyCompletedStandaloneSurfaces.values()) {
+      clearTimeout(timer);
+    }
+    this.recentlyCompletedStandaloneSurfaces.clear();
     this.hostBashProxy?.dispose();
     this.hostBrowserProxy?.dispose();
     this.hostCuProxy?.dispose();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for user-confirmation-primitive.md.

**Gap:** Late surface actions after timeout/resolution could fall through to the LLM path
**What was expected:** Late actions silently dropped
**What was found:** Late actions enqueued as model messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
