### PR TITLE
fix(embed_pkb_file): swallow ENOENT for files deleted between enqueue and run

### DIFF
--- a/assistant/src/memory/jobs/embed-pkb-file.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.ts
@@ -27,7 +27,19 @@ export async function embedPkbFileJob(
   const memoryScopeId = asString(job.payload.memoryScopeId);
   if (!pkbRoot || !absPath || !memoryScopeId) return;
 
-  await indexPkbFile(pkbRoot, absPath, memoryScopeId);
+  try {
+    await indexPkbFile(pkbRoot, absPath, memoryScopeId);
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      return;
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
Address Codex P2 on #26403. PKB embed jobs run asynchronously from enqueue. If the file is deleted/moved/renamed between enqueue and execution (common with save-via-rename editors), indexPkbFile threw ENOENT and the worker marked the job failed — producing noise on every normal filesystem churn. Catch ENOENT in the handler as a benign no-op; re-throw any other error so real failures still surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
