### PR TITLE
fix(file_write): gate PKB index enqueue on .md extension

### DIFF
--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -117,7 +117,11 @@ class FileWriteTool implements Tool {
     // was written successfully and that is the user-facing contract.
     try {
       const pkbRoot = join(getWorkspaceDir(), "pkb");
-      if (isInsidePkbRoot(filePath, pkbRoot)) {
+      // Gate on `.md` to match `scanPkbFiles`, which only walks markdown.
+      // Indexing `pkb/*.json` (or any other extension) here would produce
+      // chunks the reconciler can't see, leading to orphaned vectors and
+      // pointless embedding work.
+      if (filePath.endsWith(".md") && isInsidePkbRoot(filePath, pkbRoot)) {
         enqueuePkbIndexJob({
           pkbRoot,
           absPath: filePath,


### PR DESCRIPTION
Address Codex on #26411. (1) Scope-clobber concern resolved by #26472 which namespaced PKB target_id by memory_scope_id — verified. (2) The file_write hook enqueued indexing for any path under pkb/, but scanPkbFiles only walks *.md, so non-markdown writes (pkb/*.json etc.) created embedding jobs producing inconsistent vectors and queue load. Gate the enqueue on .md extension to match the scanner.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
