### PR TITLE
fix(update-bulletin-job): dynamic workspace path + wrap full body in try/catch

### DIFF
--- a/assistant/src/prompts/update-bulletin-job.ts
+++ b/assistant/src/prompts/update-bulletin-job.ts
@@ -10,14 +10,20 @@ import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { deleteConversation } from "../memory/conversation-crud.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspacePromptPath } from "../util/platform.js";
+import {
+  getWorkspaceDirDisplay,
+  getWorkspacePromptPath,
+} from "../util/platform.js";
 
 const log = getLogger("update-bulletin-job");
 
 const HASH_CHECKPOINT_KEY = "updates:last_processed_hash";
 const EMPTY_HASH = "empty";
-const UPDATE_BULLETIN_HINT =
-  "Check ~/.vellum/workspace/UPDATES.md — new release notes are present. Apply any assistant-facing behavior changes (new tools, deprecations, memory updates). If the user would benefit from knowing about a user-facing change, surface it only when the next topic makes it relevant — do not interrupt them with a proactive message. When you're done processing, delete the file by running `cd ~/.vellum/workspace && rm UPDATES.md` (the bare-filename `rm UPDATES.md` is auto-allowed; path-qualified deletes are not). A silent no-op is preferable to low-signal chatter.";
+
+function updateBulletinHint(): string {
+  const workspace = getWorkspaceDirDisplay();
+  return `Check ${workspace}/UPDATES.md — new release notes are present. Apply any assistant-facing behavior changes (new tools, deprecations, memory updates). If the user would benefit from knowing about a user-facing change, surface it only when the next topic makes it relevant — do not interrupt them with a proactive message. When you're done processing, delete the file by running \`cd ${workspace} && rm UPDATES.md\` (the bare-filename \`rm UPDATES.md\` is auto-allowed; path-qualified deletes are not). A silent no-op is preferable to low-signal chatter.`;
+}
 
 type ReadResult =
   | { kind: "missing" }
@@ -65,32 +71,32 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
     return;
   }
 
-  const updatesPath = getWorkspacePromptPath("UPDATES.md");
-  const initial = readTrimmedContent(updatesPath);
-
-  if (initial.kind === "error") {
-    log.warn(
-      { err: initial.err, path: updatesPath },
-      "update-bulletin-job: failed to read UPDATES.md; leaving checkpoint unchanged so next startup retries",
-    );
-    return;
-  }
-
-  if (initial.kind === "missing" || initial.content.length === 0) {
-    const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
-    if (stored !== EMPTY_HASH) {
-      setMemoryCheckpoint(HASH_CHECKPOINT_KEY, EMPTY_HASH);
-    }
-    return;
-  }
-
-  const currentHash = computeHash(initial.content);
-  const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
-  if (stored === currentHash) {
-    return;
-  }
-
   try {
+    const updatesPath = getWorkspacePromptPath("UPDATES.md");
+    const initial = readTrimmedContent(updatesPath);
+
+    if (initial.kind === "error") {
+      log.warn(
+        { err: initial.err, path: updatesPath },
+        "update-bulletin-job: failed to read UPDATES.md; leaving checkpoint unchanged so next startup retries",
+      );
+      return;
+    }
+
+    if (initial.kind === "missing" || initial.content.length === 0) {
+      const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
+      if (stored !== EMPTY_HASH) {
+        setMemoryCheckpoint(HASH_CHECKPOINT_KEY, EMPTY_HASH);
+      }
+      return;
+    }
+
+    const currentHash = computeHash(initial.content);
+    const stored = getMemoryCheckpoint(HASH_CHECKPOINT_KEY);
+    if (stored === currentHash) {
+      return;
+    }
+
     const conv = bootstrapConversation({
       conversationType: "background",
       source: "updates_bulletin",
@@ -100,7 +106,7 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
     });
     const wakeResult = await wakeAgentForOpportunity({
       conversationId: conv.id,
-      hint: UPDATE_BULLETIN_HINT,
+      hint: updateBulletinHint(),
       source: "updates_bulletin",
     });
 


### PR DESCRIPTION
Address Codex + Devin on #26399. (1) UPDATE_BULLETIN_HINT hardcoded ~/.vellum/workspace/UPDATES.md, breaking multi-instance and Docker where BASE_DATA_DIR/VELLUM_WORKSPACE_DIR overrides the path. Convert to a function that uses getWorkspaceDirDisplay() for runtime-correct paths. (2) getMemoryCheckpoint/setMemoryCheckpoint calls sat outside the try/catch but call into Drizzle/SQLite which can throw — violating the JSDoc never-throws contract. Wrap the entire body so callers can safely fire-and-forget.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
