### PR TITLE
fix: add cancel and dismiss to reserved action IDs

### DIFF
--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -1145,6 +1145,50 @@ describe("ui request — --actions parsing", () => {
     expect(lastIpcCall).toBeNull();
   });
 
+  test("rejects 'cancel' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"cancel","label":"Cancel"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('id "cancel" is reserved for internal use');
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'dismiss' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"dismiss","label":"Dismiss"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('id "dismiss" is reserved for internal use');
+    expect(lastIpcCall).toBeNull();
+  });
+
   test("non-reserved IDs are accepted alongside validation", async () => {
     process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
       conversationId: "conv-1",

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -151,15 +151,24 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
 
 /**
  * Action IDs reserved for internal surface lifecycle events. These IDs
- * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
- * as non-terminal events (early return without resolving the pending
- * `ui_request`). If a caller defines one of these as a custom button ID,
- * clicking it would silently return early without resolving.
+ * have special behavior in `handleSurfaceAction` (conversation-surfaces.ts)
+ * and must not be used as custom button IDs:
+ *
+ * - `selection_changed`, `content_changed`, `state_update` — Intercepted
+ *   as non-terminal events (early return without resolving the pending
+ *   `ui_request`). Using one as a button ID would silently swallow the click.
+ *
+ * - `cancel`, `dismiss` — Treated as cancellation signals, resolving the
+ *   `ui_request` with `status: "cancelled"` instead of the expected
+ *   `status: "submitted"`. A caller expecting submission semantics would
+ *   get the wrong status.
  */
 export const RESERVED_ACTION_IDS = new Set([
   "selection_changed",
   "content_changed",
   "state_update",
+  "cancel",
+  "dismiss",
 ]);
 
 /** Valid variant values for action buttons. */


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ui-request-gap-remediation.md.

**Gap:** cancel and dismiss action IDs have special status-mapping but are not reserved
**What was expected:** All IDs with special behavior should be blocked
**What was found:** handleSurfaceAction treats cancel/dismiss as cancellations, but RESERVED_ACTION_IDS didn't include them
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
