### PR TITLE
feat(macos): add attemptRePair() to re-bootstrap stale credentials

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -222,6 +222,18 @@ extension AppDelegate {
         }
     }
 
+    /// Clears any stored actor-token credentials and re-runs the initial
+    /// bootstrap flow. Unlike `ensureActorCredentials()`, which short-circuits
+    /// when a stored token is already present, this method deliberately wipes
+    /// the existing credential first so `performInitialBootstrap()` is forced
+    /// to re-provision from scratch. Intended as a recovery primitive for
+    /// stale/invalid credentials (see `GatewayConnectionManager.attemptRePair()`).
+    func forceReBootstrap() async {
+        log.info("forceReBootstrap: clearing stored credentials and re-running bootstrap")
+        ActorTokenManager.deleteAllCredentials()
+        await performInitialBootstrap()
+    }
+
     /// Performs the initial actor token bootstrap, reactively waiting for a
     /// gateway connection before each attempt. Called only when no actor token
     /// exists (first launch or after credential wipe).

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -134,6 +134,14 @@ extension AppDelegate {
             try? await self.vellumCli.upgradeFinalize(name: name, fromVersion: fromVersion)
         }
 
+        // Re-pair recovery: clear stored credentials and re-run bootstrap.
+        // Invoked by `GatewayConnectionManager.attemptRePair()` when the UI
+        // surfaces the "Try to reconnect" action (added in a later PR).
+        connectionManager.rePairHandler = { [weak self] in
+            guard let self else { return }
+            await self.forceReBootstrap()
+        }
+
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()

--- a/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
+++ b/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
@@ -48,4 +48,49 @@ final class GatewayConnectionManagerAuthTests: XCTestCase {
         gcm._testIngestHealthStatus(200)
         XCTAssertFalse(gcm.isAuthFailed, "200 after a single 401 must leave isAuthFailed false")
     }
+
+    // MARK: - attemptRePair clears isAuthFailed on successful bootstrap
+
+    func testAttemptRePairClearsIsAuthFailedOnSuccess() async {
+        let gcm = GatewayConnectionManager()
+
+        for _ in 0..<4 {
+            gcm._testIngestHealthStatus(401)
+        }
+        XCTAssertTrue(gcm.isAuthFailed, "Four 401s should trip isAuthFailed before re-pair")
+
+        await gcm.attemptRePair(bootstrap: {
+            // Successful fake bootstrap — no-op.
+        })
+
+        XCTAssertFalse(gcm.isAuthFailed, "Successful re-pair should flip isAuthFailed back to false")
+    }
+
+    // MARK: - Overlapping attemptRePair calls coalesce
+
+    func testOverlappingAttemptRePairCallsCoalesce() async {
+        let gcm = GatewayConnectionManager()
+
+        // Actor-safe counter for concurrent increments.
+        actor Counter {
+            var value = 0
+            func increment() { value += 1 }
+            func read() -> Int { value }
+        }
+        let counter = Counter()
+
+        // A bootstrap that suspends long enough for a second call to observe
+        // `isAttemptingRePair == true` and bail out.
+        let bootstrap: @MainActor @Sendable () async throws -> Void = {
+            await counter.increment()
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+
+        async let first: Void = gcm.attemptRePair(bootstrap: bootstrap)
+        async let second: Void = gcm.attemptRePair(bootstrap: bootstrap)
+        _ = await (first, second)
+
+        let invocations = await counter.read()
+        XCTAssertEqual(invocations, 1, "Overlapping attemptRePair calls should coalesce to a single bootstrap invocation")
+    }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -112,6 +112,16 @@ public final class GatewayConnectionManager {
     // MARK: - Auto-Wake
 
     @ObservationIgnored public var wakeHandler: (@MainActor @Sendable () async throws -> Void)?
+    /// Handler invoked by `attemptRePair()` to re-run the bootstrap flow
+    /// (clear stored credentials + re-provision). Set by the macOS app to
+    /// `AppDelegate.forceReBootstrap()`; iOS does not currently wire one up.
+    /// Keeping this as an injected closure avoids a shared-module dependency
+    /// on the macOS-only `AppDelegate`.
+    @ObservationIgnored public var rePairHandler: (@MainActor @Sendable () async throws -> Void)?
+    /// Guards against concurrent `attemptRePair()` invocations. The flag is
+    /// flipped on the main actor before the handler runs and cleared when the
+    /// call returns (success or failure).
+    @ObservationIgnored private var isAttemptingRePair: Bool = false
     /// Handler called after a Sparkle update is detected.
     /// Receives `(name: String, fromVersion: String)` so the macOS app can invoke
     /// CLI `upgradeFinalize` without the shared module depending on `AppDelegate`.
@@ -691,6 +701,44 @@ public final class GatewayConnectionManager {
             case .transientError:
                 break // Coordinator already logs warning
             }
+        }
+    }
+
+    // MARK: - Re-Pair Recovery
+
+    /// Attempts to recover from a stuck `isAuthFailed` state by re-running
+    /// the bootstrap flow (clear stored credentials + re-provision). Runs the
+    /// injected `rePairHandler` by default, but callers (e.g. unit tests) may
+    /// supply an explicit `bootstrap` closure to substitute a fake.
+    ///
+    /// Concurrent invocations coalesce — if a re-pair is already in flight,
+    /// subsequent calls return immediately without re-running the handler.
+    /// On success, the `AuthFailureTracker` is reset so the UI flips back
+    /// promptly on the next health check. On failure, the tracker is left
+    /// alone (the next successful health check will eventually clear it).
+    public func attemptRePair(
+        bootstrap: (@MainActor @Sendable () async throws -> Void)? = nil
+    ) async {
+        if isAttemptingRePair {
+            log.info("attemptRePair: already in flight — skipping")
+            return
+        }
+        isAttemptingRePair = true
+        defer { isAttemptingRePair = false }
+
+        log.info("attemptRePair: started")
+        let handler = bootstrap ?? rePairHandler
+        guard let handler else {
+            log.error("attemptRePair: failed — no bootstrap handler configured")
+            return
+        }
+        do {
+            try await handler()
+            authFailureTracker.recordSuccess()
+            updateAuthFailedSignal()
+            log.info("attemptRePair: completed")
+        } catch {
+            log.error("attemptRePair: failed — \(error.localizedDescription, privacy: .public)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `forceReBootstrap()` in AppDelegate+Bootstrap that clears the stored token and calls `performInitialBootstrap()`.
- Add `GatewayConnectionManager.attemptRePair()` that coalesces concurrent calls, invokes forceReBootstrap, and resets the AuthFailureTracker on success.
- Extend GatewayConnectionManagerAuthTests with success + coalescing cases.

Part of plan: macos-auth-failed-state.md (PR 5 of 6)