### PR TITLE
fix(macos): reset isLiveScrolling when MessageListScrollObserver swaps views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -135,6 +135,14 @@ struct MessageListScrollObserver: NSViewRepresentable {
             // conversation switch destroys + recreates the ScrollView) does
             // not treat the new content height as a delta over the old.
             self.lastContentHeight = 0
+            // Reset live-scroll tracking: if the old scroll view emitted
+            // `willStartLiveScrollNotification` but was replaced before
+            // `didEndLiveScrollNotification` fired, the flag would stay
+            // stuck `true` on the coordinator and suppress anchor
+            // compensation in the new view until the user performed a
+            // fresh full scroll cycle.
+            self.isLiveScrolling = false
+            self.lastSnapshot = nil
             installObservers()
         }
 


### PR DESCRIPTION
Address Codex + Devin on #26324. attachIfNeeded reset lastContentHeight when swapping scroll views but didn't reset isLiveScrolling. If the old view's willStartLiveScrollNotification fired but didEndLiveScrollNotification hasn't, the flag stayed true on the coordinator and suppressed anchor compensation in the new view until the user performed another full scroll cycle — causing visible drift during streaming on conversation switches. Now reset isLiveScrolling alongside lastContentHeight.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
