### PR TITLE
feat(macos): add Re-pair Assistant action to menubar dropdown

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -442,6 +442,18 @@ extension AppDelegate {
         statusItem.image = status.statusIcon
         menu.addItem(statusItem)
 
+        if currentAssistantStatus == .authFailed {
+            let item = NSMenuItem(
+                title: "Re-pair Assistant",
+                action: #selector(rePairAssistant),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.image = VIcon.refreshCw.nsImage(size: 16)
+            menu.addItem(item)
+            menu.addItem(.separator())
+        }
+
         // During onboarding, only show the status line and Quit to prevent
         // users from bypassing the onboarding flow via Settings or conversations.
         if onboardingWindow == nil {
@@ -608,6 +620,12 @@ extension AppDelegate {
         guard !isBootstrapping else { return }
         showMainWindow()
         mainWindow?.windowState.dismissOverlay()
+    }
+
+    @objc private func rePairAssistant() {
+        Task { @MainActor in
+            await self.connectionManager.attemptRePair()
+        }
     }
 
     @objc public func openNewChat() {


### PR DESCRIPTION
## Summary
- Add a 'Re-pair Assistant' menu item to the menubar dropdown that appears only when `currentAssistantStatus == .authFailed`.
- Wire its action to `GatewayConnectionManager.attemptRePair()`, which clears the stale bearer token and re-runs the existing bootstrap path.
- Final PR of the macOS auth-failed-state plan — closes out the UX gap where the app couldn't distinguish auth-broken from generic disconnected.

Part of plan: macos-auth-failed-state.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
