### PR TITLE
fix(pkb-hints): default pkbWorkingDir to pkbRoot in hint guard

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1272,8 +1272,8 @@ export async function applyRuntimeInjections(
     pkbRoot?: string;
     /**
      * Working directory against which relative `file_read` tool paths
-     * resolve. Required alongside `pkbConversation` + `pkbRoot` to detect
-     * workspace-relative reads like `pkb/threads.md`.
+     * resolve, used to detect workspace-relative reads like
+     * `pkb/threads.md`. Falls back to `pkbRoot` when omitted.
      */
     pkbWorkingDir?: string;
     nowScratchpad?: string | null;
@@ -1342,8 +1342,7 @@ export async function applyRuntimeInjections(
         queryVector.length > 0 &&
         options.pkbScopeId &&
         options.pkbConversation &&
-        options.pkbRoot &&
-        options.pkbWorkingDir
+        options.pkbRoot
       ) {
         try {
           const results = await searchPkbFiles(
@@ -1352,11 +1351,12 @@ export async function applyRuntimeInjections(
             8,
             [options.pkbScopeId],
           );
+          const workingDir = options.pkbWorkingDir ?? options.pkbRoot;
           const inContext = getInContextPkbPaths(
             options.pkbConversation,
             options.pkbAutoInjectList ?? [],
             options.pkbRoot,
-            options.pkbWorkingDir,
+            workingDir,
           );
           const pkbRoot = options.pkbRoot;
           hints = results

--- a/assistant/src/daemon/pkb-context-tracker.test.ts
+++ b/assistant/src/daemon/pkb-context-tracker.test.ts
@@ -129,10 +129,9 @@ describe("getInContextPkbPaths", () => {
   });
 
   test("workspace-relative file_read path inside pkb/ is recognized", () => {
-    // Regression: previously `pkb/threads.md` was resolved against `pkbRoot`
-    // itself (→ `<pkbRoot>/pkb/threads.md`) and missed entirely. The model
-    // actually emits workspace-relative paths, so the tracker must resolve
-    // them against `workingDir` and then verify they fall inside `pkbRoot`.
+    // The model emits workspace-relative paths like `pkb/threads.md`.
+    // The tracker resolves them against `workingDir` (matching `file_read`'s
+    // own rule) and verifies the result falls inside `pkbRoot`.
     const conversation = makeConversation([
       assistantMessageWithBlocks([fileReadToolUse("pkb/threads.md")]),
     ]);


### PR DESCRIPTION
- Guard no longer requires `pkbWorkingDir` in `applyRuntimeInjections`; falls back to `pkbRoot` inline so callers that provide the other PKB fields don't silently skip `searchPkbFiles` and regress hint quality.
- Rewrite `pkb-context-tracker.test.ts` comment to describe current behavior without narrating history (AGENTS.md rule against "previously used Y" comments).

Addresses feedback on #26467.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
