### PR TITLE
fix(pkb): skip reconciliation deletes when PKB directory is missing

### DIFF
--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -112,7 +112,8 @@ describe("scanPkbFiles", () => {
     await utimes(join(root, "b.md"), mtimeB, mtimeB);
 
     const entries = await scanPkbFiles(root);
-    const byPath = new Map(entries.map((e) => [e.path, e]));
+    expect(entries).not.toBeNull();
+    const byPath = new Map(entries!.map((e) => [e.path, e]));
 
     expect(byPath.size).toBe(2);
     expect(byPath.has("a.md")).toBe(true);
@@ -126,7 +127,7 @@ describe("scanPkbFiles", () => {
 
     // Hash is stable across scans.
     const entriesAgain = await scanPkbFiles(root);
-    const aAgain = entriesAgain.find((e) => e.path === "a.md")!;
+    const aAgain = entriesAgain!.find((e) => e.path === "a.md")!;
     expect(aAgain.contentHash).toBe(a.contentHash);
   });
 
@@ -138,7 +139,38 @@ describe("scanPkbFiles", () => {
 
     const entries = await scanPkbFiles(root);
     expect(entries).toHaveLength(1);
-    expect(entries[0].path).toBe(join("sub", "nested.md"));
+    expect(entries![0].path).toBe(join("sub", "nested.md"));
+  });
+
+  test("returns null when pkbRoot does not exist", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "pkb-scan-missing-"));
+    const missing = join(parent, "does-not-exist");
+    const entries = await scanPkbFiles(missing);
+    expect(entries).toBeNull();
+  });
+
+  test("returns null when pkbRoot existed then was removed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-scan-removed-"));
+    await writeFile(join(root, "a.md"), "# A");
+    await rm(root, { recursive: true, force: true });
+
+    const entries = await scanPkbFiles(root);
+    expect(entries).toBeNull();
+  });
+
+  test("returns [] (not null) when pkbRoot exists but is empty", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-scan-empty-"));
+    const entries = await scanPkbFiles(root);
+    expect(entries).not.toBeNull();
+    expect(entries).toEqual([]);
+  });
+
+  test("returns null when pkbRoot points at a file instead of a directory", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "pkb-scan-file-"));
+    const filePath = join(parent, "not-a-dir");
+    await writeFile(filePath, "just a file");
+    const entries = await scanPkbFiles(filePath);
+    expect(entries).toBeNull();
   });
 });
 

--- a/assistant/src/memory/pkb/pkb-index.ts
+++ b/assistant/src/memory/pkb/pkb-index.ts
@@ -33,9 +33,36 @@ const CHAR_WINDOW_SIZE = 4000;
  * every `*.md` file found. Paths in the returned entries are relative to
  * `pkbRoot`; mtime is read from the filesystem and `contentHash` is the
  * first 16 hex chars of the sha256 of the file's contents.
+ *
+ * Returns `null` if `pkbRoot` does not exist (or is not a directory). This
+ * is distinct from returning `[]` for a directory that exists but has no
+ * `*.md` files — callers that run destructive reconciliation against the
+ * result (e.g. `reconcilePkbIndex`) use the sentinel to avoid interpreting
+ * a transiently missing directory as "delete every indexed point".
  */
-export async function scanPkbFiles(pkbRoot: string): Promise<PkbIndexEntry[]> {
+export async function scanPkbFiles(
+  pkbRoot: string,
+): Promise<PkbIndexEntry[] | null> {
   const entries: PkbIndexEntry[] = [];
+
+  // Verify the root exists up front. If it doesn't, return the missing
+  // sentinel so callers can distinguish "nothing on disk" from "root
+  // vanished". Other stat errors (permissions, etc.) fall through to the
+  // recursive walk, which logs+swallows per-directory errors.
+  try {
+    const rootStat = await stat(pkbRoot);
+    if (!rootStat.isDirectory()) {
+      return null;
+    }
+  } catch (err) {
+    if (isEnoent(err)) {
+      return null;
+    }
+    // Non-ENOENT stat errors: treat as empty (same conservative behavior
+    // the per-directory walk has). The destructive delete path is still
+    // gated by the explicit missing-directory check above.
+    return entries;
+  }
 
   async function walk(dir: string): Promise<void> {
     let dirents;
@@ -80,6 +107,15 @@ export async function scanPkbFiles(pkbRoot: string): Promise<PkbIndexEntry[]> {
 
   await walk(pkbRoot);
   return entries;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: unknown }).code === "ENOENT"
+  );
 }
 
 /**

--- a/assistant/src/memory/pkb/pkb-reconcile.test.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -92,7 +92,7 @@ async function seedPkbAndHash(
   }
   const entries = await scanPkbFiles(root);
   const byPath = new Map<string, string>();
-  for (const e of entries) byPath.set(e.path, e.contentHash);
+  for (const e of entries ?? []) byPath.set(e.path, e.contentHash);
   return byPath;
 }
 
@@ -188,6 +188,41 @@ describe("reconcilePkbIndex", () => {
     expect(result.deleted).toBe(1);
     expect(deleteCalls).toEqual(["gone.md"]);
     expect(enqueuedJobs).toHaveLength(0);
+  });
+
+  test("missing pkbRoot: indexed points are preserved (no wholesale deletion)", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "pkb-reconcile-missing-"));
+    const missing = join(parent, "does-not-exist");
+
+    // Qdrant has points for paths that would look "stale" if we treated a
+    // missing root as an empty disk view — the regression this test guards
+    // against is those being wholesale-deleted.
+    scrollPoints = [
+      pkbPoint("a.md", "aaaaaaaaaaaaaaaa"),
+      pkbPoint("b.md", "bbbbbbbbbbbbbbbb"),
+      pkbPoint("notes/c.md", "cccccccccccccccc"),
+    ];
+
+    const result = await reconcilePkbIndex(missing, "default");
+
+    expect(result.enqueued).toBe(0);
+    expect(result.deleted).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("pkbRoot existed then was removed: indexed points are preserved", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-reconcile-vanished-"));
+    await writeFile(join(root, "a.md"), "# A");
+    await rm(root, { recursive: true, force: true });
+
+    scrollPoints = [pkbPoint("a.md", "aaaaaaaaaaaaaaaa")];
+
+    const result = await reconcilePkbIndex(root, "default");
+
+    expect(result.enqueued).toBe(0);
+    expect(result.deleted).toBe(0);
+    expect(deleteCalls).toHaveLength(0);
   });
 
   test("collapses multiple chunk points for the same path", async () => {

--- a/assistant/src/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.ts
@@ -42,7 +42,21 @@ export async function reconcilePkbIndex(
   // Build the on-disk view keyed by relative path. `scanPkbFiles` emits one
   // entry per chunk — every chunk of the same file shares the same
   // contentHash, so collapsing to a per-path map is lossless for our purposes.
+  //
+  // `scanPkbFiles` returns `null` when `pkbRoot` itself is missing (vs. `[]`
+  // for an existing-but-empty directory). Treating a missing root as "empty"
+  // would cause reconciliation to delete every indexed PKB point in Qdrant,
+  // which is catastrophic if the directory is only transiently gone (fs
+  // hiccup, workspace dir mis-set, user moved the workspace). Bail out with
+  // a warning instead of touching Qdrant in that case.
   const diskEntries = await scanPkbFiles(pkbRoot);
+  if (diskEntries === null) {
+    log.warn(
+      { pkbRoot, memoryScopeId },
+      "PKB root directory missing — skipping reconciliation to avoid wiping the index",
+    );
+    return { enqueued: 0, deleted: 0 };
+  }
   const diskByPath = new Map<string, { contentHash: string }>();
   for (const entry of diskEntries) {
     if (!diskByPath.has(entry.path)) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pkb-reminder-hints.md.

**Gap:** If the workspace PKB directory is transiently missing on startup, reconciliation was interpreting an empty disk scan as 'delete every indexed PKB point.'
**Fix:** scanPkbFiles now returns null for missing (vs. [] for genuinely empty), and reconcilePkbIndex bails out with a warn log in the null case instead of deleting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
