### PR TITLE
fix(pkb): namespace point IDs by scope, scope-filter deletes, index path field, self-clean on re-index

### DIFF
--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -44,12 +44,20 @@ mock.module("../../config/loader.js", () => ({
 }));
 
 // Track Qdrant deletes by capturing the filter the client sends.
-const qdrantDeleteCalls: Array<{ targetType: string; path: string }> = [];
+const qdrantDeleteCalls: Array<{
+  targetType: string;
+  path: string;
+  memoryScopeId: string;
+}> = [];
 
 mock.module("../qdrant-client.js", () => ({
   getQdrantClient: () => ({
-    deleteByTargetTypeAndPath: async (targetType: string, path: string) => {
-      qdrantDeleteCalls.push({ targetType, path });
+    deleteByTargetTypeAndPath: async (
+      targetType: string,
+      path: string,
+      memoryScopeId: string,
+    ) => {
+      qdrantDeleteCalls.push({ targetType, path, memoryScopeId });
     },
   }),
 }));
@@ -177,6 +185,7 @@ describe("scanPkbFiles", () => {
 describe("indexPkbFile", () => {
   beforeEach(() => {
     embedAndUpsertCalls.length = 0;
+    qdrantDeleteCalls.length = 0;
   });
 
   test("invokes embedAndUpsert once per chunk with pkb_file target_type", async () => {
@@ -189,7 +198,7 @@ describe("indexPkbFile", () => {
     expect(embedAndUpsertCalls).toHaveLength(1);
     const call = embedAndUpsertCalls[0];
     expect(call.targetType).toBe("pkb_file");
-    expect(call.targetId).toBe("doc.md#0");
+    expect(call.targetId).toBe("scope-xyz:doc.md#0");
     expect(call.input).toEqual({ type: "text", text: "# hello\nworld" });
     const payload = call.extraPayload as Record<string, unknown>;
     expect(payload.path).toBe("doc.md");
@@ -213,11 +222,39 @@ describe("indexPkbFile", () => {
     await indexPkbFile(root, filePath, "scope-1");
 
     expect(embedAndUpsertCalls).toHaveLength(2);
-    expect(embedAndUpsertCalls[0].targetId).toBe("big.md#0");
-    expect(embedAndUpsertCalls[1].targetId).toBe("big.md#1");
+    expect(embedAndUpsertCalls[0].targetId).toBe("scope-1:big.md#0");
+    expect(embedAndUpsertCalls[1].targetId).toBe("scope-1:big.md#1");
     expect(embedAndUpsertCalls.every((c) => c.targetType === "pkb_file")).toBe(
       true,
     );
+  });
+
+  test("scope-namespaces target ids so two scopes indexing the same path do not collide", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-scope-"));
+    const filePath = join(root, "shared.md");
+    await writeFile(filePath, "# shared");
+
+    await indexPkbFile(root, filePath, "alpha");
+    await indexPkbFile(root, filePath, "beta");
+
+    expect(embedAndUpsertCalls).toHaveLength(2);
+    const ids = embedAndUpsertCalls.map((c) => c.targetId);
+    expect(ids).toEqual(["alpha:shared.md#0", "beta:shared.md#0"]);
+  });
+
+  test("deletes prior chunks for this (scope, path) before upserting new ones", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-shrink-"));
+    const filePath = join(root, "shrinking.md");
+    await writeFile(filePath, "# just one");
+
+    await indexPkbFile(root, filePath, "scope-xyz");
+
+    expect(qdrantDeleteCalls).toHaveLength(1);
+    expect(qdrantDeleteCalls[0]).toEqual({
+      targetType: "pkb_file",
+      path: "shrinking.md",
+      memoryScopeId: "scope-xyz",
+    });
   });
 });
 
@@ -226,13 +263,14 @@ describe("deletePkbFilePoints", () => {
     qdrantDeleteCalls.length = 0;
   });
 
-  test("sends a filter with both target_type and path predicates", async () => {
-    await deletePkbFilePoints("notes/todo.md");
+  test("sends a filter with target_type, path, and memory_scope_id predicates", async () => {
+    await deletePkbFilePoints("notes/todo.md", "scope-xyz");
 
     expect(qdrantDeleteCalls).toHaveLength(1);
     expect(qdrantDeleteCalls[0]).toEqual({
       targetType: "pkb_file",
       path: "notes/todo.md",
+      memoryScopeId: "scope-xyz",
     });
   });
 });

--- a/assistant/src/memory/pkb/pkb-index.ts
+++ b/assistant/src/memory/pkb/pkb-index.ts
@@ -179,6 +179,12 @@ export function chunkPkbFile(content: string): string[] {
  * Read a PKB file, chunk it, and upsert each chunk to Qdrant via the shared
  * embedding pipeline. `relPath` in the payload is computed relative to
  * `pkbRoot`.
+ *
+ * Self-cleaning: deletes any previously-indexed chunks for this (scope, path)
+ * before upserting the new ones. This keeps the index consistent when a file
+ * shrinks — e.g. a prior run wrote chunks `#0..#3` and the new content only
+ * produces `#0..#1`; without the pre-delete, `#2` and `#3` would linger as
+ * orphaned stale results in search.
  */
 export async function indexPkbFile(
   pkbRoot: string,
@@ -194,9 +200,15 @@ export async function indexPkbFile(
 
   const config = getConfig();
 
+  await deletePkbFilePoints(relPath, memoryScopeId);
+
   for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
     const chunk = chunks[chunkIndex];
-    const targetId = `${relPath}#${chunkIndex}`;
+    // Scope-namespace the target_id so `qdrant.upsert` — which dedupes on
+    // (target_type, target_id) — cannot collapse distinct scopes' chunks of
+    // the same relpath into a single point. Without the scope prefix, the
+    // second scope to index a shared path would overwrite the first's vectors.
+    const targetId = `${memoryScopeId}:${relPath}#${chunkIndex}`;
     await embedAndUpsert(
       config,
       PKB_TARGET_TYPE,
@@ -214,13 +226,18 @@ export async function indexPkbFile(
 }
 
 /**
- * Remove every Qdrant point belonging to a given PKB file (all chunks).
- * `relPath` must match the `path` payload written by `indexPkbFile`.
+ * Remove every Qdrant point belonging to a given PKB file (all chunks) within
+ * a single memory scope. `relPath` must match the `path` payload written by
+ * `indexPkbFile`. The `memoryScopeId` filter is required — omitting it would
+ * wipe that relpath's chunks across every scope that indexes the same file.
  */
-export async function deletePkbFilePoints(relPath: string): Promise<void> {
+export async function deletePkbFilePoints(
+  relPath: string,
+  memoryScopeId: string,
+): Promise<void> {
   const qdrant = getQdrantClient();
   await withQdrantBreaker(() =>
-    qdrant.deleteByTargetTypeAndPath(PKB_TARGET_TYPE, relPath),
+    qdrant.deleteByTargetTypeAndPath(PKB_TARGET_TYPE, relPath, memoryScopeId),
   );
 }
 

--- a/assistant/src/memory/pkb/pkb-reconcile.test.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.test.ts
@@ -30,7 +30,7 @@ mock.module("../jobs/embed-pkb-file.js", () => ({
 
 // Capture calls into the fake Qdrant client.
 let scrollPoints: Array<{ id: string; payload: Record<string, unknown> }> = [];
-const deleteCalls: string[] = [];
+const deleteCalls: Array<{ path: string; memoryScopeId: string }> = [];
 
 mock.module("../qdrant-client.js", () => ({
   getQdrantClient: () => ({
@@ -38,8 +38,12 @@ mock.module("../qdrant-client.js", () => ({
       _targetType: string,
       _options?: { memoryScopeId?: string },
     ) => scrollPoints,
-    deleteByTargetTypeAndPath: async (_targetType: string, path: string) => {
-      deleteCalls.push(path);
+    deleteByTargetTypeAndPath: async (
+      _targetType: string,
+      path: string,
+      memoryScopeId: string,
+    ) => {
+      deleteCalls.push({ path, memoryScopeId });
     },
   }),
 }));
@@ -186,7 +190,9 @@ describe("reconcilePkbIndex", () => {
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(1);
-    expect(deleteCalls).toEqual(["gone.md"]);
+    expect(deleteCalls).toEqual([
+      { path: "gone.md", memoryScopeId: "default" },
+    ]);
     expect(enqueuedJobs).toHaveLength(0);
   });
 

--- a/assistant/src/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.ts
@@ -104,7 +104,7 @@ export async function reconcilePkbIndex(
   for (const relPath of indexedByPath.keys()) {
     if (!diskByPath.has(relPath)) {
       try {
-        await deletePkbFilePoints(relPath);
+        await deletePkbFilePoints(relPath, memoryScopeId);
         deleted++;
       } catch (err) {
         log.warn(

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -503,12 +503,15 @@ export class VellumQdrantClient {
   }
 
   /**
-   * Delete all vectors matching both a target_type and a payload path.
-   * Used to remove every chunk belonging to a single PKB file.
+   * Delete all vectors matching target_type, payload path, and memory scope.
+   * Used to remove every chunk belonging to a single PKB file within a scope.
+   * The memory_scope_id filter is required — omitting it would wipe that
+   * path's chunks across every scope that happens to index the same relpath.
    */
   async deleteByTargetTypeAndPath(
     targetType: string,
     path: string,
+    memoryScopeId: string,
   ): Promise<void> {
     await this.ensureCollection();
 
@@ -519,6 +522,7 @@ export class VellumQdrantClient {
           must: [
             { key: "target_type", match: { value: targetType } },
             { key: "path", match: { value: path } },
+            { key: "memory_scope_id", match: { value: memoryScopeId } },
           ],
         },
       });
@@ -643,6 +647,10 @@ export class VellumQdrantClient {
       }),
       this.client.createPayloadIndex(this.collection, {
         field_name: "memory_scope_id",
+        field_schema: "keyword",
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: "path",
         field_schema: "keyword",
       }),
     ]);


### PR DESCRIPTION
Address Codex (×2) + Devin (×2) on #26397. (1) target_id used relPath#chunkIndex without memory_scope_id, so qdrant.upsert deduped across scopes — second scope's index wiped first scope's vectors. Now include memory_scope_id in target_id. (2) deleteByTargetTypeAndPath filtered only on (target_type, path), wiping all scopes when one scope deleted — add memory_scope_id to filter and thread through callers. (3) ensurePayloadIndexes lacked an index on path, so the new path-filtered delete brute-forced — register a keyword payload index for path. (4) indexPkbFile didn't clean stale higher-indexed chunks when files shrink, leaving orphan chunks searchable — make indexPkbFile call deletePkbFilePoints first so it's self-cleaning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
