### PR TITLE
test(pkb-hints): pass pkbWorkingDir in conversation-runtime-assembly tests

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1800,9 +1800,11 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
 
   const FLAT_REMINDER = buildPkbReminder([]);
 
-  // Use a platform-agnostic absolute root so the tests work on macOS and
-  // Linux runners alike.
-  const pkbRoot = "/tmp/fake-pkb-root";
+  // Use a platform-agnostic absolute workspace root so the tests work on
+  // macOS and Linux runners alike. `pkbRoot` sits under `pkbWorkingDir` to
+  // mirror production, where `pkbRoot = join(workingDir, "pkb")`.
+  const pkbWorkingDir = "/tmp/fake-workspace";
+  const pkbRoot = `${pkbWorkingDir}/pkb`;
 
   function makePkbOptions(overrides: Record<string, unknown> = {}) {
     return {
@@ -1811,6 +1813,7 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
       pkbScopeId: "scope-1",
       pkbConversation: { messages: baseMessages },
       pkbRoot,
+      pkbWorkingDir,
       pkbAutoInjectList: [],
       ...overrides,
     };
@@ -2013,6 +2016,7 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
       pkbScopeId: "scope-1",
       pkbConversation: preCompactionConversation,
       pkbRoot,
+      pkbWorkingDir,
       pkbAutoInjectList: [],
     });
     // Unwrap the injected reminder from the last user message.
@@ -2057,6 +2061,7 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
       pkbScopeId: "scope-1",
       pkbConversation: postCompactionConversation,
       pkbRoot,
+      pkbWorkingDir,
       pkbAutoInjectList: [],
     });
     const rebuiltTexts = extractTexts(rebuiltResult);


### PR DESCRIPTION
## Summary
- Four `applyRuntimeInjections — PKB relevance hints` tests went red on main after #26467 added a required `pkbWorkingDir` option to activate the hint path. The tests never passed it, so the hint branch short-circuited and the flat fallback reminder was emitted instead of the expected file bullets.
- Align the test setup with `pkb-context-tracker.test.ts`: declare `pkbWorkingDir` and make `pkbRoot = <pkbWorkingDir>/pkb` (mirrors production `pkbRoot = join(workingDir, "pkb")`), then thread `pkbWorkingDir` through `makePkbOptions` and the two explicit options objects in the compaction test.
- Test-only change; no production code touched.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24615742755/job/71977536186
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
