### PR TITLE
fix(gmail): align outreach scan caps with TOOLS.json

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -16,8 +16,8 @@ function isRateLimitError(e: unknown): boolean {
   return /\b429\b/.test(e.message);
 }
 
-const MAX_MESSAGES_CAP = 5000;
-const MAX_IDS_PER_SENDER = 5000;
+const MAX_MESSAGES_CAP = 2000;
+const MAX_IDS_PER_SENDER = 2000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface OutreachSenderAggregation {
@@ -51,7 +51,7 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const account = input.account as string | undefined;
   const maxMessages = Math.min(
-    (input.max_messages as number) ?? 2000,
+    (input.max_messages as number) ?? 1000,
     MAX_MESSAGES_CAP,
   );
   const maxSenders = (input.max_senders as number) ?? 30;

--- a/assistant/src/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.ts
@@ -16,7 +16,6 @@ import { join } from "node:path";
 import { getLogger } from "../../util/logger.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
 import { getQdrantClient } from "../qdrant-client.js";
-
 import { deletePkbFilePoints, scanPkbFiles } from "./pkb-index.js";
 import { PKB_TARGET_TYPE } from "./types.js";
 


### PR DESCRIPTION
Updates the gmail_outreach_scan implementation to match the TOOLS.json descriptions that were updated in #26387:
- MAX_MESSAGES_CAP: 5000 → 2000
- MAX_IDS_PER_SENDER: 5000 → 2000
- Default max_messages: 2000 → 1000

Addresses feedback from #26387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
