### PR TITLE
fix(assistant): hydrate ui_request conversations from storage and tag not-found cancellations

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -836,12 +836,45 @@ export class DaemonServer {
 
     // Install the interactive UI resolver so skills and IPC handlers can
     // present ad-hoc UI surfaces (confirmations, forms) to the user via
-    // `requestInteractiveUi()`. The resolver verifies the target
-    // conversation exists and is live, then delegates to the
-    // conversation-level standalone surface lifecycle which blocks until
-    // the user responds or the timeout elapses.
+    // `requestInteractiveUi()`. The resolver uses a two-step lookup:
+    //   Step A: use the in-memory conversation when present.
+    //   Step B: if absent (evicted), check persistent storage and hydrate
+    //           via getOrCreateConversation when the conversation exists
+    //           in the DB.
+    // When the conversation does not exist at all, the resolver returns
+    // `status: "cancelled"` with `cancellationReason: "conversation_not_found"`
+    // so callers can distinguish not-found from other fail-closed outcomes.
     registerInteractiveUiResolver(async (request) => {
-      const conversation = this.conversations.get(request.conversationId);
+      // Step A: fast path — in-memory conversation
+      let conversation = this.conversations.get(request.conversationId);
+
+      // Step B: conversation was evicted from memory — check persistent
+      // storage and hydrate if the conversation exists in the DB.
+      if (!conversation) {
+        const persisted = getConversation(request.conversationId);
+        if (persisted) {
+          try {
+            conversation = await this.getOrCreateConversation(
+              request.conversationId,
+            );
+          } catch (err) {
+            log.warn(
+              {
+                err,
+                conversationId: request.conversationId,
+                surfaceType: request.surfaceType,
+              },
+              "interactive-ui resolver: failed to hydrate persisted conversation; failing closed",
+            );
+            return {
+              status: "cancelled" as const,
+              surfaceId: `ui-resolver-${Date.now()}`,
+              cancellationReason: "resolver_error" as const,
+            };
+          }
+        }
+      }
+
       if (!conversation) {
         log.warn(
           {
@@ -853,6 +886,7 @@ export class DaemonServer {
         return {
           status: "cancelled" as const,
           surfaceId: `ui-resolver-${Date.now()}`,
+          cancellationReason: "conversation_not_found" as const,
         };
       }
 

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -339,6 +339,64 @@ describe("ui_request IPC route", () => {
     expect(result.result!.cancellationReason).toBeUndefined();
   });
 
+  // ── Persisted-but-not-loaded conversation (hydration path) ─────────
+
+  test("succeeds for a valid persisted-but-not-loaded conversation ID", async () => {
+    // Simulates the daemon resolver's Step B: the conversation was
+    // evicted from memory but still exists in persistent storage.
+    // The resolver hydrates it and delegates to the surface lifecycle.
+    const hydratedConversationId = "conv-persisted-not-loaded";
+    registerInteractiveUiResolver(
+      async (req: InteractiveUiRequest): Promise<InteractiveUiResult> => {
+        // Simulate successful hydration: the resolver found the
+        // conversation in storage and reconstituted it.
+        expect(req.conversationId).toBe(hydratedConversationId);
+        return {
+          status: "submitted",
+          actionId: "confirm",
+          surfaceId: `hydrated-surface-${req.conversationId}`,
+        };
+      },
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: hydratedConversationId }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.actionId).toBe("confirm");
+    expect(result.result!.surfaceId).toContain(hydratedConversationId);
+  });
+
+  // ── Truly unknown conversation ID ─────────────────────────────────
+
+  test("returns cancelled with conversation_not_found for truly unknown conversation ID", async () => {
+    // Simulates the daemon resolver when the conversation does not
+    // exist in memory OR in persistent storage — the resolver returns
+    // conversation_not_found without throwing.
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: `ui-resolver-not-found`,
+        cancellationReason: "conversation_not_found",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: "conv-truly-unknown-xyz" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("conversation_not_found");
+    expect(result.result!.surfaceId).toBeDefined();
+  });
+
   // ── Optional fields (continued) ────────────────────────────────────
 
   test("accepts form surfaceType with submittedData", async () => {


### PR DESCRIPTION
## Summary
- Replaces direct in-memory conversation lookup with two-step resolver (memory then storage)
- Tags unknown conversation IDs with cancellationReason: conversation_not_found
- Preserves fail-closed behavior for deterministic script responses

Part of plan: ui-request-gap-remediation.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
