### PR TITLE
fix: update messaging SKILL.md to remove stale bundled Gmail tool references

### DIFF
--- a/assistant/src/__tests__/messaging-skill-split.test.ts
+++ b/assistant/src/__tests__/messaging-skill-split.test.ts
@@ -16,7 +16,6 @@ function loadManifest(skillDir: string) {
 }
 
 const messagingManifest = loadManifest("messaging");
-const gmailManifest = loadManifest("gmail");
 const sequencesManifest = loadManifest("sequences");
 describe("Messaging skill split", () => {
   const expectedMessagingToolNames = [
@@ -30,22 +29,6 @@ describe("Messaging skill split", () => {
     "messaging_draft",
     "messaging_sender_digest",
     "messaging_archive_by_sender",
-  ];
-
-  const expectedGmailToolNames = [
-    "gmail_archive",
-    "gmail_label",
-    "gmail_trash",
-    "gmail_unsubscribe",
-    "gmail_draft",
-    "gmail_send_draft",
-    "gmail_attachments",
-    "gmail_forward",
-    "gmail_follow_up",
-    "gmail_filters",
-    "gmail_vacation",
-    "gmail_sender_digest",
-    "gmail_outreach_scan",
   ];
 
   const expectedSequenceToolNames = [
@@ -80,15 +63,6 @@ describe("Messaging skill split", () => {
     }
   });
 
-  test("gmail/TOOLS.json contains all expected gmail_* tool names", () => {
-    const names: string[] = gmailManifest.tools.map(
-      (t: { name: string }) => t.name,
-    );
-    for (const name of expectedGmailToolNames) {
-      expect(names).toContain(name);
-    }
-  });
-
   test("sequences/TOOLS.json contains all expected sequence_* tool names", () => {
     const names: string[] = sequencesManifest.tools.map(
       (t: { name: string }) => t.name,
@@ -101,20 +75,15 @@ describe("Messaging skill split", () => {
 
   test("total tools across all manifests meets expected minimum", () => {
     const expectedMinimum =
-      expectedMessagingToolNames.length +
-      expectedGmailToolNames.length +
-      expectedSequenceToolNames.length;
+      expectedMessagingToolNames.length + expectedSequenceToolNames.length;
     const totalTools =
-      messagingManifest.tools.length +
-      gmailManifest.tools.length +
-      sequencesManifest.tools.length;
+      messagingManifest.tools.length + sequencesManifest.tools.length;
     expect(totalTools).toBeGreaterThanOrEqual(expectedMinimum);
   });
 
-  test("no tool name collisions across messaging, gmail, and sequences manifests", () => {
+  test("no tool name collisions across messaging and sequences manifests", () => {
     const allNames = [
       ...messagingManifest.tools.map((t: { name: string }) => t.name),
-      ...gmailManifest.tools.map((t: { name: string }) => t.name),
       ...sequencesManifest.tools.map((t: { name: string }) => t.name),
     ];
     const unique = new Set(allNames);

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -177,7 +177,7 @@ Medium and high risk tools require a confidence score between 0 and 1:
 
 When a user asks to declutter, clean up, or organize their email:
 
-- **Gmail connected**: Load the **gmail** skill, which has the full decluttering workflow with `gmail_sender_digest`, `gmail_archive`, `gmail_unsubscribe`, and `gmail_filters`.
+- **Gmail connected**: Load the **gmail** skill, which has the full decluttering workflow with sender-digest scanning, batch archiving, unsubscribe support, and filter management.
 - **Non-Gmail email connected**: Use the generic tools (`messaging_sender_digest`, `messaging_archive_by_sender`) - they work with any provider that supports these operations. Skip unsubscribe and filter offers since they are Gmail-specific.
 - **Nothing connected**: Ask which email provider they use. If it's Gmail, go straight into the Gmail connection flow. For other providers, let the user know only Gmail is supported right now and offer to set up Gmail instead. Don't present a menu of options or explain what OAuth is.
 
@@ -195,4 +195,4 @@ When a user asks to declutter, clean up, or organize their email:
 
 ### Query-Based Archiving
 
-Unlike Gmail's `gmail_archive` (which supports `scan_id` + `sender_ids`), `messaging_archive_by_sender` is query-based. Build `from:<email>` queries from the sender digest results to target specific senders. Include the same date/category filters used in the original scan to keep the scope consistent.
+Unlike the Gmail skill's archive script (which supports `cache_key` + sender emails), `messaging_archive_by_sender` is query-based. Build `from:<email>` queries from the sender digest results to target specific senders. Include the same date/category filters used in the original scan to keep the scope consistent.


### PR DESCRIPTION
## Summary
Updates messaging skill's SKILL.md to remove references to deleted bundled Gmail tool names.

**Gap:** Stale bundled Gmail tool references in messaging SKILL.md
**What was expected:** No references to deleted bundled Gmail tools
**What was found:** messaging SKILL.md references gmail_sender_digest, gmail_archive, gmail_unsubscribe, gmail_filters
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
