### PR TITLE
docs(updates-schema): drop hardcoded ~/.vellum/workspace path from description

### DIFF
--- a/assistant/src/config/schemas/updates.ts
+++ b/assistant/src/config/schemas/updates.ts
@@ -6,7 +6,7 @@ export const UpdatesConfigSchema = z
       .boolean({ error: "updates.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Whether to dispatch a background conversation when ~/.vellum/workspace/UPDATES.md has unprocessed content. When false, release-update bulletins are written by migrations but never processed by the agent.",
+        "Whether to dispatch a background conversation when <workspace>/UPDATES.md has unprocessed content. When false, release-update bulletins are written by migrations but never processed by the agent.",
       ),
   })
   .describe("Release update bulletin configuration");


### PR DESCRIPTION
Address Codex on #26415. The updates.enabled description hardcoded ~/.vellum/workspace/UPDATES.md, but workspace path is runtime-dependent (VELLUM_WORKSPACE_DIR / BASE_DATA_DIR overrides for multi-instance and Docker). Use a relative reference (e.g. <workspace>/UPDATES.md) so the doc is correct under every layout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
