### PR TITLE
test(shared): align AuthFailureTrackerTests helper default with production window

### DIFF
--- a/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
@@ -13,8 +13,12 @@ final class AuthFailureTrackerTests: XCTestCase {
         }
     }
 
+    /// Default `windowSeconds` matches the production `AuthFailureTracker` default (90s)
+    /// so helper-using tests exercise the real config by default. Tests whose timing
+    /// assertions depend on a specific window size (e.g. pruning at specific offsets)
+    /// must pass `windowSeconds:` explicitly at the call site.
     private func makeTracker(
-        windowSeconds: TimeInterval = 30,
+        windowSeconds: TimeInterval = 90,
         minFailures: Int = 4,
         clock: Clock
     ) -> AuthFailureTracker {


### PR DESCRIPTION
## Summary
Addresses a gap from round-2 self-review: the `makeTracker` helper in `AuthFailureTrackerTests.swift` defaulted to `windowSeconds=30`, even though the production default was widened to 90 in PR #26495. Six of eight tests used the helper, so they were silently exercising the old config.

Bumped the helper default to 90. Tests whose timing assertions depend on the 30s window now pass `windowSeconds: 30` explicitly so intent is locked in at the call site and future drifts of the production default become visible.

**Gap:** test helper default stale
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
