### PR TITLE
pkb: register embed_pkb_file background job

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -27,6 +27,7 @@ export type MemoryJobType =
   | "embed_attachment"
   | "generate_conversation_starters"
   | "embed_graph_node"
+  | "embed_pkb_file"
   | "graph_extract"
   | "graph_decay"
   | "graph_consolidate"
@@ -41,6 +42,7 @@ const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_media",
   "embed_attachment",
   "embed_graph_node",
+  "embed_pkb_file",
   "graph_trigger_embed",
 ];
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -44,6 +44,7 @@ import {
   RETRY_MAX_ATTEMPTS,
   retryDelayForAttempt,
 } from "./job-utils.js";
+import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
 import {
   claimMemoryJobs,
   completeMemoryJob,
@@ -419,6 +420,9 @@ async function processJob(
       return;
     case "embed_graph_node":
       await embedGraphNodeJob(job, config);
+      return;
+    case "embed_pkb_file":
+      await embedPkbFileJob(job, config);
       return;
     case "graph_trigger_embed":
       await embedGraphTriggerJob(job, config);

--- a/assistant/src/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.test.ts
@@ -1,0 +1,168 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track calls to indexPkbFile so we can assert the handler forwards payload
+// fields correctly.
+const indexPkbFileCalls: Array<{
+  pkbRoot: string;
+  absPath: string;
+  memoryScopeId: string;
+}> = [];
+
+mock.module("../pkb/pkb-index.js", () => ({
+  indexPkbFile: async (
+    pkbRoot: string,
+    absPath: string,
+    memoryScopeId: string,
+  ) => {
+    indexPkbFileCalls.push({ pkbRoot, absPath, memoryScopeId });
+  },
+}));
+
+mock.module("../../config/loader.js", () => ({
+  loadConfig: () => ({}),
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+}));
+
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getDb, initializeDb } from "../db.js";
+import {
+  claimMemoryJobs,
+  type MemoryJob,
+  type MemoryJobType,
+} from "../jobs-store.js";
+import { memoryJobs } from "../schema.js";
+import { embedPkbFileJob, enqueuePkbIndexJob } from "./embed-pkb-file.js";
+
+const TEST_CONFIG: AssistantConfig = DEFAULT_CONFIG;
+
+function makeJob(payload: Record<string, unknown>): MemoryJob {
+  return {
+    id: "job-1",
+    type: "embed_pkb_file",
+    payload,
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+describe("embedPkbFileJob", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    indexPkbFileCalls.length = 0;
+    const db = getDb();
+    db.delete(memoryJobs).run();
+  });
+
+  test("calls indexPkbFile with payload fields", async () => {
+    await embedPkbFileJob(
+      makeJob({
+        pkbRoot: "/pkb/root",
+        absPath: "/pkb/root/note.md",
+        memoryScopeId: "scope-123",
+      }),
+      TEST_CONFIG,
+    );
+
+    expect(indexPkbFileCalls).toHaveLength(1);
+    expect(indexPkbFileCalls[0]).toEqual({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+      memoryScopeId: "scope-123",
+    });
+  });
+
+  test("skips when pkbRoot is missing", async () => {
+    await embedPkbFileJob(
+      makeJob({ absPath: "/pkb/root/note.md", memoryScopeId: "scope-123" }),
+      TEST_CONFIG,
+    );
+    expect(indexPkbFileCalls).toHaveLength(0);
+  });
+
+  test("skips when absPath is missing", async () => {
+    await embedPkbFileJob(
+      makeJob({ pkbRoot: "/pkb/root", memoryScopeId: "scope-123" }),
+      TEST_CONFIG,
+    );
+    expect(indexPkbFileCalls).toHaveLength(0);
+  });
+
+  test("skips when memoryScopeId is missing", async () => {
+    await embedPkbFileJob(
+      makeJob({ pkbRoot: "/pkb/root", absPath: "/pkb/root/note.md" }),
+      TEST_CONFIG,
+    );
+    expect(indexPkbFileCalls).toHaveLength(0);
+  });
+});
+
+describe("enqueuePkbIndexJob", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    indexPkbFileCalls.length = 0;
+    const db = getDb();
+    db.delete(memoryJobs).run();
+  });
+
+  test("enqueues a pending embed_pkb_file job with payload", () => {
+    const id = enqueuePkbIndexJob({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+      memoryScopeId: "scope-abc",
+    });
+    expect(id).toBeTruthy();
+
+    const claimed = claimMemoryJobs(10);
+    expect(claimed).toHaveLength(1);
+    const [job] = claimed;
+    const expectedType: MemoryJobType = "embed_pkb_file";
+    expect(job.type).toBe(expectedType);
+    expect(job.payload).toEqual({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+      memoryScopeId: "scope-abc",
+    });
+  });
+
+  test("round-trip: enqueued job dispatched to handler invokes indexPkbFile", async () => {
+    enqueuePkbIndexJob({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+      memoryScopeId: "scope-rt",
+    });
+
+    const claimed = claimMemoryJobs(10);
+    expect(claimed).toHaveLength(1);
+    const [job] = claimed;
+    expect(job.type).toBe("embed_pkb_file");
+
+    await embedPkbFileJob(job, TEST_CONFIG);
+    expect(indexPkbFileCalls).toHaveLength(1);
+    expect(indexPkbFileCalls[0]).toEqual({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+      memoryScopeId: "scope-rt",
+    });
+  });
+});

--- a/assistant/src/memory/jobs/embed-pkb-file.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.ts
@@ -1,0 +1,42 @@
+import type { AssistantConfig } from "../../config/types.js";
+import { asString } from "../job-utils.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import { indexPkbFile } from "../pkb/pkb-index.js";
+
+/**
+ * Input shape for the `embed_pkb_file` background job.
+ */
+export interface EmbedPkbFileJobInput {
+  pkbRoot: string;
+  absPath: string;
+  memoryScopeId: string;
+}
+
+/**
+ * Job handler: read a PKB markdown file, chunk it, and upsert each chunk to
+ * Qdrant via the shared embedding pipeline. Thin wrapper around
+ * {@link indexPkbFile} so write hooks and startup reconciliation can
+ * fire-and-forget into the async job queue.
+ */
+export async function embedPkbFileJob(
+  job: MemoryJob,
+  _config: AssistantConfig,
+): Promise<void> {
+  const pkbRoot = asString(job.payload.pkbRoot);
+  const absPath = asString(job.payload.absPath);
+  const memoryScopeId = asString(job.payload.memoryScopeId);
+  if (!pkbRoot || !absPath || !memoryScopeId) return;
+
+  await indexPkbFile(pkbRoot, absPath, memoryScopeId);
+}
+
+/**
+ * Enqueue an `embed_pkb_file` job (async, fire-and-forget).
+ */
+export function enqueuePkbIndexJob(input: EmbedPkbFileJobInput): string {
+  return enqueueMemoryJob("embed_pkb_file", {
+    pkbRoot: input.pkbRoot,
+    absPath: input.absPath,
+    memoryScopeId: input.memoryScopeId,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the embed_pkb_file background job + enqueuePkbIndexJob helper.
- Handler calls indexPkbFile from PR 6.
- Wires registration alongside embed_graph_node in the existing job registry.

Part of plan: pkb-reminder-hints.md (PR 7 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
