### PR TITLE
feat(assistant): remove UPDATES.md injection from system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -345,34 +345,14 @@ describe("buildSystemPrompt", () => {
     });
   });
 
-  test("includes UPDATES.md content when file exists", () => {
-    writeFileSync(join(TEST_DIR, "UPDATES.md"), "# v1.2\n\nNew feature added.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("## Recent Updates");
-    expect(result).toContain("New feature added.");
-  });
-
-  test("omits updates section when UPDATES.md is empty", () => {
-    writeFileSync(join(TEST_DIR, "UPDATES.md"), "   \n  \n  ");
+  test("never includes UPDATES.md content in system prompt", () => {
+    const updatesBody = "# v1.2\n\nNew feature added. UNIQUE_UPDATES_MARKER.";
+    writeFileSync(join(TEST_DIR, "UPDATES.md"), updatesBody);
     const result = buildSystemPrompt();
     expect(result).not.toContain("## Recent Updates");
-  });
-
-  test("omits updates section when UPDATES.md does not exist", () => {
-    const result = buildSystemPrompt();
-    expect(result).not.toContain("## Recent Updates");
-  });
-
-  test("includes update handling instructions when UPDATES.md exists", () => {
-    writeFileSync(join(TEST_DIR, "UPDATES.md"), "# v1.3\n\nSome update notes.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("### Update Handling");
-    expect(result).toContain("Use your judgment");
-  });
-
-  test("omits update handling instructions when UPDATES.md is absent", () => {
-    const result = buildSystemPrompt();
-    expect(result).not.toContain("### Update Handling");
+    expect(result).not.toContain(updatesBody);
+    expect(result).not.toContain("UNIQUE_UPDATES_MARKER");
+    expect(result).not.toContain("Update Handling");
   });
 
   test("strips comment lines starting with _ from prompt files", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -271,12 +271,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const soulPath = getWorkspacePromptPath("SOUL.md");
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
-  const updatesPath = getWorkspacePromptPath("UPDATES.md");
 
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
   const bootstrap = readPromptFile(bootstrapPath);
-  const updates = readPromptFile(updatesPath);
 
   const includeBootstrap = !!bootstrap && !options?.excludeBootstrap;
 
@@ -325,23 +323,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
           "Use this to personalize your opener and skip redundant discovery.",
       );
     }
-  }
-  if (updates) {
-    dynamicParts.push(
-      [
-        "## Recent Updates",
-        "",
-        updates,
-        "",
-        "### Update Handling",
-        "",
-        "Use your judgment to decide when and how to surface updates to the user:",
-        "- Inform the user about updates that are relevant to what they are doing or asking about.",
-        "- Apply assistant-relevant changes (e.g., new tools, behavior adjustments) without forced announcement.",
-        "- Do not interrupt the user with updates unprompted — weave them naturally into conversation when relevant.",
-        "- When you are satisfied all updates have been actioned or communicated, delete `UPDATES.md` to signal completion.",
-      ].join("\n"),
-    );
   }
   // Configuration section removed — workspace files are self-describing,
   // tool routing lives in tool descriptions.


### PR DESCRIPTION
## Summary
- Removes the `## Recent Updates` section and its `### Update Handling` subsection from `buildSystemPrompt()`. UPDATES.md is no longer injected into the system prompt on every turn.
- Drops the four UPDATES.md-specific tests in `system-prompt.test.ts` and replaces them with a single regression test confirming `buildSystemPrompt()` never includes UPDATES.md content.

Part of plan: updates-md-background-job.md (PR 2 of 9)