### PR TITLE
fix(surfaces): coerce number field values to numeric types on form submit

### DIFF
--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -333,8 +333,19 @@ public struct FormSurfaceView: View {
         }
         for field in allFields {
             switch field.type {
-            case .text, .textarea, .number, .password:
+            case .text, .textarea, .password:
                 values[field.id] = textValues[field.id] ?? ""
+            case .number:
+                let raw = textValues[field.id] ?? ""
+                if raw.isEmpty {
+                    values[field.id] = NSNull()
+                } else if let intVal = Int(raw) {
+                    values[field.id] = intVal
+                } else if let doubleVal = Double(raw) {
+                    values[field.id] = doubleVal
+                } else {
+                    values[field.id] = raw  // fallback: unparseable string passes through
+                }
             case .toggle:
                 values[field.id] = toggleValues[field.id] ?? false
             case .select:


### PR DESCRIPTION
## Summary
- Split number field handling from text/textarea/password in FormSurfaceView's submitForm()
- Empty number fields now produce null instead of empty string
- Numeric strings are coerced to Int or Double; unparseable values pass through as strings

Part of plan: fix-ui-cli-bugs.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
