### PR TITLE
fix(migration-222): null-guard content array entries to prevent migration failure

### DIFF
--- a/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
+++ b/assistant/src/memory/migrations/222-strip-placeholder-sentinels-from-messages.ts
@@ -64,6 +64,7 @@ export function migrateStripPlaceholderSentinelsFromMessages(
           }
 
           const stripped = blocks.filter((b) => {
+            if (typeof b !== "object" || b === null) return false;
             if (b.type !== "text") return true;
             const text = typeof b.text === "string" ? b.text : "";
             return !isPlaceholderSentinelText(text);


### PR DESCRIPTION
Address Codex on #26325. Migration 222's blocks.filter dereferenced b.type without guarding that b was a non-null object. A null element in any imported/older message threw TypeError, which withCrashRecovery marked as a permanent failure — skipping later sentinel rows on subsequent boots. Add a typeof===object && b !== null guard so malformed entries are dropped safely without crashing the migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
