### PR TITLE
fix(migration-040): skip Anthropic callsite seed when default provider differs

### DIFF
--- a/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
+++ b/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
@@ -28,12 +28,28 @@ import type { WorkspaceMigration } from "./types.js";
  * Without the fresh-install branch, new users permanently fall through
  * to `llm.default` (opus + max effort) because `LLMSchema.callSites`
  * defaults to `{}` and nothing else seeds the latency-optimized entries.
+ *
+ * **Provider gating.** `mergeDefaultWorkspaceConfig()` applies
+ * `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` *after* migrations run, so a
+ * platform-provided override that sets `llm.default.provider = openai`
+ * (or any non-Anthropic provider) without also setting `llm.callSites`
+ * would otherwise leave the workspace with OpenAI as the default but
+ * Anthropic model IDs in the seeded call sites — guaranteed
+ * invalid-model errors. Skip seeding when:
+ *   - `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set (defer to that
+ *     config to own the call-site seeds), or
+ *   - `llm.default.provider` is explicitly set to a non-Anthropic value.
  */
 export const seedLatencyCallSiteDefaultsMigration: WorkspaceMigration = {
   id: "040-seed-latency-callsite-defaults",
   description:
     "Seed latency-optimized call-site defaults for background LLM tasks",
   run(workspaceDir: string): void {
+    // If a platform default-config overlay is in play, it runs after
+    // migrations and is the authoritative source for both provider and
+    // call-site seeds. Skip to avoid mismatched provider/model pairs.
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
     const configPath = join(workspaceDir, "config.json");
     const configExisted = existsSync(configPath);
 
@@ -51,13 +67,14 @@ export const seedLatencyCallSiteDefaultsMigration: WorkspaceMigration = {
     const llm = readObject(config.llm) ?? {};
     const defaultBlock = readObject(llm.default);
 
-    // Fresh install: no config.json yet, so no explicit provider — fall
-    // back to the schema default ("anthropic"). A platform-provided
-    // `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` override that specifies a
-    // non-anthropic provider should also set `llm.callSites` in that
-    // override file, since it runs after migrations via
-    // `mergeDefaultWorkspaceConfig` and will overwrite our seeds.
-    const provider = readString(defaultBlock?.provider) ?? "anthropic";
+    // Only seed when the resolved provider is Anthropic. If the user has
+    // explicitly configured a different provider, skip — their config
+    // (or the provider's own defaults) should own the call-site seeds.
+    const explicitProvider = readString(defaultBlock?.provider);
+    if (explicitProvider !== undefined && explicitProvider !== "anthropic") {
+      return;
+    }
+    const provider = explicitProvider ?? "anthropic";
     const fastModel = resolveLatencyModel(provider);
     if (fastModel === undefined) return;
 


### PR DESCRIPTION
Prevent the latency-optimized seed from writing Anthropic model IDs into call sites when the workspace's default provider is configured to a different provider (e.g. via VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH). This avoids invalid-model errors on fresh installs with custom provider config.

Addresses feedback on #26477.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
