### PR TITLE
fix(cache): differentiate delete output when key exists vs doesn't exist

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -467,7 +467,7 @@ describe("cache get", () => {
 
 describe("cache delete", () => {
   test("sends cache/delete IPC and succeeds", async () => {
-    mockIpcResult = { ok: true, result: {} };
+    mockIpcResult = { ok: true, result: { deleted: true } };
 
     const { exitCode } = await runCommand(["cache", "delete", "my-key"]);
 
@@ -476,8 +476,8 @@ describe("cache delete", () => {
     expect(lastIpcCall!.params).toEqual({ key: "my-key" });
   });
 
-  test("--json outputs { ok: true } on success", async () => {
-    mockIpcResult = { ok: true, result: {} };
+  test("--json outputs { ok: true, deleted: true } on success", async () => {
+    mockIpcResult = { ok: true, result: { deleted: true } };
 
     const { exitCode, stdout } = await runCommand([
       "cache",
@@ -488,7 +488,22 @@ describe("cache delete", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed).toEqual({ ok: true });
+    expect(parsed).toEqual({ ok: true, deleted: true });
+  });
+
+  test("--json outputs { ok: true, deleted: false } when key did not exist", async () => {
+    mockIpcResult = { ok: true, result: { deleted: false } };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "missing-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, deleted: false });
   });
 
   test("exits with error on IPC failure", async () => {

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -289,15 +289,15 @@ Arguments:
   key   The cache key to remove. Run 'assistant cache get <key>' to
         verify a key exists before deleting.
 
-Removes the entry from the cache. Succeeds silently if the key does not
-exist (idempotent).
+Removes the entry from the cache. Idempotent — exits 0 whether the key
+existed or not, but reports whether an entry was actually removed.
 
 Examples:
   $ assistant cache delete my-key
   $ assistant cache delete my-key --json`,
     )
     .action(async (key: string, opts: { json?: boolean }) => {
-      const result = await cliIpcCall<Record<string, never>>("cache/delete", {
+      const result = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
         key,
       });
 
@@ -313,10 +313,16 @@ Examples:
         return;
       }
 
+      const deleted = result.result!.deleted;
+
       if (opts.json) {
-        process.stdout.write(JSON.stringify({ ok: true }) + "\n");
+        process.stdout.write(JSON.stringify({ ok: true, deleted }) + "\n");
       } else {
-        log.info(`Deleted cache entry "${key}".`);
+        if (deleted) {
+          log.info(`Deleted cache entry "${key}".`);
+        } else {
+          log.info(`No cache entry "${key}" (nothing to delete).`);
+        }
       }
     });
 }

--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -84,7 +84,7 @@ describe("cache IPC routes", () => {
 
   // ── Delete ────────────────────────────────────────────────────────
 
-  test("delete returns empty object and makes later get return null", async () => {
+  test("delete returns deleted: true and makes later get return null", async () => {
     // Store an entry first.
     const setResult = await cliIpcCall<{ key: string }>("cache/set", {
       data: 42,
@@ -93,11 +93,11 @@ describe("cache IPC routes", () => {
     expect(setResult.ok).toBe(true);
 
     // Delete it.
-    const delResult = await cliIpcCall<object>("cache/delete", {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
       key: "to-delete",
     });
     expect(delResult.ok).toBe(true);
-    expect(delResult.result).toEqual({});
+    expect(delResult.result).toEqual({ deleted: true });
 
     // Get should now return null.
     const getResult = await cliIpcCall<null>("cache/get", {
@@ -105,6 +105,14 @@ describe("cache IPC routes", () => {
     });
     expect(getResult.ok).toBe(true);
     expect(getResult.result).toBeNull();
+  });
+
+  test("delete on non-existent key returns deleted: false", async () => {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
+      key: "never-existed",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({ deleted: false });
   });
 
   // ── Get for non-existent key returns null ─────────────────────────
@@ -210,11 +218,11 @@ describe("cache IPC routes", () => {
   test("cache_delete alias works identically to cache/delete", async () => {
     await cliIpcCall("cache/set", { data: "to-remove", key: "cd-alias" });
 
-    const delResult = await cliIpcCall<object>("cache_delete", {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache_delete", {
       key: "cd-alias",
     });
     expect(delResult.ok).toBe(true);
-    expect(delResult.result).toEqual({});
+    expect(delResult.result).toEqual({ deleted: true });
 
     const getResult = await cliIpcCall<null>("cache/get", { key: "cd-alias" });
     expect(getResult.ok).toBe(true);

--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -45,10 +45,12 @@ function handleCacheGet(
   return getCacheEntry(key);
 }
 
-function handleCacheDelete(params?: Record<string, unknown>): object {
+function handleCacheDelete(params?: Record<string, unknown>): {
+  deleted: boolean;
+} {
   const { key } = CacheKeyParams.parse(params);
-  deleteCacheEntry(key);
-  return {};
+  const deleted = deleteCacheEntry(key);
+  return { deleted };
 }
 
 // ── Route definitions ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Propagate the `deleted` boolean from `deleteCacheEntry()` through the IPC handler to the CLI
- Text mode: show "Deleted cache entry" on hit, "No cache entry (nothing to delete)" on miss
- JSON mode: include `deleted: true/false` in the response
- Update IPC integration tests and CLI unit tests for both hit and miss cases
- Update help text to document the differentiated output

Part of plan: fix-cache-cli-bugs.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
