### PR TITLE
fix(assistant): harden update-bulletin background job

### DIFF
--- a/assistant/src/__tests__/update-bulletin-job.test.ts
+++ b/assistant/src/__tests__/update-bulletin-job.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import {
   afterEach,
   beforeEach,
@@ -10,6 +10,30 @@ import {
 } from "bun:test";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
+
+// ── fs.readFileSync override (for gap 3 test) ────────────────────────
+// We mock node:fs so we can inject a readFileSync that throws for the
+// workspace path. All other call sites fall through to the real fs.
+const realReadFileSync = readFileSync;
+const realExistsSync = existsSync;
+
+let readFileSyncOverride:
+  | ((path: Parameters<typeof readFileSync>[0]) => string | undefined)
+  | null = null;
+
+mock.module("node:fs", () => ({
+  existsSync: realExistsSync,
+  readFileSync: ((
+    path: Parameters<typeof readFileSync>[0],
+    opts?: Parameters<typeof readFileSync>[1],
+  ) => {
+    if (readFileSyncOverride) {
+      const override = readFileSyncOverride(path);
+      if (override !== undefined) return override;
+    }
+    return realReadFileSync(path, opts);
+  }) as typeof readFileSync,
+}));
 
 // ── In-memory checkpoint store ───────────────────────────────────────
 const store = new Map<string, string>();
@@ -32,29 +56,38 @@ mock.module("../config/loader.js", () => ({
 
 // ── bootstrapConversation + wakeAgentForOpportunity mocks ────────────
 let bootstrapCalls = 0;
+let bootstrapLastArgs: Record<string, unknown> | null = null;
 let wakeCalls = 0;
+let wakeLastArgs: Record<string, unknown> | null = null;
 let wakeShouldThrow = false;
+let wakeInvoked = true;
+let wakeProducedToolCalls = false;
 // A side-effect function invoked during wake. Lets tests simulate the
 // agent deleting UPDATES.md while the wake is in flight.
 let wakeSideEffect: (() => void) | null = null;
 
 mock.module("../memory/conversation-bootstrap.js", () => ({
-  bootstrapConversation: (_opts: unknown) => {
+  bootstrapConversation: (opts: Record<string, unknown>) => {
     bootstrapCalls += 1;
+    bootstrapLastArgs = opts;
     return { id: `conv-${bootstrapCalls}` };
   },
 }));
 
 mock.module("../runtime/agent-wake.js", () => ({
-  wakeAgentForOpportunity: async () => {
+  wakeAgentForOpportunity: async (opts: Record<string, unknown>) => {
     wakeCalls += 1;
+    wakeLastArgs = opts;
     if (wakeSideEffect) {
       wakeSideEffect();
     }
     if (wakeShouldThrow) {
       throw new Error("simulated wake failure");
     }
-    return { invoked: true, producedToolCalls: false };
+    return {
+      invoked: wakeInvoked,
+      producedToolCalls: wakeProducedToolCalls,
+    };
   },
 }));
 
@@ -76,9 +109,14 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     store.clear();
     setCheckpointCallCount = 0;
     bootstrapCalls = 0;
+    bootstrapLastArgs = null;
     wakeCalls = 0;
+    wakeLastArgs = null;
     wakeShouldThrow = false;
+    wakeInvoked = true;
+    wakeProducedToolCalls = false;
     wakeSideEffect = null;
+    readFileSyncOverride = null;
     updatesConfig.enabled = true;
     if (existsSync(workspacePath)) {
       rmSync(workspacePath);
@@ -137,15 +175,20 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
 
-  test("file present with content, stored hash absent — bootstrap + wake; stored hash is sha256(trimmed)", async () => {
+  test("file present with content, wake produced tool calls — bootstrap + wake; stored hash is sha256(trimmed); source/origin are snake_case", async () => {
     const content = "## Release 1.2.3\n\nNew thing.\n";
     writeFileSync(workspacePath, content, "utf-8");
+    wakeProducedToolCalls = true;
 
     await runUpdateBulletinJobIfNeeded();
 
     expect(bootstrapCalls).toBe(1);
     expect(wakeCalls).toBe(1);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(content.trim()));
+    // Gap 4: confirm snake_case reached the downstream mocks.
+    expect(bootstrapLastArgs?.source).toBe("updates_bulletin");
+    expect(bootstrapLastArgs?.origin).toBe("updates_bulletin");
+    expect(wakeLastArgs?.source).toBe("updates_bulletin");
   });
 
   test("file present, stored hash matches current — no wake", async () => {
@@ -161,23 +204,40 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("file present, stored hash differs — wake invoked; stored hash updates", async () => {
-    const oldContent = "## Old";
-    const newContent = "## New content v2";
-    writeFileSync(workspacePath, newContent, "utf-8");
-    store.set(HASH_CHECKPOINT_KEY, sha256(oldContent));
+  test("wake returns invoked:false — checkpoint UNCHANGED (resolver not registered case)", async () => {
+    const content = "## Release Q\n\nResolver-missing scenario.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = false;
+    wakeProducedToolCalls = false;
 
     await runUpdateBulletinJobIfNeeded();
 
     expect(bootstrapCalls).toBe(1);
     expect(wakeCalls).toBe(1);
-    expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(newContent.trim()));
-    expect(store.get(HASH_CHECKPOINT_KEY)).not.toBe(sha256(oldContent));
+    // Critical: do NOT poison the checkpoint.
+    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
+    expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("agent deletes file mid-wake — stored hash becomes 'empty'", async () => {
-    const content = "## Release X\n\nStuff to process.\n";
+  test("wake invoked but no tool calls AND file unchanged — checkpoint UNCHANGED (retry next startup)", async () => {
+    const content = "## Release R\n\nSilent no-op scenario.\n";
     writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = true;
+    wakeProducedToolCalls = false;
+
+    await runUpdateBulletinJobIfNeeded();
+
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
+    expect(setCheckpointCallCount).toBe(0);
+  });
+
+  test("wake invoked, no tool calls, but file deleted mid-wake — checkpoint becomes 'empty'", async () => {
+    const content = "## Release S\n\nAgent deleted file.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = true;
+    wakeProducedToolCalls = false;
     wakeSideEffect = () => {
       rmSync(workspacePath);
     };
@@ -190,21 +250,71 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
 
-  test("wake completes but file unchanged — stored hash = hash of content; rerun is a no-op", async () => {
-    const content = "## Release Y\n\nAgent chose to no-op.\n";
+  test("wake invoked + produced tool calls + file unchanged — checkpoint = hash of content (agent decided this is the right state)", async () => {
+    const content = "## Release T\n\nAgent processed, chose to leave file.\n";
     writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = true;
+    wakeProducedToolCalls = true;
 
     await runUpdateBulletinJobIfNeeded();
 
     expect(bootstrapCalls).toBe(1);
     expect(wakeCalls).toBe(1);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(content.trim()));
+  });
 
-    // Second run — hash matches, so we short-circuit before bootstrap/wake.
+  test("file present, stored hash differs — wake invoked; stored hash updates", async () => {
+    const oldContent = "## Old";
+    const newContent = "## New content v2";
+    writeFileSync(workspacePath, newContent, "utf-8");
+    store.set(HASH_CHECKPOINT_KEY, sha256(oldContent));
+    wakeProducedToolCalls = true;
+
     await runUpdateBulletinJobIfNeeded();
 
     expect(bootstrapCalls).toBe(1);
     expect(wakeCalls).toBe(1);
+    expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(newContent.trim()));
+    expect(store.get(HASH_CHECKPOINT_KEY)).not.toBe(sha256(oldContent));
+  });
+
+  test("agent deletes file mid-wake (producedToolCalls=true) — stored hash becomes 'empty'", async () => {
+    const content = "## Release X\n\nStuff to process.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+    wakeProducedToolCalls = true;
+    wakeSideEffect = () => {
+      rmSync(workspacePath);
+    };
+
+    await runUpdateBulletinJobIfNeeded();
+
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    expect(existsSync(workspacePath)).toBe(false);
+    expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
+  });
+
+  test("file present but readFileSync throws — checkpoint UNCHANGED; warn logged (gap 3)", async () => {
+    const content = "## Release U\n\nSimulated read failure.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+
+    readFileSyncOverride = (path) => {
+      if (typeof path === "string" && path === workspacePath) {
+        throw new Error("EACCES simulated");
+      }
+      return undefined;
+    };
+
+    try {
+      await runUpdateBulletinJobIfNeeded();
+    } finally {
+      readFileSyncOverride = null;
+    }
+
+    expect(bootstrapCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
+    expect(setCheckpointCallCount).toBe(0);
   });
 
   test("wake throws — function does not reject; warning logged", async () => {

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -37,7 +37,7 @@ export type TitleOrigin =
   | "filing"
   | "local"
   | "task_submit"
-  | "updates-bulletin"
+  | "updates_bulletin"
   | "misc";
 
 export interface TitleContext {

--- a/assistant/src/prompts/update-bulletin-job.ts
+++ b/assistant/src/prompts/update-bulletin-job.ts
@@ -16,18 +16,23 @@ const log = getLogger("update-bulletin-job");
 const HASH_CHECKPOINT_KEY = "updates:last_processed_hash";
 const EMPTY_HASH = "empty";
 const UPDATE_BULLETIN_HINT =
-  "Check ~/.vellum/workspace/UPDATES.md — new release notes are present. Apply any assistant-facing behavior changes (new tools, deprecations, memory updates). If the user would benefit from knowing about a user-facing change, surface it only when the next topic makes it relevant — do not interrupt them with a proactive message. When you're done processing, delete UPDATES.md with `rm ~/.vellum/workspace/UPDATES.md` (already auto-allowed). A silent no-op is preferable to low-signal chatter.";
+  "Check ~/.vellum/workspace/UPDATES.md — new release notes are present. Apply any assistant-facing behavior changes (new tools, deprecations, memory updates). If the user would benefit from knowing about a user-facing change, surface it only when the next topic makes it relevant — do not interrupt them with a proactive message. When you're done processing, delete the file by running `cd ~/.vellum/workspace && rm UPDATES.md` (the bare-filename `rm UPDATES.md` is auto-allowed; path-qualified deletes are not). A silent no-op is preferable to low-signal chatter.";
+
+type ReadResult =
+  | { kind: "missing" }
+  | { kind: "error"; err: unknown }
+  | { kind: "ok"; content: string };
 
 function computeHash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-function readTrimmedContent(path: string): string | null {
-  if (!existsSync(path)) return null;
+function readTrimmedContent(path: string): ReadResult {
+  if (!existsSync(path)) return { kind: "missing" };
   try {
-    return readFileSync(path, "utf-8").trim();
-  } catch {
-    return null;
+    return { kind: "ok", content: readFileSync(path, "utf-8").trim() };
+  } catch (err) {
+    return { kind: "error", err };
   }
 }
 
@@ -43,6 +48,16 @@ function readTrimmedContent(path: string): string | null {
  * The function never throws: any error inside the bootstrap/wake flow is
  * logged at `warn` and swallowed, so callers can safely invoke it in a
  * non-awaited context.
+ *
+ * Checkpoint write rules (intentionally conservative — prefer retry over
+ * poisoning the checkpoint when state is ambiguous):
+ *   - File missing → checkpoint = `EMPTY_HASH`.
+ *   - File present but unreadable → checkpoint UNCHANGED, warn logged.
+ *   - Wake not invoked (e.g. resolver not yet registered) → UNCHANGED.
+ *   - Wake invoked but no tool calls AND file unchanged → UNCHANGED
+ *     (indistinguishable from a silent failure; safer to retry).
+ *   - Wake invoked + (produced tool calls OR file deleted) → checkpoint
+ *     reflects the post-wake state.
  */
 export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
   if (getConfig().updates.enabled === false) {
@@ -50,9 +65,17 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
   }
 
   const updatesPath = getWorkspacePromptPath("UPDATES.md");
-  const trimmed = readTrimmedContent(updatesPath);
+  const initial = readTrimmedContent(updatesPath);
 
-  if (trimmed === null || trimmed.length === 0) {
+  if (initial.kind === "error") {
+    log.warn(
+      { err: initial.err, path: updatesPath },
+      "update-bulletin-job: failed to read UPDATES.md; leaving checkpoint unchanged so next startup retries",
+    );
+    return;
+  }
+
+  if (initial.kind === "missing" || initial.content.length === 0) {
     const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
     if (stored !== EMPTY_HASH) {
       setMemoryCheckpoint(HASH_CHECKPOINT_KEY, EMPTY_HASH);
@@ -60,7 +83,7 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
     return;
   }
 
-  const currentHash = computeHash(trimmed);
+  const currentHash = computeHash(initial.content);
   const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
   if (stored === currentHash) {
     return;
@@ -69,27 +92,63 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
   try {
     const conv = bootstrapConversation({
       conversationType: "background",
-      source: "updates-bulletin",
-      origin: "updates-bulletin",
+      source: "updates_bulletin",
+      origin: "updates_bulletin",
       systemHint: "Processing release updates",
       groupId: "system:background",
     });
-    await wakeAgentForOpportunity({
+    const wakeResult = await wakeAgentForOpportunity({
       conversationId: conv.id,
       hint: UPDATE_BULLETIN_HINT,
-      source: "updates-bulletin",
+      source: "updates_bulletin",
     });
 
-    // Self-healing: re-read after the wake. If the agent deleted the file
-    // (or emptied it), store the empty sentinel. Otherwise, store the
-    // fresh hash so we don't re-wake on the same content if the agent
-    // chose to no-op.
-    const afterTrimmed = readTrimmedContent(updatesPath);
-    if (afterTrimmed === null || afterTrimmed.length === 0) {
-      setMemoryCheckpoint(HASH_CHECKPOINT_KEY, EMPTY_HASH);
-    } else {
-      setMemoryCheckpoint(HASH_CHECKPOINT_KEY, computeHash(afterTrimmed));
+    if (!wakeResult.invoked) {
+      log.warn(
+        { conversationId: conv.id },
+        "update-bulletin-job: wake not invoked (e.g. default resolver not yet registered); leaving checkpoint unchanged so next startup retries",
+      );
+      return;
     }
+
+    // Re-read after the wake. We need to know whether the file was deleted
+    // or modified to decide whether to advance the checkpoint.
+    const after = readTrimmedContent(updatesPath);
+
+    if (after.kind === "error") {
+      log.warn(
+        { err: after.err, path: updatesPath },
+        "update-bulletin-job: failed to re-read UPDATES.md after wake; leaving checkpoint unchanged so next startup retries",
+      );
+      return;
+    }
+
+    const fileMissingOrEmpty =
+      after.kind === "missing" || after.content.length === 0;
+
+    if (fileMissingOrEmpty) {
+      // The agent (or another process) emptied/removed the file. This is the
+      // expected happy path — record the empty sentinel.
+      setMemoryCheckpoint(HASH_CHECKPOINT_KEY, EMPTY_HASH);
+      return;
+    }
+
+    if (!wakeResult.producedToolCalls) {
+      // Wake returned cleanly but the agent did nothing observable AND the
+      // file is still here. We can't distinguish "agent processed and chose
+      // to no-op" from "silent failure", so leave the checkpoint alone and
+      // let the next startup retry.
+      log.warn(
+        { conversationId: conv.id },
+        "update-bulletin-job: wake produced no tool calls and file is unchanged; leaving checkpoint unchanged so next startup retries",
+      );
+      return;
+    }
+
+    // Wake produced tool calls and the file is still present — the agent
+    // intentionally left it (or modified it). Record the current hash so we
+    // don't re-wake on the same content.
+    setMemoryCheckpoint(HASH_CHECKPOINT_KEY, computeHash(after.content));
   } catch (err) {
     log.warn(
       { err },


### PR DESCRIPTION
## Summary
Fixes four gaps identified during plan review for `updates-md-background-job.md`:

- **Inspect WakeResult before writing checkpoint.** Previously, when the default wake resolver wasn't yet registered (or the wake silently no-op'd for any other reason), the post-wake code unconditionally wrote the file's content hash, permanently short-circuiting the bulletin. Now we only update the checkpoint when the wake meaningfully ran (invoked AND (produced tool calls OR file was actually deleted)). All other cases leave the checkpoint untouched so the next startup retries.
- **Fix rm hint to use auto-allowed bare-filename form.** The hint previously instructed `rm ~/.vellum/workspace/UPDATES.md`, which fails the `isRmOfKnownSafeFile` path-separator check and is classified High risk. Background conversations have no UI to surface an approval, so the file would never be deleted. The hint now instructs `cd ~/.vellum/workspace && rm UPDATES.md` to match the auto-allowed pattern in `permissions/defaults.ts`.
- **Distinguish file-missing from read-error.** Previously a transient EACCES/EISDIR on `UPDATES.md` was indistinguishable from "file missing" and silently persisted `EMPTY_HASH`. Now read errors are logged at warn and the checkpoint is left unchanged so next startup retries.
- **Rename TitleOrigin/source from `updates-bulletin` to `updates_bulletin`** to match the snake_case convention used by every other value in the union.

Tests cover all five new behavioral branches.

Part of plan: updates-md-background-job.md (post-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
