### PR TITLE
fix(oauth): backfill gmail.settings.basic scope for existing providers

### DIFF
--- a/assistant/src/workspace/migrations/041-backfill-google-gmail-settings-scope.ts
+++ b/assistant/src/workspace/migrations/041-backfill-google-gmail-settings-scope.ts
@@ -1,0 +1,57 @@
+import { rawGet, rawRun } from "../../memory/raw-query.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const GMAIL_SETTINGS_BASIC_SCOPE =
+  "https://www.googleapis.com/auth/gmail.settings.basic";
+
+/**
+ * Backfill the `gmail.settings.basic` scope for existing Google provider rows.
+ *
+ * The scope was added to PROVIDER_SEED_DATA in #25970, but `seedProviders()`
+ * intentionally preserves `defaultScopes` on conflict (the `onConflictDoUpdate`
+ * in `oauth-store.ts` omits `defaultScopes` and `scopePolicy`). Any workspace
+ * that already had a `google` provider row never picked up the new scope.
+ *
+ * This migration reads the current `defaultScopes` JSON array for the `google`
+ * provider and appends the scope if it is not already present.
+ */
+export const backfillGoogleGmailSettingsScopeMigration: WorkspaceMigration = {
+  id: "041-backfill-google-gmail-settings-scope",
+  description:
+    "Backfill gmail.settings.basic scope for existing Google provider rows",
+  run(_workspaceDir: string): void {
+    let row: { defaultScopes: string } | null;
+    try {
+      row = rawGet<{ defaultScopes: string }>(
+        `SELECT defaultScopes FROM oauth_providers WHERE provider = 'google'`,
+      );
+    } catch {
+      // DB not initialized yet — nothing to backfill.
+      return;
+    }
+
+    if (!row) return; // No google provider row — seed will create it fresh.
+
+    let scopes: string[];
+    try {
+      const parsed = JSON.parse(row.defaultScopes);
+      scopes = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      scopes = [];
+    }
+
+    if (scopes.includes(GMAIL_SETTINGS_BASIC_SCOPE)) return; // Already present.
+
+    scopes.push(GMAIL_SETTINGS_BASIC_SCOPE);
+
+    rawRun(
+      `UPDATE oauth_providers SET defaultScopes = ?, updatedAt = ? WHERE provider = 'google'`,
+      JSON.stringify(scopes),
+      new Date().toISOString(),
+    );
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: removing the scope would break Gmail settings functionality
+    // for users who have already started using it.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -38,6 +38,7 @@ import { createMeetsDirMigration } from "./037-create-meets-dir.js";
 import { unifyLlmCallSiteConfigsMigration } from "./038-unify-llm-callsite-configs.js";
 import { dropLegacyLlmKeysMigration } from "./039-drop-legacy-llm-keys.js";
 import { seedLatencyCallSiteDefaultsMigration } from "./040-seed-latency-callsite-defaults.js";
+import { backfillGoogleGmailSettingsScopeMigration } from "./041-backfill-google-gmail-settings-scope.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -87,4 +88,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   unifyLlmCallSiteConfigsMigration,
   dropLegacyLlmKeysMigration,
   seedLatencyCallSiteDefaultsMigration,
+  backfillGoogleGmailSettingsScopeMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration `041-backfill-google-gmail-settings-scope` to update existing Google OAuth provider rows with the `gmail.settings.basic` scope.
- `seedProviders()` preserves `defaultScopes` on conflict (the `onConflictDoUpdate` omits `defaultScopes`), so existing installations never picked up the new scope added in #25970.
- The migration reads the current `defaultScopes` array, checks if the scope is already present, and appends it if missing. Idempotent and forward-only.

Addresses feedback from #25970.

## Test plan
- [ ] Verify the migration runs successfully on a workspace with an existing Google provider row that lacks the `gmail.settings.basic` scope
- [ ] Verify the migration is a no-op when the scope is already present
- [ ] Verify the migration is a no-op when no Google provider row exists (fresh install)
- [ ] Verify type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
