### PR TITLE
fix(cache): reject `--ttl ""` instead of silently using default TTL

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -360,6 +360,28 @@ describe("TTL parsing", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --ttl");
   });
+
+  test("rejects empty string TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", ""]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on empty string TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('Invalid --ttl value ""');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -30,11 +30,17 @@ const TTL_MULTIPLIERS: Record<string, number> = {
 
 /**
  * Parse a human-friendly duration string (e.g. `"30s"`, `"5m"`, `"2h"`)
- * into milliseconds. Returns `undefined` when the input is falsy.
- * Throws on malformed input so the CLI can surface actionable errors.
+ * into milliseconds. Returns `undefined` when the input is `undefined`.
+ * Throws on empty/whitespace-only or malformed input so the CLI can
+ * surface actionable errors.
  */
 function parseTtl(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
+  if (raw === undefined) return undefined;
+  if (!raw.trim()) {
+    throw new Error(
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+    );
+  }
   const match = TTL_PATTERN.exec(raw.trim());
   if (!match) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Reject empty-string and whitespace-only `--ttl` values with a clear validation error instead of silently falling through to the default 30m TTL
- Add tests covering empty string and JSON error output for empty TTL

Part of plan: fix-cache-cli-bugs.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
