### PR TITLE
perf(macos): cache scroll-debug-overlay flag to remove per-tick lock from scroll geometry handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -38,7 +38,11 @@ extension MessageListView {
         }
 
         // --- Debug metrics (flag-gated — hot path pays nothing when off) ---
-        if MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") {
+        // Read the cached `isScrollDebugOverlayEnabled` @State on the view
+        // instead of calling `MacOSClientFeatureFlagManager.shared.isEnabled(...)`
+        // per tick — the flag manager takes an `NSLock` and linearly scans
+        // registry keys, which adds jitter to the very path being instrumented.
+        if isScrollDebugOverlayEnabled {
             scrollState.recordDebugSnapshot(
                 offsetY: newState.contentOffsetY,
                 contentH: newState.contentHeight,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -121,6 +121,12 @@ struct MessageListView: View {
     /// Native SwiftUI scroll position struct (macOS 15+). Replaces
     /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
     @State var scrollPosition = ScrollPosition()
+    /// Cached `scroll-debug-overlay` flag value. Read from the hot scroll
+    /// path (geometry tick, anchor shift, anchor decision) to skip HUD work
+    /// without taking the flag-manager's `NSLock` and linearly scanning
+    /// registry keys per tick. Seeded on first appear and refreshed via
+    /// `.assistantFeatureFlagDidChange` — same pattern as `ScrollDebugOverlayView`.
+    @State var isScrollDebugOverlayEnabled: Bool = false
 
     // MARK: - Body
 
@@ -152,18 +158,19 @@ struct MessageListView: View {
                                     // page's height would race the snap.
                                     !scrollState.isPaginationInFlight
                                 },
-                                onAnchorShift: { [scrollState] in
+                                onAnchorShift: { [scrollState, isScrollDebugOverlayEnabled] in
                                     // Debug-only counter for anchor-preserver
-                                    // activations. Flag-gated so the hot path
-                                    // pays nothing when the overlay is off.
-                                    guard MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") else { return }
+                                    // activations. Gated on the cached flag
+                                    // so the hot path doesn't take the flag
+                                    // manager's `NSLock` per shift.
+                                    guard isScrollDebugOverlayEnabled else { return }
                                     scrollState.recordDebugAnchorShift()
                                 },
-                                onAnchorDecision: { [scrollState] event in
+                                onAnchorDecision: { [scrollState, isScrollDebugOverlayEnabled] event in
                                     // Debug-only full-decision log. Captures
                                     // skips (shrinks, live-scroll gate, etc.)
                                     // plus applies, with pre/post offsets.
-                                    guard MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay") else { return }
+                                    guard isScrollDebugOverlayEnabled else { return }
                                     scrollState.recordAnchorDecision(event)
                                 }
                             )
@@ -209,6 +216,11 @@ struct MessageListView: View {
             }
             .onAppear {
                 handleAppear()
+                isScrollDebugOverlayEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
+                guard let key = notification.userInfo?["key"] as? String, key == "scroll-debug-overlay" else { return }
+                isScrollDebugOverlayEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
             }
             .onDisappear {
                 scrollState.cancelAll()


### PR DESCRIPTION
Address Codex on #26358. handleScrollGeometryUpdate called MacOSClientFeatureFlagManager.shared.isEnabled per scroll tick, taking an NSLock and linearly scanning registry keys — even with the overlay off, the hot scroll loop paid synchronous lock+scan work and added jitter to the very path being instrumented. Cache the flag in coordinator @State refreshed via assistantFeatureFlagDidChange (the same pattern ScrollDebugOverlayView already uses). Codex's separate idle-redraw concern was already addressed by #26361 — discarded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
