### PR TITLE
fix(pkb): atomic reindex + refresh stale PKB_WORKSPACE_SCOPE rationale

### DIFF
--- a/assistant/src/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/memory/pkb/pkb-index.test.ts
@@ -50,6 +50,24 @@ const qdrantDeleteCalls: Array<{
   memoryScopeId: string;
 }> = [];
 
+// Track per-target deletes (used by write-then-cleanup in indexPkbFile).
+const qdrantDeleteByTargetCalls: Array<{
+  targetType: string;
+  targetId: string;
+}> = [];
+
+// Points the mocked scroll will return on the next call. Tests mutate this
+// to simulate pre-existing PKB chunks on disk.
+let scrollReturnPoints: Array<{
+  id: string;
+  payload: Record<string, unknown>;
+}> = [];
+const qdrantScrollCalls: Array<{
+  targetType: string;
+  memoryScopeId?: string;
+  path?: string;
+}> = [];
+
 mock.module("../qdrant-client.js", () => ({
   getQdrantClient: () => ({
     deleteByTargetTypeAndPath: async (
@@ -58,6 +76,24 @@ mock.module("../qdrant-client.js", () => ({
       memoryScopeId: string,
     ) => {
       qdrantDeleteCalls.push({ targetType, path, memoryScopeId });
+    },
+    deleteByTarget: async (targetType: string, targetId: string) => {
+      qdrantDeleteByTargetCalls.push({ targetType, targetId });
+    },
+    scrollByTargetType: async (
+      targetType: string,
+      options?: {
+        memoryScopeId?: string;
+        path?: string;
+        batchSize?: number;
+      },
+    ) => {
+      qdrantScrollCalls.push({
+        targetType,
+        memoryScopeId: options?.memoryScopeId,
+        path: options?.path,
+      });
+      return scrollReturnPoints;
     },
   }),
 }));
@@ -186,6 +222,9 @@ describe("indexPkbFile", () => {
   beforeEach(() => {
     embedAndUpsertCalls.length = 0;
     qdrantDeleteCalls.length = 0;
+    qdrantDeleteByTargetCalls.length = 0;
+    qdrantScrollCalls.length = 0;
+    scrollReturnPoints = [];
   });
 
   test("invokes embedAndUpsert once per chunk with pkb_file target_type", async () => {
@@ -242,19 +281,72 @@ describe("indexPkbFile", () => {
     expect(ids).toEqual(["alpha:shared.md#0", "beta:shared.md#0"]);
   });
 
-  test("deletes prior chunks for this (scope, path) before upserting new ones", async () => {
-    const root = await mkdtemp(join(tmpdir(), "pkb-index-shrink-"));
-    const filePath = join(root, "shrinking.md");
-    await writeFile(filePath, "# just one");
+  test("scrolls existing chunks scoped to (target_type, scope, path) before upserting", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-scroll-"));
+    const filePath = join(root, "noted.md");
+    await writeFile(filePath, "# one");
 
     await indexPkbFile(root, filePath, "scope-xyz");
 
-    expect(qdrantDeleteCalls).toHaveLength(1);
-    expect(qdrantDeleteCalls[0]).toEqual({
+    expect(qdrantScrollCalls).toHaveLength(1);
+    expect(qdrantScrollCalls[0]).toEqual({
       targetType: "pkb_file",
-      path: "shrinking.md",
       memoryScopeId: "scope-xyz",
+      path: "noted.md",
     });
+  });
+
+  test("deletes only stale chunks after upserting (write-then-cleanup)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-shrink-"));
+    const filePath = join(root, "shrinking.md");
+    // New content produces a single chunk (index #0). Pre-existing chunks
+    // #0..#2 simulate a prior run over a larger file.
+    await writeFile(filePath, "# just one");
+    scrollReturnPoints = [
+      {
+        id: "point-0",
+        payload: { target_id: "scope-xyz:shrinking.md#0" },
+      },
+      {
+        id: "point-1",
+        payload: { target_id: "scope-xyz:shrinking.md#1" },
+      },
+      {
+        id: "point-2",
+        payload: { target_id: "scope-xyz:shrinking.md#2" },
+      },
+    ];
+
+    await indexPkbFile(root, filePath, "scope-xyz");
+
+    // Exactly one upsert for the surviving chunk.
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    expect(embedAndUpsertCalls[0].targetId).toBe("scope-xyz:shrinking.md#0");
+
+    // The pre-delete is gone; only the two stale chunks are removed.
+    expect(qdrantDeleteCalls).toHaveLength(0);
+    const staleTargetIds = qdrantDeleteByTargetCalls.map((c) => c.targetId);
+    expect(staleTargetIds.sort()).toEqual([
+      "scope-xyz:shrinking.md#1",
+      "scope-xyz:shrinking.md#2",
+    ]);
+  });
+
+  test("does not delete points whose target_id is regenerated", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-stable-"));
+    const filePath = join(root, "stable.md");
+    await writeFile(filePath, "# same");
+    scrollReturnPoints = [
+      {
+        id: "point-0",
+        payload: { target_id: "scope-xyz:stable.md#0" },
+      },
+    ];
+
+    await indexPkbFile(root, filePath, "scope-xyz");
+
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    expect(qdrantDeleteByTargetCalls).toHaveLength(0);
   });
 });
 

--- a/assistant/src/memory/pkb/pkb-index.ts
+++ b/assistant/src/memory/pkb/pkb-index.ts
@@ -168,11 +168,13 @@ export function chunkPkbFile(content: string): string[] {
  * embedding pipeline. `relPath` in the payload is computed relative to
  * `pkbRoot`.
  *
- * Self-cleaning: deletes any previously-indexed chunks for this (scope, path)
- * before upserting the new ones. This keeps the index consistent when a file
- * shrinks — e.g. a prior run wrote chunks `#0..#3` and the new content only
- * produces `#0..#1`; without the pre-delete, `#2` and `#3` would linger as
- * orphaned stale results in search.
+ * Write-then-cleanup: enumerate the existing chunk target_ids for this
+ * (scope, path), upsert every new chunk, then delete only the stale
+ * target_ids (those the fresh content no longer produces). Upsert dedupes on
+ * (target_type, target_id), so matching chunk indexes are replaced in place
+ * and the prior index stays queryable if any embed/upsert call throws. A
+ * pre-delete would instead leave the file unsearchable on transient failure
+ * until a successful retry.
  */
 export async function indexPkbFile(
   pkbRoot: string,
@@ -188,8 +190,15 @@ export async function indexPkbFile(
 
   const config = getConfig();
 
-  await deletePkbFilePoints(relPath, memoryScopeId);
+  const qdrant = getQdrantClient();
+  const existing = await withQdrantBreaker(() =>
+    qdrant.scrollByTargetType(PKB_TARGET_TYPE, {
+      memoryScopeId,
+      path: relPath,
+    }),
+  );
 
+  const newTargetIds = new Set<string>();
   for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
     const chunk = chunks[chunkIndex];
     // Scope-namespace the target_id so `qdrant.upsert` — which dedupes on
@@ -197,6 +206,7 @@ export async function indexPkbFile(
     // the same relpath into a single point. Without the scope prefix, the
     // second scope to index a shared path would overwrite the first's vectors.
     const targetId = `${memoryScopeId}:${relPath}#${chunkIndex}`;
+    newTargetIds.add(targetId);
     await embedAndUpsert(
       config,
       PKB_TARGET_TYPE,
@@ -209,6 +219,17 @@ export async function indexPkbFile(
         content_hash: contentHash,
         memory_scope_id: memoryScopeId,
       },
+    );
+  }
+
+  // All upserts succeeded — safe to remove stale chunks that the new content
+  // did not regenerate (e.g. the file shrunk from 4 chunks to 2).
+  for (const point of existing) {
+    const staleTargetId = point.payload.target_id;
+    if (typeof staleTargetId !== "string") continue;
+    if (newTargetIds.has(staleTargetId)) continue;
+    await withQdrantBreaker(() =>
+      qdrant.deleteByTarget(PKB_TARGET_TYPE, staleTargetId),
     );
   }
 }

--- a/assistant/src/memory/pkb/types.ts
+++ b/assistant/src/memory/pkb/types.ts
@@ -9,15 +9,11 @@ export const PKB_TARGET_TYPE = "pkb_file" as const;
 
 /**
  * Sentinel `memory_scope_id` under which ALL PKB points are indexed and
- * searched. PKB files live at workspace level (one copy on disk shared by
- * every conversation in the workspace), so every writer — the `remember`
- * tool, file writes, startup reconciliation — must pin to the same scope or
- * search would return a fragmented view of the workspace's knowledge base.
- *
- * Note: `indexPkbFile` now scope-namespaces each chunk's `target_id` (see
- * `pkb-index.ts`), so a stray per-conversation scope would no longer clobber
- * another scope's vectors at the Qdrant level. The sentinel is still required
- * for the semantic reason above: PKB is workspace-shared, not per-scope.
+ * searched. PKB files are a workspace-shared resource: one copy on disk is
+ * visible to every conversation in the workspace, so every writer — the
+ * `remember` tool, file writes, startup reconciliation — pins to this scope
+ * so search returns a single coherent view of the workspace's knowledge base
+ * instead of a per-conversation fragment.
  */
 export const PKB_WORKSPACE_SCOPE = "_pkb_workspace" as const;
 

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -697,7 +697,11 @@ export class VellumQdrantClient {
    */
   async scrollByTargetType(
     targetType: string,
-    options?: { memoryScopeId?: string; batchSize?: number },
+    options?: {
+      memoryScopeId?: string;
+      path?: string;
+      batchSize?: number;
+    },
   ): Promise<Array<{ id: string; payload: Record<string, unknown> }>> {
     await this.ensureCollection();
 
@@ -710,6 +714,9 @@ export class VellumQdrantClient {
         key: "memory_scope_id",
         match: { value: options.memoryScopeId },
       });
+    }
+    if (options?.path) {
+      must.push({ key: "path", match: { value: options.path } });
     }
     const filter = {
       must,


### PR DESCRIPTION
- Make reindex atomic: upsert new chunks first, then delete stale points, so transient failures don't leave files unsearchable.
- Rewrite PKB_WORKSPACE_SCOPE comment to reflect current design (scope-namespaced target_id) without referencing the solved dedup problem.

Addresses feedback on #26472.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
