### PR TITLE
fix(macos): bound attemptRePair with timeout; reset isAuthFailed on disconnect

### DIFF
--- a/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
+++ b/clients/macos/vellum-assistantTests/GatewayConnectionManagerAuthTests.swift
@@ -93,4 +93,56 @@ final class GatewayConnectionManagerAuthTests: XCTestCase {
         let invocations = await counter.read()
         XCTAssertEqual(invocations, 1, "Overlapping attemptRePair calls should coalesce to a single bootstrap invocation")
     }
+
+    // MARK: - attemptRePair bounds the bootstrap with a timeout
+
+    /// Regression test for the `attemptRePair` latch bug: if the injected
+    /// bootstrap hangs indefinitely (offline network, stuck guardian poll,
+    /// etc.) the method must still release the `isAttemptingRePair` guard
+    /// within the timeout budget so subsequent clicks aren't silently
+    /// dropped with "already in flight — skipping". We use a 100ms timeout
+    /// here to keep the test fast.
+    func testAttemptRePairTimesOutWhenBootstrapHangs() async {
+        let gcm = GatewayConnectionManager()
+
+        // A bootstrap that effectively never returns on the test's timescale.
+        let hangingBootstrap: @MainActor @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: 500_000_000_000) // 500s
+        }
+
+        let start = Date()
+        await gcm.attemptRePair(bootstrap: hangingBootstrap, timeout: 0.1)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(elapsed, 5.0, "attemptRePair must return well before the hanging bootstrap completes")
+
+        // A follow-up call must be able to run — i.e. the latch was released.
+        actor Invoked { var value = false; func mark() { value = true }; func read() -> Bool { value } }
+        let invoked = Invoked()
+        await gcm.attemptRePair(bootstrap: {
+            await invoked.mark()
+        }, timeout: 1.0)
+        let didInvoke = await invoked.read()
+        XCTAssertTrue(didInvoke, "After a timeout, a subsequent attemptRePair must not be short-circuited by the stuck latch")
+    }
+
+    // MARK: - disconnect() clears isAuthFailed
+
+    /// Regression test for the stale `isAuthFailed` bug: `disconnect()` /
+    /// `disconnectInternal()` must reset the auth-failed state so a
+    /// subsequent reconnect does not inherit a stale trip from the previous
+    /// session (e.g. the managed-404 teardown path, or an explicit
+    /// `disconnect()` call from the app).
+    func testDisconnectClearsIsAuthFailed() {
+        let gcm = GatewayConnectionManager()
+
+        for _ in 0..<4 {
+            gcm._testIngestHealthStatus(401)
+        }
+        XCTAssertTrue(gcm.isAuthFailed, "Four 401s should trip isAuthFailed before disconnect")
+
+        gcm.disconnect()
+
+        XCTAssertFalse(gcm.isAuthFailed, "disconnect() must clear isAuthFailed so reconnect starts clean")
+    }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -4,6 +4,12 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "GatewayConnectionManager")
 
+/// Thrown by `attemptRePair` when the injected bootstrap handler exceeds the
+/// timeout budget. Keeping this as a distinct type lets the catch site log a
+/// clear "timed out" message and avoid treating a stuck bootstrap as a regular
+/// failure.
+private struct RePairTimeout: Error {}
+
 /// Minimal decode of the /v1/health response to extract the version field.
 private struct HealthVersionResponse: Decodable {
     let version: String?
@@ -273,6 +279,18 @@ public final class GatewayConnectionManager {
         consecutiveHealthCheckSuccesses = 0
         setConnected(false)
 
+        // Reset auth-failed state on teardown. Every reconnect should start
+        // from a clean slate — otherwise a stale `isAuthFailed = true` can
+        // leak through a disconnect/reconnect cycle (e.g. the managed
+        // 404-retired path, or an explicit `disconnect()` from the app)
+        // until the tracker's sliding window drains naturally. Route through
+        // `updateAuthFailedSignal()` so the single-transition log line still
+        // fires and the invariant "`isAuthFailed` is only mutated through the
+        // helper" is preserved. `reconfigure()` reaches this via
+        // `disconnect()`, so it automatically inherits the reset.
+        authFailureTracker.recordSuccess()
+        updateAuthFailedSignal()
+
         eventStreamClient.stopSSE()
     }
 
@@ -299,13 +317,10 @@ public final class GatewayConnectionManager {
         lastAutoWakeAttempt = nil
         #endif
 
-        // Reset published state
+        // Reset published state. `isAuthFailed` + the underlying tracker are
+        // cleared by `disconnectInternal()` (called via `disconnect()` above),
+        // so no explicit reset is needed here.
         isConnected = false
-        if isAuthFailed {
-            isAuthFailed = false
-            log.info("AuthFailureTracker cleared")
-        }
-        authFailureTracker.recordSuccess()
         assistantVersion = nil
         versionMismatch = false
         isUpdateInProgress = false
@@ -706,6 +721,11 @@ public final class GatewayConnectionManager {
 
     // MARK: - Re-Pair Recovery
 
+    /// Default timeout for `attemptRePair`. Long enough for a real bootstrap
+    /// (guardian token poll + provision) to land, short enough that the
+    /// Re-pair menu item becomes clickable again after a stuck attempt.
+    internal static let defaultRePairTimeout: TimeInterval = 90.0
+
     /// Attempts to recover from a stuck `isAuthFailed` state by re-running
     /// the bootstrap flow (clear stored credentials + re-provision). Runs the
     /// injected `rePairHandler` by default, but callers (e.g. unit tests) may
@@ -713,11 +733,19 @@ public final class GatewayConnectionManager {
     ///
     /// Concurrent invocations coalesce — if a re-pair is already in flight,
     /// subsequent calls return immediately without re-running the handler.
+    /// The handler is bounded by `timeout` (default 90s) so a stuck bootstrap
+    /// — e.g. offline network, guardian endpoint flapping, indefinite retry
+    /// loop inside `performInitialBootstrap` — cannot latch
+    /// `isAttemptingRePair = true` forever and silently swallow every
+    /// subsequent menu click.
+    ///
     /// On success, the `AuthFailureTracker` is reset so the UI flips back
-    /// promptly on the next health check. On failure, the tracker is left
-    /// alone (the next successful health check will eventually clear it).
+    /// promptly on the next health check. On failure/timeout, the tracker is
+    /// left alone (the next successful health check will eventually clear it)
+    /// and `isAttemptingRePair` is released via `defer` regardless of path.
     public func attemptRePair(
-        bootstrap: (@MainActor @Sendable () async throws -> Void)? = nil
+        bootstrap: (@MainActor @Sendable () async throws -> Void)? = nil,
+        timeout: TimeInterval = GatewayConnectionManager.defaultRePairTimeout
     ) async {
         if isAttemptingRePair {
             log.info("attemptRePair: already in flight — skipping")
@@ -733,10 +761,24 @@ public final class GatewayConnectionManager {
             return
         }
         do {
-            try await handler()
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await handler() }
+                group.addTask {
+                    let nanoseconds = UInt64(max(0, timeout) * 1_000_000_000)
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                    throw RePairTimeout()
+                }
+                // Wait for the first task to complete (handler or timer) then
+                // cancel the loser so it doesn't keep running in the
+                // background.
+                try await group.next()
+                group.cancelAll()
+            }
             authFailureTracker.recordSuccess()
             updateAuthFailedSignal()
             log.info("attemptRePair: completed")
+        } catch is RePairTimeout {
+            log.error("attemptRePair: timed out after \(timeout, privacy: .public)s")
         } catch {
             log.error("attemptRePair: failed — \(error.localizedDescription, privacy: .public)")
         }


### PR DESCRIPTION
## Summary
Addresses two gaps from self-review:

- **attemptRePair latch**: forceReBootstrap's underlying performInitialBootstrap can spin indefinitely when the guardian endpoint is unreachable, leaving `isAttemptingRePair = true` and silently swallowing subsequent Re-pair clicks. Bound the inner bootstrap with a 90-second timeout; release the flag via defer on all exit paths.
- **Stale isAuthFailed on disconnect**: moved the auth-failed reset out of reconfigure() and into disconnectInternal() so every teardown path (disconnect, reconfigure, managed-assistant-retired) clears the tracker consistently via updateAuthFailedSignal().

**Gaps:** attemptRePair latch; disconnect does not reset isAuthFailed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
