### PR TITLE
feat(macos): track sustained 401/429 in GatewayConnectionManager

### DIFF
--- a/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
+++ b/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Unit tests for the `isAuthFailed` signal on `GatewayConnectionManager`.
+///
+/// Rather than stand up a `URLProtocol` fake, these tests drive the same
+/// internal code path that `performHealthCheck()` uses when an HTTP outcome
+/// is decoded. See the `_testIngestHealthStatus` hook on GCM.
+@MainActor
+final class GatewayConnectionManagerAuthTests: XCTestCase {
+
+    // MARK: - Sustained failures trip the signal
+
+    func testFourSequential401sTripsIsAuthFailed() {
+        let gcm = GatewayConnectionManager()
+        XCTAssertFalse(gcm.isAuthFailed, "Fresh GCM should not be in auth-failed state")
+
+        for _ in 0..<4 {
+            gcm._testIngestHealthStatus(401)
+        }
+
+        XCTAssertTrue(gcm.isAuthFailed, "Four sequential 401s should trip isAuthFailed")
+    }
+
+    // MARK: - 200 after trip clears the signal
+
+    func testSuccessAfterTripClearsIsAuthFailed() {
+        let gcm = GatewayConnectionManager()
+
+        for _ in 0..<4 {
+            gcm._testIngestHealthStatus(401)
+        }
+        XCTAssertTrue(gcm.isAuthFailed)
+
+        gcm._testIngestHealthStatus(200)
+
+        XCTAssertFalse(gcm.isAuthFailed, "A 200 after trip should clear isAuthFailed")
+    }
+
+    // MARK: - A single 401 followed by 200 never trips
+
+    func testSingle401ThenSuccessNeverTrips() {
+        let gcm = GatewayConnectionManager()
+
+        gcm._testIngestHealthStatus(401)
+        XCTAssertFalse(gcm.isAuthFailed, "One 401 alone must not trip")
+
+        gcm._testIngestHealthStatus(200)
+        XCTAssertFalse(gcm.isAuthFailed, "200 after a single 401 must leave isAuthFailed false")
+    }
+}

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -32,6 +32,11 @@ public final class GatewayConnectionManager {
     // MARK: - Observable State
 
     public var isConnected: Bool = false
+    /// Independent signal from `isConnected`: flips to `true` after sustained
+    /// auth failures (401/429) observed by `authFailureTracker`. Cleared on
+    /// the next successful health check. Observe alongside `isConnected` —
+    /// the two represent orthogonal failure modes of "unable to make progress".
+    public var isAuthFailed: Bool = false
     public var isConnecting: Bool = false
     public internal(set) var assistantVersion: String?
     public internal(set) var versionMismatch: Bool = false
@@ -85,6 +90,7 @@ public final class GatewayConnectionManager {
     // MARK: - Health Check
 
     @ObservationIgnored private var healthCheckTask: Task<Void, Never>?
+    @ObservationIgnored private let authFailureTracker = AuthFailureTracker()
     private let healthCheckInterval: TimeInterval = 15.0
     @ObservationIgnored private var shouldReconnect = true
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
@@ -285,6 +291,11 @@ public final class GatewayConnectionManager {
 
         // Reset published state
         isConnected = false
+        if isAuthFailed {
+            isAuthFailed = false
+            log.info("AuthFailureTracker cleared")
+        }
+        authFailureTracker.recordSuccess()
         assistantVersion = nil
         versionMismatch = false
         isUpdateInProgress = false
@@ -366,15 +377,24 @@ public final class GatewayConnectionManager {
             consecutiveHealthCheckSuccesses = 0
             log.error("Health check client error: \(error.localizedDescription, privacy: .public)")
             setConnected(false)
+            updateAuthFailedSignal()
             throw ConnectionError.healthCheckFailed
         } catch {
             consecutiveHealthCheckSuccesses = 0
             log.error("Health check failed: \(error.localizedDescription, privacy: .public)")
             setConnected(false)
+            updateAuthFailedSignal()
             throw ConnectionError.healthCheckFailed
         }
 
         guard (200..<300).contains(outcome.statusCode) else {
+            // Feed auth-relevant statuses into the sliding-window tracker.
+            // AuthFailureTracker itself filters to the 401/429 it cares about;
+            // passing 403 here is harmless and keeps the call site honest
+            // about which statuses look like auth problems.
+            if outcome.statusCode == 401 || outcome.statusCode == 403 || outcome.statusCode == 429 {
+                authFailureTracker.recordFailure(statusCode: outcome.statusCode, path: "/v1/health")
+            }
             if outcome.statusCode == 401 {
                 handleAuthenticationFailure()
             } else if outcome.statusCode == 404, isManaged {
@@ -382,8 +402,13 @@ public final class GatewayConnectionManager {
             }
             consecutiveHealthCheckSuccesses = 0
             setConnected(false)
+            updateAuthFailedSignal()
             throw ConnectionError.healthCheckFailed
         }
+
+        // 2xx — auth is working. Any accumulated window is cleared.
+        authFailureTracker.recordSuccess()
+        updateAuthFailedSignal()
 
         if let newVersion = outcome.version, newVersion != assistantVersion {
             assistantVersion = newVersion
@@ -395,6 +420,39 @@ public final class GatewayConnectionManager {
             log.info("Health check passed")
         }
         setConnected(true)
+    }
+
+    /// Reconciles `isAuthFailed` against the tracker's current state and logs
+    /// the single transition lines. Idempotent — safe to call on every health
+    /// check cycle. The two signals (`isConnected`, `isAuthFailed`) are
+    /// independent; a tripped auth signal never forces `isConnected = false`
+    /// on its own and vice-versa.
+    private func updateAuthFailedSignal() {
+        let tripped = authFailureTracker.isAuthFailed
+        guard tripped != isAuthFailed else { return }
+        isAuthFailed = tripped
+        if tripped {
+            let status = authFailureTracker.lastStatusCode ?? -1
+            let path = authFailureTracker.lastPath ?? "?"
+            log.warning("AuthFailureTracker tripped: status=\(status, privacy: .public) path=\(path, privacy: .public) window=30 failures=4")
+        } else {
+            log.info("AuthFailureTracker cleared")
+        }
+    }
+
+    // MARK: - Test Hooks
+
+    /// Internal hook used by unit tests to drive the same code path as
+    /// `performHealthCheck()` without standing up a URLProtocol fake. Mirrors
+    /// the tracker-update + signal-update behavior used on real HTTP
+    /// outcomes. Production code must not call this.
+    internal func _testIngestHealthStatus(_ statusCode: Int) {
+        if (200..<300).contains(statusCode) {
+            authFailureTracker.recordSuccess()
+        } else if statusCode == 401 || statusCode == 403 || statusCode == 429 {
+            authFailureTracker.recordFailure(statusCode: statusCode, path: "/v1/health")
+        }
+        updateAuthFailedSignal()
     }
 
     private func startHealthCheckLoop() {


### PR DESCRIPTION
## Summary
- Wire AuthFailureTracker into GatewayConnectionManager; record 401/403/429 responses from health checks and reset on 2xx.
- Expose `@Published isAuthFailed: Bool` as an independent signal from `isConnected`.
- Two transition log lines (tripped / cleared) for observability.
- Unit tests drive the transitions deterministically.

Part of plan: macos-auth-failed-state.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
