### PR TITLE
fix(gateway): exempt loopback peers from auth rate limiter

### DIFF
--- a/gateway/src/__tests__/rate-limit-loopback.test.ts
+++ b/gateway/src/__tests__/rate-limit-loopback.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { AuthRateLimiter } from "../auth-rate-limiter.js";
+import { checkAuthRateLimit } from "../http/middleware/rate-limit.js";
+
+const URL_V1 = new URL("http://local/v1/assistants/foo/identity/");
+
+function blockedLimiter(ip: string, failures = 20): AuthRateLimiter {
+  const limiter = new AuthRateLimiter();
+  for (let i = 0; i < failures; i++) limiter.recordFailure(ip);
+  return limiter;
+}
+
+describe("checkAuthRateLimit loopback exemption", () => {
+  test("blocks non-loopback peers that exceed the threshold", () => {
+    const ip = "203.0.113.5";
+    const limiter = blockedLimiter(ip);
+    expect(limiter.isBlocked(ip)).toBe(true);
+
+    const res = checkAuthRateLimit(URL_V1, limiter, ip);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+  });
+
+  test("exempts plain IPv4 loopback (127.0.0.1)", () => {
+    const ip = "127.0.0.1";
+    const limiter = blockedLimiter(ip);
+    expect(limiter.isBlocked(ip)).toBe(true);
+
+    expect(checkAuthRateLimit(URL_V1, limiter, ip)).toBeNull();
+  });
+
+  test("exempts IPv4 loopback anywhere in 127.0.0.0/8", () => {
+    const ip = "127.50.1.2";
+    expect(checkAuthRateLimit(URL_V1, blockedLimiter(ip), ip)).toBeNull();
+  });
+
+  test("exempts IPv6 loopback (::1)", () => {
+    const ip = "::1";
+    expect(checkAuthRateLimit(URL_V1, blockedLimiter(ip), ip)).toBeNull();
+  });
+
+  test("exempts IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
+    const ip = "::ffff:127.0.0.1";
+    expect(checkAuthRateLimit(URL_V1, blockedLimiter(ip), ip)).toBeNull();
+  });
+
+  test("returns null for unrelated routes regardless of block state", () => {
+    const ip = "203.0.113.5";
+    const limiter = blockedLimiter(ip);
+    const res = checkAuthRateLimit(
+      new URL("http://local/v1/browser-relay"),
+      limiter,
+      ip,
+    );
+    expect(res).toBeNull();
+  });
+});

--- a/gateway/src/http/middleware/rate-limit.ts
+++ b/gateway/src/http/middleware/rate-limit.ts
@@ -1,5 +1,6 @@
 import type { AuthRateLimiter } from "../../auth-rate-limiter.js";
 import { getLogger } from "../../logger.js";
+import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 
 const log = getLogger("rate-limit");
 
@@ -7,6 +8,14 @@ const log = getLogger("rate-limit");
  * Check whether a request should be rate-limited based on prior auth failures.
  *
  * Returns a 429 Response if the client IP is blocked, or null to continue.
+ *
+ * Loopback peers (127.0.0.0/8, ::1, and IPv4-mapped IPv6 equivalents) are
+ * exempt: a misbehaving local client that can't attach a bearer token must
+ * not be able to rate-limit the whole gateway for everything else coming
+ * from the same machine (the CLI's `vellum ps`, skill HTTP calls via
+ * `$INTERNAL_GATEWAY_BASE_URL`, etc.). The auth middleware already bypasses
+ * loopback for token validation; this keeps the rate limiter consistent
+ * with that policy.
  */
 export function checkAuthRateLimit(
   url: URL,
@@ -14,6 +23,7 @@ export function checkAuthRateLimit(
   clientIp: string,
 ): Response | null {
   if (!isRateLimitedRoute(url)) return null;
+  if (isLoopbackAddress(clientIp)) return null;
 
   if (authRateLimiter.isBlocked(clientIp)) {
     log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");


### PR DESCRIPTION
## Summary
- Skip the \`isBlocked\` check in \`checkAuthRateLimit\` when the client IP is loopback (\`127.0.0.0/8\`, \`::1\`, \`::ffff:127.*\`), matching the loopback bypass that \`requireEdgeAuth\` already applies for token validation.
- Prevents a single misbehaving local client from cascading into 429 responses for every other consumer on the same machine (CLI \`vellum ps\`, skills, app health polling) — the exact symptom that surfaced as "Disconnected from Assistant" + \`vellum ps\` showing \`🔴 error (429)\` when the desktop app's bearer token was missing.
- Adds a focused test file covering plain IPv4, 127.0.0.0/8, \`::1\`, IPv4-mapped IPv6, and the non-loopback (still-blocked) case.

## Original prompt
1 and 2 in separate PRs and /create-plan for 3