### PR TITLE
feat(assistant): run update-bulletin job on daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -72,7 +72,6 @@ import {
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
-import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -543,16 +542,13 @@ export async function runDaemon(): Promise<void> {
     log.info("Daemon startup: loading config");
     const config = loadConfig();
 
-    // Run bulletin sync AFTER the config merge + load so that getConfig()
-    // inside syncUpdateBulletinOnStartup() observes the fully merged config.
-    // Running it earlier would populate the config cache with pre-merge
-    // values, poisoning every downstream getConfig() consumer.
+    // Kick off the update bulletin background job once the DB is ready.
     if (dbReady) {
-      try {
-        syncUpdateBulletinOnStartup();
-      } catch (err) {
-        log.warn({ err }, "Bulletin sync failed — continuing startup");
-      }
+      void import("../prompts/update-bulletin-job.js")
+        .then((m) => m.runUpdateBulletinJobIfNeeded())
+        .catch((err) =>
+          log.warn({ err }, "Update bulletin job failed — continuing startup"),
+        );
     }
 
     // Seed module-level ingress state from the workspace config so that


### PR DESCRIPTION
## Summary
- Swaps the blocking `syncUpdateBulletinOnStartup()` call in the daemon startup path for a fire-and-forget dynamic import of `runUpdateBulletinJobIfNeeded()`. The job module is only loaded once `dbReady` is true.
- Respects the daemon-never-blocks-startup invariant: any failure is logged at warn and startup continues.

Part of plan: updates-md-background-job.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
