### PR TITLE
fix: pass explicit action IDs to ConfirmationSurfaceView in SurfaceContainerView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -62,8 +62,12 @@ struct SurfaceContainerView: View {
                     viewModel.onAction("select", ["selectedIds": selectedIds])
                 })
             case .confirmation(let data):
+                let confirmId = surface.actions.first(where: { $0.style == .primary })?.id ?? "confirm"
+                let cancelId = surface.actions.first(where: { $0.style != .primary })?.id ?? "cancel"
                 ConfirmationSurfaceView(
                     data: data,
+                    confirmActionId: confirmId,
+                    cancelActionId: cancelId,
                     onAction: { actionId in
                         viewModel.onAction(actionId, nil)
                     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-ui-cli-bugs.md.

**Gap:** SurfaceContainerView.swift not updated to pass explicit action IDs
**What was expected:** All call sites of ConfirmationSurfaceView should pass the explicit action IDs
**What was found:** SurfaceContainerView created ConfirmationSurfaceView without confirmActionId or cancelActionId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
