### PR TITLE
docs: clarify migration runner is authoritative idempotency for release-notes migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,10 +238,11 @@ Release notes for user/assistant-facing changes ship via **workspace migrations*
 
 **To ship release notes:**
 
-1. Add a new migration file at `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts`. Use the next available sequence number (migrations are append-only). Put the release-note text inline as a string literal inside the migration.
-2. The migration must be idempotent: check for the HTML marker comment `<!-- vellum-migration:<id> -->` in `UPDATES.md` before appending, and skip if the marker is already present. The `<id>` should match the migration's registry ID so re-runs are a no-op.
-3. Append the new migration's export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Never reorder or remove existing entries.
-4. Skip the migration entirely for no-op releases — do not add an empty migration.
+1. Add a new migration file at `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts`. Use the next available sequence number (migrations are append-only). Put the release-note text inline as a string literal inside the migration and append it to `UPDATES.md` in the migration's `run()`.
+2. Append the new migration's export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Never reorder or remove existing entries.
+3. Skip the migration entirely for no-op releases — do not add an empty migration.
+
+**Idempotency is handled by the workspace-migration runner.** `runWorkspaceMigrations()` in `assistant/src/workspace/migrations/runner.ts` records each successfully applied migration's `WorkspaceMigration.id` in `~/.vellum/workspace/data/.workspace-migrations.json` and never re-runs an ID that is already in the `applied` set. Release-notes migrations therefore do not need their own in-file guard — the runner is the authoritative single source of truth for "has this migration run yet?". (If you want belt-and-suspenders for the rare case where the checkpoint file is wiped but `UPDATES.md` survives, you may optionally embed an HTML marker like `<!-- vellum-migration:<id> -->` in the appended block and skip the append when the marker is already present. This is a secondary defense, not the primary mechanism.)
 
 **Processing:** After workspace migrations run at daemon startup, `runUpdateBulletinJobIfNeeded()` fires a background-only conversation (`conversationType: "background"`) via `wakeAgentForOpportunity()` to process `UPDATES.md`. The agent reads the file, acts on whatever is relevant, and deletes `UPDATES.md` when done. `rm UPDATES.md` remains auto-allowed so deletion needs no approval. The job short-circuits when the content hash matches the previously processed value (`updates:last_processed_hash`), so running on every startup is safe.
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -754,7 +754,7 @@ Release-driven update notification system that dispatches a background conversat
 
 **Data flow:**
 
-1. **Storage** — Release notes live at `~/.vellum/workspace/UPDATES.md`. The file is written by workspace migrations; each release that needs to surface notes ships a dedicated migration in `src/workspace/migrations/` that appends an idempotency-gated block (keyed by an HTML marker comment `<!-- vellum-migration:<id> -->`) to the file.
+1. **Storage** — Release notes live at `~/.vellum/workspace/UPDATES.md`. The file is written by workspace migrations; each release that needs to surface notes ships a dedicated migration in `src/workspace/migrations/` that appends a release-notes block to the file. The workspace-migration runner is the authoritative idempotency mechanism: `runWorkspaceMigrations()` records each migration's `WorkspaceMigration.id` in `~/.vellum/workspace/data/.workspace-migrations.json` and never re-runs an ID that is already in the `applied` set.
 2. **Dispatch** — At daemon startup (after `runWorkspaceMigrations()`), `runUpdateBulletinJobIfNeeded()` is invoked fire-and-forget. It hashes the current `UPDATES.md` content and compares against the `updates:last_processed_hash` checkpoint. When the hashes differ, it bootstraps a `conversationType: "background"` conversation and calls `wakeAgentForOpportunity()` so the agent processes the bulletin without any interactive session.
 3. **Completion** — The agent acts on the contents and deletes `UPDATES.md` when done. The job persists the new hash to `updates:last_processed_hash` post-wake, so subsequent startups short-circuit until the file is repopulated by a future migration.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -49,7 +49,7 @@ cp .env.example .env
 
 Release notes are surfaced via a background conversation dispatched at daemon startup. Workspace migrations write release notes to `~/.vellum/workspace/UPDATES.md`; `runUpdateBulletinJobIfNeeded()` then spawns a `conversationType: "background"` conversation (via `wakeAgentForOpportunity()`) whenever the file's content hash changes. The agent uses judgment to surface updates to the user when relevant, and deletes the file when done.
 
-**For release maintainers:** Add a new migration under `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts` with the release notes inline as a string literal, and append the export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Migrations are append-only and must be idempotent — guard the append with an HTML marker comment (`<!-- vellum-migration:<id> -->`) so re-runs are a no-op. Skip the migration entirely for releases with no user/assistant-facing changes.
+**For release maintainers:** Add a new migration under `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts` with the release notes inline as a string literal, and append the export to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`. Migrations are append-only. Idempotency is handled by the workspace-migration runner — `runWorkspaceMigrations()` records each migration's `WorkspaceMigration.id` in `~/.vellum/workspace/data/.workspace-migrations.json` and never re-runs an ID that is already in the `applied` set, so release-notes migrations do not need an in-file guard. Skip the migration entirely for releases with no user/assistant-facing changes.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
The release-notes migration docs in root AGENTS.md and assistant/README.md previously prescribed an HTML marker comment as the idempotency mechanism, which contradicts how every other workspace migration works. The runner already skips re-runs of any migration whose `WorkspaceMigration.id` is in `data/.workspace-migrations.json`'s applied set. This PR rewrites the docs to make the runner the authoritative mechanism and drops the marker requirement.

Part of plan: updates-md-background-job.md (post-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
