### PR TITLE
fix: isolate token mint failures, gate on confirm, add token to confirm output

### DIFF
--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -449,6 +449,79 @@ describe("ui confirm — JSON output", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual({ ok: false, error: "Daemon not running" });
   });
+
+  test("includes decisionToken in JSON output when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-token",
+        decisionToken: "eyJ0ZXN0IjoidG9rZW4ifQ.abc123",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.decisionToken).toBe("eyJ0ZXN0IjoidG9rZW4ifQ.abc123");
+  });
+
+  test("includes summary in JSON output when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-summary",
+        summary: "User confirmed deployment",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.summary).toBe("User confirmed deployment");
+  });
+
+  test("omits decisionToken and summary from JSON when absent", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-no-extras",
+      },
+    };
+
+    const { stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.decisionToken).toBeUndefined();
+    expect(parsed.summary).toBeUndefined();
+    expect("decisionToken" in parsed).toBe(false);
+    expect("summary" in parsed).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -499,15 +499,20 @@ Examples:
         const confirmed = r.status === "submitted" && r.actionId === "confirm";
 
         if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({
-              ok: true,
-              confirmed,
-              status: r.status,
-              actionId: r.actionId,
-              surfaceId: r.surfaceId,
-            }) + "\n",
-          );
+          const jsonOut: Record<string, unknown> = {
+            ok: true,
+            confirmed,
+            status: r.status,
+            actionId: r.actionId,
+            surfaceId: r.surfaceId,
+          };
+          if (r.decisionToken !== undefined) {
+            jsonOut.decisionToken = r.decisionToken;
+          }
+          if (r.summary !== undefined) {
+            jsonOut.summary = r.summary;
+          }
+          process.stdout.write(JSON.stringify(jsonOut) + "\n");
         } else {
           if (confirmed) {
             log.info("Confirmed.");

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -289,10 +289,10 @@ describe("surfaceId handling", () => {
 // ── Decision token minting ──────────────────────────────────────────
 
 describe("decision token", () => {
-  test("mints token for submitted confirmation request", async () => {
+  test("mints token for affirmative confirm action", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "approve",
+      actionId: "confirm",
       surfaceId: "confirm-surface-1",
     }));
 
@@ -311,12 +311,30 @@ describe("decision token", () => {
     expect(payload).not.toBeNull();
     expect(payload!.conversationId).toBe("conv-token-1");
     expect(payload!.surfaceId).toBe("confirm-surface-1");
-    expect(payload!.action).toBe("approve");
+    expect(payload!.action).toBe("confirm");
     expect(payload!.issuedAt).toBeString();
     expect(payload!.expiresAt).toBeString();
   });
 
-  test("token encodes actionId when present", async () => {
+  test("does not mint token for non-confirm actionId (e.g. approve)", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "approve",
+      surfaceId: "approve-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-approve",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("approve");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for deny action on confirmation", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
       actionId: "deny",
@@ -324,16 +342,17 @@ describe("decision token", () => {
     }));
 
     const result = await requestInteractiveUi({
-      conversationId: "conv-token-action",
+      conversationId: "conv-token-deny",
       surfaceType: "confirmation",
       data: {},
     });
 
-    const payload = decodeDecisionToken(result.decisionToken!);
-    expect(payload!.action).toBe("deny");
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("deny");
+    expect(result.decisionToken).toBeUndefined();
   });
 
-  test("token uses 'submitted' as action when actionId is absent", async () => {
+  test("does not mint token when actionId is absent on confirmation", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
       surfaceId: "no-action-surface",
@@ -345,14 +364,14 @@ describe("decision token", () => {
       data: {},
     });
 
-    const payload = decodeDecisionToken(result.decisionToken!);
-    expect(payload!.action).toBe("submitted");
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeUndefined();
   });
 
   test("token has expiry in the future", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "ok",
+      actionId: "confirm",
       surfaceId: "expiry-surface",
     }));
 
@@ -424,7 +443,7 @@ describe("decision token", () => {
   test("each minted token is unique", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "ok",
+      actionId: "confirm",
       surfaceId: "unique-surface",
     }));
 

--- a/assistant/src/runtime/decision-token.ts
+++ b/assistant/src/runtime/decision-token.ts
@@ -25,7 +25,7 @@ export interface DecisionTokenPayload {
   conversationId: string;
   /** Surface identifier that was displayed. */
   surfaceId: string;
-  /** Action the user took (`submitted`, `cancelled`, `timed_out`). */
+  /** The action ID the user selected (e.g. "confirm"). Only present on affirmative confirmation. */
   action: string;
   /** ISO-8601 timestamp when the decision was recorded. */
   issuedAt: string;

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -217,10 +217,13 @@ function emitAuditLog(
  * Fails closed: when no resolver is registered (headless, tests without
  * setup), returns `{ status: "cancelled", surfaceId }` immediately.
  *
- * When the surface type is `"confirmation"` and the user submits, a
- * short-lived informational decision token is minted and attached to
- * the result. The token is non-authoritative — see
- * {@link mintDecisionToken} for details.
+ * When the surface type is `"confirmation"` and the user selects the
+ * `"confirm"` action, a short-lived informational decision token is
+ * minted and attached to the result. Deny actions and other non-confirm
+ * outcomes do not receive a token. If token minting fails, the user's
+ * decision is still returned as `submitted` (the token is best-effort).
+ * The token is non-authoritative — see {@link mintDecisionToken} for
+ * details.
  *
  * Structured audit logs are emitted for all terminal outcomes
  * (`submitted`, `cancelled`, `timed_out`).
@@ -260,18 +263,26 @@ export async function requestInteractiveUi(
       surfaceId: finalSurfaceId,
     };
 
-    // Mint an informational decision token for submitted confirmation
-    // requests. The token encodes the decision metadata and is
-    // short-lived (5 minutes). It is non-authoritative in v1.
+    // Mint an informational decision token only for affirmative
+    // confirmation actions. The token is short-lived (5 minutes) and
+    // non-authoritative in v1. Deny/cancel/timeout do not receive tokens.
     if (
       result.status === "submitted" &&
-      request.surfaceType === "confirmation"
+      request.surfaceType === "confirmation" &&
+      result.actionId === "confirm"
     ) {
-      result.decisionToken = mintDecisionToken({
-        conversationId: request.conversationId,
-        surfaceId: finalSurfaceId,
-        action: result.actionId ?? "submitted",
-      });
+      try {
+        result.decisionToken = mintDecisionToken({
+          conversationId: request.conversationId,
+          surfaceId: finalSurfaceId,
+          action: result.actionId,
+        });
+      } catch (tokenErr) {
+        log.warn(
+          { err: tokenErr, surfaceId: finalSurfaceId },
+          "interactive-ui: failed to mint decision token; continuing without it",
+        );
+      }
     }
 
     emitAuditLog(request, result);

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -132,6 +132,8 @@
 
   **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
 
+  **Decision token**: When the user affirmatively confirms (action `"confirm"`), the JSON output includes a `decisionToken` field — a short-lived, non-authoritative token encoding metadata about the decision (conversation, surface, action, timestamps). Use it for audit trails and cross-system correlation. The token is informational only and does not grant any capability. It is absent for deny, cancel, and timeout outcomes.
+
   ### Conversation ID resolution
 
   Inside a skill context, the conversation ID is auto-resolved from `__SKILL_CONTEXT_JSON` (set by the skill sandbox runner). Override with `--conversation-id <id>` if needed — run `assistant conversations list` to find available IDs.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for user-confirmation-primitive.md.

**Gap 1:** Token mint failure no longer downgrades submitted to cancelled
**Gap 2:** Decision token only minted for affirmative confirm actions
**Gap 3:** Fixed misleading JSDoc on DecisionTokenPayload.action
**Gap 4:** Added decisionToken and summary to confirm --json output
**Gap 5:** Documented decisionToken in skill authoring guidance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
