### PR TITLE
fix(chrome-extension): remap platform runtime host for cloud auth fallback

### DIFF
--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -171,7 +171,28 @@ describe('signInCloud', () => {
     expect(seenUrls[1]).not.toContain('assistant_id=');
   });
 
-  test('retries against runtimeBaseUrl after webBaseUrl auth page load failures', async () => {
+  test('does not retry against platform runtime host for auth fallback', async () => {
+    const seenUrls: string[] = [];
+    launchWebAuthFlowImpl = async (details) => {
+      seenUrls.push(details.url);
+      throw new Error('Authorization page could not be loaded.');
+    };
+
+    await expect(
+      signInCloud(ASSISTANT_A, {
+        ...config,
+        runtimeBaseUrl: 'https://platform.vellum.ai',
+      }),
+    ).rejects.toThrow('Authorization page could not be loaded.');
+
+    // platform.vellum.ai remaps to www.vellum.ai, so both runtime
+    // fallback attempts are deduped against the primary base URL.
+    expect(seenUrls.length).toBe(2);
+    expect(seenUrls[0]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrls[1]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
+  });
+
+  test('retries against assistant-web host derived from runtimeBaseUrl', async () => {
     const seenUrls: string[] = [];
     launchWebAuthFlowImpl = async (details) => {
       seenUrls.push(details.url);
@@ -183,13 +204,13 @@ describe('signInCloud', () => {
 
     await signInCloud(ASSISTANT_A, {
       ...config,
-      runtimeBaseUrl: 'https://platform.vellum.ai',
+      runtimeBaseUrl: 'https://dev-platform.vellum.ai',
     });
 
     expect(seenUrls.length).toBe(3);
     expect(seenUrls[0]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
     expect(seenUrls[1]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
-    expect(seenUrls[2]).toContain('https://platform.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrls[2]).toContain('https://dev-assistant.vellum.ai/accounts/chrome-extension/start');
   });
 });
 

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -32,7 +32,10 @@ export interface CloudAuthConfig {
    * Optional runtime/gateway origin for the selected assistant.
    *
    * Used only as a fallback when Chrome reports the primary authorization
-   * page could not be loaded.
+   * page could not be loaded. Platform API hosts (for example
+   * `platform.vellum.ai`) are remapped to their assistant-web hosts
+   * (`www.vellum.ai`) before use so WorkOS redirect URI validation
+   * remains valid.
    */
   runtimeBaseUrl?: string;
   /** OAuth client id registered for the chrome extension. */
@@ -233,6 +236,36 @@ function normalizeBaseUrl(raw: string): string {
   return raw.trim().replace(/\/$/, '');
 }
 
+function remapPlatformHostnameForWebAuth(hostname: string): string {
+  const host = hostname.toLowerCase();
+  if (host === 'platform.vellum.ai') {
+    return 'www.vellum.ai';
+  }
+  if (host === 'local-platform.vellum.ai') {
+    return 'local-assistant.vellum.ai';
+  }
+  if (host.endsWith('-platform.vellum.ai')) {
+    return host.replace('-platform.vellum.ai', '-assistant.vellum.ai');
+  }
+  return host;
+}
+
+function normalizeRuntimeFallbackBaseUrl(runtimeBaseUrl: string): string {
+  const normalized = normalizeBaseUrl(runtimeBaseUrl);
+  try {
+    const url = new URL(normalized);
+    const remappedHost = remapPlatformHostnameForWebAuth(url.hostname);
+    if (remappedHost !== url.hostname) {
+      url.hostname = remappedHost;
+      return normalizeBaseUrl(url.toString());
+    }
+  } catch {
+    // Ignore malformed runtime URLs and let the caller decide whether
+    // this fallback candidate can be used.
+  }
+  return normalized;
+}
+
 function buildAuthUrl(
   config: CloudAuthConfig,
   assistantId: string,
@@ -261,7 +294,12 @@ interface AuthUrlCandidate {
 }
 
 function buildAuthUrlCandidates(config: CloudAuthConfig, assistantId: string): AuthUrlCandidate[] {
-  const baseCandidates = [config.webBaseUrl, config.runtimeBaseUrl]
+  const runtimeFallbackBaseUrl =
+    typeof config.runtimeBaseUrl === 'string' && config.runtimeBaseUrl.trim().length > 0
+      ? normalizeRuntimeFallbackBaseUrl(config.runtimeBaseUrl)
+      : undefined;
+
+  const baseCandidates = [config.webBaseUrl, runtimeFallbackBaseUrl]
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
     .map((value) => normalizeBaseUrl(value));
   const baseUrls = Array.from(new Set(baseCandidates));


### PR DESCRIPTION
## Summary
- Remap cloud OAuth fallback hosts from platform API domains to assistant web domains before launching `chrome.identity.launchWebAuthFlow`.
- Prevent fallback attempts from generating `platform.vellum.ai` auth-start URLs that can fail WorkOS redirect/session handling.
- Add focused cloud-auth tests for `platform -> www` dedupe and `*-platform -> *-assistant` fallback mapping.

## Original prompt
the changes needed in both of the two repos
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
