### PR TITLE
refactor(watchers): decouple calendar watcher providers from bundled skill imports

### DIFF
--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -6,21 +6,141 @@
  * Falls back to listing recent upcoming events if the syncToken has expired (410 Gone).
  */
 
-import {
-  CalendarApiError,
-  listEvents,
-} from "../../config/bundled-skills/google-calendar/calendar-client.js";
-import type { CalendarEvent } from "../../config/bundled-skills/google-calendar/types.js";
 import type { OAuthConnection } from "../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
-
-const GOOGLE_CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
 import { getLogger } from "../../util/logger.js";
 import type {
   FetchResult,
   WatcherItem,
   WatcherProvider,
 } from "../provider-types.js";
+
+const GOOGLE_CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
+
+// ---------------------------------------------------------------------------
+// Inlined types & helpers (previously imported from bundled-skills)
+// ---------------------------------------------------------------------------
+
+/** Event time - either a dateTime with timezone or a date for all-day events. */
+interface EventDateTime {
+  dateTime?: string;
+  date?: string;
+  timeZone?: string;
+}
+
+/** Calendar event attendee. */
+interface EventAttendee {
+  email: string;
+  displayName?: string;
+  responseStatus?: "needsAction" | "declined" | "tentative" | "accepted";
+  self?: boolean;
+  organizer?: boolean;
+  optional?: boolean;
+}
+
+/** Calendar event organizer. */
+interface EventOrganizer {
+  email?: string;
+  displayName?: string;
+  self?: boolean;
+}
+
+/** A single Google Calendar event. */
+interface CalendarEvent {
+  id: string;
+  status?: "confirmed" | "tentative" | "cancelled";
+  summary?: string;
+  description?: string;
+  location?: string;
+  start?: EventDateTime;
+  end?: EventDateTime;
+  attendees?: EventAttendee[];
+  organizer?: EventOrganizer;
+  htmlLink?: string;
+  created?: string;
+  updated?: string;
+}
+
+/** Events list response. */
+interface CalendarEventsListResponse {
+  items?: CalendarEvent[];
+  nextPageToken?: string;
+  nextSyncToken?: string;
+}
+
+class CalendarApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CalendarApiError";
+  }
+}
+
+/** List events from a calendar. */
+async function listEvents(
+  connection: OAuthConnection,
+  calendarId = "primary",
+  options?: {
+    timeMin?: string;
+    timeMax?: string;
+    maxResults?: number;
+    query?: string;
+    singleEvents?: boolean;
+    orderBy?: "startTime" | "updated";
+    pageToken?: string;
+    syncToken?: string;
+  },
+): Promise<CalendarEventsListResponse> {
+  const query: Record<string, string> = {};
+
+  if (options?.timeMin) query.timeMin = options.timeMin;
+  if (options?.timeMax) query.timeMax = options.timeMax;
+  query.maxResults = String(options?.maxResults ?? 25);
+  if (options?.query) query.q = options.query;
+
+  // Default to expanding recurring events into instances
+  const singleEvents = options?.singleEvents ?? true;
+  query.singleEvents = String(singleEvents);
+
+  if (singleEvents && options?.orderBy) {
+    query.orderBy = options.orderBy;
+  } else if (singleEvents) {
+    query.orderBy = "startTime";
+  }
+
+  if (options?.pageToken) query.pageToken = options.pageToken;
+  if (options?.syncToken) query.syncToken = options.syncToken;
+
+  const resp = await connection.request({
+    method: "GET",
+    path: `/calendars/${encodeURIComponent(calendarId)}/events`,
+    query,
+    baseUrl: GOOGLE_CALENDAR_BASE_URL,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (resp.status < 200 || resp.status >= 300) {
+    const bodyStr =
+      typeof resp.body === "string"
+        ? resp.body
+        : JSON.stringify(resp.body ?? "");
+    throw new CalendarApiError(
+      resp.status,
+      "",
+      `Calendar API ${resp.status}: ${bodyStr}`,
+    );
+  }
+
+  if (resp.status === 204 || resp.body === undefined) {
+    return undefined as unknown as CalendarEventsListResponse;
+  }
+  return resp.body as CalendarEventsListResponse;
+}
 
 const log = getLogger("watcher:google-calendar");
 

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -18,7 +18,7 @@ import type {
 const GOOGLE_CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
 
 // ---------------------------------------------------------------------------
-// Inlined types & helpers (previously imported from bundled-skills)
+// Local types & helpers used by the watcher provider
 // ---------------------------------------------------------------------------
 
 /** Event time - either a dateTime with timezone or a date for all-day events. */

--- a/assistant/src/watcher/providers/outlook-calendar.ts
+++ b/assistant/src/watcher/providers/outlook-calendar.ts
@@ -8,8 +8,6 @@
  * token has expired (410 Gone).
  */
 
-import { OutlookCalendarApiError } from "../../config/bundled-skills/outlook-calendar/calendar-client.js";
-import type { OutlookCalendarEvent } from "../../config/bundled-skills/outlook-calendar/types.js";
 import type { OAuthConnection } from "../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
 import { getLogger } from "../../util/logger.js";
@@ -18,6 +16,48 @@ import type {
   WatcherItem,
   WatcherProvider,
 } from "../provider-types.js";
+
+// ---------------------------------------------------------------------------
+// Inlined types & helpers (previously imported from bundled-skills)
+// ---------------------------------------------------------------------------
+
+/** Microsoft Graph date+time pair. timeZone may be omitted when dateTime carries an offset. */
+interface OutlookDateTimeZone {
+  dateTime: string;
+  timeZone?: string;
+}
+
+/** A single calendar event from Microsoft Graph (subset used by watcher). */
+interface OutlookCalendarEvent {
+  id: string;
+  subject?: string;
+  bodyPreview?: string;
+  start?: OutlookDateTimeZone;
+  end?: OutlookDateTimeZone;
+  location?: { displayName?: string };
+  attendees?: Array<{
+    emailAddress: { address: string };
+    status?: { response: string };
+  }>;
+  organizer?: { emailAddress: { address: string; name?: string } };
+  isAllDay?: boolean;
+  isCancelled?: boolean;
+  showAs?: string;
+  webLink?: string;
+  createdDateTime?: string;
+  lastModifiedDateTime?: string;
+}
+
+class OutlookCalendarApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "OutlookCalendarApiError";
+  }
+}
 
 const CREDENTIAL_SERVICE = "outlook";
 const log = getLogger("watcher:outlook-calendar");

--- a/assistant/src/watcher/providers/outlook-calendar.ts
+++ b/assistant/src/watcher/providers/outlook-calendar.ts
@@ -18,7 +18,7 @@ import type {
 } from "../provider-types.js";
 
 // ---------------------------------------------------------------------------
-// Inlined types & helpers (previously imported from bundled-skills)
+// Local types & helpers used by the watcher provider
 // ---------------------------------------------------------------------------
 
 /** Microsoft Graph date+time pair. timeZone may be omitted when dateTime carries an offset. */


### PR DESCRIPTION
## Summary
- Inline CalendarEvent types and listEvents function into Google Calendar watcher provider
- Inline OutlookCalendarEvent types and OutlookCalendarApiError into Outlook Calendar watcher provider
- Remove all imports from bundled-skills/google-calendar/ and bundled-skills/outlook-calendar/

Part of plan: migrate-cal-skills.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
