### PR TITLE
pkb: re-index on file_write writes under pkb root

### DIFF
--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
@@ -8,7 +9,45 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// Track calls to enqueuePkbIndexJob across tests. Captured via mock.module
+// below; individual tests clear and inspect the array.
+const enqueueCalls: Array<{
+  pkbRoot: string;
+  absPath: string;
+  memoryScopeId: string;
+}> = [];
+let enqueueThrows = false;
+
+mock.module("../memory/jobs/embed-pkb-file.js", () => ({
+  enqueuePkbIndexJob: (input: {
+    pkbRoot: string;
+    absPath: string;
+    memoryScopeId: string;
+  }) => {
+    if (enqueueThrows) {
+      throw new Error("simulated enqueue failure");
+    }
+    enqueueCalls.push(input);
+    return "job-id";
+  },
+}));
+
+// Override workspace dir via VELLUM_WORKSPACE_DIR so PKB-root detection
+// targets a temp directory without having to mock platform.js wholesale
+// (which would destabilize the rest of the tool registry's dependency tree).
+function setWorkspaceDir(dir: string): void {
+  process.env.VELLUM_WORKSPACE_DIR = dir;
+}
 
 import { getTool } from "../tools/registry.js";
 import type { Tool, ToolContext } from "../tools/types.js";
@@ -32,6 +71,24 @@ function makeContext(workingDir: string): ToolContext {
 afterEach(() => {
   for (const dir of testDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const originalWorkspaceDirEnv = process.env.VELLUM_WORKSPACE_DIR;
+
+beforeEach(() => {
+  enqueueCalls.length = 0;
+  enqueueThrows = false;
+  // Reset to a stable tmp path so the sandbox tests (which don't use pkb/)
+  // deterministically land outside any configured PKB root.
+  process.env.VELLUM_WORKSPACE_DIR = tmpdir();
+});
+
+afterEach(() => {
+  if (originalWorkspaceDirEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDirEnv;
   }
 });
 
@@ -116,5 +173,94 @@ describe("file_write tool (sandbox)", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("exceeds");
+  });
+});
+
+describe("file_write tool PKB re-index hook", () => {
+  test("enqueues a PKB re-index job when writing under pkb/", async () => {
+    const workingDir = makeTempDir();
+    setWorkspaceDir(workingDir);
+    mkdirSync(join(workingDir, "pkb"), { recursive: true });
+
+    const result = await fileWriteTool.execute(
+      { path: "pkb/note.md", content: "# hello\nworld\n" },
+      makeContext(workingDir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]).toEqual({
+      pkbRoot: join(workingDir, "pkb"),
+      absPath: join(workingDir, "pkb", "note.md"),
+      memoryScopeId: "default",
+    });
+  });
+
+  test("forwards memoryScopeId from context when present", async () => {
+    const workingDir = makeTempDir();
+    setWorkspaceDir(workingDir);
+    mkdirSync(join(workingDir, "pkb"), { recursive: true });
+
+    const ctx: ToolContext = {
+      ...makeContext(workingDir),
+      memoryScopeId: "private:abc123",
+    };
+
+    const result = await fileWriteTool.execute(
+      { path: "pkb/private.md", content: "secret\n" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]?.memoryScopeId).toBe("private:abc123");
+  });
+
+  test("does NOT enqueue when writing outside pkb/", async () => {
+    const workingDir = makeTempDir();
+    setWorkspaceDir(workingDir);
+
+    const result = await fileWriteTool.execute(
+      { path: "notes.md", content: "# not pkb\n" },
+      makeContext(workingDir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("does NOT enqueue for a sibling directory whose name is a pkb prefix", async () => {
+    // Guard against `<root>/pkbsomethingelse` being treated as inside `<root>/pkb`.
+    const workingDir = makeTempDir();
+    setWorkspaceDir(workingDir);
+    mkdirSync(join(workingDir, "pkbsibling"), { recursive: true });
+
+    const result = await fileWriteTool.execute(
+      { path: "pkbsibling/file.md", content: "not pkb\n" },
+      makeContext(workingDir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(enqueueCalls).toHaveLength(0);
+  });
+
+  test("enqueue failure is swallowed and write result stays successful", async () => {
+    const workingDir = makeTempDir();
+    setWorkspaceDir(workingDir);
+    mkdirSync(join(workingDir, "pkb"), { recursive: true });
+    enqueueThrows = true;
+
+    const result = await fileWriteTool.execute(
+      { path: "pkb/oops.md", content: "still writes\n" },
+      makeContext(workingDir),
+    );
+
+    expect(result.isError).toBe(false);
+    // The mock throws, so nothing gets pushed to enqueueCalls. The critical
+    // behavior is that the thrown error never surfaces through execute().
+    expect(enqueueCalls).toHaveLength(0);
+    expect(
+      existsSync(join(workingDir, "pkb", "oops.md")),
+    ).toBe(true);
   });
 });

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,10 +1,33 @@
+import { join, resolve, sep } from "node:path";
+
+import { enqueuePkbIndexJob } from "../../memory/jobs/embed-pkb-file.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
 import { registerTool } from "../registry.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+const logger = getLogger("file-write");
+
+/**
+ * Returns `true` iff `absPath` is an absolute path that resolves strictly
+ * inside `pkbRoot`. Matches the containment semantics used elsewhere in the
+ * daemon (e.g. `pkb-context-tracker`): a root-with-separator prefix check,
+ * guarding against `<root>siblingDir` false positives.
+ */
+function isInsidePkbRoot(absPath: string, pkbRoot: string): boolean {
+  const normalizedRoot = resolve(pkbRoot);
+  const normalized = resolve(absPath);
+  if (normalized === normalizedRoot) return false;
+  const rootWithSep = normalizedRoot.endsWith(sep)
+    ? normalizedRoot
+    : normalizedRoot + sep;
+  return normalized.startsWith(rootWithSep);
+}
 
 class FileWriteTool implements Tool {
   name = "file_write";
@@ -86,6 +109,30 @@ class FileWriteTool implements Tool {
     }
 
     const { filePath, oldContent, newContent, isNewFile } = result.value;
+
+    // If the write landed inside the workspace PKB root, enqueue a
+    // fire-and-forget re-index job so Qdrant stays in sync with on-disk
+    // content. Failures here must never surface to the caller — a file
+    // was written successfully and that is the user-facing contract.
+    try {
+      const pkbRoot = join(getWorkspaceDir(), "pkb");
+      if (isInsidePkbRoot(filePath, pkbRoot)) {
+        enqueuePkbIndexJob({
+          pkbRoot,
+          absPath: filePath,
+          memoryScopeId: context.memoryScopeId ?? "default",
+        });
+      }
+    } catch (err) {
+      logger.warn(
+        {
+          filePath,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to enqueue PKB re-index job after file_write",
+      );
+    }
+
     return {
       content: `Successfully wrote to ${filePath} ${formatWriteSummary(
         oldContent,


### PR DESCRIPTION
## Summary
- Hooks enqueuePkbIndexJob into the file_write tool so writes landing under the workspace PKB root trigger re-indexing.
- Non-PKB writes behave identically to before.
- Enqueue failures are caught and logged; they do not surface to the caller.

Part of plan: pkb-reminder-hints.md (PR 9 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
