### PR TITLE
fix(cli): self-heal guardian token across VELLUM_ENVIRONMENT switches

### DIFF
--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -7,6 +7,7 @@ import {
   getOrCreatePersistedDeviceId,
   loadGuardianToken,
   saveGuardianToken,
+  seedGuardianTokenFromSiblingEnv,
   type GuardianTokenData,
 } from "../lib/guardian-token.js";
 
@@ -168,5 +169,56 @@ describe("guardian-token paths are env-scoped", () => {
     const first = getOrCreatePersistedDeviceId();
     const second = getOrCreatePersistedDeviceId();
     expect(first).toBe(second);
+  });
+
+  test("seedGuardianTokenFromSiblingEnv copies a dev token into the current local env", () => {
+    // Write a token under the dev env.
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    saveGuardianToken("alpha", makeTokenData("dev"));
+
+    // Switch to local env — no token present yet.
+    process.env.VELLUM_ENVIRONMENT = "local";
+    expect(loadGuardianToken("alpha")).toBeNull();
+
+    const seeded = seedGuardianTokenFromSiblingEnv("alpha");
+    expect(seeded).toBe(true);
+
+    const localPath = join(
+      tempHome,
+      "vellum-local",
+      "assistants",
+      "alpha",
+      "guardian-token.json",
+    );
+    expect(existsSync(localPath)).toBe(true);
+    const loaded = loadGuardianToken("alpha");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.guardianPrincipalId).toBe("principal-dev");
+
+    // Idempotent — second call is a no-op.
+    expect(seedGuardianTokenFromSiblingEnv("alpha")).toBe(false);
+  });
+
+  test("seedGuardianTokenFromSiblingEnv returns false when no sibling token exists", () => {
+    process.env.VELLUM_ENVIRONMENT = "local";
+    expect(seedGuardianTokenFromSiblingEnv("nonexistent")).toBe(false);
+    expect(loadGuardianToken("nonexistent")).toBeNull();
+  });
+
+  test("seedGuardianTokenFromSiblingEnv does not overwrite an existing token", () => {
+    // Token already present in the current env.
+    process.env.VELLUM_ENVIRONMENT = "local";
+    saveGuardianToken("alpha", makeTokenData("local"));
+
+    // And a different sibling token in dev.
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    saveGuardianToken("alpha", makeTokenData("dev"));
+
+    // Back to local — seed should no-op because a token is already present.
+    process.env.VELLUM_ENVIRONMENT = "local";
+    expect(seedGuardianTokenFromSiblingEnv("alpha")).toBe(false);
+    expect(loadGuardianToken("alpha")!.guardianPrincipalId).toBe(
+      "principal-local",
+    );
   });
 });

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -6,6 +6,7 @@ import {
   saveAssistantEntry,
 } from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
+import { seedGuardianTokenFromSiblingEnv } from "../lib/guardian-token.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import {
   generateLocalSigningKey,
@@ -180,6 +181,16 @@ export async function wake(): Promise<void> {
     } else {
       await startGateway(watch, resources, { signingKey });
     }
+  }
+
+  // Self-heal the guardian token when the current environment's config dir
+  // is missing it. Hatch cross-writes the lockfile across env dirs but the
+  // guardian token is only persisted under the hatch-time env, so a desktop
+  // app built under a different VELLUM_ENVIRONMENT can't find a bearer and
+  // cascades into 401 → auth-rate-limit → 429. A sibling env copy is cheap
+  // and strictly additive.
+  if (seedGuardianTokenFromSiblingEnv(entry.assistantId)) {
+    console.log("   Seeded guardian token from sibling environment.");
   }
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "path";
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
+import { SEEDS } from "./environments/seeds.js";
 
 const DEVICE_ID_SALT = "vellum-assistant-host-id";
 
@@ -199,4 +200,51 @@ export async function leaseGuardianToken(
 
   saveGuardianToken(assistantId, tokenData);
   return tokenData;
+}
+
+/**
+ * Copy a guardian token from a sibling environment's config directory into
+ * the current environment's dir when the current one is missing it.
+ *
+ * The CLI's per-environment config layout (`~/.config/vellum{-env}/`) scopes
+ * the lockfile and the guardian token by VELLUM_ENVIRONMENT. Lockfiles are
+ * cross-written at hatch time, but a guardian token is only written under
+ * the env the assistant was hatched in. If the user later wakes the same
+ * assistant under a different env (e.g. a freshly built desktop app ships
+ * with VELLUM_ENVIRONMENT=local while the original hatch was under dev),
+ * the app cannot locate a bearer token and falls into a 401 → auth-rate-
+ * limit → 429 cascade against the local gateway.
+ *
+ * Returns true if a token was seeded, false if a token was already present
+ * or no sibling env had one to copy.
+ */
+export function seedGuardianTokenFromSiblingEnv(assistantId: string): boolean {
+  if (loadGuardianToken(assistantId) !== null) return false;
+
+  const currentEnvName = getCurrentEnvironment().name;
+  const destPath = getGuardianTokenPath(assistantId);
+
+  for (const env of Object.values(SEEDS)) {
+    if (env.name === currentEnvName) continue;
+    const sibling = join(
+      getConfigDir(env),
+      "assistants",
+      assistantId,
+      "guardian-token.json",
+    );
+    if (!existsSync(sibling)) continue;
+    try {
+      const raw = readFileSync(sibling);
+      const dir = dirname(destPath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+      }
+      writeFileSync(destPath, raw, { mode: 0o600 });
+      chmodSync(destPath, 0o600);
+      return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- Add \`seedGuardianTokenFromSiblingEnv(assistantId)\` that copies a guardian token from the first sibling \`VELLUM_ENVIRONMENT\` config dir containing one into the current env's dir.
- Call it from \`vellum wake\` after the gateway starts, so the desktop app can always find a bearer token under the env it was built against.
- Fixes a cascading 401 → rate-limited 429 failure mode when a user rebuilds the desktop app under a different \`VELLUM_ENVIRONMENT\` than the original hatch.

## Original prompt
1 and 2 in separate PRs and /create-plan for 3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
