### PR TITLE
fix(daemon): drop legacy system:reflections group to dedupe sidebar

### DIFF
--- a/assistant/src/memory/__tests__/conversation-group-migration.test.ts
+++ b/assistant/src/memory/__tests__/conversation-group-migration.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { ensureGroupMigration } from "../conversation-group-migration.js";
+import { initializeDb, rawAll, rawExec, rawGet, rawRun } from "../db.js";
+
+initializeDb();
+
+// Simulate a legacy install that has the `system:reflections` system group
+// plus a conversation pointing at it. The migration must:
+//   1. Seed the current system groups (without `system:reflections`).
+//   2. Move the legacy conversation to `system:background` (step 6).
+//   3. Delete the orphaned `system:reflections` row (step 7).
+//
+// We pre-create the `conversation_groups` table and `group_id` column directly
+// because the migration's own CREATE TABLE IF NOT EXISTS / ALTER TABLE steps
+// would otherwise be the first to introduce them — there's no way to seed the
+// "legacy" row until they exist.
+describe("ensureGroupMigration — reflections cleanup", () => {
+  beforeAll(() => {
+    rawExec(`
+      CREATE TABLE IF NOT EXISTS conversation_groups (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        sort_position REAL NOT NULL DEFAULT 0,
+        is_system_group BOOLEAN NOT NULL DEFAULT FALSE,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+      )
+    `);
+    try {
+      rawRun(
+        "ALTER TABLE conversations ADD COLUMN group_id TEXT REFERENCES conversation_groups(id) ON DELETE SET NULL",
+      );
+    } catch {
+      // column already present — ok
+    }
+    rawRun(
+      "INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group) VALUES ('system:reflections', 'Reflections', 100, TRUE)",
+    );
+    const now = Math.floor(Date.now() / 1000);
+    rawRun(
+      "INSERT INTO conversations (id, created_at, updated_at, group_id) VALUES (?, ?, ?, ?)",
+      "legacy-refl-1",
+      now,
+      now,
+      "system:reflections",
+    );
+
+    ensureGroupMigration();
+  });
+
+  test("moves legacy system:reflections conversations to system:background", () => {
+    const legacy = rawGet<{ group_id: string | null }>(
+      "SELECT group_id FROM conversations WHERE id = 'legacy-refl-1'",
+    );
+    expect(legacy?.group_id).toBe("system:background");
+  });
+
+  test("deletes the orphaned system:reflections group row", () => {
+    const refl = rawGet<{ id: string }>(
+      "SELECT id FROM conversation_groups WHERE id = 'system:reflections'",
+    );
+    expect(refl).toBeNull();
+  });
+
+  test("seeds the current system groups without system:reflections", () => {
+    const systemIds = rawAll<{ id: string }>(
+      "SELECT id FROM conversation_groups WHERE id LIKE 'system:%' ORDER BY id",
+    ).map((r) => r.id);
+    expect(systemIds).toEqual([
+      "system:all",
+      "system:background",
+      "system:pinned",
+      "system:scheduled",
+    ]);
+  });
+
+  test("records the cleanup sentinel so the step is idempotent", () => {
+    const sentinel = rawGet<{ id: string }>(
+      "SELECT id FROM conversation_groups WHERE id = '_reflections_group_deleted_complete'",
+    );
+    expect(sentinel?.id).toBe("_reflections_group_deleted_complete");
+  });
+
+  test("re-running ensureGroupMigration does not recreate the stale group", () => {
+    expect(() => ensureGroupMigration()).not.toThrow();
+    const refl = rawGet<{ id: string }>(
+      "SELECT id FROM conversation_groups WHERE id = 'system:reflections'",
+    );
+    expect(refl).toBeNull();
+  });
+});

--- a/assistant/src/memory/conversation-group-migration.ts
+++ b/assistant/src/memory/conversation-group-migration.ts
@@ -58,10 +58,6 @@ export function ensureGroupMigration(): void {
   }
 
   // 3. Seed system groups.
-  //
-  // `system:reflections` is a legacy group kept for backward compatibility
-  // with existing installations. New auto-analysis conversations are assigned
-  // to `system:background`; the migration in step 6 moves existing ones.
   const now = Math.floor(Date.now() / 1000);
   rawExec(`
     INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group, created_at, updated_at)
@@ -69,8 +65,7 @@ export function ensureGroupMigration(): void {
       ('system:pinned', 'Pinned', 0, TRUE, ${now}, ${now}),
       ('system:scheduled', 'Scheduled', 1, TRUE, ${now}, ${now}),
       ('system:background', 'Background', 2, TRUE, ${now}, ${now}),
-      ('system:all', 'Recents', 3, TRUE, ${now}, ${now}),
-      ('system:reflections', 'Reflections', 100, TRUE, ${now}, ${now})
+      ('system:all', 'Recents', 3, TRUE, ${now}, ${now})
   `);
 
   // One-time migration: move system:all to sortPosition 3 (from 999999).
@@ -241,6 +236,43 @@ export function ensureGroupMigration(): void {
     } catch (err) {
       rawExec("ROLLBACK");
       log.error({ err }, "reflections-to-background migration failed, rolled back");
+      throw err;
+    }
+  }
+
+  // 7. One-time cleanup: delete the orphaned system:reflections group row.
+  //
+  // Reflections render as a sub-group under Background via the client's
+  // sub-group label provider; the standalone system:reflections group is no
+  // longer referenced by any conversation after step 6. Leaving the row in
+  // place causes the macOS sidebar to render an empty duplicate "Reflections"
+  // entry with a fallback folder icon alongside the Background sub-group.
+  const reflectionsGroupDeleted = rawGet<{ id: string }>(
+    "SELECT id FROM conversation_groups WHERE id = '_reflections_group_deleted_complete'",
+  );
+
+  if (!reflectionsGroupDeleted) {
+    try {
+      rawExec("BEGIN");
+
+      // Belt-and-suspenders: re-run the conversation move in case a straggler
+      // crept in between step 6's sentinel being set and this step shipping.
+      rawExec(`
+        UPDATE conversations SET group_id = 'system:background'
+        WHERE group_id = 'system:reflections'
+      `);
+
+      rawExec(`DELETE FROM conversation_groups WHERE id = 'system:reflections'`);
+
+      rawExec(`
+        INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group)
+        VALUES ('_reflections_group_deleted_complete', '_reflections_group_deleted_complete', -1, TRUE)
+      `);
+
+      rawExec("COMMIT");
+    } catch (err) {
+      rawExec("ROLLBACK");
+      log.error({ err }, "reflections-group deletion failed, rolled back");
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- The macOS sidebar rendered two "Reflections" rows — the correct Background sub-group and an empty folder-icon duplicate. PR #25998 moved Reflections under Background and deleted `SidebarReflectionsSection`, but left the daemon seeding a stale `system:reflections` row that the generic system-group renderer kept drawing.
- Daemon-side fix: drop `system:reflections` from the seed SQL and add idempotent step 7 that re-runs the conversation move and deletes the orphaned row. Guarded by `_reflections_group_deleted_complete`.
- New test seeds legacy state (stale group row + a conversation referencing it) and asserts conversations move to `system:background`, the stale row is gone, the sentinel is recorded, and re-running the migration is a no-op.

## Original prompt
it