### PR TITLE
fix(llm-callsite): seed latency-optimized callsites on fresh install

### DIFF
--- a/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
+++ b/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
- * Seed latency-optimized call-site defaults for existing workspaces.
+ * Seed latency-optimized call-site defaults for background LLM tasks.
  *
  * Migration 038 consolidated scattered LLM config keys but only wrote
  * per-call-site entries when the legacy config had *explicit* overrides.
@@ -13,9 +13,21 @@ import type { WorkspaceMigration } from "./types.js";
  * entries, causing them to fall through to `llm.default` (opus with max
  * effort) — a significant cost and latency regression.
  *
- * This migration seeds the missing entries with the appropriate fast
- * model for the workspace's configured provider. Existing user-defined
- * overrides are preserved.
+ * Seeds the missing entries with the appropriate fast model for the
+ * workspace's configured provider. Runs in two modes:
+ *
+ *   1. **Existing workspace** (config.json present): read provider from
+ *      `llm.default.provider`, merge seeds into `llm.callSites` without
+ *      overwriting any user-defined overrides.
+ *   2. **Fresh install** (config.json absent): write a minimal starter
+ *      config with just the callSite seeds, using the default provider
+ *      (anthropic — same as the schema default). `loadConfig()` runs
+ *      after migrations and backfills the remaining schema defaults via
+ *      `deepMergeMissing`, which preserves our seeded callSites.
+ *
+ * Without the fresh-install branch, new users permanently fall through
+ * to `llm.default` (opus + max effort) because `LLMSchema.callSites`
+ * defaults to `{}` and nothing else seeds the latency-optimized entries.
  */
 export const seedLatencyCallSiteDefaultsMigration: WorkspaceMigration = {
   id: "040-seed-latency-callsite-defaults",
@@ -23,25 +35,29 @@ export const seedLatencyCallSiteDefaultsMigration: WorkspaceMigration = {
     "Seed latency-optimized call-site defaults for background LLM tasks",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
-    if (!existsSync(configPath)) return;
+    const configExisted = existsSync(configPath);
 
-    let config: Record<string, unknown>;
-    try {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
-      config = raw as Record<string, unknown>;
-    } catch {
-      return;
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
     }
 
-    const llm = readObject(config.llm);
-    if (llm === null) return;
-
+    const llm = readObject(config.llm) ?? {};
     const defaultBlock = readObject(llm.default);
-    if (defaultBlock === null) return;
 
-    const provider =
-      readString(defaultBlock.provider) ?? "anthropic";
+    // Fresh install: no config.json yet, so no explicit provider — fall
+    // back to the schema default ("anthropic"). A platform-provided
+    // `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` override that specifies a
+    // non-anthropic provider should also set `llm.callSites` in that
+    // override file, since it runs after migrations via
+    // `mergeDefaultWorkspaceConfig` and will overwrite our seeds.
+    const provider = readString(defaultBlock?.provider) ?? "anthropic";
     const fastModel = resolveLatencyModel(provider);
     if (fastModel === undefined) return;
 


### PR DESCRIPTION
Address Codex + Devin feedback on #26286.

PR #26286 changed `LLMSchema.callSites` default from `LATENCY_OPTIMIZED_CALLSITE_DEFAULTS` to `{}` to restore schema invariants, but that opened a new regression for fresh installs: migration 040 (which seeds latency-optimized callsites) short-circuits when `config.json` doesn't exist yet, so new users permanently fell through to `llm.default` (Opus + max effort) for background callsites like `notificationDecision`, `interactionClassifier`, `guardianQuestionCopy`, etc. — the exact cost/latency regression migration 040 was created to prevent.

This extends migration 040 to handle the fresh-install case: when config.json is missing, write a minimal starter config containing just `llm.callSites` seeds. `loadConfig()` runs after migrations and backfills the remaining schema defaults via `deepMergeMissing`, which preserves the seeded callSites while filling in `llm.default`, `profiles`, etc. on disk.

Provider-aware: reads `llm.default.provider` from existing config when present (existing-workspace path unchanged); falls back to `anthropic` for fresh installs (matches the schema default). This preserves the cross-provider-correctness posture from Codex's separate #26275 concern — the right model is picked per provider via the existing `PROVIDER_LATENCY_MODELS` table rather than hardcoded Anthropic IDs baked into the schema.

No changes to the schema — `LLMSchema.callSites` stays `.default({})`, preserving the invariant work from #26286.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
