### PR TITLE
fix(surfaces): use explicit action IDs for confirmation surface buttons

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -81,7 +81,14 @@ public struct InlineSurfaceRouter: View {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
         } else if case .confirmation(let data) = surface.data {
             // Confirmations manage their own card chrome — collapse to a chip after user acts
-            ConfirmationSurfaceView(data: data, showCardChrome: true) { actionId in
+            let confirmId = surface.actions.first(where: { $0.style == .primary })?.id ?? "confirm"
+            let cancelId = surface.actions.first(where: { $0.style != .primary })?.id ?? "cancel"
+            ConfirmationSurfaceView(
+                data: data,
+                showCardChrome: true,
+                confirmActionId: confirmId,
+                cancelActionId: cancelId
+            ) { actionId in
                 onAction(surface.id, actionId, nil)
             }
             .widthCap(540)
@@ -316,7 +323,13 @@ public struct InlineSurfaceRouter: View {
             }
             .id(surface.id)
         case .confirmation(let data):
-            ConfirmationSurfaceView(data: data) { actionId in
+            let confirmId = surface.actions.first(where: { $0.style == .primary })?.id ?? "confirm"
+            let cancelId = surface.actions.first(where: { $0.style != .primary })?.id ?? "cancel"
+            ConfirmationSurfaceView(
+                data: data,
+                confirmActionId: confirmId,
+                cancelActionId: cancelId
+            ) { actionId in
                 onAction(surface.id, actionId, nil)
             }
         #if os(macOS)

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -12,19 +12,27 @@ public struct ConfirmationSurfaceView: View {
 
     @State private var selectedAction: SelectedAction?
 
-    public init(data: ConfirmationSurfaceData, showCardChrome: Bool = false, onAction: @escaping (String) -> Void) {
+    /// The action ID to emit when the user confirms.
+    /// Defaults to "confirm"; overridden when explicit actions are provided.
+    private let confirmActionId: String
+
+    /// The action ID to emit when the user cancels/denies.
+    /// Defaults to "cancel"; overridden when explicit actions are provided.
+    private let cancelActionId: String
+
+    public init(
+        data: ConfirmationSurfaceData,
+        showCardChrome: Bool = false,
+        confirmActionId: String = "confirm",
+        cancelActionId: String = "cancel",
+        onAction: @escaping (String) -> Void
+    ) {
         self.data = data
         self.showCardChrome = showCardChrome
+        self.confirmActionId = confirmActionId
+        self.cancelActionId = cancelActionId
         self.onAction = onAction
     }
-
-    /// The action ID to emit when the user cancels.
-    /// Always "cancel" — the visible label is controlled by `data.cancelLabel`.
-    private var cancelActionId: String { "cancel" }
-
-    /// The action ID to emit when the user confirms.
-    /// Always "confirm" — the visible label is controlled by `data.confirmLabel`.
-    private var confirmActionId: String { "confirm" }
 
     public var body: some View {
         Group {


### PR DESCRIPTION
## Summary
- Make ConfirmationSurfaceView accept explicit confirmActionId and cancelActionId parameters instead of hardcoding them
- Update InlineSurfaceRouter to extract action IDs from the surface.actions array and pass them through
- Fixes the bug where clicking 'Deny' sent actionId 'cancel' instead of 'deny'

Part of plan: fix-ui-cli-bugs.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
