### PR TITLE
fix(pkb-reconcile): treat hash disagreement as stale; gate on qdrantStarted; canonical scroll retry

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -781,6 +781,30 @@ export async function runDaemon(): Promise<void> {
             "Qdrant client initialization failed — memory features will be degraded",
           );
         }
+
+        // Reconcile the PKB Qdrant index against the on-disk tree. Kept
+        // inside the `qdrantStarted` guard so we don't call
+        // `getQdrantClient()` (which throws "not initialized") on every
+        // startup when Qdrant is unavailable. Fire-and-forget so enqueued
+        // re-index jobs drain in the background and first-turn latency
+        // stays unaffected.
+        void (async () => {
+          try {
+            const { reconcilePkbIndex } = await import(
+              "../memory/pkb/pkb-reconcile.js"
+            );
+            const { PKB_WORKSPACE_SCOPE } = await import(
+              "../memory/pkb/types.js"
+            );
+            const pkbRoot = join(getWorkspaceDir(), "pkb");
+            await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
+          } catch (err) {
+            log.warn(
+              { err },
+              "PKB index reconciliation failed — continuing startup",
+            );
+          }
+        })();
       }
 
       log.info("Daemon startup: starting memory worker");
@@ -830,27 +854,6 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Graph bootstrap check failed — continuing");
       }
 
-      // Reconcile the PKB Qdrant index against the on-disk tree. Runs after
-      // Qdrant is ready so the scroll query can succeed; fire-and-forget so
-      // enqueued re-index jobs drain in the background and first-turn latency
-      // stays unaffected.
-      void (async () => {
-        try {
-          const { reconcilePkbIndex } = await import(
-            "../memory/pkb/pkb-reconcile.js"
-          );
-          const { PKB_WORKSPACE_SCOPE } = await import(
-            "../memory/pkb/types.js"
-          );
-          const pkbRoot = join(getWorkspaceDir(), "pkb");
-          await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
-        } catch (err) {
-          log.warn(
-            { err },
-            "PKB index reconciliation failed — continuing startup",
-          );
-        }
-      })();
     }
 
     registerWatcherProviders();

--- a/assistant/src/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/memory/pkb/pkb-reconcile.ts
@@ -65,13 +65,20 @@ export async function reconcilePkbIndex(
   }
 
   // Build the indexed view keyed by relative path. Qdrant stores one point
-  // per (path, chunk_index), so multiple scroll results can share the same
-  // path; we only need the content_hash, which is identical across chunks.
+  // per (path, chunk_index); every chunk for a given file SHOULD share a
+  // single content_hash, but an interrupted/partial index run can leave
+  // chunks of the same file with differing hashes. Track whether any two
+  // chunks disagree (`mixed`) so we can force a re-index — otherwise stale
+  // chunks remain searchable as long as the first chunk's hash happened to
+  // match the current disk content.
   const qdrant = getQdrantClient();
   const points = await qdrant.scrollByTargetType(PKB_TARGET_TYPE, {
     memoryScopeId,
   });
-  const indexedByPath = new Map<string, { contentHash: string }>();
+  const indexedByPath = new Map<
+    string,
+    { contentHash: string; mixed: boolean }
+  >();
   for (const { payload } of points) {
     const path = typeof payload.path === "string" ? payload.path : undefined;
     const contentHash =
@@ -79,18 +86,26 @@ export async function reconcilePkbIndex(
         ? payload.content_hash
         : undefined;
     if (!path || !contentHash) continue;
-    if (!indexedByPath.has(path)) {
-      indexedByPath.set(path, { contentHash });
+    const existing = indexedByPath.get(path);
+    if (!existing) {
+      indexedByPath.set(path, { contentHash, mixed: false });
+    } else if (existing.contentHash !== contentHash) {
+      existing.mixed = true;
     }
   }
 
   let enqueued = 0;
   let deleted = 0;
 
-  // Re-index files that are new or have changed on disk.
+  // Re-index files that are new, have changed on disk, or have mixed
+  // per-chunk hashes in the index (partial/interrupted prior indexing).
   for (const [relPath, disk] of diskByPath) {
     const indexed = indexedByPath.get(relPath);
-    if (!indexed || indexed.contentHash !== disk.contentHash) {
+    if (
+      !indexed ||
+      indexed.mixed ||
+      indexed.contentHash !== disk.contentHash
+    ) {
       enqueuePkbIndexJob({
         pkbRoot,
         absPath: join(pkbRoot, relPath),

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -716,29 +716,42 @@ export class VellumQdrantClient {
       must_not: [{ key: "_meta", match: { value: true } }],
     };
 
-    const out: Array<{ id: string; payload: Record<string, unknown> }> = [];
-    let offset: string | number | undefined = undefined;
     // Guard against a pathological pagination loop.
     const maxIterations = 10_000;
-    for (let i = 0; i < maxIterations; i++) {
-      const result = await this.client.scroll(this.collection, {
-        filter,
-        limit: batchSize,
-        with_payload: true,
-        with_vector: false,
-        ...(offset !== undefined ? { offset } : {}),
-      });
-      for (const point of result.points) {
-        const id =
-          typeof point.id === "string" ? point.id : String(point.id);
-        const payload = (point.payload ?? {}) as Record<string, unknown>;
-        out.push({ id, payload });
+    const doScroll = async () => {
+      const out: Array<{ id: string; payload: Record<string, unknown> }> = [];
+      let offset: string | number | undefined = undefined;
+      for (let i = 0; i < maxIterations; i++) {
+        const result = await this.client.scroll(this.collection, {
+          filter,
+          limit: batchSize,
+          with_payload: true,
+          with_vector: false,
+          ...(offset !== undefined ? { offset } : {}),
+        });
+        for (const point of result.points) {
+          const id =
+            typeof point.id === "string" ? point.id : String(point.id);
+          const payload = (point.payload ?? {}) as Record<string, unknown>;
+          out.push({ id, payload });
+        }
+        const next = result.next_page_offset;
+        if (next == null) break;
+        offset = typeof next === "string" ? next : (next as number);
       }
-      const next = result.next_page_offset;
-      if (next == null) break;
-      offset = typeof next === "string" ? next : (next as number);
+      return out;
+    };
+
+    try {
+      return await doScroll();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        return await doScroll();
+      }
+      throw err;
     }
-    return out;
   }
 
   private async findByTarget(


### PR DESCRIPTION
Address Codex + Devin (×2) on #26410. (1) reconcile stored only the first content_hash per path; mixed hashes across chunks of the same file (after interrupted indexing) caused stale chunks to remain searchable. Now treat any per-path hash disagreement as stale and re-index. (2) The reconciliation IIFE in lifecycle.ts ran outside the qdrantStarted guard — getQdrantClient() threw 'not initialized' on every Qdrant-down startup, producing a misleading warning. Move inside the guard. (3) scrollByTargetType lacked the isCollectionMissing/ensureCollection retry that every other public client method uses; a mid-scroll collection drop didn't self-heal. Wrap in the canonical retry try/catch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
