### PR TITLE
fix(ios): start SSE message loop on conversation open for cross-device sync (LUM-1034)

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -1088,6 +1088,10 @@ class IOSConversationStore: ObservableObject {
                 observeForForkAvailability(vm: existing, conversationLocalId: conversationLocalId)
             }
             updateForkCommandHandler(vm: existing, conversationLocalId: conversationLocalId)
+            // Ensure the SSE message loop is running so cross-device messages
+            // (e.g. sent from macOS) appear in real-time. ensureMessageLoopStarted()
+            // is a no-op when the loop is already active (guards on messageLoopTask).
+            existing.ensureMessageLoopStarted()
             return existing
         }
         let vm = ChatViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
@@ -1110,6 +1114,10 @@ class IOSConversationStore: ObservableObject {
         observeForForkAvailability(vm: vm, conversationLocalId: conversationLocalId)
         updateForkCommandHandler(vm: vm, conversationLocalId: conversationLocalId)
         observeForActivityTracking(vm: vm, conversationLocalId: conversationLocalId)
+        // Start the SSE message loop so messages from other devices (e.g. macOS)
+        // appear in real-time. Without this, the loop only starts as a side-effect
+        // of sending a message via MessageSendCoordinator. (LUM-1034)
+        vm.ensureMessageLoopStarted()
         return vm
     }
 


### PR DESCRIPTION
## Problem

Messages sent from macOS don't appear on iOS in real-time. They only show up after restarting the iOS app. The reverse direction (iOS → macOS) works because `MessageSendCoordinator` starts the message loop as a side-effect of sending.

## Root Cause

iOS never calls `ensureMessageLoopStarted()` on the `ChatViewModel`. macOS does this in `ConversationSelectionStore` and `ConversationManager` when selecting a conversation. iOS's `IOSConversationStore.viewModel(for:)` creates the VM and sets `conversationId` but never starts the SSE listener.

## Fix

Add `ensureMessageLoopStarted()` in both code paths of `viewModel(for:)`:
- **Existing VM path** (line ~1091): `existing.ensureMessageLoopStarted()` — no-op if already running
- **New VM path** (line ~1116): `vm.ensureMessageLoopStarted()` — starts the SSE message loop after setting conversationId

`ensureMessageLoopStarted()` guards on `messageLoopTask != nil` so calling it on every SwiftUI body evaluation is safe.

## Testing

1. Open a conversation on iOS
2. Send a message from macOS in the same conversation
3. Message should appear on iOS in real-time (previously required app restart)

## Related

- [LUM-1034](https://linear.app/vellum/issue/LUM-1034)
- ATL-94 "Cross Device Message Sync" (prior work by Emmie)

*PR by Vex ✦*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
