### PR TITLE
fix(pkb): thread PKB_DEFAULT_FILES fallback into in-context tracker

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -222,7 +222,12 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   findLastInjectedNowContent: () => null,
   readNowScratchpad: () => null,
   readPkbContext: () => null,
-  readAutoinjectList: () => null,
+  getPkbAutoInjectList: () => [
+    "INDEX.md",
+    "essentials.md",
+    "threads.md",
+    "buffer.md",
+  ],
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -212,7 +212,12 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   findLastInjectedNowContent: () => null,
   readNowScratchpad: () => null,
   readPkbContext: () => null,
-  readAutoinjectList: () => null,
+  getPkbAutoInjectList: () => [
+    "INDEX.md",
+    "essentials.md",
+    "threads.md",
+    "buffer.md",
+  ],
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1841,6 +1841,42 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     expect(reminder).toContain("these files look especially relevant");
   });
 
+  test("default auto-injected files (from PKB_DEFAULT_FILES) are filtered out of hints", async () => {
+    // Regression test: when `_autoinject.md` is missing, `readPkbContext`
+    // falls back to PKB_DEFAULT_FILES — so those files ARE in the prompt.
+    // The tracker must know about them too, otherwise the reminder would
+    // redundantly recommend e.g. `essentials.md` even though its contents
+    // are already injected. The agent-loop passes the effective auto-inject
+    // list (via `getPkbAutoInjectList`) to `applyRuntimeInjections`.
+    pkbSearchResults = [
+      { path: "essentials.md", score: 0.95 },
+      { path: "topics/alpha.md", score: 0.9 },
+    ];
+    pkbSearchThrows = null;
+
+    const result = await applyRuntimeInjections(
+      baseMessages,
+      makePkbOptions({
+        // Simulate the fallback the agent-loop now threads through:
+        // `_autoinject.md` is missing, so defaults are injected.
+        pkbAutoInjectList: [
+          "INDEX.md",
+          "essentials.md",
+          "threads.md",
+          "buffer.md",
+        ],
+      }),
+    );
+    const texts = extractTexts(result);
+    const reminder = texts.find((t) => t.startsWith("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    // essentials.md is a default auto-inject file, so it's already in the
+    // prompt — the reminder must not recommend it again.
+    expect(reminder).not.toContain("- essentials.md");
+    // The other hit, which is not auto-injected, still appears.
+    expect(reminder).toContain("- topics/alpha.md");
+  });
+
   test("in-context paths are filtered out of hints", async () => {
     pkbSearchResults = [
       { path: "topics/alpha.md", score: 0.9 },

--- a/assistant/src/__tests__/pkb-autoinject.test.ts
+++ b/assistant/src/__tests__/pkb-autoinject.test.ts
@@ -3,7 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { readAutoinjectList } from "../daemon/conversation-runtime-assembly.js";
+import {
+  getPkbAutoInjectList,
+  readAutoinjectList,
+} from "../daemon/conversation-runtime-assembly.js";
+
+const PKB_DEFAULT_FILES = [
+  "INDEX.md",
+  "essentials.md",
+  "threads.md",
+  "buffer.md",
+];
 
 // ---------------------------------------------------------------------------
 // Setup / Teardown
@@ -92,5 +102,31 @@ describe("readAutoinjectList", () => {
       "utf-8",
     );
     expect(readAutoinjectList(pkbDir)).toEqual(["INDEX.md", "essentials.md"]);
+  });
+});
+
+describe("getPkbAutoInjectList", () => {
+  test("returns PKB_DEFAULT_FILES when _autoinject.md is missing", () => {
+    // No _autoinject.md in the fresh pkbDir.
+    expect(getPkbAutoInjectList(pkbDir)).toEqual(PKB_DEFAULT_FILES);
+  });
+
+  test("returns parsed list when _autoinject.md is present", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "INDEX.md\ncustom-topic.md\n",
+      "utf-8",
+    );
+    expect(getPkbAutoInjectList(pkbDir)).toEqual([
+      "INDEX.md",
+      "custom-topic.md",
+    ]);
+  });
+
+  test("returns empty list (explicit opt-out) when _autoinject.md is empty", () => {
+    // Empty file is an explicit "inject nothing" signal — do NOT fall back
+    // to defaults.
+    writeFileSync(join(pkbDir, "_autoinject.md"), "", "utf-8");
+    expect(getPkbAutoInjectList(pkbDir)).toEqual([]);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -121,7 +121,7 @@ import {
   findLastInjectedNowContent,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
-  readAutoinjectList,
+  getPkbAutoInjectList,
   readNowScratchpad,
   readPkbContext,
   stripInjectionsForCompaction,
@@ -862,7 +862,7 @@ export async function runAgentLoopImpl(
     // the updated conversation history.
     const pkbRoot = pkbActive ? join(getWorkspaceDir(), "pkb") : undefined;
     const pkbAutoInjectList = pkbRoot
-      ? (readAutoinjectList(pkbRoot) ?? undefined)
+      ? getPkbAutoInjectList(pkbRoot)
       : undefined;
     // Pass `ctx` directly — `PkbContextConversation` is structural and
     // `getInContextPkbPaths` re-reads `conversation.messages` on each call,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -642,6 +642,21 @@ export function readAutoinjectList(pkbDir: string): string[] | null {
 }
 
 /**
+ * Resolve the effective list of auto-inject filenames for a PKB directory.
+ *
+ * This is the single source of truth used both by `readPkbContext` (which
+ * actually injects the files) and by the PKB reminder-hint tracker in
+ * `conversation-agent-loop.ts` (which needs to know what's already in
+ * context so it doesn't redundantly recommend those files).
+ *
+ * Returns `PKB_DEFAULT_FILES` when `_autoinject.md` is missing/unreadable,
+ * or the parsed list (possibly empty) when it is present.
+ */
+export function getPkbAutoInjectList(pkbRoot: string): string[] {
+  return readAutoinjectList(pkbRoot) ?? PKB_DEFAULT_FILES;
+}
+
+/**
  * Read the always-loaded PKB files and append a nudge encouraging the
  * assistant to proactively read topic files and use `remember` aggressively.
  *
@@ -655,7 +670,7 @@ export function readPkbContext(): string | null {
   const pkbDir = join(getWorkspaceDir(), "pkb");
   if (!existsSync(pkbDir)) return null;
 
-  const filesToInject = readAutoinjectList(pkbDir) ?? PKB_DEFAULT_FILES;
+  const filesToInject = getPkbAutoInjectList(pkbDir);
 
   const parts: string[] = [];
   for (const file of filesToInject) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pkb-reminder-hints.md.

**Gap:** When pkb/_autoinject.md was missing, readPkbContext still injected PKB_DEFAULT_FILES — but the agent-loop passed [] to getInContextPkbPaths, so the reminder could redundantly recommend files already in the prompt.
**Fix:** Shared getPkbAutoInjectList(pkbRoot) helper returning readAutoinjectList(...) ?? PKB_DEFAULT_FILES. Both the injection site and the tracker-exclusion site now use it.