### PR TITLE
fix(assistant): eliminate update-bulletin wake-resolver race + clean up orphans

### DIFF
--- a/assistant/src/__tests__/update-bulletin-job.test.ts
+++ b/assistant/src/__tests__/update-bulletin-job.test.ts
@@ -74,6 +74,22 @@ mock.module("../memory/conversation-bootstrap.js", () => ({
   },
 }));
 
+// ── deleteConversation mock (orphan cleanup path) ────────────────────
+let deleteCalls = 0;
+const deletedIds: string[] = [];
+let deleteShouldThrow = false;
+
+mock.module("../memory/conversation-crud.js", () => ({
+  deleteConversation: (id: string) => {
+    deleteCalls += 1;
+    deletedIds.push(id);
+    if (deleteShouldThrow) {
+      throw new Error("simulated delete failure");
+    }
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+}));
+
 mock.module("../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: async (opts: Record<string, unknown>) => {
     wakeCalls += 1;
@@ -118,6 +134,9 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     wakeSideEffect = null;
     readFileSyncOverride = null;
     updatesConfig.enabled = true;
+    deleteCalls = 0;
+    deletedIds.length = 0;
+    deleteShouldThrow = false;
     if (existsSync(workspacePath)) {
       rmSync(workspacePath);
     }
@@ -204,7 +223,7 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("wake returns invoked:false — checkpoint UNCHANGED (resolver not registered case)", async () => {
+  test("wake returns invoked:false — checkpoint UNCHANGED + orphan conversation is cleaned up", async () => {
     const content = "## Release Q\n\nResolver-missing scenario.\n";
     writeFileSync(workspacePath, content, "utf-8");
     wakeInvoked = false;
@@ -214,9 +233,45 @@ describe("runUpdateBulletinJobIfNeeded", () => {
 
     expect(bootstrapCalls).toBe(1);
     expect(wakeCalls).toBe(1);
-    // Critical: do NOT poison the checkpoint.
+    // Critical: do NOT poison the checkpoint (round-1 behavior preserved).
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
     expect(setCheckpointCallCount).toBe(0);
+    // Belt-and-suspenders: the orphan background conversation bootstrapped
+    // before the wake must be deleted so we don't leak DB rows on every
+    // silent no-op.
+    expect(deleteCalls).toBe(1);
+    expect(deletedIds).toEqual(["conv-1"]);
+  });
+
+  test("wake returns invoked:false AND deleteConversation throws — function still returns (cleanup error is swallowed)", async () => {
+    const content = "## Release Q2\n\nDelete-throws scenario.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = false;
+    wakeProducedToolCalls = false;
+    deleteShouldThrow = true;
+
+    await expect(runUpdateBulletinJobIfNeeded()).resolves.toBeUndefined();
+
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    expect(deleteCalls).toBe(1);
+    // Checkpoint still untouched.
+    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
+    expect(setCheckpointCallCount).toBe(0);
+  });
+
+  test("wake invoked normally — deleteConversation is NOT called (happy path)", async () => {
+    const content = "## Release Q3\n\nNormal happy-path scenario.\n";
+    writeFileSync(workspacePath, content, "utf-8");
+    wakeInvoked = true;
+    wakeProducedToolCalls = true;
+
+    await runUpdateBulletinJobIfNeeded();
+
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    expect(deleteCalls).toBe(0);
+    expect(deletedIds).toEqual([]);
   });
 
   test("wake invoked but no tool calls AND file unchanged — checkpoint UNCHANGED (retry next startup)", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -544,15 +544,6 @@ export async function runDaemon(): Promise<void> {
     log.info("Daemon startup: loading config");
     const config = loadConfig();
 
-    // Kick off the update bulletin background job once the DB is ready.
-    if (dbReady) {
-      void import("../prompts/update-bulletin-job.js")
-        .then((m) => m.runUpdateBulletinJobIfNeeded())
-        .catch((err) =>
-          log.warn({ err }, "Update bulletin job failed — continuing startup"),
-        );
-    }
-
     // Seed module-level ingress state from the workspace config so that
     // getIngressPublicBaseUrl() returns the correct value immediately after
     // startup (before any handleIngressConfig("set") call). Without this,
@@ -687,6 +678,24 @@ export async function runDaemon(): Promise<void> {
 
     await server.start();
     log.info("Daemon startup: DaemonServer started");
+
+    // Kick off the update bulletin background job AFTER `server.start()`
+    // resolves. `server.start()` installs the default wake resolver (via
+    // `registerDefaultWakeResolver()`), which the job depends on to actually
+    // invoke the agent. Dispatching before that point races the resolver
+    // registration and causes `wakeAgentForOpportunity()` to silently return
+    // `{invoked: false}`, leaving an orphan background conversation and a
+    // wasted LLM title-generation call every startup.
+    //
+    // Kept fire-and-forget (`void import(...).then(...).catch(...)`) so the
+    // daemon never blocks startup on it.
+    if (dbReady) {
+      void import("../prompts/update-bulletin-job.js")
+        .then((m) => m.runUpdateBulletinJobIfNeeded())
+        .catch((err) =>
+          log.warn({ err }, "Update bulletin job failed — continuing startup"),
+        );
+    }
 
     // Mutable refs for Qdrant, memory worker, and backup worker so background
     // init can assign them and the shutdown handler always sees the latest value.

--- a/assistant/src/prompts/update-bulletin-job.ts
+++ b/assistant/src/prompts/update-bulletin-job.ts
@@ -7,6 +7,7 @@ import {
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { deleteConversation } from "../memory/conversation-crud.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
@@ -106,8 +107,35 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
     if (!wakeResult.invoked) {
       log.warn(
         { conversationId: conv.id },
-        "update-bulletin-job: wake not invoked (e.g. default resolver not yet registered); leaving checkpoint unchanged so next startup retries",
+        "Update bulletin wake silently no-op'd (invoked=false); cleaning up orphan background conversation and leaving checkpoint unchanged so next startup retries",
       );
+      // Belt-and-suspenders cleanup: even though `runUpdateBulletinJobIfNeeded`
+      // is now dispatched after `server.start()` (so the default wake
+      // resolver is registered before we wake), `wakeAgentForOpportunity()`
+      // can still return `{invoked: false}` for other reasons (resolver
+      // returns null because the conversation cannot be hydrated, a future
+      // regression, etc.). Without this cleanup each such occurrence leaks
+      // a conversation DB row.
+      //
+      // Wrapped in its own try/catch so a cleanup failure never propagates
+      // out of this fire-and-forget task.
+      //
+      // TODO: the `queueGenerateConversationTitle()` call that
+      // `bootstrapConversation()` fires is already in flight by the time we
+      // reach here. The title service checks `isReplaceableTitle()` before
+      // writing, but the LLM sidechain call itself still runs against the
+      // now-deleted conversation id. Adding a cancellation/existence hook
+      // in `conversation-title-service.ts` would plug this one-call waste,
+      // but this code path is rare (resolver race is fixed by the primary
+      // change in `lifecycle.ts`), so we accept the one-time cost.
+      try {
+        deleteConversation(conv.id);
+      } catch (err) {
+        log.warn(
+          { err, conversationId: conv.id },
+          "update-bulletin-job: failed to delete orphan background conversation; continuing",
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- **Primary race fix**: `runUpdateBulletinJobIfNeeded()` is now dispatched AFTER `DaemonServer.start()` resolves, which is where `registerDefaultWakeResolver()` runs. The previous dispatch site ran concurrently with server startup, so the wake fired before the resolver was in place and silently returned `{invoked: false}`. The dispatch remains fire-and-forget (`void import(...).then(...).catch(...)`), preserving the 'daemon must never block startup' invariant.
- **Belt-and-suspenders cleanup**: even with the race fix, `wakeAgentForOpportunity()` can return `{invoked: false}` for other reasons (conversation-not-found, future regressions). The job now detects this and deletes the orphan background conversation it just bootstrapped, so we don't leak DB rows and LLM title-generation calls.
- Added a regression test that asserts both branches (race-case cleanup + normal-case no cleanup).

Part of plan: updates-md-background-job.md (round 2 post-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
