### PR TITLE
fix(file_write): make PKB markdown gate case-insensitive

### DIFF
--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -121,7 +121,7 @@ class FileWriteTool implements Tool {
       // Indexing `pkb/*.json` (or any other extension) here would produce
       // chunks the reconciler can't see, leading to orphaned vectors and
       // pointless embedding work.
-      if (filePath.endsWith(".md") && isInsidePkbRoot(filePath, pkbRoot)) {
+      if (filePath.toLowerCase().endsWith(".md") && isInsidePkbRoot(filePath, pkbRoot)) {
         enqueuePkbIndexJob({
           pkbRoot,
           absPath: filePath,


### PR DESCRIPTION
Match scanPkbFiles's case-insensitive .md check so uppercase extensions (notes.MD, README.Md) trigger real-time PKB re-index.

Addresses feedback on #26478.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
