### PR TITLE
feat(macos): add `.authFailed` case to `AssistantStatus`

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
@@ -5,6 +5,7 @@ enum AssistantStatus {
     case thinking
     case error
     case disconnected
+    case authFailed
 
     var menuTitle: String {
         menuTitle(assistantName: nil)
@@ -17,6 +18,7 @@ enum AssistantStatus {
         case .thinking: return "\(name) is thinking..."
         case .error: return "\(name) encountered an error"
         case .disconnected: return "Disconnected from \(name)"
+        case .authFailed: return "Authentication failed — click to re-pair \(name)"
         }
     }
 
@@ -26,6 +28,7 @@ enum AssistantStatus {
         case .thinking: return .systemGreen
         case .error: return .systemRed
         case .disconnected: return .systemOrange
+        case .authFailed: return .systemYellow
         }
     }
 
@@ -35,6 +38,7 @@ enum AssistantStatus {
         case .thinking:     return Self.thinkingIcon
         case .error:        return Self.errorIcon
         case .disconnected: return Self.disconnectedIcon
+        case .authFailed:   return Self.authFailedIcon
         }
     }
 
@@ -42,6 +46,7 @@ enum AssistantStatus {
     private static let thinkingIcon     = makeStatusDot(color: .systemGreen)
     private static let errorIcon        = makeStatusDot(color: .systemRed)
     private static let disconnectedIcon = makeStatusDot(color: .systemOrange)
+    private static let authFailedIcon   = makeStatusDot(color: .systemYellow)
 
     private static func makeStatusDot(color: NSColor) -> NSImage {
         let size: CGFloat = 8

--- a/clients/macos/vellum-assistantTests/AssistantStatusTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantStatusTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class AssistantStatusTests: XCTestCase {
+
+    func testAuthFailedMenuTitleContainsAuthenticationAndAssistantName() {
+        let title = AssistantStatus.authFailed.menuTitle(assistantName: "Vellum")
+        XCTAssertTrue(title.contains("Authentication"), "menuTitle should mention Authentication: \(title)")
+        XCTAssertTrue(title.contains("Vellum"), "menuTitle should include the assistant name: \(title)")
+    }
+
+    func testAuthFailedStatusColorIsDistinctFromDisconnected() {
+        XCTAssertNotEqual(
+            AssistantStatus.authFailed.statusColor,
+            AssistantStatus.disconnected.statusColor,
+            "authFailed and disconnected should be visually distinct"
+        )
+    }
+
+    func testAuthFailedDoesNotPulse() {
+        XCTAssertFalse(AssistantStatus.authFailed.shouldPulse, "authFailed is a steady state, not animated")
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `.authFailed` case to AssistantStatus enum, distinct from `.disconnected`.
- Wire it into menuTitle/statusColor/statusIcon with yellow dot and 'Authentication failed — click to re-pair' string.
- Add AssistantStatusTests covering the new case.

Part of plan: macos-auth-failed-state.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
