### PR TITLE
fix(macos): always reset apiKeyText on provider change in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -310,6 +310,11 @@ struct InferenceServiceCard: View {
                 return
             }
             guard didInitialSync else { return }
+            // Always clear any unsaved API key text on a real provider
+            // transition — it belongs to the previous provider's context
+            // and must not leak forward, even when the model itself is
+            // preserved by the cross-provider validity check below.
+            apiKeyText = ""
             // Defense-in-depth: preserve draftModel when it is already a
             // valid ID in the new provider's catalog. Cross-provider model
             // IDs essentially never overlap, so this still triggers the
@@ -322,7 +327,6 @@ struct InferenceServiceCard: View {
                 let defaultModel = store.dynamicProviderDefaultModel(newProvider)
                 let fallback = providerModels.first?.id ?? ""
                 draftModel = defaultModel.isEmpty ? fallback : defaultModel
-                apiKeyText = ""
             }
         }
         .onChange(of: draftMode) { _, newMode in


### PR DESCRIPTION
Address Codex on #26320. The new model-preservation guard short-circuited the apiKeyText reset whenever the model was still valid in the new provider's catalog. A draftMode→draftProvider cascade (managed-mode flip with a pre-validated model) left stale API key text from the old provider attached to the new context. Decouple the apiKeyText reset from the model-preservation conditional so it always runs on real provider transitions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
