### PR TITLE
feat(assistant): stop watching UPDATES.md in config-watcher

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -157,12 +157,12 @@ describe("ConfigWatcher workspace file handlers", () => {
     expect(evictCallCount).toBe(1);
   });
 
-  test("UPDATES.md change triggers onConversationEvict", async () => {
+  test("UPDATES.md change does NOT trigger onConversationEvict", async () => {
     watcher.start(onConversationEvict);
     simulateFileChange(WORKSPACE_DIR, "UPDATES.md");
 
     await new Promise((r) => setTimeout(r, 300));
-    expect(evictCallCount).toBe(1);
+    expect(evictCallCount).toBe(0);
   });
 
   test("config.json change calls refreshConfigFromSources", async () => {

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -172,7 +172,6 @@ export class ConfigWatcher {
         onConversationEvict();
         onIdentityChanged?.();
       },
-      "UPDATES.md": () => onConversationEvict(),
     };
 
     const watchDir = (


### PR DESCRIPTION
## Summary
- Removes the `UPDATES.md` handler from the daemon's config-watcher; the prompt no longer depends on the file, so eviction on change is unnecessary.

Part of plan: updates-md-background-job.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
