### PR TITLE
fix: remove duplicate comment in buildStandaloneSurfaceData

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -587,9 +587,6 @@ function buildStandaloneSurfaceData(
     // of top-level `fields` may omit the latter entirely.
     const raw = request.data as Record<string, unknown>;
     const hasFields = Array.isArray(raw.fields) && raw.fields.length > 0;
-
-    // Ensure `fields` is always a valid array — callers that supply `pages`
-    // instead of top-level `fields` may omit the latter entirely.
     const fields: FormSurfaceData["fields"] = hasFields
       ? (raw.fields as FormSurfaceData["fields"])
       : [];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ui-request-gap-remediation.md.

**Gap:** Duplicate comment in buildStandaloneSurfaceData
**What was expected:** Single clear comment
**What was found:** Two consecutive comments saying the same thing about fields normalization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
