### PR TITLE
fix(ios): make defaultRePairTimeout public to unblock iOS build

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -727,7 +727,7 @@ public final class GatewayConnectionManager {
     /// Default timeout for `attemptRePair`. Long enough for a real bootstrap
     /// (guardian token poll + provision) to land, short enough that the
     /// Re-pair menu item becomes clickable again after a stuck attempt.
-    internal static let defaultRePairTimeout: TimeInterval = 90.0
+    public static let defaultRePairTimeout: TimeInterval = 90.0
 
     /// Attempts to recover from a stuck `isAuthFailed` state by re-running
     /// the bootstrap flow (clear stored credentials + re-provision). Runs the


### PR DESCRIPTION
## Summary
- iOS Build CI was failing with \`error: static property 'defaultRePairTimeout' is internal and cannot be referenced from a default argument value\` in \`clients/shared/Network/GatewayConnectionManager.swift\`.
- The \`attemptRePair\` function is \`public\` but its default argument referenced the \`internal\` static \`defaultRePairTimeout\`. Swift requires default-argument values to have at least the same access level as the function they belong to.
- Promoting \`defaultRePairTimeout\` to \`public\` resolves the build error without changing runtime behavior.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24616282165/job/71978903245