### PR TITLE
fix(pkb): surface query vector on per-turn retrieval

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -293,11 +293,13 @@ export class ConversationGraphMemory {
     /** Retrieval pipeline metrics (null for noop/error paths). */
     metrics: RetrievalMetrics | null;
     /**
-     * Dense query vector computed from recent conversation summaries during
-     * context-load. Surfaced so downstream callers (e.g. the PKB hint
-     * retriever in `applyRuntimeInjections`) can reuse the same embedding
-     * for a second Qdrant query without paying for another embedding call.
-     * `undefined` for per-turn mode or when embedding failed.
+     * Dense query vector computed from the retrieval query — recent summaries
+     * for context-load, the last-exchange text for per-turn. Surfaced so
+     * downstream callers (e.g. the PKB hint retriever in
+     * `applyRuntimeInjections`) can reuse the same embedding for a second
+     * Qdrant query without paying for another embedding call. `undefined`
+     * when no text was embedded (image-only turn, empty queries) or the
+     * embedding call failed (circuit breaker).
      */
     queryVector?: number[];
     /** Optional sparse vector accompanying `queryVector`. */
@@ -498,6 +500,8 @@ export class ConversationGraphMemory {
         mode: "per-turn" as const,
         injectedBlockText: null,
         metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
       };
     }
 
@@ -513,6 +517,8 @@ export class ConversationGraphMemory {
         mode: "per-turn" as const,
         injectedBlockText: null,
         metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
       };
     }
 
@@ -535,6 +541,8 @@ export class ConversationGraphMemory {
       mode: "per-turn" as const,
       injectedBlockText: injectionBlock,
       metrics: result.metrics,
+      queryVector: result.queryVector,
+      sparseVector: result.sparseVector,
     };
   }
 }

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -53,7 +53,8 @@ mock.module("../../providers/provider-send-message.js", () => ({
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { initializeDb, resetDb } from "../db.js";
-import { loadContextMemory } from "./retriever.js";
+import { InContextTracker } from "./injection.js";
+import { loadContextMemory, retrieveForTurn } from "./retriever.js";
 
 const TEST_CONFIG: AssistantConfig = { ...DEFAULT_CONFIG };
 
@@ -103,6 +104,70 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
       scopeId: "test-scope",
       recentSummaries: [],
       config: TEST_CONFIG,
+    });
+
+    expect(result.queryVector).toBeUndefined();
+    expect(result.sparseVector).toBeUndefined();
+  });
+});
+
+describe("retrieveForTurn — query/sparse vector surfacing", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    embedShouldThrow = false;
+    embedVector = [0.1, 0.2, 0.3];
+    resetDb();
+    initializeDb();
+  });
+
+  test("returns the dense queryVector when embedding succeeds", async () => {
+    embedVector = [0.9, 0.8, 0.7];
+
+    const tracker = new InContextTracker();
+    const result = await retrieveForTurn({
+      assistantLastMessage: "What did we decide yesterday?",
+      userLastMessage: "We decided to ship on Friday.",
+      scopeId: "test-scope",
+      config: TEST_CONFIG,
+      tracker,
+    });
+
+    // Even though the scored candidate list is empty (mocked Qdrant returns
+    // nothing), the queryVector should still be surfaced so the PKB hint
+    // retriever can fire on every turn.
+    expect(result.queryVector).toEqual([0.9, 0.8, 0.7]);
+    expect(result.sparseVector).toBeUndefined();
+  });
+
+  test("returns undefined queryVector when the embedding backend throws", async () => {
+    embedShouldThrow = true;
+
+    const tracker = new InContextTracker();
+    const result = await retrieveForTurn({
+      assistantLastMessage: "hello",
+      userLastMessage: "how are you?",
+      scopeId: "test-scope",
+      config: TEST_CONFIG,
+      tracker,
+    });
+
+    // Circuit-breaker path: embedding failure is swallowed; no throw and no
+    // vector surfaced.
+    expect(result.queryVector).toBeUndefined();
+    expect(result.sparseVector).toBeUndefined();
+  });
+
+  test("returns undefined queryVector when there is no text to embed", async () => {
+    const tracker = new InContextTracker();
+    const result = await retrieveForTurn({
+      assistantLastMessage: "",
+      userLastMessage: "",
+      scopeId: "test-scope",
+      config: TEST_CONFIG,
+      tracker,
     });
 
     expect(result.queryVector).toBeUndefined();

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -746,6 +746,21 @@ export interface TurnRetrievalResult {
   triggeredNodes: TriggeredResult[];
   latencyMs: number;
   metrics: RetrievalMetrics;
+  /**
+   * Dense query vector computed from the last-exchange text (assistant +
+   * user message). Surfaced so downstream callers (e.g. the PKB hint
+   * retriever in `applyRuntimeInjections`) can reuse the same embedding
+   * for a second Qdrant query without paying for another embedding call.
+   * `undefined` when no text was embedded (image-only turn) or embedding
+   * failed (circuit breaker).
+   */
+  queryVector?: number[];
+  /**
+   * Optional sparse vector passed alongside `queryVector`. Currently always
+   * `undefined` — reserved for future hybrid retrieval that produces a
+   * sparse vector at the call site.
+   */
+  sparseVector?: QdrantSparseVector;
 }
 
 /**
@@ -848,6 +863,8 @@ export async function retrieveForTurn(
         embeddingModel,
         queryContext: queryText || null,
       },
+      queryVector: undefined,
+      sparseVector: undefined,
     };
   }
 
@@ -920,6 +937,8 @@ export async function retrieveForTurn(
             embeddingModel,
             queryContext: queryText || null,
           },
+          queryVector: undefined,
+          sparseVector: undefined,
         };
       }
     }
@@ -972,6 +991,8 @@ export async function retrieveForTurn(
         embeddingModel,
         queryContext: queryText || null,
       },
+      queryVector: queryEmbeddings[0],
+      sparseVector: undefined,
     };
   }
 
@@ -1154,5 +1175,7 @@ export async function retrieveForTurn(
       queryContext: queryText || null,
       topCandidates,
     },
+    queryVector: queryEmbeddings[0],
+    sparseVector: undefined,
   };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pkb-reminder-hints.md.

**Gap:** PKB hints only fired on context-load turns because runPerTurn omitted queryVector/sparseVector.
**Fix:** Surface those vectors from retrieveForTurn so every turn's applyRuntimeInjections can run searchPkbFiles.