### PR TITLE
docs(agent-loop): clarify priorAssistantHadVisibleText returns true for any prior visible text

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -471,6 +471,14 @@ export class AgentLoop {
         // a side-effect tool like `remember`), an empty follow-up is the model
         // correctly ending its turn — nudging would mislead it into thinking
         // its earlier text didn't land and cause a verbatim re-send.
+        //
+        // Note: we check ANY prior assistant turn in history, not just the
+        // most recent one. In multi-step tool-use chains (say-something →
+        // call-tool → call-another-tool → end), the "say-something" text
+        // lives on an earlier assistant turn while the most recent assistant
+        // turn is a pure tool_use with no text. Restricting the check to the
+        // most recent assistant turn would falsely nudge in that case and
+        // trigger a duplicate re-send of text the user already saw.
         const hasVisibleText = response.content.some(
           (block) => block.type === "text" && block.text.trim().length > 0,
         );


### PR DESCRIPTION
Address Devin on #26275. PR #26275 changed priorAssistantHadVisibleText from .some() on the most-recent assistant message to true-if-ANY-prior-visible-text. Behavior matches the inline comment but the broader semantics shift wasn't called out. Strengthen the comment to explain why we want any-prior (so an empty later turn in a tool-use chain isn't nudged when an earlier turn already responded). Heartbeat dual-emit and LATENCY_OPTIMIZED schema defaults flagged in the same review were already restored/changed in #26286 — verified, no further action.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
