### PR TITLE
fix(macos): block TCC-protected directories in sandbox profile

### DIFF
--- a/assistant/src/__tests__/tcc-sandbox-deny.test.ts
+++ b/assistant/src/__tests__/tcc-sandbox-deny.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for macOS TCC-protected directory deny rules in the sandbox profile.
+ *
+ * Verifies that the SBPL sandbox profile blocks access to TCC-protected
+ * directories (Photos, Contacts, Calendar, etc.) to prevent macOS
+ * permission prompts during filesystem traversal.
+ */
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { MACOS_TCC_PROTECTED_PATHS } from "../tools/terminal/backends/native.js";
+
+// We can't call buildSandboxProfile directly (not exported), but we can
+// exercise it through NativeBackend.wrap() on macOS and inspect the
+// generated .sb profile file on disk.
+
+const isMacOS = process.platform === "darwin";
+
+describe("macOS TCC sandbox deny rules", () => {
+  // On macOS, generate a profile and inspect it. On other platforms,
+  // just verify the constant is well-formed.
+
+  test("MACOS_TCC_PROTECTED_PATHS is non-empty", () => {
+    expect(MACOS_TCC_PROTECTED_PATHS.length).toBeGreaterThan(0);
+  });
+
+  test("all paths are relative (no leading slash)", () => {
+    for (const p of MACOS_TCC_PROTECTED_PATHS) {
+      expect(p.startsWith("/")).toBe(false);
+    }
+  });
+
+  test("no duplicate paths", () => {
+    const unique = new Set(MACOS_TCC_PROTECTED_PATHS);
+    expect(unique.size).toBe(MACOS_TCC_PROTECTED_PATHS.length);
+  });
+
+  if (isMacOS) {
+    const profilePaths: string[] = [];
+
+    // Generate a profile by calling NativeBackend.wrap()
+    test("generated SBPL profile contains deny rules for all TCC paths", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const result = backend.wrap("true", "/tmp/tcc-test", {
+        networkMode: "off",
+      });
+
+      // The profile path is the second arg after -f
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      expect(existsSync(profilePath)).toBe(true);
+
+      const profile = readFileSync(profilePath, "utf-8");
+      const home = process.env.HOME ?? "";
+      expect(home.length).toBeGreaterThan(0);
+
+      for (const rel of MACOS_TCC_PROTECTED_PATHS) {
+        const abs = join(home, rel);
+        expect(profile).toContain(`(deny file-read* (subpath "${abs}")`);
+      }
+    });
+
+    test("all TCC deny rules include (with no-log)", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const result = backend.wrap("true", "/tmp/tcc-test-nolog", {
+        networkMode: "off",
+      });
+
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      const profile = readFileSync(profilePath, "utf-8");
+      const home = process.env.HOME ?? "";
+
+      for (const rel of MACOS_TCC_PROTECTED_PATHS) {
+        const abs = join(home, rel);
+        expect(profile).toContain(
+          `(deny file-read* (subpath "${abs}") (with no-log))`,
+        );
+      }
+    });
+
+    test("TCC deny rules appear after (allow file-read*)", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const result = backend.wrap("true", "/tmp/tcc-test-order", {
+        networkMode: "off",
+      });
+
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      const profile = readFileSync(profilePath, "utf-8");
+      const home = process.env.HOME ?? "";
+
+      const allowIdx = profile.indexOf("(allow file-read*)");
+      expect(allowIdx).toBeGreaterThanOrEqual(0);
+
+      for (const rel of MACOS_TCC_PROTECTED_PATHS) {
+        const abs = join(home, rel);
+        const denyIdx = profile.indexOf(`(deny file-read* (subpath "${abs}")`);
+        expect(denyIdx).toBeGreaterThan(allowIdx);
+      }
+    });
+
+    test("paths with spaces are handled correctly", async () => {
+      const { NativeBackend } =
+        await import("../tools/terminal/backends/native.js");
+      const backend = new NativeBackend();
+      const result = backend.wrap("true", "/tmp/tcc-test-spaces", {
+        networkMode: "off",
+      });
+
+      const profilePath = result.args[1]!;
+      profilePaths.push(profilePath);
+      const profile = readFileSync(profilePath, "utf-8");
+      const home = process.env.HOME ?? "";
+
+      // Photos Library.photoslibrary has a space — verify it's in the profile
+      const photosPath = join(home, "Pictures/Photos Library.photoslibrary");
+      expect(profile).toContain(`(subpath "${photosPath}")`);
+    });
+
+    afterAll(() => {
+      for (const p of profilePaths) {
+        try {
+          unlinkSync(p);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+  }
+});

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -13,6 +13,33 @@ const log = getLogger("sandbox");
 const HASH_DISPLAY_LENGTH = 12;
 
 /**
+ * macOS TCC-protected directories that trigger permission prompts when accessed.
+ * Unconditionally denied in the SBPL sandbox profile to prevent the assistant
+ * from triggering Photos, Contacts, Calendar, etc. dialogs during filesystem
+ * traversal (e.g. `find ~ -name .git`).
+ *
+ * Paths are relative to $HOME. Only directories that trigger TCC prompts for
+ * non-App-Sandbox apps are listed — ~/Desktop and ~/Documents are
+ * TCC-protected only under App Sandbox, which the daemon does not use.
+ */
+export const MACOS_TCC_PROTECTED_PATHS = [
+  "Pictures/Photos Library.photoslibrary",
+  "Library/Photos",
+  "Library/Calendars",
+  "Library/Reminders",
+  "Library/AddressBook",
+  "Library/Messages",
+  "Library/Mail",
+  "Library/Safari",
+  "Library/Cookies",
+  "Library/HomeKit",
+  "Library/IdentityServices",
+  "Library/Metadata/CoreSpotlight",
+  "Library/PersonalizationPortrait",
+  "Library/Suggestions",
+];
+
+/**
  * Build a macOS sandbox-exec SBPL profile.
  *
  * The profile restricts shell commands:
@@ -33,6 +60,18 @@ function buildSandboxProfile(
   const networkRule = allowNetwork
     ? ";; Allow network access (proxied mode - needed to reach the credential proxy)\n(allow network*)"
     : ";; Block network access\n(deny network*)";
+
+  // Block macOS TCC-protected directories to prevent permission prompts
+  // during filesystem traversal. Placed AFTER (allow file-read*) because
+  // SBPL uses last-match-wins semantics.
+  const home = process.env.HOME ?? "";
+  const tccDenyRules = home
+    ? "\n;; Block macOS TCC-protected directories to prevent permission prompts\n" +
+      MACOS_TCC_PROTECTED_PATHS.map(
+        (rel) =>
+          `(deny file-read* (subpath "${escapeSBPL(join(home, rel))}") (with no-log))`,
+      ).join("\n")
+    : "";
 
   // Build deny-read rules for protected paths (CES shell lockdown).
   // These are placed AFTER the allow file-read* rule because SBPL uses
@@ -55,6 +94,7 @@ function buildSandboxProfile(
 
 ;; Allow read access to the filesystem (tools, libraries, etc.)
 (allow file-read*)
+${tccDenyRules}
 ${denyReadRules}
 
 ;; Allow write access to the working directory and its children
@@ -120,12 +160,13 @@ function getProfilePath(
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  // Include the network flag and deny-read paths in the hash so profiles
-  // with different configurations don't collide.
+  // Include the network flag, deny-read paths, and HOME in the hash so
+  // profiles with different configurations don't collide.
   let hashInput = allowNetwork ? `${workingDir}:proxied` : workingDir;
   if (denyReadPaths && denyReadPaths.length > 0) {
     hashInput += `:deny-read:${denyReadPaths.sort().join(",")}`;
   }
+  hashInput += `:home:${process.env.HOME ?? ""}`;
   const hash = createHash("sha256")
     .update(hashInput)
     .digest("hex")


### PR DESCRIPTION
## Summary
- Adds `MACOS_TCC_PROTECTED_PATHS` constant listing 14 TCC-protected directories (Photos, Contacts, Calendar, Messages, Mail, Safari, etc.)
- Generates `(deny file-read* (subpath "...") (with no-log))` SBPL rules in the sandbox profile to block access to these directories
- Prevents macOS permission dialogs (e.g. "Would Like to Access Your Photo Library") from appearing when the assistant traverses the filesystem

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] New tests in `tcc-sandbox-deny.test.ts` pass (7/7)
- [x] Existing CES lockdown tests pass (10/10)
- [ ] Manual: build macOS app, run `find ~ -name .git` via assistant, confirm no TCC dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
