### PR TITLE
pkb: surface relevance hints in PKB system reminder

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -216,10 +216,13 @@ mock.module("../daemon/conversation-memory.js", () => ({
 
 let mockApplyRuntimeInjections: (msgs: Message[]) => Message[] = (msgs) => msgs;
 mock.module("../daemon/conversation-runtime-assembly.js", () => ({
-  applyRuntimeInjections: (msgs: Message[]) => mockApplyRuntimeInjections(msgs),
+  applyRuntimeInjections: async (msgs: Message[]) =>
+    mockApplyRuntimeInjections(msgs),
   stripInjectionsForCompaction: (msgs: Message[]) => msgs,
   findLastInjectedNowContent: () => null,
   readNowScratchpad: () => null,
+  readPkbContext: () => null,
+  readAutoinjectList: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -207,10 +207,12 @@ mock.module("../daemon/conversation-memory.js", () => ({
 }));
 
 mock.module("../daemon/conversation-runtime-assembly.js", () => ({
-  applyRuntimeInjections: (msgs: Message[]) => msgs,
+  applyRuntimeInjections: async (msgs: Message[]) => msgs,
   stripInjectionsForCompaction: (msgs: Message[]) => msgs,
   findLastInjectedNowContent: () => null,
   readNowScratchpad: () => null,
+  readPkbContext: () => null,
+  readAutoinjectList: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// PKB search is mocked so the reminder-hints tests can assert behavior
+// without standing up Qdrant. The mock returns whatever is staged in
+// `pkbSearchResults` / `pkbSearchThrows` for the enclosing test.
+let pkbSearchResults: Array<{ path: string; score: number }> = [];
+let pkbSearchThrows: Error | null = null;
+mock.module("../memory/pkb/pkb-search.js", () => ({
+  searchPkbFiles: async () => {
+    if (pkbSearchThrows) throw pkbSearchThrows;
+    return pkbSearchResults;
+  },
+}));
 
 import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type {
@@ -20,6 +32,7 @@ import {
   stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
+import { buildPkbReminder } from "../daemon/pkb-reminder-builder.js";
 import type { Message } from "../providers/types.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -422,7 +435,7 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
     },
   ];
 
-  test("injects channel capabilities when provided", () => {
+  test("injects channel capabilities when provided", async () => {
     const caps: ChannelCapabilities = {
       channel: "telegram",
       dashboardCapable: false,
@@ -430,7 +443,7 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
       supportsVoiceInput: false,
     };
 
-    const result = applyRuntimeInjections(baseMessages, {
+    const result = await applyRuntimeInjections(baseMessages, {
       channelCapabilities: caps,
     });
 
@@ -442,8 +455,8 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
     );
   });
 
-  test("does not inject when channelCapabilities is null", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("does not inject when channelCapabilities is null", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       channelCapabilities: null,
     });
 
@@ -451,14 +464,14 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
     expect(result[0].content.length).toBe(1);
   });
 
-  test("does not inject when channelCapabilities is omitted", () => {
-    const result = applyRuntimeInjections(baseMessages, {});
+  test("does not inject when channelCapabilities is omitted", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {});
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
   });
 
-  test("combines with other injections", () => {
+  test("combines with other injections", async () => {
     const caps: ChannelCapabilities = {
       channel: "telegram",
       dashboardCapable: false,
@@ -466,7 +479,7 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
       supportsVoiceInput: false,
     };
 
-    const result = applyRuntimeInjections(baseMessages, {
+    const result = await applyRuntimeInjections(baseMessages, {
       channelCapabilities: caps,
     });
 
@@ -612,8 +625,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     isNonInteractive: true,
   };
 
-  test("full mode (default) includes all injections", () => {
-    const result = applyRuntimeInjections(baseMessages, fullOptions);
+  test("full mode (default) includes all injections", async () => {
+    const result = await applyRuntimeInjections(baseMessages, fullOptions);
     const allText = result[0].content
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
       .map((b) => b.text)
@@ -630,8 +643,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<pkb>");
   });
 
-  test("explicit mode: 'full' behaves the same as default", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("explicit mode: 'full' behaves the same as default", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "full",
     });
@@ -646,8 +659,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<NOW.md");
   });
 
-  test("minimal mode skips high-token optional blocks", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("minimal mode skips high-token optional blocks", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "minimal",
     });
@@ -665,8 +678,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).not.toContain("<pkb>");
   });
 
-  test("minimal mode preserves safety-critical blocks", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("minimal mode preserves safety-critical blocks", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "minimal",
     });
@@ -681,12 +694,12 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<channel_capabilities>");
   });
 
-  test("minimal mode produces strictly fewer content blocks than full mode", () => {
-    const fullResult = applyRuntimeInjections(baseMessages, {
+  test("minimal mode produces strictly fewer content blocks than full mode", async () => {
+    const fullResult = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "full",
     });
-    const minimalResult = applyRuntimeInjections(baseMessages, {
+    const minimalResult = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "minimal",
     });
@@ -696,8 +709,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     );
   });
 
-  test("minimal mode still preserves the original user message text", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("minimal mode still preserves the original user message text", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       ...fullOptions,
       mode: "minimal",
     });
@@ -1015,8 +1028,8 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     },
   ];
 
-  test("injects NOW.md block when provided", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("injects NOW.md block when provided", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       nowScratchpad: "Current focus: fix the bug",
     });
 
@@ -1028,8 +1041,8 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     expect(text).toContain("Current focus: fix the bug");
   });
 
-  test("scratchpad appears before user's original text content", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("scratchpad appears before user's original text content", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       nowScratchpad: "scratchpad notes",
     });
 
@@ -1043,8 +1056,8 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     );
   });
 
-  test("does not inject when nowScratchpad is null", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("does not inject when nowScratchpad is null", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       nowScratchpad: null,
     });
 
@@ -1052,15 +1065,15 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     expect(result[0].content.length).toBe(1);
   });
 
-  test("does not inject when nowScratchpad is omitted", () => {
-    const result = applyRuntimeInjections(baseMessages, {});
+  test("does not inject when nowScratchpad is omitted", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {});
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
   });
 
-  test("skipped in minimal mode", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("skipped in minimal mode", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       nowScratchpad: "Current focus: fix the bug",
       mode: "minimal",
     });
@@ -1463,8 +1476,8 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
   const sampleBlock =
     "<turn_context>\ncurrent_time: 2026-04-02T12:00:00Z\ninterface: macos\n</turn_context>";
 
-  test("injects unifiedTurnContext when provided", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("injects unifiedTurnContext when provided", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       unifiedTurnContext: sampleBlock,
     });
 
@@ -1479,8 +1492,8 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
     );
   });
 
-  test("does not inject when unifiedTurnContext is null", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("does not inject when unifiedTurnContext is null", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       unifiedTurnContext: null,
     });
 
@@ -1488,15 +1501,15 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
     expect(result[0].content).toHaveLength(1);
   });
 
-  test("does not inject when unifiedTurnContext is omitted", () => {
-    const result = applyRuntimeInjections(baseMessages, {});
+  test("does not inject when unifiedTurnContext is omitted", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {});
 
     expect(result).toHaveLength(1);
     expect(result[0].content).toHaveLength(1);
   });
 
-  test("injected in full mode", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("injected in full mode", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       unifiedTurnContext: sampleBlock,
       mode: "full",
     });
@@ -1509,8 +1522,8 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
     expect(allText).toContain("<turn_context>");
   });
 
-  test("injected in minimal mode (no mode guard)", () => {
-    const result = applyRuntimeInjections(baseMessages, {
+  test("injected in minimal mode (no mode guard)", async () => {
+    const result = await applyRuntimeInjections(baseMessages, {
       unifiedTurnContext: sampleBlock,
       mode: "minimal",
     });
@@ -1723,8 +1736,8 @@ describe("applyRuntimeInjections — subagent status", () => {
     content: [{ type: "text", text: "user message" }],
   };
 
-  test("includes subagent status in full mode", () => {
-    const result = applyRuntimeInjections([userMsg], {
+  test("includes subagent status in full mode", async () => {
+    const result = await applyRuntimeInjections([userMsg], {
       subagentStatusBlock:
         "<active_subagents>\n- [running] test\n</active_subagents>",
       mode: "full",
@@ -1736,8 +1749,8 @@ describe("applyRuntimeInjections — subagent status", () => {
     expect(texts.some((t) => t.includes("<active_subagents>"))).toBe(true);
   });
 
-  test("skips subagent status in minimal mode", () => {
-    const result = applyRuntimeInjections([userMsg], {
+  test("skips subagent status in minimal mode", async () => {
+    const result = await applyRuntimeInjections([userMsg], {
       subagentStatusBlock:
         "<active_subagents>\n- [running] test\n</active_subagents>",
       mode: "minimal",
@@ -1770,5 +1783,255 @@ describe("stripInjectionsForCompaction — subagent status", () => {
       .map((b) => b.text);
     expect(texts.some((t) => t.includes("<active_subagents>"))).toBe(false);
     expect(texts).toContain("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections — PKB relevance hints
+// ---------------------------------------------------------------------------
+
+describe("applyRuntimeInjections — PKB relevance hints", () => {
+  const baseMessages: Message[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Tell me about project foo" }],
+    },
+  ];
+
+  const FLAT_REMINDER = buildPkbReminder([]);
+
+  // Use a platform-agnostic absolute root so the tests work on macOS and
+  // Linux runners alike.
+  const pkbRoot = "/tmp/fake-pkb-root";
+
+  function makePkbOptions(overrides: Record<string, unknown> = {}) {
+    return {
+      pkbActive: true,
+      pkbQueryVector: [0.1, 0.2, 0.3],
+      pkbScopeId: "scope-1",
+      pkbConversation: { messages: baseMessages },
+      pkbRoot,
+      pkbAutoInjectList: [],
+      ...overrides,
+    };
+  }
+
+  function extractTexts(result: Message[]): string[] {
+    const tail = result[result.length - 1];
+    return tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+  }
+
+  test("three uninvolved hits → reminder contains all three bullets", async () => {
+    pkbSearchResults = [
+      { path: "topics/alpha.md", score: 0.9 },
+      { path: "topics/beta.md", score: 0.8 },
+      { path: "topics/gamma.md", score: 0.7 },
+    ];
+    pkbSearchThrows = null;
+
+    const result = await applyRuntimeInjections(baseMessages, makePkbOptions());
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    expect(reminder).toContain("- topics/alpha.md");
+    expect(reminder).toContain("- topics/beta.md");
+    expect(reminder).toContain("- topics/gamma.md");
+    expect(reminder).toContain("these files look especially relevant");
+  });
+
+  test("in-context paths are filtered out of hints", async () => {
+    pkbSearchResults = [
+      { path: "topics/alpha.md", score: 0.9 },
+      { path: "topics/beta.md", score: 0.8 },
+      { path: "topics/gamma.md", score: 0.7 },
+    ];
+    pkbSearchThrows = null;
+
+    // Build a conversation that has already read topics/beta.md via file_read.
+    const conversationWithRead: { messages: Message[] } = {
+      messages: [
+        ...baseMessages,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu_1",
+              name: "file_read",
+              input: { path: `${pkbRoot}/topics/beta.md` },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions({ pkbConversation: conversationWithRead }),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    expect(reminder).toContain("- topics/alpha.md");
+    expect(reminder).not.toContain("- topics/beta.md");
+    expect(reminder).toContain("- topics/gamma.md");
+  });
+
+  test("empty search → reminder equals flat fallback text byte-for-byte", async () => {
+    pkbSearchResults = [];
+    pkbSearchThrows = null;
+
+    const result = await applyRuntimeInjections(baseMessages, makePkbOptions());
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBe(FLAT_REMINDER);
+  });
+
+  test("search throws → reminder equals flat fallback text byte-for-byte", async () => {
+    pkbSearchResults = [];
+    pkbSearchThrows = new Error("qdrant exploded");
+
+    const result = await applyRuntimeInjections(baseMessages, makePkbOptions());
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBe(FLAT_REMINDER);
+  });
+
+  test("missing query vector → flat fallback, search is not attempted", async () => {
+    pkbSearchThrows = new Error("should not be called");
+
+    const result = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions({ pkbQueryVector: undefined }),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBe(FLAT_REMINDER);
+  });
+
+  test("stripInjectionsForCompaction removes the PKB reminder (flat and hinted)", () => {
+    // Verifies the existing strip pipeline still catches the new reminder
+    // text — it still opens with `<system_reminder>`, which is already in
+    // RUNTIME_INJECTION_PREFIXES.
+    const flatMessage: Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "hello" },
+        { type: "text", text: buildPkbReminder([]) },
+      ],
+    };
+    const hintedMessage: Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "hello" },
+        {
+          type: "text",
+          text: buildPkbReminder(["topics/alpha.md", "topics/beta.md"]),
+        },
+      ],
+    };
+
+    for (const msg of [flatMessage, hintedMessage]) {
+      const stripped = stripInjectionsForCompaction([msg]);
+      const texts = stripped[0].content
+        .filter((b): b is { type: "text"; text: string } => b.type === "text")
+        .map((b) => b.text);
+      expect(texts.some((t) => t.startsWith("<system_reminder>"))).toBe(false);
+      expect(texts).toContain("hello");
+    }
+  });
+
+  test("after simulated compaction (strip + rebuild), fresh hints are emitted from post-compaction tool_use blocks", async () => {
+    pkbSearchResults = [
+      { path: "topics/alpha.md", score: 0.9 },
+      { path: "topics/beta.md", score: 0.8 },
+      { path: "topics/gamma.md", score: 0.7 },
+    ];
+    pkbSearchThrows = null;
+
+    // Pre-compaction conversation: beta was already read.
+    const preCompactionConversation: { messages: Message[] } = {
+      messages: [
+        ...baseMessages,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu_pre",
+              name: "file_read",
+              input: { path: `${pkbRoot}/topics/beta.md` },
+            },
+          ],
+        },
+      ],
+    };
+
+    // 1. Initial injection sees the pre-compaction state — beta should be
+    // filtered out.
+    const initialResult = await applyRuntimeInjections(baseMessages, {
+      pkbActive: true,
+      pkbQueryVector: [0.1, 0.2],
+      pkbScopeId: "scope-1",
+      pkbConversation: preCompactionConversation,
+      pkbRoot,
+      pkbAutoInjectList: [],
+    });
+    // Unwrap the injected reminder from the last user message.
+    const initialTexts = extractTexts(initialResult);
+    const initialReminder = initialTexts.find(
+      (t) =>
+        t.startsWith("<system_reminder>") &&
+        t.includes("these files look especially relevant"),
+    );
+    expect(initialReminder).toBeDefined();
+    expect(initialReminder).not.toContain("- topics/beta.md");
+
+    // 2. Simulate compaction: strip all runtime injections, rebuild
+    // conversation to reflect the post-compaction state (tool_use blocks
+    // are serialized into summary text, so the only live file_read is the
+    // newly-read gamma).
+    const postCompactionConversation: { messages: Message[] } = {
+      messages: [
+        ...baseMessages,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu_post",
+              name: "file_read",
+              input: { path: `${pkbRoot}/topics/gamma.md` },
+            },
+          ],
+        },
+      ],
+    };
+    const postCompactionMessages = stripInjectionsForCompaction(
+      initialResult,
+    );
+
+    // 3. Re-inject with the new conversation — gamma (now in context)
+    // should be filtered, and beta (no longer "in context") should appear.
+    const rebuiltResult = await applyRuntimeInjections(postCompactionMessages, {
+      pkbActive: true,
+      pkbQueryVector: [0.1, 0.2],
+      pkbScopeId: "scope-1",
+      pkbConversation: postCompactionConversation,
+      pkbRoot,
+      pkbAutoInjectList: [],
+    });
+    const rebuiltTexts = extractTexts(rebuiltResult);
+    const rebuiltReminder = rebuiltTexts.find(
+      (t) =>
+        t.startsWith("<system_reminder>") &&
+        t.includes("these files look especially relevant"),
+    );
+    expect(rebuiltReminder).toBeDefined();
+    expect(rebuiltReminder).toContain("- topics/alpha.md");
+    expect(rebuiltReminder).toContain("- topics/beta.md");
+    expect(rebuiltReminder).not.toContain("- topics/gamma.md");
   });
 });

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -58,9 +58,9 @@ describe("Workspace top-level context — injection", () => {
 });
 
 describe("applyRuntimeInjections — workspace top-level context", () => {
-  test("injects workspace context when provided", () => {
+  test("injects workspace context when provided", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       workspaceTopLevelContext: sampleContext,
     });
 
@@ -70,9 +70,9 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
     expect((result[0].content[1] as { text: string }).text).toBe("Hello");
   });
 
-  test("does not inject when workspace context is null", () => {
+  test("does not inject when workspace context is null", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       workspaceTopLevelContext: null,
     });
 
@@ -80,9 +80,9 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
     expect(result[0].content).toHaveLength(1);
   });
 
-  test("workspace context appears before active surface context in content", () => {
+  test("workspace context appears before active surface context in content", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
       workspaceTopLevelContext: sampleContext,
     });
@@ -100,9 +100,9 @@ describe("applyRuntimeInjections — workspace top-level context", () => {
 });
 
 describe("applyRuntimeInjections — minimal mode skips workspace blocks", () => {
-  test("minimal mode skips workspace top-level context", () => {
+  test("minimal mode skips workspace top-level context", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       workspaceTopLevelContext: sampleContext,
       mode: "minimal",
     });
@@ -112,9 +112,9 @@ describe("applyRuntimeInjections — minimal mode skips workspace blocks", () =>
     expect((result[0].content[0] as { text: string }).text).toBe("Hello");
   });
 
-  test("minimal mode skips active surface context", () => {
+  test("minimal mode skips active surface context", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
       mode: "minimal",
     });
@@ -124,9 +124,9 @@ describe("applyRuntimeInjections — minimal mode skips workspace blocks", () =>
     expect((result[0].content[0] as { text: string }).text).toBe("Hello");
   });
 
-  test("full mode (default) still includes workspace blocks", () => {
+  test("full mode (default) still includes workspace blocks", async () => {
     const messages: Message[] = [userMsg("Hello")];
-    const result = applyRuntimeInjections(messages, {
+    const result = await applyRuntimeInjections(messages, {
       workspaceTopLevelContext: sampleContext,
       activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
     });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -7,6 +7,8 @@
  * runAgentLoop method here via the AgentLoopConversationContext interface.
  */
 
+import { join } from "node:path";
+
 import { v4 as uuid } from "uuid";
 
 import type {
@@ -72,6 +74,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { timeAgo } from "../util/time.js";
 import { truncate } from "../util/truncate.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
@@ -118,6 +121,7 @@ import {
   findLastInjectedNowContent,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
+  readAutoinjectList,
   readNowScratchpad,
   readPkbContext,
   stripInjectionsForCompaction,
@@ -640,7 +644,10 @@ export async function runAgentLoopImpl(
     let runMessages = ctx.messages;
 
     // Memory graph retrieval — dispatches to context-load / per-turn based on
-    // conversation state.
+    // conversation state. Keep the query vector around so the PKB reminder
+    // can reuse it for relevance-hint search (see `applyRuntimeInjections`).
+    let pkbQueryVector: number[] | undefined;
+    let pkbSparseVector: import("../memory/qdrant-client.js").QdrantSparseVector | undefined;
     const isTrustedActor = resolveTrustClass(ctx.trustContext) === "guardian";
     if (isTrustedActor) {
       const graphResult = await ctx.graphMemory.prepareMemory(
@@ -650,6 +657,8 @@ export async function runAgentLoopImpl(
         onEvent,
       );
       runMessages = graphResult.runMessages;
+      pkbQueryVector = graphResult.queryVector;
+      pkbSparseVector = graphResult.sparseVector;
 
       // Persist the injected block text in message metadata so it survives
       // conversation reloads (eviction, restart, fork). loadFromDb re-injects
@@ -848,6 +857,19 @@ export async function runAgentLoopImpl(
     const pkbContext = shouldInjectNowAndPkb ? currentPkbContent : null;
     const pkbActive = currentPkbContent !== null;
 
+    // PKB relevance-hint inputs. Resolved once per turn and reused across
+    // re-injections so post-compaction rebuilds pick up fresh hints against
+    // the updated conversation history.
+    const pkbRoot = pkbActive ? join(getWorkspaceDir(), "pkb") : undefined;
+    const pkbAutoInjectList = pkbRoot
+      ? (readAutoinjectList(pkbRoot) ?? undefined)
+      : undefined;
+    // Pass `ctx` directly — `PkbContextConversation` is structural and
+    // `getInContextPkbPaths` re-reads `conversation.messages` on each call,
+    // so post-compaction re-injects see the updated history.
+    const pkbConversation = pkbActive ? ctx : undefined;
+    const pkbScopeId = pkbActive ? ctx.memoryPolicy.scopeId : undefined;
+
     // Subagent status injection — gives the parent LLM visibility into active/completed children.
     // Skipped when this conversation IS a subagent (no nesting) or has no children.
     const subagentStatusBlock = ctx.isSubagent
@@ -867,6 +889,12 @@ export async function runAgentLoopImpl(
       unifiedTurnContext: unifiedTurnContextStr,
       pkbContext,
       pkbActive,
+      pkbQueryVector,
+      pkbSparseVector,
+      pkbScopeId,
+      pkbConversation,
+      pkbAutoInjectList,
+      pkbRoot,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
@@ -876,7 +904,7 @@ export async function runAgentLoopImpl(
 
     let currentInjectionMode: InjectionMode = "full";
 
-    runMessages = applyRuntimeInjections(runMessages, {
+    runMessages = await applyRuntimeInjections(runMessages, {
       ...injectionOpts,
       mode: currentInjectionMode,
     });
@@ -996,7 +1024,7 @@ export async function runAgentLoopImpl(
         // When compaction ran it strips existing NOW.md / PKB blocks, so we
         // must re-inject the current content. Otherwise rely on the deduplicated
         // value from injectionOpts to avoid duplicate injection.
-        runMessages = applyRuntimeInjections(ctx.messages, {
+        runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
           ...(step.compactionResult?.compacted && {
             pkbContext: currentPkbContent,
@@ -1198,7 +1226,7 @@ export async function runAgentLoopImpl(
       // stripInjectionsForCompaction() unconditionally removed the existing
       // NOW.md block from ctx.messages above, so we must always re-inject
       // the current content regardless of whether compaction actually ran.
-      runMessages = applyRuntimeInjections(ctx.messages, {
+      runMessages = await applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
         pkbContext: currentPkbContent,
         nowScratchpad: currentNowContent,
@@ -1423,7 +1451,7 @@ export async function runAgentLoopImpl(
         // Only re-inject NOW.md when ctx.messages was actually stripped;
         // otherwise the existing NOW.md block is still present and
         // re-injecting would duplicate it.
-        runMessages = applyRuntimeInjections(ctx.messages, {
+        runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
           pkbContext: currentPkbContent,
           nowScratchpad: convergenceStripped ? currentNowContent : null,
@@ -1551,7 +1579,7 @@ export async function runAgentLoopImpl(
 
             // Only re-inject NOW.md when ctx.messages was actually stripped;
             // otherwise the existing block is still present.
-            runMessages = applyRuntimeInjections(ctx.messages, {
+            runMessages = await applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
               pkbContext: currentPkbContent,
               nowScratchpad: convergenceStripped ? currentNowContent : null,
@@ -1675,7 +1703,7 @@ export async function runAgentLoopImpl(
 
           // Only re-inject NOW.md when ctx.messages was actually stripped;
           // otherwise the existing block is still present.
-          runMessages = applyRuntimeInjections(ctx.messages, {
+          runMessages = await applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
             pkbContext: currentPkbContent,
             nowScratchpad: convergenceStripped ? currentNowContent : null,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -10,14 +10,24 @@ import { join, resolve } from "node:path";
 
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
+import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
+import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
+import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import {
+  getInContextPkbPaths,
+  type PkbContextConversation,
+} from "./pkb-context-tracker.js";
+import { buildPkbReminder } from "./pkb-reminder-builder.js";
+
+const pkbReminderLog = getLogger("pkb-reminder");
 
 /**
  * Describes the capabilities of the channel through which the user is
@@ -606,12 +616,6 @@ const AUTOINJECT_FILENAME = "_autoinject.md";
 
 /** Max buffer.md lines injected into prompts — keeps context bounded even when filing is off. */
 const MAX_BUFFER_LINES = 50;
-
-const PKB_SYSTEM_REMINDER =
-  "<system_reminder>" +
-  "\nRead any unread PKB files that might be even partially relevant to this conversation" +
-  "\nUse `remember` for anything you learn immediately" +
-  "\n</system_reminder>";
 
 /**
  * Read `_autoinject.md` from the PKB directory and return the list of
@@ -1219,7 +1223,7 @@ export type InjectionMode = "full" | "minimal";
  * Each injection is optional — pass `null`/`undefined` to skip it.
  * Returns the final message array ready for the provider.
  */
-export function applyRuntimeInjections(
+export async function applyRuntimeInjections(
   runMessages: Message[],
   options: {
     activeSurface?: ActiveSurfaceContext | null;
@@ -1230,13 +1234,34 @@ export function applyRuntimeInjections(
     voiceCallControlPrompt?: string | null;
     pkbContext?: string | null;
     pkbActive?: boolean;
+    /**
+     * Dense query vector surfaced from the graph memory retriever (PR 3).
+     * When present together with `pkbActive`, used to run `searchPkbFiles`
+     * to surface relevance hints in the PKB system reminder. When missing,
+     * the reminder falls back to the flat static text.
+     */
+    pkbQueryVector?: number[];
+    /** Optional sparse vector accompanying `pkbQueryVector`. */
+    pkbSparseVector?: QdrantSparseVector;
+    /** Memory scope id used to filter PKB search results. */
+    pkbScopeId?: string;
+    /**
+     * The live conversation (or a minimal shape containing `messages`) used
+     * to compute which PKB paths are already "in context" and therefore
+     * suppressed from hint suggestions.
+     */
+    pkbConversation?: PkbContextConversation;
+    /** Auto-injected PKB filenames (resolved relative to `pkbRoot`). */
+    pkbAutoInjectList?: string[];
+    /** Absolute path to the PKB directory (e.g. `<workspace>/pkb`). */
+    pkbRoot?: string;
     nowScratchpad?: string | null;
     subagentStatusBlock?: string | null;
     isNonInteractive?: boolean;
     transportHints?: string[] | null;
     mode?: InjectionMode;
   },
-): Message[] {
+): Promise<Message[]> {
   const mode = options.mode ?? "full";
   let result = runMessages;
 
@@ -1282,17 +1307,59 @@ export function applyRuntimeInjections(
   }
 
   // PKB behavioral nudge — injected on every turn when PKB is active so
-  // the model keeps reading topic files and calling `remember`.
+  // the model keeps reading topic files and calling `remember`. When a
+  // query vector is available from the graph memory retriever, run a
+  // hybrid PKB search to surface up to three relevance hints; fall back
+  // to the flat static reminder on empty results or any error.
   if (mode === "full" && options.pkbActive) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
+      let hints: string[] = [];
+      const queryVector = options.pkbQueryVector;
+      if (
+        queryVector &&
+        queryVector.length > 0 &&
+        options.pkbScopeId &&
+        options.pkbConversation &&
+        options.pkbRoot
+      ) {
+        try {
+          const results = await searchPkbFiles(
+            queryVector,
+            options.pkbSparseVector,
+            8,
+            [options.pkbScopeId],
+          );
+          const inContext = getInContextPkbPaths(
+            options.pkbConversation,
+            options.pkbAutoInjectList ?? [],
+            options.pkbRoot,
+          );
+          const pkbRoot = options.pkbRoot;
+          hints = results
+            .filter((r) => {
+              const abs = resolve(pkbRoot, r.path);
+              return !inContext.has(abs);
+            })
+            .slice(0, 3)
+            .map((r) => r.path);
+        } catch (err) {
+          pkbReminderLog.warn(
+            { err: err instanceof Error ? err.message : String(err) },
+            "PKB hint search failed — falling back to flat reminder",
+          );
+          hints = [];
+        }
+      }
+
+      const reminder = buildPkbReminder(hints);
       result = [
         ...result.slice(0, -1),
         {
           ...userTail,
           content: [
             ...userTail.content,
-            { type: "text" as const, text: PKB_SYSTEM_REMINDER },
+            { type: "text" as const, text: reminder },
           ],
         },
       ];

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getDb } from "../db.js";
+import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
 import {
@@ -291,6 +292,16 @@ export class ConversationGraphMemory {
     injectedBlockText: string | null;
     /** Retrieval pipeline metrics (null for noop/error paths). */
     metrics: RetrievalMetrics | null;
+    /**
+     * Dense query vector computed from recent conversation summaries during
+     * context-load. Surfaced so downstream callers (e.g. the PKB hint
+     * retriever in `applyRuntimeInjections`) can reuse the same embedding
+     * for a second Qdrant query without paying for another embedding call.
+     * `undefined` for per-turn mode or when embedding failed.
+     */
+    queryVector?: number[];
+    /** Optional sparse vector accompanying `queryVector`. */
+    sparseVector?: QdrantSparseVector;
   }> {
     this.tracker.advanceTurn();
 
@@ -376,6 +387,8 @@ export class ConversationGraphMemory {
         mode: "context-load" as const,
         injectedBlockText: null,
         metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
       };
     }
 
@@ -395,6 +408,8 @@ export class ConversationGraphMemory {
         mode: "context-load" as const,
         injectedBlockText: null,
         metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
       };
     }
 
@@ -427,6 +442,8 @@ export class ConversationGraphMemory {
       mode: "context-load" as const,
       injectedBlockText: contextBlock,
       metrics: result.metrics,
+      queryVector: result.queryVector,
+      sparseVector: result.sparseVector,
     };
   }
 

--- a/assistant/src/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.ts
@@ -16,7 +16,6 @@ import { join } from "node:path";
 import { getLogger } from "../../util/logger.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
 import { getQdrantClient } from "../qdrant-client.js";
-
 import { deletePkbFilePoints, scanPkbFiles } from "./pkb-index.js";
 import { PKB_TARGET_TYPE } from "./types.js";
 


### PR DESCRIPTION
## Summary
- At injection time, run searchPkbFiles against the query vector already computed for graph memory retrieval; subtract paths already in context (auto-inject + structured file_read tool_use); take top 3; render via buildPkbReminder.
- Fall back to the original static reminder text byte-for-byte on empty results or any error.
- Static PKB_SYSTEM_REMINDER constant removed.

Completes plan: pkb-reminder-hints.md (PR 11 of 11)