### PR TITLE
fix(macos): advance scroll-observer baseline after jitter-skipped frames

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -209,15 +209,14 @@ struct MessageListScrollObserver: NSViewRepresentable {
                     at: Date()
                 ))
             }
-            // Hold `lastContentHeight` steady across sub-threshold skips so a
-            // series of small monotonic deltas can accumulate into a single
-            // compensation once they cross the minimum — rebaselining on every
-            // jitter frame would silently swallow that drift.
-            if case .skipped(.jitterBelowThreshold) = decision {
-                // no-op: keep prior baseline
-            } else {
-                lastContentHeight = currentContentHeight
-            }
+            // Advance the baseline on every emit, including jitter-skipped
+            // frames. Leaving the baseline stale on a sub-threshold skip lets
+            // subsequent bounds/scroll notifications (which don't change the
+            // document height) still compute a non-zero `contentHDelta` against
+            // the old baseline, producing inflated `onAnchorDecision` events
+            // and false "missed compensation" entries in the debug overlay's
+            // CSV. The SKIP decision itself is unchanged — only the bookkeeping.
+            lastContentHeight = currentContentHeight
 
             let snapshot = ScrollGeometrySnapshot(
                 contentOffsetY: clipView.bounds.origin.y,


### PR DESCRIPTION
Prevent stale contentHDelta values from inflating later anchor-decision telemetry when the jitter threshold skips compensation.

Addresses feedback on #26464.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
