### PR TITLE
pkb: add shared types and target_type constant for PKB indexing

### DIFF
--- a/assistant/src/memory/pkb/types.ts
+++ b/assistant/src/memory/pkb/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared types and constants for PKB (Personal Knowledge Base) indexing.
+ *
+ * Scaffolding for upcoming PKB Qdrant indexing work — consumers (search,
+ * index writer) land in later PRs.
+ */
+
+export const PKB_TARGET_TYPE = "pkb_file" as const;
+
+export interface PkbSearchResult {
+  path: string;
+  score: number;
+  snippet?: string;
+}
+
+export interface PkbIndexEntry {
+  path: string;
+  mtimeMs: number;
+  contentHash: string;
+  chunkIndex: number;
+}
+
+export interface PkbIndexPayload {
+  target_type: typeof PKB_TARGET_TYPE;
+  target_id: string;
+  path: string;
+  mtime_ms: number;
+  chunk_index: number;
+  content_hash: string;
+  memory_scope_id: string;
+}


### PR DESCRIPTION
## Summary
- Scaffolding types for upcoming PKB Qdrant indexing work.
- Adds PKB_TARGET_TYPE constant, PkbSearchResult, PkbIndexEntry, PkbIndexPayload interfaces.

Part of plan: pkb-reminder-hints.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
