### PR TITLE
fix(memory): exclude _meta sentinel on dense-only path in PKB and graph search

### DIFF
--- a/assistant/src/memory/graph/graph-search.test.ts
+++ b/assistant/src/memory/graph/graph-search.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let breakerOpen = false;
+const hybridSearchCalls: Array<{
+  denseVector: number[];
+  sparseVector: { indices: number[]; values: number[] };
+  filter?: unknown;
+  limit: number;
+  prefetchLimit?: number;
+}> = [];
+const searchCalls: Array<{
+  vector: number[];
+  limit: number;
+  filter?: unknown;
+}> = [];
+
+mock.module("../qdrant-circuit-breaker.js", () => ({
+  isQdrantBreakerOpen: () => breakerOpen,
+  withQdrantBreaker: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  shouldAllowQdrantProbe: () => true,
+  _resetQdrantBreaker: () => {},
+  QdrantCircuitOpenError: class extends Error {},
+}));
+
+mock.module("../qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    hybridSearch: async (params: {
+      denseVector: number[];
+      sparseVector: { indices: number[]; values: number[] };
+      filter?: unknown;
+      limit: number;
+      prefetchLimit?: number;
+    }) => {
+      hybridSearchCalls.push(params);
+      return [];
+    },
+    search: async (
+      vector: number[],
+      limit: number,
+      filter?: Record<string, unknown>,
+    ) => {
+      searchCalls.push({ vector, limit, filter });
+      return [];
+    },
+  }),
+  initQdrantClient: () => {},
+  VellumQdrantClient: class {},
+}));
+
+const { searchGraphNodes } = await import("./graph-search.js");
+
+describe("searchGraphNodes — _meta filter parity", () => {
+  beforeEach(() => {
+    breakerOpen = false;
+    hybridSearchCalls.length = 0;
+    searchCalls.length = 0;
+  });
+
+  test("hybrid path excludes _meta sentinel points", async () => {
+    await searchGraphNodes([0.1], 5, ["default"], {
+      indices: [1],
+      values: [1],
+    });
+
+    expect(hybridSearchCalls).toHaveLength(1);
+    const filter = hybridSearchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const metaClause = filter.must_not.find((c) => c.key === "_meta") as
+      | { match: { value: boolean } }
+      | undefined;
+    expect(metaClause?.match.value).toBe(true);
+  });
+
+  test("dense-only path also excludes _meta sentinel points", async () => {
+    await searchGraphNodes([0.1], 5, ["default"]);
+
+    expect(searchCalls).toHaveLength(1);
+    const filter = searchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const metaClause = filter.must_not.find((c) => c.key === "_meta") as
+      | { match: { value: boolean } }
+      | undefined;
+    expect(metaClause?.match.value).toBe(true);
+  });
+});

--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -110,7 +110,10 @@ export async function searchGraphNodes(
     denseMusts.push({ key: "created_at", range: { lte: dateRange.beforeMs } });
   }
 
-  const filter: Record<string, unknown> = { must: denseMusts };
+  const filter: Record<string, unknown> = {
+    must: denseMusts,
+    must_not: [{ key: "_meta", match: { value: true } }],
+  };
 
   const results: QdrantSearchResult[] = await withQdrantBreaker(async () => {
     return client.search(queryVector, limit, filter);

--- a/assistant/src/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/memory/pkb/pkb-search.test.ts
@@ -119,6 +119,34 @@ describe("searchPkbFiles", () => {
     expect(targetTypeClause?.match.value).toBe("pkb_file");
   });
 
+  test("both search paths exclude _meta sentinel points", async () => {
+    // Hybrid path
+    hybridResults = [];
+    await searchPkbFiles(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+    );
+    const hybridFilter = hybridSearchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const hybridMetaClause = hybridFilter.must_not.find(
+      (c) => c.key === "_meta",
+    ) as { match: { value: boolean } } | undefined;
+    expect(hybridMetaClause?.match.value).toBe(true);
+
+    // Dense-only path (no sparse vector)
+    denseResults = [];
+    await searchPkbFiles([0.1], undefined, 5);
+    const denseFilter = searchCalls[0]?.filter as {
+      must_not: Array<Record<string, unknown>>;
+    };
+    const denseMetaClause = denseFilter.must_not.find(
+      (c) => c.key === "_meta",
+    ) as { match: { value: boolean } } | undefined;
+    expect(denseMetaClause?.match.value).toBe(true);
+  });
+
   test("two points on the same path collapse to the higher score", async () => {
     hybridResults = [
       {

--- a/assistant/src/memory/pkb/pkb-search.ts
+++ b/assistant/src/memory/pkb/pkb-search.ts
@@ -80,7 +80,10 @@ export async function searchPkbFiles(
       });
     }
 
-    const filter: Record<string, unknown> = { must: denseMusts };
+    const filter: Record<string, unknown> = {
+      must: denseMusts,
+      must_not: [{ key: "_meta", match: { value: true } }],
+    };
 
     results = await withQdrantBreaker(async () => {
       return client.search(queryVector, prefetchLimit, filter);


### PR DESCRIPTION
## Summary
Fixes the last deferred gap from the pkb-reminder-hints plan review: the dense-only fallback in \`searchPkbFiles\` (and, pre-existing, \`searchGraphNodes\`) was missing the \`must_not: [{ key: \"_meta\", match: { value: true } }]\` filter that the hybrid path applies. \`_meta\` sentinel points are planted by Qdrant collection initialization; without the filter, they can leak into results when the sparse vector is absent (no text to embed into BM25) or empty.

### Fix
- \`assistant/src/memory/pkb/pkb-search.ts\`: add \`must_not\` to the dense-only filter.
- \`assistant/src/memory/graph/graph-search.ts\`: same fix — brings the two search functions into parity.

### Tests
- \`pkb-search.test.ts\`: new test asserting both hybrid and dense-only paths include the \`_meta\` exclusion.
- \`graph-search.test.ts\` (new): focused mocked test of \`searchGraphNodes\` verifying the same parity on both paths.

### Rationale for shipping this repo-wide
The PKB plan mirrored \`searchGraphNodes\` when authoring \`searchPkbFiles\`, inheriting the asymmetry. Fixing only \`pkb-search\` would have left \`graph-search\` inconsistent with its own downstream copy. Both functions now use the same filter shape for both paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
