### PR TITLE
fix(macos): gate Re-pair menu item on non-onboarding; drop duplicate separator

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -442,22 +442,23 @@ extension AppDelegate {
         statusItem.image = status.statusIcon
         menu.addItem(statusItem)
 
-        if currentAssistantStatus == .authFailed {
-            let item = NSMenuItem(
-                title: "Re-pair Assistant",
-                action: #selector(rePairAssistant),
-                keyEquivalent: ""
-            )
-            item.target = self
-            item.image = VIcon.refreshCw.nsImage(size: 16)
-            menu.addItem(item)
-            menu.addItem(.separator())
-        }
-
         // During onboarding, only show the status line and Quit to prevent
         // users from bypassing the onboarding flow via Settings or conversations.
+        // The Re-pair item must respect this policy too: calling forceReBootstrap()
+        // while onboarding's credential flow is in progress would race it.
         if onboardingWindow == nil {
             menu.addItem(NSMenuItem.separator())
+
+            if currentAssistantStatus == .authFailed {
+                let item = NSMenuItem(
+                    title: "Re-pair Assistant",
+                    action: #selector(rePairAssistant),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.image = VIcon.refreshCw.nsImage(size: 16)
+                menu.addItem(item)
+            }
 
             let currentConversationItem: NSMenuItem = {
                 let shortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"


### PR DESCRIPTION
## Summary
Two menu-layout gaps from self-review:

- **Re-pair during onboarding**: the Re-pair menu item was inserted above the `onboardingWindow == nil` gate, so during onboarding it could race the in-progress credential flow by calling `forceReBootstrap()` + `deleteAllCredentials()`. Moved the `.authFailed` block inside the gate so it respects the same policy as every other interactive menu item.
- **Double separator**: the Re-pair block ended with a separator, and the next block opened with another. Dropped the trailing separator in the Re-pair block.

**Gaps:** Re-pair button exposed during onboarding; Menu shows double separator when .authFailed and not onboarding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
