### PR TITLE
docs(assistant): clarify ui cancellation semantics and custom action usage

### DIFF
--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -92,9 +92,11 @@ User decisions — including declining — are normal operational results:
 
 Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
 
-### Cancellation reasons
+### Cancellation reasons (`ui request` only)
 
-A `cancelled` status includes a `cancellationReason` field that distinguishes **user-driven** cancellations from **operational fail-closed** cancellations. This allows scripts to choose different recovery strategies depending on why the surface was cancelled.
+When using `assistant ui request --json`, a `cancelled` result includes a `cancellationReason` field that distinguishes **user-driven** cancellations from **operational fail-closed** cancellations. This allows scripts to choose different recovery strategies depending on why the surface was cancelled.
+
+> **Note:** `assistant ui confirm --json` does not include `cancellationReason`. For confirmations, use the exit code (0 = confirmed, non-zero = denied/cancelled) or check the `status` field.
 
 #### User-driven cancellation
 

--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -177,6 +177,6 @@ switch (result.status) {
 }
 ```
 
-For `ui request --json`, the output additionally includes a `cancellationReason` field when `status` is `"cancelled"`, allowing scripts to distinguish user dismissal (`user_dismissed`) from operational failures (`no_interactive_surface`, `conversation_not_found`, etc.). See the [cancellation reasons](#cancellation-reasons) section above and `skills/AGENTS.md` for the `ui request` branching pattern.
+For `ui request --json`, the output additionally includes a `cancellationReason` field when `status` is `"cancelled"`, allowing scripts to distinguish user dismissal (`user_dismissed`) from operational failures (`no_interactive_surface`, `conversation_not_found`, etc.). See the [cancellation reasons](#cancellation-reasons-ui-request-only) section above and `skills/AGENTS.md` for the `ui request` branching pattern.
 
 The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs** (throw or log as errors).

--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -125,9 +125,9 @@ These indicate infrastructure or configuration problems, not user decisions:
 
 In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
 
-### Branching pattern
+### Branching pattern for `ui confirm`
 
-The canonical pattern branches on `status` first, then on `cancellationReason` when the status is `cancelled`:
+The `ui confirm --json` output includes `ok`, `confirmed`, `status`, `actionId`, `surfaceId`, and optional `decisionToken`/`summary` — but does **not** include `cancellationReason`. Branch on `status` and `confirmed`:
 
 ```typescript
 const proc = Bun.spawn(
@@ -153,7 +153,7 @@ const result = JSON.parse(raw);
 
 if (!result.ok) {
   // Operational error — IPC failure, no conversation, etc.
-  throw new Error(`UI request failed: ${result.error}`);
+  throw new Error(`UI confirm failed: ${result.error}`);
 }
 
 switch (result.status) {
@@ -167,17 +167,14 @@ switch (result.status) {
     }
     break;
   case "cancelled":
-    if (result.cancellationReason === "user_dismissed") {
-      // User deliberately closed the surface — treat like a deny
-      return { sent: false, reason: "User dismissed" };
-    }
-    // Operational cancellation — the surface could not be shown
-    log.warn(`Surface cancelled (reason: ${result.cancellationReason})`);
-    return { sent: false, reason: result.cancellationReason };
+    // User dismissed the surface — treat like a deny
+    return { sent: false, reason: "User dismissed" };
   case "timed_out":
     // No response — abort safely
     return { sent: false, reason: "Timed out" };
 }
 ```
 
-The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **Operational cancellations are environment issues** (log a warning, consider retry or fallback). **IPC failures and missing context are bugs** (throw or log as errors).
+For `ui request --json`, the output additionally includes a `cancellationReason` field when `status` is `"cancelled"`, allowing scripts to distinguish user dismissal (`user_dismissed`) from operational failures (`no_interactive_surface`, `conversation_not_found`, etc.). See the [cancellation reasons](#cancellation-reasons) section above and `skills/AGENTS.md` for the `ui request` branching pattern.
+
+The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs** (throw or log as errors).

--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -92,6 +92,29 @@ User decisions — including declining — are normal operational results:
 
 Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
 
+### Cancellation reasons
+
+A `cancelled` status includes a `cancellationReason` field that distinguishes **user-driven** cancellations from **operational fail-closed** cancellations. This allows scripts to choose different recovery strategies depending on why the surface was cancelled.
+
+#### User-driven cancellation
+
+| `cancellationReason` | Meaning                                                                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user_dismissed`     | The user explicitly closed or dismissed the surface (e.g. clicked the close button, pressed Escape). This is a deliberate user choice — handle it the same as a deny action. |
+
+#### Operational (fail-closed) cancellations
+
+These indicate the surface could not be shown or could not complete due to infrastructure/environment conditions. The runtime fails closed to `{ status: "cancelled" }` (a normal `ok: true` result) rather than raising an IPC error, so scripts must inspect `cancellationReason` to distinguish them from user dismissals.
+
+| `cancellationReason`     | Meaning                                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `no_interactive_surface` | No UI resolver is registered — the channel is headless, API-only, or does not support interactive surfaces.             |
+| `conversation_not_found` | The target conversation could not be located (not in memory and not restorable from storage).                           |
+| `resolver_unavailable`   | A UI resolver is registered but the surface transport is disconnected (e.g. the desktop client dropped its connection). |
+| `resolver_error`         | The UI resolver threw an unexpected error while attempting to show the surface.                                         |
+
+**Why this matters**: A `user_dismissed` cancellation requires no special handling — the user made a conscious choice. An operational cancellation (`no_interactive_surface`, `conversation_not_found`, etc.) may warrant retry logic, a fallback path, or logging for investigation. Scripts that only check `status === "cancelled"` continue to work but cannot differentiate the two categories.
+
 ### Operational errors (exceptional)
 
 These indicate infrastructure or configuration problems, not user decisions:
@@ -99,11 +122,12 @@ These indicate infrastructure or configuration problems, not user decisions:
 - **IPC unavailable**: The daemon is not running or the socket is unreachable. The CLI exits non-zero with an error message.
 - **No conversation context**: Neither `--conversation-id` nor `__SKILL_CONTEXT_JSON` provided a valid conversation ID.
 - **Invalid payload**: Malformed JSON in `--payload` or stdin.
-- **No interactive surface**: The active channel does not support interactive UI (headless/API mode). Note: the runtime fails closed to `{ status: "cancelled" }` (a normal result with `ok: true`), not an IPC error. Scripts should check `status` to detect this case.
 
 In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
 
 ### Branching pattern
+
+The canonical pattern branches on `status` first, then on `cancellationReason` when the status is `cancelled`:
 
 ```typescript
 const proc = Bun.spawn(
@@ -143,12 +167,17 @@ switch (result.status) {
     }
     break;
   case "cancelled":
-    // User dismissed — abort gracefully
-    return { sent: false, reason: "User cancelled" };
+    if (result.cancellationReason === "user_dismissed") {
+      // User deliberately closed the surface — treat like a deny
+      return { sent: false, reason: "User dismissed" };
+    }
+    // Operational cancellation — the surface could not be shown
+    log.warn(`Surface cancelled (reason: ${result.cancellationReason})`);
+    return { sent: false, reason: result.cancellationReason };
   case "timed_out":
     // No response — abort safely
     return { sent: false, reason: "Timed out" };
 }
 ```
 
-The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs or environment issues** (throw or log as errors).
+The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **Operational cancellations are environment issues** (log a warning, consider retry or fallback). **IPC failures and missing context are bugs** (throw or log as errors).

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -120,17 +120,103 @@
   fi
   ```
 
-  ### Status branching reference
+  ### `--actions` — custom action buttons
 
-  Every `assistant ui` response includes a `status` field. Handle all three terminal states:
+  Use `--actions` to define custom buttons on a `ui request` surface. Each action has an `id`, `label`, and optional `variant` (`"primary"`, `"danger"`, or `"secondary"`). The user's chosen action is returned in `actionId`.
+
+  ```bash
+  # Present a multi-option surface with custom actions
+  RESULT=$(assistant ui request \
+    --payload '{"message":"The staging deploy found 3 failing tests."}' \
+    --title "Deploy decision" \
+    --actions '[
+      {"id":"deploy_anyway","label":"Deploy Anyway","variant":"danger"},
+      {"id":"fix_first","label":"Fix Tests First","variant":"primary"},
+      {"id":"skip","label":"Skip This Deploy","variant":"secondary"}
+    ]' \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  ACTION=$(echo "$RESULT" | jq -r '.actionId')
+
+  if [ "$STATUS" = "submitted" ]; then
+    case "$ACTION" in
+      deploy_anyway)
+        run_deploy --force
+        ;;
+      fix_first)
+        echo "Aborting deploy. Fix the tests and re-run."
+        exit 0
+        ;;
+      skip)
+        echo "Deploy skipped."
+        exit 0
+        ;;
+    esac
+  elif [ "$STATUS" = "cancelled" ]; then
+    REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
+    if [ "$REASON" = "user_dismissed" ]; then
+      echo "User dismissed the prompt."
+    else
+      echo "Surface cancelled (reason: $REASON). No action taken."
+    fi
+  else
+    echo "Timed out. No action taken."
+  fi
+  ```
+
+  Reserved action IDs (`selection_changed`, `content_changed`, `state_update`) are used internally for surface lifecycle events and are rejected by `--actions` validation.
+
+  ### Status and cancellation reason branching reference
+
+  Every `assistant ui` response includes a `status` field and, when `status` is `"cancelled"`, a `cancellationReason` field. Branch on **both** to handle all outcomes safely.
 
   | Status | Meaning | Typical action |
   |--------|---------|----------------|
   | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | Check `actionId` to determine the action taken — e.g. `"confirm"` or `"deny"` for confirmations. For `ui confirm`, exit code 0 = confirmed, 1 = denied. |
-  | `cancelled` | User dismissed the surface without choosing an action (e.g. closed the dialog) | Abort gracefully. Inform the user the action was skipped. |
+  | `cancelled` | Surface was cancelled — check `cancellationReason` to determine why | See cancellation reason table below. |
   | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
 
-  **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
+  **Cancellation reasons**: The `cancellationReason` field distinguishes user-driven from operational cancellations:
+
+  | `cancellationReason` | Category | Meaning |
+  |----------------------|----------|---------|
+  | `user_dismissed` | User-driven | User explicitly closed the surface. Treat as a deliberate "no." |
+  | `no_interactive_surface` | Operational | No interactive UI is available (headless/API channel). Consider a fallback. |
+  | `conversation_not_found` | Operational | Target conversation could not be located. Check the conversation ID. |
+  | `resolver_unavailable` | Operational | UI transport is disconnected (e.g. desktop client dropped). May be transient. |
+  | `resolver_error` | Operational | UI resolver threw an unexpected error. Log for investigation. |
+
+  **Canonical branching pattern** for scripts that need to distinguish user dismissal from operational failures:
+
+  ```bash
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  case "$STATUS" in
+    submitted)
+      # Handle based on actionId
+      ;;
+    cancelled)
+      REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
+      if [ "$REASON" = "user_dismissed" ]; then
+        echo "User chose not to proceed."
+        exit 0
+      fi
+      # Operational cancellation — log and decide on recovery
+      echo "Surface cancelled: $REASON" >&2
+      exit 1
+      ;;
+    timed_out)
+      echo "Timed out — aborting."
+      exit 1
+      ;;
+    *)
+      echo "Unexpected status: $STATUS" >&2
+      exit 1
+      ;;
+  esac
+  ```
+
+  Scripts that do not need to differentiate cancellation reasons can continue checking `status` alone — the `cancellationReason` field is optional and additive.
 
   **Decision token**: When the user affirmatively confirms (action `"confirm"`), the JSON output includes a `decisionToken` field — a short-lived, non-authoritative token encoding metadata about the decision (conversation, surface, action, timestamps). Use it for audit trails and cross-system correlation. The token is informational only and does not grant any capability. It is absent for deny, cancel, and timeout outcomes.
 

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -169,15 +169,15 @@
 
   ### Status and cancellation reason branching reference
 
-  Every `assistant ui` response includes a `status` field and, when `status` is `"cancelled"`, a `cancellationReason` field. Branch on **both** to handle all outcomes safely.
+  Both `ui confirm` and `ui request` return a `status` field in `--json` mode. However, the `cancellationReason` field is only available in `ui request --json` output. The `ui confirm` command uses the simpler exit-code pattern (0 = confirmed, 1 = denied/cancelled/timed out) and its `--json` output includes `ok`, `confirmed`, `status`, `actionId`, `surfaceId`, and optional `decisionToken`/`summary` — but not `cancellationReason`.
 
   | Status | Meaning | Typical action |
   |--------|---------|----------------|
-  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | Check `actionId` to determine the action taken — e.g. `"confirm"` or `"deny"` for confirmations. For `ui confirm`, exit code 0 = confirmed, 1 = denied. |
-  | `cancelled` | Surface was cancelled — check `cancellationReason` to determine why | See cancellation reason table below. |
+  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | For `ui confirm`: exit code 0 = confirmed, 1 = denied. For `ui request`: check `actionId` or `submittedData`. |
+  | `cancelled` | Surface was cancelled | For `ui confirm`: exit code 1 — abort gracefully. For `ui request`: check `cancellationReason` to determine why. |
   | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
 
-  **Cancellation reasons**: The `cancellationReason` field distinguishes user-driven from operational cancellations:
+  **Cancellation reasons** (`ui request` only): The `cancellationReason` field distinguishes user-driven from operational cancellations. This field is only present in `ui request --json` output.
 
   | `cancellationReason` | Category | Meaning |
   |----------------------|----------|---------|
@@ -187,13 +187,18 @@
   | `resolver_unavailable` | Operational | UI transport is disconnected (e.g. desktop client dropped). May be transient. |
   | `resolver_error` | Operational | UI resolver threw an unexpected error. Log for investigation. |
 
-  **Canonical branching pattern** for scripts that need to distinguish user dismissal from operational failures:
+  **Canonical branching pattern for `ui request`** — for scripts that need to distinguish user dismissal from operational failures:
 
   ```bash
+  RESULT=$(assistant ui request \
+    --payload '{"message":"Confirm the operation"}' \
+    --title "Operation" \
+    --json)
+
   STATUS=$(echo "$RESULT" | jq -r '.status')
   case "$STATUS" in
     submitted)
-      # Handle based on actionId
+      # Handle based on actionId or submittedData
       ;;
     cancelled)
       REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
@@ -216,7 +221,7 @@
   esac
   ```
 
-  Scripts that do not need to differentiate cancellation reasons can continue checking `status` alone — the `cancellationReason` field is optional and additive.
+  For `ui confirm`, use the simpler exit-code pattern (see the `ui confirm` section above) or check `status` and `confirmed` fields in `--json` mode. Do not branch on `cancellationReason` with `ui confirm` — it is not included in the output.
 
   **Decision token**: When the user affirmatively confirms (action `"confirm"`), the JSON output includes a `decisionToken` field — a short-lived, non-authoritative token encoding metadata about the decision (conversation, surface, action, timestamps). Use it for audit trails and cross-system correlation. The token is informational only and does not grant any capability. It is absent for deny, cancel, and timeout outcomes.
 

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -36,8 +36,10 @@ assistant oauth request --help
 
 **Side-effect requests require explicit user confirmation.** If the request performs a side-effect (updates data, sends an email, deletes a record, etc.), gate it with `assistant ui confirm` so the user has a hard runtime veto — do not rely solely on SKILL.md prose instructions.
 
+For simple shell branching (proceed on confirm, abort otherwise), use the exit code directly:
+
 ```bash
-# Example: gate a destructive OAuth request on user confirmation
+# Simple gate: exit code 0 = confirmed, 1 = denied/cancelled/timed_out
 if assistant ui confirm \
   --title "Send email" \
   --message "Send draft to jane@example.com — Subject: Q2 Report" \
@@ -49,6 +51,44 @@ else
   echo "Cancelled — email not sent."
   exit 0
 fi
+```
+
+For scripts that need to distinguish why the surface was cancelled (user dismissal vs. operational failure), use `--json` and branch on both `status` and `cancellationReason`:
+
+```bash
+RESULT=$(assistant ui confirm \
+  --title "Delete calendar event" \
+  --message "Permanently delete '${EVENT_TITLE}'?" \
+  --confirm-label "Delete" \
+  --deny-label "Keep" \
+  --json)
+
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+case "$STATUS" in
+  submitted)
+    CONFIRMED=$(echo "$RESULT" | jq -r '.confirmed')
+    if [ "$CONFIRMED" = "true" ]; then
+      assistant oauth request DELETE "/v1.0/me/events/${EVENT_ID}" \
+        --provider microsoft-graph
+    else
+      echo "User chose to keep the event."
+    fi
+    ;;
+  cancelled)
+    REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
+    if [ "$REASON" = "user_dismissed" ]; then
+      echo "User dismissed the prompt — event not deleted."
+    else
+      # Operational cancellation (no_interactive_surface, conversation_not_found, etc.)
+      echo "Could not show confirmation surface (reason: $REASON). Aborting." >&2
+      exit 1
+    fi
+    ;;
+  timed_out)
+    echo "Confirmation timed out — event not deleted."
+    ;;
+esac
 ```
 
 For read-only requests (fetching data, listing resources), no confirmation gate is needed.

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -53,7 +53,7 @@ else
 fi
 ```
 
-For scripts that need to distinguish why the surface was cancelled (user dismissal vs. operational failure), use `--json` and branch on both `status` and `cancellationReason`:
+For scripts that need to inspect the result programmatically, use `--json` and branch on `status` and `confirmed`:
 
 ```bash
 RESULT=$(assistant ui confirm \
@@ -76,20 +76,15 @@ case "$STATUS" in
     fi
     ;;
   cancelled)
-    REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
-    if [ "$REASON" = "user_dismissed" ]; then
-      echo "User dismissed the prompt — event not deleted."
-    else
-      # Operational cancellation (no_interactive_surface, conversation_not_found, etc.)
-      echo "Could not show confirmation surface (reason: $REASON). Aborting." >&2
-      exit 1
-    fi
+    echo "User dismissed the prompt — event not deleted."
     ;;
   timed_out)
     echo "Confirmation timed out — event not deleted."
     ;;
 esac
 ```
+
+> **Note**: The `cancellationReason` field (for distinguishing user dismissal from operational failures like `no_interactive_surface`) is only available in `assistant ui request --json` output, not `ui confirm --json`. For `ui confirm`, use the exit-code pattern above for simple cases, or branch on `status` and `confirmed` for `--json` mode.
 
 For read-only requests (fetching data, listing resources), no confirmation gate is needed.
 


### PR DESCRIPTION
## Summary
- Differentiates user-driven vs operational cancellation reasons in error handling docs
- Updates AGENTS.md examples to branch on status + cancellationReason
- Adds assistant ui request --actions examples for custom interaction flows
- Updates OAuth guidance with new branching semantics

Part of plan: ui-request-gap-remediation.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
