### PR TITLE
fix(http-server): make method-guard branch reachable on meet events route

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1064,7 +1064,7 @@ export class RuntimeHttpServer {
     // Skill-registered routes (e.g. meet-bot event ingress). Handled before
     // JWT auth because skills may use their own auth (e.g. per-meeting bearer
     // tokens minted by a session manager).
-    const skillMatch = matchSkillRoute(path, req.method);
+    const skillMatch = matchSkillRoute(path);
     if (skillMatch) {
       return await skillMatch.route.handler(req, skillMatch.match);
     }

--- a/assistant/src/runtime/skill-route-registry.ts
+++ b/assistant/src/runtime/skill-route-registry.ts
@@ -33,15 +33,18 @@ export function registerSkillRoute(route: SkillRoute): void {
 }
 
 /**
- * Try to match an inbound request against registered skill routes.
+ * Try to match an inbound request path against registered skill routes.
  * Returns `null` if no route matches.
+ *
+ * Matching is path-only — handlers enforce their own method guards so
+ * non-matching methods get an accurate 405 with `Allow` rather than
+ * falling through to JWT auth / 404. `SkillRoute.methods` remains on
+ * the contract for documentation and registration-time logging.
  */
 export function matchSkillRoute(
   path: string,
-  method: string,
 ): { route: SkillRoute; match: RegExpMatchArray } | null {
   for (const route of routes) {
-    if (!route.methods.includes(method)) continue;
     const match = path.match(route.pattern);
     if (match) return { route, match };
   }


### PR DESCRIPTION
Address Codex P3: dispatcher only invoked the handler on POST, so the 405 branch was dead and non-POST requests returned 401/404 instead. Addresses feedback on #25759.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
