### PR TITLE
fix(cache): reject sub-second TTLs that expire before CLI can read them

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -294,9 +294,9 @@ describe("TTL parsing", () => {
     mockStdinContent = "1";
     mockIpcResult = { ok: true, result: { key: "k" } };
 
-    await runCommand(["cache", "set", "--ttl", "500ms"]);
+    await runCommand(["cache", "set", "--ttl", "1000ms"]);
 
-    expect(lastIpcCall!.params!.ttl_ms).toBe(500);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
   });
 
   test("parses seconds", async () => {
@@ -359,6 +359,63 @@ describe("TTL parsing", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --ttl");
+  });
+
+  test("rejects sub-second TTL (100ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "100ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects sub-second TTL (500ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "500ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects sub-second TTL (999ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "999ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("accepts exactly 1000ms", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1000ms"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
+  });
+
+  test("accepts 1s", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1s"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
+  });
+
+  test("accepts 1500ms (resolves to >= 1s)", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1500ms"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1500);
+  });
+
+  test("--json outputs error on sub-second TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "500ms",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("at least 1s");
   });
 
   test("rejects empty string TTL", async () => {

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -53,6 +53,13 @@ function parseTtl(raw: string | undefined): number | undefined {
   if (ms <= 0) {
     throw new Error(`--ttl must resolve to a positive duration, got ${ms}ms.`);
   }
+  if (ms < 1000) {
+    throw new Error(
+      `--ttl must be at least 1s (got ${ms}ms). Sub-second TTLs are not ` +
+        `supported because CLI round-trip overhead would cause entries to ` +
+        `expire before they can be read.`,
+    );
+  }
   return ms;
 }
 
@@ -142,7 +149,7 @@ Examples:
     )
     .option(
       "--ttl <duration>",
-      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
+      "Time-to-live (minimum 1s). Units: s, m, h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
     )
     .option("--json", "Output result as machine-readable JSON.")
     .addHelpText(
@@ -159,8 +166,8 @@ Arguments:
 
 Options:
   --key <key>       Cache key string. Omit to auto-generate a random hex key.
-  --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
-                    Examples: 500ms, 30s, 5m, 2h. Defaults to 30m if omitted.
+  --ttl <duration>  Expiry duration (minimum 1s). Units: s, m, h.
+                    Examples: 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }
 
 Examples:


### PR DESCRIPTION
## Summary
- Reject TTLs that resolve to less than 1 second with a clear error explaining that CLI round-trip overhead makes sub-second entries unusable
- Update help text to remove `500ms` example and document the 1s minimum
- Keep `ms` unit valid for values >= 1s (e.g. `1000ms`, `5000ms`)
- Update existing `500ms` test and add comprehensive boundary tests

Part of plan: fix-cache-cli-bugs.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
