### PR TITLE
docs(architecture): refresh key-files table after update-bulletin cleanup

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -764,12 +764,14 @@ Release-driven update notification system that dispatches a background conversat
 
 **Key source files:**
 
-| File                                  | Purpose                                                              |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| `src/workspace/migrations/`           | Per-release migrations that append release notes to `UPDATES.md`     |
-| `src/workspace/migrations/registry.ts`| Append-only `WORKSPACE_MIGRATIONS` registry                          |
-| `src/prompts/update-bulletin-job.ts`  | `runUpdateBulletinJobIfNeeded()` — hash check and background dispatch |
-| `src/permissions/defaults.ts`         | Auto-allow rules for file_read/write/edit + rm UPDATES.md            |
+| File                                   | Purpose                                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------------------- |
+| `src/workspace/migrations/`            | Per-release migrations that append release notes to `UPDATES.md`                       |
+| `src/workspace/migrations/registry.ts` | Append-only `WORKSPACE_MIGRATIONS` registry                                            |
+| `src/prompts/update-bulletin-job.ts`   | `runUpdateBulletinJobIfNeeded()` — hash check, background dispatch, and checkpoint update |
+| `src/daemon/lifecycle.ts`              | Fire-and-forget dispatch of `runUpdateBulletinJobIfNeeded()` after DB init at startup  |
+| `src/config/schemas/updates.ts`        | `updates.enabled` config toggle (defaults to `true`; disables the background dispatch) |
+| `src/permissions/defaults.ts`          | Auto-allow rules for file_read/write/edit + bare-filename `rm UPDATES.md`              |
 
 ---
 


### PR DESCRIPTION
Address Devin on #26398. Reconcile the key-source-files table in ARCHITECTURE.md to reflect the current state of assistant/src/prompts/ after the updates-bg-job plan deleted obsolete helpers (update-bulletin-format.ts, update-bulletin-state.ts, update-bulletin-template-path.ts, templates/UPDATES.md). Codex asked to revert the docs to the old materialization story — discarded as it would contradict the merged plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
