### PR TITLE
fix: navigate to first page with validation errors in multi-page forms

### DIFF
--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -361,6 +361,18 @@ public struct FormSurfaceView: View {
         let errors = validate()
         if !errors.isEmpty {
             validationErrors = errors
+            isSubmitted = false
+            // Navigate to the first page that contains a failing field
+            if let pages = data.pages, !pages.isEmpty {
+                for (index, page) in pages.enumerated() {
+                    if page.fields.contains(where: { errors.contains($0.id) }) {
+                        withAnimation(VAnimation.fast) {
+                            currentPageIndex = index
+                        }
+                        break
+                    }
+                }
+            }
             return
         }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-ui-cli-bugs.md.

**Gap:** Multi-page form validation blocks submit with no visible error feedback
**What was expected:** User should be navigated to the page with errors
**What was found:** Validation checked all pages but errors only showed on current page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
