### PR TITLE
fix(macos): replace TimelineView with Timer.publish for progress card timers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1085,14 +1085,20 @@ private struct ThinkingStepRow: View {
     }
 }
 
-// MARK: - Processing Dots Label (Isolated TimelineView)
+// MARK: - Processing Dots Label (Timer-based)
 
 /// Self-contained view for the processing phase label with animated dots.
-/// Extracted so the TimelineView's periodic ticks (every 0.4s) only
-/// re-evaluate this small subtree, not the entire progress card.
+/// Extracted so the periodic ticks (every 0.4s) only re-evaluate this
+/// small subtree, not the entire progress card.
+///
+/// Uses `Timer.publish` on `.main` / `.common` instead of `TimelineView`
+/// for the same reliability reasons as `ElapsedTimeLabel`.
 private struct ProcessingDotsLabel: View {
     let processingStatusText: String?
     let anchor: Date
+    @State private var now = Date()
+
+    private let timer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
 
     var body: some View {
         let initialLabel = ChatBubble.friendlyProcessingLabel(processingStatusText)
@@ -1103,44 +1109,56 @@ private struct ProcessingDotsLabel: View {
             "Finalizing your response",
         ]
 
-        TimelineView(.periodic(from: .now, by: 0.4)) { context in
-            let elapsed = max(0, context.date.timeIntervalSince(anchor))
-            let labelIndex = max(0, min(Int(elapsed / 8), labels.count - 1))
-            let dotPhase = max(0, Int(elapsed / 0.4) % 3)
+        let elapsed = max(0, now.timeIntervalSince(anchor))
+        let labelIndex = max(0, min(Int(elapsed / 8), labels.count - 1))
+        let dotPhase = max(0, Int(elapsed / 0.4) % 3)
 
-            HStack(spacing: VSpacing.xs) {
-                Text(labels[labelIndex])
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-                    .animation(.easeInOut(duration: 0.3), value: labelIndex)
+        HStack(spacing: VSpacing.xs) {
+            Text(labels[labelIndex])
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .animation(.easeInOut(duration: 0.3), value: labelIndex)
 
-                ForEach(0..<3, id: \.self) { index in
-                    Circle()
-                        .fill(VColor.contentSecondary)
-                        .frame(width: 5, height: 5)
-                        .opacity(dotPhase == index ? 1.0 : 0.4)
-                }
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.contentSecondary)
+                    .frame(width: 5, height: 5)
+                    .opacity(dotPhase == index ? 1.0 : 0.4)
             }
+        }
+        .onReceive(timer) { date in
+            now = date
         }
     }
 }
 
-// MARK: - Elapsed Time Label (Isolated TimelineView)
+// MARK: - Elapsed Time Label (Timer-based)
 
 /// Self-contained view for the elapsed time counter.
-/// Extracted so the TimelineView's periodic ticks (every 1.0s) only
-/// re-evaluate this small subtree, not the entire progress card.
+/// Extracted so the periodic ticks (every 1.0s) only re-evaluate this
+/// small subtree, not the entire progress card.
+///
+/// Uses `Timer.publish` on `.main` / `.common` instead of `TimelineView`
+/// because `TimelineView(.periodic)` can silently stop firing on macOS
+/// when the view hierarchy is idle or during heavy layout passes, causing
+/// the elapsed counter to freeze.
 private struct ElapsedTimeLabel: View {
     let startDate: Date
+    @State private var now = Date()
+
+    private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 1.0)) { context in
-            let elapsed = max(0, context.date.timeIntervalSince(startDate))
+        let elapsed = max(0, now.timeIntervalSince(startDate))
+        Group {
             if elapsed >= 5 {
                 Text(RunningIndicator.formatElapsed(elapsed))
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
+        }
+        .onReceive(timer) { date in
+            now = date
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -17,7 +17,10 @@ struct RunningIndicator: View {
     var onTap: (() -> Void)?
 
     @State private var startDate: Date = Date()
+    @State private var now: Date = Date()
     @State private var isHovered: Bool = false
+
+    private let timer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
 
     static func formatElapsed(_ elapsed: TimeInterval) -> String {
         let seconds = Int(elapsed)
@@ -49,52 +52,53 @@ struct RunningIndicator: View {
     }
 
     private var indicatorContent: some View {
-        TimelineView(.periodic(from: .now, by: 0.4)) { context in
-            let elapsed = context.date.timeIntervalSince(startDate)
-            let phase = Int(elapsed / 0.4) % 3
-            let currentLabel = displayLabel(elapsed: elapsed)
-            let labelIndex = progressiveLabels.isEmpty ? 0 : min(Int(elapsed / labelInterval), progressiveLabels.count - 1)
-            HStack(spacing: VSpacing.xs) {
-                if showIcon {
-                    VIconView(.terminal, size: 10)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-
-                Text(currentLabel)
-                    .font(VFont.labelDefault)
+        let elapsed = now.timeIntervalSince(startDate)
+        let phase = Int(elapsed / 0.4) % 3
+        let currentLabel = displayLabel(elapsed: elapsed)
+        let labelIndex = progressiveLabels.isEmpty ? 0 : min(Int(elapsed / labelInterval), progressiveLabels.count - 1)
+        return HStack(spacing: VSpacing.xs) {
+            if showIcon {
+                VIconView(.terminal, size: 10)
                     .foregroundStyle(VColor.contentSecondary)
-                    .animation(.easeInOut(duration: 0.3), value: labelIndex)
-
-                ForEach(0..<3, id: \.self) { index in
-                    Circle()
-                        .fill(VColor.contentSecondary)
-                        .frame(width: 5, height: 5)
-                        .opacity(phase == index ? 1.0 : 0.4)
-                }
-
-                if elapsed >= 5 {
-                    Text(Self.formatElapsed(elapsed))
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-
-                if onTap != nil {
-                    VIconView(.chevronRight, size: 9)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-
-                Spacer()
             }
-            .padding(.horizontal, onTap != nil ? VSpacing.sm : 0)
-            .padding(.vertical, VSpacing.xs)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isHovered ? VColor.surfaceBase.opacity(0.6) : Color.clear)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+
+            Text(currentLabel)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .animation(.easeInOut(duration: 0.3), value: labelIndex)
+
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.contentSecondary)
+                    .frame(width: 5, height: 5)
+                    .opacity(phase == index ? 1.0 : 0.4)
+            }
+
+            if elapsed >= 5 {
+                Text(Self.formatElapsed(elapsed))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            if onTap != nil {
+                VIconView(.chevronRight, size: 9)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            Spacer()
         }
+        .padding(.horizontal, onTap != nil ? VSpacing.sm : 0)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(isHovered ? VColor.surfaceBase.opacity(0.6) : Color.clear)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
             startDate = Date()
+        }
+        .onReceive(timer) { date in
+            now = date
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `TimelineView(.periodic)` with `Timer.publish` on `RunLoop.main` / `.common` in all three progress timer components (`ElapsedTimeLabel`, `ProcessingDotsLabel`, `RunningIndicator`)
- `TimelineView(.periodic)` can silently stop firing on macOS when the view hierarchy is idle or during layout passes, causing elapsed time counters to freeze mid-execution
- `Timer.publish` in `.common` run loop mode fires reliably through scroll tracking and modal display

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
