### PR TITLE
fix: enforce reserved action ID validation at IPC layer

### DIFF
--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -17,9 +17,10 @@ import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import type {
-  InteractiveUiAction,
-  InteractiveUiResult,
+import {
+  type InteractiveUiAction,
+  type InteractiveUiResult,
+  RESERVED_ACTION_IDS,
 } from "../../runtime/interactive-ui.js";
 import { log } from "../logger.js";
 
@@ -148,28 +149,6 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
 }
 
 // ── Action parsing ────────────────────────────────────────────────────
-
-/**
- * Action IDs reserved for internal surface lifecycle events. These IDs
- * have special behavior in `handleSurfaceAction` (conversation-surfaces.ts)
- * and must not be used as custom button IDs:
- *
- * - `selection_changed`, `content_changed`, `state_update` — Intercepted
- *   as non-terminal events (early return without resolving the pending
- *   `ui_request`). Using one as a button ID would silently swallow the click.
- *
- * - `cancel`, `dismiss` — Treated as cancellation signals, resolving the
- *   `ui_request` with `status: "cancelled"` instead of the expected
- *   `status: "submitted"`. A caller expecting submission semantics would
- *   get the wrong status.
- */
-export const RESERVED_ACTION_IDS = new Set([
-  "selection_changed",
-  "content_changed",
-  "state_update",
-  "cancel",
-  "dismiss",
-]);
 
 /** Valid variant values for action buttons. */
 const VALID_VARIANTS = new Set(["primary", "danger", "secondary"]);

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -255,6 +255,77 @@ describe("ui_request IPC route", () => {
     expect(result.error).toBeDefined();
   });
 
+  // ── Reserved action IDs ──────────────────────────────────────────
+
+  test("rejects action with reserved id 'selection_changed'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "selection_changed", label: "Select" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'content_changed'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "content_changed", label: "Change" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'state_update'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "state_update", label: "Update" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'cancel'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "cancel", label: "Cancel" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'dismiss'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "dismiss", label: "Dismiss" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects when any action in the array uses a reserved id", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [
+        { id: "approve", label: "Approve" },
+        { id: "state_update", label: "Bad Action" },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
   // ── Optional fields ───────────────────────────────────────────────
 
   test("accepts request with optional title", async () => {

--- a/assistant/src/ipc/routes/ui-request.ts
+++ b/assistant/src/ipc/routes/ui-request.ts
@@ -9,7 +9,10 @@
 
 import { z } from "zod";
 
-import { requestInteractiveUi } from "../../runtime/interactive-ui.js";
+import {
+  requestInteractiveUi,
+  RESERVED_ACTION_IDS,
+} from "../../runtime/interactive-ui.js";
 import type { IpcRoute } from "../cli-server.js";
 
 // ── Param schema ──────────────────────────────────────────────────────
@@ -22,7 +25,12 @@ const UiRequestParams = z.object({
   actions: z
     .array(
       z.object({
-        id: z.string().min(1),
+        id: z
+          .string()
+          .min(1)
+          .refine((id) => !RESERVED_ACTION_IDS.has(id), {
+            message: `Action id is reserved for internal use. Reserved IDs: ${[...RESERVED_ACTION_IDS].sort().join(", ")}`,
+          }),
         label: z.string().min(1),
         variant: z.enum(["primary", "danger", "secondary"]).optional(),
       }),

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -39,6 +39,27 @@ import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
+// ── Reserved action IDs ──────────────────────────────────────────────
+
+/**
+ * Action IDs reserved for internal surface lifecycle events. These IDs
+ * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
+ * as non-terminal events (early return without resolving the pending
+ * `ui_request`). If a caller defines one of these as a custom button ID,
+ * clicking it would silently return early without resolving.
+ *
+ * Used for validation in both the CLI (`parseActions`) and the IPC route
+ * (`ui_request` Zod schema) to reject reserved IDs before they reach the
+ * surface lifecycle.
+ */
+export const RESERVED_ACTION_IDS = new Set([
+  "selection_changed",
+  "content_changed",
+  "state_update",
+  "cancel",
+  "dismiss",
+]);
+
 // ── Cancellation reasons ─────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ui-request-gap-remediation.md.

**Gap:** Reserved action ID validation is CLI-only
**What was expected:** Reserved IDs should be rejected at the IPC layer too
**What was found:** Only the CLI parseActions() checks for reserved IDs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
