### PR TITLE
fix(macos): compensate scroll anchor for shrink and drop notification task hop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -210,13 +210,21 @@ struct MessageListScrollObserver: NSViewRepresentable {
             scrollView.postsFrameChangedNotifications = true
             documentView?.postsFrameChangedNotifications = true
 
+            // `queue: .main` runs the block synchronously on the main thread
+            // for the notification that's currently being delivered. We
+            // `MainActor.assumeIsolated` to call the main-actor-isolated
+            // Coordinator methods without deferring to a `Task`. Deferring
+            // opens a 1-frame race where the display can draw the new
+            // layout (post-growth/shrink contentH) before the anchor shift
+            // has been applied to `clipView.bounds.origin.y`, which the user
+            // perceives as a flicker at the streaming cadence.
             let center = NotificationCenter.default
             observers.append(center.addObserver(
                 forName: NSView.boundsDidChangeNotification,
                 object: clipView,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     self?.emitCurrentSnapshotIfPossible()
                 }
             })
@@ -225,7 +233,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 object: clipView,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     self?.emitCurrentSnapshotIfPossible()
                 }
             })
@@ -234,7 +242,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 object: scrollView,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     self?.emitCurrentSnapshotIfPossible()
                 }
             })
@@ -244,7 +252,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                     object: documentView,
                     queue: .main
                 ) { [weak self] _ in
-                    Task { @MainActor [weak self] in
+                    MainActor.assumeIsolated {
                         self?.emitCurrentSnapshotIfPossible()
                     }
                 })
@@ -262,7 +270,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 object: scrollView,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     guard let self else { return }
                     self.isLiveScrolling = true
                     // Emit so downstream observers (e.g. the debug overlay)
@@ -277,7 +285,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 object: scrollView,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                MainActor.assumeIsolated {
                     guard let self else { return }
                     self.isLiveScrolling = false
                     // Re-baseline without applying a delta: any growth
@@ -314,7 +322,7 @@ enum ScrollAnchorPreserver {
         case anchorPreservationDisabled
         case userLiveScrolling
         case firstLayout
-        case notGrowth
+        case contentHUnchanged
         case pinnedToLatest
     }
 
@@ -331,10 +339,12 @@ enum ScrollAnchorPreserver {
     /// In the inverted scroll, `contentOffsetY = 0` is the visual bottom
     /// (latest messages). The streaming assistant response lives at the
     /// low end of the document (doc Y near 0), so its growth pushes every
-    /// higher-Y item further from the visual bottom. A user reading older
-    /// content (positive `contentOffsetY`) sees that content scroll upward
-    /// off the top of the viewport unless the offset is shifted by the
-    /// growth amount.
+    /// higher-Y item further from the visual bottom — and symmetrically,
+    /// when the streaming edge shrinks (pin spacer release, thinking-block
+    /// collapse during streaming, height-estimate correction) every
+    /// higher-Y item is pulled back toward the visual bottom. Either
+    /// direction moves the user's visible region off the current doc-Y
+    /// window unless the offset is shifted by the same signed delta.
     static func decide(
         currentContentHeight: CGFloat,
         lastContentHeight: CGFloat,
@@ -346,15 +356,15 @@ enum ScrollAnchorPreserver {
         if !shouldPreserveAnchor { return .skipped(.anchorPreservationDisabled) }
         if isUserLiveScrolling { return .skipped(.userLiveScrolling) }
         if lastContentHeight <= 0 { return .skipped(.firstLayout) }
-        if currentContentHeight <= lastContentHeight { return .skipped(.notGrowth) }
+        if currentContentHeight == lastContentHeight { return .skipped(.contentHUnchanged) }
         if contentOffsetY <= pinnedToLatestEpsilon { return .skipped(.pinnedToLatest) }
         return .applied(delta: currentContentHeight - lastContentHeight)
     }
 
     /// Returns the offset delta to add to `contentOffsetY` so the visible
-    /// content stays anchored when the document grows, or `nil` if no
-    /// adjustment is needed. Kept for tests and simple callers — see
-    /// `decide(...)` for the richer outcome.
+    /// content stays anchored when the document height changes (either
+    /// direction), or `nil` if no adjustment is needed. Kept for tests and
+    /// simple callers — see `decide(...)` for the richer outcome.
     static func offsetDelta(
         currentContentHeight: CGFloat,
         lastContentHeight: CGFloat,

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -306,15 +306,14 @@ final class ScrollDebugRecorder {
         let anchorsPerSecond: Int
         let anchorTotal: Int
         /// Outcome string of the most recent anchor decision: `"applied"` or
-        /// the skip reason (`"notGrowth"`, `"pinnedToLatest"`, etc.). Empty
-        /// before the first decision fires.
+        /// the skip reason (`"contentHUnchanged"`, `"pinnedToLatest"`, etc.).
+        /// Empty before the first decision fires.
         let anchorOutcome: String
         /// Delta applied by the anchor preserver on the most recent decision.
-        /// `0` for skips.
+        /// `0` for skips. Signed: positive for growth, negative for shrink.
         let anchorDelta: CGFloat
         /// Content-height delta the preserver saw on the most recent decision.
-        /// Negative values mean content shrunk — the preserver currently does
-        /// not compensate for shrinks.
+        /// Signed: negative means content shrunk.
         let anchorContentHDelta: CGFloat
         let anchorPreOffsetY: CGFloat
         let anchorPostOffsetY: CGFloat

--- a/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
@@ -66,13 +66,50 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         ))
     }
 
-    func testSkipsWhenContentShrunk() {
-        // A collapse (e.g., thinking-block dismissal) reduces height. We
-        // do not pull the user toward the streaming edge in that case.
-        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+    func testCompensatesOnContentShrink() {
+        // Symmetric case to the streaming-growth bug: when the streaming
+        // edge collapses (pin-latest-turn spacer release at end-of-stream,
+        // thinking-block dismissal during streaming, height-estimate
+        // correction), existing items at higher doc Y are pulled back
+        // toward the visual bottom by the same amount. Without a negative
+        // offset shift, the user's visible content drifts off the viewport
+        // in the opposite direction from the growth case.
+        let delta = ScrollAnchorPreserver.offsetDelta(
             currentContentHeight: 900,
             lastContentHeight: 1000,
             contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, -100)
+    }
+
+    func testCompensatesOnSmallShrinkFromRecordedRegression() {
+        // A per-frame HUD recording captured a 34pt shrink at the tail of
+        // a streaming response with no compensation, producing a visible
+        // 34pt viewport jump. With shrink compensation enabled the offset
+        // shifts by -34 and the viewport stays put.
+        let delta = ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 9741,
+            lastContentHeight: 9775,
+            contentOffsetY: 1798.5,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        )
+        XCTAssertEqual(delta, -34)
+    }
+
+    func testSkipsShrinkWhenPinnedToVisualBottom() {
+        // Symmetric to the growth case: when the user is pinned to the
+        // visual bottom, shrink doesn't apply a negative shift either —
+        // NSScrollView auto-clamps at offset 0 and pulling "past" that
+        // would violate the pinned state the user chose.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            currentContentHeight: 900,
+            lastContentHeight: 1000,
+            contentOffsetY: 5,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
             pinnedToLatestEpsilon: Self.epsilon


### PR DESCRIPTION
## Summary
- `ScrollAnchorPreserver.decide` now applies a signed delta for both growth and shrink. When the streaming edge collapses (pin-latest-turn spacer release, thinking-block dismissal, height-estimate correction), the preserver shifts offsetY by the negative delta instead of letting NSScrollView auto-clamp. The previous growth-only guard was the root cause of the 34pt viewport jump captured in the telemetry recording.
- Dropped `Task { @MainActor }` from every notification handler in `MessageListScrollObserver`. The notification runs on `queue: .main` already; deferring to a Task pushed the anchor shift to the next runloop iteration, opening a 1-frame race where the display could draw new contentH with unadjusted offsetY. Replaced with `MainActor.assumeIsolated` so the shift is synchronous to the notification delivery — which is what the "flickers up and down a few times a second" observation pointed at.
- Tests: `testSkipsWhenContentShrunk` replaced with `testCompensatesOnContentShrink` (expects `-100`), added `testCompensatesOnSmallShrinkFromRecordedRegression` (regression from the observed `-34pt` case) and `testSkipsShrinkWhenPinnedToVisualBottom` (symmetry with the pinned-growth skip). All 13 scroll anchor tests pass.

## Original prompt
it