### PR TITLE
feat(shared): add AuthFailureTracker for sustained-401/429 detection

### DIFF
--- a/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class AuthFailureTrackerTests: XCTestCase {
+    /// Helper that exposes a mutable `Date` the tracker reads via its injected clock.
+    private final class Clock {
+        var now: Date
+        init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+            self.now = start
+        }
+        func advance(_ seconds: TimeInterval) {
+            now = now.addingTimeInterval(seconds)
+        }
+    }
+
+    private func makeTracker(
+        windowSeconds: TimeInterval = 30,
+        minFailures: Int = 4,
+        clock: Clock
+    ) -> AuthFailureTracker {
+        AuthFailureTracker(
+            windowSeconds: windowSeconds,
+            minFailures: minFailures,
+            now: { clock.now }
+        )
+    }
+
+    /// (a) A single 401 does NOT trip `isAuthFailed`.
+    func testSingleFailureDoesNotTrip() {
+        let clock = Clock()
+        let tracker = makeTracker(clock: clock)
+
+        tracker.recordFailure(statusCode: 401, path: "/api/ping")
+
+        XCTAssertFalse(tracker.isAuthFailed)
+        XCTAssertEqual(tracker.lastStatusCode, 401)
+        XCTAssertEqual(tracker.lastPath, "/api/ping")
+    }
+
+    /// (b) `minFailures` 401s inside the window DOES trip it.
+    func testMinFailuresInWindowTrips() {
+        let clock = Clock()
+        let tracker = makeTracker(clock: clock)
+
+        for _ in 0..<4 {
+            tracker.recordFailure(statusCode: 401, path: "/api/ping")
+            clock.advance(1)
+        }
+
+        XCTAssertTrue(tracker.isAuthFailed)
+    }
+
+    /// (c) Failures outside the window are pruned and do not count.
+    func testFailuresOutsideWindowArePruned() {
+        let clock = Clock()
+        let tracker = makeTracker(windowSeconds: 30, minFailures: 4, clock: clock)
+
+        // Three old failures that will fall outside the window.
+        for _ in 0..<3 {
+            tracker.recordFailure(statusCode: 401, path: "/api/old")
+            clock.advance(1)
+        }
+
+        // Jump past the window.
+        clock.advance(60)
+
+        // One new failure inside the current window.
+        tracker.recordFailure(statusCode: 401, path: "/api/new")
+
+        // Only one live entry -> not tripped, even though we've recorded 4 total.
+        XCTAssertFalse(tracker.isAuthFailed)
+    }
+
+    /// (d) A 500 or 404 does not accumulate.
+    func testNonAuthStatusCodesDoNotAccumulate() {
+        let clock = Clock()
+        let tracker = makeTracker(clock: clock)
+
+        for code in [500, 404, 502, 403, 400, 418] {
+            tracker.recordFailure(statusCode: code, path: "/api/other")
+            clock.advance(1)
+        }
+
+        XCTAssertFalse(tracker.isAuthFailed)
+        // lastStatusCode / lastPath should remain nil because nothing was recorded.
+        XCTAssertNil(tracker.lastStatusCode)
+        XCTAssertNil(tracker.lastPath)
+    }
+
+    /// (e) `recordSuccess()` resets the tracker back to `isAuthFailed == false` immediately.
+    func testRecordSuccessResetsTracker() {
+        let clock = Clock()
+        let tracker = makeTracker(clock: clock)
+
+        for _ in 0..<4 {
+            tracker.recordFailure(statusCode: 401, path: "/api/ping")
+            clock.advance(1)
+        }
+        XCTAssertTrue(tracker.isAuthFailed)
+
+        tracker.recordSuccess()
+
+        XCTAssertFalse(tracker.isAuthFailed)
+    }
+
+    /// (f) `429` counts the same as `401`.
+    func test429CountsSameAs401() {
+        let clock = Clock()
+        let tracker = makeTracker(clock: clock)
+
+        for _ in 0..<4 {
+            tracker.recordFailure(statusCode: 429, path: "/api/ping")
+            clock.advance(1)
+        }
+
+        XCTAssertTrue(tracker.isAuthFailed)
+        XCTAssertEqual(tracker.lastStatusCode, 429)
+    }
+}

--- a/clients/shared/Network/AuthFailureTracker.swift
+++ b/clients/shared/Network/AuthFailureTracker.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Sliding-window tracker for authentication failures (HTTP 401 / 429).
+///
+/// A single transient 401 or 429 is not enough to conclude the auth path is
+/// broken — proxies, brief credential refreshes, and rate limits all produce
+/// isolated failures that recover on their own. `AuthFailureTracker` accumulates
+/// failures within a rolling time window and only reports `isAuthFailed == true`
+/// once at least `minFailures` have occurred inside `windowSeconds`. Any 2xx
+/// response (signalled via `recordSuccess()`) immediately clears the window.
+///
+/// The clock is injected so tests can drive time deterministically without
+/// relying on `sleep`. All mutation is serialized through a private
+/// `DispatchQueue` so the tracker is safe to call from a periodic health-check
+/// task and from request-completion callbacks concurrently.
+public final class AuthFailureTracker {
+    private struct Entry {
+        let timestamp: Date
+        let statusCode: Int
+        let path: String
+    }
+
+    private let windowSeconds: TimeInterval
+    private let minFailures: Int
+    private let now: () -> Date
+    private let queue = DispatchQueue(label: "ai.vellum.AuthFailureTracker")
+
+    private var entries: [Entry] = []
+    private var _lastStatusCode: Int?
+    private var _lastPath: String?
+
+    public init(
+        windowSeconds: TimeInterval = 30,
+        minFailures: Int = 4,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.windowSeconds = windowSeconds
+        self.minFailures = minFailures
+        self.now = now
+    }
+
+    /// Record a completed HTTP response. Only 401 and 429 contribute to the
+    /// sliding window; every other status code is ignored. Entries older than
+    /// `windowSeconds` are pruned on every call.
+    public func recordFailure(statusCode: Int, path: String) {
+        guard statusCode == 401 || statusCode == 429 else { return }
+        queue.sync {
+            let current = now()
+            pruneLocked(relativeTo: current)
+            entries.append(Entry(timestamp: current, statusCode: statusCode, path: path))
+            _lastStatusCode = statusCode
+            _lastPath = path
+        }
+    }
+
+    /// Clear the entire window. Any 2xx health-check response means the auth
+    /// path is working again, so accumulated failures should be discarded.
+    public func recordSuccess() {
+        queue.sync {
+            entries.removeAll()
+        }
+    }
+
+    /// `true` iff the post-prune count of in-window failures is at least
+    /// `minFailures`.
+    public var isAuthFailed: Bool {
+        queue.sync {
+            pruneLocked(relativeTo: now())
+            return entries.count >= minFailures
+        }
+    }
+
+    /// Most recent failure's status code, or `nil` if none has been recorded.
+    public var lastStatusCode: Int? {
+        queue.sync { _lastStatusCode }
+    }
+
+    /// Most recent failure's path, or `nil` if none has been recorded.
+    public var lastPath: String? {
+        queue.sync { _lastPath }
+    }
+
+    // MARK: - Private
+
+    private func pruneLocked(relativeTo current: Date) {
+        let cutoff = current.addingTimeInterval(-windowSeconds)
+        entries.removeAll { $0.timestamp < cutoff }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AuthFailureTracker` in `clients/shared/Network/` — sliding-window counter that trips only after sustained 401/429 responses (not a single transient failure).
- Thread-safe via a private serial DispatchQueue; clock injectable for deterministic tests.
- Six unit tests covering single-failure, window-trip, pruning, non-auth status codes, success reset, and 429 equivalence.

Part of plan: macos-auth-failed-state.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
