### PR TITLE
fix: use repeated query params for Gmail metadataHeaders and add fields parameter

### DIFF
--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -18,26 +18,26 @@ All operations use CLI scripts that return JSON:
 - **Success**: `{ "ok": true, "data": ... }`
 - **Failure**: `{ "ok": false, "error": "..." }`
 
-| Script            | Operation       | Description                                                              |
-| ----------------- | --------------- | ------------------------------------------------------------------------ |
-| `gmail-email.ts`  | `draft`         | Create email drafts in the Drafts folder (including reply drafts)        |
-| `gmail-email.ts`  | `send-draft`    | Send an existing draft (**requires explicit user confirmation**)         |
-| `gmail-email.ts`  | `forward`       | Create forward drafts, preserving attachments                            |
-| `gmail-email.ts`  | `trash`         | Move messages to Trash                                                   |
-| `gmail-manage.ts` | `label`         | Add or remove labels on messages                                         |
-| `gmail-manage.ts` | `follow-up`     | Track/untrack messages for follow-up using a dedicated "Follow-up" label |
-| `gmail-manage.ts` | `attachments`   | List and download email attachments                                      |
-| `gmail-manage.ts` | `filters`       | Create, list, and delete Gmail filters                                   |
-| `gmail-manage.ts` | `vacation`      | Get, enable, or disable the vacation auto-responder                      |
-| `gmail-manage.ts` | `unsubscribe`   | Unsubscribe from mailing lists (**requires explicit user confirmation**) |
-| `gmail-scan.ts`   | `sender-digest` | Scan inbox and group messages by sender for declutter workflows          |
-| `gmail-scan.ts`   | `outreach-scan` | Identify cold outreach senders (no List-Unsubscribe header)              |
-| `gmail-archive.ts`| `archive`       | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
-| `gmail-prefs.ts`  | `list`          | List blocklist and safelist preferences                                  |
-| `gmail-prefs.ts`  | `add-blocklist` | Add sender emails to the blocklist                                       |
-| `gmail-prefs.ts`  | `add-safelist`  | Add sender emails to the safelist                                        |
-| `gmail-prefs.ts`  | `remove-blocklist` | Remove sender emails from the blocklist                               |
-| `gmail-prefs.ts`  | `remove-safelist`  | Remove sender emails from the safelist                                |
+| Script             | Operation          | Description                                                                  |
+| ------------------ | ------------------ | ---------------------------------------------------------------------------- |
+| `gmail-email.ts`   | `draft`            | Create email drafts in the Drafts folder (including reply drafts)            |
+| `gmail-email.ts`   | `send-draft`       | Send an existing draft (**requires explicit user confirmation**)             |
+| `gmail-email.ts`   | `forward`          | Create forward drafts, preserving attachments                                |
+| `gmail-email.ts`   | `trash`            | Move messages to Trash                                                       |
+| `gmail-manage.ts`  | `label`            | Add or remove labels on messages                                             |
+| `gmail-manage.ts`  | `follow-up`        | Track/untrack messages for follow-up using a dedicated "Follow-up" label     |
+| `gmail-manage.ts`  | `attachments`      | List and download email attachments                                          |
+| `gmail-manage.ts`  | `filters`          | Create, list, and delete Gmail filters                                       |
+| `gmail-manage.ts`  | `vacation`         | Get, enable, or disable the vacation auto-responder                          |
+| `gmail-manage.ts`  | `unsubscribe`      | Unsubscribe from mailing lists (**requires explicit user confirmation**)     |
+| `gmail-scan.ts`    | `sender-digest`    | Scan inbox and group messages by sender for declutter workflows              |
+| `gmail-scan.ts`    | `outreach-scan`    | Identify cold outreach senders (no List-Unsubscribe header)                  |
+| `gmail-archive.ts` | `archive`          | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
+| `gmail-prefs.ts`   | `list`             | List blocklist and safelist preferences                                      |
+| `gmail-prefs.ts`   | `add-blocklist`    | Add sender emails to the blocklist                                           |
+| `gmail-prefs.ts`   | `add-safelist`     | Add sender emails to the safelist                                            |
+| `gmail-prefs.ts`   | `remove-blocklist` | Remove sender emails from the blocklist                                      |
+| `gmail-prefs.ts`   | `remove-safelist`  | Remove sender emails from the safelist                                       |
 
 ### Email Operations
 
@@ -204,7 +204,7 @@ When searching Gmail, the query uses Gmail's search operators:
 | `newer_than:`    | `newer_than:7d`          | Messages from the last 7 days       |
 | `older_than:`    | `older_than:30d`         | Messages older than 30 days         |
 | `is:unread`      | `is:unread`              | Unread messages                     |
-| `has:attachment`  | `has:attachment`         | Messages with attachments           |
+| `has:attachment` | `has:attachment`         | Messages with attachments           |
 | `label:`         | `label:work`             | Messages with a specific label      |
 
 ## Email Decluttering
@@ -224,7 +224,12 @@ When a user asks to declutter, clean up, or organize their email - start scannin
    - **Action buttons (exactly 2)**: "Archive & Unsubscribe" (primary), "Archive Only" (secondary). **NEVER offer Delete, Trash, or any destructive action.**
 3. **Embed cache_key in button data**: When constructing the action buttons, include the `cache_key` from the scan result in each button's `data` field. This ensures `cache_key` is forwarded automatically when the user clicks — the LLM does not need to recall it from earlier context:
    ```json
-   { "id": "archive_unsubscribe", "label": "Archive & Unsubscribe", "style": "primary", "data": { "cache_key": "<cache_key value here>" } }
+   {
+     "id": "archive_unsubscribe",
+     "label": "Archive & Unsubscribe",
+     "style": "primary",
+     "data": { "cache_key": "<cache_key value here>" }
+   }
    ```
 4. **Wait for user action**: Stop and wait. Do NOT proceed to archiving or unsubscribing until the user explicitly confirms which senders to clean up and which action to take. When the user clicks an action button you will receive an action message containing `action data: { cache_key, selectedIds }`:
    - `selectedIds` are **sender IDs** (base64-encoded email addresses) — NOT Gmail message IDs. Always use them as sender emails with `cache_key`, never as `message_ids`.

--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -193,15 +193,19 @@ async function archiveByCacheKey(
   let cachedData: Record<string, string[]> | null = null;
 
   try {
-    const proc = Bun.spawn(
-      ["assistant", "cache", "get", cacheKey, "--json"],
-      { stdout: "pipe", stderr: "pipe" },
-    );
+    const proc = Bun.spawn(["assistant", "cache", "get", cacheKey, "--json"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     const stdout = await new Response(proc.stdout).text();
     await proc.exited;
 
     const parsed = JSON.parse(stdout);
-    if (parsed.ok === true && parsed.data !== null && parsed.data !== undefined) {
+    if (
+      parsed.ok === true &&
+      parsed.data !== null &&
+      parsed.data !== undefined
+    ) {
       cachedData = parsed.data as Record<string, string[]>;
     }
   } catch {

--- a/skills/gmail/scripts/gmail-manage.ts
+++ b/skills/gmail/scripts/gmail-manage.ts
@@ -22,6 +22,7 @@ import {
   gmailPost,
   gmailPut,
   gmailDelete,
+  gmailRequest,
   batchFetchMessages,
   type GmailMessage,
   type GmailMessagePart,
@@ -182,6 +183,8 @@ async function handleFollowUp(
         "metadata",
         ["From", "Subject", "Date"],
         account,
+        undefined,
+        "id,threadId,payload/headers",
       );
       const items = messages.map((m) => {
         const headers = m.payload?.headers ?? [];
@@ -656,15 +659,18 @@ async function handleUnsubscribe(
   const account = optionalArg(args, "account");
   const skipConfirm = args["skip-confirm"] === true;
 
-  // Fetch message metadata with unsubscribe headers and sender info
-  const res = await gmailGet<GmailMessage>(
-    `/messages/${messageId}`,
-    {
-      format: "metadata",
-      metadataHeaders: "List-Unsubscribe,List-Unsubscribe-Post,From",
-    },
+  // Fetch message metadata with unsubscribe headers and sender info.
+  // metadataHeaders must be sent as repeated query params, not comma-separated.
+  const unsubMetadataHeaders = ["List-Unsubscribe", "List-Unsubscribe-Post", "From"];
+  const res = await gmailRequest<GmailMessage>({
+    method: "GET",
+    path: `/messages/${messageId}`,
+    query: { format: "metadata" },
     account,
-  );
+    pathSuffix: unsubMetadataHeaders
+      .map((h) => `&metadataHeaders=${encodeURIComponent(h)}`)
+      .join(""),
+  });
   if (!res.ok) {
     printError(`Failed to get message headers (HTTP ${res.status})`);
   }

--- a/skills/gmail/scripts/gmail-manage.ts
+++ b/skills/gmail/scripts/gmail-manage.ts
@@ -99,11 +99,7 @@ interface LabelsListResponse {
 const FOLLOW_UP_LABEL_NAME = "Follow-up";
 
 async function getOrCreateFollowUpLabel(account?: string): Promise<string> {
-  const res = await gmailGet<LabelsListResponse>(
-    "/labels",
-    undefined,
-    account,
-  );
+  const res = await gmailGet<LabelsListResponse>("/labels", undefined, account);
   if (!res.ok) {
     printError(`Failed to list labels (HTTP ${res.status})`);
   }
@@ -395,10 +391,7 @@ async function handleFilters(
     }
     case "delete": {
       const filterId = requireArg(args, "filter-id");
-      const res = await gmailDelete(
-        `/settings/filters/${filterId}`,
-        account,
-      );
+      const res = await gmailDelete(`/settings/filters/${filterId}`, account);
       if (!res.ok) {
         printError(`Failed to delete filter (HTTP ${res.status})`);
       }
@@ -469,9 +462,7 @@ async function handleVacation(
         account,
       );
       if (!res.ok) {
-        printError(
-          `Failed to enable vacation responder (HTTP ${res.status})`,
-        );
+        printError(`Failed to enable vacation responder (HTTP ${res.status})`);
       }
       ok(res.data);
       break;
@@ -483,9 +474,7 @@ async function handleVacation(
         account,
       );
       if (!res.ok) {
-        printError(
-          `Failed to disable vacation responder (HTTP ${res.status})`,
-        );
+        printError(`Failed to disable vacation responder (HTTP ${res.status})`);
       }
       ok({ disabled: true });
       break;
@@ -661,7 +650,11 @@ async function handleUnsubscribe(
 
   // Fetch message metadata with unsubscribe headers and sender info.
   // metadataHeaders must be sent as repeated query params, not comma-separated.
-  const unsubMetadataHeaders = ["List-Unsubscribe", "List-Unsubscribe-Post", "From"];
+  const unsubMetadataHeaders = [
+    "List-Unsubscribe",
+    "List-Unsubscribe-Post",
+    "From",
+  ];
   const res = await gmailRequest<GmailMessage>({
     method: "GET",
     path: `/messages/${messageId}`,
@@ -811,11 +804,7 @@ async function handleUnsubscribe(
       .replace(/\//g, "_")
       .replace(/=+$/, "");
 
-    const sendRes = await gmailPost(
-      "/messages/send",
-      { raw },
-      account,
-    );
+    const sendRes = await gmailPost("/messages/send", { raw }, account);
 
     if (sendRes.ok) {
       ok({

--- a/skills/gmail/scripts/gmail-prefs.ts
+++ b/skills/gmail/scripts/gmail-prefs.ts
@@ -113,7 +113,7 @@ function main(): void {
 
   if (!action || typeof action !== "string") {
     printError(
-      'Missing required argument: --action (list, add-blocklist, add-safelist, remove-blocklist, remove-safelist)',
+      "Missing required argument: --action (list, add-blocklist, add-safelist, remove-blocklist, remove-safelist)",
     );
   }
 

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -198,11 +198,15 @@ async function senderDigest(args: Record<string, string | boolean>) {
       const pageSize = Math.min(500, maxMessages - allMessageIds.length);
       let listResp;
       try {
-        listResp = await gmailGet<ListMessagesResponse>("/messages", {
-          q: query,
-          maxResults: String(pageSize),
-          ...(pageToken ? { pageToken } : {}),
-        }, account);
+        listResp = await gmailGet<ListMessagesResponse>(
+          "/messages",
+          {
+            q: query,
+            maxResults: String(pageSize),
+            ...(pageToken ? { pageToken } : {}),
+          },
+          account,
+        );
       } catch (e) {
         if (isRateLimitError(e)) {
           rateLimited = true;
@@ -456,11 +460,15 @@ async function outreachScan(args: Record<string, string | boolean>) {
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
       let listResp;
       try {
-        listResp = await gmailGet<ListMessagesResponse>("/messages", {
-          q: query,
-          maxResults: String(pageSize),
-          ...(pageToken ? { pageToken } : {}),
-        }, account);
+        listResp = await gmailGet<ListMessagesResponse>(
+          "/messages",
+          {
+            q: query,
+            maxResults: String(pageSize),
+            ...(pageToken ? { pageToken } : {}),
+          },
+          account,
+        );
       } catch (e) {
         if (isRateLimitError(e)) {
           rateLimited = true;

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -236,6 +236,7 @@ async function senderDigest(args: Record<string, string | boolean>) {
           metadataHeaders,
           account,
           fetchAbort.signal,
+          "id,internalDate,payload/headers",
         ),
       );
 
@@ -493,6 +494,7 @@ async function outreachScan(args: Record<string, string | boolean>) {
           metadataHeaders,
           account,
           fetchAbort.signal,
+          "id,internalDate,payload/headers",
         ),
       );
 

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -96,7 +96,9 @@ export async function gmailRequest<T = unknown>(
       path += "?" + qs;
     }
     if (opts.pathSuffix) {
-      path += path.includes("?") ? opts.pathSuffix : "?" + opts.pathSuffix.replace(/^&/, "");
+      path += path.includes("?")
+        ? opts.pathSuffix
+        : "?" + opts.pathSuffix.replace(/^&/, "");
     }
 
     args.push(path);

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -12,6 +12,8 @@ export interface GmailRequestOptions {
   body?: unknown;
   account?: string;
   headers?: Record<string, string>;
+  /** Raw query string to append after the standard query params (e.g. repeated params). */
+  pathSuffix?: string;
 }
 
 export interface GmailResponse<T = unknown> {
@@ -92,6 +94,9 @@ export async function gmailRequest<T = unknown>(
     if (opts.query && Object.keys(opts.query).length > 0) {
       const qs = new URLSearchParams(opts.query).toString();
       path += "?" + qs;
+    }
+    if (opts.pathSuffix) {
+      path += path.includes("?") ? opts.pathSuffix : "?" + opts.pathSuffix.replace(/^&/, "");
     }
 
     args.push(path);
@@ -198,6 +203,7 @@ export async function batchFetchMessages(
   metadataHeaders?: string[],
   account?: string,
   signal?: AbortSignal,
+  fields?: string,
 ): Promise<GmailMessage[]> {
   const results: GmailMessage[] = [];
 
@@ -208,14 +214,28 @@ export async function batchFetchMessages(
     const waveResults = await Promise.all(
       wave.map(async (id) => {
         const query: Record<string, string> = { format };
-        if (metadataHeaders && metadataHeaders.length > 0) {
-          query.metadataHeaders = metadataHeaders.join(",");
+        if (fields) {
+          query.fields = fields;
         }
-        const response = await gmailGet<GmailMessage>(
-          `/messages/${id}`,
+
+        // Build metadataHeaders as repeated query params to avoid
+        // URL-encoding issues with comma-separated values.
+        // Gmail API expects: metadataHeaders=From&metadataHeaders=Subject
+        // NOT: metadataHeaders=From%2CSubject
+        let pathSuffix = "";
+        if (metadataHeaders && metadataHeaders.length > 0) {
+          pathSuffix = metadataHeaders
+            .map((h) => `&metadataHeaders=${encodeURIComponent(h)}`)
+            .join("");
+        }
+
+        const response = await gmailRequest<GmailMessage>({
+          method: "GET",
+          path: `/messages/${id}`,
           query,
           account,
-        );
+          pathSuffix,
+        });
         return response.ok ? response.data : null;
       }),
     );


### PR DESCRIPTION
## Summary
Fixes batchFetchMessages to send metadataHeaders as repeated query params instead of comma-separated.

**Gap:** metadataHeaders encoding
**What was expected:** metadataHeaders=From&metadataHeaders=Subject (repeated params)
**What was found:** metadataHeaders=From,Subject (comma-separated, URL-encoded)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
