### PR TITLE
pkb: re-index on remember tool writes

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -14,6 +14,7 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import { buildExcerpt, buildFtsMatchQuery } from "../conversation-queries.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
+import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
 import { searchGraphNodes } from "./graph-search.js";
 import { getNodesByIds } from "./store.js";
 
@@ -260,7 +261,7 @@ export interface RememberResult {
 export function handleRemember(
   input: RememberInput,
   _conversationId: string,
-  _scopeId: string,
+  scopeId: string,
 ): RememberResult {
   if (!input.content || input.content.trim().length === 0) {
     return { success: false, message: "content is required" };
@@ -287,6 +288,7 @@ export function handleRemember(
   // Append to buffer.md
   const bufferPath = join(pkbDir, "buffer.md");
   appendFileSync(bufferPath, entry, "utf-8");
+  enqueuePkbReindex(pkbDir, bufferPath, scopeId);
 
   // Append to daily archive
   const yyyy = now.getFullYear();
@@ -297,6 +299,26 @@ export function handleRemember(
     appendFileSync(archivePath, `# ${month} ${day}, ${yyyy}\n\n`, "utf-8");
   }
   appendFileSync(archivePath, entry, "utf-8");
+  enqueuePkbReindex(pkbDir, archivePath, scopeId);
 
   return { success: true, message: "Saved to knowledge base." };
+}
+
+/**
+ * Fire-and-forget enqueue of a PKB re-index job for a file we just wrote.
+ *
+ * Wrapped in try/catch so an enqueue failure (e.g. DB hiccup) cannot break
+ * the remember call — the write has already succeeded and the user's fact
+ * is safe on disk.
+ */
+function enqueuePkbReindex(
+  pkbRoot: string,
+  absPath: string,
+  memoryScopeId: string,
+): void {
+  try {
+    enqueuePkbIndexJob({ pkbRoot, absPath, memoryScopeId });
+  } catch (err) {
+    log.warn({ err, absPath }, "Failed to enqueue PKB re-index job");
+  }
 }

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -1,12 +1,44 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import type { ToolContext } from "../types.js";
 
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;
+
+// Track calls to enqueuePkbIndexJob so we can assert remember wires writes
+// through to the re-index queue. Declared at module scope so the mock.module
+// factory (hoisted) can close over it.
+const enqueueCalls: Array<{
+  pkbRoot: string;
+  absPath: string;
+  memoryScopeId: string;
+}> = [];
+let enqueueShouldThrow = false;
+
+mock.module("../../memory/jobs/embed-pkb-file.js", () => ({
+  enqueuePkbIndexJob: (input: {
+    pkbRoot: string;
+    absPath: string;
+    memoryScopeId: string;
+  }) => {
+    enqueueCalls.push(input);
+    if (enqueueShouldThrow) {
+      throw new Error("simulated enqueue failure");
+    }
+    return "job-mock-id";
+  },
+}));
 
 beforeAll(() => {
   tmpWorkspace = mkdtempSync(join(tmpdir(), "remember-tool-test-"));
@@ -26,11 +58,12 @@ afterAll(() => {
 // Import after the env var is set so getWorkspaceDir() resolves to the tmpdir.
 const { rememberTool } = await import("./register.js");
 
-function makeContext(): ToolContext {
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     workingDir: tmpWorkspace,
     conversationId: "test-conversation",
     trustClass: "guardian",
+    ...overrides,
   };
 }
 
@@ -69,5 +102,81 @@ describe("rememberTool.execute — finish_turn", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.yieldToUser).toBe(true);
+  });
+});
+
+describe("rememberTool.execute — PKB re-index enqueue", () => {
+  beforeEach(() => {
+    enqueueCalls.length = 0;
+    enqueueShouldThrow = false;
+  });
+
+  test("enqueues re-index jobs for both buffer and daily archive paths", async () => {
+    const result = await rememberTool.execute(
+      { content: "index me please" },
+      makeContext({ memoryScopeId: "scope-enqueue" }),
+    );
+    expect(result.isError).toBe(false);
+
+    const pkbRoot = join(tmpWorkspace, "pkb");
+    const bufferPath = join(pkbRoot, "buffer.md");
+
+    // Archive path is dated; derive from today's date the same way
+    // handleRemember does.
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const archivePath = join(pkbRoot, "archive", `${yyyy}-${mm}-${dd}.md`);
+
+    expect(enqueueCalls).toHaveLength(2);
+    expect(enqueueCalls[0]).toEqual({
+      pkbRoot,
+      absPath: bufferPath,
+      memoryScopeId: "scope-enqueue",
+    });
+    expect(enqueueCalls[1]).toEqual({
+      pkbRoot,
+      absPath: archivePath,
+      memoryScopeId: "scope-enqueue",
+    });
+  });
+
+  test("does not enqueue when content is empty (write was skipped)", async () => {
+    const result = await rememberTool.execute(
+      { content: "   " },
+      makeContext({ memoryScopeId: "scope-empty" }),
+    );
+    expect(result.isError).toBe(true);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("thrown enqueue does not surface; remember still writes files", async () => {
+    enqueueShouldThrow = true;
+
+    const result = await rememberTool.execute(
+      { content: "enqueue will throw" },
+      makeContext({ memoryScopeId: "scope-throw" }),
+    );
+
+    // Remember call succeeded despite enqueue throwing for each write.
+    expect(result.isError).toBe(false);
+
+    // Both writes attempted their enqueue.
+    expect(enqueueCalls).toHaveLength(2);
+
+    // Files were written correctly.
+    const pkbRoot = join(tmpWorkspace, "pkb");
+    const bufferPath = join(pkbRoot, "buffer.md");
+    const bufferContents = readFileSync(bufferPath, "utf-8");
+    expect(bufferContents).toContain("enqueue will throw");
+
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const archivePath = join(pkbRoot, "archive", `${yyyy}-${mm}-${dd}.md`);
+    const archiveContents = readFileSync(archivePath, "utf-8");
+    expect(archiveContents).toContain("enqueue will throw");
   });
 });


### PR DESCRIPTION
## Summary
- Hooks enqueuePkbIndexJob into the remember tool so PKB files get re-indexed after each successful write.
- Enqueue failures are caught and logged; they do not surface to the remember caller.

Part of plan: pkb-reminder-hints.md (PR 8 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
