### PR TITLE
fix: add cancellationReason to dispose path for standalone surfaces

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -761,7 +761,11 @@ export class Conversation {
       } catch {
         // Best-effort: the client may already be disconnected during dispose.
       }
-      entry.resolve({ status: "cancelled", surfaceId });
+      entry.resolve({
+        status: "cancelled",
+        surfaceId,
+        cancellationReason: "resolver_unavailable",
+      });
     }
     this.pendingStandaloneSurfaces.clear();
     // Clear tombstone timers to prevent dangling references after dispose.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ui-request-gap-remediation.md.

**Gap:** Dispose path lacks cancellationReason
**What was expected:** Dispose-triggered cancellations should include a deterministic reason
**What was found:** conversation.ts resolves with bare { status: cancelled } without a reason
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
