### PR TITLE
fix(macos): guard MessageListScrollObserver against synchronous re-entry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -89,6 +89,15 @@ struct MessageListScrollObserver: NSViewRepresentable {
         /// materialization — or any other concurrent source — cannot fight
         /// the user's gesture with a mid-gesture `setBoundsOrigin` shift.
         private var isLiveScrolling: Bool = false
+        /// Guards against synchronous re-entry of
+        /// `emitCurrentSnapshotIfPossible`. `clipView.setBoundsOrigin(_:)`
+        /// synchronously posts `NSView.boundsDidChangeNotification`, which our
+        /// `queue: .main` observer dispatches synchronously via
+        /// `MainActor.assumeIsolated`. Without this guard, the
+        /// anchor-preservation branch would re-enter and call
+        /// `setBoundsOrigin` again before `lastContentHeight` is updated,
+        /// producing unbounded recursion until the main-thread stack overflows.
+        private var isEmitting: Bool = false
         /// In inverted-scroll coords, `contentOffsetY ≈ 0` means the user is
         /// pinned to the visual bottom (latest messages). Below this small
         /// epsilon we treat the user as pinned and let streaming growth
@@ -141,6 +150,10 @@ struct MessageListScrollObserver: NSViewRepresentable {
         }
 
         func emitCurrentSnapshotIfPossible() {
+            guard !isEmitting else { return }
+            isEmitting = true
+            defer { isEmitting = false }
+
             guard let scrollView,
                   let documentView = scrollView.documentView
             else { return }


### PR DESCRIPTION
## Summary
- Crash: \`EXC_BAD_ACCESS / KERN_PROTECTION_FAILURE\` — "Thread stack size exceeded due to excessive recursion" with 1500+ identical frames in \`MessageListScrollObserver.Coordinator.emitCurrentSnapshotIfPossible()\`.
- Root cause: \`clipView.setBoundsOrigin(_:)\` synchronously posts \`NSView.boundsDidChangeNotification\`, which the \`queue: .main\` observer dispatches synchronously via \`MainActor.assumeIsolated\`. The re-entered call sees stale \`lastContentHeight\` (only updated after \`setBoundsOrigin\`), recomputes the same delta, and recurses forever. The previous \`Task { @MainActor }\` hop in 27c704b7e3 had been the implicit safeguard.
- Fix: add an \`isEmitting\` re-entry guard. Restoring the \`Task\` hop would re-introduce the 1-frame anchor-shift flicker that 27c704b7e3 set out to fix.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
