### PR TITLE
fix(gmail): respect explicit guardian approval in surface action gates

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -178,7 +178,7 @@ Merge results from all passes before presenting the final table. Each pass cover
 
 The `gmail_preferences` tool persists sender preferences across cleanup sessions:
 
-- **Blocklist**: Sender emails archived in previous sessions. On future cleanups, pre-pass archive all blocklisted senders before scanning (use `gmail_archive` with `query: "from:email1 OR from:email2 ... in:inbox"`).
+- **Blocklist**: Sender emails archived in previous sessions. On future cleanups, pre-pass archive all blocklisted senders before scanning (use `gmail_archive` with `query: "from:email1 OR from:email2 ... in:inbox"`). The user will see a permission prompt for the archive — once approved, the tool proceeds.
 - **Safelist**: Sender emails the user explicitly deselected (chose to keep). Exclude these senders from future cleanup tables entirely.
 
 ### Workflow integration

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -65,7 +65,11 @@ export async function run(
   // Resolve message IDs via priority: query → scan_id+sender_ids → message_ids → message_id
   if (query) {
     // Query path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+    if (
+      !context.triggeredBySurfaceAction &&
+      !context.batchAuthorizedByTask &&
+      !context.approvedViaPrompt
+    ) {
       return err(
         "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );
@@ -120,7 +124,11 @@ export async function run(
     }
   } else if (scanId && senderIds?.length) {
     // Scan path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+    if (
+      !context.triggeredBySurfaceAction &&
+      !context.batchAuthorizedByTask &&
+      !context.approvedViaPrompt
+    ) {
       return err(
         "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );
@@ -203,7 +211,11 @@ export async function run(
     }
   } else if (messageIds?.length) {
     // Batch message_ids path requires surface action confirmation
-    if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+    if (
+      !context.triggeredBySurfaceAction &&
+      !context.batchAuthorizedByTask &&
+      !context.approvedViaPrompt
+    ) {
       return err(
         "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
       );

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -19,7 +19,11 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const account = input.account as string | undefined;
-  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+  if (
+    !context.triggeredBySurfaceAction &&
+    !context.batchAuthorizedByTask &&
+    !context.approvedViaPrompt
+  ) {
     return err(
       "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -8,7 +8,11 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+  if (
+    !context.triggeredBySurfaceAction &&
+    !context.batchAuthorizedByTask &&
+    !context.approvedViaPrompt
+  ) {
     return err(
       "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
@@ -14,7 +14,7 @@ export async function run(
   const draftId = input.draft_id as string;
   if (!draftId) return err("draft_id is required.");
 
-  if (!context.triggeredBySurfaceAction) {
+  if (!context.triggeredBySurfaceAction && !context.approvedViaPrompt) {
     return err(
       "This tool requires user confirmation via a surface action. Present the draft details with a send button and wait for the user to click before proceeding.",
     );

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
@@ -23,7 +23,11 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const account = input.account as string | undefined;
-  if (!context.triggeredBySurfaceAction && !context.batchAuthorizedByTask) {
+  if (
+    !context.triggeredBySurfaceAction &&
+    !context.batchAuthorizedByTask &&
+    !context.approvedViaPrompt
+  ) {
     return err(
       "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -132,6 +132,10 @@ export class ToolExecutor {
         if (!permResult.allowed) {
           return { content: permResult.content, isError: true };
         }
+
+        if (permResult.wasPrompted) {
+          context.approvedViaPrompt = true;
+        }
       }
 
       const hookResult = await getHookManager().trigger("pre-tool-execute", {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -29,7 +29,12 @@ import type { Tool, ToolContext, ToolLifecycleEvent } from "./types.js";
 const log = getLogger("permission-checker");
 
 export type PermissionDecision =
-  | { allowed: true; decision: string; riskLevel: string }
+  | {
+      allowed: true;
+      decision: string;
+      riskLevel: string;
+      wasPrompted?: boolean;
+    }
   | { allowed: false; decision: string; riskLevel: string; content: string };
 
 export class PermissionChecker {
@@ -502,7 +507,7 @@ export class PermissionChecker {
           );
         }
 
-        return { allowed: true, decision, riskLevel };
+        return { allowed: true, decision, riskLevel, wasPrompted: true };
       }
 
       // result.decision === 'allow'

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -163,6 +163,8 @@ export interface ToolContext {
   callSessionId?: string;
   /** True when the tool invocation was triggered by a user clicking a surface action button (not a regular message). */
   triggeredBySurfaceAction?: boolean;
+  /** True when the user explicitly approved this tool invocation via the interactive permission prompt (not auto-approved by trust rules or temporary overrides). */
+  approvedViaPrompt?: boolean;
   /**
    * True when the invocation is inside a scheduled task run whose
    * `required_tools` array pre-authorized this tool at task-creation time.


### PR DESCRIPTION
## Summary

- Added `approvedViaPrompt` field to `ToolContext` that's set when the user explicitly approves a tool via the interactive permission prompt (not auto-approved by trust rules or temporary overrides)
- Updated all 6 surface action gates (gmail-archive, gmail-unsubscribe, outlook-unsubscribe, outlook-send-draft, messaging-archive-by-sender) to accept `approvedViaPrompt` as a third authorization path
- Clarified SKILL.md blocklist pre-pass docs to note the permission prompt flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
