### PR TITLE
fix(gmail): preserve senders on rate-limited outreach scan enrichment

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -236,6 +236,14 @@ export async function run(
     // Enrich with prior-reply signal: check if user has ever sent to each sender.
     // Uses bounded concurrency (batches of 10) and AbortController to cancel
     // in-flight requests when the time budget expires.
+    //
+    // Three-valued enrichment map:
+    //   true  = confirmed prior reply (enrichment succeeded, found replies)
+    //   false = confirmed no prior reply (enrichment succeeded, no replies)
+    //   undefined (absent) = unknown (enrichment skipped — rate-limited or timed out)
+    //
+    // Only senders with confirmed `true` are filtered out. Senders with unknown
+    // status are kept and returned with `has_prior_reply: null`.
     const ENRICHMENT_CONCURRENCY = 10;
     const priorReplyMap = new Map<string, boolean>();
     if (!rateLimited) {
@@ -264,11 +272,16 @@ export async function run(
                 connection,
                 `from:me to:${s.email}`,
                 1,
+                undefined,
+                undefined,
+                abortController.signal,
               );
               priorReplyMap.set(s.email, (resp.messages?.length ?? 0) > 0);
             } catch {
-              // Non-fatal — default to safe direction (assume prior reply exists)
-              priorReplyMap.set(s.email, true);
+              // Non-fatal — leave absent in map (unknown status).
+              // Abort errors from the signal are also caught here, which is
+              // intentional: the sender keeps unknown status rather than being
+              // dropped.
             }
           });
           await Promise.race([
@@ -287,32 +300,25 @@ export async function run(
       } finally {
         clearTimeout(budgetTimer);
       }
-
-      // Default any un-enriched senders to safe direction
-      for (const s of sorted) {
-        if (!priorReplyMap.has(s.email)) {
-          priorReplyMap.set(s.email, true);
-        }
-      }
-    } else {
-      // Rate limited — default all to safe direction
-      for (const s of sorted) {
-        priorReplyMap.set(s.email, true);
-      }
     }
+    // When rate-limited or timed-out, senders simply have no entry in
+    // priorReplyMap — they are kept with unknown reply status.
 
-    // Filter out senders with prior replies, then cap to maxSenders.
+    // Filter out senders with confirmed prior replies, then cap to maxSenders.
     // This is the purpose of over-fetching (maxSenders * 3): enrich more
     // candidates, discard those with existing replies, then take the top N.
+    // Senders with unknown enrichment status (absent from priorReplyMap) are kept.
     const capped = sorted
-      .filter((s) => !priorReplyMap.get(s.email))
+      .filter((s) => priorReplyMap.get(s.email) !== true)
       .slice(0, maxSenders);
     const senders = capped.map((s) => ({
       id: Buffer.from(s.email).toString("base64url"),
       display_name: s.displayName || s.email.split("@")[0],
       email: s.email,
       message_count: s.messageCount,
-      has_prior_reply: priorReplyMap.get(s.email) ?? true,
+      has_prior_reply: priorReplyMap.has(s.email)
+        ? priorReplyMap.get(s.email)!
+        : null,
       newest_message_id: s.newestMessageId,
       oldest_date: s.oldestDate,
       newest_date: s.newestDate,

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -217,6 +217,7 @@ export async function listMessages(
   maxResults = 20,
   pageToken?: string,
   labelIds?: string[],
+  signal?: AbortSignal,
 ): Promise<GmailMessageListResponse> {
   const params = new URLSearchParams();
   if (query) params.set("q", query);
@@ -230,6 +231,7 @@ export async function listMessages(
     "/messages",
     undefined,
     paramsToQuery(params),
+    signal,
   );
 }
 


### PR DESCRIPTION
## Summary
- Fix bug where outreach scan returned empty results when rate-limited: the post-enrichment filter defaulted all unenriched senders to `true` (has prior reply), then filtered them all out
- Use three-valued enrichment map (`true`/`false`/absent) so rate-limited and timed-out senders are kept with `has_prior_reply: null` indicating unknown status
- Wire `AbortController` signal into `listMessages` calls so timeout actually cancels in-flight HTTP requests

## Test plan
- [ ] Verify outreach scan returns senders when rate-limited (previously returned empty array)
- [ ] Verify enriched senders with confirmed prior replies are still filtered out
- [ ] Verify `has_prior_reply` is `null` for unenriched senders, `true`/`false` for enriched ones
- [ ] Verify abort signal cancels in-flight enrichment requests on timeout

Addresses feedback from #25978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
