### PR TITLE
fix(assistant): update updates.enabled config description for new bulletin flow

### DIFF
--- a/assistant/src/config/schemas/updates.ts
+++ b/assistant/src/config/schemas/updates.ts
@@ -6,7 +6,7 @@ export const UpdatesConfigSchema = z
       .boolean({ error: "updates.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Whether the release update bulletin (UPDATES.md) is materialized into the workspace on daemon startup",
+        "Whether to dispatch a background conversation when ~/.vellum/workspace/UPDATES.md has unprocessed content. When false, release-update bulletins are written by migrations but never processed by the agent.",
       ),
   })
   .describe("Release update bulletin configuration");


### PR DESCRIPTION
## Summary
The `updates.enabled` config flag previously described itself as gating workspace materialization on startup, but that materialization was removed by plan `updates-md-background-job.md`. The flag now gates whether the background job dispatches a wake to process `UPDATES.md`. Description updated accordingly.

Part of plan: updates-md-background-job.md (post-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
