### PR TITLE
fix(remember): use strict === true check for finish_turn opt-in

### DIFF
--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -38,7 +38,7 @@ class RememberTool implements Tool {
     return {
       content: result.message,
       isError: !result.success,
-      ...(typedInput.finish_turn ? { yieldToUser: true } : {}),
+      ...(typedInput.finish_turn === true ? { yieldToUser: true } : {}),
     };
   }
 }


### PR DESCRIPTION
Address Codex on #26367. The truthy check on finish_turn accepted any non-falsy value, including string "false" or "0" emitted by the model — silently truncating normal chat replies. Tighten to === true so only the intended boolean opt-in yields control to the user.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
