### PR TITLE
fix(macos): refresh conversationType in ConversationRestorer merge path

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -323,6 +323,7 @@ final class ConversationRestorer {
                 }
                 existing.lastInteractedAt = Date(timeIntervalSince1970: TimeInterval(session.lastMessageAt ?? session.updatedAt) / 1000.0)
                 existing.source = session.source
+                existing.conversationType = session.conversationType
                 existing.originChannel = session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
                 delegate.conversations[existingIdx] = existing
                 // Attention merge must go through mergeAssistantAttention so that


### PR DESCRIPTION
Mirror the assignment from the new-row construction path into the existing-row merge block so locally-created conversations get their type refreshed from the server payload.

Addresses feedback on #26456.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
