### PR TITLE
feat(gmail-skill): add Gmail API client, shared utilities, and MIME builder

### DIFF
--- a/skills/gmail/scripts/lib/common.ts
+++ b/skills/gmail/scripts/lib/common.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+
+/**
+ * Shared utilities for gmail scripts.
+ * Provides CLI argument parsing, JSON output helpers, and common patterns.
+ */
+
+/** Parse `--key value` and `--flag` CLI arguments. */
+export function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      result[key] = true;
+    } else {
+      result[key] = next;
+      i++;
+    }
+  }
+  return result;
+}
+
+/** Write JSON to stdout. */
+export function printJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data) + "\n");
+}
+
+/** Write `{ ok: false, error: message }` to stdout and exit. */
+export function printError(message: string): void {
+  printJson({ ok: false, error: message });
+  process.exit(1);
+}
+
+/** Write `{ ok: true, data }` to stdout. */
+export function ok(data: unknown): void {
+  printJson({ ok: true, data });
+}
+
+/** Extract a required string argument or call `printError`. */
+export function requireArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    printError(`Missing required argument: --${name}`);
+    // printError calls process.exit(1), but TypeScript doesn't know that
+    throw new Error("unreachable");
+  }
+  return value;
+}
+
+/** Extract an optional string argument. */
+export function optionalArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Split comma-separated values, trim whitespace. */
+export function parseCsv(value: string): string[] {
+  return value.split(",").map((s) => s.trim());
+}

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env bun
+
+/**
+ * Authenticated Gmail API client.
+ * Uses `assistant oauth request` under the hood for portable OAuth.
+ */
+
+export interface GmailRequestOptions {
+  method?: string;
+  path: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  account?: string;
+  headers?: Record<string, string>;
+}
+
+export interface GmailResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+export interface GmailMessage {
+  id: string;
+  threadId?: string;
+  internalDate?: string;
+  payload?: {
+    headers?: Array<{ name: string; value: string }>;
+    parts?: GmailMessagePart[];
+    body?: { data?: string; attachmentId?: string; size?: number };
+  };
+  labelIds?: string[];
+}
+
+export interface GmailMessagePart {
+  partId?: string;
+  mimeType?: string;
+  filename?: string;
+  body?: { data?: string; attachmentId?: string; size?: number };
+  parts?: GmailMessagePart[];
+}
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1_000;
+const IDEMPOTENT_METHODS = new Set([
+  "GET",
+  "HEAD",
+  "PUT",
+  "DELETE",
+  "OPTIONS",
+  "PATCH",
+]);
+const BATCH_CONCURRENCY = 10;
+
+/**
+ * Execute an authenticated Gmail API request via `assistant oauth request`.
+ * Retries 429 and 5xx errors with exponential backoff for idempotent methods.
+ */
+export async function gmailRequest<T = unknown>(
+  opts: GmailRequestOptions,
+): Promise<GmailResponse<T>> {
+  const method = (opts.method ?? "GET").toUpperCase();
+  const canRetry = IDEMPOTENT_METHODS.has(method);
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const args: string[] = [
+      "assistant",
+      "oauth",
+      "request",
+      "--provider",
+      "google",
+    ];
+
+    args.push("-X", method);
+
+    if (opts.body !== undefined) {
+      args.push("-d", JSON.stringify(opts.body));
+      args.push("-H", "Content-Type: application/json");
+    }
+
+    if (opts.headers) {
+      for (const [key, value] of Object.entries(opts.headers)) {
+        args.push("-H", `${key}: ${value}`);
+      }
+    }
+
+    if (opts.account) {
+      args.push("--account", opts.account);
+    }
+
+    let path = opts.path;
+    if (opts.query && Object.keys(opts.query).length > 0) {
+      const qs = new URLSearchParams(opts.query).toString();
+      path += "?" + qs;
+    }
+
+    args.push(path);
+    args.push("--json");
+
+    let proc: ReturnType<typeof Bun.spawn>;
+    try {
+      proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    } catch (err) {
+      throw new Error(
+        `Failed to spawn assistant oauth request: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    let result: {
+      ok: boolean;
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+    };
+    try {
+      result = JSON.parse(stdout);
+    } catch (err) {
+      if (exitCode !== 0) {
+        throw new Error(
+          `assistant oauth request failed (exit ${exitCode}): ${stderr || stdout}`,
+        );
+      }
+      throw new Error(
+        `Failed to parse assistant oauth request output: ${err instanceof Error ? err.message : String(err)}. stdout: ${stdout}`,
+      );
+    }
+
+    // Retry on 429 (rate limit) and 5xx (server error) for idempotent methods
+    const isRetryable =
+      result.status === 429 || (result.status >= 500 && result.status < 600);
+    if (canRetry && isRetryable && attempt < MAX_RETRIES) {
+      const retryAfter = result.headers?.["retry-after"];
+      const delayMs = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+      await new Promise((r) => setTimeout(r, delayMs));
+      continue;
+    }
+
+    return {
+      ok: result.ok,
+      status: result.status,
+      data: result.body as T,
+    };
+  }
+
+  // Should not be reached, but satisfy TypeScript
+  throw new Error("Retry loop exhausted without returning");
+}
+
+/** Convenience wrapper for GET requests. */
+export async function gmailGet<T = unknown>(
+  path: string,
+  query?: Record<string, string>,
+  account?: string,
+): Promise<GmailResponse<T>> {
+  return gmailRequest<T>({ method: "GET", path, query, account });
+}
+
+/** Convenience wrapper for POST requests. */
+export async function gmailPost<T = unknown>(
+  path: string,
+  body: unknown,
+  account?: string,
+): Promise<GmailResponse<T>> {
+  return gmailRequest<T>({ method: "POST", path, body, account });
+}
+
+/** Convenience wrapper for PUT requests. */
+export async function gmailPut<T = unknown>(
+  path: string,
+  body: unknown,
+  account?: string,
+): Promise<GmailResponse<T>> {
+  return gmailRequest<T>({ method: "PUT", path, body, account });
+}
+
+/** Convenience wrapper for DELETE requests. */
+export async function gmailDelete(
+  path: string,
+  account?: string,
+): Promise<GmailResponse<void>> {
+  return gmailRequest<void>({ method: "DELETE", path, account });
+}
+
+/**
+ * Fetch multiple messages individually with bounded concurrency.
+ * Processes messages in waves of BATCH_CONCURRENCY (10) at a time.
+ * Supports AbortSignal for cancellation between waves.
+ */
+export async function batchFetchMessages(
+  messageIds: string[],
+  format: string,
+  metadataHeaders?: string[],
+  account?: string,
+  signal?: AbortSignal,
+): Promise<GmailMessage[]> {
+  const results: GmailMessage[] = [];
+
+  for (let i = 0; i < messageIds.length; i += BATCH_CONCURRENCY) {
+    if (signal?.aborted) break;
+
+    const wave = messageIds.slice(i, i + BATCH_CONCURRENCY);
+    const waveResults = await Promise.all(
+      wave.map(async (id) => {
+        const query: Record<string, string> = { format };
+        if (metadataHeaders && metadataHeaders.length > 0) {
+          query.metadataHeaders = metadataHeaders.join(",");
+        }
+        const response = await gmailGet<GmailMessage>(
+          `/messages/${id}`,
+          query,
+          account,
+        );
+        return response.ok ? response.data : null;
+      }),
+    );
+
+    for (const msg of waveResults) {
+      if (msg) results.push(msg);
+    }
+  }
+
+  return results;
+}

--- a/skills/gmail/scripts/lib/mime-builder.ts
+++ b/skills/gmail/scripts/lib/mime-builder.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+
+/**
+ * Pure-function MIME builder for multipart messages with attachments.
+ * Returns a base64url-encoded string suitable for the Gmail API's `raw` field.
+ */
+
+import { randomBytes } from "node:crypto";
+
+export interface MimeAttachment {
+  filename: string;
+  mimeType: string;
+  data: Buffer;
+}
+
+export interface MimeMessageOptions {
+  to: string;
+  subject: string;
+  body: string;
+  inReplyTo?: string;
+  cc?: string;
+  bcc?: string;
+  attachments: MimeAttachment[];
+}
+
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+/** Convert a Buffer to base64url encoding (URL-safe, no padding). */
+export function toBase64Url(input: Buffer): string {
+  return input
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Build a multipart/mixed MIME message with attachments.
+ * Returns a base64url-encoded string ready for Gmail's messages.send `raw` field.
+ */
+export function buildMultipartMime(options: MimeMessageOptions): string {
+  const { to, subject, body, inReplyTo, cc, bcc, attachments } = options;
+  const boundary = `----=_Part_${randomBytes(16).toString("hex")}`;
+
+  const sanitizedTo = sanitizeHeaderValue(to);
+  const sanitizedSubject = sanitizeHeaderValue(subject);
+  const sanitizedCc = cc ? sanitizeHeaderValue(cc) : undefined;
+  const sanitizedBcc = bcc ? sanitizeHeaderValue(bcc) : undefined;
+  const sanitizedInReplyTo = inReplyTo
+    ? sanitizeHeaderValue(inReplyTo)
+    : undefined;
+
+  const headers = [
+    `To: ${sanitizedTo}`,
+    `Subject: ${sanitizedSubject}`,
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+  ];
+  if (sanitizedCc) headers.push(`Cc: ${sanitizedCc}`);
+  if (sanitizedBcc) headers.push(`Bcc: ${sanitizedBcc}`);
+  if (sanitizedInReplyTo) {
+    headers.push(`In-Reply-To: ${sanitizedInReplyTo}`);
+    headers.push(`References: ${sanitizedInReplyTo}`);
+  }
+
+  const parts: string[] = [];
+
+  // Text body part
+  parts.push(
+    `--${boundary}\r\n` +
+      "Content-Type: text/plain; charset=utf-8\r\n" +
+      "Content-Transfer-Encoding: 7bit\r\n" +
+      "\r\n" +
+      body,
+  );
+
+  // Attachment parts
+  for (const att of attachments) {
+    const b64 = att.data.toString("base64");
+    parts.push(
+      `--${boundary}\r\n` +
+        `Content-Type: ${att.mimeType}; name="${att.filename}"\r\n` +
+        "Content-Transfer-Encoding: base64\r\n" +
+        `Content-Disposition: attachment; filename="${att.filename}"\r\n` +
+        "\r\n" +
+        b64,
+    );
+  }
+
+  const mimeMessage = `${headers.join("\r\n")}\r\n\r\n${parts.join(
+    "\r\n",
+  )}\r\n--${boundary}--`;
+  return toBase64Url(Buffer.from(mimeMessage, "utf-8"));
+}


### PR DESCRIPTION
## Summary
- Add portable Gmail API client wrapping `assistant oauth request --provider google` with retry logic
- Add shared CLI utilities (parseArgs, printJson, ok, etc.) matching the Outlook pattern
- Port MIME builder for creating raw base64url-encoded messages for Gmail's draft/send APIs

Part of plan: migrate-gmail-skill.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
