### PR TITLE
fix(macos): reset MessageHeightCache on conversation switch + correct flag default and description

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -171,6 +171,10 @@ extension MessageListView {
         highlightedMessageId = nil
         scrollState.highlightDismissTask?.cancel()
         scrollState.highlightDismissTask = nil
+        // `.id(conversationId)` is on the inner ScrollView, so this view's
+        // `@State` survives conversation switches. Fixed-sentinel row IDs
+        // (e.g. queuedMarker) would otherwise reuse heights across chats.
+        messageHeightCache.reset()
         // Reset scroll state for the new conversation.
         scrollState.reset(for: conversationId)
         // Capture the new conversation's activity phase so a conversation

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -108,9 +108,13 @@ struct MessageListView: View {
     @State var filePreviewExpansionStore = FilePreviewExpansionStore()
     /// Caches each transcript row's measured height so the LazyVStack reports
     /// an accurate `contentSize` for off-screen cells. Gated on the
-    /// `message-height-cache` macOS feature flag. Reset on conversation
-    /// switch (via `.id(conversationId)`), column-width change, and
-    /// typography-generation change.
+    /// `message-height-cache` macOS feature flag. `.id(conversationId)` is
+    /// applied to the inner `ScrollView` (not `MessageListView`), so SwiftUI
+    /// preserves this `@State` across conversation switches — the cache must
+    /// be cleared explicitly in `handleConversationSwitched()` to avoid
+    /// reusing heights keyed by fixed-sentinel UUIDs (e.g. queuedMarker)
+    /// across conversations. Also reset on column-width and typography
+    /// changes, which reflow every row.
     @State var messageHeightCache = MessageHeightCache()
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State var resizeScrollTask: Task<Void, Never>?

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -366,8 +366,8 @@
       "scope": "macos",
       "key": "message-height-cache",
       "label": "Message Height Cache",
-      "description": "Render the transcript with a plain VStack instead of LazyVStack so scrollContentHeight is always the true sum of row heights. Fixes the estimator drift that caused jerky scroll near the top of a conversation. Tradeoff: eager layout, slower first paint on very long conversations.",
-      "defaultEnabled": true
+      "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned — the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout — every row measures up-front, which can stall for many seconds to minutes on very long conversations. Off by default; opt-in experiment only.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
Address Codex + Devin on #26379. (1) MessageHeightCache lived as @State on MessageListView and was only reset on width/typography changes; SwiftUI preserves MessageListView across conversation switches (.id(conversationId) is on the inner ScrollView), so a queued-marker height (fixed sentinel UUID) leaked across conversations. Reset cache from handleConversationSwitched() and correct the docstring. (2) message-height-cache defaultEnabled was true, making the transcript a plain VStack (eager) for all users — violates clients/AGENTS.md rule against eager containers in unbounded ScrollView lists and contradicts MessageListContentView's multi-minute hang warning. Flip to false to keep this opt-in. (3) Flag description in registry claimed rows were frame-pinned with clip risk, but CachedHeightRow no longer pins frames (removed for overlap). Correct the description to describe the real mechanism (LazyVStack→VStack swap). Frame-pinning regression risks raised by Codex/Devin first comments — discarded as the change was already removed before merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
