### PR TITLE
pkb: add getInContextPkbPaths helper and tests

### DIFF
--- a/assistant/src/daemon/pkb-context-tracker.test.ts
+++ b/assistant/src/daemon/pkb-context-tracker.test.ts
@@ -1,0 +1,137 @@
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../providers/types.js";
+import type { Conversation } from "./conversation.js";
+import { getInContextPkbPaths } from "./pkb-context-tracker.js";
+
+const PKB_ROOT = path.resolve("/tmp/test-pkb-root");
+
+// The helper only reads `conversation.messages`. Constructing a real
+// `Conversation` instance would require a full daemon setup; casting a
+// minimal object through `unknown` keeps the test isolated and pure while
+// still exercising the public type.
+function makeConversation(messages: Message[]): Conversation {
+  return { messages } as unknown as Conversation;
+}
+
+function fileReadToolUse(filePath: string): ContentBlock {
+  return {
+    type: "tool_use",
+    id: `toolu_${Math.random().toString(36).slice(2, 10)}`,
+    name: "file_read",
+    input: { path: filePath },
+  };
+}
+
+function assistantMessageWithBlocks(blocks: ContentBlock[]): Message {
+  return { role: "assistant", content: blocks };
+}
+
+describe("getInContextPkbPaths", () => {
+  test("auto-inject paths are always present (even with empty conversation)", () => {
+    const conversation = makeConversation([]);
+    const result = getInContextPkbPaths(
+      conversation,
+      ["notes/index.md", "journal/2026-04-18.md"],
+      PKB_ROOT,
+    );
+    expect(result).toEqual(
+      new Set([
+        path.join(PKB_ROOT, "notes/index.md"),
+        path.join(PKB_ROOT, "journal/2026-04-18.md"),
+      ]),
+    );
+  });
+
+  test("includes a file_read tool_use with a path inside pkbRoot", () => {
+    const insidePath = path.join(PKB_ROOT, "notes/thoughts.md");
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([fileReadToolUse(insidePath)]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    expect(result).toEqual(new Set([insidePath]));
+  });
+
+  test("excludes a file_read tool_use whose path is outside pkbRoot", () => {
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([fileReadToolUse("/etc/hosts")]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    expect(result).toEqual(new Set());
+  });
+
+  test("excludes a non-file_read tool_use with a PKB-like path", () => {
+    const insidePath = path.join(PKB_ROOT, "notes/thoughts.md");
+    const bogus: ContentBlock = {
+      type: "tool_use",
+      id: "toolu_bogus",
+      name: "file_write",
+      input: { path: insidePath },
+    };
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([bogus]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    expect(result).toEqual(new Set());
+  });
+
+  test("post-compaction context-summary user message returns only auto-inject paths", () => {
+    // After compaction, the structured tool_use blocks have been serialized
+    // away and the conversation is just a user-role text message containing
+    // the summary.
+    const summaryMessage: Message = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[Context summary] Previously you read notes/thoughts.md and journal/2026-04-18.md...",
+        },
+      ],
+    };
+    const conversation = makeConversation([summaryMessage]);
+    const autoInject = ["profile/identity.md"];
+    const result = getInContextPkbPaths(conversation, autoInject, PKB_ROOT);
+    expect(result).toEqual(
+      new Set([path.join(PKB_ROOT, "profile/identity.md")]),
+    );
+  });
+
+  test("path-traversal attempt via ../../etc/passwd is excluded", () => {
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([
+        fileReadToolUse("../../etc/passwd"),
+        fileReadToolUse("notes/../../../etc/shadow"),
+      ]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    expect(result).toEqual(new Set());
+  });
+
+  test("resolves relative auto-inject paths against pkbRoot", () => {
+    const conversation = makeConversation([]);
+    const result = getInContextPkbPaths(
+      conversation,
+      ["./notes/relative.md"],
+      PKB_ROOT,
+    );
+    expect(result).toEqual(
+      new Set([path.join(PKB_ROOT, "notes/relative.md")]),
+    );
+  });
+
+  test("auto-inject and file_read paths union (no duplicates)", () => {
+    const insidePath = path.join(PKB_ROOT, "notes/shared.md");
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([fileReadToolUse(insidePath)]),
+    ]);
+    const result = getInContextPkbPaths(
+      conversation,
+      ["notes/shared.md"],
+      PKB_ROOT,
+    );
+    expect(result.size).toBe(1);
+    expect(result.has(insidePath)).toBe(true);
+  });
+});

--- a/assistant/src/daemon/pkb-context-tracker.ts
+++ b/assistant/src/daemon/pkb-context-tracker.ts
@@ -1,0 +1,108 @@
+/**
+ * pkb-context-tracker
+ *
+ * Pure helper that reports which PKB file paths are already "in context" for
+ * a given conversation. A path is considered in context if either:
+ *
+ *   1. It was explicitly auto-injected (caller supplies `autoInjectPaths`),
+ *      typically via a system-reminder that embeds the file contents.
+ *   2. The conversation history contains a structured `file_read` tool_use
+ *      block whose `input.path` resolves to a path inside `pkbRoot`.
+ *
+ * Used by the PKB system reminder so we don't suggest files the model has
+ * already loaded.
+ *
+ * Post-compaction note: structured `tool_use` blocks get serialized into a
+ * plain-text summary and dropped from the live message array. After a
+ * compaction, this helper will naturally only see the `autoInjectPaths` —
+ * which is the desired semantics.
+ *
+ * No I/O, no globals, no side effects.
+ */
+
+import path from "node:path";
+
+import type { ContentBlock, Message } from "../providers/types.js";
+
+/**
+ * Minimal shape this helper needs from a `Conversation`. Defining it as an
+ * interface (rather than importing the full `Conversation` class) keeps the
+ * helper pure and trivial to unit-test without constructing a real daemon
+ * conversation.
+ */
+export interface PkbContextConversation {
+  messages: Message[];
+}
+
+/**
+ * The structured tool_use block name the assistant emits when reading files
+ * from the workspace (see `assistant/src/tools/filesystem/read.ts`).
+ */
+const FILE_READ_TOOL_NAME = "file_read";
+
+/**
+ * Resolve `candidate` against `pkbRoot` and return the absolute path ONLY if
+ * it stays inside `pkbRoot`. Otherwise return `undefined`. Guards against
+ * `..`-style path traversal.
+ */
+function resolveInsidePkbRoot(
+  candidate: string,
+  pkbRoot: string,
+): string | undefined {
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    return undefined;
+  }
+  const resolved = path.resolve(pkbRoot, candidate);
+  // `path.resolve` normalizes any `..` segments in `candidate`. We still need
+  // to verify the result is inside `pkbRoot`. Comparing with a trailing
+  // separator avoids treating `<pkbRoot>somethingElse` as inside the root.
+  if (resolved === pkbRoot) {
+    return resolved;
+  }
+  const rootWithSep = pkbRoot.endsWith(path.sep) ? pkbRoot : pkbRoot + path.sep;
+  if (resolved.startsWith(rootWithSep)) {
+    return resolved;
+  }
+  return undefined;
+}
+
+/**
+ * Returns the set of absolute PKB file paths already in the conversation's
+ * in-memory context. This is the union of `autoInjectPaths` (resolved into
+ * `pkbRoot`) and any `file_read` tool_use block inputs found in
+ * `conversation.messages` that resolve inside `pkbRoot`.
+ *
+ * Paths outside `pkbRoot` (including `..`-traversal attempts) are excluded.
+ * Tool uses whose `name` is not `file_read` are ignored.
+ */
+export function getInContextPkbPaths(
+  conversation: PkbContextConversation,
+  autoInjectPaths: string[],
+  pkbRoot: string,
+): Set<string> {
+  const normalizedRoot = path.resolve(pkbRoot);
+  const inContext = new Set<string>();
+
+  for (const candidate of autoInjectPaths) {
+    const resolved = resolveInsidePkbRoot(candidate, normalizedRoot);
+    if (resolved !== undefined) {
+      inContext.add(resolved);
+    }
+  }
+
+  for (const message of conversation.messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content as ContentBlock[]) {
+      if (block.type !== "tool_use") continue;
+      if (block.name !== FILE_READ_TOOL_NAME) continue;
+      const rawPath = block.input?.path;
+      if (typeof rawPath !== "string") continue;
+      const resolved = resolveInsidePkbRoot(rawPath, normalizedRoot);
+      if (resolved !== undefined) {
+        inContext.add(resolved);
+      }
+    }
+  }
+
+  return inContext;
+}


### PR DESCRIPTION
## Summary
- Pure helper that returns the set of PKB file paths already in the current conversation context.
- Unions auto-inject paths with paths from structured file_read tool_use blocks (path-traversal safe).
- Post-compaction, structured tool_use blocks are dropped, so the helper naturally only sees auto-inject paths.

Part of plan: pkb-reminder-hints.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
