### PR TITLE
feat(cli): auto-inject __CONVERSATION_ID into bash tool subprocess env

### DIFF
--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -42,7 +42,8 @@ const IPC_TIMEOUT_BUFFER_MS = 10_000; // 10s
  * Resolve the conversation ID by precedence:
  *   1. Explicit `--conversation-id` flag
  *   2. `__SKILL_CONTEXT_JSON` env var (set by skill sandbox runner)
- *   3. Fail with an actionable error
+ *   3. `__CONVERSATION_ID` env var (set by bash tool subprocess)
+ *   4. Fail with an actionable error
  */
 function resolveConversationId(explicit?: string): string {
   if (explicit) return explicit;
@@ -55,14 +56,19 @@ function resolveConversationId(explicit?: string): string {
         return parsed.conversationId;
       }
     } catch {
-      // Fall through to the error below.
+      // Fall through
     }
+  }
+
+  const envConvId = process.env.__CONVERSATION_ID;
+  if (envConvId && typeof envConvId === "string") {
+    return envConvId;
   }
 
   throw new Error(
     "No conversation ID available.\n" +
       "Provide --conversation-id explicitly (run 'assistant conversations list' to find it),\n" +
-      "or run this command from a skill context where __SKILL_CONTEXT_JSON is set.",
+      "or run this command from a skill or bash tool context.",
   );
 }
 
@@ -171,7 +177,8 @@ forms) to the user via the running assistant and block until the user
 responds or the request times out.
 
 The conversation ID is resolved automatically when running inside a skill
-context (__SKILL_CONTEXT_JSON). Override with --conversation-id if needed.
+or bash tool context (__SKILL_CONTEXT_JSON or __CONVERSATION_ID).
+Override with --conversation-id if needed.
 
 Examples:
   $ echo '{"message":"Delete all logs?"}' | assistant ui request --json
@@ -194,7 +201,7 @@ Examples:
     .option("--title <title>", "Title displayed on the surface")
     .option(
       "--conversation-id <id>",
-      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
     )
     .option(
       "--timeout <ms>",
@@ -362,7 +369,7 @@ Examples:
     )
     .option(
       "--conversation-id <id>",
-      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
+      "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
     )
     .option(
       "--timeout <ms>",

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -152,6 +152,7 @@ function spawnRunner(
       workingDir: context.workingDir,
       conversationId: context.conversationId,
     });
+    env.__CONVERSATION_ID = context.conversationId;
 
     const child = spawn(wrapped.command, wrapped.args, {
       cwd: runDir,
@@ -219,7 +220,8 @@ function spawnRunner(
       if (code !== 0) {
         const truncatedStderr =
           stderr.length > MAX_OUTPUT_CHARS
-            ? safeStringSlice(stderr, 0, MAX_OUTPUT_CHARS) + "\n[stderr truncated]"
+            ? safeStringSlice(stderr, 0, MAX_OUTPUT_CHARS) +
+              "\n[stderr truncated]"
             : stderr;
         resolve({
           content: `Skill tool script "${executorPath}" exited with code ${code}:\n${truncatedStderr}`,
@@ -230,7 +232,8 @@ function spawnRunner(
 
       const truncatedStdout =
         stdout.length > MAX_OUTPUT_CHARS
-          ? safeStringSlice(stdout, 0, MAX_OUTPUT_CHARS) + "\n[stdout truncated]"
+          ? safeStringSlice(stdout, 0, MAX_OUTPUT_CHARS) +
+            "\n[stdout truncated]"
           : stdout;
       resolve({ content: truncatedStdout, isError: false });
     });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -306,6 +306,7 @@ class ShellTool implements Tool {
     }
 
     const env = buildSanitizedEnv();
+    env.__CONVERSATION_ID = context.conversationId;
     if (proxyEnv) {
       Object.assign(env, proxyEnv);
     }


### PR DESCRIPTION
## Summary
- Inject __CONVERSATION_ID into bash tool and skill sandbox subprocess environments
- Add __CONVERSATION_ID as a fallback in resolveConversationId() for assistant ui commands
- Update help text to reflect that conversation ID is auto-resolved from bash tool context

Part of plan: fix-ui-cli-bugs.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
