### PR TITLE
fix(autocomplete): XML-escape interpolated content in framing tags

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2165,18 +2165,28 @@ export async function handleSendMessage(
   );
 }
 
+function escapeXmlContent(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 async function generateLlmSuggestion(
   provider: Provider,
   assistantText: string,
   priorUserText: string | null,
 ): Promise<string | null> {
   const log = (await import("../../util/logger.js")).getLogger("runtime-http");
-  const truncatedAssistant =
-    assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
+  const truncatedAssistant = escapeXmlContent(
+    assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText,
+  );
   const truncatedUser =
     priorUserText && priorUserText.length > 500
-      ? priorUserText.slice(-500)
-      : priorUserText;
+      ? escapeXmlContent(priorUserText.slice(-500))
+      : priorUserText
+        ? escapeXmlContent(priorUserText)
+        : priorUserText;
 
   const systemPrompt =
     "You generate short, casual reply suggestions a user might type next in a chat. Match the tone and register of the preceding conversation. Output only the reply text inside the requested tags — no preamble, no commentary.";


### PR DESCRIPTION
Address Codex on #26289. The XML framing interpolates truncatedUser/truncatedAssistant raw, so common chat content (code snippets, JSX, XML) with </div> or &lt;tag&gt; breaks the tag boundaries that the framing relies on — the model receives malformed XML and the meta-explanation leak the PR intended to prevent can resurface. Add an escapeXmlContent helper (& first, then < and >) and apply before interpolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
