### PR TITLE
fix(assistant): sort imports in pkb-index to unblock lint on main

### DIFF
--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile, utimes } from "node:fs/promises";
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/assistant/src/memory/pkb/pkb-index.ts
+++ b/assistant/src/memory/pkb/pkb-index.ts
@@ -19,7 +19,6 @@ import { getConfig } from "../../config/loader.js";
 import { embedAndUpsert } from "../job-utils.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
-
 import type { PkbIndexEntry } from "./types.js";
 import { PKB_TARGET_TYPE } from "./types.js";
 


### PR DESCRIPTION
## Summary
- Reorder imports in \`assistant/src/memory/pkb/pkb-index.ts\` and \`pkb-index.test.ts\` to satisfy \`simple-import-sort/imports\`.
- Lint has been red on \`main\` since commit c2080ddfd6; this restores green.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24613597878/job/71972072374
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
