### PR TITLE
docs(meet/conversation-bridge): update module docstring after participant-role change

### DIFF
--- a/skills/meet-join/daemon/conversation-bridge.ts
+++ b/skills/meet-join/daemon/conversation-bridge.ts
@@ -27,9 +27,11 @@
  *      pointer / call messages (see `assistant/src/calls/call-pointer-messages.ts`).
  *
  *   4. **Participant changes** (`participant.change`) are persisted as
- *      short `"assistant"`-role lines (`"<name> joined"` / `"<name> left"`)
- *      with `automated: true` in metadata so they don't pollute memory
- *      indexing.
+ *      short `"user"`-role lines (`"[Meeting] <name> joined"` /
+ *      `"[Meeting] <name> left"`) with `automated: true` in metadata so
+ *      they don't pollute memory indexing. Using `"user"` role keeps
+ *      untrusted participant names from carrying assistant-level
+ *      authority in model context.
  *
  * `speaker.change` and `lifecycle` are intentionally consumed elsewhere
  * (PR 18 storage writer, PR 19 lifecycle listener, PR 21 speaker


### PR DESCRIPTION
Address Devin on #26277. The conversation-bridge module docstring still described participant changes as assistant-role lines, but the code now inserts them as user-role. Refresh the docstring to describe current behavior. (Codex/Devin's feature-flag nesting flags were already addressed in #26368 — verified.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
