### PR TITLE
fix(macos): plumb conversationType through ConversationRestorer cold-start path

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -353,6 +353,7 @@ final class ConversationRestorer {
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.lastMessageAt ?? session.updatedAt) / 1000.0),
                 kind: kind,
                 source: session.source,
+                conversationType: session.conversationType,
                 hostAccess: session.hostAccess ?? false,
                 scheduleJobId: session.scheduleJobId,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,


### PR DESCRIPTION
Address Codex on #26321. Cold-start/reconnect restore in ConversationRestorer.handleConversationListResponse constructed ConversationModel without conversationType, so PR #26321's badge filter saw nil for page-1 watcher/filing threads and fell through to source heuristics — defeating the fix. Pass conversationType from the session payload through to the model so the new exclusion applies on the very first page restore.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
