### PR TITLE
test(profiler): raise archive-size-limit test timeout to 30s

### DIFF
--- a/assistant/src/__tests__/profiler-routes.test.ts
+++ b/assistant/src/__tests__/profiler-routes.test.ts
@@ -383,7 +383,7 @@ describe("Profiler routes", () => {
       };
       expect(body.error.code).toBe("INTERNAL_ERROR");
       expect(body.error.message).toContain("archive size");
-    });
+    }, 30000);
   });
 
   describe("DELETE /v1/profiler/runs/:runId", () => {


### PR DESCRIPTION
## Summary
- The 'returns 500 when archive exceeds size limit' test in `profiler-routes.test.ts` produces 55MB of incompressible random data to force `createTarGz` past its 50MB cap; on CI the tar+gzip step takes ~7s, past Bun's default 5000ms per-test timeout.
- Raised the per-test timeout to 30000ms to match the `spawnSync("tar", ...)` timeout already set in `archive-utils.ts`, giving the compression step enough headroom without reducing test fidelity.
- Fixes the flaky failure observed on https://github.com/vellum-ai/vellum-assistant/actions/runs/24615489194/job/71976910169.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24615489194/job/71976910169
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
