### PR TITLE
fix(cache): fix sub-second TTL, delete output, and empty TTL bugs

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -294,9 +294,9 @@ describe("TTL parsing", () => {
     mockStdinContent = "1";
     mockIpcResult = { ok: true, result: { key: "k" } };
 
-    await runCommand(["cache", "set", "--ttl", "500ms"]);
+    await runCommand(["cache", "set", "--ttl", "1000ms"]);
 
-    expect(lastIpcCall!.params!.ttl_ms).toBe(500);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
   });
 
   test("parses seconds", async () => {
@@ -359,6 +359,63 @@ describe("TTL parsing", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --ttl");
+  });
+
+  test("rejects sub-second TTL (100ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "100ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects sub-second TTL (500ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "500ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects sub-second TTL (999ms)", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", "999ms"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("accepts exactly 1000ms", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1000ms"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
+  });
+
+  test("accepts 1s", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1s"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1000);
+  });
+
+  test("accepts 1500ms (resolves to >= 1s)", async () => {
+    mockStdinContent = "1";
+    mockIpcResult = { ok: true, result: { key: "k" } };
+    await runCommand(["cache", "set", "--ttl", "1500ms"]);
+    expect(lastIpcCall!.params!.ttl_ms).toBe(1500);
+  });
+
+  test("--json outputs error on sub-second TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "500ms",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("at least 1s");
   });
 
   test("rejects empty string TTL", async () => {

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -439,6 +439,13 @@ describe("TTL parsing", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain('Invalid --ttl value ""');
   });
+
+  test("rejects whitespace-only TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", " "]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -553,6 +560,12 @@ describe("cache delete", () => {
     expect(exitCode).toBe(0);
     expect(lastIpcCall!.method).toBe("cache/delete");
     expect(lastIpcCall!.params).toEqual({ key: "my-key" });
+  });
+
+  test("succeeds with exit 0 when key did not exist", async () => {
+    mockIpcResult = { ok: true, result: { deleted: false } };
+    const { exitCode } = await runCommand(["cache", "delete", "missing-key"]);
+    expect(exitCode).toBe(0);
   });
 
   test("--json outputs { ok: true, deleted: true } on success", async () => {

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -360,6 +360,28 @@ describe("TTL parsing", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --ttl");
   });
+
+  test("rejects empty string TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode } = await runCommand(["cache", "set", "--ttl", ""]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("--json outputs error on empty string TTL", async () => {
+    mockStdinContent = "1";
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "set",
+      "--ttl",
+      "",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('Invalid --ttl value ""');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -489,7 +489,7 @@ describe("cache get", () => {
 
 describe("cache delete", () => {
   test("sends cache/delete IPC and succeeds", async () => {
-    mockIpcResult = { ok: true, result: {} };
+    mockIpcResult = { ok: true, result: { deleted: true } };
 
     const { exitCode } = await runCommand(["cache", "delete", "my-key"]);
 
@@ -498,8 +498,8 @@ describe("cache delete", () => {
     expect(lastIpcCall!.params).toEqual({ key: "my-key" });
   });
 
-  test("--json outputs { ok: true } on success", async () => {
-    mockIpcResult = { ok: true, result: {} };
+  test("--json outputs { ok: true, deleted: true } on success", async () => {
+    mockIpcResult = { ok: true, result: { deleted: true } };
 
     const { exitCode, stdout } = await runCommand([
       "cache",
@@ -510,7 +510,22 @@ describe("cache delete", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed).toEqual({ ok: true });
+    expect(parsed).toEqual({ ok: true, deleted: true });
+  });
+
+  test("--json outputs { ok: true, deleted: false } when key did not exist", async () => {
+    mockIpcResult = { ok: true, result: { deleted: false } };
+
+    const { exitCode, stdout } = await runCommand([
+      "cache",
+      "delete",
+      "missing-key",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, deleted: false });
   });
 
   test("exits with error on IPC failure", async () => {

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -295,15 +295,15 @@ Arguments:
   key   The cache key to remove. Run 'assistant cache get <key>' to
         verify a key exists before deleting.
 
-Removes the entry from the cache. Succeeds silently if the key does not
-exist (idempotent).
+Removes the entry from the cache. Idempotent — exits 0 whether the key
+existed or not, but reports whether an entry was actually removed.
 
 Examples:
   $ assistant cache delete my-key
   $ assistant cache delete my-key --json`,
     )
     .action(async (key: string, opts: { json?: boolean }) => {
-      const result = await cliIpcCall<Record<string, never>>("cache/delete", {
+      const result = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
         key,
       });
 
@@ -319,10 +319,16 @@ Examples:
         return;
       }
 
+      const deleted = result.result!.deleted;
+
       if (opts.json) {
-        process.stdout.write(JSON.stringify({ ok: true }) + "\n");
+        process.stdout.write(JSON.stringify({ ok: true, deleted }) + "\n");
       } else {
-        log.info(`Deleted cache entry "${key}".`);
+        if (deleted) {
+          log.info(`Deleted cache entry "${key}".`);
+        } else {
+          log.info(`No cache entry "${key}" (nothing to delete).`);
+        }
       }
     });
 }

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -30,11 +30,17 @@ const TTL_MULTIPLIERS: Record<string, number> = {
 
 /**
  * Parse a human-friendly duration string (e.g. `"30s"`, `"5m"`, `"2h"`)
- * into milliseconds. Returns `undefined` when the input is falsy.
- * Throws on malformed input so the CLI can surface actionable errors.
+ * into milliseconds. Returns `undefined` when the input is `undefined`.
+ * Throws on empty/whitespace-only or malformed input so the CLI can
+ * surface actionable errors.
  */
 function parseTtl(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
+  if (raw === undefined) return undefined;
+  if (!raw.trim()) {
+    throw new Error(
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+    );
+  }
   const match = TTL_PATTERN.exec(raw.trim());
   if (!match) {
     throw new Error(

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -38,13 +38,13 @@ function parseTtl(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   if (!raw.trim()) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
     );
   }
   const match = TTL_PATTERN.exec(raw.trim());
   if (!match) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
     );
   }
   const value = Number(match[1]);

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -53,6 +53,13 @@ function parseTtl(raw: string | undefined): number | undefined {
   if (ms <= 0) {
     throw new Error(`--ttl must resolve to a positive duration, got ${ms}ms.`);
   }
+  if (ms < 1000) {
+    throw new Error(
+      `--ttl must be at least 1s (got ${ms}ms). Sub-second TTLs are not ` +
+        `supported because CLI round-trip overhead would cause entries to ` +
+        `expire before they can be read.`,
+    );
+  }
   return ms;
 }
 
@@ -142,7 +149,7 @@ Examples:
     )
     .option(
       "--ttl <duration>",
-      "Time-to-live with unit: ms, s, m, or h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
+      "Time-to-live (minimum 1s). Units: s, m, h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
     )
     .option("--json", "Output result as machine-readable JSON.")
     .addHelpText(
@@ -159,8 +166,8 @@ Arguments:
 
 Options:
   --key <key>       Cache key string. Omit to auto-generate a random hex key.
-  --ttl <duration>  Expiry duration. Accepted units: ms, s, m, h.
-                    Examples: 500ms, 30s, 5m, 2h. Defaults to 30m if omitted.
+  --ttl <duration>  Expiry duration (minimum 1s). Units: s, m, h.
+                    Examples: 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }
 
 Examples:

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -38,13 +38,13 @@ function parseTtl(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   if (!raw.trim()) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "1000ms", "30s", "5m", "2h"). Minimum 1s.`,
     );
   }
   const match = TTL_PATTERN.exec(raw.trim());
   if (!match) {
     throw new Error(
-      `Invalid --ttl value "${raw}". Expected a number followed by a unit: s, m, or h (e.g. "30s", "5m", "2h").`,
+      `Invalid --ttl value "${raw}". Expected a number followed by a unit: ms, s, m, or h (e.g. "1000ms", "30s", "5m", "2h"). Minimum 1s.`,
     );
   }
   const value = Number(match[1]);
@@ -149,7 +149,7 @@ Examples:
     )
     .option(
       "--ttl <duration>",
-      "Time-to-live (minimum 1s). Units: s, m, h (e.g. 30s, 5m, 2h). Defaults to 30m if omitted.",
+      "Time-to-live (minimum 1s). Units: ms, s, m, h (e.g. 1000ms, 30s, 5m, 2h). Defaults to 30m if omitted.",
     )
     .option("--json", "Output result as machine-readable JSON.")
     .addHelpText(
@@ -166,8 +166,8 @@ Arguments:
 
 Options:
   --key <key>       Cache key string. Omit to auto-generate a random hex key.
-  --ttl <duration>  Expiry duration (minimum 1s). Units: s, m, h.
-                    Examples: 30s, 5m, 2h. Defaults to 30m if omitted.
+  --ttl <duration>  Expiry duration (minimum 1s). Units: ms, s, m, h.
+                    Examples: 1000ms, 30s, 5m, 2h. Defaults to 30m if omitted.
   --json            Output as JSON: { "ok": true, "key": "..." }
 
 Examples:

--- a/assistant/src/ipc/__tests__/cache-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/cache-ipc.test.ts
@@ -84,7 +84,7 @@ describe("cache IPC routes", () => {
 
   // ── Delete ────────────────────────────────────────────────────────
 
-  test("delete returns empty object and makes later get return null", async () => {
+  test("delete returns deleted: true and makes later get return null", async () => {
     // Store an entry first.
     const setResult = await cliIpcCall<{ key: string }>("cache/set", {
       data: 42,
@@ -93,11 +93,11 @@ describe("cache IPC routes", () => {
     expect(setResult.ok).toBe(true);
 
     // Delete it.
-    const delResult = await cliIpcCall<object>("cache/delete", {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
       key: "to-delete",
     });
     expect(delResult.ok).toBe(true);
-    expect(delResult.result).toEqual({});
+    expect(delResult.result).toEqual({ deleted: true });
 
     // Get should now return null.
     const getResult = await cliIpcCall<null>("cache/get", {
@@ -105,6 +105,14 @@ describe("cache IPC routes", () => {
     });
     expect(getResult.ok).toBe(true);
     expect(getResult.result).toBeNull();
+  });
+
+  test("delete on non-existent key returns deleted: false", async () => {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache/delete", {
+      key: "never-existed",
+    });
+    expect(delResult.ok).toBe(true);
+    expect(delResult.result).toEqual({ deleted: false });
   });
 
   // ── Get for non-existent key returns null ─────────────────────────
@@ -210,11 +218,11 @@ describe("cache IPC routes", () => {
   test("cache_delete alias works identically to cache/delete", async () => {
     await cliIpcCall("cache/set", { data: "to-remove", key: "cd-alias" });
 
-    const delResult = await cliIpcCall<object>("cache_delete", {
+    const delResult = await cliIpcCall<{ deleted: boolean }>("cache_delete", {
       key: "cd-alias",
     });
     expect(delResult.ok).toBe(true);
-    expect(delResult.result).toEqual({});
+    expect(delResult.result).toEqual({ deleted: true });
 
     const getResult = await cliIpcCall<null>("cache/get", { key: "cd-alias" });
     expect(getResult.ok).toBe(true);

--- a/assistant/src/ipc/routes/cache.ts
+++ b/assistant/src/ipc/routes/cache.ts
@@ -45,10 +45,12 @@ function handleCacheGet(
   return getCacheEntry(key);
 }
 
-function handleCacheDelete(params?: Record<string, unknown>): object {
+function handleCacheDelete(params?: Record<string, unknown>): {
+  deleted: boolean;
+} {
   const { key } = CacheKeyParams.parse(params);
-  deleteCacheEntry(key);
-  return {};
+  const deleted = deleteCacheEntry(key);
+  return { deleted };
 }
 
 // ── Route definitions ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fix three bugs found during the initial smoke test of the `assistant cache` CLI:
1. Sub-second TTLs (e.g. `500ms`) silently expire before they can be read — now rejected with a 1s minimum and clear error
2. `delete` on a missing key falsely claims "Deleted cache entry" — now differentiates hit vs miss in both text and JSON modes
3. `--ttl ""` is silently accepted as the default 30m TTL — now rejected with the same validation error as other malformed inputs

## Self-review result
PASS — 3 gaps found in round 1, all fixed in #26544

## PRs merged into feature branch
- #26533: fix(cache): reject `--ttl ""` instead of silently using default TTL
- #26535: fix(cache): differentiate delete output when key exists vs doesn't exist
- #26538: fix(cache): reject sub-second TTLs that expire before CLI can read them

### Fix PRs
- #26544: fix: add missing cache CLI tests and align error messages with help text

Part of plan: fix-cache-cli-bugs.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
