### PR TITLE
fix: add missing cache CLI tests and align error messages with help text

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -439,6 +439,13 @@ describe("TTL parsing", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain('Invalid --ttl value ""');
   });
+
+  test("rejects whitespace-only TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", " "]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -553,6 +560,12 @@ describe("cache delete", () => {
     expect(exitCode).toBe(0);
     expect(lastIpcCall!.method).toBe("cache/delete");
     expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("succeeds with exit 0 when key did not exist", async () => {
+    mockIpcResult = { ok: true, result: { deleted: false } };
+    const { exitCode } = await runCommand(["cache", "delete", "missing-key"]);
+    expect(exitCode).toBe(0);
   });
 
   test("--json outputs { ok: true, deleted: true } on success", async () => {

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -38,13 +38,13 @@ function parseTtl(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   if (!raw.trim()) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
     );
   }
   const match = TTL_PATTERN.exec(raw.trim());
   if (!match) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
     );
   }
   const value = Number(match[1]);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for fix-cache-cli-bugs.md.

**Gap 1:** Add whitespace-only TTL test
**Gap 2:** Add non-JSON delete miss test
**Gap 3:** Remove `ms` from error messages to match updated help text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
