### PR TITLE
fix(llm-callsite): wrap guardian/approval generators in CallSiteRoutingProvider; sync self-info fallback model

### DIFF
--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -1,5 +1,7 @@
 import { loadConfig } from "../config/loader.js";
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import { getProvider, listProviders } from "../providers/registry.js";
+import type { Provider } from "../providers/types.js";
 import {
   APPROVAL_COPY_MAX_TOKENS,
   APPROVAL_COPY_SYSTEM_PROMPT,
@@ -89,12 +91,15 @@ const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
 export function createApprovalCopyGenerator(): ApprovalCopyGenerator {
   return async (context, options = {}) => {
     const config = loadConfig();
-    let provider;
+    let baseProvider: Provider;
     try {
-      provider = getProvider(config.llm.default.provider);
+      baseProvider = getProvider(config.llm.default.provider);
     } catch {
       return null;
     }
+    // Wrap so per-call `callSite` can route to an alternative provider
+    // transport when `llm.callSites.<id>.provider` overrides the default.
+    const provider = wrapWithCallSiteRouting(baseProvider);
 
     const fallbackText =
       options.fallbackText?.trim() || getFallbackMessage(context);
@@ -145,7 +150,9 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     if (!listProviders().includes(config.llm.default.provider)) {
       throw new Error("No provider available for approval conversation");
     }
-    const provider = getProvider(config.llm.default.provider);
+    const provider = wrapWithCallSiteRouting(
+      getProvider(config.llm.default.provider),
+    );
 
     const pendingDescription = context.pendingApprovals
       .map((p) => `- Request ${p.requestId}: tool "${p.toolName}"`)
@@ -214,4 +221,20 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     }
     return result;
   };
+}
+
+/**
+ * Wrap a base Provider so per-call `callSite` metadata can route the actual
+ * transport to a different provider when `llm.callSites.<id>.provider`
+ * differs from the default. Without this wrapper, only request metadata
+ * reflects the callSite — the HTTP transport stays bound to the default.
+ */
+function wrapWithCallSiteRouting(base: Provider): Provider {
+  return new CallSiteRoutingProvider(base, (name) => {
+    try {
+      return getProvider(name);
+    } catch {
+      return undefined;
+    }
+  });
 }

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -1,4 +1,7 @@
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import { getProvider } from "../providers/registry.js";
+import type { Provider } from "../providers/types.js";
 import {
   buildGuardianActionGenerationPrompt,
   getGuardianActionFallbackMessage,
@@ -25,8 +28,12 @@ import type {
  */
 export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator {
   return async (context, options = {}) => {
-    const provider = await getConfiguredProvider("guardianQuestionCopy");
-    if (!provider) return null;
+    const baseProvider = await getConfiguredProvider("guardianQuestionCopy");
+    if (!baseProvider) return null;
+    // Wrap so the per-call `callSite` can route to a different provider
+    // transport when `llm.callSites.guardianQuestionCopy.provider` overrides
+    // the default. Without this, callSite only affects request metadata.
+    const provider = wrapWithCallSiteRouting(baseProvider);
 
     const fallbackText =
       options.fallbackText?.trim() || getGuardianActionFallbackMessage(context);
@@ -124,10 +131,11 @@ const VALID_FOLLOWUP_DISPOSITIONS: ReadonlySet<string> = new Set([
  */
 export function createGuardianFollowUpConversationGenerator(): GuardianFollowUpConversationGenerator {
   return async (context) => {
-    const provider = await getConfiguredProvider("guardianQuestionCopy");
-    if (!provider) {
+    const baseProvider = await getConfiguredProvider("guardianQuestionCopy");
+    if (!baseProvider) {
       throw new Error("No configured provider available for follow-up conversation");
     }
+    const provider = wrapWithCallSiteRouting(baseProvider);
 
     const userPrompt = [
       `Original question from the voice call: "${context.questionText}"`,
@@ -183,4 +191,20 @@ export function createGuardianFollowUpConversationGenerator(): GuardianFollowUpC
     };
     return result;
   };
+}
+
+/**
+ * Wrap a base Provider so per-call `callSite` metadata can route the actual
+ * transport to a different provider when `llm.callSites.<id>.provider`
+ * differs from the default. Without this wrapper, only request metadata
+ * reflects the callSite — the HTTP transport stays bound to the default.
+ */
+function wrapWithCallSiteRouting(base: Provider): Provider {
+  return new CallSiteRoutingProvider(base, (name) => {
+    try {
+      return getProvider(name);
+    } catch {
+      return undefined;
+    }
+  });
 }

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -106,7 +106,7 @@ async function main(): Promise<void> {
     let config: { model?: string; provider?: string; mode?: string };
     if (raw === "(not set)" || raw === "") {
       config = {
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         provider: "anthropic",
         mode: "your-own",
       };


### PR DESCRIPTION
Address Devin on #26258. (1) guardian-action-generators.ts and approval-generators.ts pass callSite to sendMessage but obtain the provider via bare getProvider(); without CallSiteRoutingProvider wrapping, per-callSite provider overrides are silently ignored. Mirror the wrapping pattern from subagent/manager.ts. (2) skills/vellum-self-knowledge/scripts/self-info.ts hardcoded claude-opus-4-6 as the inference fallback — sync to claude-opus-4-7 to match the current schema default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
