### PR TITLE
fix(meet): plug late-socket leak in MeetAudioIngest.start()

### DIFF
--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -312,6 +312,18 @@ export class MeetAudioIngest {
       this.socketPath = null;
       throw err;
     }
+    // If stop() was called concurrently while listen() was in flight, it
+    // already observed this.server === null and finished, so the freshly
+    // returned `server` would be orphaned if we assigned it. Close it
+    // locally and bail out.
+    if (this.stopped) {
+      try {
+        await server.close();
+      } catch (err) {
+        log.warn({ err }, "MeetAudioIngest: server close after stop threw");
+      }
+      return;
+    }
     this.server = server;
 
     server.onError((err) => {


### PR DESCRIPTION
Follow-up to Codex P2 on #25772.

Codex P1 (unhandled rejection on audioIngestPromise) and the stopped-guards after createTranscriber() / transcriber.start() were already addressed in #26277. The remaining gap: if stop() ran between await this.listen(socketPath) returning and the this.server = server assignment, the fresh socket server was never closed — stop() had already observed this.server === null and finished, so the late server was orphaned.

This PR adds a stopped-guard immediately after await this.listen(...) that closes the returned server locally and bails out, matching the pattern the task from #25772 review asked for.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
