### PR TITLE
memory: return query/sparse vectors from loadContextMemory

### DIFF
--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// retriever.test.ts — focused unit tests for loadContextMemory
+//
+// The full retrieval pipeline touches SQLite, Qdrant, LLM providers, and the
+// embedding backend. These tests stub only the external boundaries that would
+// otherwise reach out over the network (embedding backend, Qdrant search, LLM
+// provider). Everything else (real in-process SQLite, real triggers/scoring)
+// runs unmocked so the mocks do not leak across test files in a shared
+// process.
+//
+// Focus: the plumbing added in PR 3 — surfacing the dense query vector
+// (and the optional sparse vector) on ContextLoadResult so downstream callers
+// can reuse them without re-embedding.
+// ---------------------------------------------------------------------------
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Configurable embed-mock state — reset between tests.
+let embedShouldThrow = false;
+let embedVector: number[] = [0.1, 0.2, 0.3];
+
+mock.module("../embed.js", () => ({
+  embedWithRetry: async () => {
+    if (embedShouldThrow) throw new Error("embedding backend down");
+    return {
+      vectors: [embedVector],
+      provider: "test-provider",
+      model: "test-model",
+    };
+  },
+}));
+
+mock.module("../embedding-backend.js", () => ({
+  selectedBackendSupportsMultimodal: async () => false,
+}));
+
+mock.module("./graph-search.js", () => ({
+  searchGraphNodes: async () => [],
+}));
+
+// Returning `null` from getConfiguredProvider causes rerankAndDedup and
+// dedupCrossCategory to fall back to the candidate list without calling an
+// LLM, keeping these tests fully offline.
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => null,
+  userMessage: (text: string) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }),
+  extractToolUse: () => null,
+}));
+
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { initializeDb, resetDb } from "../db.js";
+import { loadContextMemory } from "./retriever.js";
+
+const TEST_CONFIG: AssistantConfig = { ...DEFAULT_CONFIG };
+
+describe("loadContextMemory — query/sparse vector surfacing", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    embedShouldThrow = false;
+    embedVector = [0.1, 0.2, 0.3];
+    resetDb();
+    initializeDb();
+  });
+
+  test("returns the dense queryVector when embedding succeeds", async () => {
+    embedVector = [0.42, 0.5, 0.7];
+
+    const result = await loadContextMemory({
+      scopeId: "test-scope",
+      recentSummaries: ["recent summary one", "recent summary two"],
+      config: TEST_CONFIG,
+    });
+
+    expect(result.queryVector).toEqual([0.42, 0.5, 0.7]);
+    // Sparse vector is reserved for future hybrid retrieval — currently not
+    // produced inside loadContextMemory, so it should be undefined.
+    expect(result.sparseVector).toBeUndefined();
+  });
+
+  test("returns undefined queryVector when the embedding backend throws", async () => {
+    embedShouldThrow = true;
+
+    const result = await loadContextMemory({
+      scopeId: "test-scope",
+      recentSummaries: ["recent summary"],
+      config: TEST_CONFIG,
+    });
+
+    // Circuit-breaker path: embedding failure is swallowed; no throw.
+    expect(result.queryVector).toBeUndefined();
+    expect(result.sparseVector).toBeUndefined();
+  });
+
+  test("returns undefined queryVector when no summaries are provided", async () => {
+    const result = await loadContextMemory({
+      scopeId: "test-scope",
+      recentSummaries: [],
+      config: TEST_CONFIG,
+    });
+
+    expect(result.queryVector).toBeUndefined();
+    expect(result.sparseVector).toBeUndefined();
+  });
+});

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -16,6 +16,7 @@ import type { ContentBlock, ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { embedWithRetry } from "../embed.js";
 import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
+import type { QdrantSparseVector } from "../qdrant-client.js";
 import { searchGraphNodes } from "./graph-search.js";
 import type { InContextTracker } from "./injection.js";
 import {
@@ -355,6 +356,19 @@ export interface ContextLoadResult {
   triggeredNodes: TriggeredResult[];
   latencyMs: number;
   metrics: RetrievalMetrics;
+  /**
+   * Dense query vector computed from `recentSummaries`. Surfaced so downstream
+   * callers (e.g. the PKB hint retriever) can reuse the same embedding for a
+   * second Qdrant query without paying for another embedding call. `undefined`
+   * when no summaries were provided or embedding failed (circuit breaker).
+   */
+  queryVector?: number[];
+  /**
+   * Optional sparse vector passed into `searchGraphNodes` alongside the dense
+   * query vector. Currently always `undefined` — reserved for future hybrid
+   * retrieval that produces a sparse vector at the call site.
+   */
+  sparseVector?: QdrantSparseVector;
 }
 
 /**
@@ -380,6 +394,7 @@ export async function loadContextMemory(
 
   // 1. Embed recent conversation summaries as retrieval queries
   let queryVector: number[] | null = null;
+  const sparseVector: QdrantSparseVector | undefined = undefined;
   let embeddingProvider: string | null = null;
   let embeddingModel: string | null = null;
   let contextQueryText: string | null = null;
@@ -406,9 +421,12 @@ export async function loadContextMemory(
   if (queryVector) {
     const searchStart = Date.now();
     try {
-      const results = await searchGraphNodes(queryVector, maxNodes * 3, [
-        opts.scopeId,
-      ]);
+      const results = await searchGraphNodes(
+        queryVector,
+        maxNodes * 3,
+        [opts.scopeId],
+        sparseVector,
+      );
       for (const r of results) {
         semanticCandidateIds.set(r.nodeId, r.score);
       }
@@ -697,6 +715,8 @@ export async function loadContextMemory(
       queryContext: contextQueryText,
       topCandidates,
     },
+    queryVector: queryVector ?? undefined,
+    sparseVector,
   };
 }
 


### PR DESCRIPTION
## Summary
- Surface the dense query vector and optional sparse vector already computed inside loadContextMemory on the ContextLoadResult shape.
- Fields are optional — no existing caller is affected; sets the stage for PR 11 to reuse the same vectors for a second Qdrant query against PKB files.

Part of plan: pkb-reminder-hints.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
