### PR TITLE
fix(gmail): remove duplicate const remaining declaration in archive script

### DIFF
--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -130,7 +130,6 @@ async function collectMessageIds(
     const ids = (resp.data.messages ?? []).map((m) => m.id);
     if (ids.length === 0) break;
 
-    const remaining = MAX_MESSAGES - allIds.length;
     allIds.push(...ids.slice(0, remaining));
 
     pageToken = resp.data.nextPageToken ?? undefined;


### PR DESCRIPTION
## Summary
- Remove duplicate `const remaining` declaration in `collectMessageIds` that caused a `SyntaxError` at parse time
- The variable was already declared earlier in the same `while` block scope; the second declaration was a leftover from refactoring

## Original prompt
push up a fix to address this feedback: https://github.com/vellum-ai/vellum-assistant/pull/26532#discussion_r3106072404
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
