### PR TITLE
fix(llm-callsite): pass callSite in approval generators

### DIFF
--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -55,6 +55,8 @@ export const LLMCallSiteEnum = z.enum([
   "notificationDecision",
   "preferenceExtraction",
   "guardianQuestionCopy",
+  "approvalCopy",
+  "approvalConversation",
   "watchCommentary",
   "watchSummary",
   "interactionClassifier",

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -119,6 +119,7 @@ export function createApprovalCopyGenerator(): ApprovalCopyGenerator {
       {
         config: {
           max_tokens: options.maxTokens ?? APPROVAL_COPY_MAX_TOKENS,
+          callSite: "approvalCopy",
         },
         signal: AbortSignal.timeout(
           options.timeoutMs ?? APPROVAL_COPY_TIMEOUT_MS,
@@ -173,6 +174,7 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
       {
         config: {
           max_tokens: APPROVAL_CONVERSATION_MAX_TOKENS,
+          callSite: "approvalConversation",
         },
         signal: AbortSignal.timeout(APPROVAL_CONVERSATION_TIMEOUT_MS),
       },


### PR DESCRIPTION
Add approval-specific call sites and pass them through sendMessage options so CallSiteRoutingProvider can select per-site routing.

Addresses feedback on #26466.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
