### PR TITLE
docs: release notes ship via workspace migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,16 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 
 ## Release Update Hygiene
 
-When shipping a release with user/assistant-facing changes, update `assistant/src/prompts/templates/UPDATES.md`. Leave empty for no-op releases. Don't modify `~/.vellum/workspace/UPDATES.md` directly. Checkpoint keys (`updates:active_releases`, `updates:completed_releases`) in `memory_checkpoints` track bulletin lifecycle — don't manipulate directly.
+Release notes for user/assistant-facing changes ship via **workspace migrations**. There is no bundled template to edit and no checkpoint state to clear — the notes are just a migration that writes to `~/.vellum/workspace/UPDATES.md`.
+
+**To ship release notes:**
+
+1. Add a new migration file at `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts`. Use the next available sequence number (migrations are append-only). Put the release-note text inline as a string literal inside the migration.
+2. The migration must be idempotent: check for the HTML marker comment `<!-- vellum-migration:<id> -->` in `UPDATES.md` before appending, and skip if the marker is already present. The `<id>` should match the migration's registry ID so re-runs are a no-op.
+3. Append the new migration's export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Never reorder or remove existing entries.
+4. Skip the migration entirely for no-op releases — do not add an empty migration.
+
+**Processing:** After workspace migrations run at daemon startup, `runUpdateBulletinJobIfNeeded()` fires a background-only conversation (`conversationType: "background"`) via `wakeAgentForOpportunity()` to process `UPDATES.md`. The agent reads the file, acts on whatever is relevant, and deletes `UPDATES.md` when done. `rm UPDATES.md` remains auto-allowed so deletion needs no approval. The job short-circuits when the content hash matches the previously processed value (`updates:last_processed_hash`), so running on every startup is safe.
 
 ## Companion Repos
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -750,32 +750,26 @@ These differences are intentional — the adapters were designed for their respe
 
 ### Update Bulletin System
 
-Release-driven update notification system that surfaces release notes to the assistant via the system prompt.
+Release-driven update notification system that dispatches a background conversation to process release notes when a release lands.
 
 **Data flow:**
 
-1. **Bundled template** (`src/prompts/templates/UPDATES.md`) — source of release notes, maintained per-release in the repo.
-2. **Startup sync** (`syncUpdateBulletinOnStartup()` in `src/config/update-bulletin.ts`) — materializes the bundled template into the workspace `UPDATES.md` on daemon boot. Uses atomic write (temp + rename) for crash safety.
-3. **System prompt injection** — `buildSystemPrompt()` reads workspace `UPDATES.md` and injects it as a `## Recent Updates` section with judgment-based handling instructions.
-4. **Completion by deletion** — the assistant deletes `UPDATES.md` when it has actioned all updates. Next startup detects the deletion and marks those releases as completed in checkpoint state.
-5. **Cross-release merge** — if pending updates from a prior release exist when a new release lands, both release blocks coexist in the same file.
+1. **Storage** — Release notes live at `~/.vellum/workspace/UPDATES.md`. The file is written by workspace migrations; each release that needs to surface notes ships a dedicated migration in `src/workspace/migrations/` that appends an idempotency-gated block (keyed by an HTML marker comment `<!-- vellum-migration:<id> -->`) to the file.
+2. **Dispatch** — At daemon startup (after `runWorkspaceMigrations()`), `runUpdateBulletinJobIfNeeded()` is invoked fire-and-forget. It hashes the current `UPDATES.md` content and compares against the `updates:last_processed_hash` checkpoint. When the hashes differ, it bootstraps a `conversationType: "background"` conversation and calls `wakeAgentForOpportunity()` so the agent processes the bulletin without any interactive session.
+3. **Completion** — The agent acts on the contents and deletes `UPDATES.md` when done. The job persists the new hash to `updates:last_processed_hash` post-wake, so subsequent startups short-circuit until the file is repopulated by a future migration.
 
 **Checkpoint keys** (in `memory_checkpoints` table):
 
-- `updates:active_releases` — JSON array of version strings currently active.
-- `updates:completed_releases` — JSON array of version strings already completed.
+- `updates:last_processed_hash` — content hash of the `UPDATES.md` payload most recently dispatched to the background job.
 
 **Key source files:**
 
-| File                                   | Purpose                                                   |
-| -------------------------------------- | --------------------------------------------------------- |
-| `src/prompts/templates/UPDATES.md`     | Bundled release-note template                             |
-| `src/config/update-bulletin.ts`        | Startup sync logic (materialize, delete-complete, merge)  |
-| `src/config/update-bulletin-format.ts` | Release block formatter/parser helpers                    |
-| `src/config/update-bulletin-state.ts`  | Checkpoint state helpers for active/completed releases    |
-| `src/prompts/system-prompt.ts`         | Prompt injection of updates section                       |
-| `src/daemon/config-watcher.ts`         | File watcher — evicts sessions on UPDATES.md changes      |
-| `src/permissions/defaults.ts`          | Auto-allow rules for file_read/write/edit + rm UPDATES.md |
+| File                                  | Purpose                                                              |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `src/workspace/migrations/`           | Per-release migrations that append release notes to `UPDATES.md`     |
+| `src/workspace/migrations/registry.ts`| Append-only `WORKSPACE_MIGRATIONS` registry                          |
+| `src/prompts/update-bulletin-job.ts`  | `runUpdateBulletinJobIfNeeded()` — hash check and background dispatch |
+| `src/permissions/defaults.ts`         | Auto-allow rules for file_read/write/edit + rm UPDATES.md            |
 
 ---
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -47,9 +47,9 @@ cp .env.example .env
 
 ## Update Bulletin
 
-When a release includes relevant updates, the assistant materializes release notes from the bundled `src/prompts/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
+Release notes are surfaced via a background conversation dispatched at daemon startup. Workspace migrations write release notes to `~/.vellum/workspace/UPDATES.md`; `runUpdateBulletinJobIfNeeded()` then spawns a `conversationType: "background"` conversation (via `wakeAgentForOpportunity()`) whenever the file's content hash changes. The agent uses judgment to surface updates to the user when relevant, and deletes the file when done.
 
-**For release maintainers:** Update `assistant/src/prompts/templates/UPDATES.md` with release notes before each relevant release. Leave the template empty (or comment-only) for releases with no user/assistant-facing changes.
+**For release maintainers:** Add a new migration under `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts` with the release notes inline as a string literal, and append the export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Migrations are append-only and must be idempotent — guard the append with an HTML marker comment (`<!-- vellum-migration:<id> -->`) so re-runs are a no-op. Skip the migration entirely for releases with no user/assistant-facing changes.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Rewrites the Release Update Hygiene section in root CLAUDE.md, the updates-bulletin section in assistant/ARCHITECTURE.md, and the release-maintainer steps in assistant/README.md to describe the new flow: per-release workspace migrations write UPDATES.md; a background job processes it on startup via `wakeAgentForOpportunity()` when the content hash changes.
- Removes references to the old template file, `updates:active_releases` / `updates:completed_releases` checkpoints, and dismissal detection.

Part of plan: updates-md-background-job.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
