### PR TITLE
perf(gmail): speed up sender digest scan

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -171,7 +171,7 @@ Merge results from all passes before presenting the final table. Each pass cover
 
 - **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
-- **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured. Offer to run additional date-range passes to cover the remaining messages (see Large Inbox Handling above).
+- **Truncation handling**: The scan covers up to 1,000 messages by default (cap 2,000). If `truncated` is true, the top senders are still captured. Offer to run additional date-range passes to cover the remaining messages (see Large Inbox Handling above).
 - **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Offer to run additional date-range passes for uncovered periods.
 
 ## Cleanup Preferences (Blocklist & Safelist)

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -494,7 +494,7 @@
           },
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 5000)"
+            "description": "Maximum messages to scan (default 1000, cap 2000)"
           },
           "max_senders": {
             "type": "number",
@@ -502,7 +502,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
+            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 2,000 messages in a single call)"
           },
           "activity": {
             "type": "string",
@@ -527,7 +527,7 @@
         "properties": {
           "max_messages": {
             "type": "number",
-            "description": "Maximum messages to scan (default 2000, cap 5000)"
+            "description": "Maximum messages to scan (default 1000, cap 2000)"
           },
           "max_senders": {
             "type": "number",
@@ -539,7 +539,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
+            "description": "Resume token from a previous scan (rarely needed - scans now cover up to 2,000 messages in a single call)"
           },
           "activity": {
             "type": "string",
@@ -564,7 +564,13 @@
         "properties": {
           "action": {
             "type": "string",
-            "enum": ["list", "add_blocklist", "add_safelist", "remove_blocklist", "remove_safelist"],
+            "enum": [
+              "list",
+              "add_blocklist",
+              "add_safelist",
+              "remove_blocklist",
+              "remove_safelist"
+            ],
             "description": "Preference action: list all preferences, or add/remove emails from blocklist or safelist"
           },
           "emails": {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -18,7 +18,8 @@ function isRateLimitError(e: unknown): boolean {
 
 function isAbortError(e: unknown): boolean {
   if (e instanceof DOMException && e.name === "AbortError") return true;
-  if (e instanceof Error && e.message === "fetch deadline exceeded") return true;
+  if (e instanceof Error && e.message === "fetch deadline exceeded")
+    return true;
   // AbortSignal.reason propagated through promise chains
   if (
     e instanceof Error &&
@@ -30,8 +31,8 @@ function isAbortError(e: unknown): boolean {
   return false;
 }
 
-const MAX_MESSAGES_CAP = 5000;
-const MAX_IDS_PER_SENDER = 5000;
+const MAX_MESSAGES_CAP = 2000;
+const MAX_IDS_PER_SENDER = 2000;
 const MAX_SAMPLE_SUBJECTS = 3;
 const MAX_SENDERS_CAP = 75;
 const MAX_SUBJECT_LENGTH = 80;
@@ -74,7 +75,7 @@ export async function run(
   const query =
     (input.query as string) ?? "in:inbox category:promotions newer_than:90d";
   const maxMessages = Math.min(
-    (input.max_messages as number) ?? 2000,
+    (input.max_messages as number) ?? 1000,
     MAX_MESSAGES_CAP,
   );
   const maxSenders = Math.min(
@@ -107,15 +108,10 @@ export async function run(
         truncated = true;
         break;
       }
-      const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+      const pageSize = Math.min(500, maxMessages - allMessageIds.length);
       let listResp;
       try {
-        listResp = await listMessages(
-          connection,
-          query,
-          pageSize,
-          pageToken,
-        );
+        listResp = await listMessages(connection, query, pageSize, pageToken);
       } catch (e) {
         if (isRateLimitError(e)) {
           rateLimited = true;


### PR DESCRIPTION
## Summary
- Increase Gmail `messages.list` page size from 100 to 500 (the API maximum), cutting pagination round-trips by 5x
- Lower default `max_messages` from 2000 to 1000 and cap from 5000 to 2000 — 1000 messages is plenty to identify top senders
- Update tool descriptions and SKILL.md to reflect new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
