### PR TITLE
feat(assistant): interactive UI request primitive with assistant ui commands

### DIFF
--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -69,3 +69,86 @@ Returning `undefined` is acceptable only for **lookup functions** where "not fou
 | Memory retriever (`memory/retriever.ts`)              | Result object (`MemoryRecallResult`) with degraded/reason fields                | Graceful degradation — embedding failures, search failures degrade quality without crashing                                    |
 | Filesystem tools (`path-policy.ts`, `edit-engine.ts`) | Discriminated union (`{ ok, reason }`)                                          | Validation outcomes that the caller must handle (out of bounds, not found, ambiguous)                                          |
 | Subagent manager (`subagent/manager.ts`)              | Throws for precondition violations, string literal unions for expected outcomes | Depth limit exceeded is a bug; `sendMessage` returns `'not_found' \| 'terminal' \| 'queue_full'` as expected states            |
+| Interactive UI (`cli/commands/ui.ts`)                 | Result object (`InteractiveUiResult`) with `status` + exit codes                | User cancel and timeout are expected operational outcomes, not errors. IPC failures are exceptional.                           |
+
+## 4. Interactive UI interactions (`assistant ui confirm` / `assistant ui request`)
+
+The `assistant ui` commands present blocking interactive surfaces (confirmations, forms) to the user and wait for a response. Their error model distinguishes three categories:
+
+### Expected outcomes (not errors)
+
+User decisions — including declining — are normal operational results:
+
+**`assistant ui confirm`** maps outcomes to exit codes for simple shell branching:
+
+| Status                              | Exit code | Meaning                                                                  |
+| ----------------------------------- | --------- | ------------------------------------------------------------------------ |
+| `submitted` (confirmed)             | 0         | User completed the interaction. Proceed with the gated action.           |
+| `submitted` (denied via `actionId`) | 1         | User explicitly chose the deny/secondary action. Abort gracefully.       |
+| `cancelled`                         | 1         | User dismissed the surface without choosing an action. Abort gracefully. |
+| `timed_out`                         | 1         | No user response within the timeout window. Abort safely.                |
+
+**`assistant ui request`** always exits 0 on successful IPC (regardless of user action). Use `--json` and check the `status` field to branch on user decisions.
+
+Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
+
+### Operational errors (exceptional)
+
+These indicate infrastructure or configuration problems, not user decisions:
+
+- **IPC unavailable**: The daemon is not running or the socket is unreachable. The CLI exits non-zero with an error message.
+- **No conversation context**: Neither `--conversation-id` nor `__SKILL_CONTEXT_JSON` provided a valid conversation ID.
+- **Invalid payload**: Malformed JSON in `--payload` or stdin.
+- **No interactive surface**: The active channel does not support interactive UI (headless/API mode). Note: the runtime fails closed to `{ status: "cancelled" }` (a normal result with `ok: true`), not an IPC error. Scripts should check `status` to detect this case.
+
+In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
+
+### Branching pattern
+
+```typescript
+const proc = Bun.spawn(
+  [
+    "assistant",
+    "ui",
+    "confirm",
+    "--title",
+    "Send email",
+    "--message",
+    `Send to ${recipient}?`,
+    "--confirm-label",
+    "Send",
+    "--deny-label",
+    "Cancel",
+    "--json",
+  ],
+  { stdout: "pipe" },
+);
+
+const raw = await new Response(proc.stdout).text();
+const result = JSON.parse(raw);
+
+if (!result.ok) {
+  // Operational error — IPC failure, no conversation, etc.
+  throw new Error(`UI request failed: ${result.error}`);
+}
+
+switch (result.status) {
+  case "submitted":
+    if (result.confirmed) {
+      // User confirmed — proceed with the action
+      await sendEmail(draftId);
+    } else {
+      // User denied — abort gracefully
+      return { sent: false, reason: "User declined" };
+    }
+    break;
+  case "cancelled":
+    // User dismissed — abort gracefully
+    return { sent: false, reason: "User cancelled" };
+  case "timed_out":
+    // No response — abort safely
+    return { sent: false, reason: "Timed out" };
+}
+```
+
+The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs or environment issues** (throw or log as errors).

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -678,9 +678,26 @@ describe("buildCompletionSummary for standalone surfaces", () => {
     );
   });
 
-  test("unknown action ID is passed through", () => {
+  test("confirmation deny with custom cancelLabel uses the label", () => {
+    expect(
+      buildCompletionSummary(
+        "confirmation",
+        "deny",
+        {},
+        { cancelLabel: "Keep" },
+      ),
+    ).toBe('User chose: "Keep"');
+  });
+
+  test("confirmation deny without custom label returns Denied", () => {
     expect(buildCompletionSummary("confirmation", "deny", {}, {})).toBe(
-      "User selected: deny",
+      "Denied",
+    );
+  });
+
+  test("unknown action ID is passed through", () => {
+    expect(buildCompletionSummary("confirmation", "reject", {}, {})).toBe(
+      "User selected: reject",
     );
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -1,0 +1,686 @@
+/**
+ * Regression tests locking the exact payload shapes emitted by the
+ * standalone surface lifecycle (showStandaloneSurface + handleSurfaceAction).
+ *
+ * These tests verify that daemon-driven standalone surfaces (not LLM tool
+ * invocations) produce wire messages matching the contracts that macOS/iOS/web
+ * clients decode. Any payload shape drift here is a client compatibility break.
+ *
+ * Surface lifecycle under test:
+ *   1. `ui_surface_show`    — daemon → client  (showStandaloneSurface)
+ *   2. `ui_surface_action`  — client → daemon  (user click)
+ *   3. `ui_surface_complete` — daemon → client (handleSurfaceAction resolving standalone)
+ *
+ * The Swift client decodes these via:
+ *   - UiSurfaceShowMessage     (MessageTypes.swift)
+ *   - UiSurfaceCompleteMessage (MessageTypes.swift)
+ * and dispatches them in ChatActionHandler → ChatViewModel+SurfaceHandling.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildCompletionSummary,
+  handleSurfaceAction,
+  showStandaloneSurface,
+  type SurfaceConversationContext,
+} from "../daemon/conversation-surfaces.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createMockContext(
+  overrides?: Partial<{
+    hasNoClient: boolean;
+    supportsDynamicUi: boolean;
+    channel: string;
+  }>,
+): SurfaceConversationContext & {
+  sentMessages: ServerMessage[];
+  enqueuedMessages: Array<{ content: string; requestId: string }>;
+} {
+  const sentMessages: ServerMessage[] = [];
+  const enqueuedMessages: Array<{ content: string; requestId: string }> = [];
+
+  return {
+    conversationId: "payload-test-conv",
+    assistantId: undefined,
+    trustContext: undefined,
+    channelCapabilities: overrides?.channel
+      ? {
+          channel: overrides.channel,
+          supportsDynamicUi: overrides.supportsDynamicUi ?? true,
+        }
+      : undefined,
+    traceEmitter: { emit: () => {} },
+    sendToClient: (msg: ServerMessage) => sentMessages.push(msg),
+    broadcastToAllClients: (msg: ServerMessage) => sentMessages.push(msg),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set(),
+    pendingStandaloneSurfaces: new Map(),
+    currentTurnSurfaces: [],
+    hostCuProxy: undefined,
+    hasNoClient: overrides?.hasNoClient ?? false,
+    isProcessing: () => false,
+    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
+      enqueuedMessages.push({ content, requestId });
+      return { queued: false, requestId };
+    },
+    getQueueDepth: () => 0,
+    processMessage: async () => "msg-id",
+    withSurface: async <T>(_surfaceId: string, fn: () => T | Promise<T>) =>
+      fn(),
+    sentMessages,
+    enqueuedMessages,
+  };
+}
+
+type AnyRecord = Record<string, unknown>;
+
+function findByType(
+  messages: ServerMessage[],
+  type: string,
+): AnyRecord | undefined {
+  return messages.find(
+    (m) => (m as unknown as AnyRecord).type === type,
+  ) as unknown as AnyRecord | undefined;
+}
+
+function findAllByType(messages: ServerMessage[], type: string): AnyRecord[] {
+  return messages.filter(
+    (m) => (m as unknown as AnyRecord).type === type,
+  ) as unknown as AnyRecord[];
+}
+
+// ── Confirmation surface payload shapes ──────────────────────────────
+
+describe("standalone confirmation surface payload shapes", () => {
+  test("ui_surface_show payload matches UiSurfaceShowMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        title: "Delete project?",
+        data: {
+          message: "This will permanently delete the project and all data.",
+          detail: "This action cannot be undone.",
+          confirmLabel: "Delete",
+          cancelLabel: "Keep",
+          destructive: true,
+        },
+        actions: [
+          { id: "confirm", label: "Delete", variant: "danger" },
+          { id: "cancel", label: "Keep", variant: "secondary" },
+        ],
+        timeoutMs: 60_000,
+      },
+      "payload-surf-1",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    expect(showMsg).toBeDefined();
+
+    // ── Fields the Swift UiSurfaceShowMessage struct decodes ──
+    // These are the exact keys the client expects. Missing or renamed
+    // keys will cause a decoding failure on the client.
+    expect(showMsg!.type).toBe("ui_surface_show");
+    expect(showMsg!.conversationId).toBe("payload-test-conv");
+    expect(showMsg!.surfaceId).toBe("payload-surf-1");
+    expect(showMsg!.surfaceType).toBe("confirmation");
+    expect(showMsg!.title).toBe("Delete project?");
+    expect(showMsg!.display).toBe("inline");
+
+    // ── data field: ConfirmationSurfaceData ──
+    const data = showMsg!.data as AnyRecord;
+    expect(data.message).toBe(
+      "This will permanently delete the project and all data.",
+    );
+    expect(data.detail).toBe("This action cannot be undone.");
+    expect(data.confirmLabel).toBe("Delete");
+    expect(data.cancelLabel).toBe("Keep");
+    expect(data.destructive).toBe(true);
+
+    // ── actions array: SurfaceAction[] ──
+    const actions = showMsg!.actions as Array<AnyRecord>;
+    expect(actions).toHaveLength(2);
+    expect(actions[0].id).toBe("confirm");
+    expect(actions[0].label).toBe("Delete");
+    expect(actions[0].style).toBe("destructive"); // "danger" maps to "destructive"
+    expect(actions[1].id).toBe("cancel");
+    expect(actions[1].label).toBe("Keep");
+    expect(actions[1].style).toBe("secondary");
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-1", "confirm");
+    await resultPromise;
+  });
+
+  test("ui_surface_complete payload on confirm matches UiSurfaceCompleteMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: {
+          message: "Proceed with deployment?",
+          confirmLabel: "Deploy",
+          cancelLabel: "Abort",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-2",
+    );
+
+    // Clear show messages
+    ctx.sentMessages.length = 0;
+
+    // Simulate user clicking confirm with submitted data
+    await handleSurfaceAction(ctx, "payload-surf-2", "confirm", {
+      environment: "production",
+    });
+    await resultPromise;
+
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+
+    // ── Fields the Swift UiSurfaceCompleteMessage struct decodes ──
+    expect(completeMsg!.type).toBe("ui_surface_complete");
+    expect(completeMsg!.conversationId).toBe("payload-test-conv");
+    expect(completeMsg!.surfaceId).toBe("payload-surf-2");
+    expect(typeof completeMsg!.summary).toBe("string");
+    expect(completeMsg!.summary).toBe('User chose: "Deploy"');
+    // submittedData should contain the action data from the user click
+    expect(completeMsg!.submittedData).toEqual({ environment: "production" });
+  });
+
+  test("ui_surface_complete payload on cancel matches UiSurfaceCompleteMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: {
+          message: "Discard changes?",
+          cancelLabel: "Keep editing",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-3",
+    );
+
+    ctx.sentMessages.length = 0;
+
+    await handleSurfaceAction(ctx, "payload-surf-3", "cancel");
+    await resultPromise;
+
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+
+    expect(completeMsg!.type).toBe("ui_surface_complete");
+    expect(completeMsg!.conversationId).toBe("payload-test-conv");
+    expect(completeMsg!.surfaceId).toBe("payload-surf-3");
+    expect(completeMsg!.summary).toBe('User chose: "Keep editing"');
+    // No submittedData on cancel without explicit data
+    expect(completeMsg!.submittedData).toBeUndefined();
+  });
+
+  test("ui_surface_complete on timeout matches UiSurfaceCompleteMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "Quick confirm" },
+        timeoutMs: 50,
+      },
+      "payload-surf-4",
+    );
+
+    await resultPromise;
+
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+
+    expect(completeMsg!.type).toBe("ui_surface_complete");
+    expect(completeMsg!.conversationId).toBe("payload-test-conv");
+    expect(completeMsg!.surfaceId).toBe("payload-surf-4");
+    expect(completeMsg!.summary).toBe("Timed out");
+    // No submittedData on timeout
+    expect(completeMsg!).not.toHaveProperty("submittedData");
+  });
+});
+
+// ── Form surface payload shapes ──────────────────────────────────────
+
+describe("standalone form surface payload shapes", () => {
+  test("ui_surface_show payload for form matches UiSurfaceShowMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Configure settings",
+        data: {
+          description: "Adjust your preferences below.",
+          fields: [
+            {
+              id: "name",
+              type: "text",
+              label: "Display Name",
+              placeholder: "Enter your name",
+              required: true,
+            },
+            {
+              id: "theme",
+              type: "select",
+              label: "Theme",
+              options: [
+                { label: "Light", value: "light" },
+                { label: "Dark", value: "dark" },
+              ],
+              defaultValue: "dark",
+            },
+            {
+              id: "notifications",
+              type: "toggle",
+              label: "Enable notifications",
+              defaultValue: true,
+            },
+          ],
+          submitLabel: "Save",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-form-1",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    expect(showMsg).toBeDefined();
+
+    // ── Core wire fields ──
+    expect(showMsg!.type).toBe("ui_surface_show");
+    expect(showMsg!.conversationId).toBe("payload-test-conv");
+    expect(showMsg!.surfaceId).toBe("payload-surf-form-1");
+    expect(showMsg!.surfaceType).toBe("form");
+    expect(showMsg!.title).toBe("Configure settings");
+    expect(showMsg!.display).toBe("inline");
+
+    // ── data field: FormSurfaceData ──
+    const data = showMsg!.data as AnyRecord;
+    expect(data.description).toBe("Adjust your preferences below.");
+    expect(data.submitLabel).toBe("Save");
+
+    const fields = data.fields as Array<AnyRecord>;
+    expect(fields).toHaveLength(3);
+
+    // Text field
+    expect(fields[0].id).toBe("name");
+    expect(fields[0].type).toBe("text");
+    expect(fields[0].label).toBe("Display Name");
+    expect(fields[0].placeholder).toBe("Enter your name");
+    expect(fields[0].required).toBe(true);
+
+    // Select field
+    expect(fields[1].id).toBe("theme");
+    expect(fields[1].type).toBe("select");
+    expect(fields[1].label).toBe("Theme");
+    expect(fields[1].options).toEqual([
+      { label: "Light", value: "light" },
+      { label: "Dark", value: "dark" },
+    ]);
+    expect(fields[1].defaultValue).toBe("dark");
+
+    // Toggle field
+    expect(fields[2].id).toBe("notifications");
+    expect(fields[2].type).toBe("toggle");
+    expect(fields[2].label).toBe("Enable notifications");
+    expect(fields[2].defaultValue).toBe(true);
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-form-1", "submit", {
+      name: "Alice",
+    });
+    await resultPromise;
+  });
+
+  test("ui_surface_complete payload on form submit matches UiSurfaceCompleteMessage contract", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "User info",
+        data: {
+          fields: [
+            { id: "email", type: "text", label: "Email", required: true },
+            { id: "age", type: "number", label: "Age" },
+          ],
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-form-2",
+    );
+
+    ctx.sentMessages.length = 0;
+
+    await handleSurfaceAction(ctx, "payload-surf-form-2", "submit", {
+      email: "alice@example.com",
+      age: 30,
+    });
+    await resultPromise;
+
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+
+    expect(completeMsg!.type).toBe("ui_surface_complete");
+    expect(completeMsg!.conversationId).toBe("payload-test-conv");
+    expect(completeMsg!.surfaceId).toBe("payload-surf-form-2");
+    expect(completeMsg!.summary).toBe("Submitted");
+    expect(completeMsg!.submittedData).toEqual({
+      email: "alice@example.com",
+      age: 30,
+    });
+  });
+
+  test("form dismiss action resolves as cancelled with correct payload", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        data: { fields: [{ id: "x", type: "text", label: "X" }] },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-form-3",
+    );
+
+    ctx.sentMessages.length = 0;
+
+    await handleSurfaceAction(ctx, "payload-surf-form-3", "dismiss");
+    const result = await resultPromise;
+
+    // Standalone result
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("payload-surf-form-3");
+    expect(result.actionId).toBe("dismiss");
+
+    // Client-facing ui_surface_complete
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg!.surfaceId).toBe("payload-surf-form-3");
+    expect(typeof completeMsg!.summary).toBe("string");
+  });
+});
+
+// ── Cross-surface contract invariants ────────────────────────────────
+
+describe("standalone surface contract invariants", () => {
+  test("standalone surfaces never enqueue LLM messages", async () => {
+    const ctx = createMockContext();
+
+    // Confirmation flow
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "Yes?" },
+        timeoutMs: 60_000,
+      },
+      "invariant-surf-1",
+    );
+    await handleSurfaceAction(ctx, "invariant-surf-1", "confirm");
+    await p1;
+
+    // Form flow
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "invariant-surf-2",
+    );
+    await handleSurfaceAction(ctx, "invariant-surf-2", "submit", {
+      val: "test",
+    });
+    await p2;
+
+    // No messages should have been enqueued to the LLM for standalone surfaces
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("every ui_surface_show has required fields for Swift deserialization", async () => {
+    const ctx = createMockContext();
+
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "A?" },
+        timeoutMs: 60_000,
+      },
+      "schema-surf-1",
+    );
+
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "schema-surf-2",
+    );
+
+    const showMessages = findAllByType(ctx.sentMessages, "ui_surface_show");
+    expect(showMessages).toHaveLength(2);
+
+    for (const msg of showMessages) {
+      // Required fields per UiSurfaceShowMessage(Decodable) in MessageTypes.swift:
+      //   conversationId: String? — present (nullable but present)
+      //   surfaceId: String       — required
+      //   surfaceType: String     — required
+      //   data: AnyCodable        — required
+      expect(msg).toHaveProperty("conversationId");
+      expect(typeof msg.surfaceId).toBe("string");
+      expect(typeof msg.surfaceType).toBe("string");
+      expect(msg.data).toBeDefined();
+      expect(msg.data).not.toBeNull();
+    }
+
+    // Cleanup
+    await handleSurfaceAction(ctx, "schema-surf-1", "confirm");
+    await handleSurfaceAction(ctx, "schema-surf-2", "submit", {});
+    await p1;
+    await p2;
+  });
+
+  test("every ui_surface_complete has required fields for Swift deserialization", async () => {
+    const ctx = createMockContext();
+
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "B?" },
+        timeoutMs: 60_000,
+      },
+      "schema-surf-3",
+    );
+    await handleSurfaceAction(ctx, "schema-surf-3", "confirm");
+    await p1;
+
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "schema-surf-4",
+    );
+    await handleSurfaceAction(ctx, "schema-surf-4", "submit", { k: "v" });
+    await p2;
+
+    const completeMessages = findAllByType(
+      ctx.sentMessages,
+      "ui_surface_complete",
+    );
+    expect(completeMessages.length).toBeGreaterThanOrEqual(2);
+
+    for (const msg of completeMessages) {
+      // Required fields per UiSurfaceCompleteMessage(Decodable) in MessageTypes.swift:
+      //   conversationId: String? — present (nullable but present)
+      //   surfaceId: String       — required
+      //   summary: String         — required
+      //   submittedData: [String: AnyCodable]? — optional
+      expect(msg).toHaveProperty("conversationId");
+      expect(typeof msg.surfaceId).toBe("string");
+      expect(typeof msg.summary).toBe("string");
+      expect(msg.summary).not.toBe("");
+    }
+  });
+
+  test("standalone surface cleanup leaves no stale state", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "Clean?" },
+        timeoutMs: 60_000,
+      },
+      "cleanup-surf-1",
+    );
+
+    // Verify state exists before action
+    expect(ctx.pendingStandaloneSurfaces!.has("cleanup-surf-1")).toBe(true);
+    expect(ctx.surfaceState.has("cleanup-surf-1")).toBe(true);
+
+    await handleSurfaceAction(ctx, "cleanup-surf-1", "confirm");
+    await resultPromise;
+
+    // After resolution, all related state maps should be clean
+    expect(ctx.pendingStandaloneSurfaces!.has("cleanup-surf-1")).toBe(false);
+    expect(ctx.surfaceState.has("cleanup-surf-1")).toBe(false);
+    expect(ctx.pendingSurfaceActions.has("cleanup-surf-1")).toBe(false);
+    expect(ctx.lastSurfaceAction.has("cleanup-surf-1")).toBe(false);
+    expect(ctx.accumulatedSurfaceState.has("cleanup-surf-1")).toBe(false);
+    expect(ctx.surfaceUndoStacks.has("cleanup-surf-1")).toBe(false);
+  });
+
+  test("action variant mapping: danger → destructive, unset → secondary", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "confirmation",
+        data: { message: "Variants?" },
+        actions: [
+          { id: "a", label: "Primary", variant: "primary" },
+          { id: "b", label: "Danger", variant: "danger" },
+          { id: "c", label: "Secondary", variant: "secondary" },
+          { id: "d", label: "Default" }, // no variant
+        ],
+        timeoutMs: 60_000,
+      },
+      "variant-surf-1",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    const actions = showMsg!.actions as Array<AnyRecord>;
+
+    // Verify the mapping matches what Swift SurfaceActionButton expects:
+    //   "primary" → "primary"
+    //   "danger" → "destructive"
+    //   "secondary" → "secondary"
+    //   undefined → "secondary" (default)
+    expect(actions[0].style).toBe("primary");
+    expect(actions[1].style).toBe("destructive");
+    expect(actions[2].style).toBe("secondary");
+    expect(actions[3].style).toBe("secondary");
+
+    await handleSurfaceAction(ctx, "variant-surf-1", "a");
+    await resultPromise;
+  });
+});
+
+// ── Completion summary consistency ───────────────────────────────────
+
+describe("buildCompletionSummary for standalone surfaces", () => {
+  test("confirmation confirm with custom label", () => {
+    expect(
+      buildCompletionSummary(
+        "confirmation",
+        "confirm",
+        {},
+        { confirmLabel: "Yes, proceed" },
+      ),
+    ).toBe('User chose: "Yes, proceed"');
+  });
+
+  test("confirmation confirm without custom label", () => {
+    expect(buildCompletionSummary("confirmation", "confirm", {}, {})).toBe(
+      "Confirmed",
+    );
+  });
+
+  test("confirmation cancel with custom label", () => {
+    expect(
+      buildCompletionSummary(
+        "confirmation",
+        "cancel",
+        {},
+        { cancelLabel: "Never mind" },
+      ),
+    ).toBe('User chose: "Never mind"');
+  });
+
+  test("confirmation cancel without custom label", () => {
+    expect(buildCompletionSummary("confirmation", "cancel", {}, {})).toBe(
+      "Cancelled",
+    );
+  });
+
+  test("form submit", () => {
+    expect(buildCompletionSummary("form", "submit", { k: "v" })).toBe(
+      "Submitted",
+    );
+  });
+
+  test("unknown action ID is passed through", () => {
+    expect(buildCompletionSummary("confirmation", "deny", {}, {})).toBe(
+      "User selected: deny",
+    );
+  });
+});

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -1,0 +1,558 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  canShowInteractiveUi,
+  cleanupStandaloneSurface,
+  handleSurfaceAction,
+  showStandaloneSurface,
+  type SurfaceConversationContext,
+} from "../daemon/conversation-surfaces.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal SurfaceConversationContext stub for testing standalone
+ * surface lifecycle. Only the fields accessed by the standalone surface
+ * functions are populated.
+ */
+function createMockContext(
+  overrides?: Partial<{
+    hasNoClient: boolean;
+    supportsDynamicUi: boolean;
+    channel: string;
+  }>,
+): SurfaceConversationContext & {
+  sentMessages: ServerMessage[];
+  enqueuedMessages: Array<{ content: string; requestId: string }>;
+} {
+  const sentMessages: ServerMessage[] = [];
+  const enqueuedMessages: Array<{ content: string; requestId: string }> = [];
+
+  return {
+    conversationId: "test-conv-1",
+    assistantId: undefined,
+    trustContext: undefined,
+    channelCapabilities: overrides?.channel
+      ? {
+          channel: overrides.channel,
+          supportsDynamicUi: overrides.supportsDynamicUi ?? true,
+        }
+      : undefined,
+    traceEmitter: {
+      emit: () => {},
+    },
+    sendToClient: (msg: ServerMessage) => sentMessages.push(msg),
+    broadcastToAllClients: (msg: ServerMessage) => sentMessages.push(msg),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set(),
+    pendingStandaloneSurfaces: new Map(),
+    currentTurnSurfaces: [],
+    hostCuProxy: undefined,
+    hasNoClient: overrides?.hasNoClient ?? false,
+    isProcessing: () => false,
+    enqueueMessage: (content, _attachments, _onEvent, requestId) => {
+      enqueuedMessages.push({ content, requestId });
+      return { queued: false, requestId };
+    },
+    getQueueDepth: () => 0,
+    processMessage: async () => "msg-id",
+    withSurface: async <T>(_surfaceId: string, fn: () => T | Promise<T>) =>
+      fn(),
+    sentMessages,
+    enqueuedMessages,
+  };
+}
+
+// ── canShowInteractiveUi ─────────────────────────────────────────────
+
+describe("canShowInteractiveUi", () => {
+  test("returns true when client is connected and no channel caps", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when hasNoClient is true", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: true,
+        channelCapabilities: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when channel does not support dynamic UI", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: { channel: "sms", supportsDynamicUi: false },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when channel supports dynamic UI", () => {
+    expect(
+      canShowInteractiveUi({
+        hasNoClient: false,
+        channelCapabilities: { channel: "web", supportsDynamicUi: true },
+      }),
+    ).toBe(true);
+  });
+});
+
+// ── showStandaloneSurface ────────────────────────────────────────────
+
+describe("showStandaloneSurface", () => {
+  let timers: ReturnType<typeof setTimeout>[] = [];
+
+  beforeEach(() => {
+    timers = [];
+  });
+
+  afterEach(() => {
+    // Safety cleanup of any lingering timers
+    for (const t of timers) clearTimeout(t);
+  });
+
+  test("fails closed when no client is connected", async () => {
+    const ctx = createMockContext({ hasNoClient: true });
+    const result = await showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Are you sure?" },
+      },
+      "surf-1",
+    );
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("surf-1");
+    // No ui_surface_show should have been emitted
+    expect(ctx.sentMessages).toHaveLength(0);
+    // No pending entries
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("fails closed when channel does not support dynamic UI", async () => {
+    const ctx = createMockContext({ channel: "sms", supportsDynamicUi: false });
+    const result = await showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Are you sure?" },
+      },
+      "surf-2",
+    );
+
+    expect(result.status).toBe("cancelled");
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("emits ui_surface_show and registers pending entry", async () => {
+    const ctx = createMockContext();
+
+    // Start the surface request (it will block until action or timeout)
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        title: "Confirm action",
+        data: { message: "Are you sure?" },
+        actions: [
+          { id: "confirm", label: "Yes", variant: "primary" },
+          { id: "cancel", label: "No", variant: "secondary" },
+        ],
+        timeoutMs: 60_000,
+      },
+      "surf-3",
+    );
+
+    // Pending entry should be registered
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-3")).toBe(true);
+    // Surface state should be stored
+    expect(ctx.surfaceState.has("surf-3")).toBe(true);
+    // ui_surface_show should have been emitted
+    expect(ctx.sentMessages.length).toBeGreaterThanOrEqual(1);
+    const showMsg = ctx.sentMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type === "ui_surface_show",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(showMsg).toBeDefined();
+    expect(showMsg?.surfaceId).toBe("surf-3");
+    expect(showMsg?.surfaceType).toBe("confirmation");
+    expect(showMsg?.title).toBe("Confirm action");
+
+    // Resolve by simulating user action via handleSurfaceAction
+    await handleSurfaceAction(ctx, "surf-3", "confirm", {});
+
+    const result = await resultPromise;
+    expect(result.status).toBe("submitted");
+    expect(result.surfaceId).toBe("surf-3");
+    expect(result.actionId).toBe("confirm");
+  });
+
+  test("resolves with submitted status on confirm action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-4",
+    );
+
+    await handleSurfaceAction(ctx, "surf-4", "confirm", { extra: "data" });
+    const result = await resultPromise;
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.submittedData).toEqual({ extra: "data" });
+  });
+
+  test("resolves with cancelled status on cancel action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-5",
+    );
+
+    await handleSurfaceAction(ctx, "surf-5", "cancel");
+    const result = await resultPromise;
+
+    expect(result.status).toBe("cancelled");
+    expect(result.actionId).toBe("cancel");
+  });
+
+  test("resolves with timed_out status on timeout", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50, // Very short timeout for test
+      },
+      "surf-6",
+    );
+
+    const result = await resultPromise;
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("surf-6");
+  });
+
+  test("timeout emits ui_surface_complete to dismiss the client surface", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50, // Very short timeout for test
+      },
+      "surf-6b",
+    );
+
+    await resultPromise;
+
+    // The timeout handler should emit ui_surface_complete so the client
+    // dismisses the surface and prevents stale interactions.
+    const completeMsg = ctx.sentMessages.find((m) => {
+      const r = m as unknown as Record<string, unknown>;
+      return r.type === "ui_surface_complete" && r.surfaceId === "surf-6b";
+    }) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.conversationId).toBe("test-conv-1");
+    expect(completeMsg?.summary).toBe("Timed out");
+  });
+
+  test("late action after timeout is silently dropped — not forwarded to LLM", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50,
+      },
+      "surf-6c",
+    );
+
+    // Wait for timeout to fire
+    const result = await resultPromise;
+    expect(result.status).toBe("timed_out");
+
+    // Now simulate a late user click after the surface has timed out.
+    // Since the timeout handler emits ui_surface_complete, the client should
+    // not send this — but if it does, it must NOT trigger an LLM follow-up.
+    // Because the surface was cleaned up AND there is no pendingSurfaceActions
+    // entry, handleSurfaceAction falls through to the history-restored path
+    // which would enqueue a message to the LLM. Verify that doesn't happen
+    // because the client-side dismiss prevents the click from arriving. The
+    // key invariant is that cleanup + client dismiss together prevent stale turns.
+    //
+    // Verify the server-side state is fully cleaned up after timeout.
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-6c")).toBe(false);
+    expect(ctx.surfaceState.has("surf-6c")).toBe(false);
+    expect(ctx.pendingSurfaceActions.has("surf-6c")).toBe(false);
+    // No messages should have been enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("consumed callback does NOT trigger LLM follow-up", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-7",
+    );
+
+    await handleSurfaceAction(ctx, "surf-7", "confirm");
+    await resultPromise;
+
+    // Verify no messages were enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("emits ui_surface_complete on user action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-8",
+    );
+
+    await handleSurfaceAction(ctx, "surf-8", "confirm", { answer: "yes" });
+    await resultPromise;
+
+    const completeMsg = ctx.sentMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+        "ui_surface_complete",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.surfaceId).toBe("surf-8");
+    expect(completeMsg?.conversationId).toBe("test-conv-1");
+  });
+});
+
+// ── cleanupStandaloneSurface ─────────────────────────────────────────
+
+describe("cleanupStandaloneSurface", () => {
+  test("clears timer, pending entry, and all surface state", () => {
+    const ctx = createMockContext();
+    const timer = setTimeout(() => {}, 60_000);
+
+    ctx.pendingStandaloneSurfaces!.set("surf-c1", {
+      resolve: () => {},
+      timer,
+      surfaceType: "confirmation",
+    });
+    ctx.surfaceState.set("surf-c1", {
+      surfaceType: "confirmation",
+      data: { message: "test" } as never,
+    });
+    ctx.pendingSurfaceActions.set("surf-c1", { surfaceType: "confirmation" });
+    ctx.lastSurfaceAction.set("surf-c1", { actionId: "confirm" });
+    ctx.accumulatedSurfaceState.set("surf-c1", { key: "val" });
+    ctx.surfaceUndoStacks.set("surf-c1", ["old"]);
+
+    cleanupStandaloneSurface(ctx, "surf-c1");
+
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-c1")).toBe(false);
+    expect(ctx.surfaceState.has("surf-c1")).toBe(false);
+    expect(ctx.pendingSurfaceActions.has("surf-c1")).toBe(false);
+    expect(ctx.lastSurfaceAction.has("surf-c1")).toBe(false);
+    expect(ctx.accumulatedSurfaceState.has("surf-c1")).toBe(false);
+    expect(ctx.surfaceUndoStacks.has("surf-c1")).toBe(false);
+
+    // Cleanup the timer ourselves for the test
+    clearTimeout(timer);
+  });
+
+  test("is idempotent — safe to call multiple times", () => {
+    const ctx = createMockContext();
+    // Call on a surfaceId that was never registered
+    cleanupStandaloneSurface(ctx, "nonexistent");
+    // No error should be thrown, no state should change
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+    expect(ctx.surfaceState.size).toBe(0);
+  });
+});
+
+// ── Cleanup on dispose path ──────────────────────────────────────────
+
+describe("standalone surface cleanup on conversation dispose", () => {
+  test("all pending standalone surfaces are cancelled on dispose", async () => {
+    const ctx = createMockContext();
+    const results: InteractiveUiResult[] = [];
+
+    // Start two standalone surfaces
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "First?" },
+        timeoutMs: 60_000,
+      },
+      "surf-d1",
+    );
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "surf-d2",
+    );
+
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(2);
+
+    // Simulate conversation dispose — cancel all pending with dismiss
+    // notifications, matching the Conversation.dispose() implementation.
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    for (const [surfaceId, entry] of ctx.pendingStandaloneSurfaces!) {
+      clearTimeout(entry.timer);
+      emit({
+        type: "ui_surface_dismiss",
+        conversationId: ctx.conversationId,
+        surfaceId,
+      });
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    ctx.pendingStandaloneSurfaces!.clear();
+
+    results.push(await p1, await p2);
+
+    expect(results[0].status).toBe("cancelled");
+    expect(results[0].surfaceId).toBe("surf-d1");
+    expect(results[1].status).toBe("cancelled");
+    expect(results[1].surfaceId).toBe("surf-d2");
+    expect(ctx.pendingStandaloneSurfaces!.size).toBe(0);
+  });
+
+  test("dispose emits ui_surface_dismiss for each pending surface", async () => {
+    const ctx = createMockContext();
+
+    // Start two standalone surfaces
+    const p1 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "First?" },
+        timeoutMs: 60_000,
+      },
+      "surf-d3",
+    );
+    const p2 = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        data: { fields: [] },
+        timeoutMs: 60_000,
+      },
+      "surf-d4",
+    );
+
+    // Clear sentMessages so we only see dispose-related messages
+    ctx.sentMessages.length = 0;
+
+    // Simulate the dispose path (matching Conversation.dispose())
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    for (const [surfaceId, entry] of ctx.pendingStandaloneSurfaces!) {
+      clearTimeout(entry.timer);
+      emit({
+        type: "ui_surface_dismiss",
+        conversationId: ctx.conversationId,
+        surfaceId,
+      });
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    ctx.pendingStandaloneSurfaces!.clear();
+
+    await p1;
+    await p2;
+
+    // Verify a ui_surface_dismiss was emitted for each surface
+    const dismissMessages = ctx.sentMessages.filter(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type === "ui_surface_dismiss",
+    ) as unknown as Array<Record<string, unknown>>;
+    expect(dismissMessages).toHaveLength(2);
+    const dismissedIds = dismissMessages.map((m) => m.surfaceId).sort();
+    expect(dismissedIds).toEqual(["surf-d3", "surf-d4"]);
+  });
+});
+
+// ── Form surface type ────────────────────────────────────────────────
+
+describe("standalone form surface", () => {
+  test("resolves with submitted data on submit action", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "form",
+        title: "Enter details",
+        data: {
+          fields: [{ id: "name", type: "text", label: "Name", required: true }],
+        },
+        timeoutMs: 60_000,
+      },
+      "surf-f1",
+    );
+
+    // Verify surface state was created correctly for form type
+    const state = ctx.surfaceState.get("surf-f1");
+    expect(state?.surfaceType).toBe("form");
+
+    await handleSurfaceAction(ctx, "surf-f1", "submit", { name: "Alice" });
+    const result = await resultPromise;
+
+    expect(result.status).toBe("submitted");
+    expect(result.submittedData).toEqual({ name: "Alice" });
+
+    // Cleanup should be complete
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-f1")).toBe(false);
+    expect(ctx.surfaceState.has("surf-f1")).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -288,6 +288,43 @@ describe("showStandaloneSurface", () => {
     expect(completeMsg?.summary).toBe("Timed out");
   });
 
+  test("timeout still resolves when emit throws", async () => {
+    const ctx = createMockContext();
+    // Override broadcastToAllClients to throw on ui_surface_complete
+    let showEmitted = false;
+    ctx.broadcastToAllClients = (msg: ServerMessage) => {
+      const type = (msg as unknown as Record<string, unknown>).type;
+      if (type === "ui_surface_show") {
+        showEmitted = true;
+        ctx.sentMessages.push(msg);
+        return;
+      }
+      if (type === "ui_surface_complete") {
+        throw new Error("emit failed");
+      }
+    };
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Quick!" },
+        timeoutMs: 50,
+      },
+      "surf-emit-err",
+    );
+
+    const result = await resultPromise;
+    expect(showEmitted).toBe(true);
+    // Despite the emit error, the promise should resolve with timed_out
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("surf-emit-err");
+    // Cleanup should still have happened
+    expect(ctx.pendingStandaloneSurfaces!.has("surf-emit-err")).toBe(false);
+    expect(ctx.surfaceState.has("surf-emit-err")).toBe(false);
+  });
+
   test("late action after timeout is silently dropped — not forwarded to LLM", async () => {
     const ctx = createMockContext();
     const resultPromise = showStandaloneSurface(

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -52,6 +52,7 @@ function createMockContext(
     accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set(),
     pendingStandaloneSurfaces: new Map(),
+    recentlyCompletedStandaloneSurfaces: new Map(),
     currentTurnSurfaces: [],
     hostCuProxy: undefined,
     hasNoClient: overrides?.hasNoClient ?? false,
@@ -342,19 +343,47 @@ describe("showStandaloneSurface", () => {
     const result = await resultPromise;
     expect(result.status).toBe("timed_out");
 
-    // Now simulate a late user click after the surface has timed out.
-    // Since the timeout handler emits ui_surface_complete, the client should
-    // not send this — but if it does, it must NOT trigger an LLM follow-up.
-    // Because the surface was cleaned up AND there is no pendingSurfaceActions
-    // entry, handleSurfaceAction falls through to the history-restored path
-    // which would enqueue a message to the LLM. Verify that doesn't happen
-    // because the client-side dismiss prevents the click from arriving. The
-    // key invariant is that cleanup + client dismiss together prevent stale turns.
-    //
     // Verify the server-side state is fully cleaned up after timeout.
     expect(ctx.pendingStandaloneSurfaces!.has("surf-6c")).toBe(false);
     expect(ctx.surfaceState.has("surf-6c")).toBe(false);
     expect(ctx.pendingSurfaceActions.has("surf-6c")).toBe(false);
+
+    // The surfaceId should now be in the tombstone set.
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-6c")).toBe(true);
+
+    // Now simulate a late user click after the surface has timed out.
+    // Without the tombstone guard, this would fall through to the
+    // history-restored path and enqueue a message to the LLM.
+    await handleSurfaceAction(ctx, "surf-6c", "confirm", {});
+
+    // No messages should have been enqueued to the LLM
+    expect(ctx.enqueuedMessages).toHaveLength(0);
+  });
+
+  test("late action after user-resolved surface is silently dropped", async () => {
+    const ctx = createMockContext();
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "test-conv-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      "surf-6d",
+    );
+
+    // User confirms — resolves the surface
+    await handleSurfaceAction(ctx, "surf-6d", "confirm");
+    const result = await resultPromise;
+    expect(result.status).toBe("submitted");
+
+    // Tombstone should be recorded
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-6d")).toBe(true);
+
+    // A duplicate/late click arrives — must be silently dropped
+    await handleSurfaceAction(ctx, "surf-6d", "confirm", {});
+
     // No messages should have been enqueued to the LLM
     expect(ctx.enqueuedMessages).toHaveLength(0);
   });
@@ -436,8 +465,14 @@ describe("cleanupStandaloneSurface", () => {
     expect(ctx.accumulatedSurfaceState.has("surf-c1")).toBe(false);
     expect(ctx.surfaceUndoStacks.has("surf-c1")).toBe(false);
 
-    // Cleanup the timer ourselves for the test
+    // Tombstone should be recorded for the completed surface
+    expect(ctx.recentlyCompletedStandaloneSurfaces!.has("surf-c1")).toBe(true);
+
+    // Cleanup the timer and tombstone timer ourselves for the test
     clearTimeout(timer);
+    const tombstoneTimer =
+      ctx.recentlyCompletedStandaloneSurfaces!.get("surf-c1");
+    if (tombstoneTimer) clearTimeout(tombstoneTimer);
   });
 
   test("is idempotent — safe to call multiple times", () => {

--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Tests for the `assistant ui confirm` CLI command.
+ *
+ * Validates:
+ *   - Confirmation surface shape (actions, surfaceType)
+ *   - Exit code: 0 on confirm, 1 on deny/cancel/timeout
+ *   - --title, --message, --confirm-label, --deny-label mapping
+ *   - --json output contract: { ok, confirmed, status, actionId, surfaceId }
+ *   - Conversation ID resolution (same as ui request)
+ *   - IPC error handling
+ */
+
+import { existsSync as actualExistsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: { timeoutMs?: number };
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = {
+  ok: true,
+  result: {
+    status: "submitted",
+    actionId: "confirm",
+    surfaceId: "test-surface-1",
+  },
+};
+
+/** Saved env for restoration. */
+let savedEnv: Record<string, string | undefined> = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: () => {
+    throw new Error("ui confirm should not read stdin");
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerUiCommand } = await import("../ui.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerUiCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: {
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "test-surface-1",
+    },
+  };
+  process.exitCode = 0;
+
+  savedEnv = {
+    __SKILL_CONTEXT_JSON: process.env.__SKILL_CONTEXT_JSON,
+  };
+  // Set a default skill context so tests don't need to repeat it
+  process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+    conversationId: "conv-default",
+  });
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Confirmation surface shape
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — surface shape", () => {
+  test("sends confirmation surfaceType with confirm/deny actions", async () => {
+    await runCommand(["ui", "confirm", "--message", "Delete?"]);
+
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("ui_request");
+    expect(lastIpcCall!.params!.surfaceType).toBe("confirmation");
+    expect(lastIpcCall!.params!.actions).toEqual([
+      { id: "confirm", label: "Confirm", variant: "primary" },
+      { id: "deny", label: "Deny", variant: "secondary" },
+    ]);
+  });
+
+  test("maps --message to data.message", async () => {
+    await runCommand(["ui", "confirm", "--message", "Are you sure?"]);
+
+    expect(lastIpcCall!.params!.data).toEqual({
+      message: "Are you sure?",
+      confirmLabel: "Confirm",
+      cancelLabel: "Deny",
+    });
+  });
+
+  test("maps --title to IPC title param", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--title",
+      "Danger",
+      "--message",
+      "Really?",
+    ]);
+
+    expect(lastIpcCall!.params!.title).toBe("Danger");
+  });
+
+  test("uses custom --confirm-label and --deny-label in actions", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "Continue?",
+      "--confirm-label",
+      "Yes",
+      "--deny-label",
+      "No",
+    ]);
+
+    expect(lastIpcCall!.params!.actions).toEqual([
+      { id: "confirm", label: "Yes", variant: "primary" },
+      { id: "deny", label: "No", variant: "secondary" },
+    ]);
+  });
+
+  test("passes custom labels in data.confirmLabel and data.cancelLabel", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "Continue?",
+      "--confirm-label",
+      "Yes",
+      "--deny-label",
+      "No",
+    ]);
+
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Yes");
+    expect(data.cancelLabel).toBe("No");
+  });
+
+  test("passes default labels in data.confirmLabel and data.cancelLabel", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Confirm");
+    expect(data.cancelLabel).toBe("Deny");
+  });
+
+  test("includes confirmLabel and cancelLabel in data even when --message is omitted", async () => {
+    await runCommand(["ui", "confirm"]);
+
+    const data = lastIpcCall!.params!.data as Record<string, unknown>;
+    expect(data.confirmLabel).toBe("Confirm");
+    expect(data.cancelLabel).toBe("Deny");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit code behavior
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — exit codes", () => {
+  test("exits 0 when user confirms", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-1",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 when user denies", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "deny",
+        surfaceId: "s-2",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when request is cancelled", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "cancelled",
+        surfaceId: "s-3",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when request times out", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "timed_out",
+        surfaceId: "s-4",
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 on IPC error", async () => {
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — JSON output", () => {
+  test("outputs { ok: true, confirmed: true } on confirm", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-1",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({
+      ok: true,
+      confirmed: true,
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "s-1",
+    });
+  });
+
+  test("outputs { ok: true, confirmed: false } on deny", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "deny",
+        surfaceId: "s-2",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.confirmed).toBe(false);
+    expect(parsed.status).toBe("submitted");
+    expect(parsed.actionId).toBe("deny");
+  });
+
+  test("outputs { ok: true, confirmed: false } on timeout", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "timed_out",
+        surfaceId: "s-3",
+      },
+    };
+
+    const { stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.confirmed).toBe(false);
+    expect(parsed.status).toBe("timed_out");
+  });
+
+  test("outputs { ok: false, error } on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Daemon not running" };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: false, error: "Daemon not running" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation ID resolution
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — conversation ID", () => {
+  test("uses explicit --conversation-id", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--conversation-id",
+      "explicit-conv",
+    ]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("explicit-conv");
+  });
+
+  test("falls back to __SKILL_CONTEXT_JSON", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("conv-default");
+  });
+
+  test("errors when no conversation ID is available", async () => {
+    delete process.env.__SKILL_CONTEXT_JSON;
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout configuration
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — timeout", () => {
+  test("passes --timeout to IPC params", async () => {
+    await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "30000",
+    ]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(30_000);
+    expect(lastIpcCall!.options!.timeoutMs).toBe(40_000); // +10s buffer
+  });
+
+  test("uses default timeout when --timeout is omitted", async () => {
+    await runCommand(["ui", "confirm", "--message", "OK?"]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(300_000);
+    expect(lastIpcCall!.options!.timeoutMs).toBe(310_000);
+  });
+
+  test("rejects --timeout with trailing non-digit characters like '30s'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "30s",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with scientific notation like '1e3'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--timeout",
+      "1e3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation ID discovery hint
+// ---------------------------------------------------------------------------
+
+describe("ui confirm — conversation ID discovery hint", () => {
+  test("error message mentions 'assistant conversations list'", async () => {
+    delete process.env.__SKILL_CONTEXT_JSON;
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("assistant conversations list");
+  });
+});

--- a/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui-confirm.test.ts
@@ -449,6 +449,79 @@ describe("ui confirm — JSON output", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual({ ok: false, error: "Daemon not running" });
   });
+
+  test("includes decisionToken in JSON output when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-token",
+        decisionToken: "eyJ0ZXN0IjoidG9rZW4ifQ.abc123",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.decisionToken).toBe("eyJ0ZXN0IjoidG9rZW4ifQ.abc123");
+  });
+
+  test("includes summary in JSON output when present", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-summary",
+        summary: "User confirmed deployment",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.summary).toBe("User confirmed deployment");
+  });
+
+  test("omits decisionToken and summary from JSON when absent", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "s-no-extras",
+      },
+    };
+
+    const { stdout } = await runCommand([
+      "ui",
+      "confirm",
+      "--message",
+      "OK?",
+      "--json",
+    ]);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.decisionToken).toBeUndefined();
+    expect(parsed.summary).toBeUndefined();
+    expect("decisionToken" in parsed).toBe(false);
+    expect("summary" in parsed).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -1,0 +1,698 @@
+/**
+ * Tests for the `assistant ui request` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration (request, confirm)
+ *   - Payload parsing from --payload flag and stdin
+ *   - Conversation ID resolution (explicit, __SKILL_CONTEXT_JSON, missing)
+ *   - IPC param mapping (surfaceType, title, timeoutMs)
+ *   - IPC timeout budget (request timeout + buffer)
+ *   - JSON output shape for success and error
+ *   - Exit code behavior on IPC errors
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: { timeoutMs?: number };
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = {
+  ok: true,
+  result: {
+    status: "submitted",
+    actionId: "confirm",
+    surfaceId: "test-surface-1",
+  },
+};
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+/** Whether to simulate stdin as a TTY (no piped input). */
+let mockStdinIsTTY: boolean = false;
+
+/** Saved env for restoration. */
+let savedEnv: Record<string, string | undefined> = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ) => {
+    lastIpcCall = { method, params, options };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerUiCommand } = await import("../ui.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const localStderrChunks: string[] = [];
+
+  const originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: mockStdinIsTTY ? true : undefined,
+    configurable: true,
+  });
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    localStderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerUiCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: localStderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = {
+    ok: true,
+    result: {
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "test-surface-1",
+    },
+  };
+  mockStdinContent = null;
+  mockStdinIsTTY = false;
+  process.exitCode = 0;
+
+  // Save and clear env
+  savedEnv = {
+    __SKILL_CONTEXT_JSON: process.env.__SKILL_CONTEXT_JSON,
+  };
+  delete process.env.__SKILL_CONTEXT_JSON;
+});
+
+// Restore env after each test
+import { afterEach } from "bun:test";
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe("subcommand registration", () => {
+  test("registers request and confirm subcommands under ui", () => {
+    const program = new Command();
+    registerUiCommand(program);
+    const ui = program.commands.find((c) => c.name() === "ui");
+    expect(ui).toBeDefined();
+    const subcommandNames = ui!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual(["confirm", "request"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — payload parsing
+// ---------------------------------------------------------------------------
+
+describe("ui request — payload parsing", () => {
+  test("parses --payload flag and sends ui_request IPC", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"message":"Proceed?"}',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("ui_request");
+    expect(lastIpcCall!.params!.data).toEqual({ message: "Proceed?" });
+  });
+
+  test("parses JSON from stdin when no --payload flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinContent = '{"message":"From stdin"}';
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.data).toEqual({ message: "From stdin" });
+  });
+
+  test("errors on invalid JSON in --payload", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      "{bad json}",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(
+      (await runCommand(["ui", "request", "--payload", "{bad}", "--json"]))
+        .stdout,
+    );
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON");
+  });
+
+  test("errors on non-object --payload (array)", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      "[1,2,3]",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("JSON object");
+  });
+
+  test("errors on TTY stdin with no --payload", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinIsTTY = true;
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("errors on empty stdin", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-123",
+    });
+    mockStdinContent = "   ";
+
+    const { exitCode } = await runCommand(["ui", "request"]);
+
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — conversation ID resolution
+// ---------------------------------------------------------------------------
+
+describe("ui request — conversation ID resolution", () => {
+  test("uses explicit --conversation-id over env", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "from-env",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--conversation-id",
+      "explicit-id",
+    ]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("explicit-id");
+  });
+
+  test("falls back to __SKILL_CONTEXT_JSON.conversationId", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "skill-conv-42",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("skill-conv-42");
+  });
+
+  test("errors when no conversation ID is available", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+
+  test("errors when __SKILL_CONTEXT_JSON is invalid JSON", async () => {
+    process.env.__SKILL_CONTEXT_JSON = "not-valid-json";
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+
+  test("errors when __SKILL_CONTEXT_JSON has no conversationId field", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({ workingDir: "/tmp" });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No conversation ID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — IPC param mapping
+// ---------------------------------------------------------------------------
+
+describe("ui request — IPC param mapping", () => {
+  test("passes surfaceType from --surface-type flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"fields":[]}',
+      "--surface-type",
+      "form",
+    ]);
+
+    expect(lastIpcCall!.params!.surfaceType).toBe("form");
+  });
+
+  test("defaults surfaceType to confirmation", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.surfaceType).toBe("confirmation");
+  });
+
+  test("passes title from --title flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--title",
+      "Important",
+    ]);
+
+    expect(lastIpcCall!.params!.title).toBe("Important");
+  });
+
+  test("does not include title when --title is omitted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.title).toBeUndefined();
+  });
+
+  test("passes timeoutMs from --timeout flag", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "60000",
+    ]);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(60_000);
+  });
+
+  test("uses default timeoutMs when --timeout is omitted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand(["ui", "request", "--payload", '{"msg":"test"}']);
+
+    expect(lastIpcCall!.params!.timeoutMs).toBe(300_000);
+  });
+
+  test("IPC call timeout = request timeout + 10s buffer", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "60000",
+    ]);
+
+    expect(lastIpcCall!.options!.timeoutMs).toBe(70_000);
+  });
+
+  test("errors on invalid --timeout value", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "abc",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with trailing non-digit characters like '30s'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "30s",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with scientific notation like '1e3'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "1e3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+
+  test("rejects --timeout with decimal like '12.5'", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--timeout",
+      "12.5",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — output
+// ---------------------------------------------------------------------------
+
+describe("ui request — output", () => {
+  test("--json outputs full result on success", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = {
+      ok: true,
+      result: {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "surface-abc",
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.status).toBe("submitted");
+    expect(parsed.actionId).toBe("confirm");
+    expect(parsed.surfaceId).toBe("surface-abc");
+  });
+
+  test("--json outputs error on IPC failure", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = { ok: false, error: "Connection refused" };
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Connection refused");
+  });
+
+  test("exits 0 on successful IPC result", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = {
+      ok: true,
+      result: { status: "cancelled", surfaceId: "s-1" },
+    };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    // ui request exits 0 on any successful IPC result (even cancelled/timed_out),
+    // because it reports the status — it's ui confirm that gates on actionId
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 on IPC error", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+    mockIpcResult = { ok: false, error: "timeout" };
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui request — conversation ID discovery hint
+// ---------------------------------------------------------------------------
+
+describe("ui request — conversation ID discovery hint", () => {
+  test("error message mentions 'assistant conversations list'", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("assistant conversations list");
+  });
+});

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -499,15 +499,20 @@ Examples:
         const confirmed = r.status === "submitted" && r.actionId === "confirm";
 
         if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({
-              ok: true,
-              confirmed,
-              status: r.status,
-              actionId: r.actionId,
-              surfaceId: r.surfaceId,
-            }) + "\n",
-          );
+          const jsonOut: Record<string, unknown> = {
+            ok: true,
+            confirmed,
+            status: r.status,
+            actionId: r.actionId,
+            surfaceId: r.surfaceId,
+          };
+          if (r.decisionToken !== undefined) {
+            jsonOut.decisionToken = r.decisionToken;
+          }
+          if (r.summary !== undefined) {
+            jsonOut.summary = r.summary;
+          }
+          process.stdout.write(JSON.stringify(jsonOut) + "\n");
         } else {
           if (confirmed) {
             log.info("Confirmed.");

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -1,0 +1,528 @@
+/**
+ * `assistant ui` CLI namespace.
+ *
+ * Subcommands:
+ *   - `assistant ui request`  — Present an arbitrary interactive surface to
+ *     the user and block until they respond. Input is a JSON payload
+ *     describing the surface (via `--payload` or stdin).
+ *   - `assistant ui confirm`  — Convenience wrapper that presents a yes/no
+ *     confirmation prompt and exits 0 on confirm, 1 on deny/cancel/timeout.
+ *
+ * Both commands delegate to the daemon's `ui_request` IPC method, which
+ * manages the surface lifecycle on the active conversation.
+ */
+
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { InteractiveUiResult } from "../../runtime/interactive-ui.js";
+import { log } from "../logger.js";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/**
+ * Default request timeout in milliseconds (5 minutes). This is the time
+ * the daemon will wait for the user to respond before the surface
+ * auto-cancels with `status: "timed_out"`.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
+
+/**
+ * Extra buffer added to the IPC call timeout beyond the request timeout
+ * so the IPC socket stays open long enough for the daemon to resolve the
+ * surface and send the response.
+ */
+const IPC_TIMEOUT_BUFFER_MS = 10_000; // 10s
+
+// ── Conversation ID resolution ────────────────────────────────────────
+
+/**
+ * Resolve the conversation ID by precedence:
+ *   1. Explicit `--conversation-id` flag
+ *   2. `__SKILL_CONTEXT_JSON` env var (set by skill sandbox runner)
+ *   3. Fail with an actionable error
+ */
+function resolveConversationId(explicit?: string): string {
+  if (explicit) return explicit;
+
+  const contextJson = process.env.__SKILL_CONTEXT_JSON;
+  if (contextJson) {
+    try {
+      const parsed = JSON.parse(contextJson);
+      if (parsed.conversationId && typeof parsed.conversationId === "string") {
+        return parsed.conversationId;
+      }
+    } catch {
+      // Fall through to the error below.
+    }
+  }
+
+  throw new Error(
+    "No conversation ID available.\n" +
+      "Provide --conversation-id explicitly (run 'assistant conversations list' to find it),\n" +
+      "or run this command from a skill context where __SKILL_CONTEXT_JSON is set.",
+  );
+}
+
+// ── Payload parsing ───────────────────────────────────────────────────
+
+/**
+ * Read a JSON payload from either the `--payload` flag or stdin.
+ * Returns the parsed object. Throws on invalid input.
+ */
+function readPayload(payloadFlag?: string): Record<string, unknown> {
+  if (payloadFlag) {
+    try {
+      const parsed = JSON.parse(payloadFlag);
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error(
+          "--payload must be a JSON object (not array or primitive).",
+        );
+      }
+      return parsed as Record<string, unknown>;
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(
+          `Invalid JSON in --payload: ${err.message}\n` +
+            '  Example: --payload \'{"message":"Are you sure?"}\'',
+        );
+      }
+      throw err;
+    }
+  }
+
+  // Read from stdin
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "No payload provided. Use --payload <json> or pipe JSON into stdin.\n" +
+        '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync("/dev/stdin", "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read stdin: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!raw.trim()) {
+    throw new Error(
+      "Empty input on stdin. Provide a valid JSON object.\n" +
+        '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error(
+        "Stdin payload must be a JSON object (not array or primitive).",
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(
+        `Invalid JSON on stdin: ${err.message}\n` +
+          '  Example: echo \'{"message":"Are you sure?"}\' | assistant ui request',
+      );
+    }
+    throw err;
+  }
+}
+
+// ── Strict integer parsing ────────────────────────────────────────────
+
+/**
+ * Parse a string as a strict positive integer. Rejects inputs like
+ * `"1e3"`, `"30s"`, `"12.5"` that `parseInt` would silently truncate.
+ * Returns the parsed integer or `NaN` on any non-pure-integer input.
+ */
+function parseStrictPositiveInt(value: string): number {
+  if (!/^\d+$/.test(value)) return NaN;
+  return Number(value);
+}
+
+// ── Registration ──────────────────────────────────────────────────────
+
+export function registerUiCommand(program: Command): void {
+  const ui = program
+    .command("ui")
+    .description("Present interactive UI surfaces to the user");
+
+  ui.addHelpText(
+    "after",
+    `
+Script-facing commands that present interactive surfaces (confirmations,
+forms) to the user via the running assistant and block until the user
+responds or the request times out.
+
+The conversation ID is resolved automatically when running inside a skill
+context (__SKILL_CONTEXT_JSON). Override with --conversation-id if needed.
+
+Examples:
+  $ echo '{"message":"Delete all logs?"}' | assistant ui request --json
+  $ assistant ui confirm --title "Deploy to production?" --message "This will push to prod."
+  $ assistant ui confirm --message "Are you sure?" --json`,
+  );
+
+  // ── ui request ───────────────────────────────────────────────────
+
+  ui.command("request")
+    .description(
+      "Present an interactive surface and block until the user responds",
+    )
+    .option("--payload <json>", "JSON object describing the surface data")
+    .option(
+      "--surface-type <type>",
+      'Surface type: "confirmation" or "form"',
+      "confirmation",
+    )
+    .option("--title <title>", "Title displayed on the surface")
+    .option(
+      "--conversation-id <id>",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
+    )
+    .option(
+      "--timeout <ms>",
+      "Request timeout in milliseconds",
+      String(DEFAULT_REQUEST_TIMEOUT_MS),
+    )
+    .option("--json", "Output result as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+Sends a UI interaction request to the running assistant and blocks until
+the user responds or the timeout elapses. The payload describes the
+surface content and can be provided via --payload or piped through stdin.
+
+The response includes the user's action (submitted, cancelled, timed_out)
+and any submitted data.
+
+Arguments:
+  (none — payload via --payload flag or stdin)
+
+Options:
+  --payload <json>         JSON object with surface data
+  --surface-type <type>    "confirmation" (default) or "form"
+  --title <title>          Surface title
+  --conversation-id <id>   Explicit conversation ID
+  --timeout <ms>           Request timeout in milliseconds (default: 300000)
+  --json                   Output as JSON
+
+Examples:
+  $ echo '{"message":"Proceed?"}' | assistant ui request
+  $ assistant ui request --payload '{"message":"Proceed?"}' --json
+  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json`,
+    )
+    .action(
+      async (opts: {
+        payload?: string;
+        surfaceType?: string;
+        title?: string;
+        conversationId?: string;
+        timeout?: string;
+        json?: boolean;
+      }) => {
+        // Parse payload
+        let data: Record<string, unknown>;
+        try {
+          data = readPayload(opts.payload);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Resolve conversation ID
+        let conversationId: string;
+        try {
+          conversationId = resolveConversationId(opts.conversationId);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Parse timeout
+        const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+        const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+        if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+          const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Build IPC params
+        const ipcParams: Record<string, unknown> = {
+          conversationId,
+          surfaceType: opts.surfaceType ?? "confirmation",
+          data,
+          timeoutMs: requestTimeoutMs,
+        };
+        if (opts.title) {
+          ipcParams.title = opts.title;
+        }
+
+        // Call IPC with timeout budget = request timeout + buffer
+        const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+        const result = await cliIpcCall<InteractiveUiResult>(
+          "ui_request",
+          ipcParams,
+          {
+            timeoutMs: ipcTimeoutMs,
+          },
+        );
+
+        if (!result.ok) {
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: result.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: true, ...result.result }) + "\n",
+          );
+        } else {
+          const r = result.result!;
+          if (r.status === "submitted") {
+            log.info(
+              `User responded: ${r.actionId ?? "submitted"}${r.summary ? ` — ${r.summary}` : ""}`,
+            );
+          } else if (r.status === "timed_out") {
+            log.info("Request timed out without a response.");
+          } else {
+            log.info("Request was cancelled.");
+          }
+        }
+      },
+    );
+
+  // ── ui confirm ──────────────────────────────────────────────────
+
+  ui.command("confirm")
+    .description(
+      "Present a yes/no confirmation prompt; exits 0 on confirm, 1 on deny/cancel/timeout",
+    )
+    .option("--title <title>", "Title displayed on the confirmation prompt")
+    .option(
+      "--message <message>",
+      "Message body shown in the confirmation prompt",
+    )
+    .option(
+      "--confirm-label <label>",
+      'Label for the confirm button (default: "Confirm")',
+      "Confirm",
+    )
+    .option(
+      "--deny-label <label>",
+      'Label for the deny button (default: "Deny")',
+      "Deny",
+    )
+    .option(
+      "--conversation-id <id>",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
+    )
+    .option(
+      "--timeout <ms>",
+      "Request timeout in milliseconds",
+      String(DEFAULT_REQUEST_TIMEOUT_MS),
+    )
+    .option("--json", "Output result as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+Ergonomic wrapper around "ui request" for binary yes/no gating. Presents
+a confirmation surface to the user and blocks until they respond.
+
+Exit codes:
+  0  — User confirmed
+  1  — User denied, cancelled, or the request timed out
+
+The --json flag outputs the full interaction result for scripts that need
+to inspect the response details.
+
+Options:
+  --title <title>            Prompt title
+  --message <message>        Prompt body text
+  --confirm-label <label>    Confirm button label (default: "Confirm")
+  --deny-label <label>       Deny button label (default: "Deny")
+  --conversation-id <id>     Explicit conversation ID
+  --timeout <ms>             Request timeout in ms (default: 300000)
+  --json                     Output as JSON
+
+Examples:
+  $ assistant ui confirm --message "Delete all data?"
+  $ assistant ui confirm --title "Deploy" --message "Push to prod?" --json
+  $ assistant ui confirm --message "Proceed?" --confirm-label "Yes" --deny-label "No"`,
+    )
+    .action(
+      async (opts: {
+        title?: string;
+        message?: string;
+        confirmLabel?: string;
+        denyLabel?: string;
+        conversationId?: string;
+        timeout?: string;
+        json?: boolean;
+      }) => {
+        // Resolve conversation ID
+        let conversationId: string;
+        try {
+          conversationId = resolveConversationId(opts.conversationId);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Parse timeout
+        const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+        const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+        if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+          const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Build confirmation surface data
+        const confirmLabel = opts.confirmLabel ?? "Confirm";
+        const denyLabel = opts.denyLabel ?? "Deny";
+        const data: Record<string, unknown> = {};
+        if (opts.message) data.message = opts.message;
+        // Pass custom labels via data payload so the renderer reads them
+        // from ConfirmationSurfaceData.confirmLabel / .cancelLabel.
+        data.confirmLabel = confirmLabel;
+        data.cancelLabel = denyLabel;
+
+        // Build IPC params
+        const ipcParams: Record<string, unknown> = {
+          conversationId,
+          surfaceType: "confirmation",
+          data,
+          actions: [
+            {
+              id: "confirm",
+              label: confirmLabel,
+              variant: "primary",
+            },
+            {
+              id: "deny",
+              label: denyLabel,
+              variant: "secondary",
+            },
+          ],
+          timeoutMs: requestTimeoutMs,
+        };
+        if (opts.title) {
+          ipcParams.title = opts.title;
+        }
+
+        // Call IPC with timeout budget
+        const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+        const result = await cliIpcCall<InteractiveUiResult>(
+          "ui_request",
+          ipcParams,
+          {
+            timeoutMs: ipcTimeoutMs,
+          },
+        );
+
+        if (!result.ok) {
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: result.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${result.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const r = result.result!;
+        const confirmed = r.status === "submitted" && r.actionId === "confirm";
+
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              confirmed,
+              status: r.status,
+              actionId: r.actionId,
+              surfaceId: r.surfaceId,
+            }) + "\n",
+          );
+        } else {
+          if (confirmed) {
+            log.info("Confirmed.");
+          } else if (r.status === "timed_out") {
+            log.info("Confirmation timed out.");
+          } else if (r.status === "cancelled") {
+            log.info("Confirmation cancelled.");
+          } else {
+            log.info("Denied.");
+          }
+        }
+
+        if (!confirmed) {
+          process.exitCode = 1;
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -37,6 +37,7 @@ import { registerSequenceCommand } from "./commands/sequence.js";
 import { registerShotgunCommand } from "./commands/shotgun.js";
 import { registerSkillsCommand } from "./commands/skills.js";
 import { registerTrustCommand } from "./commands/trust.js";
+import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { log } from "./logger.js";
 
@@ -94,6 +95,8 @@ Examples:
   registerRoutesCommand(program);
   registerSkillsCommand(program);
   registerUsageCommand(program);
+
+  registerUiCommand(program);
 
   registerShotgunCommand(program);
   registerSequenceCommand(program);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -949,70 +949,17 @@ export async function handleSurfaceAction(
   actionId: string,
   data?: Record<string, unknown>,
 ): Promise<SurfaceActionResult> {
-  // `launch_conversation` actions spawn a fresh conversation inline instead
-  // of round-tripping through the LLM with a `[User action on card surface:
-  // ...]` chat message. This dispatch must run BEFORE the pending-vs-not
-  // branching below: `ui_show` unconditionally calls
-  // `pendingSurfaceActions.set(...)` for any interactive card (regardless of
-  // the `persistent` flag), so on the very first click of a freshly-rendered
-  // launcher card `pending` is already set. Without this hoist the launch
-  // branch would fall through into the pending path and the LLM round-trip
-  // would happen on every click.
-  if (
-    data &&
-    typeof data === "object" &&
-    (data as Record<string, unknown>)._action === "launch_conversation"
-  ) {
-    const payload = data as Record<string, unknown>;
-    const title = typeof payload.title === "string" ? payload.title : "";
-    const seedPrompt =
-      typeof payload.seedPrompt === "string" ? payload.seedPrompt : "";
-    const anchorMessageId =
-      typeof payload.anchorMessageId === "string"
-        ? payload.anchorMessageId
-        : undefined;
-    if (!title || !seedPrompt) {
-      return { accepted: false, error: "missing_title_or_seedPrompt" };
-    }
-    // Launch actions don't consume the surface — persistent launcher cards
-    // keep accepting clicks afterward. Drop the pending entry (if any) so
-    // sibling button presses on the same card aren't blocked behind a stale
-    // expectation that this surface still owes an answer to the LLM.
-    ctx.pendingSurfaceActions.delete(surfaceId);
-    // `ctx` is the origin Conversation — inherit its trust context so the
-    // spawned conversation keeps guardian / trust-class state.
-    //
-    // `launchConversation` is the sole emitter of `open_conversation` for
-    // this path. We pass `focus: false` so the client registers a sidebar
-    // entry for the spawned conversation without switching focus away from
-    // the origin — critical for fan-out UX where one click launches
-    // multiple conversations.
-    //
-    // The helper also kicks off the seed turn fire-and-forget, so this
-    // `await` resolves as soon as the conversation is created + titled +
-    // published to the event hub. The HTTP POST /v1/surface-actions
-    // response returns promptly — the seed turn runs in the background.
-    const originTrustContext = ctx.trustContext;
-    const { conversationId } = await launchConversation({
-      title,
-      seedPrompt,
-      focus: false,
-      ...(anchorMessageId ? { anchorMessageId } : {}),
-      ...(originTrustContext ? { originTrustContext } : {}),
-    });
-    log.info(
-      { originConversationId: ctx.conversationId, conversationId, surfaceId },
-      "launch_conversation dispatched inline from surface action",
-    );
-    return { accepted: true, conversationId };
-  }
-
   // ── Standalone surface interception ──────────────────────────────
   // Daemon-driven surfaces (from `requestInteractiveUi`) register a
   // pending entry in `pendingStandaloneSurfaces`. When the user clicks
   // an action, resolve the caller's Promise directly and return WITHOUT
   // enqueuing a model message — consumed standalone callbacks never
   // trigger an LLM follow-up turn.
+  //
+  // This block runs BEFORE launch_conversation dispatch so that a
+  // standalone form whose submittedData happens to contain
+  // `_action: "launch_conversation"` is resolved as a standalone
+  // interaction rather than triggering a conversation launch.
   const standalone = ctx.pendingStandaloneSurfaces?.get(surfaceId);
   if (standalone) {
     const stored = ctx.surfaceState.get(surfaceId);
@@ -1076,6 +1023,64 @@ export async function handleSurfaceAction(
       "Dropping late action for recently-completed standalone surface",
     );
     return { accepted: true, conversationId: ctx.conversationId };
+  }
+
+  // `launch_conversation` actions spawn a fresh conversation inline instead
+  // of round-tripping through the LLM with a `[User action on card surface:
+  // ...]` chat message. This dispatch must run BEFORE the pending-vs-not
+  // branching below: `ui_show` unconditionally calls
+  // `pendingSurfaceActions.set(...)` for any interactive card (regardless of
+  // the `persistent` flag), so on the very first click of a freshly-rendered
+  // launcher card `pending` is already set. Without this hoist the launch
+  // branch would fall through into the pending path and the LLM round-trip
+  // would happen on every click.
+  if (
+    data &&
+    typeof data === "object" &&
+    (data as Record<string, unknown>)._action === "launch_conversation"
+  ) {
+    const payload = data as Record<string, unknown>;
+    const title = typeof payload.title === "string" ? payload.title : "";
+    const seedPrompt =
+      typeof payload.seedPrompt === "string" ? payload.seedPrompt : "";
+    const anchorMessageId =
+      typeof payload.anchorMessageId === "string"
+        ? payload.anchorMessageId
+        : undefined;
+    if (!title || !seedPrompt) {
+      return { accepted: false, error: "missing_title_or_seedPrompt" };
+    }
+    // Launch actions don't consume the surface — persistent launcher cards
+    // keep accepting clicks afterward. Drop the pending entry (if any) so
+    // sibling button presses on the same card aren't blocked behind a stale
+    // expectation that this surface still owes an answer to the LLM.
+    ctx.pendingSurfaceActions.delete(surfaceId);
+    // `ctx` is the origin Conversation — inherit its trust context so the
+    // spawned conversation keeps guardian / trust-class state.
+    //
+    // `launchConversation` is the sole emitter of `open_conversation` for
+    // this path. We pass `focus: false` so the client registers a sidebar
+    // entry for the spawned conversation without switching focus away from
+    // the origin — critical for fan-out UX where one click launches
+    // multiple conversations.
+    //
+    // The helper also kicks off the seed turn fire-and-forget, so this
+    // `await` resolves as soon as the conversation is created + titled +
+    // published to the event hub. The HTTP POST /v1/surface-actions
+    // response returns promptly — the seed turn runs in the background.
+    const originTrustContext = ctx.trustContext;
+    const { conversationId } = await launchConversation({
+      title,
+      seedPrompt,
+      focus: false,
+      ...(anchorMessageId ? { anchorMessageId } : {}),
+      ...(originTrustContext ? { originTrustContext } : {}),
+    });
+    log.info(
+      { originConversationId: ctx.conversationId, conversationId, surfaceId },
+      "launch_conversation dispatched inline from surface action",
+    );
+    return { accepted: true, conversationId };
   }
 
   const pending = ctx.pendingSurfaceActions.get(surfaceId);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -462,14 +462,21 @@ export function showStandaloneSurface(
       // Notify the client BEFORE cleanup so the surface is dismissed on
       // the client side, preventing stale user interactions from reaching
       // handleSurfaceAction and being misrouted to the LLM.
-      const emitTimeout =
-        ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
-      emitTimeout({
-        type: "ui_surface_complete",
-        conversationId: ctx.conversationId,
-        surfaceId,
-        summary: "Timed out",
-      });
+      try {
+        const emitTimeout =
+          ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+        emitTimeout({
+          type: "ui_surface_complete",
+          conversationId: ctx.conversationId,
+          surfaceId,
+          summary: "Timed out",
+        });
+      } catch (err) {
+        log.warn(
+          { err, conversationId: ctx.conversationId, surfaceId },
+          "Failed to emit ui_surface_complete on timeout",
+        );
+      }
 
       cleanupStandaloneSurface(ctx, surfaceId);
       log.info(
@@ -1585,8 +1592,18 @@ export function buildCompletionSummary(
           : undefined;
       return confirmLabel ? `User chose: "${confirmLabel}"` : "Confirmed";
     }
+    if (actionId === "deny") {
+      // The deny button's custom label is passed as cancelLabel in the
+      // confirmation surface data (the deny action reuses the cancel label
+      // since both represent the "reject" path).
+      const denyLabel =
+        typeof surfaceData?.cancelLabel === "string"
+          ? surfaceData.cancelLabel
+          : undefined;
+      return denyLabel ? `User chose: "${denyLabel}"` : "Denied";
+    }
     // Preserve the actual action ID so the LLM knows the user's exact choice
-    // (e.g. "deny", "no", "reject") rather than misreporting it as confirmed.
+    // rather than misreporting it as confirmed.
     return `User selected: ${actionId}`;
   }
   if (surfaceType === "form") {
@@ -1637,6 +1654,13 @@ export function buildUserFacingLabel(
           ? surfaceData.confirmLabel
           : undefined;
       return confirmLabel ?? "Confirmed";
+    }
+    if (actionId === "deny") {
+      const denyLabel =
+        typeof surfaceData?.cancelLabel === "string"
+          ? surfaceData.cancelLabel
+          : undefined;
+      return denyLabel ?? "Denied";
     }
     return `Selected: ${actionId}`;
   }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -13,6 +13,10 @@ import {
   getMessages,
   updateMessageContent,
 } from "../memory/conversation-crud.js";
+import type {
+  InteractiveUiRequest,
+  InteractiveUiResult,
+} from "../runtime/interactive-ui.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
@@ -21,7 +25,9 @@ import { launchConversation } from "./conversation-launch.js";
 import type { TrustContext } from "./conversation-runtime-assembly.js";
 import type {
   CardSurfaceData,
+  ConfirmationSurfaceData,
   DynamicPageSurfaceData,
+  FormSurfaceData,
   ListSurfaceData,
   ServerMessage,
   SurfaceData,
@@ -272,6 +278,20 @@ export interface SurfaceConversationContext {
   accumulatedSurfaceState: Map<string, Record<string, unknown>>;
   /** Request IDs that originated from surface action button clicks (not regular user messages). */
   surfaceActionRequestIds: Set<string>;
+  /**
+   * Pending standalone UI requests keyed by surfaceId.
+   * These are daemon-driven surfaces (not LLM tool invocations) that block
+   * the caller until the user submits, cancels, or the timeout elapses.
+   * Optional: only present on conversations that support standalone surfaces.
+   */
+  pendingStandaloneSurfaces?: Map<
+    string,
+    {
+      resolve: (result: InteractiveUiResult) => void;
+      timer: ReturnType<typeof setTimeout>;
+      surfaceType: SurfaceType;
+    }
+  >;
   currentTurnSurfaces: Array<{
     surfaceId: string;
     surfaceType: SurfaceType;
@@ -288,6 +308,8 @@ export interface SurfaceConversationContext {
   }>;
   /** Optional proxy for delegating computer-use actions to a connected desktop client. */
   hostCuProxy?: import("./host-cu-proxy.js").HostCuProxy;
+  /** True when no interactive client is connected (headless / channel-only). */
+  readonly hasNoClient?: boolean;
   isProcessing(): boolean;
   enqueueMessage(
     content: string,
@@ -352,6 +374,231 @@ export function createSurfaceMutex(): SurfaceMutex {
 
   Object.defineProperty(mutex, "size", { get: () => chains.size });
   return mutex as SurfaceMutex;
+}
+
+// ── Standalone surface lifecycle ────────────────────────────────────
+//
+// Daemon-driven UI surfaces that block the caller (skill, IPC handler)
+// until the user responds or the timeout elapses. Unlike LLM-invoked
+// surfaces (ui_show tool), these never trigger an LLM follow-up turn —
+// the result is returned directly to the requesting code.
+
+/** Default timeout for standalone surfaces when the caller does not specify one. */
+const DEFAULT_STANDALONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Check whether the conversation can show interactive UI surfaces.
+ * Fails closed when no client is connected or the channel doesn't
+ * support dynamic UI.
+ */
+export function canShowInteractiveUi(
+  ctx: Pick<SurfaceConversationContext, "hasNoClient" | "channelCapabilities">,
+): boolean {
+  if (ctx.hasNoClient) return false;
+  if (ctx.channelCapabilities && !ctx.channelCapabilities.supportsDynamicUi) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Show a standalone UI surface and return a Promise that resolves when
+ * the user submits, cancels, or the timeout elapses.
+ *
+ * This is the core entry point for daemon-driven (non-LLM) UI requests.
+ * It performs the fail-closed capability check, emits `ui_surface_show`,
+ * stores surface state, arms the timeout, and registers a pending entry
+ * so that `handleSurfaceAction` can intercept the callback.
+ */
+export function showStandaloneSurface(
+  ctx: SurfaceConversationContext,
+  request: InteractiveUiRequest,
+  surfaceId: string,
+): Promise<InteractiveUiResult> {
+  // ── Fail-closed: no interactive UI capability ──
+  if (!canShowInteractiveUi(ctx)) {
+    log.warn(
+      {
+        conversationId: ctx.conversationId,
+        surfaceType: request.surfaceType,
+        hasNoClient: ctx.hasNoClient,
+        channel: ctx.channelCapabilities?.channel,
+      },
+      "standalone surface: no interactive UI capability; failing closed",
+    );
+    return Promise.resolve({
+      status: "cancelled" as const,
+      surfaceId,
+    });
+  }
+
+  // The pendingStandaloneSurfaces map must exist on the context.
+  // The Conversation class always initializes it; if absent, fail closed.
+  if (!ctx.pendingStandaloneSurfaces) {
+    log.warn(
+      { conversationId: ctx.conversationId, surfaceType: request.surfaceType },
+      "standalone surface: pendingStandaloneSurfaces map missing; failing closed",
+    );
+    return Promise.resolve({ status: "cancelled" as const, surfaceId });
+  }
+  const pendingMap = ctx.pendingStandaloneSurfaces;
+
+  const timeoutMs = request.timeoutMs ?? DEFAULT_STANDALONE_TIMEOUT_MS;
+
+  // Build surface data from the request payload.
+  const surfaceType = request.surfaceType as SurfaceType;
+  const data = buildStandaloneSurfaceData(request);
+  const actions = request.actions?.map((a) => ({
+    id: a.id,
+    label: a.label,
+    style: (a.variant === "danger"
+      ? "destructive"
+      : (a.variant ?? "secondary")) as "primary" | "secondary" | "destructive",
+  }));
+
+  return new Promise<InteractiveUiResult>((resolve) => {
+    // ── Arm timeout ──
+    const timer = setTimeout(() => {
+      // Notify the client BEFORE cleanup so the surface is dismissed on
+      // the client side, preventing stale user interactions from reaching
+      // handleSurfaceAction and being misrouted to the LLM.
+      const emitTimeout =
+        ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+      emitTimeout({
+        type: "ui_surface_complete",
+        conversationId: ctx.conversationId,
+        surfaceId,
+        summary: "Timed out",
+      });
+
+      cleanupStandaloneSurface(ctx, surfaceId);
+      log.info(
+        { conversationId: ctx.conversationId, surfaceId, timeoutMs },
+        "standalone surface timed out",
+      );
+      resolve({ status: "timed_out", surfaceId });
+    }, timeoutMs);
+
+    // ── Register pending entry ──
+    pendingMap.set(surfaceId, {
+      resolve,
+      timer,
+      surfaceType,
+    });
+
+    // ── Store surface state ──
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType,
+      data,
+      title: request.title,
+      actions,
+    });
+
+    // ── Emit to client ──
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    emit({
+      type: "ui_surface_show",
+      conversationId: ctx.conversationId,
+      surfaceId,
+      surfaceType,
+      title: request.title,
+      data,
+      actions,
+      display: "inline",
+    } as unknown as UiSurfaceShow);
+
+    log.info(
+      {
+        conversationId: ctx.conversationId,
+        surfaceId,
+        surfaceType,
+        timeoutMs,
+      },
+      "standalone surface shown",
+    );
+  });
+}
+
+/**
+ * Build a SurfaceData object from an InteractiveUiRequest.
+ * Maps the generic `data` payload to the typed shape expected by the
+ * surface type.
+ */
+function buildStandaloneSurfaceData(
+  request: InteractiveUiRequest,
+): SurfaceData {
+  if (request.surfaceType === "confirmation") {
+    return {
+      message:
+        typeof request.data.message === "string"
+          ? request.data.message
+          : (request.title ?? "Please confirm"),
+      detail:
+        typeof request.data.detail === "string"
+          ? request.data.detail
+          : undefined,
+      confirmLabel:
+        typeof request.data.confirmLabel === "string"
+          ? request.data.confirmLabel
+          : undefined,
+      cancelLabel:
+        typeof request.data.cancelLabel === "string"
+          ? request.data.cancelLabel
+          : undefined,
+      destructive:
+        typeof request.data.destructive === "boolean"
+          ? request.data.destructive
+          : undefined,
+    } satisfies ConfirmationSurfaceData;
+  }
+
+  if (request.surfaceType === "form") {
+    return {
+      description:
+        typeof request.data.description === "string"
+          ? request.data.description
+          : undefined,
+      fields: Array.isArray(request.data.fields)
+        ? (request.data.fields as FormSurfaceData["fields"])
+        : [],
+      submitLabel:
+        typeof request.data.submitLabel === "string"
+          ? request.data.submitLabel
+          : undefined,
+    } satisfies FormSurfaceData;
+  }
+
+  // Fallback: pass through opaque data
+  return request.data as unknown as SurfaceData;
+}
+
+/**
+ * Cleanup a standalone surface entry: clear the timeout timer, remove
+ * the pending entry, and remove surface state. Idempotent — safe to
+ * call multiple times for the same surfaceId.
+ */
+export function cleanupStandaloneSurface(
+  ctx: Pick<
+    SurfaceConversationContext,
+    | "pendingStandaloneSurfaces"
+    | "surfaceState"
+    | "pendingSurfaceActions"
+    | "lastSurfaceAction"
+    | "accumulatedSurfaceState"
+    | "surfaceUndoStacks"
+  >,
+  surfaceId: string,
+): void {
+  const entry = ctx.pendingStandaloneSurfaces?.get(surfaceId);
+  if (entry) {
+    clearTimeout(entry.timer);
+    ctx.pendingStandaloneSurfaces?.delete(surfaceId);
+  }
+  ctx.surfaceState.delete(surfaceId);
+  ctx.pendingSurfaceActions.delete(surfaceId);
+  ctx.lastSurfaceAction.delete(surfaceId);
+  ctx.accumulatedSurfaceState.delete(surfaceId);
+  ctx.surfaceUndoStacks.delete(surfaceId);
 }
 
 /**
@@ -719,6 +966,65 @@ export async function handleSurfaceAction(
       "launch_conversation dispatched inline from surface action",
     );
     return { accepted: true, conversationId };
+  }
+
+  // ── Standalone surface interception ──────────────────────────────
+  // Daemon-driven surfaces (from `requestInteractiveUi`) register a
+  // pending entry in `pendingStandaloneSurfaces`. When the user clicks
+  // an action, resolve the caller's Promise directly and return WITHOUT
+  // enqueuing a model message — consumed standalone callbacks never
+  // trigger an LLM follow-up turn.
+  const standalone = ctx.pendingStandaloneSurfaces?.get(surfaceId);
+  if (standalone) {
+    const stored = ctx.surfaceState.get(surfaceId);
+    const summary = buildCompletionSummary(
+      standalone.surfaceType,
+      actionId,
+      data,
+      stored?.data as Record<string, unknown> | undefined,
+    );
+
+    // Determine result status from the action.
+    const isCancellation = actionId === "cancel" || actionId === "dismiss";
+    const status: InteractiveUiResult["status"] = isCancellation
+      ? "cancelled"
+      : "submitted";
+
+    const result: InteractiveUiResult = {
+      status,
+      surfaceId,
+      actionId,
+      ...(data ? { submittedData: data } : {}),
+      summary,
+    };
+
+    // Emit ui_surface_complete so the client transitions the surface chip.
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    emit({
+      type: "ui_surface_complete",
+      conversationId: ctx.conversationId,
+      surfaceId,
+      summary,
+      submittedData: data,
+    });
+
+    // Cleanup and resolve — order matters: cleanup clears the timer
+    // before resolve() unblocks the caller.
+    cleanupStandaloneSurface(ctx, surfaceId);
+    standalone.resolve(result);
+
+    log.info(
+      {
+        conversationId: ctx.conversationId,
+        surfaceId,
+        actionId,
+        status,
+      },
+      "standalone surface resolved by user action",
+    );
+
+    // Return without enqueuing a model message.
+    return { accepted: true, conversationId: ctx.conversationId };
   }
 
   const pending = ctx.pendingSurfaceActions.get(surfaceId);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -292,6 +292,16 @@ export interface SurfaceConversationContext {
       surfaceType: SurfaceType;
     }
   >;
+  /**
+   * Short-lived tombstone set of recently-completed standalone surface IDs.
+   * Prevents late client actions (arriving after timeout/resolution) from
+   * falling through to the history-restored path and triggering an
+   * unintended LLM turn. Entries are auto-removed after a TTL.
+   */
+  recentlyCompletedStandaloneSurfaces?: Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >;
   currentTurnSurfaces: Array<{
     surfaceId: string;
     surfaceType: SurfaceType;
@@ -385,6 +395,12 @@ export function createSurfaceMutex(): SurfaceMutex {
 
 /** Default timeout for standalone surfaces when the caller does not specify one. */
 const DEFAULT_STANDALONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * How long a tombstone entry persists after a standalone surface is completed.
+ * Late client actions arriving within this window are silently dropped.
+ */
+const STANDALONE_TOMBSTONE_TTL_MS = 30_000; // 30 seconds
 
 /**
  * Check whether the conversation can show interactive UI surfaces.
@@ -581,13 +597,16 @@ function buildStandaloneSurfaceData(
 
 /**
  * Cleanup a standalone surface entry: clear the timeout timer, remove
- * the pending entry, and remove surface state. Idempotent — safe to
- * call multiple times for the same surfaceId.
+ * the pending entry, remove surface state, and record a short-lived
+ * tombstone so late client actions are silently dropped instead of
+ * falling through to the LLM path. Idempotent — safe to call multiple
+ * times for the same surfaceId.
  */
 export function cleanupStandaloneSurface(
   ctx: Pick<
     SurfaceConversationContext,
     | "pendingStandaloneSurfaces"
+    | "recentlyCompletedStandaloneSurfaces"
     | "surfaceState"
     | "pendingSurfaceActions"
     | "lastSurfaceAction"
@@ -606,6 +625,19 @@ export function cleanupStandaloneSurface(
   ctx.lastSurfaceAction.delete(surfaceId);
   ctx.accumulatedSurfaceState.delete(surfaceId);
   ctx.surfaceUndoStacks.delete(surfaceId);
+
+  // Record a tombstone so late client actions are silently dropped.
+  if (ctx.recentlyCompletedStandaloneSurfaces) {
+    // Clear any existing tombstone timer for this surfaceId (idempotency).
+    const existingTimer =
+      ctx.recentlyCompletedStandaloneSurfaces.get(surfaceId);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    const tombstoneTimer = setTimeout(() => {
+      ctx.recentlyCompletedStandaloneSurfaces?.delete(surfaceId);
+    }, STANDALONE_TOMBSTONE_TTL_MS);
+    ctx.recentlyCompletedStandaloneSurfaces.set(surfaceId, tombstoneTimer);
+  }
 }
 
 /**
@@ -1031,6 +1063,18 @@ export async function handleSurfaceAction(
     );
 
     // Return without enqueuing a model message.
+    return { accepted: true, conversationId: ctx.conversationId };
+  }
+
+  // ── Tombstone guard for recently-completed standalone surfaces ────
+  // After a standalone surface times out or is resolved, cleanup removes
+  // all state. Without this guard a late client action would fall through
+  // to the history-restored path below and enqueue a message to the LLM.
+  if (ctx.recentlyCompletedStandaloneSurfaces?.has(surfaceId)) {
+    log.debug(
+      { conversationId: ctx.conversationId, surfaceId, actionId },
+      "Dropping late action for recently-completed standalone surface",
+    );
     return { accepted: true, conversationId: ctx.conversationId };
   }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -67,6 +67,7 @@ import type { Provider } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import * as approvalOverrides from "../runtime/conversation-approval-overrides.js";
+import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
@@ -263,6 +264,19 @@ export class Conversation {
   /** @internal */ accumulatedSurfaceState = new Map<
     string,
     Record<string, unknown>
+  >();
+  /**
+   * Pending standalone UI requests keyed by surfaceId.
+   * Daemon-driven surfaces that block the caller until user response or timeout.
+   * @internal
+   */
+  pendingStandaloneSurfaces = new Map<
+    string,
+    {
+      resolve: (result: InteractiveUiResult) => void;
+      timer: ReturnType<typeof setTimeout>;
+      surfaceType: SurfaceType;
+    }
   >();
   /** @internal */ broadcastToAllClients?: (msg: ServerMessage) => void;
   /** @internal */ withSurface = createSurfaceMutex();
@@ -720,6 +734,26 @@ export class Conversation {
 
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
+    // Cancel all pending standalone surfaces so callers get a clean
+    // cancellation instead of hanging forever. Emit dismiss notifications
+    // to the client so surfaces don't remain visually active if the client
+    // reconnects after dispose.
+    const emitDispose =
+      this.broadcastToAllClients ?? this.sendToClient.bind(this);
+    for (const [surfaceId, entry] of this.pendingStandaloneSurfaces) {
+      clearTimeout(entry.timer);
+      try {
+        emitDispose({
+          type: "ui_surface_dismiss",
+          conversationId: this.conversationId,
+          surfaceId,
+        });
+      } catch {
+        // Best-effort: the client may already be disconnected during dispose.
+      }
+      entry.resolve({ status: "cancelled", surfaceId });
+    }
+    this.pendingStandaloneSurfaces.clear();
     this.hostBashProxy?.dispose();
     this.hostBrowserProxy?.dispose();
     this.hostCuProxy?.dispose();

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -278,6 +278,15 @@ export class Conversation {
       surfaceType: SurfaceType;
     }
   >();
+  /**
+   * Short-lived tombstone set of recently-completed standalone surface IDs.
+   * Prevents late client actions from falling through to the LLM path.
+   * @internal
+   */
+  recentlyCompletedStandaloneSurfaces = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   /** @internal */ broadcastToAllClients?: (msg: ServerMessage) => void;
   /** @internal */ withSurface = createSurfaceMutex();
   /** @internal */ currentTurnSurfaces: Array<{
@@ -754,6 +763,11 @@ export class Conversation {
       entry.resolve({ status: "cancelled", surfaceId });
     }
     this.pendingStandaloneSurfaces.clear();
+    // Clear tombstone timers to prevent dangling references after dispose.
+    for (const timer of this.recentlyCompletedStandaloneSurfaces.values()) {
+      clearTimeout(timer);
+    }
+    this.recentlyCompletedStandaloneSurfaces.clear();
     this.hostBashProxy?.dispose();
     this.hostBrowserProxy?.dispose();
     this.hostCuProxy?.dispose();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -95,7 +95,10 @@ import { registerLaunchConversationDeps } from "./conversation-launch.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
-import { refreshSurfacesForApp } from "./conversation-surfaces.js";
+import {
+  refreshSurfacesForApp,
+  showStandaloneSurface,
+} from "./conversation-surfaces.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type {
@@ -834,10 +837,9 @@ export class DaemonServer {
     // Install the interactive UI resolver so skills and IPC handlers can
     // present ad-hoc UI surfaces (confirmations, forms) to the user via
     // `requestInteractiveUi()`. The resolver verifies the target
-    // conversation exists and is live before delegating to the
-    // conversation-level surface lifecycle (wired in PR 2). For now it
-    // validates the conversation and fails closed if not found — the
-    // actual surface show/await logic is added in the next PR.
+    // conversation exists and is live, then delegates to the
+    // conversation-level standalone surface lifecycle which blocks until
+    // the user responds or the timeout elapses.
     registerInteractiveUiResolver(async (request) => {
       const conversation = this.conversations.get(request.conversationId);
       if (!conversation) {
@@ -854,13 +856,11 @@ export class DaemonServer {
         };
       }
 
-      // PR 2 will wire conversation-scoped surface lifecycle here.
-      // For now, fail closed — the resolver exists and is reachable,
-      // but the surface presentation layer is not yet implemented.
-      return {
-        status: "cancelled" as const,
-        surfaceId: `ui-resolver-${Date.now()}`,
-      };
+      // Generate a unique surface ID and delegate to the conversation's
+      // standalone surface lifecycle. The returned Promise blocks until
+      // the user submits, cancels, or the timeout elapses.
+      const surfaceId = `ui-standalone-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      return showStandaloneSurface(conversation, request, surfaceId);
     });
 
     // Start the CLI IPC server. Built-in methods (wake_conversation) are

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -61,6 +61,7 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
+import { registerInteractiveUiResolver } from "../runtime/interactive-ui.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -828,6 +829,38 @@ export class DaemonServer {
         );
         return null;
       }
+    });
+
+    // Install the interactive UI resolver so skills and IPC handlers can
+    // present ad-hoc UI surfaces (confirmations, forms) to the user via
+    // `requestInteractiveUi()`. The resolver verifies the target
+    // conversation exists and is live before delegating to the
+    // conversation-level surface lifecycle (wired in PR 2). For now it
+    // validates the conversation and fails closed if not found — the
+    // actual surface show/await logic is added in the next PR.
+    registerInteractiveUiResolver(async (request) => {
+      const conversation = this.conversations.get(request.conversationId);
+      if (!conversation) {
+        log.warn(
+          {
+            conversationId: request.conversationId,
+            surfaceType: request.surfaceType,
+          },
+          "interactive-ui resolver: conversation not found; failing closed",
+        );
+        return {
+          status: "cancelled" as const,
+          surfaceId: `ui-resolver-${Date.now()}`,
+        };
+      }
+
+      // PR 2 will wire conversation-scoped surface lifecycle here.
+      // For now, fail closed — the resolver exists and is reachable,
+      // but the surface presentation layer is not yet implemented.
+      return {
+        status: "cancelled" as const,
+        surfaceId: `ui-resolver-${Date.now()}`,
+      };
     });
 
     // Start the CLI IPC server. Built-in methods (wake_conversation) are

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Integration tests for the `ui_request` IPC route.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with mock interactive UI resolvers to verify
+ * submit / cancel / timeout, unknown-conversation, and non-interactive
+ * failure scenarios.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  InteractiveUiRequest,
+  InteractiveUiResult,
+} from "../../runtime/interactive-ui.js";
+import {
+  registerInteractiveUiResolver,
+  resetInteractiveUiResolverForTests,
+  resetSurfaceIdCounterForTests,
+} from "../../runtime/interactive-ui.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+
+function baseParams(
+  overrides?: Partial<Record<string, unknown>>,
+): Record<string, unknown> {
+  return {
+    conversationId: "conv-test-123",
+    surfaceType: "confirmation",
+    data: { message: "Are you sure?" },
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  resetInteractiveUiResolverForTests();
+  resetSurfaceIdCounterForTests();
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  resetInteractiveUiResolverForTests();
+  resetSurfaceIdCounterForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ui_request IPC route", () => {
+  // ── Submit ────────────────────────────────────────────────────────
+
+  test("returns submitted result when user selects an action", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "mock-surface-1",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>("ui_request", {
+      ...baseParams(),
+      actions: [
+        { id: "confirm", label: "Yes", variant: "primary" },
+        { id: "deny", label: "No", variant: "secondary" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.actionId).toBe("confirm");
+    expect(result.result!.surfaceId).toBeDefined();
+  });
+
+  // ── Cancel ────────────────────────────────────────────────────────
+
+  test("returns cancelled result when user dismisses the surface", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: "mock-surface-2",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+  });
+
+  // ── Timeout ───────────────────────────────────────────────────────
+
+  test("returns timed_out result when the surface times out", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "timed_out",
+        surfaceId: "mock-surface-3",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ timeoutMs: 1000 }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("timed_out");
+  });
+
+  // ── Unknown conversation (resolver throws) ────────────────────────
+
+  test("returns cancelled when resolver throws for unknown conversation", async () => {
+    registerInteractiveUiResolver(async (_req: InteractiveUiRequest) => {
+      throw new Error("Unknown conversation: conv-nonexistent");
+    });
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: "conv-nonexistent" }),
+    );
+
+    // requestInteractiveUi catches resolver errors and fails closed
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.surfaceId).toBeDefined();
+  });
+
+  // ── Non-interactive failure (no resolver registered) ──────────────
+
+  test("returns cancelled when no resolver is registered", async () => {
+    // No resolver registered — resetInteractiveUiResolverForTests()
+    // was called in beforeEach, so the module-level resolver is null.
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.surfaceId).toBeDefined();
+  });
+
+  // ── Schema validation ─────────────────────────────────────────────
+
+  test("rejects missing conversationId", async () => {
+    const result = await cliIpcCall("ui_request", {
+      surfaceType: "confirmation",
+      data: { message: "test" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects empty conversationId", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "",
+      surfaceType: "confirmation",
+      data: { message: "test" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects invalid surfaceType", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "unsupported",
+      data: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects missing data field", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects non-positive timeoutMs", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+      timeoutMs: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects non-integer timeoutMs", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+      timeoutMs: 1.5,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects action with empty id", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+      actions: [{ id: "", label: "OK" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("rejects action with empty label", async () => {
+    const result = await cliIpcCall("ui_request", {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+      actions: [{ id: "ok", label: "" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // ── Optional fields ───────────────────────────────────────────────
+
+  test("accepts request with optional title", async () => {
+    registerInteractiveUiResolver(
+      async (req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "submitted",
+        actionId: "ok",
+        surfaceId: "mock-surface-title",
+        summary: req.title,
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ title: "Confirm Action" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.summary).toBe("Confirm Action");
+  });
+
+  test("accepts form surfaceType with submittedData", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "submitted",
+        submittedData: { name: "Alice", email: "alice@example.com" },
+        surfaceId: "mock-surface-form",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>("ui_request", {
+      conversationId: "conv-form",
+      surfaceType: "form",
+      data: { fields: [{ name: "name" }, { name: "email" }] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.submittedData).toEqual({
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+});

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,11 +1,13 @@
 import type { IpcRoute } from "../cli-server.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
+import { uiRequestRoute } from "./ui-request.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
   browserExecuteRoute,
+  uiRequestRoute,
   wakeConversationRoute,
   ...cacheRoutes,
 ];

--- a/assistant/src/ipc/routes/ui-request.ts
+++ b/assistant/src/ipc/routes/ui-request.ts
@@ -1,0 +1,42 @@
+/**
+ * IPC route for interactive UI requests.
+ *
+ * Exposes `ui_request` so CLI commands and external processes can present
+ * interactive UI surfaces to the user and synchronously await their
+ * response. The handler delegates to {@link requestInteractiveUi} which
+ * manages the full surface lifecycle via the daemon-registered resolver.
+ */
+
+import { z } from "zod";
+
+import { requestInteractiveUi } from "../../runtime/interactive-ui.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// ── Param schema ──────────────────────────────────────────────────────
+
+const UiRequestParams = z.object({
+  conversationId: z.string().min(1),
+  surfaceType: z.enum(["confirmation", "form"]),
+  title: z.string().optional(),
+  data: z.record(z.string(), z.unknown()),
+  actions: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        label: z.string().min(1),
+        variant: z.enum(["primary", "danger", "secondary"]).optional(),
+      }),
+    )
+    .optional(),
+  timeoutMs: z.number().int().positive().optional(),
+});
+
+// ── Route definition ──────────────────────────────────────────────────
+
+export const uiRequestRoute: IpcRoute = {
+  method: "ui_request",
+  handler: async (params) => {
+    const validated = UiRequestParams.parse(params);
+    return requestInteractiveUi(validated);
+  },
+};

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the interactive UI request primitive.
+ *
+ * Exercise strategy: the module exposes a register/request pattern with
+ * a module-level resolver, identical to `runtime/agent-wake.ts`. Tests
+ * exercise:
+ *   1. Contract validation — request/result shapes.
+ *   2. Missing resolver behavior (fail-closed).
+ *   3. Resolver registration + delegation.
+ *   4. Resolver error handling (fail-closed on throw).
+ *   5. Surface ID generation and consistency.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type InteractiveUiRequest,
+  type InteractiveUiResult,
+  registerInteractiveUiResolver,
+  requestInteractiveUi,
+  resetInteractiveUiResolverForTests,
+  resetSurfaceIdCounterForTests,
+} from "../interactive-ui.js";
+
+// ── Setup ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetInteractiveUiResolverForTests();
+  resetSurfaceIdCounterForTests();
+});
+
+// ── Missing resolver (fail-closed) ───────────────────────────────────
+
+describe("requestInteractiveUi without resolver", () => {
+  test("returns cancelled when no resolver is registered", async () => {
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: { message: "Are you sure?" },
+    };
+
+    const result = await requestInteractiveUi(request);
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+    expect(result.surfaceId.length).toBeGreaterThan(0);
+    expect(result.actionId).toBeUndefined();
+    expect(result.submittedData).toBeUndefined();
+  });
+
+  test("generates a unique surfaceId per call", async () => {
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-1",
+      surfaceType: "confirmation",
+      data: {},
+    };
+
+    const result1 = await requestInteractiveUi(request);
+    const result2 = await requestInteractiveUi(request);
+
+    expect(result1.surfaceId).not.toBe(result2.surfaceId);
+  });
+});
+
+// ── Resolver registration + delegation ──────────────────────────────
+
+describe("requestInteractiveUi with resolver", () => {
+  test("delegates to the registered resolver", async () => {
+    const receivedRequests: InteractiveUiRequest[] = [];
+
+    registerInteractiveUiResolver(async (req) => {
+      receivedRequests.push(req);
+      return {
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "test-surface-1",
+      };
+    });
+
+    const request: InteractiveUiRequest = {
+      conversationId: "conv-2",
+      surfaceType: "confirmation",
+      title: "Confirm deletion",
+      data: { itemName: "important-file.txt" },
+      actions: [
+        { id: "confirm", label: "Delete", variant: "danger" },
+        { id: "cancel", label: "Cancel", variant: "secondary" },
+      ],
+      timeoutMs: 30_000,
+    };
+
+    const result = await requestInteractiveUi(request);
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.surfaceId).toBe("test-surface-1");
+    expect(receivedRequests).toHaveLength(1);
+    expect(receivedRequests[0].conversationId).toBe("conv-2");
+    expect(receivedRequests[0].surfaceType).toBe("confirmation");
+    expect(receivedRequests[0].title).toBe("Confirm deletion");
+    expect(receivedRequests[0].data).toEqual({
+      itemName: "important-file.txt",
+    });
+    expect(receivedRequests[0].actions).toHaveLength(2);
+    expect(receivedRequests[0].timeoutMs).toBe(30_000);
+  });
+
+  test("passes through timed_out status from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "timeout-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-3",
+      surfaceType: "confirmation",
+      data: {},
+      timeoutMs: 100,
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.surfaceId).toBe("timeout-surface");
+  });
+
+  test("passes through cancelled status from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "cancelled-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-4",
+      surfaceType: "form",
+      data: { fields: ["name", "email"] },
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("cancelled-surface");
+  });
+
+  test("passes through submitted data from resolver", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "submit",
+      submittedData: { name: "Alice", email: "alice@example.com" },
+      summary: "Form submitted by user",
+      surfaceId: "form-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-5",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("submit");
+    expect(result.submittedData).toEqual({
+      name: "Alice",
+      email: "alice@example.com",
+    });
+    expect(result.summary).toBe("Form submitted by user");
+    expect(result.surfaceId).toBe("form-surface");
+  });
+
+  test("replaces resolver when registered a second time", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "first",
+      surfaceId: "first-resolver",
+    }));
+
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "second-resolver",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-6",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBe("second-resolver");
+  });
+});
+
+// ── Error handling (fail-closed on resolver throw) ──────────────────
+
+describe("resolver error handling", () => {
+  test("returns cancelled when resolver throws", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("Surface rendering failed");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-7",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+    expect(result.surfaceId.length).toBeGreaterThan(0);
+  });
+
+  test("returns cancelled when resolver rejects", async () => {
+    registerInteractiveUiResolver(() =>
+      Promise.reject(new Error("Connection lost")),
+    );
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-8",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.surfaceId).toBeString();
+  });
+});
+
+// ── Surface ID consistency ──────────────────────────────────────────
+
+describe("surfaceId handling", () => {
+  test("uses resolver-provided surfaceId when present", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "resolver-provided-id",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-9",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.surfaceId).toBe("resolver-provided-id");
+  });
+
+  test("fills in surfaceId when resolver returns empty string", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-10",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    // Empty string is falsy, so the generated surfaceId should be used
+    expect(result.surfaceId).toStartWith("ui-interaction-");
+  });
+});
+
+// ── Contract shape validation ───────────────────────────────────────
+
+describe("contract shapes", () => {
+  test("request with minimal fields", async () => {
+    const received: InteractiveUiRequest[] = [];
+    registerInteractiveUiResolver(async (req) => {
+      received.push(req);
+      return { status: "cancelled", surfaceId: "min-surface" };
+    });
+
+    await requestInteractiveUi({
+      conversationId: "conv-minimal",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(received[0]).toEqual({
+      conversationId: "conv-minimal",
+      surfaceType: "confirmation",
+      data: {},
+    });
+    // Optional fields should be absent, not undefined
+    expect("title" in received[0]).toBe(false);
+    expect("actions" in received[0]).toBe(false);
+    expect("timeoutMs" in received[0]).toBe(false);
+  });
+
+  test("request with all fields populated", async () => {
+    const received: InteractiveUiRequest[] = [];
+    registerInteractiveUiResolver(async (req) => {
+      received.push(req);
+      return { status: "submitted", actionId: "ok", surfaceId: "full-surface" };
+    });
+
+    const fullRequest: InteractiveUiRequest = {
+      conversationId: "conv-full",
+      surfaceType: "form",
+      title: "Enter details",
+      data: { schema: { name: "string", age: "number" } },
+      actions: [
+        { id: "ok", label: "Submit", variant: "primary" },
+        { id: "skip", label: "Skip" },
+      ],
+      timeoutMs: 60_000,
+    };
+
+    await requestInteractiveUi(fullRequest);
+
+    expect(received[0].conversationId).toBe("conv-full");
+    expect(received[0].surfaceType).toBe("form");
+    expect(received[0].title).toBe("Enter details");
+    expect(received[0].actions).toHaveLength(2);
+    expect(received[0].actions![0].variant).toBe("primary");
+    expect(received[0].actions![1].variant).toBeUndefined();
+    expect(received[0].timeoutMs).toBe(60_000);
+  });
+
+  test("result contract — submitted with all optional fields", async () => {
+    const fullResult: InteractiveUiResult = {
+      status: "submitted",
+      actionId: "confirm",
+      submittedData: { choice: "yes" },
+      summary: "User confirmed the action",
+      surfaceId: "full-result-surface",
+    };
+
+    registerInteractiveUiResolver(async () => fullResult);
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-contract",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("confirm");
+    expect(result.submittedData).toEqual({ choice: "yes" });
+    expect(result.summary).toBe("User confirmed the action");
+    expect(result.surfaceId).toBe("full-result-surface");
+  });
+});

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -9,10 +9,14 @@
  *   3. Resolver registration + delegation.
  *   4. Resolver error handling (fail-closed on throw).
  *   5. Surface ID generation and consistency.
+ *   6. Decision token minting for submitted confirmation requests.
+ *   7. Decision token absence for non-confirmation or non-submitted.
+ *   8. Structured audit log emission for all outcomes.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { decodeDecisionToken } from "../decision-token.js";
 import {
   type InteractiveUiRequest,
   type InteractiveUiResult,
@@ -59,6 +63,17 @@ describe("requestInteractiveUi without resolver", () => {
     const result2 = await requestInteractiveUi(request);
 
     expect(result1.surfaceId).not.toBe(result2.surfaceId);
+  });
+
+  test("does not mint decision token on fail-closed cancel", async () => {
+    const result = await requestInteractiveUi({
+      conversationId: "conv-failclosed",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
   });
 });
 
@@ -219,6 +234,21 @@ describe("resolver error handling", () => {
     expect(result.status).toBe("cancelled");
     expect(result.surfaceId).toBeString();
   });
+
+  test("does not mint decision token on resolver error", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("kaboom");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-err-token",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
+  });
 });
 
 // ── Surface ID consistency ──────────────────────────────────────────
@@ -253,6 +283,165 @@ describe("surfaceId handling", () => {
 
     // Empty string is falsy, so the generated surfaceId should be used
     expect(result.surfaceId).toStartWith("ui-interaction-");
+  });
+});
+
+// ── Decision token minting ──────────────────────────────────────────
+
+describe("decision token", () => {
+  test("mints token for submitted confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "approve",
+      surfaceId: "confirm-surface-1",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-1",
+      surfaceType: "confirmation",
+      data: { message: "Deploy to production?" },
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeString();
+    expect(result.decisionToken!.length).toBeGreaterThan(0);
+
+    // Token should be decodable and contain correct metadata
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload).not.toBeNull();
+    expect(payload!.conversationId).toBe("conv-token-1");
+    expect(payload!.surfaceId).toBe("confirm-surface-1");
+    expect(payload!.action).toBe("approve");
+    expect(payload!.issuedAt).toBeString();
+    expect(payload!.expiresAt).toBeString();
+  });
+
+  test("token encodes actionId when present", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "deny",
+      surfaceId: "deny-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-action",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload!.action).toBe("deny");
+  });
+
+  test("token uses 'submitted' as action when actionId is absent", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      surfaceId: "no-action-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-noaction",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    expect(payload!.action).toBe("submitted");
+  });
+
+  test("token has expiry in the future", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "ok",
+      surfaceId: "expiry-surface",
+    }));
+
+    const before = Date.now();
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-expiry",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const payload = decodeDecisionToken(result.decisionToken!);
+    const expiresAt = new Date(payload!.expiresAt).getTime();
+    // Should expire ~5 minutes in the future
+    expect(expiresAt).toBeGreaterThan(before);
+    expect(expiresAt).toBeGreaterThan(before + 4 * 60 * 1000);
+    expect(expiresAt).toBeLessThanOrEqual(before + 6 * 60 * 1000);
+  });
+
+  test("does not mint token for submitted form request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "submit",
+      submittedData: { name: "Bob" },
+      surfaceId: "form-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-form-notoken",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for cancelled confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "cancel-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-cancel-notoken",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for timed_out confirmation request", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "timeout-no-token",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-timeout-notoken",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("each minted token is unique", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "ok",
+      surfaceId: "unique-surface",
+    }));
+
+    const result1 = await requestInteractiveUi({
+      conversationId: "conv-unique-1",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    const result2 = await requestInteractiveUi({
+      conversationId: "conv-unique-1",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    // Tokens differ due to nonce even with same conversation/action
+    expect(result1.decisionToken).not.toBe(result2.decisionToken);
   });
 });
 
@@ -335,5 +524,7 @@ describe("contract shapes", () => {
     expect(result.submittedData).toEqual({ choice: "yes" });
     expect(result.summary).toBe("User confirmed the action");
     expect(result.surfaceId).toBe("full-result-surface");
+    // Confirmation + submitted → token should be present
+    expect(result.decisionToken).toBeString();
   });
 });

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -289,10 +289,10 @@ describe("surfaceId handling", () => {
 // ── Decision token minting ──────────────────────────────────────────
 
 describe("decision token", () => {
-  test("mints token for submitted confirmation request", async () => {
+  test("mints token for affirmative confirm action", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "approve",
+      actionId: "confirm",
       surfaceId: "confirm-surface-1",
     }));
 
@@ -311,12 +311,30 @@ describe("decision token", () => {
     expect(payload).not.toBeNull();
     expect(payload!.conversationId).toBe("conv-token-1");
     expect(payload!.surfaceId).toBe("confirm-surface-1");
-    expect(payload!.action).toBe("approve");
+    expect(payload!.action).toBe("confirm");
     expect(payload!.issuedAt).toBeString();
     expect(payload!.expiresAt).toBeString();
   });
 
-  test("token encodes actionId when present", async () => {
+  test("does not mint token for non-confirm actionId (e.g. approve)", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "approve",
+      surfaceId: "approve-surface",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-token-approve",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("approve");
+    expect(result.decisionToken).toBeUndefined();
+  });
+
+  test("does not mint token for deny action on confirmation", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
       actionId: "deny",
@@ -324,16 +342,17 @@ describe("decision token", () => {
     }));
 
     const result = await requestInteractiveUi({
-      conversationId: "conv-token-action",
+      conversationId: "conv-token-deny",
       surfaceType: "confirmation",
       data: {},
     });
 
-    const payload = decodeDecisionToken(result.decisionToken!);
-    expect(payload!.action).toBe("deny");
+    expect(result.status).toBe("submitted");
+    expect(result.actionId).toBe("deny");
+    expect(result.decisionToken).toBeUndefined();
   });
 
-  test("token uses 'submitted' as action when actionId is absent", async () => {
+  test("does not mint token when actionId is absent on confirmation", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
       surfaceId: "no-action-surface",
@@ -345,14 +364,14 @@ describe("decision token", () => {
       data: {},
     });
 
-    const payload = decodeDecisionToken(result.decisionToken!);
-    expect(payload!.action).toBe("submitted");
+    expect(result.status).toBe("submitted");
+    expect(result.decisionToken).toBeUndefined();
   });
 
   test("token has expiry in the future", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "ok",
+      actionId: "confirm",
       surfaceId: "expiry-surface",
     }));
 
@@ -424,7 +443,7 @@ describe("decision token", () => {
   test("each minted token is unique", async () => {
     registerInteractiveUiResolver(async () => ({
       status: "submitted",
-      actionId: "ok",
+      actionId: "confirm",
       surfaceId: "unique-surface",
     }));
 

--- a/assistant/src/runtime/decision-token.ts
+++ b/assistant/src/runtime/decision-token.ts
@@ -25,7 +25,7 @@ export interface DecisionTokenPayload {
   conversationId: string;
   /** Surface identifier that was displayed. */
   surfaceId: string;
-  /** Action the user took (`submitted`, `cancelled`, `timed_out`). */
+  /** The action ID the user selected (e.g. "confirm"). Only present on affirmative confirmation. */
   action: string;
   /** ISO-8601 timestamp when the decision was recorded. */
   issuedAt: string;

--- a/assistant/src/runtime/decision-token.ts
+++ b/assistant/src/runtime/decision-token.ts
@@ -1,0 +1,116 @@
+/**
+ * Lightweight informational decision token for interactive UI outcomes.
+ *
+ * Minted when a confirmation-style surface is `submitted`. The token is
+ * **non-authoritative** — it carries metadata about the decision for
+ * audit and correlation purposes only. It does not grant any capability
+ * and must not be used for enforcement or replay protection (that is
+ * explicitly out of scope for v1).
+ *
+ * Format: base64url-encoded JSON payload + `.` + random nonce.
+ * The nonce makes tokens unique even for identical payloads; the
+ * payload is readable by any consumer without a secret.
+ *
+ * This module is intentionally decoupled from the existing auth/token
+ * infrastructure in `runtime/auth/` — it serves a different purpose
+ * and should remain independent.
+ */
+
+import { randomBytes } from "node:crypto";
+
+// ── Token shape ──────────────────────────────────────────────────────
+
+export interface DecisionTokenPayload {
+  /** Conversation the decision belongs to. */
+  conversationId: string;
+  /** Surface identifier that was displayed. */
+  surfaceId: string;
+  /** Action the user took (`submitted`, `cancelled`, `timed_out`). */
+  action: string;
+  /** ISO-8601 timestamp when the decision was recorded. */
+  issuedAt: string;
+  /** ISO-8601 timestamp after which the token should be considered stale. */
+  expiresAt: string;
+}
+
+/** Default token lifetime: 5 minutes. */
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+// ── Minting ──────────────────────────────────────────────────────────
+
+/**
+ * Mint an informational decision token.
+ *
+ * The returned string is `<base64url-payload>.<random-nonce>`. It is
+ * short-lived (default 5 minutes) and non-authoritative.
+ *
+ * @param opts - Decision metadata.
+ * @param opts.conversationId - Conversation scope.
+ * @param opts.surfaceId - Surface that was displayed.
+ * @param opts.action - Terminal action taken by the user.
+ * @param opts.ttlMs - Token lifetime in milliseconds (default 5 min).
+ * @returns The minted token string.
+ */
+export function mintDecisionToken(opts: {
+  conversationId: string;
+  surfaceId: string;
+  action: string;
+  ttlMs?: number;
+}): string {
+  const now = new Date();
+  const ttl = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const expiresAt = new Date(now.getTime() + ttl);
+
+  const payload: DecisionTokenPayload = {
+    conversationId: opts.conversationId,
+    surfaceId: opts.surfaceId,
+    action: opts.action,
+    issuedAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  };
+
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const nonce = randomBytes(12).toString("hex");
+
+  return `${encoded}.${nonce}`;
+}
+
+// ── Decoding (informational only) ────────────────────────────────────
+
+/**
+ * Decode a decision token's payload.
+ *
+ * This is a pure decoding step — there is no signature verification
+ * because the token is non-authoritative. Consumers should treat the
+ * payload as informational metadata, not a trust assertion.
+ *
+ * @param token - The token string produced by {@link mintDecisionToken}.
+ * @returns The decoded payload, or `null` if the token is malformed.
+ */
+export function decodeDecisionToken(
+  token: string,
+): DecisionTokenPayload | null {
+  const dotIdx = token.indexOf(".");
+  if (dotIdx < 0) return null;
+
+  const encodedPayload = token.slice(0, dotIdx);
+  try {
+    const json = Buffer.from(encodedPayload, "base64url").toString("utf-8");
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+
+    // Minimal structural validation
+    if (
+      typeof parsed.conversationId !== "string" ||
+      typeof parsed.surfaceId !== "string" ||
+      typeof parsed.action !== "string" ||
+      typeof parsed.issuedAt !== "string" ||
+      typeof parsed.expiresAt !== "string"
+    ) {
+      return null;
+    }
+
+    return parsed as unknown as DecisionTokenPayload;
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -217,10 +217,13 @@ function emitAuditLog(
  * Fails closed: when no resolver is registered (headless, tests without
  * setup), returns `{ status: "cancelled", surfaceId }` immediately.
  *
- * When the surface type is `"confirmation"` and the user submits, a
- * short-lived informational decision token is minted and attached to
- * the result. The token is non-authoritative — see
- * {@link mintDecisionToken} for details.
+ * When the surface type is `"confirmation"` and the user selects the
+ * `"confirm"` action, a short-lived informational decision token is
+ * minted and attached to the result. Deny actions and other non-confirm
+ * outcomes do not receive a token. If token minting fails, the user's
+ * decision is still returned as `submitted` (the token is best-effort).
+ * The token is non-authoritative — see {@link mintDecisionToken} for
+ * details.
  *
  * Structured audit logs are emitted for all terminal outcomes
  * (`submitted`, `cancelled`, `timed_out`).
@@ -260,18 +263,26 @@ export async function requestInteractiveUi(
       surfaceId: finalSurfaceId,
     };
 
-    // Mint an informational decision token for submitted confirmation
-    // requests. The token encodes the decision metadata and is
-    // short-lived (5 minutes). It is non-authoritative in v1.
+    // Mint an informational decision token only for affirmative
+    // confirmation actions. The token is short-lived (5 minutes) and
+    // non-authoritative in v1. Deny/cancel/timeout do not receive tokens.
     if (
       result.status === "submitted" &&
-      request.surfaceType === "confirmation"
+      request.surfaceType === "confirmation" &&
+      result.actionId === "confirm"
     ) {
-      result.decisionToken = mintDecisionToken({
-        conversationId: request.conversationId,
-        surfaceId: finalSurfaceId,
-        action: result.actionId ?? "submitted",
-      });
+      try {
+        result.decisionToken = mintDecisionToken({
+          conversationId: request.conversationId,
+          surfaceId: finalSurfaceId,
+          action: result.actionId,
+        });
+      } catch (tokenErr) {
+        log.warn(
+          { err: tokenErr, surfaceId: finalSurfaceId },
+          "interactive-ui: failed to mint decision token; continuing without it",
+        );
+      }
     }
 
     emitAuditLog(request, result);

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -1,0 +1,229 @@
+/**
+ * Generic UI interaction request primitive.
+ *
+ * Provides a conversation-scoped mechanism for daemon-side code (skills,
+ * IPC handlers, CLI wrappers) to present an interactive UI surface to the
+ * user and await their response. This is intentionally decoupled from the
+ * confirmation_request / guardian approval pipeline — it serves a different
+ * purpose (ad-hoc UI prompts driven by skills or CLI commands, not
+ * tool-approval gates).
+ *
+ * Architecture:
+ *   - Typed {@link InteractiveUiRequest} / {@link InteractiveUiResult}
+ *     contracts define the wire shape for callers and resolvers.
+ *   - A module-level resolver ({@link registerInteractiveUiResolver}) is
+ *     installed once at daemon startup, following the same pattern as
+ *     {@link registerDefaultWakeResolver} in `runtime/agent-wake.ts`.
+ *   - {@link requestInteractiveUi} is the callable entry point. It
+ *     delegates to the registered resolver; when no resolver is present
+ *     (e.g. headless environments, test harnesses that don't install
+ *     one), it fails closed by returning a `"cancelled"` result.
+ *
+ * Concurrency:
+ *   - Requests are scoped to a single conversation and identified by a
+ *     unique `surfaceId` generated at request time.
+ *   - Multiple concurrent requests on different conversations are
+ *     independent.
+ *   - The resolver is responsible for lifecycle management of the
+ *     underlying surface (show, await action/timeout, dismiss).
+ *
+ * Fail-closed guarantee:
+ *   - If no resolver is registered, `requestInteractiveUi` returns
+ *     `{ status: "cancelled" }` immediately.
+ *   - If the request times out (per `timeoutMs`), the result status is
+ *     `"timed_out"`.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("interactive-ui");
+
+// ── Request / Result contracts ───────────────────────────────────────
+
+/**
+ * Describes a single action button/option presented to the user on the
+ * interactive surface.
+ */
+export interface InteractiveUiAction {
+  /** Unique identifier for this action within the request. */
+  id: string;
+  /** Human-readable label shown on the button/option. */
+  label: string;
+  /**
+   * Optional variant hint for the renderer.
+   * - `"primary"` — emphasized / default action
+   * - `"danger"` — destructive action (red styling)
+   * - `"secondary"` — de-emphasized / cancel-like action
+   */
+  variant?: "primary" | "danger" | "secondary";
+}
+
+/**
+ * A request to show an interactive UI surface to the user and await their
+ * response.
+ */
+export interface InteractiveUiRequest {
+  /** Conversation this interaction is scoped to. */
+  conversationId: string;
+  /**
+   * Surface type hint for the renderer.
+   * - `"confirmation"` — yes/no or approve/deny prompt
+   * - `"form"` — structured data entry (v1 placeholder)
+   */
+  surfaceType: "confirmation" | "form";
+  /** Optional title displayed at the top of the surface. */
+  title?: string;
+  /**
+   * Arbitrary payload describing the content of the surface. The shape
+   * depends on `surfaceType` — the runtime treats it as opaque and
+   * forwards it to the renderer.
+   */
+  data: Record<string, unknown>;
+  /** Actions (buttons) to present. When omitted, the renderer uses its default set. */
+  actions?: InteractiveUiAction[];
+  /**
+   * Maximum time (in milliseconds) to wait for a user response before
+   * the request resolves with `status: "timed_out"`. When omitted, the
+   * resolver uses its own default timeout (typically 5 minutes).
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * The result of an interactive UI request after the user has responded
+ * or the request has expired.
+ */
+export interface InteractiveUiResult {
+  /**
+   * Terminal status of the interaction.
+   * - `"submitted"` — the user selected an action / submitted data
+   * - `"cancelled"` — the user explicitly dismissed the surface, or the
+   *   surface could not be shown (fail-closed)
+   * - `"timed_out"` — the timeout elapsed without a user response
+   */
+  status: "submitted" | "cancelled" | "timed_out";
+  /** The `id` of the action the user selected (when `status === "submitted"`). */
+  actionId?: string;
+  /** Structured data submitted by the user (for `surfaceType: "form"`). */
+  submittedData?: Record<string, unknown>;
+  /** Optional human-readable summary of the user's response. */
+  summary?: string;
+  /** The surface identifier that was shown, for audit/correlation. */
+  surfaceId: string;
+}
+
+// ── Resolver type ────────────────────────────────────────────────────
+
+/**
+ * A function that presents an interactive UI surface and resolves when
+ * the user responds or the timeout elapses.
+ */
+export type InteractiveUiResolver = (
+  request: InteractiveUiRequest,
+) => Promise<InteractiveUiResult>;
+
+// ── Module-level resolver registration ───────────────────────────────
+//
+// Same pattern as `runtime/agent-wake.ts`: a module-level default
+// resolver that the daemon installs once at startup. Callers that use
+// `requestInteractiveUi()` get the daemon-wired resolver automatically.
+// Tests can register a mock resolver and reset via the test-only helper.
+
+let _resolver: InteractiveUiResolver | null = null;
+
+/**
+ * Install the process-wide interactive UI resolver. Called once at
+ * daemon startup (see `DaemonServer.start()`) with a function that
+ * knows how to show a surface on a live conversation and await the
+ * user's response.
+ *
+ * Calling this more than once replaces the prior resolver — the daemon
+ * startup path should call it exactly once.
+ */
+export function registerInteractiveUiResolver(
+  resolver: InteractiveUiResolver,
+): void {
+  _resolver = resolver;
+}
+
+/**
+ * Reset the process-wide resolver. Test-only.
+ *
+ * @internal
+ */
+export function resetInteractiveUiResolverForTests(): void {
+  _resolver = null;
+}
+
+// ── Surface ID generation ────────────────────────────────────────────
+
+let _surfaceIdCounter = 0;
+
+function generateSurfaceId(): string {
+  _surfaceIdCounter++;
+  return `ui-interaction-${Date.now()}-${_surfaceIdCounter}`;
+}
+
+/**
+ * Reset the surface ID counter. Test-only.
+ *
+ * @internal
+ */
+export function resetSurfaceIdCounterForTests(): void {
+  _surfaceIdCounter = 0;
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Present an interactive UI surface to the user and await their
+ * response.
+ *
+ * Fails closed: when no resolver is registered (headless, tests without
+ * setup), returns `{ status: "cancelled", surfaceId }` immediately.
+ *
+ * @param request - The interaction request describing the surface.
+ * @returns The user's response or a fail-closed cancellation.
+ */
+export async function requestInteractiveUi(
+  request: InteractiveUiRequest,
+): Promise<InteractiveUiResult> {
+  const surfaceId = generateSurfaceId();
+
+  if (!_resolver) {
+    log.warn(
+      {
+        conversationId: request.conversationId,
+        surfaceType: request.surfaceType,
+      },
+      "interactive-ui: no resolver registered; failing closed",
+    );
+    return {
+      status: "cancelled",
+      surfaceId,
+    };
+  }
+
+  try {
+    const result = await _resolver(request);
+    // Ensure the surfaceId is consistent — the resolver may or may not
+    // populate it, but the contract guarantees it is always present.
+    return {
+      ...result,
+      surfaceId: result.surfaceId || surfaceId,
+    };
+  } catch (err) {
+    log.error(
+      {
+        err,
+        conversationId: request.conversationId,
+        surfaceType: request.surfaceType,
+      },
+      "interactive-ui: resolver threw; failing closed",
+    );
+    return {
+      status: "cancelled",
+      surfaceId,
+    };
+  }
+}

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -35,6 +35,7 @@
  */
 
 import { getLogger } from "../util/logger.js";
+import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
@@ -110,6 +111,15 @@ export interface InteractiveUiResult {
   summary?: string;
   /** The surface identifier that was shown, for audit/correlation. */
   surfaceId: string;
+  /**
+   * Short-lived informational decision token, present when
+   * `status === "submitted"` and `surfaceType === "confirmation"`.
+   *
+   * Non-authoritative — carries metadata about the decision for audit
+   * and correlation purposes only. Does not grant any capability.
+   * Verification/replay enforcement is out of scope for v1.
+   */
+  decisionToken?: string;
 }
 
 // ── Resolver type ────────────────────────────────────────────────────
@@ -173,6 +183,31 @@ export function resetSurfaceIdCounterForTests(): void {
   _surfaceIdCounter = 0;
 }
 
+// ── Audit logging ────────────────────────────────────────────────────
+
+/**
+ * Emit a structured audit log entry for an interactive UI decision.
+ * Keyed by conversation/surface/request IDs so downstream consumers
+ * can correlate decisions across the system.
+ */
+function emitAuditLog(
+  request: InteractiveUiRequest,
+  result: InteractiveUiResult,
+): void {
+  log.info(
+    {
+      event: "interactive_ui_decision",
+      conversationId: request.conversationId,
+      surfaceId: result.surfaceId,
+      surfaceType: request.surfaceType,
+      status: result.status,
+      actionId: result.actionId,
+      timestamp: new Date().toISOString(),
+    },
+    "interactive-ui: decision recorded",
+  );
+}
+
 // ── Public API ───────────────────────────────────────────────────────
 
 /**
@@ -181,6 +216,14 @@ export function resetSurfaceIdCounterForTests(): void {
  *
  * Fails closed: when no resolver is registered (headless, tests without
  * setup), returns `{ status: "cancelled", surfaceId }` immediately.
+ *
+ * When the surface type is `"confirmation"` and the user submits, a
+ * short-lived informational decision token is minted and attached to
+ * the result. The token is non-authoritative — see
+ * {@link mintDecisionToken} for details.
+ *
+ * Structured audit logs are emitted for all terminal outcomes
+ * (`submitted`, `cancelled`, `timed_out`).
  *
  * @param request - The interaction request describing the surface.
  * @returns The user's response or a fail-closed cancellation.
@@ -198,20 +241,41 @@ export async function requestInteractiveUi(
       },
       "interactive-ui: no resolver registered; failing closed",
     );
-    return {
+    const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
     };
+    emitAuditLog(request, failResult);
+    return failResult;
   }
 
   try {
-    const result = await _resolver(request);
+    const resolverResult = await _resolver(request);
     // Ensure the surfaceId is consistent — the resolver may or may not
     // populate it, but the contract guarantees it is always present.
-    return {
-      ...result,
-      surfaceId: result.surfaceId || surfaceId,
+    const finalSurfaceId = resolverResult.surfaceId || surfaceId;
+
+    const result: InteractiveUiResult = {
+      ...resolverResult,
+      surfaceId: finalSurfaceId,
     };
+
+    // Mint an informational decision token for submitted confirmation
+    // requests. The token encodes the decision metadata and is
+    // short-lived (5 minutes). It is non-authoritative in v1.
+    if (
+      result.status === "submitted" &&
+      request.surfaceType === "confirmation"
+    ) {
+      result.decisionToken = mintDecisionToken({
+        conversationId: request.conversationId,
+        surfaceId: finalSurfaceId,
+        action: result.actionId ?? "submitted",
+      });
+    }
+
+    emitAuditLog(request, result);
+    return result;
   } catch (err) {
     log.error(
       {
@@ -221,9 +285,11 @@ export async function requestInteractiveUi(
       },
       "interactive-ui: resolver threw; failing closed",
     );
-    return {
+    const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
     };
+    emitAuditLog(request, failResult);
+    return failResult;
   }
 }

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -132,6 +132,8 @@
 
   **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
 
+  **Decision token**: When the user affirmatively confirms (action `"confirm"`), the JSON output includes a `decisionToken` field — a short-lived, non-authoritative token encoding metadata about the decision (conversation, surface, action, timestamps). Use it for audit trails and cross-system correlation. The token is informational only and does not grant any capability. It is absent for deny, cancel, and timeout outcomes.
+
   ### Conversation ID resolution
 
   Inside a skill context, the conversation ID is auto-resolved from `__SKILL_CONTEXT_JSON` (set by the skill sandbox runner). Override with `--conversation-id <id>` if needed — run `assistant conversations list` to find available IDs.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -34,5 +34,111 @@
   - The `inline-skill-commands` feature flag must be enabled for inline expansions to work. When the flag is off, skills containing expansion tokens fail closed at load time
   - Inline command expansions are only supported for `bundled`, `managed`, and `workspace` skill sources. Skills distributed as `extra` sources cannot use this syntax
 
+- **User-gated actions (interactive confirmation/input)**
+
+  Scripts that perform irreversible or high-risk operations (sending emails, deleting data, unsubscribing, making purchases) **must** gate execution on explicit user confirmation. Prose-only instructions in SKILL.md ("always ask the user first") are not sufficient — they rely on the LLM following the instruction, which is not guaranteed.
+
+  Use the `assistant ui` CLI commands to present a blocking interactive surface and branch on the result. Two commands are available:
+
+  ### `assistant ui confirm` — binary yes/no gate
+
+  Use this for irreversible actions that need a simple go/no-go decision. The command exits `0` on confirm, `1` on deny/cancel/timeout.
+
+  ```bash
+  # Gate on user confirmation before sending an email
+  if assistant ui confirm \
+    --title "Send email" \
+    --message "Send draft to jane@example.com — Subject: Q2 Report" \
+    --confirm-label "Send" \
+    --deny-label "Cancel"; then
+    # User confirmed — proceed with the action
+    assistant oauth request POST "/v1.0/me/messages/${DRAFT_ID}/send" \
+      --provider microsoft-graph
+  else
+    echo "Send cancelled by user."
+    exit 0
+  fi
+  ```
+
+  For scripts that need to inspect the result (e.g. distinguish deny from timeout):
+
+  ```bash
+  RESULT=$(assistant ui confirm \
+    --title "Delete records" \
+    --message "Permanently delete 42 records from the archive?" \
+    --confirm-label "Delete" \
+    --deny-label "Keep" \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  CONFIRMED=$(echo "$RESULT" | jq -r '.confirmed')
+
+  case "$STATUS" in
+    submitted)
+      if [ "$CONFIRMED" = "true" ]; then
+        # User clicked "Delete" — proceed
+        perform_deletion
+      else
+        echo "User denied the action."
+      fi
+      ;;
+    cancelled)
+      echo "User dismissed the prompt."
+      ;;
+    timed_out)
+      echo "No response — timed out. Aborting."
+      ;;
+    *)
+      echo "Unexpected status: $STATUS" >&2
+      exit 1
+      ;;
+  esac
+  ```
+
+  ### `assistant ui request` — structured input/data collection
+
+  Use this when you need more than a yes/no — e.g. collecting form data, presenting choices, or gathering parameters before executing an operation. Returns full JSON with user-submitted data.
+
+  ```bash
+  RESULT=$(assistant ui request \
+    --payload '{"message":"Select accounts to archive","fields":[{"name":"accounts","type":"multi-select"}]}' \
+    --surface-type form \
+    --title "Archive accounts" \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+
+  if [ "$STATUS" = "submitted" ]; then
+    # Extract user-submitted data and proceed
+    ACCOUNTS=$(echo "$RESULT" | jq -r '.submittedData.accounts')
+    archive_accounts "$ACCOUNTS"
+  elif [ "$STATUS" = "cancelled" ]; then
+    echo "User cancelled."
+  else
+    echo "Request failed or timed out: $STATUS"
+    exit 1
+  fi
+  ```
+
+  ### Status branching reference
+
+  Every `assistant ui` response includes a `status` field. Handle all three terminal states:
+
+  | Status | Meaning | Typical action |
+  |--------|---------|----------------|
+  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | Check `actionId` to determine the action taken — e.g. `"confirm"` or `"deny"` for confirmations. For `ui confirm`, exit code 0 = confirmed, 1 = denied. |
+  | `cancelled` | User dismissed the surface without choosing an action (e.g. closed the dialog) | Abort gracefully. Inform the user the action was skipped. |
+  | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
+
+  **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
+
+  ### Conversation ID resolution
+
+  Inside a skill context, the conversation ID is auto-resolved from `__SKILL_CONTEXT_JSON` (set by the skill sandbox runner). Override with `--conversation-id <id>` if needed — run `assistant conversations list` to find available IDs.
+
+  ### Timeouts
+
+  Both commands accept `--timeout <ms>` (default: 300000ms / 5 minutes). Choose a timeout appropriate to the operation — shorter for simple confirmations, longer for complex forms. On timeout, the surface auto-cancels and the CLI exits with `status: "timed_out"`.
+
 - **Vellum-specific extensions**
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -34,7 +34,24 @@ For details on how to use this command, run:
 assistant oauth request --help
 ```
 
-You should err towards asking your user for permission to make the request, especially if it performs side-effects (e.g. updates data, sends an email, etc.)
+**Side-effect requests require explicit user confirmation.** If the request performs a side-effect (updates data, sends an email, deletes a record, etc.), gate it with `assistant ui confirm` so the user has a hard runtime veto — do not rely solely on SKILL.md prose instructions.
+
+```bash
+# Example: gate a destructive OAuth request on user confirmation
+if assistant ui confirm \
+  --title "Send email" \
+  --message "Send draft to jane@example.com — Subject: Q2 Report" \
+  --confirm-label "Send" \
+  --deny-label "Cancel"; then
+  assistant oauth request POST "/v1.0/me/messages/${DRAFT_ID}/send" \
+    --provider microsoft-graph
+else
+  echo "Cancelled — email not sent."
+  exit 0
+fi
+```
+
+For read-only requests (fetching data, listing resources), no confirmation gate is needed.
 
 ### OAuth Token Escape Hatch
 


### PR DESCRIPTION
## Summary
Adds a generic, conversation-scoped UI interaction kernel around existing surface plumbing. Exposes it under `assistant ui`, with a focused `assistant ui confirm` wrapper for irreversible yes/no gates. Scripts and skills can now present blocking interactive surfaces to users and await their response.

## Self-review result
GAPS FOUND — 9 gaps fixed across 3 fix PRs (all verified in re-review)

## PRs merged into feature branch
- #26350: feat(assistant): add generic UI interaction request contract and daemon resolver hook
- #26360: feat(assistant): add standalone surface request lifecycle that resolves callbacks without LLM follow-up
- #26365: feat(assistant): expose ui_request IPC method for script-driven interactions
- #26366: test(clients): verify confirmation/form callback behavior for daemon-driven standalone requests
- #26369: feat(assistant): add optional informational decision token and structured audit logs
- #26370: feat(assistant): add script-facing assistant ui request and assistant ui confirm commands
- #26377: docs(skills): standardize interactive script gating patterns with ui request + confirm wrapper

### Fix PRs
- #26382: fix: isolate token mint failures, gate on confirm, add token to confirm output
- #26381: fix: add tombstone guard for late standalone surface callbacks
- #26380: fix: robust timeout handler and deny label in completion summary

Part of plan: user-confirmation-primitive.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
