### PR TITLE
docs(pkb): refresh PKB_WORKSPACE_SCOPE rationale post scope-namespacing

### DIFF
--- a/assistant/src/memory/pkb/types.ts
+++ b/assistant/src/memory/pkb/types.ts
@@ -10,12 +10,14 @@ export const PKB_TARGET_TYPE = "pkb_file" as const;
 /**
  * Sentinel `memory_scope_id` under which ALL PKB points are indexed and
  * searched. PKB files live at workspace level (one copy on disk shared by
- * every conversation in the workspace), so per-conversation scoping would
- * cause same-file writes from different scopes to silently overwrite each
- * other's Qdrant points (upsert dedupes by `target_type + target_id`, which
- * does not include the scope). Pinning every PKB write and search to a
- * single sentinel keeps the index consistent regardless of which
- * conversation triggered the write.
+ * every conversation in the workspace), so every writer — the `remember`
+ * tool, file writes, startup reconciliation — must pin to the same scope or
+ * search would return a fragmented view of the workspace's knowledge base.
+ *
+ * Note: `indexPkbFile` now scope-namespaces each chunk's `target_id` (see
+ * `pkb-index.ts`), so a stray per-conversation scope would no longer clobber
+ * another scope's vectors at the Qdrant level. The sentinel is still required
+ * for the semantic reason above: PKB is workspace-shared, not per-scope.
  */
 export const PKB_WORKSPACE_SCOPE = "_pkb_workspace" as const;
 


### PR DESCRIPTION
## Summary
- Follow-up on review feedback from #26408.
- The Codex P1 cross-scope clobber concern is fully resolved by #26472 (which scope-namespaces each PKB chunk's `target_id` and filters deletes by scope) combined with the pre-existing sentinel-scope design: the `remember` tool, filesystem writes, and startup reconciliation all already pin to `PKB_WORKSPACE_SCOPE`, so cross-scope clobber is impossible.
- No behavioral change needed; however, the `PKB_WORKSPACE_SCOPE` comment justified the sentinel by saying 'upsert dedupes by target_type + target_id, which does not include the scope' — that is now stale, since #26472 made `target_id` encode the scope. Updated the comment to state the correct (still-valid) reason: PKB is workspace-shared, not per-conversation-scoped, so every writer must agree on one scope to avoid fragmented search.

## Files
- `assistant/src/memory/pkb/types.ts` — doc comment refresh only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
