### PR TITLE
fix(pkb): pin PKB indexing to workspace sentinel scope and tighten tracker

### DIFF
--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -49,6 +49,7 @@ function setWorkspaceDir(dir: string): void {
   process.env.VELLUM_WORKSPACE_DIR = dir;
 }
 
+import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import { getTool } from "../tools/registry.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 
@@ -192,11 +193,11 @@ describe("file_write tool PKB re-index hook", () => {
     expect(enqueueCalls[0]).toEqual({
       pkbRoot: join(workingDir, "pkb"),
       absPath: join(workingDir, "pkb", "note.md"),
-      memoryScopeId: "default",
+      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
   });
 
-  test("forwards memoryScopeId from context when present", async () => {
+  test("always uses PKB_WORKSPACE_SCOPE regardless of context.memoryScopeId", async () => {
     const workingDir = makeTempDir();
     setWorkspaceDir(workingDir);
     mkdirSync(join(workingDir, "pkb"), { recursive: true });
@@ -213,7 +214,10 @@ describe("file_write tool PKB re-index hook", () => {
 
     expect(result.isError).toBe(false);
     expect(enqueueCalls).toHaveLength(1);
-    expect(enqueueCalls[0]?.memoryScopeId).toBe("private:abc123");
+    // PKB files are workspace-level — the per-conversation scopeId is NOT
+    // threaded through so different conversations can't overwrite each
+    // other's Qdrant points via target_id upsert deduplication.
+    expect(enqueueCalls[0]?.memoryScopeId).toBe(PKB_WORKSPACE_SCOPE);
   });
 
   test("does NOT enqueue when writing outside pkb/", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -66,6 +66,7 @@ import {
 } from "../memory/conversation-title-service.js";
 import type { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
+import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
@@ -871,7 +872,9 @@ export async function runAgentLoopImpl(
     // `getInContextPkbPaths` re-reads `conversation.messages` on each call,
     // so post-compaction re-injects see the updated history.
     const pkbConversation = pkbActive ? ctx : undefined;
-    const pkbScopeId = pkbActive ? ctx.memoryPolicy.scopeId : undefined;
+    // PKB points live under a single workspace sentinel scope, not the
+    // conversation's memoryPolicy.scopeId. See `PKB_WORKSPACE_SCOPE` for why.
+    const pkbScopeId = pkbActive ? PKB_WORKSPACE_SCOPE : undefined;
 
     // Subagent status injection — gives the parent LLM visibility into active/completed children.
     // Skipped when this conversation IS a subagent (no nesting) or has no children.

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -839,8 +839,11 @@ export async function runDaemon(): Promise<void> {
           const { reconcilePkbIndex } = await import(
             "../memory/pkb/pkb-reconcile.js"
           );
+          const { PKB_WORKSPACE_SCOPE } = await import(
+            "../memory/pkb/types.js"
+          );
           const pkbRoot = join(getWorkspaceDir(), "pkb");
-          await reconcilePkbIndex(pkbRoot, "default");
+          await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
         } catch (err) {
           log.warn(
             { err },

--- a/assistant/src/daemon/pkb-context-tracker.test.ts
+++ b/assistant/src/daemon/pkb-context-tracker.test.ts
@@ -108,6 +108,23 @@ describe("getInContextPkbPaths", () => {
     expect(result).toEqual(new Set());
   });
 
+  test("relative file_read path is NOT treated as inside pkbRoot", () => {
+    // `file_read` accepts absolute paths and paths relative to the tool's
+    // working directory — NOT to `pkbRoot`. So a relative path like
+    // `"notes.md"` is ambiguous: the actual file might have been read from
+    // `<workingDir>/notes.md`, not `<pkbRoot>/notes.md`. Marking it as
+    // in-context would false-positive and suppress hints for files the
+    // model did not actually load.
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([
+        fileReadToolUse("notes.md"),
+        fileReadToolUse("./deep/subdir/file.md"),
+      ]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    expect(result).toEqual(new Set());
+  });
+
   test("resolves relative auto-inject paths against pkbRoot", () => {
     const conversation = makeConversation([]);
     const result = getInContextPkbPaths(

--- a/assistant/src/daemon/pkb-context-tracker.ts
+++ b/assistant/src/daemon/pkb-context-tracker.ts
@@ -97,6 +97,12 @@ export function getInContextPkbPaths(
       if (block.name !== FILE_READ_TOOL_NAME) continue;
       const rawPath = block.input?.path;
       if (typeof rawPath !== "string") continue;
+      // `file_read` accepts both absolute paths and paths relative to the
+      // tool's working directory — NOT to `pkbRoot`. Resolving a relative
+      // `rawPath` against `pkbRoot` would treat e.g. `"notes.md"` as inside
+      // the PKB even if the actual read was against `workingDir/notes.md`.
+      // Only absolute paths are unambiguous here.
+      if (!path.isAbsolute(rawPath)) continue;
       const resolved = resolveInsidePkbRoot(rawPath, normalizedRoot);
       if (resolved !== undefined) {
         inContext.add(resolved);

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -15,6 +15,7 @@ import { buildExcerpt, buildFtsMatchQuery } from "../conversation-queries.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
+import { PKB_WORKSPACE_SCOPE } from "../pkb/types.js";
 import { searchGraphNodes } from "./graph-search.js";
 import { getNodesByIds } from "./store.js";
 
@@ -261,7 +262,7 @@ export interface RememberResult {
 export function handleRemember(
   input: RememberInput,
   _conversationId: string,
-  scopeId: string,
+  _scopeId: string,
 ): RememberResult {
   if (!input.content || input.content.trim().length === 0) {
     return { success: false, message: "content is required" };
@@ -288,7 +289,7 @@ export function handleRemember(
   // Append to buffer.md
   const bufferPath = join(pkbDir, "buffer.md");
   appendFileSync(bufferPath, entry, "utf-8");
-  enqueuePkbReindex(pkbDir, bufferPath, scopeId);
+  enqueuePkbReindex(pkbDir, bufferPath);
 
   // Append to daily archive
   const yyyy = now.getFullYear();
@@ -299,7 +300,7 @@ export function handleRemember(
     appendFileSync(archivePath, `# ${month} ${day}, ${yyyy}\n\n`, "utf-8");
   }
   appendFileSync(archivePath, entry, "utf-8");
-  enqueuePkbReindex(pkbDir, archivePath, scopeId);
+  enqueuePkbReindex(pkbDir, archivePath);
 
   return { success: true, message: "Saved to knowledge base." };
 }
@@ -307,17 +308,20 @@ export function handleRemember(
 /**
  * Fire-and-forget enqueue of a PKB re-index job for a file we just wrote.
  *
+ * Always indexes under {@link PKB_WORKSPACE_SCOPE}. See the comment on that
+ * constant for why PKB points are not per-conversation-scoped.
+ *
  * Wrapped in try/catch so an enqueue failure (e.g. DB hiccup) cannot break
  * the remember call — the write has already succeeded and the user's fact
  * is safe on disk.
  */
-function enqueuePkbReindex(
-  pkbRoot: string,
-  absPath: string,
-  memoryScopeId: string,
-): void {
+function enqueuePkbReindex(pkbRoot: string, absPath: string): void {
   try {
-    enqueuePkbIndexJob({ pkbRoot, absPath, memoryScopeId });
+    enqueuePkbIndexJob({
+      pkbRoot,
+      absPath,
+      memoryScopeId: PKB_WORKSPACE_SCOPE,
+    });
   } catch (err) {
     log.warn({ err, absPath }, "Failed to enqueue PKB re-index job");
   }

--- a/assistant/src/memory/pkb/types.ts
+++ b/assistant/src/memory/pkb/types.ts
@@ -7,6 +7,18 @@
 
 export const PKB_TARGET_TYPE = "pkb_file" as const;
 
+/**
+ * Sentinel `memory_scope_id` under which ALL PKB points are indexed and
+ * searched. PKB files live at workspace level (one copy on disk shared by
+ * every conversation in the workspace), so per-conversation scoping would
+ * cause same-file writes from different scopes to silently overwrite each
+ * other's Qdrant points (upsert dedupes by `target_type + target_id`, which
+ * does not include the scope). Pinning every PKB write and search to a
+ * single sentinel keeps the index consistent regardless of which
+ * conversation triggered the write.
+ */
+export const PKB_WORKSPACE_SCOPE = "_pkb_workspace" as const;
+
 export interface PkbSearchResult {
   path: string;
   score: number;

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,6 +1,7 @@
 import { join, resolve, sep } from "node:path";
 
 import { enqueuePkbIndexJob } from "../../memory/jobs/embed-pkb-file.js";
+import { PKB_WORKSPACE_SCOPE } from "../../memory/pkb/types.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -120,7 +121,7 @@ class FileWriteTool implements Tool {
         enqueuePkbIndexJob({
           pkbRoot,
           absPath: filePath,
-          memoryScopeId: context.memoryScopeId ?? "default",
+          memoryScopeId: PKB_WORKSPACE_SCOPE,
         });
       }
     } catch (err) {

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -11,6 +11,7 @@ import {
   test,
 } from "bun:test";
 
+import { PKB_WORKSPACE_SCOPE } from "../../memory/pkb/types.js";
 import type { ToolContext } from "../types.js";
 
 let tmpWorkspace: string;
@@ -114,6 +115,8 @@ describe("rememberTool.execute — PKB re-index enqueue", () => {
   test("enqueues re-index jobs for both buffer and daily archive paths", async () => {
     const result = await rememberTool.execute(
       { content: "index me please" },
+      // Passes a non-default per-conversation scopeId to prove the PKB
+      // enqueue ignores it and pins to PKB_WORKSPACE_SCOPE instead.
       makeContext({ memoryScopeId: "scope-enqueue" }),
     );
     expect(result.isError).toBe(false);
@@ -133,12 +136,12 @@ describe("rememberTool.execute — PKB re-index enqueue", () => {
     expect(enqueueCalls[0]).toEqual({
       pkbRoot,
       absPath: bufferPath,
-      memoryScopeId: "scope-enqueue",
+      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
     expect(enqueueCalls[1]).toEqual({
       pkbRoot,
       absPath: archivePath,
-      memoryScopeId: "scope-enqueue",
+      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes two deferred gaps from the pkb-reminder-hints plan review.

### Gap 1 — Cross-scope target_id collision
PKB files live at workspace level (one copy on disk shared by every conversation in the workspace), but every call site was threading the conversation's \`memoryPolicy.scopeId\` into the Qdrant payload. Since \`embedAndUpsert\` deduplicates by \`target_type + target_id\` only, two conversations writing to the same file from different scopes would silently overwrite each other's points (last-write-wins), and the losing scope's search would return nothing — with no user-visible signal that it failed.

Fix: introduce \`PKB_WORKSPACE_SCOPE = \"_pkb_workspace\"\` sentinel in \`memory/pkb/types.ts\` and pin every PKB write + search + reconcile to it. Per-conversation scope is no longer threaded into PKB paths at all.

Call sites updated:
- \`conversation-agent-loop.ts\`: \`pkbScopeId\` is now the sentinel, not \`ctx.memoryPolicy.scopeId\`.
- \`tools/filesystem/write.ts\`: file_write hook uses the sentinel, not \`context.memoryScopeId\`.
- \`memory/graph/tool-handlers.ts\`: remember hook uses the sentinel; \`handleRemember\`'s \`scopeId\` parameter is preserved for signature stability but unused (prefixed \`_scopeId\`).
- \`daemon/lifecycle.ts\`: startup reconciliation uses the sentinel.

### Gap 2 — Relative path false-positive in getInContextPkbPaths
\`file_read\` accepts both absolute paths and paths relative to the tool's working directory (NOT to \`pkbRoot\`). The tracker was calling \`path.resolve(pkbRoot, rawPath)\` on any relative \`rawPath\`, which would treat e.g. \`\"notes.md\"\` as \`<pkbRoot>/notes.md\` even if the actual read was against \`<workingDir>/notes.md\` somewhere else entirely. Low-severity (only suppresses hint suggestions, doesn't break correctness), but the containment guard implied a stronger guarantee than it was delivering.

Fix: reject non-absolute \`input.path\` values in the file_read scan branch. Absolute paths still get the full \`path.resolve\` + trailing-separator containment check. The auto-inject branch intentionally accepts relative paths and is unchanged.

### Tests
- \`pkb-context-tracker.test.ts\`: new test covering the relative-path rejection.
- \`file-write-tool.test.ts\`: renamed the scope-forwarding test to assert PKB_WORKSPACE_SCOPE is used regardless of \`context.memoryScopeId\`.
- \`register.test.ts\`: asserts remember hook passes PKB_WORKSPACE_SCOPE even when caller has a non-default scopeId.
- All existing PKB tests still pass (108 in runtime-assembly, 26 across pkb-context-tracker/file-write/remember).

### Migration
Existing PKB Qdrant points written under non-default scopes before this change will be orphaned (invisible to both the new search and the reconciler). Startup reconciliation writes fresh points under the sentinel on next boot; orphaned points remain in Qdrant but are harmless (filtered out by the new target_type + sentinel filter). A future pass could sweep orphans via a scope-agnostic scroll if needed — out of scope here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
