### PR TITLE
fix(assistant): sort imports in pkb-context-tracker.test.ts

### DIFF
--- a/assistant/src/daemon/pkb-context-tracker.test.ts
+++ b/assistant/src/daemon/pkb-context-tracker.test.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-
 import { describe, expect, test } from "bun:test";
 
 import type { ContentBlock, Message } from "../providers/types.js";


### PR DESCRIPTION
## Summary
- Fix lint failure in \`pkb-context-tracker.test.ts\` by merging the \`node:path\` and \`bun:test\` imports into a single group, per \`simple-import-sort/imports\`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24613508622/job/71971838012
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
