### PR TITLE
feat(assistant): support custom actions in assistant ui request

### DIFF
--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -762,6 +762,27 @@ describe("ui request — --actions parsing", () => {
     expect(lastIpcCall!.params!.actions).toBeUndefined();
   });
 
+  test("errors when --actions is an empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON in --actions");
+  });
+
   test("errors on malformed JSON in --actions", async () => {
     process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
       conversationId: "conv-1",

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -696,3 +696,329 @@ describe("ui request — conversation ID discovery hint", () => {
     expect(parsed.error).toContain("assistant conversations list");
   });
 });
+
+// ---------------------------------------------------------------------------
+// ui request — --actions parsing
+// ---------------------------------------------------------------------------
+
+describe("ui request — --actions parsing", () => {
+  test("valid actions are parsed and included in IPC params", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "approve", label: "Approve", variant: "primary" },
+      { id: "reject", label: "Reject", variant: "danger" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"Choose"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
+
+  test("actions without variant are accepted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [{ id: "ok", label: "OK" }];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toEqual([{ id: "ok", label: "OK" }]);
+  });
+
+  test("actions are omitted from IPC params when --actions is not provided", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toBeUndefined();
+  });
+
+  test("errors on malformed JSON in --actions", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "{not valid json",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON in --actions");
+  });
+
+  test("errors when --actions is not an array", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '{"id":"ok","label":"OK"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must be a JSON array");
+  });
+
+  test("errors when --actions is an empty array", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "[]",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("at least one action");
+  });
+
+  test("errors when action is missing id", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"label":"OK"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"id" is required');
+  });
+
+  test("errors when action id is empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"","label":"OK"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"id" is required');
+  });
+
+  test("errors when action is missing label", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"label" is required');
+  });
+
+  test("errors when action label is empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok","label":""}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"label" is required');
+  });
+
+  test("errors when action has invalid variant", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok","label":"OK","variant":"invalid"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"variant" must be one of');
+  });
+
+  test("errors when action item is not an object", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '["not-an-object"]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must be a JSON object");
+  });
+
+  test("accepts all valid variant values", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "a", label: "Primary", variant: "primary" },
+      { id: "b", label: "Danger", variant: "danger" },
+      { id: "c", label: "Secondary", variant: "secondary" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
+
+  test("action error references the correct array index", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    // Second action is invalid (index 1)
+    const actions = [
+      { id: "ok", label: "OK" },
+      { id: "bad", label: "" },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--actions[1]");
+  });
+
+  test("action errors output as text when --json is not set", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "{bad",
+    ]);
+
+    expect(exitCode).toBe(1);
+    // When --json is not set, errors go to log.error (mocked as no-op),
+    // so stdout should be empty and IPC should not have been called
+    expect(lastIpcCall).toBeNull();
+  });
+});

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -1042,4 +1042,130 @@ describe("ui request — --actions parsing", () => {
     // so stdout should be empty and IPC should not have been called
     expect(lastIpcCall).toBeNull();
   });
+
+  test("rejects 'selection_changed' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"selection_changed","label":"Select"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "selection_changed" is reserved for internal use',
+    );
+    expect(parsed.error).toContain("Reserved IDs:");
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'content_changed' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"content_changed","label":"Change"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "content_changed" is reserved for internal use',
+    );
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'state_update' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"state_update","label":"Update"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "state_update" is reserved for internal use',
+    );
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("reserved ID error references the correct array index", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    // First action is valid, second uses a reserved ID
+    const actions = [
+      { id: "approve", label: "Approve" },
+      { id: "state_update", label: "Update State" },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--actions[1]");
+    expect(parsed.error).toContain('id "state_update" is reserved');
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("non-reserved IDs are accepted alongside validation", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "approve", label: "Approve" },
+      { id: "reject", label: "Reject" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
 });

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -17,7 +17,10 @@ import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import type { InteractiveUiResult } from "../../runtime/interactive-ui.js";
+import type {
+  InteractiveUiAction,
+  InteractiveUiResult,
+} from "../../runtime/interactive-ui.js";
 import { log } from "../logger.js";
 
 // ── Constants ─────────────────────────────────────────────────────────
@@ -144,6 +147,91 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
   }
 }
 
+// ── Action parsing ────────────────────────────────────────────────────
+
+/** Valid variant values for action buttons. */
+const VALID_VARIANTS = new Set(["primary", "danger", "secondary"]);
+
+/**
+ * Parse and validate the `--actions` JSON flag.
+ *
+ * Expected shape: an array of objects, each with:
+ *   - `id`      (string, required, non-empty)
+ *   - `label`   (string, required, non-empty)
+ *   - `variant` (optional: "primary" | "danger" | "secondary")
+ *
+ * Returns the validated array, or throws with an actionable CLI error.
+ */
+function parseActions(raw: string): InteractiveUiAction[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in --actions: ${err instanceof SyntaxError ? err.message : String(err)}\n` +
+        "  --actions must be a JSON array of action objects.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"},{"id":"reject","label":"Reject","variant":"danger"}]\'',
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "--actions must be a JSON array of action objects.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"}]\'',
+    );
+  }
+
+  if (parsed.length === 0) {
+    throw new Error(
+      "--actions must contain at least one action.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"}]\'',
+    );
+  }
+
+  const actions: InteractiveUiAction[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    const item = parsed[i];
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new Error(
+        `--actions[${i}]: each action must be a JSON object with "id" and "label" fields.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    const obj = item as Record<string, unknown>;
+
+    if (typeof obj.id !== "string" || obj.id.length === 0) {
+      throw new Error(
+        `--actions[${i}]: "id" is required and must be a non-empty string.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    if (typeof obj.label !== "string" || obj.label.length === 0) {
+      throw new Error(
+        `--actions[${i}]: "label" is required and must be a non-empty string.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    const action: InteractiveUiAction = { id: obj.id, label: obj.label };
+
+    if (obj.variant !== undefined) {
+      if (typeof obj.variant !== "string" || !VALID_VARIANTS.has(obj.variant)) {
+        throw new Error(
+          `--actions[${i}]: "variant" must be one of "primary", "danger", or "secondary" (got ${JSON.stringify(obj.variant)}).\n` +
+            '  Example: {"id":"delete","label":"Delete","variant":"danger"}',
+        );
+      }
+      action.variant = obj.variant as InteractiveUiAction["variant"];
+    }
+
+    actions.push(action);
+  }
+
+  return actions;
+}
+
 // ── Strict integer parsing ────────────────────────────────────────────
 
 /**
@@ -193,6 +281,10 @@ Examples:
     )
     .option("--title <title>", "Title displayed on the surface")
     .option(
+      "--actions <json>",
+      "JSON array of action objects defining custom buttons/options",
+    )
+    .option(
       "--conversation-id <id>",
       "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
     )
@@ -212,6 +304,10 @@ surface content and can be provided via --payload or piped through stdin.
 The response includes the user's action (submitted, cancelled, timed_out)
 and any submitted data.
 
+Custom actions can be defined via --actions to control the buttons shown
+on the surface. Each action requires an "id" and "label", with an optional
+"variant" hint ("primary", "danger", or "secondary").
+
 Arguments:
   (none — payload via --payload flag or stdin)
 
@@ -219,6 +315,7 @@ Options:
   --payload <json>         JSON object with surface data
   --surface-type <type>    "confirmation" (default) or "form"
   --title <title>          Surface title
+  --actions <json>         JSON array of custom action objects
   --conversation-id <id>   Explicit conversation ID
   --timeout <ms>           Request timeout in milliseconds (default: 300000)
   --json                   Output as JSON
@@ -226,13 +323,16 @@ Options:
 Examples:
   $ echo '{"message":"Proceed?"}' | assistant ui request
   $ assistant ui request --payload '{"message":"Proceed?"}' --json
-  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json`,
+  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json
+  $ assistant ui request --payload '{"message":"Choose an option"}' \\
+      --actions '[{"id":"approve","label":"Approve","variant":"primary"},{"id":"reject","label":"Reject","variant":"danger"}]'`,
     )
     .action(
       async (opts: {
         payload?: string;
         surfaceType?: string;
         title?: string;
+        actions?: string;
         conversationId?: string;
         timeout?: string;
         json?: boolean;
@@ -271,6 +371,25 @@ Examples:
           return;
         }
 
+        // Parse actions (if provided)
+        let actions: InteractiveUiAction[] | undefined;
+        if (opts.actions) {
+          try {
+            actions = parseActions(opts.actions);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
+            }
+            process.exitCode = 1;
+            return;
+          }
+        }
+
         // Parse timeout
         const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
         const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
@@ -296,6 +415,9 @@ Examples:
         };
         if (opts.title) {
           ipcParams.title = opts.title;
+        }
+        if (actions) {
+          ipcParams.actions = actions;
         }
 
         // Call IPC with timeout budget = request timeout + buffer

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -149,6 +149,19 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
 
 // ── Action parsing ────────────────────────────────────────────────────
 
+/**
+ * Action IDs reserved for internal surface lifecycle events. These IDs
+ * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
+ * as non-terminal events (early return without resolving the pending
+ * `ui_request`). If a caller defines one of these as a custom button ID,
+ * clicking it would silently return early without resolving.
+ */
+export const RESERVED_ACTION_IDS = new Set([
+  "selection_changed",
+  "content_changed",
+  "state_update",
+]);
+
 /** Valid variant values for action buttons. */
 const VALID_VARIANTS = new Set(["primary", "danger", "secondary"]);
 
@@ -204,6 +217,13 @@ function parseActions(raw: string): InteractiveUiAction[] {
       throw new Error(
         `--actions[${i}]: "id" is required and must be a non-empty string.\n` +
           '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    if (RESERVED_ACTION_IDS.has(obj.id)) {
+      const reserved = [...RESERVED_ACTION_IDS].sort().join(", ");
+      throw new Error(
+        `--actions[${i}]: id "${obj.id}" is reserved for internal use. Reserved IDs: ${reserved}`,
       );
     }
 

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -373,7 +373,7 @@ Examples:
 
         // Parse actions (if provided)
         let actions: InteractiveUiAction[] | undefined;
-        if (opts.actions) {
+        if (opts.actions !== undefined) {
           try {
             actions = parseActions(opts.actions);
           } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `--actions <json>` option to `assistant ui request` for custom action definitions
- Implements strict JSON parsing/validation with actionable CLI errors
- Passes parsed actions through IPC params to `ui_request`

Part of plan: ui-request-gap-remediation.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
