### PR TITLE
pkb: add buildPkbReminder pure function and tests

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildPkbReminder } from "./pkb-reminder-builder.js";
+
+// Byte-for-byte fixture of the original PKB_SYSTEM_REMINDER from
+// conversation-runtime-assembly.ts. If this ever needs to change, the
+// matching string in conversation-runtime-assembly.ts must change too.
+const ORIGINAL_REMINDER =
+  "<system_reminder>" +
+  "\nRead any unread PKB files that might be even partially relevant to this conversation" +
+  "\nUse `remember` for anything you learn immediately" +
+  "\n</system_reminder>";
+
+describe("buildPkbReminder", () => {
+  test("empty hints returns exact original reminder byte-for-byte", () => {
+    expect(buildPkbReminder([])).toBe(ORIGINAL_REMINDER);
+  });
+
+  test("single hint renders one bullet with no duplicates or trailing blank line", () => {
+    const out = buildPkbReminder(["projects/alpha.md"]);
+    const expected =
+      "<system_reminder>" +
+      "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+      "\nBased on the current context, these files look especially relevant:" +
+      "\n- projects/alpha.md" +
+      "\nUse `remember` for anything you learn immediately" +
+      "\n</system_reminder>";
+    expect(out).toBe(expected);
+
+    // Exactly one bullet.
+    const bulletCount = (out.match(/^- /gm) ?? []).length;
+    expect(bulletCount).toBe(1);
+
+    // No blank line before closing tag.
+    expect(out.includes("\n\n</system_reminder>")).toBe(false);
+  });
+
+  test("three hints render all three in order", () => {
+    const hints = ["a.md", "sub/b.md", "c/d/e.md"];
+    const out = buildPkbReminder(hints);
+    const expected =
+      "<system_reminder>" +
+      "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+      "\nBased on the current context, these files look especially relevant:" +
+      "\n- a.md" +
+      "\n- sub/b.md" +
+      "\n- c/d/e.md" +
+      "\nUse `remember` for anything you learn immediately" +
+      "\n</system_reminder>";
+    expect(out).toBe(expected);
+
+    // Order check — each should appear after the previous.
+    const idxA = out.indexOf("- a.md");
+    const idxB = out.indexOf("- sub/b.md");
+    const idxC = out.indexOf("- c/d/e.md");
+    expect(idxA).toBeGreaterThan(-1);
+    expect(idxB).toBeGreaterThan(idxA);
+    expect(idxC).toBeGreaterThan(idxB);
+  });
+
+  test("hints with special chars (< and &) are emitted verbatim (no escaping)", () => {
+    const hints = ["weird<name>.md", "foo&bar.md"];
+    const out = buildPkbReminder(hints);
+    expect(out).toContain("- weird<name>.md");
+    expect(out).toContain("- foo&bar.md");
+    // Ensure no HTML-style escaping happened.
+    expect(out).not.toContain("&lt;");
+    expect(out).not.toContain("&amp;");
+  });
+});

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -1,0 +1,31 @@
+/**
+ * Render the PKB system_reminder text, optionally with a bulleted list of
+ * hint paths that look especially relevant to the current conversation.
+ *
+ * When `hints` is empty, returns the legacy two-line reminder byte-for-byte.
+ * When `hints` is non-empty, renders an extended reminder with a bullet per
+ * hint. Hints are emitted verbatim — they are trusted internal paths, not
+ * user input, so no escaping is performed.
+ *
+ * Caller is responsible for capping the hints array at 3 entries.
+ */
+export function buildPkbReminder(hints: ReadonlyArray<string>): string {
+  if (hints.length === 0) {
+    return (
+      "<system_reminder>" +
+      "\nRead any unread PKB files that might be even partially relevant to this conversation" +
+      "\nUse `remember` for anything you learn immediately" +
+      "\n</system_reminder>"
+    );
+  }
+
+  const bullets = hints.map((h) => `- ${h}`).join("\n");
+  return (
+    "<system_reminder>" +
+    "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+    "\nBased on the current context, these files look especially relevant:" +
+    `\n${bullets}` +
+    "\nUse `remember` for anything you learn immediately" +
+    "\n</system_reminder>"
+  );
+}


### PR DESCRIPTION
## Summary
- Pure function that produces the PKB system_reminder text, with optional bulleted hint list.
- Empty-hints fallback is byte-for-byte identical to the current static reminder.
- Caller is responsible for capping at 3 hints.

Part of plan: pkb-reminder-hints.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
