### PR TITLE
fix(macos): trigger web-search invalidation warning on model-only changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -66,11 +66,12 @@ struct InferenceServiceCard: View {
         authManager.isAuthenticated
     }
 
-    /// True when changing inference mode/provider would invalidate the current web search config.
+    /// True when changing inference mode/provider/model would invalidate the current web search config.
     private var wouldInvalidateWebSearch: Bool {
         let modeChanging = draftMode != store.inferenceMode
         let providerChanging = draftProvider != store.selectedInferenceProvider
-        guard modeChanging || providerChanging else { return false }
+        let modelChanging = draftModel != store.selectedModel
+        guard modeChanging || providerChanging || modelChanging else { return false }
 
         // Switching to Your Own inference while web search is Managed
         // (managed web search requires managed inference).
@@ -85,10 +86,14 @@ struct InferenceServiceCard: View {
                 return true
             }
         }
-        // Switching providers while web search uses Provider Native — invalidate
-        // when the new provider cannot support native web search.
+        // Switching providers OR models while web search uses Provider Native —
+        // invalidate when the new provider/model combo cannot support native
+        // web search. Model-only switches matter because routing providers
+        // like OpenRouter flip native capability based on the model prefix
+        // (e.g. `anthropic/*` supports native search, `openai/*` does not)
+        // while the provider ID stays the same.
         // Skip when web search is in managed mode (webSearchProvider is stale).
-        if providerChanging && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
+        if (providerChanging || modelChanging) && store.webSearchMode == "your-own" && store.webSearchProvider == "inference-provider-native" {
             if !store.isNativeWebSearchCapable(draftProvider, model: draftModel) {
                 return true
             }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -168,15 +168,28 @@ struct WebSearchServiceCard: View {
         .onChange(of: store.selectedInferenceProvider) { _, newProvider in
             // Auto-correct when the inference provider changes to one that
             // does not support native web search while provider-native is selected.
+            // Persist the fix so the daemon's services.web-search.provider does
+            // not remain pinned to "inference-provider-native" while the new
+            // provider can't support it — otherwise getWebSearchProvider falls
+            // back to Perplexity and breaks search for users without a key.
             if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(newProvider, model: store.selectedModel) {
                 draftProvider = "perplexity"
+                if store.webSearchProvider == "inference-provider-native" {
+                    store.setWebSearchProvider("perplexity")
+                    initialProvider = "perplexity"
+                }
             }
         }
         .onChange(of: store.selectedModel) { _, newModel in
             // Auto-correct when the model changes to one that breaks native web search
             // for the current provider (e.g. OpenRouter switching off an `anthropic/*` model).
+            // Persist the fix — see comment on selectedInferenceProvider above.
             if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(store.selectedInferenceProvider, model: newModel) {
                 draftProvider = "perplexity"
+                if store.webSearchProvider == "inference-provider-native" {
+                    store.setWebSearchProvider("perplexity")
+                    initialProvider = "perplexity"
+                }
             }
         }
     }


### PR DESCRIPTION
Address Codex + Devin on #26294. wouldInvalidateWebSearch short-circuited when only the model changed within an unchanged provider, so switching anthropic/* → openai/* in OpenRouter silently left services.web-search.provider = inference-provider-native while the new model doesn't support it. getWebSearchProvider then fell back to Perplexity, breaking search for users without a Perplexity key. Now invalidate when the model change drops native-web-search capability.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
