### PR TITLE
pkb: add filesystem scan + chunking + Qdrant upsert/delete primitives

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -147,7 +147,13 @@ export function truncate(text: string, max: number): string {
 
 export async function embedAndUpsert(
   config: AssistantConfig,
-  targetType: "segment" | "item" | "summary" | "media" | "graph_node",
+  targetType:
+    | "segment"
+    | "item"
+    | "summary"
+    | "media"
+    | "graph_node"
+    | "pkb_file",
   targetId: string,
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,

--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -1,0 +1,206 @@
+import { mkdtemp, mkdir, writeFile, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Capture calls to embedAndUpsert so we can assert on targetType + payload.
+const embedAndUpsertCalls: Array<{
+  config: unknown;
+  targetType: string;
+  targetId: string;
+  input: unknown;
+  extraPayload: unknown;
+}> = [];
+
+mock.module("../job-utils.js", () => ({
+  embedAndUpsert: async (
+    config: unknown,
+    targetType: string,
+    targetId: string,
+    input: unknown,
+    extraPayload: unknown,
+  ) => {
+    embedAndUpsertCalls.push({
+      config,
+      targetType,
+      targetId,
+      input,
+      extraPayload,
+    });
+  },
+}));
+
+// Minimal stub for getConfig — indexPkbFile forwards it opaquely to the
+// mocked embedAndUpsert, so any sentinel value works.
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ __stub: true }),
+}));
+
+// Track Qdrant deletes by capturing the filter the client sends.
+const qdrantDeleteCalls: Array<{ targetType: string; path: string }> = [];
+
+mock.module("../qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    deleteByTargetTypeAndPath: async (targetType: string, path: string) => {
+      qdrantDeleteCalls.push({ targetType, path });
+    },
+  }),
+}));
+
+// The circuit breaker is a thin wrapper; just call the function through.
+mock.module("../qdrant-circuit-breaker.js", () => ({
+  withQdrantBreaker: async <T,>(fn: () => Promise<T>) => fn(),
+}));
+
+import {
+  chunkPkbFile,
+  deletePkbFilePoints,
+  indexPkbFile,
+  scanPkbFiles,
+} from "./pkb-index.js";
+
+describe("chunkPkbFile", () => {
+  test("returns whole-file for small inputs", () => {
+    const small = "a".repeat(500);
+    const chunks = chunkPkbFile(small);
+    expect(chunks).toEqual([small]);
+  });
+
+  test("splits on ## headings with lossless concatenation", () => {
+    const sectionA = "## Section A\n" + "a".repeat(5990) + "\n";
+    const sectionB = "## Section B\n" + "b".repeat(6010);
+    const content = sectionA + sectionB;
+    expect(content.length).toBeGreaterThanOrEqual(12000);
+
+    const chunks = chunkPkbFile(content);
+    expect(chunks).toHaveLength(2);
+    expect(chunks.join("")).toBe(content);
+    expect(chunks[0].startsWith("## Section A")).toBe(true);
+    expect(chunks[1].startsWith("## Section B")).toBe(true);
+  });
+
+  test("falls back to char-window chunks when no ## headings exist", () => {
+    const content = "x".repeat(12000);
+    const chunks = chunkPkbFile(content);
+    // 12000 / 4000 = 3 windows.
+    expect(chunks).toHaveLength(3);
+    expect(chunks.join("")).toBe(content);
+    expect(chunks[0].length).toBe(4000);
+    expect(chunks[1].length).toBe(4000);
+    expect(chunks[2].length).toBe(4000);
+  });
+});
+
+describe("scanPkbFiles", () => {
+  test("returns entries for each .md file and ignores non-markdown", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-scan-"));
+    await writeFile(join(root, "a.md"), "# A\nalpha content");
+    await writeFile(join(root, "b.md"), "# B\nbeta content");
+    await writeFile(join(root, "notes.txt"), "plain text");
+
+    // Set deterministic mtimes so we can assert them.
+    const mtimeA = new Date(1_700_000_000_000);
+    const mtimeB = new Date(1_700_000_001_000);
+    await utimes(join(root, "a.md"), mtimeA, mtimeA);
+    await utimes(join(root, "b.md"), mtimeB, mtimeB);
+
+    const entries = await scanPkbFiles(root);
+    const byPath = new Map(entries.map((e) => [e.path, e]));
+
+    expect(byPath.size).toBe(2);
+    expect(byPath.has("a.md")).toBe(true);
+    expect(byPath.has("b.md")).toBe(true);
+    expect(byPath.has("notes.txt")).toBe(false);
+
+    const a = byPath.get("a.md")!;
+    expect(a.mtimeMs).toBe(mtimeA.getTime());
+    expect(a.chunkIndex).toBe(0);
+    expect(a.contentHash).toHaveLength(16);
+
+    // Hash is stable across scans.
+    const entriesAgain = await scanPkbFiles(root);
+    const aAgain = entriesAgain.find((e) => e.path === "a.md")!;
+    expect(aAgain.contentHash).toBe(a.contentHash);
+  });
+
+  test("walks nested directories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-scan-nested-"));
+    const sub = join(root, "sub");
+    await mkdir(sub);
+    await writeFile(join(sub, "nested.md"), "# nested");
+
+    const entries = await scanPkbFiles(root);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe(join("sub", "nested.md"));
+  });
+});
+
+describe("indexPkbFile", () => {
+  beforeEach(() => {
+    embedAndUpsertCalls.length = 0;
+  });
+
+  test("invokes embedAndUpsert once per chunk with pkb_file target_type", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-"));
+    const filePath = join(root, "doc.md");
+    await writeFile(filePath, "# hello\nworld");
+
+    await indexPkbFile(root, filePath, "scope-xyz");
+
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    const call = embedAndUpsertCalls[0];
+    expect(call.targetType).toBe("pkb_file");
+    expect(call.targetId).toBe("doc.md#0");
+    expect(call.input).toEqual({ type: "text", text: "# hello\nworld" });
+    const payload = call.extraPayload as Record<string, unknown>;
+    expect(payload.path).toBe("doc.md");
+    expect(payload.chunk_index).toBe(0);
+    expect(payload.memory_scope_id).toBe("scope-xyz");
+    expect(typeof payload.mtime_ms).toBe("number");
+    expect(typeof payload.content_hash).toBe("string");
+    expect((payload.content_hash as string).length).toBe(16);
+  });
+
+  test("emits one embedAndUpsert call per chunk for a large file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-large-"));
+    const filePath = join(root, "big.md");
+    const content =
+      "## Section A\n" +
+      "a".repeat(5990) +
+      "\n## Section B\n" +
+      "b".repeat(5990);
+    await writeFile(filePath, content);
+
+    await indexPkbFile(root, filePath, "scope-1");
+
+    expect(embedAndUpsertCalls).toHaveLength(2);
+    expect(embedAndUpsertCalls[0].targetId).toBe("big.md#0");
+    expect(embedAndUpsertCalls[1].targetId).toBe("big.md#1");
+    expect(embedAndUpsertCalls.every((c) => c.targetType === "pkb_file")).toBe(
+      true,
+    );
+  });
+});
+
+describe("deletePkbFilePoints", () => {
+  beforeEach(() => {
+    qdrantDeleteCalls.length = 0;
+  });
+
+  test("sends a filter with both target_type and path predicates", async () => {
+    await deletePkbFilePoints("notes/todo.md");
+
+    expect(qdrantDeleteCalls).toHaveLength(1);
+    expect(qdrantDeleteCalls[0]).toEqual({
+      targetType: "pkb_file",
+      path: "notes/todo.md",
+    });
+  });
+});

--- a/assistant/src/memory/pkb/pkb-index.ts
+++ b/assistant/src/memory/pkb/pkb-index.ts
@@ -1,0 +1,194 @@
+/**
+ * PKB (Personal Knowledge Base) filesystem indexing primitives.
+ *
+ * Provides the low-level building blocks used by the PKB job handler and
+ * startup reconciliation:
+ *   - `scanPkbFiles`: recursively walk a PKB root and emit one entry per chunk.
+ *   - `chunkPkbFile`: split a markdown file into retrieval-friendly chunks.
+ *   - `indexPkbFile`: embed each chunk and upsert it to Qdrant.
+ *   - `deletePkbFilePoints`: remove every Qdrant point for a given file.
+ *
+ * Consumers (job queue wiring, startup scan) land in later PRs.
+ */
+
+import { createHash } from "node:crypto";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { getConfig } from "../../config/loader.js";
+import { embedAndUpsert } from "../job-utils.js";
+import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
+import { getQdrantClient } from "../qdrant-client.js";
+
+import type { PkbIndexEntry } from "./types.js";
+import { PKB_TARGET_TYPE } from "./types.js";
+
+/** Files larger than this are split into chunks for retrieval. */
+const WHOLE_FILE_THRESHOLD = 8000;
+
+/** Character-window size when falling back for unstructured content. */
+const CHAR_WINDOW_SIZE = 4000;
+
+/**
+ * Recursively walk `pkbRoot` and return one `PkbIndexEntry` per chunk of
+ * every `*.md` file found. Paths in the returned entries are relative to
+ * `pkbRoot`; mtime is read from the filesystem and `contentHash` is the
+ * first 16 hex chars of the sha256 of the file's contents.
+ */
+export async function scanPkbFiles(pkbRoot: string): Promise<PkbIndexEntry[]> {
+  const entries: PkbIndexEntry[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let dirents;
+    try {
+      dirents = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const dirent of dirents) {
+      const absPath = join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        await walk(absPath);
+        continue;
+      }
+      if (!dirent.isFile()) continue;
+      if (!dirent.name.toLowerCase().endsWith(".md")) continue;
+
+      let content: string;
+      let mtimeMs: number;
+      try {
+        content = await readFile(absPath, "utf8");
+        const st = await stat(absPath);
+        mtimeMs = st.mtimeMs;
+      } catch {
+        continue;
+      }
+
+      const contentHash = hashContent(content);
+      const relPath = relative(pkbRoot, absPath);
+      const chunks = chunkPkbFile(content);
+      for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+        entries.push({
+          path: relPath,
+          mtimeMs,
+          contentHash,
+          chunkIndex,
+        });
+      }
+    }
+  }
+
+  await walk(pkbRoot);
+  return entries;
+}
+
+/**
+ * Split markdown content into retrieval chunks.
+ *
+ * Strategy:
+ *   - If the file is small (< WHOLE_FILE_THRESHOLD chars), return the whole
+ *     file as a single chunk.
+ *   - Otherwise split on lines starting with `## `, keeping each heading
+ *     with the body of its section. Concatenation of the returned chunks is
+ *     lossless — no content is dropped or duplicated.
+ *   - If no `## ` headings are present, fall back to fixed-size character
+ *     windows.
+ */
+export function chunkPkbFile(content: string): string[] {
+  if (content.length < WHOLE_FILE_THRESHOLD) {
+    return [content];
+  }
+
+  const headingIndices: number[] = [];
+  let cursor = 0;
+  while (cursor < content.length) {
+    // Find the next line that starts with "## " (either at the very beginning
+    // of the file or immediately after a newline).
+    const atStart = cursor === 0 && content.startsWith("## ");
+    if (atStart) {
+      headingIndices.push(0);
+      cursor = 1; // advance past the match so the `indexOf` below keeps moving
+      continue;
+    }
+    const nextNewline = content.indexOf("\n## ", cursor);
+    if (nextNewline === -1) break;
+    headingIndices.push(nextNewline + 1);
+    cursor = nextNewline + 1;
+  }
+
+  if (headingIndices.length === 0) {
+    // Fallback: fixed-size char windows.
+    const chunks: string[] = [];
+    for (let i = 0; i < content.length; i += CHAR_WINDOW_SIZE) {
+      chunks.push(content.slice(i, i + CHAR_WINDOW_SIZE));
+    }
+    return chunks;
+  }
+
+  // Build chunks from heading boundaries. Preserve any preamble before the
+  // first heading so concatenation stays lossless.
+  const chunks: string[] = [];
+  if (headingIndices[0] > 0) {
+    chunks.push(content.slice(0, headingIndices[0]));
+  }
+  for (let i = 0; i < headingIndices.length; i++) {
+    const start = headingIndices[i];
+    const end = i + 1 < headingIndices.length ? headingIndices[i + 1] : content.length;
+    chunks.push(content.slice(start, end));
+  }
+  return chunks;
+}
+
+/**
+ * Read a PKB file, chunk it, and upsert each chunk to Qdrant via the shared
+ * embedding pipeline. `relPath` in the payload is computed relative to
+ * `pkbRoot`.
+ */
+export async function indexPkbFile(
+  pkbRoot: string,
+  absPath: string,
+  memoryScopeId: string,
+): Promise<void> {
+  const content = await readFile(absPath, "utf8");
+  const st = await stat(absPath);
+  const mtimeMs = st.mtimeMs;
+  const contentHash = hashContent(content);
+  const relPath = relative(pkbRoot, absPath);
+  const chunks = chunkPkbFile(content);
+
+  const config = getConfig();
+
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+    const chunk = chunks[chunkIndex];
+    const targetId = `${relPath}#${chunkIndex}`;
+    await embedAndUpsert(
+      config,
+      PKB_TARGET_TYPE,
+      targetId,
+      { type: "text", text: chunk },
+      {
+        path: relPath,
+        mtime_ms: mtimeMs,
+        chunk_index: chunkIndex,
+        content_hash: contentHash,
+        memory_scope_id: memoryScopeId,
+      },
+    );
+  }
+}
+
+/**
+ * Remove every Qdrant point belonging to a given PKB file (all chunks).
+ * `relPath` must match the `path` payload written by `indexPkbFile`.
+ */
+export async function deletePkbFilePoints(relPath: string): Promise<void> {
+  const qdrant = getQdrantClient();
+  await withQdrantBreaker(() =>
+    qdrant.deleteByTargetTypeAndPath(PKB_TARGET_TYPE, relPath),
+  );
+}
+
+function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -20,7 +20,13 @@ export interface QdrantClientConfig {
 }
 
 export interface QdrantPointPayload {
-  target_type: "segment" | "item" | "summary" | "media" | "graph_node";
+  target_type:
+    | "segment"
+    | "item"
+    | "summary"
+    | "media"
+    | "graph_node"
+    | "pkb_file";
   target_id: string;
   text: string;
   kind?: string;
@@ -480,6 +486,40 @@ export class VellumQdrantClient {
         wait: true,
         filter: {
           must: [{ key: "target_type", match: { value: targetType } }],
+        },
+      });
+
+    try {
+      await doDelete();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        await doDelete();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * Delete all vectors matching both a target_type and a payload path.
+   * Used to remove every chunk belonging to a single PKB file.
+   */
+  async deleteByTargetTypeAndPath(
+    targetType: string,
+    path: string,
+  ): Promise<void> {
+    await this.ensureCollection();
+
+    const doDelete = () =>
+      this.client.delete(this.collection, {
+        wait: true,
+        filter: {
+          must: [
+            { key: "target_type", match: { value: targetType } },
+            { key: "path", match: { value: path } },
+          ],
         },
       });
 


### PR DESCRIPTION
## Summary
- scanPkbFiles walks pkbRoot and emits one PkbIndexEntry per chunk with mtime + sha256-16 hash.
- chunkPkbFile does whole-file for small files, `## `-heading splits for larger ones, char-window fallback otherwise.
- indexPkbFile reuses embedAndUpsert with target_type="pkb_file".
- deletePkbFilePoints uses a filtered delete on target_type + path.
- Not yet wired into the job queue or runtime — PR 7 and PR 10 will wire it in.

Part of plan: pkb-reminder-hints.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
