### PR TITLE
fix: vacation responseBodyPlainText and archive MAX_MESSAGES cap

### DIFF
--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -109,9 +109,10 @@ async function collectMessageIds(
   let pageToken: string | undefined;
 
   while (allIds.length < MAX_MESSAGES) {
+    const remaining = MAX_MESSAGES - allIds.length;
     const queryParams: Record<string, string> = {
       q: query,
-      maxResults: "500",
+      maxResults: String(Math.min(500, remaining)),
     };
     if (pageToken) queryParams.pageToken = pageToken;
 
@@ -128,7 +129,9 @@ async function collectMessageIds(
 
     const ids = (resp.data.messages ?? []).map((m) => m.id);
     if (ids.length === 0) break;
-    allIds.push(...ids);
+
+    const remaining = MAX_MESSAGES - allIds.length;
+    allIds.push(...ids.slice(0, remaining));
 
     pageToken = resp.data.nextPageToken ?? undefined;
     if (!pageToken) break;

--- a/skills/gmail/scripts/gmail-manage.ts
+++ b/skills/gmail/scripts/gmail-manage.ts
@@ -412,7 +412,7 @@ async function handleFilters(
 interface GmailVacationSettings {
   enableAutoReply: boolean;
   responseSubject?: string;
-  responseBodyHtml?: string;
+  responseBodyPlainText?: string;
   startTime?: string;
   endTime?: string;
   restrictToContacts?: boolean;
@@ -448,7 +448,7 @@ async function handleVacation(
 
       const settings: GmailVacationSettings = {
         enableAutoReply: true,
-        responseBodyHtml: message,
+        responseBodyPlainText: message,
         restrictToContacts,
         restrictToDomain,
       };


### PR DESCRIPTION
## Summary
- Fix vacation enable to use `responseBodyPlainText` instead of `responseBodyHtml` — matches the bundled skill behavior and prevents newline/HTML escaping issues when user provides plain text
- Enforce MAX_MESSAGES cap precisely in archive query path — cap `maxResults` request size and truncate final page to prevent overshooting the 5000 message limit

Addresses PR #26532 review feedback from Devin and Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
