### PR TITLE
test(cli-guardian-token): set future expiry on test fixture

### DIFF
--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -13,13 +13,14 @@ import {
 
 function makeTokenData(suffix: string): GuardianTokenData {
   const now = new Date().toISOString();
+  const oneHourFromNow = new Date(Date.now() + 60 * 60 * 1000).toISOString();
   return {
     guardianPrincipalId: `principal-${suffix}`,
     accessToken: `access-${suffix}`,
-    accessTokenExpiresAt: now,
+    accessTokenExpiresAt: oneHourFromNow,
     refreshToken: `refresh-${suffix}`,
-    refreshTokenExpiresAt: now,
-    refreshAfter: now,
+    refreshTokenExpiresAt: oneHourFromNow,
+    refreshAfter: oneHourFromNow,
     isNew: true,
     deviceId: `device-${suffix}`,
     leasedAt: now,


### PR DESCRIPTION
## Summary
- Fix failing \`seedGuardianTokenFromSiblingEnv copies a dev token into the current local env\` test in \`cli/src/__tests__/guardian-token.test.ts\`.
- The test fixture set \`refreshTokenExpiresAt\` to \`new Date().toISOString()\` (i.e. \"now\"). PR #26503 added validation that rejects sibling tokens whose refresh expiry is \`<= Date.now()\`. By the time the seed function ran, the fixture was already \"expired\" and the seed was skipped.
- Set \`refreshTokenExpiresAt\` (and the other expiry fields) one hour in the future so the fixture is treated as a valid sibling token.

## Original prompt
\`--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24616191089/job/71978678219\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
