### PR TITLE
fix(meet): publish meet.error on pre-container join failure for client UX

### DIFF
--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -776,6 +776,12 @@ class MeetSessionManagerImpl {
       );
     } catch (err) {
       this.pendingBotTokens.delete(meetingId);
+      void publishMeetEvent(
+        DAEMON_INTERNAL_ASSISTANT_ID,
+        meetingId,
+        "meet.error",
+        { detail: errorDetail(err) },
+      );
       throw err;
     }
 


### PR DESCRIPTION
Address Devin on #26266. The pre-container try/catch in session-manager cleaned up pendingBotTokens but did not emit meet.error to clients that had already received meet.joining — clients hung in the joining state. Now publish meet.error in that branch, matching the Docker spawn-failure handler. (Codex's P1 heartbeat cascade was already restored to dual-emit by #26286 — verified, no further action needed.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
