### PR TITLE
ci(assistant): bump TEST_WORKERS 8→16 to probe oversubscription gain

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Test
         run: bun run test:stable
         env:
-          TEST_WORKERS: '8'
+          TEST_WORKERS: '16'
           TEST_DURATIONS_FILE: .test-durations
           TEST_DURATIONS_OUTPUT: .test-durations
 


### PR DESCRIPTION
## Summary

- Bumps the assistant Test job's `TEST_WORKERS` from 8 to 16 on the existing 8-core runner.
- Experiment: with each test file in its own bun process (forced by `mock.module` globals), 2× oversubscription may recover some of the bun cold-start + async-wait slack on the ~2:47 Test step.
- Easy to revert if it doesn't help — pure env-var change.

## Original prompt

Bump TEST_WORKERS from 8 to 16 in the assistant test job in .github/workflows/ci-main-assistant.yaml. This is an experiment to see if oversubscribing 2× on the 8-core runner shaves time off the ~2:47 Test step. No other changes; just the env var value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
