### PR TITLE
fix(shared): widen AuthFailureTracker window for 15s health-check cadence

### DIFF
--- a/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
@@ -116,4 +116,45 @@ final class AuthFailureTrackerTests: XCTestCase {
         XCTAssertTrue(tracker.isAuthFailed)
         XCTAssertEqual(tracker.lastStatusCode, 429)
     }
+
+    /// (g) Production duty cycle: four 401s spaced 15s apart (the
+    /// `GatewayConnectionManager.performHealthCheck()` cadence) must trip the
+    /// detector. Entries land at t=0, 15, 30, 45; with the 90s default window
+    /// all four remain live and `isAuthFailed` becomes `true`.
+    func testFourFailuresSpaced15sApartTripsTracker() {
+        let clock = Clock()
+        // Use the real default windowSeconds (90) to lock in the production config.
+        let tracker = AuthFailureTracker(
+            minFailures: 4,
+            now: { clock.now }
+        )
+
+        for i in 0..<4 {
+            tracker.recordFailure(statusCode: 401, path: "/api/ping")
+            if i < 3 {
+                clock.advance(15)
+            }
+        }
+
+        XCTAssertTrue(tracker.isAuthFailed)
+    }
+
+    /// (h) Edge: three 401s at the 15s health-check cadence must NOT trip —
+    /// `minFailures=4` remains the gate even after the window was widened.
+    func testThreeFailuresSpaced15sApartDoesNotTrip() {
+        let clock = Clock()
+        let tracker = AuthFailureTracker(
+            minFailures: 4,
+            now: { clock.now }
+        )
+
+        for i in 0..<3 {
+            tracker.recordFailure(statusCode: 401, path: "/api/ping")
+            if i < 2 {
+                clock.advance(15)
+            }
+        }
+
+        XCTAssertFalse(tracker.isAuthFailed)
+    }
 }

--- a/clients/shared/Network/AuthFailureTracker.swift
+++ b/clients/shared/Network/AuthFailureTracker.swift
@@ -9,6 +9,13 @@ import Foundation
 /// once at least `minFailures` have occurred inside `windowSeconds`. Any 2xx
 /// response (signalled via `recordSuccess()`) immediately clears the window.
 ///
+/// The default `windowSeconds=90` / `minFailures=4` is sized for the production
+/// duty cycle of `GatewayConnectionManager.performHealthCheck()`, which fires
+/// every 15s in steady state. Four sequential health checks at 401 land at
+/// t≈0, 15, 30, 45 — all fit comfortably inside a 90s window with slack for
+/// jitter. A 30s window (the original default) could hold at most 3 such
+/// entries and so could never trip the detector.
+///
 /// The clock is injected so tests can drive time deterministically without
 /// relying on `sleep`. All mutation is serialized through a private
 /// `DispatchQueue` so the tracker is safe to call from a periodic health-check
@@ -30,7 +37,7 @@ public final class AuthFailureTracker {
     private var _lastPath: String?
 
     public init(
-        windowSeconds: TimeInterval = 30,
+        windowSeconds: TimeInterval = 90,
         minFailures: Int = 4,
         now: @escaping () -> Date = Date.init
     ) {


### PR DESCRIPTION
## Summary
Fixes a gap identified during self-review: AuthFailureTracker defaulted to windowSeconds=30 with minFailures=4, but the only production producer of failures is `performHealthCheck()` at 15s cadence — so at most 3 failures fit in the sliding window and `isAuthFailed` could never trip in steady state.

Raises `windowSeconds` default from 30 to 90 (covers 4 failures at 15s cadence with slack). Adds two tests locking in the new behavior.

**Gap:** Detector thresholds unreachable at production duty cycle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
