### PR TITLE
feat(tools): add user_approved gate bypass for surface action tools

### DIFF
--- a/assistant/src/__tests__/gmail-archive-gate.test.ts
+++ b/assistant/src/__tests__/gmail-archive-gate.test.ts
@@ -16,18 +16,17 @@ const mockBatchModifyMessages =
       opts: Record<string, unknown>,
     ) => Promise<void>
   >();
-const mockListMessages =
-  mock<
-    (
-      conn: unknown,
-      query: string,
-      limit: number,
-      pageToken?: string,
-    ) => Promise<{
-      messages?: { id: string }[];
-      nextPageToken?: string | null;
-    }>
-  >();
+const mockListMessages = mock<
+  (
+    conn: unknown,
+    query: string,
+    limit: number,
+    pageToken?: string,
+  ) => Promise<{
+    messages?: { id: string }[];
+    nextPageToken?: string | null;
+  }>
+>();
 const mockModifyMessage =
   mock<
     (
@@ -49,13 +48,15 @@ mock.module("../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: mockResolveOAuthConnection,
 }));
 
-mock.module("../config/bundled-skills/gmail/tools/scan-result-store.js", () => ({
-  getSenderMessageIds: () => ["msg-a", "msg-b"],
-}));
-
-const { run } = await import(
-  "../config/bundled-skills/gmail/tools/gmail-archive.js"
+mock.module(
+  "../config/bundled-skills/gmail/tools/scan-result-store.js",
+  () => ({
+    getSenderMessageIds: () => ["msg-a", "msg-b"],
+  }),
 );
+
+const { run } =
+  await import("../config/bundled-skills/gmail/tools/gmail-archive.js");
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
@@ -242,5 +243,112 @@ describe("gmail_archive gate", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Message archived");
+  });
+
+  describe("user_approved gate bypass", () => {
+    test("allows query path when user_approved is true and trustClass is guardian", async () => {
+      mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+      mockListMessages.mockResolvedValueOnce({
+        messages: [{ id: "m1" }],
+        nextPageToken: null,
+      });
+      mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+      const result = await run(
+        { query: "in:inbox", confidence: 0.99, user_approved: true },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          trustClass: "guardian",
+        }),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Archived 1 message(s)");
+    });
+
+    test("rejects query path when user_approved is true but trustClass is not guardian", async () => {
+      const result = await run(
+        { query: "in:inbox", confidence: 0.99, user_approved: true },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          trustClass: "trusted_contact",
+        }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("surface action");
+    });
+
+    test("rejects query path when user_approved is true but trustClass is unknown", async () => {
+      const result = await run(
+        { query: "in:inbox", confidence: 0.99, user_approved: true },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          trustClass: "unknown",
+        }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("surface action");
+    });
+
+    test("allows scan_id path when user_approved is true and trustClass is guardian", async () => {
+      mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+      mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+      const result = await run(
+        {
+          scan_id: "scan-1",
+          sender_ids: ["s1"],
+          confidence: 0.99,
+          user_approved: true,
+        },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          trustClass: "guardian",
+        }),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Archived 2 message(s)");
+    });
+
+    test("allows batch message_ids path when user_approved is true and trustClass is guardian", async () => {
+      mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+      mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+      const result = await run(
+        { message_ids: ["m1", "m2"], confidence: 0.99, user_approved: true },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          trustClass: "guardian",
+        }),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Archived 2 message(s)");
+    });
+  });
+
+  describe("approvedViaPrompt gate bypass", () => {
+    test("allows query path when approvedViaPrompt is true (turn-scoped propagation)", async () => {
+      mockResolveOAuthConnection.mockResolvedValueOnce({ id: "gmail-conn" });
+      mockListMessages.mockResolvedValueOnce({
+        messages: [{ id: "m1" }],
+        nextPageToken: null,
+      });
+      mockBatchModifyMessages.mockResolvedValueOnce(undefined);
+
+      const result = await run(
+        { query: "in:inbox", confidence: 0.99 },
+        makeContext({
+          triggeredBySurfaceAction: false,
+          batchAuthorizedByTask: false,
+          approvedViaPrompt: true,
+        }),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Archived 1 message(s)");
+    });
   });
 });

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -46,6 +46,10 @@
           "account": {
             "type": "string",
             "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "user_approved": {
+            "type": "boolean",
+            "description": "Set to true ONLY when the user's most recent message contains explicit approval language for this specific action (e.g. 'archive these', 'yes do it', 'go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
         "required": ["confidence"]
@@ -157,6 +161,10 @@
           "account": {
             "type": "string",
             "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "user_approved": {
+            "type": "boolean",
+            "description": "Set to true ONLY when the user's most recent message contains explicit approval language for this specific action (e.g. 'unsubscribe from these', 'yes do it', 'go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
         "required": ["message_id", "confidence"]

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -374,6 +374,10 @@
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "user_approved": {
+            "type": "boolean",
+            "description": "Set to true ONLY when the user's most recent message contains explicit approval language for this specific action (e.g. 'archive these', 'yes do it', 'go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
         "required": ["query", "confidence"]

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -309,6 +309,10 @@
           "account": {
             "type": "string",
             "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "user_approved": {
+            "type": "boolean",
+            "description": "Set to true ONLY when the user's most recent message contains explicit approval language for sending this draft (e.g. 'send it', 'yes go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
         "required": ["draft_id", "confidence"]
@@ -484,6 +488,10 @@
           "account": {
             "type": "string",
             "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "user_approved": {
+            "type": "boolean",
+            "description": "Set to true ONLY when the user's most recent message contains explicit approval language for this specific action (e.g. 'unsubscribe from these', 'yes do it', 'go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
         "required": ["message_id", "confidence"]

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -234,6 +234,7 @@ export interface AgentLoopConversationContext {
   >;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   surfaceActionRequestIds: Set<string>;
+  approvedViaPromptThisTurn?: boolean;
   currentTurnSurfaces: Array<{
     surfaceId: string;
     surfaceType: SurfaceType;
@@ -647,7 +648,9 @@ export async function runAgentLoopImpl(
     // conversation state. Keep the query vector around so the PKB reminder
     // can reuse it for relevance-hint search (see `applyRuntimeInjections`).
     let pkbQueryVector: number[] | undefined;
-    let pkbSparseVector: import("../memory/qdrant-client.js").QdrantSparseVector | undefined;
+    let pkbSparseVector:
+      | import("../memory/qdrant-client.js").QdrantSparseVector
+      | undefined;
     const isTrustedActor = resolveTrustClass(ctx.trustContext) === "guardian";
     if (isTrustedActor) {
       const graphResult = await ctx.graphMemory.prepareMemory(
@@ -2132,6 +2135,7 @@ export async function runAgentLoopImpl(
     ctx.processing = false;
     ctx.onConfirmationOutcome = undefined;
     ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
+    ctx.approvedViaPromptThisTurn = false;
     ctx.currentRequestId = undefined;
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -237,6 +237,7 @@ export class Conversation {
     languageCode?: string;
   };
   /** @internal */ surfaceActionRequestIds = new Set<string>();
+  /** @internal */ approvedViaPromptThisTurn = false;
   /** @internal */ pendingSurfaceActions = new Map<
     string,
     { surfaceType: SurfaceType }


### PR DESCRIPTION
## Summary
- Add `user_approved` boolean parameter to gmail_archive, gmail_unsubscribe, messaging_archive_by_sender, outlook_send_draft, and outlook_unsubscribe tool schemas
- Add `approvedViaPromptThisTurn` field to conversation state, reset at turn boundaries
- Add tests for user_approved gate bypass (guardian-only) and approvedViaPrompt propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
