### PR TITLE
feat(assistant): add cancellation reason metadata to interactive UI results

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -445,6 +445,7 @@ export function showStandaloneSurface(
     return Promise.resolve({
       status: "cancelled" as const,
       surfaceId,
+      cancellationReason: "no_interactive_surface",
     });
   }
 
@@ -455,7 +456,11 @@ export function showStandaloneSurface(
       { conversationId: ctx.conversationId, surfaceType: request.surfaceType },
       "standalone surface: pendingStandaloneSurfaces map missing; failing closed",
     );
-    return Promise.resolve({ status: "cancelled" as const, surfaceId });
+    return Promise.resolve({
+      status: "cancelled" as const,
+      surfaceId,
+      cancellationReason: "no_interactive_surface",
+    });
   }
   const pendingMap = ctx.pendingStandaloneSurfaces;
 
@@ -981,6 +986,9 @@ export async function handleSurfaceAction(
       surfaceId,
       actionId,
       ...(data ? { submittedData: data } : {}),
+      ...(isCancellation
+        ? { cancellationReason: "user_dismissed" as const }
+        : {}),
       summary,
     };
 

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -127,7 +127,7 @@ describe("ui_request IPC route", () => {
 
   // ── Unknown conversation (resolver throws) ────────────────────────
 
-  test("returns cancelled when resolver throws for unknown conversation", async () => {
+  test("returns cancelled with resolver_error reason when resolver throws for unknown conversation", async () => {
     registerInteractiveUiResolver(async (_req: InteractiveUiRequest) => {
       throw new Error("Unknown conversation: conv-nonexistent");
     });
@@ -141,12 +141,13 @@ describe("ui_request IPC route", () => {
     expect(result.ok).toBe(true);
     expect(result.result).toBeDefined();
     expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("resolver_error");
     expect(result.result!.surfaceId).toBeDefined();
   });
 
   // ── Non-interactive failure (no resolver registered) ──────────────
 
-  test("returns cancelled when no resolver is registered", async () => {
+  test("returns cancelled with no_interactive_surface reason when no resolver is registered", async () => {
     // No resolver registered — resetInteractiveUiResolverForTests()
     // was called in beforeEach, so the module-level resolver is null.
 
@@ -158,6 +159,7 @@ describe("ui_request IPC route", () => {
     expect(result.ok).toBe(true);
     expect(result.result).toBeDefined();
     expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("no_interactive_surface");
     expect(result.result!.surfaceId).toBeDefined();
   });
 
@@ -274,6 +276,70 @@ describe("ui_request IPC route", () => {
     expect(result.result!.status).toBe("submitted");
     expect(result.result!.summary).toBe("Confirm Action");
   });
+
+  // ── Cancellation reason round-trip ────────────────────────────────
+
+  test("round-trips user_dismissed cancellation reason from resolver", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: "mock-surface-dismissed",
+        cancellationReason: "user_dismissed",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("user_dismissed");
+  });
+
+  test("round-trips conversation_not_found cancellation reason from resolver", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: "mock-surface-not-found",
+        cancellationReason: "conversation_not_found",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: "conv-missing" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("conversation_not_found");
+  });
+
+  test("submitted result does not carry cancellationReason through IPC", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "mock-surface-submitted",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.cancellationReason).toBeUndefined();
+  });
+
+  // ── Optional fields (continued) ────────────────────────────────────
 
   test("accepts form surfaceType with submittedData", async () => {
     registerInteractiveUiResolver(

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { decodeDecisionToken } from "../decision-token.js";
 import {
+  type CancellationReason,
   type InteractiveUiRequest,
   type InteractiveUiResult,
   registerInteractiveUiResolver,
@@ -36,7 +37,7 @@ beforeEach(() => {
 // ── Missing resolver (fail-closed) ───────────────────────────────────
 
 describe("requestInteractiveUi without resolver", () => {
-  test("returns cancelled when no resolver is registered", async () => {
+  test("returns cancelled with no_interactive_surface reason when no resolver is registered", async () => {
     const request: InteractiveUiRequest = {
       conversationId: "conv-1",
       surfaceType: "confirmation",
@@ -46,6 +47,7 @@ describe("requestInteractiveUi without resolver", () => {
     const result = await requestInteractiveUi(request);
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("no_interactive_surface");
     expect(result.surfaceId).toBeString();
     expect(result.surfaceId.length).toBeGreaterThan(0);
     expect(result.actionId).toBeUndefined();
@@ -73,6 +75,7 @@ describe("requestInteractiveUi without resolver", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("no_interactive_surface");
     expect(result.decisionToken).toBeUndefined();
   });
 });
@@ -204,7 +207,7 @@ describe("requestInteractiveUi with resolver", () => {
 // ── Error handling (fail-closed on resolver throw) ──────────────────
 
 describe("resolver error handling", () => {
-  test("returns cancelled when resolver throws", async () => {
+  test("returns cancelled with resolver_error reason when resolver throws", async () => {
     registerInteractiveUiResolver(async () => {
       throw new Error("Surface rendering failed");
     });
@@ -216,11 +219,12 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.surfaceId).toBeString();
     expect(result.surfaceId.length).toBeGreaterThan(0);
   });
 
-  test("returns cancelled when resolver rejects", async () => {
+  test("returns cancelled with resolver_error reason when resolver rejects", async () => {
     registerInteractiveUiResolver(() =>
       Promise.reject(new Error("Connection lost")),
     );
@@ -232,6 +236,7 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.surfaceId).toBeString();
   });
 
@@ -247,6 +252,7 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.decisionToken).toBeUndefined();
   });
 });
@@ -461,6 +467,124 @@ describe("decision token", () => {
 
     // Tokens differ due to nonce even with same conversation/action
     expect(result1.decisionToken).not.toBe(result2.decisionToken);
+  });
+});
+
+// ── Cancellation reason propagation ──────────────────────────────────
+
+describe("cancellation reason", () => {
+  test("no_interactive_surface reason when no resolver registered", async () => {
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-no-resolver",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe(
+      "no_interactive_surface" satisfies CancellationReason,
+    );
+  });
+
+  test("resolver_error reason when resolver throws", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("boom");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-error",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe(
+      "resolver_error" satisfies CancellationReason,
+    );
+  });
+
+  test("resolver can return user_dismissed reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "dismissed-surface",
+      cancellationReason: "user_dismissed",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-user-dismissed",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("user_dismissed");
+  });
+
+  test("resolver can return conversation_not_found reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "not-found-surface",
+      cancellationReason: "conversation_not_found",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-not-found",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("conversation_not_found");
+  });
+
+  test("resolver can return resolver_unavailable reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "unavailable-surface",
+      cancellationReason: "resolver_unavailable",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-unavailable",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_unavailable");
+  });
+
+  test("submitted result does not carry cancellationReason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "no-reason-submit",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-submitted",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.cancellationReason).toBeUndefined();
+  });
+
+  test("timed_out result does not carry cancellationReason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "no-reason-timeout",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-timeout",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.cancellationReason).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -39,6 +39,25 @@ import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
+// ── Cancellation reasons ─────────────────────────────────────────────
+
+/**
+ * Machine-readable reason for a `"cancelled"` outcome.
+ *
+ * - `"user_dismissed"` — the user explicitly closed/dismissed the surface
+ * - `"no_interactive_surface"` — no resolver was registered (headless / test)
+ * - `"conversation_not_found"` — the target conversation could not be located
+ * - `"resolver_unavailable"` — a resolver was registered but is not currently
+ *   available (e.g. the surface transport is disconnected)
+ * - `"resolver_error"` — the resolver threw an unexpected error
+ */
+export type CancellationReason =
+  | "user_dismissed"
+  | "no_interactive_surface"
+  | "conversation_not_found"
+  | "resolver_unavailable"
+  | "resolver_error";
+
 // ── Request / Result contracts ───────────────────────────────────────
 
 /**
@@ -111,6 +130,16 @@ export interface InteractiveUiResult {
   summary?: string;
   /** The surface identifier that was shown, for audit/correlation. */
   surfaceId: string;
+  /**
+   * Machine-readable reason for a `"cancelled"` outcome. Present only
+   * when `status === "cancelled"`. Allows callers to distinguish
+   * user-initiated dismissals from operational fail-closed outcomes
+   * without parsing log messages.
+   *
+   * Optional for backward compatibility — existing callers that only
+   * check `status` continue to work unchanged.
+   */
+  cancellationReason?: CancellationReason;
   /**
    * Short-lived informational decision token, present when
    * `status === "submitted"` and `surfaceType === "confirmation"`.
@@ -247,6 +276,7 @@ export async function requestInteractiveUi(
     const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
+      cancellationReason: "no_interactive_surface",
     };
     emitAuditLog(request, failResult);
     return failResult;
@@ -299,6 +329,7 @@ export async function requestInteractiveUi(
     const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
+      cancellationReason: "resolver_error",
     };
     emitAuditLog(request, failResult);
     return failResult;


### PR DESCRIPTION
## Summary
- Extends InteractiveUiResult with optional cancellationReason for cancelled outcomes
- Updates fail-closed paths (no resolver, resolver error) with deterministic reason values
- Adds runtime and IPC route test coverage for reason propagation

Part of plan: ui-request-gap-remediation.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
