### PR TITLE
fix(macos): restore trailing separator after Re-pair menu item

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -458,6 +458,7 @@ extension AppDelegate {
                 item.target = self
                 item.image = VIcon.refreshCw.nsImage(size: 16)
                 menu.addItem(item)
+                menu.addItem(.separator())
             }
 
             let currentConversationItem: NSMenuItem = {


### PR DESCRIPTION
## Summary
Round-1's duplicate-separator fix over-corrected: with the `.authFailed` block now inside the `onboardingWindow == nil` branch, a trailing separator after Re-pair no longer produces a duplicate (the leading separator above is emitted unconditionally by the surrounding non-onboarding branch). Add the separator back so Re-pair is visually grouped separately from the Current Conversation / New Conversation items, matching the plan's PR 6 spec.

**Gap:** missing separator after Re-pair Assistant menu item
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
