### PR TITLE
fix: update reserved action ID docs and JSDoc to include all 5 IDs with categories

### DIFF
--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -42,15 +42,19 @@ const log = getLogger("interactive-ui");
 // ── Reserved action IDs ──────────────────────────────────────────────
 
 /**
- * Action IDs reserved for internal surface lifecycle events. These IDs
- * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
- * as non-terminal events (early return without resolving the pending
- * `ui_request`). If a caller defines one of these as a custom button ID,
- * clicking it would silently return early without resolving.
+ * Action IDs reserved for internal use. These are rejected by validation
+ * in both the CLI (`parseActions`) and the IPC route (`ui_request` Zod
+ * schema) so they never appear as custom button IDs.
  *
- * Used for validation in both the CLI (`parseActions`) and the IPC route
- * (`ui_request` Zod schema) to reject reserved IDs before they reach the
- * surface lifecycle.
+ * Two categories of reservation:
+ *
+ * - **Lifecycle events** (`selection_changed`, `content_changed`,
+ *   `state_update`) — intercepted by `handleSurfaceAction` in
+ *   conversation-surfaces.ts as non-terminal events (early return
+ *   without resolving the pending `ui_request`).
+ *
+ * - **Cancellation triggers** (`cancel`, `dismiss`) — resolve the
+ *   pending `ui_request` as `cancelled` instead of `submitted`.
  */
 export const RESERVED_ACTION_IDS = new Set([
   "selection_changed",

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -165,7 +165,10 @@
   fi
   ```
 
-  Reserved action IDs (`selection_changed`, `content_changed`, `state_update`) are used internally for surface lifecycle events and are rejected by `--actions` validation.
+  Reserved action IDs are used internally and are rejected by `--actions` validation. There are two categories:
+
+  - **Lifecycle events** (`selection_changed`, `content_changed`, `state_update`) — non-terminal events that are silently swallowed without resolving the pending request.
+  - **Cancellation triggers** (`cancel`, `dismiss`) — resolve the pending request as `cancelled` (instead of `submitted`).
 
   ### Status and cancellation reason branching reference
 


### PR DESCRIPTION
## Summary
Fixes two documentation gaps from plan review for ui-request-gap-remediation.md.

**Gap 1:** AGENTS.md only listed 3 of 5 reserved IDs
**Gap 2:** JSDoc on RESERVED_ACTION_IDS didn't distinguish reservation categories
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
