### PR TITLE
fix(pkb-context-tracker): match file_read path resolution to avoid double-prefix

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -901,6 +901,7 @@ export async function runAgentLoopImpl(
       pkbConversation,
       pkbAutoInjectList,
       pkbRoot,
+      pkbWorkingDir: pkbActive ? ctx.workingDir : undefined,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1270,6 +1270,12 @@ export async function applyRuntimeInjections(
     pkbAutoInjectList?: string[];
     /** Absolute path to the PKB directory (e.g. `<workspace>/pkb`). */
     pkbRoot?: string;
+    /**
+     * Working directory against which relative `file_read` tool paths
+     * resolve. Required alongside `pkbConversation` + `pkbRoot` to detect
+     * workspace-relative reads like `pkb/threads.md`.
+     */
+    pkbWorkingDir?: string;
     nowScratchpad?: string | null;
     subagentStatusBlock?: string | null;
     isNonInteractive?: boolean;
@@ -1336,7 +1342,8 @@ export async function applyRuntimeInjections(
         queryVector.length > 0 &&
         options.pkbScopeId &&
         options.pkbConversation &&
-        options.pkbRoot
+        options.pkbRoot &&
+        options.pkbWorkingDir
       ) {
         try {
           const results = await searchPkbFiles(
@@ -1349,6 +1356,7 @@ export async function applyRuntimeInjections(
             options.pkbConversation,
             options.pkbAutoInjectList ?? [],
             options.pkbRoot,
+            options.pkbWorkingDir,
           );
           const pkbRoot = options.pkbRoot;
           hints = results

--- a/assistant/src/daemon/pkb-context-tracker.test.ts
+++ b/assistant/src/daemon/pkb-context-tracker.test.ts
@@ -5,7 +5,8 @@ import type { ContentBlock, Message } from "../providers/types.js";
 import type { Conversation } from "./conversation.js";
 import { getInContextPkbPaths } from "./pkb-context-tracker.js";
 
-const PKB_ROOT = path.resolve("/tmp/test-pkb-root");
+const WORKING_DIR = path.resolve("/tmp/test-pkb-root");
+const PKB_ROOT = path.join(WORKING_DIR, "pkb");
 
 // The helper only reads `conversation.messages`. Constructing a real
 // `Conversation` instance would require a full daemon setup; casting a
@@ -35,6 +36,7 @@ describe("getInContextPkbPaths", () => {
       conversation,
       ["notes/index.md", "journal/2026-04-18.md"],
       PKB_ROOT,
+      WORKING_DIR,
     );
     expect(result).toEqual(
       new Set([
@@ -49,7 +51,7 @@ describe("getInContextPkbPaths", () => {
     const conversation = makeConversation([
       assistantMessageWithBlocks([fileReadToolUse(insidePath)]),
     ]);
-    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
     expect(result).toEqual(new Set([insidePath]));
   });
 
@@ -57,7 +59,7 @@ describe("getInContextPkbPaths", () => {
     const conversation = makeConversation([
       assistantMessageWithBlocks([fileReadToolUse("/etc/hosts")]),
     ]);
-    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
     expect(result).toEqual(new Set());
   });
 
@@ -72,7 +74,7 @@ describe("getInContextPkbPaths", () => {
     const conversation = makeConversation([
       assistantMessageWithBlocks([bogus]),
     ]);
-    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
     expect(result).toEqual(new Set());
   });
 
@@ -91,7 +93,12 @@ describe("getInContextPkbPaths", () => {
     };
     const conversation = makeConversation([summaryMessage]);
     const autoInject = ["profile/identity.md"];
-    const result = getInContextPkbPaths(conversation, autoInject, PKB_ROOT);
+    const result = getInContextPkbPaths(
+      conversation,
+      autoInject,
+      PKB_ROOT,
+      WORKING_DIR,
+    );
     expect(result).toEqual(
       new Set([path.join(PKB_ROOT, "profile/identity.md")]),
     );
@@ -104,25 +111,33 @@ describe("getInContextPkbPaths", () => {
         fileReadToolUse("notes/../../../etc/shadow"),
       ]),
     ]);
-    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
     expect(result).toEqual(new Set());
   });
 
-  test("relative file_read path is NOT treated as inside pkbRoot", () => {
-    // `file_read` accepts absolute paths and paths relative to the tool's
-    // working directory — NOT to `pkbRoot`. So a relative path like
-    // `"notes.md"` is ambiguous: the actual file might have been read from
-    // `<workingDir>/notes.md`, not `<pkbRoot>/notes.md`. Marking it as
-    // in-context would false-positive and suppress hints for files the
-    // model did not actually load.
+  test("relative file_read path outside pkbRoot is excluded", () => {
+    // These are resolved against `workingDir` (matching `file_read`'s own
+    // rule), land outside `pkbRoot`, and are correctly ignored.
     const conversation = makeConversation([
       assistantMessageWithBlocks([
         fileReadToolUse("notes.md"),
         fileReadToolUse("./deep/subdir/file.md"),
       ]),
     ]);
-    const result = getInContextPkbPaths(conversation, [], PKB_ROOT);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
     expect(result).toEqual(new Set());
+  });
+
+  test("workspace-relative file_read path inside pkb/ is recognized", () => {
+    // Regression: previously `pkb/threads.md` was resolved against `pkbRoot`
+    // itself (→ `<pkbRoot>/pkb/threads.md`) and missed entirely. The model
+    // actually emits workspace-relative paths, so the tracker must resolve
+    // them against `workingDir` and then verify they fall inside `pkbRoot`.
+    const conversation = makeConversation([
+      assistantMessageWithBlocks([fileReadToolUse("pkb/threads.md")]),
+    ]);
+    const result = getInContextPkbPaths(conversation, [], PKB_ROOT, WORKING_DIR);
+    expect(result).toEqual(new Set([path.join(PKB_ROOT, "threads.md")]));
   });
 
   test("resolves relative auto-inject paths against pkbRoot", () => {
@@ -131,6 +146,7 @@ describe("getInContextPkbPaths", () => {
       conversation,
       ["./notes/relative.md"],
       PKB_ROOT,
+      WORKING_DIR,
     );
     expect(result).toEqual(
       new Set([path.join(PKB_ROOT, "notes/relative.md")]),
@@ -146,6 +162,7 @@ describe("getInContextPkbPaths", () => {
       conversation,
       ["notes/shared.md"],
       PKB_ROOT,
+      WORKING_DIR,
     );
     expect(result.size).toBe(1);
     expect(result.has(insidePath)).toBe(true);

--- a/assistant/src/daemon/pkb-context-tracker.ts
+++ b/assistant/src/daemon/pkb-context-tracker.ts
@@ -7,7 +7,9 @@
  *   1. It was explicitly auto-injected (caller supplies `autoInjectPaths`),
  *      typically via a system-reminder that embeds the file contents.
  *   2. The conversation history contains a structured `file_read` tool_use
- *      block whose `input.path` resolves to a path inside `pkbRoot`.
+ *      block whose `input.path` — resolved the same way `file_read` itself
+ *      resolves it (absolute as-is, relative against `workingDir`) — lands
+ *      inside `pkbRoot`.
  *
  * Used by the PKB system reminder so we don't suggest files the model has
  * already loaded.
@@ -72,6 +74,11 @@ function resolveInsidePkbRoot(
  * `pkbRoot`) and any `file_read` tool_use block inputs found in
  * `conversation.messages` that resolve inside `pkbRoot`.
  *
+ * `file_read` resolves its `path` argument against `workingDir` (the tool's
+ * working directory), so this helper mirrors that rule: relative tool paths
+ * are resolved against `workingDir`, absolute paths are taken as-is, and the
+ * resulting absolute path is then accepted only if it falls inside `pkbRoot`.
+ *
  * Paths outside `pkbRoot` (including `..`-traversal attempts) are excluded.
  * Tool uses whose `name` is not `file_read` are ignored.
  */
@@ -79,8 +86,10 @@ export function getInContextPkbPaths(
   conversation: PkbContextConversation,
   autoInjectPaths: string[],
   pkbRoot: string,
+  workingDir: string,
 ): Set<string> {
   const normalizedRoot = path.resolve(pkbRoot);
+  const normalizedWorkingDir = path.resolve(workingDir);
   const inContext = new Set<string>();
 
   for (const candidate of autoInjectPaths) {
@@ -96,14 +105,16 @@ export function getInContextPkbPaths(
       if (block.type !== "tool_use") continue;
       if (block.name !== FILE_READ_TOOL_NAME) continue;
       const rawPath = block.input?.path;
-      if (typeof rawPath !== "string") continue;
-      // `file_read` accepts both absolute paths and paths relative to the
-      // tool's working directory — NOT to `pkbRoot`. Resolving a relative
-      // `rawPath` against `pkbRoot` would treat e.g. `"notes.md"` as inside
-      // the PKB even if the actual read was against `workingDir/notes.md`.
-      // Only absolute paths are unambiguous here.
-      if (!path.isAbsolute(rawPath)) continue;
-      const resolved = resolveInsidePkbRoot(rawPath, normalizedRoot);
+      if (typeof rawPath !== "string" || rawPath.length === 0) continue;
+      // Mirror `file_read`'s own path resolution: absolute paths are taken
+      // as-is; relative paths resolve against the tool's working directory
+      // (NOT `pkbRoot`). Resolving relative paths against `pkbRoot` would
+      // double-prefix workspace-relative inputs like `pkb/threads.md` into
+      // `<pkbRoot>/pkb/threads.md` and miss the actually-loaded file.
+      const absolute = path.isAbsolute(rawPath)
+        ? path.resolve(rawPath)
+        : path.resolve(normalizedWorkingDir, rawPath);
+      const resolved = resolveInsidePkbRoot(absolute, normalizedRoot);
       if (resolved !== undefined) {
         inContext.add(resolved);
       }


### PR DESCRIPTION
Address Codex on #26392. getInContextPkbPaths resolved every tool path against pkbRoot, but file_read resolves against workspace root. A model emitting pkb/threads.md became <workspace>/pkb/pkb/threads.md — the in-context lookup missed the loaded file and the PKB reminder kept nagging. Now resolve relative to workingDir (matching file_read), then check the absolute path is under pkbRoot before accepting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
