### PR TITLE
fix(macos): respect VS15 (U+FE0E) text-presentation selector in italic-emoji guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -989,9 +989,12 @@ fileprivate extension Character {
     /// presentation, or text-default codepoints forced into emoji presentation
     /// via U+FE0F (VS16). Excludes text-presentation characters like digits
     /// and `#`/`*` that carry the bare Emoji property but not Emoji_Presentation.
+    /// U+FE0E (VS15) explicitly requests text presentation and short-circuits
+    /// to `false` so sequences like `⌚︎` keep italic obliqueness.
     var rendersAsEmoji: Bool {
         let scalars = unicodeScalars
         if scalars.contains(where: { $0.value == 0xFE0F }) { return true }
+        if scalars.contains(where: { $0.value == 0xFE0E }) { return false }
         return scalars.contains(where: { $0.properties.isEmojiPresentation })
     }
 }


### PR DESCRIPTION
Address Codex P2 on #26319. rendersAsEmoji classified any grapheme with an Emoji_Presentation scalar as emoji and stripped italic obliqueness. Sequences with VS15 (U+FE0E) explicitly request text presentation and should keep italic — e.g. ⌚︎ (U+231A U+FE0E). Add a VS15 short-circuit before the isEmojiPresentation fallback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
