### PR TITLE
feat(assistant): ui request gap remediation — cancellation reasons, form payload, custom actions

### DIFF
--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -92,6 +92,31 @@ User decisions — including declining — are normal operational results:
 
 Scripts must handle all three non-confirmation outcomes. A `cancelled` status means the user deliberately chose not to proceed — log it as a normal flow, not an error. A `timed_out` status means the user was unresponsive — abort without side effects.
 
+### Cancellation reasons (`ui request` only)
+
+When using `assistant ui request --json`, a `cancelled` result includes a `cancellationReason` field that distinguishes **user-driven** cancellations from **operational fail-closed** cancellations. This allows scripts to choose different recovery strategies depending on why the surface was cancelled.
+
+> **Note:** `assistant ui confirm --json` does not include `cancellationReason`. For confirmations, use the exit code (0 = confirmed, non-zero = denied/cancelled) or check the `status` field.
+
+#### User-driven cancellation
+
+| `cancellationReason` | Meaning                                                                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user_dismissed`     | The user explicitly closed or dismissed the surface (e.g. clicked the close button, pressed Escape). This is a deliberate user choice — handle it the same as a deny action. |
+
+#### Operational (fail-closed) cancellations
+
+These indicate the surface could not be shown or could not complete due to infrastructure/environment conditions. The runtime fails closed to `{ status: "cancelled" }` (a normal `ok: true` result) rather than raising an IPC error, so scripts must inspect `cancellationReason` to distinguish them from user dismissals.
+
+| `cancellationReason`     | Meaning                                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `no_interactive_surface` | No UI resolver is registered — the channel is headless, API-only, or does not support interactive surfaces.             |
+| `conversation_not_found` | The target conversation could not be located (not in memory and not restorable from storage).                           |
+| `resolver_unavailable`   | A UI resolver is registered but the surface transport is disconnected (e.g. the desktop client dropped its connection). |
+| `resolver_error`         | The UI resolver threw an unexpected error while attempting to show the surface.                                         |
+
+**Why this matters**: A `user_dismissed` cancellation requires no special handling — the user made a conscious choice. An operational cancellation (`no_interactive_surface`, `conversation_not_found`, etc.) may warrant retry logic, a fallback path, or logging for investigation. Scripts that only check `status === "cancelled"` continue to work but cannot differentiate the two categories.
+
 ### Operational errors (exceptional)
 
 These indicate infrastructure or configuration problems, not user decisions:
@@ -99,11 +124,12 @@ These indicate infrastructure or configuration problems, not user decisions:
 - **IPC unavailable**: The daemon is not running or the socket is unreachable. The CLI exits non-zero with an error message.
 - **No conversation context**: Neither `--conversation-id` nor `__SKILL_CONTEXT_JSON` provided a valid conversation ID.
 - **Invalid payload**: Malformed JSON in `--payload` or stdin.
-- **No interactive surface**: The active channel does not support interactive UI (headless/API mode). Note: the runtime fails closed to `{ status: "cancelled" }` (a normal result with `ok: true`), not an IPC error. Scripts should check `status` to detect this case.
 
 In `--json` mode, operational errors return `{ "ok": false, "error": "<message>" }`. Without `--json`, they print to stderr and exit non-zero.
 
-### Branching pattern
+### Branching pattern for `ui confirm`
+
+The `ui confirm --json` output includes `ok`, `confirmed`, `status`, `actionId`, `surfaceId`, and optional `decisionToken`/`summary` — but does **not** include `cancellationReason`. Branch on `status` and `confirmed`:
 
 ```typescript
 const proc = Bun.spawn(
@@ -129,7 +155,7 @@ const result = JSON.parse(raw);
 
 if (!result.ok) {
   // Operational error — IPC failure, no conversation, etc.
-  throw new Error(`UI request failed: ${result.error}`);
+  throw new Error(`UI confirm failed: ${result.error}`);
 }
 
 switch (result.status) {
@@ -143,12 +169,14 @@ switch (result.status) {
     }
     break;
   case "cancelled":
-    // User dismissed — abort gracefully
-    return { sent: false, reason: "User cancelled" };
+    // User dismissed the surface — treat like a deny
+    return { sent: false, reason: "User dismissed" };
   case "timed_out":
     // No response — abort safely
     return { sent: false, reason: "Timed out" };
 }
 ```
 
-The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs or environment issues** (throw or log as errors).
+For `ui request --json`, the output additionally includes a `cancellationReason` field when `status` is `"cancelled"`, allowing scripts to distinguish user dismissal (`user_dismissed`) from operational failures (`no_interactive_surface`, `conversation_not_found`, etc.). See the [cancellation reasons](#cancellation-reasons-ui-request-only) section above and `skills/AGENTS.md` for the `ui request` branching pattern.
+
+The key distinction: **cancellation and denial are user decisions** (handle gracefully, no error logging). **IPC failures and missing context are bugs** (throw or log as errors).

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -701,3 +701,335 @@ describe("buildCompletionSummary for standalone surfaces", () => {
     );
   });
 });
+
+// ── Multi-page form payload shapes ───────────────────────────────────
+
+describe("standalone multi-page form payload shapes", () => {
+  test("multi-page form preserves pages and pageLabels in emitted payload", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Setup Wizard",
+        data: {
+          description: "Complete the setup steps.",
+          fields: [],
+          pages: [
+            {
+              id: "page-1",
+              title: "Personal Info",
+              description: "Enter your personal details.",
+              fields: [
+                {
+                  id: "name",
+                  type: "text",
+                  label: "Full Name",
+                  required: true,
+                },
+                { id: "email", type: "text", label: "Email", required: true },
+              ],
+            },
+            {
+              id: "page-2",
+              title: "Preferences",
+              fields: [
+                {
+                  id: "theme",
+                  type: "select",
+                  label: "Theme",
+                  options: [
+                    { label: "Light", value: "light" },
+                    { label: "Dark", value: "dark" },
+                  ],
+                },
+                {
+                  id: "notifications",
+                  type: "toggle",
+                  label: "Enable notifications",
+                },
+              ],
+            },
+          ],
+          pageLabels: {
+            next: "Continue",
+            back: "Go Back",
+            submit: "Finish Setup",
+          },
+          submitLabel: "Finish Setup",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-multipage-1",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    expect(showMsg).toBeDefined();
+
+    // Core wire fields
+    expect(showMsg!.surfaceType).toBe("form");
+    expect(showMsg!.title).toBe("Setup Wizard");
+
+    // data field: FormSurfaceData with pages
+    const data = showMsg!.data as AnyRecord;
+    expect(data.description).toBe("Complete the setup steps.");
+    expect(data.submitLabel).toBe("Finish Setup");
+
+    // pages should be preserved exactly
+    const pages = data.pages as Array<AnyRecord>;
+    expect(pages).toBeDefined();
+    expect(pages).toHaveLength(2);
+    expect(pages[0].id).toBe("page-1");
+    expect(pages[0].title).toBe("Personal Info");
+    expect(pages[0].description).toBe("Enter your personal details.");
+    expect(pages[0].fields as Array<AnyRecord>).toHaveLength(2);
+    expect(pages[1].id).toBe("page-2");
+    expect(pages[1].title).toBe("Preferences");
+    expect(pages[1].fields as Array<AnyRecord>).toHaveLength(2);
+
+    // pageLabels should be preserved exactly
+    const pageLabels = data.pageLabels as AnyRecord;
+    expect(pageLabels).toBeDefined();
+    expect(pageLabels.next).toBe("Continue");
+    expect(pageLabels.back).toBe("Go Back");
+    expect(pageLabels.submit).toBe("Finish Setup");
+
+    // fields should still be a valid array (defensive normalization)
+    expect(Array.isArray(data.fields)).toBe(true);
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-multipage-1", "submit", {
+      name: "Alice",
+      email: "alice@example.com",
+      theme: "dark",
+      notifications: true,
+    });
+    await resultPromise;
+  });
+
+  test("pages-only form (no top-level fields) normalizes fields to empty array", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Wizard",
+        data: {
+          pages: [
+            {
+              id: "p1",
+              title: "Step 1",
+              fields: [{ id: "x", type: "text", label: "X" }],
+            },
+          ],
+          pageLabels: { next: "Next", submit: "Done" },
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-pages-only",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    const data = showMsg!.data as AnyRecord;
+
+    // pages should be preserved
+    expect(data.pages).toBeDefined();
+    expect(data.pages as Array<AnyRecord>).toHaveLength(1);
+
+    // pageLabels should be preserved
+    expect(data.pageLabels).toEqual({ next: "Next", submit: "Done" });
+
+    // fields should default to empty array (defensive normalization)
+    expect(data.fields).toEqual([]);
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-pages-only", "submit", {
+      x: "val",
+    });
+    await resultPromise;
+  });
+
+  test("multi-page form submit resolves correctly end-to-end", async () => {
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Multi-Step",
+        data: {
+          pages: [
+            {
+              id: "p1",
+              title: "Step 1",
+              fields: [{ id: "a", type: "text", label: "A" }],
+            },
+            {
+              id: "p2",
+              title: "Step 2",
+              fields: [{ id: "b", type: "number", label: "B" }],
+            },
+          ],
+          pageLabels: { next: "Next", back: "Previous", submit: "Complete" },
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-multipage-submit",
+    );
+
+    ctx.sentMessages.length = 0;
+
+    await handleSurfaceAction(ctx, "payload-surf-multipage-submit", "submit", {
+      a: "hello",
+      b: 42,
+    });
+    const result = await resultPromise;
+
+    // Result should be submitted with the form data
+    expect(result.status).toBe("submitted");
+    expect(result.submittedData).toEqual({ a: "hello", b: 42 });
+
+    // ui_surface_complete should have been emitted
+    const completeMsg = findByType(ctx.sentMessages, "ui_surface_complete");
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg!.summary).toBe("Submitted");
+    expect(completeMsg!.submittedData).toEqual({ a: "hello", b: 42 });
+  });
+});
+
+// ── Forward-compatible additive keys (regression) ────────────────────
+
+describe("standalone form forward-compatible payload preservation", () => {
+  test("additive keys not in FormSurfaceData are preserved through the pipeline", async () => {
+    // Regression test: the form surface pipeline must preserve all keys from
+    // the input data — including ones not declared in FormSurfaceData (e.g.
+    // keys added in newer protocol versions) — so that forward-compatible
+    // clients can consume them.
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Future Form",
+        data: {
+          description: "A form with future keys.",
+          fields: [{ id: "f1", type: "text", label: "Field 1" }],
+          submitLabel: "Go",
+          // Hypothetical future keys that the protocol may add
+          futureStringField: "hello",
+          futureNumberField: 99,
+          futureBooleanField: true,
+          futureObjectField: { nested: "value", count: 3 },
+          futureArrayField: ["a", "b", "c"],
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-forward-compat",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    const data = showMsg!.data as AnyRecord;
+
+    // Known FormSurfaceData fields should be present
+    expect(data.description).toBe("A form with future keys.");
+    expect(data.submitLabel).toBe("Go");
+    expect(data.fields as Array<AnyRecord>).toHaveLength(1);
+
+    // Future additive keys must NOT be dropped
+    expect(data.futureStringField).toBe("hello");
+    expect(data.futureNumberField).toBe(99);
+    expect(data.futureBooleanField).toBe(true);
+    expect(data.futureObjectField).toEqual({ nested: "value", count: 3 });
+    expect(data.futureArrayField).toEqual(["a", "b", "c"]);
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-forward-compat", "submit", {});
+    await resultPromise;
+  });
+
+  test("existing single-page form behavior is unchanged", async () => {
+    // Ensure the refactored code does not regress the basic single-page
+    // form path that existed before the pages/pageLabels fix.
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Simple Form",
+        data: {
+          description: "A basic form.",
+          fields: [
+            { id: "name", type: "text", label: "Name", required: true },
+            { id: "age", type: "number", label: "Age" },
+          ],
+          submitLabel: "Submit",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-simple-form",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    const data = showMsg!.data as AnyRecord;
+
+    expect(data.description).toBe("A basic form.");
+    expect(data.submitLabel).toBe("Submit");
+    expect(data.fields as Array<AnyRecord>).toHaveLength(2);
+    expect((data.fields as Array<AnyRecord>)[0].id).toBe("name");
+    expect((data.fields as Array<AnyRecord>)[0].required).toBe(true);
+    expect((data.fields as Array<AnyRecord>)[1].id).toBe("age");
+
+    // pages/pageLabels should not be present for single-page forms
+    expect(data.pages).toBeUndefined();
+    expect(data.pageLabels).toBeUndefined();
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-simple-form", "submit", {
+      name: "Bob",
+      age: 25,
+    });
+    await resultPromise;
+  });
+
+  test("form with neither fields nor pages normalizes fields to empty array", async () => {
+    // Defensive normalization: an empty/missing form payload should still
+    // produce a valid FormSurfaceData with an empty fields array rather
+    // than undefined or a missing key.
+    const ctx = createMockContext();
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "payload-test-conv",
+        surfaceType: "form",
+        title: "Empty Form",
+        data: {
+          description: "No fields at all.",
+        },
+        timeoutMs: 60_000,
+      },
+      "payload-surf-empty-form",
+    );
+
+    const showMsg = findByType(ctx.sentMessages, "ui_surface_show");
+    const data = showMsg!.data as AnyRecord;
+
+    expect(data.description).toBe("No fields at all.");
+    // fields must always be a valid array — never undefined
+    expect(Array.isArray(data.fields)).toBe(true);
+    expect(data.fields).toEqual([]);
+
+    // Resolve to avoid dangling timer
+    await handleSurfaceAction(ctx, "payload-surf-empty-form", "submit", {});
+    await resultPromise;
+  });
+});

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -1145,6 +1145,50 @@ describe("ui request — --actions parsing", () => {
     expect(lastIpcCall).toBeNull();
   });
 
+  test("rejects 'cancel' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"cancel","label":"Cancel"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('id "cancel" is reserved for internal use');
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'dismiss' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"dismiss","label":"Dismiss"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('id "dismiss" is reserved for internal use');
+    expect(lastIpcCall).toBeNull();
+  });
+
   test("non-reserved IDs are accepted alongside validation", async () => {
     process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
       conversationId: "conv-1",

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -696,3 +696,476 @@ describe("ui request — conversation ID discovery hint", () => {
     expect(parsed.error).toContain("assistant conversations list");
   });
 });
+
+// ---------------------------------------------------------------------------
+// ui request — --actions parsing
+// ---------------------------------------------------------------------------
+
+describe("ui request — --actions parsing", () => {
+  test("valid actions are parsed and included in IPC params", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "approve", label: "Approve", variant: "primary" },
+      { id: "reject", label: "Reject", variant: "danger" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"Choose"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
+
+  test("actions without variant are accepted", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [{ id: "ok", label: "OK" }];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toEqual([{ id: "ok", label: "OK" }]);
+  });
+
+  test("actions are omitted from IPC params when --actions is not provided", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toBeUndefined();
+  });
+
+  test("errors when --actions is an empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON in --actions");
+  });
+
+  test("errors on malformed JSON in --actions", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "{not valid json",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON in --actions");
+  });
+
+  test("errors when --actions is not an array", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '{"id":"ok","label":"OK"}',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must be a JSON array");
+  });
+
+  test("errors when --actions is an empty array", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "[]",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("at least one action");
+  });
+
+  test("errors when action is missing id", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"label":"OK"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"id" is required');
+  });
+
+  test("errors when action id is empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"","label":"OK"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"id" is required');
+  });
+
+  test("errors when action is missing label", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"label" is required');
+  });
+
+  test("errors when action label is empty string", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok","label":""}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"label" is required');
+  });
+
+  test("errors when action has invalid variant", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"ok","label":"OK","variant":"invalid"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('"variant" must be one of');
+  });
+
+  test("errors when action item is not an object", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '["not-an-object"]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must be a JSON object");
+  });
+
+  test("accepts all valid variant values", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "a", label: "Primary", variant: "primary" },
+      { id: "b", label: "Danger", variant: "danger" },
+      { id: "c", label: "Secondary", variant: "secondary" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
+
+  test("action error references the correct array index", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    // Second action is invalid (index 1)
+    const actions = [
+      { id: "ok", label: "OK" },
+      { id: "bad", label: "" },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--actions[1]");
+  });
+
+  test("action errors output as text when --json is not set", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      "{bad",
+    ]);
+
+    expect(exitCode).toBe(1);
+    // When --json is not set, errors go to log.error (mocked as no-op),
+    // so stdout should be empty and IPC should not have been called
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'selection_changed' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"selection_changed","label":"Select"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "selection_changed" is reserved for internal use',
+    );
+    expect(parsed.error).toContain("Reserved IDs:");
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'content_changed' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"content_changed","label":"Change"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "content_changed" is reserved for internal use',
+    );
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects 'state_update' as a reserved action ID", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      '[{"id":"state_update","label":"Update"}]',
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      'id "state_update" is reserved for internal use',
+    );
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("reserved ID error references the correct array index", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    // First action is valid, second uses a reserved ID
+    const actions = [
+      { id: "approve", label: "Approve" },
+      { id: "state_update", label: "Update State" },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("--actions[1]");
+    expect(parsed.error).toContain('id "state_update" is reserved');
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("non-reserved IDs are accepted alongside validation", async () => {
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-1",
+    });
+
+    const actions = [
+      { id: "approve", label: "Approve" },
+      { id: "reject", label: "Reject" },
+    ];
+
+    const { exitCode } = await runCommand([
+      "ui",
+      "request",
+      "--payload",
+      '{"msg":"test"}',
+      "--actions",
+      JSON.stringify(actions),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.params!.actions).toEqual(actions);
+  });
+});

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -17,9 +17,10 @@ import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import type {
-  InteractiveUiAction,
-  InteractiveUiResult,
+import {
+  type InteractiveUiAction,
+  type InteractiveUiResult,
+  RESERVED_ACTION_IDS,
 } from "../../runtime/interactive-ui.js";
 import { log } from "../logger.js";
 
@@ -148,28 +149,6 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
 }
 
 // ── Action parsing ────────────────────────────────────────────────────
-
-/**
- * Action IDs reserved for internal surface lifecycle events. These IDs
- * have special behavior in `handleSurfaceAction` (conversation-surfaces.ts)
- * and must not be used as custom button IDs:
- *
- * - `selection_changed`, `content_changed`, `state_update` — Intercepted
- *   as non-terminal events (early return without resolving the pending
- *   `ui_request`). Using one as a button ID would silently swallow the click.
- *
- * - `cancel`, `dismiss` — Treated as cancellation signals, resolving the
- *   `ui_request` with `status: "cancelled"` instead of the expected
- *   `status: "submitted"`. A caller expecting submission semantics would
- *   get the wrong status.
- */
-export const RESERVED_ACTION_IDS = new Set([
-  "selection_changed",
-  "content_changed",
-  "state_update",
-  "cancel",
-  "dismiss",
-]);
 
 /** Valid variant values for action buttons. */
 const VALID_VARIANTS = new Set(["primary", "danger", "secondary"]);

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -17,7 +17,10 @@ import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import type { InteractiveUiResult } from "../../runtime/interactive-ui.js";
+import type {
+  InteractiveUiAction,
+  InteractiveUiResult,
+} from "../../runtime/interactive-ui.js";
 import { log } from "../logger.js";
 
 // ── Constants ─────────────────────────────────────────────────────────
@@ -144,6 +147,111 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
   }
 }
 
+// ── Action parsing ────────────────────────────────────────────────────
+
+/**
+ * Action IDs reserved for internal surface lifecycle events. These IDs
+ * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
+ * as non-terminal events (early return without resolving the pending
+ * `ui_request`). If a caller defines one of these as a custom button ID,
+ * clicking it would silently return early without resolving.
+ */
+export const RESERVED_ACTION_IDS = new Set([
+  "selection_changed",
+  "content_changed",
+  "state_update",
+]);
+
+/** Valid variant values for action buttons. */
+const VALID_VARIANTS = new Set(["primary", "danger", "secondary"]);
+
+/**
+ * Parse and validate the `--actions` JSON flag.
+ *
+ * Expected shape: an array of objects, each with:
+ *   - `id`      (string, required, non-empty)
+ *   - `label`   (string, required, non-empty)
+ *   - `variant` (optional: "primary" | "danger" | "secondary")
+ *
+ * Returns the validated array, or throws with an actionable CLI error.
+ */
+function parseActions(raw: string): InteractiveUiAction[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in --actions: ${err instanceof SyntaxError ? err.message : String(err)}\n` +
+        "  --actions must be a JSON array of action objects.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"},{"id":"reject","label":"Reject","variant":"danger"}]\'',
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "--actions must be a JSON array of action objects.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"}]\'',
+    );
+  }
+
+  if (parsed.length === 0) {
+    throw new Error(
+      "--actions must contain at least one action.\n" +
+        '  Example: --actions \'[{"id":"approve","label":"Approve"}]\'',
+    );
+  }
+
+  const actions: InteractiveUiAction[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    const item = parsed[i];
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new Error(
+        `--actions[${i}]: each action must be a JSON object with "id" and "label" fields.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    const obj = item as Record<string, unknown>;
+
+    if (typeof obj.id !== "string" || obj.id.length === 0) {
+      throw new Error(
+        `--actions[${i}]: "id" is required and must be a non-empty string.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    if (RESERVED_ACTION_IDS.has(obj.id)) {
+      const reserved = [...RESERVED_ACTION_IDS].sort().join(", ");
+      throw new Error(
+        `--actions[${i}]: id "${obj.id}" is reserved for internal use. Reserved IDs: ${reserved}`,
+      );
+    }
+
+    if (typeof obj.label !== "string" || obj.label.length === 0) {
+      throw new Error(
+        `--actions[${i}]: "label" is required and must be a non-empty string.\n` +
+          '  Example: {"id":"approve","label":"Approve"}',
+      );
+    }
+
+    const action: InteractiveUiAction = { id: obj.id, label: obj.label };
+
+    if (obj.variant !== undefined) {
+      if (typeof obj.variant !== "string" || !VALID_VARIANTS.has(obj.variant)) {
+        throw new Error(
+          `--actions[${i}]: "variant" must be one of "primary", "danger", or "secondary" (got ${JSON.stringify(obj.variant)}).\n` +
+            '  Example: {"id":"delete","label":"Delete","variant":"danger"}',
+        );
+      }
+      action.variant = obj.variant as InteractiveUiAction["variant"];
+    }
+
+    actions.push(action);
+  }
+
+  return actions;
+}
+
 // ── Strict integer parsing ────────────────────────────────────────────
 
 /**
@@ -193,6 +301,10 @@ Examples:
     )
     .option("--title <title>", "Title displayed on the surface")
     .option(
+      "--actions <json>",
+      "JSON array of action objects defining custom buttons/options",
+    )
+    .option(
       "--conversation-id <id>",
       "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill context if omitted)",
     )
@@ -212,6 +324,10 @@ surface content and can be provided via --payload or piped through stdin.
 The response includes the user's action (submitted, cancelled, timed_out)
 and any submitted data.
 
+Custom actions can be defined via --actions to control the buttons shown
+on the surface. Each action requires an "id" and "label", with an optional
+"variant" hint ("primary", "danger", or "secondary").
+
 Arguments:
   (none — payload via --payload flag or stdin)
 
@@ -219,6 +335,7 @@ Options:
   --payload <json>         JSON object with surface data
   --surface-type <type>    "confirmation" (default) or "form"
   --title <title>          Surface title
+  --actions <json>         JSON array of custom action objects
   --conversation-id <id>   Explicit conversation ID
   --timeout <ms>           Request timeout in milliseconds (default: 300000)
   --json                   Output as JSON
@@ -226,13 +343,16 @@ Options:
 Examples:
   $ echo '{"message":"Proceed?"}' | assistant ui request
   $ assistant ui request --payload '{"message":"Proceed?"}' --json
-  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json`,
+  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json
+  $ assistant ui request --payload '{"message":"Choose an option"}' \\
+      --actions '[{"id":"approve","label":"Approve","variant":"primary"},{"id":"reject","label":"Reject","variant":"danger"}]'`,
     )
     .action(
       async (opts: {
         payload?: string;
         surfaceType?: string;
         title?: string;
+        actions?: string;
         conversationId?: string;
         timeout?: string;
         json?: boolean;
@@ -271,6 +391,25 @@ Examples:
           return;
         }
 
+        // Parse actions (if provided)
+        let actions: InteractiveUiAction[] | undefined;
+        if (opts.actions !== undefined) {
+          try {
+            actions = parseActions(opts.actions);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
+            }
+            process.exitCode = 1;
+            return;
+          }
+        }
+
         // Parse timeout
         const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
         const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
@@ -296,6 +435,9 @@ Examples:
         };
         if (opts.title) {
           ipcParams.title = opts.title;
+        }
+        if (actions) {
+          ipcParams.actions = actions;
         }
 
         // Call IPC with timeout budget = request timeout + buffer

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -151,15 +151,24 @@ function readPayload(payloadFlag?: string): Record<string, unknown> {
 
 /**
  * Action IDs reserved for internal surface lifecycle events. These IDs
- * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
- * as non-terminal events (early return without resolving the pending
- * `ui_request`). If a caller defines one of these as a custom button ID,
- * clicking it would silently return early without resolving.
+ * have special behavior in `handleSurfaceAction` (conversation-surfaces.ts)
+ * and must not be used as custom button IDs:
+ *
+ * - `selection_changed`, `content_changed`, `state_update` — Intercepted
+ *   as non-terminal events (early return without resolving the pending
+ *   `ui_request`). Using one as a button ID would silently swallow the click.
+ *
+ * - `cancel`, `dismiss` — Treated as cancellation signals, resolving the
+ *   `ui_request` with `status: "cancelled"` instead of the expected
+ *   `status: "submitted"`. A caller expecting submission semantics would
+ *   get the wrong status.
  */
 export const RESERVED_ACTION_IDS = new Set([
   "selection_changed",
   "content_changed",
   "state_update",
+  "cancel",
+  "dismiss",
 ]);
 
 /** Valid variant values for action buttons. */

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -445,6 +445,7 @@ export function showStandaloneSurface(
     return Promise.resolve({
       status: "cancelled" as const,
       surfaceId,
+      cancellationReason: "no_interactive_surface",
     });
   }
 
@@ -455,7 +456,11 @@ export function showStandaloneSurface(
       { conversationId: ctx.conversationId, surfaceType: request.surfaceType },
       "standalone surface: pendingStandaloneSurfaces map missing; failing closed",
     );
-    return Promise.resolve({ status: "cancelled" as const, surfaceId });
+    return Promise.resolve({
+      status: "cancelled" as const,
+      surfaceId,
+      cancellationReason: "no_interactive_surface",
+    });
   }
   const pendingMap = ctx.pendingStandaloneSurfaces;
 
@@ -981,6 +986,9 @@ export async function handleSurfaceAction(
       surfaceId,
       actionId,
       ...(data ? { submittedData: data } : {}),
+      ...(isCancellation
+        ? { cancellationReason: "user_dismissed" as const }
+        : {}),
       summary,
     };
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -587,9 +587,6 @@ function buildStandaloneSurfaceData(
     // of top-level `fields` may omit the latter entirely.
     const raw = request.data as Record<string, unknown>;
     const hasFields = Array.isArray(raw.fields) && raw.fields.length > 0;
-
-    // Ensure `fields` is always a valid array — callers that supply `pages`
-    // instead of top-level `fields` may omit the latter entirely.
     const fields: FormSurfaceData["fields"] = hasFields
       ? (raw.fields as FormSurfaceData["fields"])
       : [];

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -581,19 +581,23 @@ function buildStandaloneSurfaceData(
   }
 
   if (request.surfaceType === "form") {
+    // Preserve the full form payload (pages, pageLabels, and any future
+    // additive keys) via spreading. Apply defensive normalization so that
+    // `fields` is always a valid array — callers that use `pages` instead
+    // of top-level `fields` may omit the latter entirely.
+    const raw = request.data as Record<string, unknown>;
+    const hasFields = Array.isArray(raw.fields) && raw.fields.length > 0;
+
+    // Ensure `fields` is always a valid array — callers that supply `pages`
+    // instead of top-level `fields` may omit the latter entirely.
+    const fields: FormSurfaceData["fields"] = hasFields
+      ? (raw.fields as FormSurfaceData["fields"])
+      : [];
+
     return {
-      description:
-        typeof request.data.description === "string"
-          ? request.data.description
-          : undefined,
-      fields: Array.isArray(request.data.fields)
-        ? (request.data.fields as FormSurfaceData["fields"])
-        : [],
-      submitLabel:
-        typeof request.data.submitLabel === "string"
-          ? request.data.submitLabel
-          : undefined,
-    } satisfies FormSurfaceData;
+      ...raw,
+      fields,
+    } as FormSurfaceData;
   }
 
   // Fallback: pass through opaque data

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -761,7 +761,11 @@ export class Conversation {
       } catch {
         // Best-effort: the client may already be disconnected during dispose.
       }
-      entry.resolve({ status: "cancelled", surfaceId });
+      entry.resolve({
+        status: "cancelled",
+        surfaceId,
+        cancellationReason: "resolver_unavailable",
+      });
     }
     this.pendingStandaloneSurfaces.clear();
     // Clear tombstone timers to prevent dangling references after dispose.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -836,12 +836,45 @@ export class DaemonServer {
 
     // Install the interactive UI resolver so skills and IPC handlers can
     // present ad-hoc UI surfaces (confirmations, forms) to the user via
-    // `requestInteractiveUi()`. The resolver verifies the target
-    // conversation exists and is live, then delegates to the
-    // conversation-level standalone surface lifecycle which blocks until
-    // the user responds or the timeout elapses.
+    // `requestInteractiveUi()`. The resolver uses a two-step lookup:
+    //   Step A: use the in-memory conversation when present.
+    //   Step B: if absent (evicted), check persistent storage and hydrate
+    //           via getOrCreateConversation when the conversation exists
+    //           in the DB.
+    // When the conversation does not exist at all, the resolver returns
+    // `status: "cancelled"` with `cancellationReason: "conversation_not_found"`
+    // so callers can distinguish not-found from other fail-closed outcomes.
     registerInteractiveUiResolver(async (request) => {
-      const conversation = this.conversations.get(request.conversationId);
+      // Step A: fast path — in-memory conversation
+      let conversation = this.conversations.get(request.conversationId);
+
+      // Step B: conversation was evicted from memory — check persistent
+      // storage and hydrate if the conversation exists in the DB.
+      if (!conversation) {
+        const persisted = getConversation(request.conversationId);
+        if (persisted) {
+          try {
+            conversation = await this.getOrCreateConversation(
+              request.conversationId,
+            );
+          } catch (err) {
+            log.warn(
+              {
+                err,
+                conversationId: request.conversationId,
+                surfaceType: request.surfaceType,
+              },
+              "interactive-ui resolver: failed to hydrate persisted conversation; failing closed",
+            );
+            return {
+              status: "cancelled" as const,
+              surfaceId: `ui-resolver-${Date.now()}`,
+              cancellationReason: "resolver_error" as const,
+            };
+          }
+        }
+      }
+
       if (!conversation) {
         log.warn(
           {
@@ -853,6 +886,7 @@ export class DaemonServer {
         return {
           status: "cancelled" as const,
           surfaceId: `ui-resolver-${Date.now()}`,
+          cancellationReason: "conversation_not_found" as const,
         };
       }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -836,44 +836,17 @@ export class DaemonServer {
 
     // Install the interactive UI resolver so skills and IPC handlers can
     // present ad-hoc UI surfaces (confirmations, forms) to the user via
-    // `requestInteractiveUi()`. The resolver uses a two-step lookup:
-    //   Step A: use the in-memory conversation when present.
-    //   Step B: if absent (evicted), check persistent storage and hydrate
-    //           via getOrCreateConversation when the conversation exists
-    //           in the DB.
-    // When the conversation does not exist at all, the resolver returns
-    // `status: "cancelled"` with `cancellationReason: "conversation_not_found"`
-    // so callers can distinguish not-found from other fail-closed outcomes.
+    // `requestInteractiveUi()`. Interactive UI requires a client to be
+    // actively connected to the conversation (via SSE), which means the
+    // conversation must be in the in-memory map. If the conversation was
+    // evicted from memory the client is definitely disconnected, so
+    // hydration from persistent storage is pointless — the hydrated
+    // conversation would have hasNoClient=true, causing
+    // canShowInteractiveUi() to return false and the surface to be
+    // cancelled with no_interactive_surface. We skip that wasted work
+    // and return conversation_not_found directly.
     registerInteractiveUiResolver(async (request) => {
-      // Step A: fast path — in-memory conversation
-      let conversation = this.conversations.get(request.conversationId);
-
-      // Step B: conversation was evicted from memory — check persistent
-      // storage and hydrate if the conversation exists in the DB.
-      if (!conversation) {
-        const persisted = getConversation(request.conversationId);
-        if (persisted) {
-          try {
-            conversation = await this.getOrCreateConversation(
-              request.conversationId,
-            );
-          } catch (err) {
-            log.warn(
-              {
-                err,
-                conversationId: request.conversationId,
-                surfaceType: request.surfaceType,
-              },
-              "interactive-ui resolver: failed to hydrate persisted conversation; failing closed",
-            );
-            return {
-              status: "cancelled" as const,
-              surfaceId: `ui-resolver-${Date.now()}`,
-              cancellationReason: "resolver_error" as const,
-            };
-          }
-        }
-      }
+      const conversation = this.conversations.get(request.conversationId);
 
       if (!conversation) {
         log.warn(
@@ -881,7 +854,7 @@ export class DaemonServer {
             conversationId: request.conversationId,
             surfaceType: request.surfaceType,
           },
-          "interactive-ui resolver: conversation not found; failing closed",
+          "interactive-ui resolver: conversation not in memory (client not connected); failing closed",
         );
         return {
           status: "cancelled" as const,

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -255,6 +255,77 @@ describe("ui_request IPC route", () => {
     expect(result.error).toBeDefined();
   });
 
+  // ── Reserved action IDs ──────────────────────────────────────────
+
+  test("rejects action with reserved id 'selection_changed'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "selection_changed", label: "Select" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'content_changed'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "content_changed", label: "Change" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'state_update'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "state_update", label: "Update" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'cancel'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "cancel", label: "Cancel" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects action with reserved id 'dismiss'", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [{ id: "dismiss", label: "Dismiss" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
+  test("rejects when any action in the array uses a reserved id", async () => {
+    const result = await cliIpcCall("ui_request", {
+      ...baseParams(),
+      actions: [
+        { id: "approve", label: "Approve" },
+        { id: "state_update", label: "Bad Action" },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("reserved");
+  });
+
   // ── Optional fields ───────────────────────────────────────────────
 
   test("accepts request with optional title", async () => {

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -339,6 +339,64 @@ describe("ui_request IPC route", () => {
     expect(result.result!.cancellationReason).toBeUndefined();
   });
 
+  // ── Persisted-but-not-loaded conversation (hydration path) ─────────
+
+  test("succeeds for a valid persisted-but-not-loaded conversation ID", async () => {
+    // Simulates the daemon resolver's Step B: the conversation was
+    // evicted from memory but still exists in persistent storage.
+    // The resolver hydrates it and delegates to the surface lifecycle.
+    const hydratedConversationId = "conv-persisted-not-loaded";
+    registerInteractiveUiResolver(
+      async (req: InteractiveUiRequest): Promise<InteractiveUiResult> => {
+        // Simulate successful hydration: the resolver found the
+        // conversation in storage and reconstituted it.
+        expect(req.conversationId).toBe(hydratedConversationId);
+        return {
+          status: "submitted",
+          actionId: "confirm",
+          surfaceId: `hydrated-surface-${req.conversationId}`,
+        };
+      },
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: hydratedConversationId }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.actionId).toBe("confirm");
+    expect(result.result!.surfaceId).toContain(hydratedConversationId);
+  });
+
+  // ── Truly unknown conversation ID ─────────────────────────────────
+
+  test("returns cancelled with conversation_not_found for truly unknown conversation ID", async () => {
+    // Simulates the daemon resolver when the conversation does not
+    // exist in memory OR in persistent storage — the resolver returns
+    // conversation_not_found without throwing.
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: `ui-resolver-not-found`,
+        cancellationReason: "conversation_not_found",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: "conv-truly-unknown-xyz" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("conversation_not_found");
+    expect(result.result!.surfaceId).toBeDefined();
+  });
+
   // ── Optional fields (continued) ────────────────────────────────────
 
   test("accepts form surfaceType with submittedData", async () => {

--- a/assistant/src/ipc/__tests__/ui-request-route.test.ts
+++ b/assistant/src/ipc/__tests__/ui-request-route.test.ts
@@ -127,7 +127,7 @@ describe("ui_request IPC route", () => {
 
   // ── Unknown conversation (resolver throws) ────────────────────────
 
-  test("returns cancelled when resolver throws for unknown conversation", async () => {
+  test("returns cancelled with resolver_error reason when resolver throws for unknown conversation", async () => {
     registerInteractiveUiResolver(async (_req: InteractiveUiRequest) => {
       throw new Error("Unknown conversation: conv-nonexistent");
     });
@@ -141,12 +141,13 @@ describe("ui_request IPC route", () => {
     expect(result.ok).toBe(true);
     expect(result.result).toBeDefined();
     expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("resolver_error");
     expect(result.result!.surfaceId).toBeDefined();
   });
 
   // ── Non-interactive failure (no resolver registered) ──────────────
 
-  test("returns cancelled when no resolver is registered", async () => {
+  test("returns cancelled with no_interactive_surface reason when no resolver is registered", async () => {
     // No resolver registered — resetInteractiveUiResolverForTests()
     // was called in beforeEach, so the module-level resolver is null.
 
@@ -158,6 +159,7 @@ describe("ui_request IPC route", () => {
     expect(result.ok).toBe(true);
     expect(result.result).toBeDefined();
     expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("no_interactive_surface");
     expect(result.result!.surfaceId).toBeDefined();
   });
 
@@ -274,6 +276,70 @@ describe("ui_request IPC route", () => {
     expect(result.result!.status).toBe("submitted");
     expect(result.result!.summary).toBe("Confirm Action");
   });
+
+  // ── Cancellation reason round-trip ────────────────────────────────
+
+  test("round-trips user_dismissed cancellation reason from resolver", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: "mock-surface-dismissed",
+        cancellationReason: "user_dismissed",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("user_dismissed");
+  });
+
+  test("round-trips conversation_not_found cancellation reason from resolver", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "cancelled",
+        surfaceId: "mock-surface-not-found",
+        cancellationReason: "conversation_not_found",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams({ conversationId: "conv-missing" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("cancelled");
+    expect(result.result!.cancellationReason).toBe("conversation_not_found");
+  });
+
+  test("submitted result does not carry cancellationReason through IPC", async () => {
+    registerInteractiveUiResolver(
+      async (_req: InteractiveUiRequest): Promise<InteractiveUiResult> => ({
+        status: "submitted",
+        actionId: "confirm",
+        surfaceId: "mock-surface-submitted",
+      }),
+    );
+
+    const result = await cliIpcCall<InteractiveUiResult>(
+      "ui_request",
+      baseParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.status).toBe("submitted");
+    expect(result.result!.cancellationReason).toBeUndefined();
+  });
+
+  // ── Optional fields (continued) ────────────────────────────────────
 
   test("accepts form surfaceType with submittedData", async () => {
     registerInteractiveUiResolver(

--- a/assistant/src/ipc/routes/ui-request.ts
+++ b/assistant/src/ipc/routes/ui-request.ts
@@ -9,7 +9,10 @@
 
 import { z } from "zod";
 
-import { requestInteractiveUi } from "../../runtime/interactive-ui.js";
+import {
+  requestInteractiveUi,
+  RESERVED_ACTION_IDS,
+} from "../../runtime/interactive-ui.js";
 import type { IpcRoute } from "../cli-server.js";
 
 // ── Param schema ──────────────────────────────────────────────────────
@@ -22,7 +25,12 @@ const UiRequestParams = z.object({
   actions: z
     .array(
       z.object({
-        id: z.string().min(1),
+        id: z
+          .string()
+          .min(1)
+          .refine((id) => !RESERVED_ACTION_IDS.has(id), {
+            message: `Action id is reserved for internal use. Reserved IDs: ${[...RESERVED_ACTION_IDS].sort().join(", ")}`,
+          }),
         label: z.string().min(1),
         variant: z.enum(["primary", "danger", "secondary"]).optional(),
       }),

--- a/assistant/src/runtime/__tests__/interactive-ui.test.ts
+++ b/assistant/src/runtime/__tests__/interactive-ui.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { decodeDecisionToken } from "../decision-token.js";
 import {
+  type CancellationReason,
   type InteractiveUiRequest,
   type InteractiveUiResult,
   registerInteractiveUiResolver,
@@ -36,7 +37,7 @@ beforeEach(() => {
 // ── Missing resolver (fail-closed) ───────────────────────────────────
 
 describe("requestInteractiveUi without resolver", () => {
-  test("returns cancelled when no resolver is registered", async () => {
+  test("returns cancelled with no_interactive_surface reason when no resolver is registered", async () => {
     const request: InteractiveUiRequest = {
       conversationId: "conv-1",
       surfaceType: "confirmation",
@@ -46,6 +47,7 @@ describe("requestInteractiveUi without resolver", () => {
     const result = await requestInteractiveUi(request);
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("no_interactive_surface");
     expect(result.surfaceId).toBeString();
     expect(result.surfaceId.length).toBeGreaterThan(0);
     expect(result.actionId).toBeUndefined();
@@ -73,6 +75,7 @@ describe("requestInteractiveUi without resolver", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("no_interactive_surface");
     expect(result.decisionToken).toBeUndefined();
   });
 });
@@ -204,7 +207,7 @@ describe("requestInteractiveUi with resolver", () => {
 // ── Error handling (fail-closed on resolver throw) ──────────────────
 
 describe("resolver error handling", () => {
-  test("returns cancelled when resolver throws", async () => {
+  test("returns cancelled with resolver_error reason when resolver throws", async () => {
     registerInteractiveUiResolver(async () => {
       throw new Error("Surface rendering failed");
     });
@@ -216,11 +219,12 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.surfaceId).toBeString();
     expect(result.surfaceId.length).toBeGreaterThan(0);
   });
 
-  test("returns cancelled when resolver rejects", async () => {
+  test("returns cancelled with resolver_error reason when resolver rejects", async () => {
     registerInteractiveUiResolver(() =>
       Promise.reject(new Error("Connection lost")),
     );
@@ -232,6 +236,7 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.surfaceId).toBeString();
   });
 
@@ -247,6 +252,7 @@ describe("resolver error handling", () => {
     });
 
     expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_error");
     expect(result.decisionToken).toBeUndefined();
   });
 });
@@ -461,6 +467,124 @@ describe("decision token", () => {
 
     // Tokens differ due to nonce even with same conversation/action
     expect(result1.decisionToken).not.toBe(result2.decisionToken);
+  });
+});
+
+// ── Cancellation reason propagation ──────────────────────────────────
+
+describe("cancellation reason", () => {
+  test("no_interactive_surface reason when no resolver registered", async () => {
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-no-resolver",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe(
+      "no_interactive_surface" satisfies CancellationReason,
+    );
+  });
+
+  test("resolver_error reason when resolver throws", async () => {
+    registerInteractiveUiResolver(async () => {
+      throw new Error("boom");
+    });
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-error",
+      surfaceType: "form",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe(
+      "resolver_error" satisfies CancellationReason,
+    );
+  });
+
+  test("resolver can return user_dismissed reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "dismissed-surface",
+      cancellationReason: "user_dismissed",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-user-dismissed",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("user_dismissed");
+  });
+
+  test("resolver can return conversation_not_found reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "not-found-surface",
+      cancellationReason: "conversation_not_found",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-not-found",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("conversation_not_found");
+  });
+
+  test("resolver can return resolver_unavailable reason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "cancelled",
+      surfaceId: "unavailable-surface",
+      cancellationReason: "resolver_unavailable",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-unavailable",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancellationReason).toBe("resolver_unavailable");
+  });
+
+  test("submitted result does not carry cancellationReason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "submitted",
+      actionId: "confirm",
+      surfaceId: "no-reason-submit",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-submitted",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("submitted");
+    expect(result.cancellationReason).toBeUndefined();
+  });
+
+  test("timed_out result does not carry cancellationReason", async () => {
+    registerInteractiveUiResolver(async () => ({
+      status: "timed_out",
+      surfaceId: "no-reason-timeout",
+    }));
+
+    const result = await requestInteractiveUi({
+      conversationId: "conv-reason-timeout",
+      surfaceType: "confirmation",
+      data: {},
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.cancellationReason).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -39,6 +39,25 @@ import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
+// ── Cancellation reasons ─────────────────────────────────────────────
+
+/**
+ * Machine-readable reason for a `"cancelled"` outcome.
+ *
+ * - `"user_dismissed"` — the user explicitly closed/dismissed the surface
+ * - `"no_interactive_surface"` — no resolver was registered (headless / test)
+ * - `"conversation_not_found"` — the target conversation could not be located
+ * - `"resolver_unavailable"` — a resolver was registered but is not currently
+ *   available (e.g. the surface transport is disconnected)
+ * - `"resolver_error"` — the resolver threw an unexpected error
+ */
+export type CancellationReason =
+  | "user_dismissed"
+  | "no_interactive_surface"
+  | "conversation_not_found"
+  | "resolver_unavailable"
+  | "resolver_error";
+
 // ── Request / Result contracts ───────────────────────────────────────
 
 /**
@@ -111,6 +130,16 @@ export interface InteractiveUiResult {
   summary?: string;
   /** The surface identifier that was shown, for audit/correlation. */
   surfaceId: string;
+  /**
+   * Machine-readable reason for a `"cancelled"` outcome. Present only
+   * when `status === "cancelled"`. Allows callers to distinguish
+   * user-initiated dismissals from operational fail-closed outcomes
+   * without parsing log messages.
+   *
+   * Optional for backward compatibility — existing callers that only
+   * check `status` continue to work unchanged.
+   */
+  cancellationReason?: CancellationReason;
   /**
    * Short-lived informational decision token, present when
    * `status === "submitted"` and `surfaceType === "confirmation"`.
@@ -247,6 +276,7 @@ export async function requestInteractiveUi(
     const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
+      cancellationReason: "no_interactive_surface",
     };
     emitAuditLog(request, failResult);
     return failResult;
@@ -299,6 +329,7 @@ export async function requestInteractiveUi(
     const failResult: InteractiveUiResult = {
       status: "cancelled",
       surfaceId,
+      cancellationReason: "resolver_error",
     };
     emitAuditLog(request, failResult);
     return failResult;

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -39,6 +39,27 @@ import { mintDecisionToken } from "./decision-token.js";
 
 const log = getLogger("interactive-ui");
 
+// ── Reserved action IDs ──────────────────────────────────────────────
+
+/**
+ * Action IDs reserved for internal surface lifecycle events. These IDs
+ * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
+ * as non-terminal events (early return without resolving the pending
+ * `ui_request`). If a caller defines one of these as a custom button ID,
+ * clicking it would silently return early without resolving.
+ *
+ * Used for validation in both the CLI (`parseActions`) and the IPC route
+ * (`ui_request` Zod schema) to reject reserved IDs before they reach the
+ * surface lifecycle.
+ */
+export const RESERVED_ACTION_IDS = new Set([
+  "selection_changed",
+  "content_changed",
+  "state_update",
+  "cancel",
+  "dismiss",
+]);
+
 // ── Cancellation reasons ─────────────────────────────────────────────
 
 /**

--- a/assistant/src/runtime/interactive-ui.ts
+++ b/assistant/src/runtime/interactive-ui.ts
@@ -42,15 +42,19 @@ const log = getLogger("interactive-ui");
 // ── Reserved action IDs ──────────────────────────────────────────────
 
 /**
- * Action IDs reserved for internal surface lifecycle events. These IDs
- * are intercepted by `handleSurfaceAction` in conversation-surfaces.ts
- * as non-terminal events (early return without resolving the pending
- * `ui_request`). If a caller defines one of these as a custom button ID,
- * clicking it would silently return early without resolving.
+ * Action IDs reserved for internal use. These are rejected by validation
+ * in both the CLI (`parseActions`) and the IPC route (`ui_request` Zod
+ * schema) so they never appear as custom button IDs.
  *
- * Used for validation in both the CLI (`parseActions`) and the IPC route
- * (`ui_request` Zod schema) to reject reserved IDs before they reach the
- * surface lifecycle.
+ * Two categories of reservation:
+ *
+ * - **Lifecycle events** (`selection_changed`, `content_changed`,
+ *   `state_update`) — intercepted by `handleSurfaceAction` in
+ *   conversation-surfaces.ts as non-terminal events (early return
+ *   without resolving the pending `ui_request`).
+ *
+ * - **Cancellation triggers** (`cancel`, `dismiss`) — resolve the
+ *   pending `ui_request` as `cancelled` instead of `submitted`.
  */
 export const RESERVED_ACTION_IDS = new Set([
   "selection_changed",

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -165,7 +165,10 @@
   fi
   ```
 
-  Reserved action IDs (`selection_changed`, `content_changed`, `state_update`) are used internally for surface lifecycle events and are rejected by `--actions` validation.
+  Reserved action IDs are used internally and are rejected by `--actions` validation. There are two categories:
+
+  - **Lifecycle events** (`selection_changed`, `content_changed`, `state_update`) — non-terminal events that are silently swallowed without resolving the pending request.
+  - **Cancellation triggers** (`cancel`, `dismiss`) — resolve the pending request as `cancelled` (instead of `submitted`).
 
   ### Status and cancellation reason branching reference
 

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -120,17 +120,108 @@
   fi
   ```
 
-  ### Status branching reference
+  ### `--actions` — custom action buttons
 
-  Every `assistant ui` response includes a `status` field. Handle all three terminal states:
+  Use `--actions` to define custom buttons on a `ui request` surface. Each action has an `id`, `label`, and optional `variant` (`"primary"`, `"danger"`, or `"secondary"`). The user's chosen action is returned in `actionId`.
+
+  ```bash
+  # Present a multi-option surface with custom actions
+  RESULT=$(assistant ui request \
+    --payload '{"message":"The staging deploy found 3 failing tests."}' \
+    --title "Deploy decision" \
+    --actions '[
+      {"id":"deploy_anyway","label":"Deploy Anyway","variant":"danger"},
+      {"id":"fix_first","label":"Fix Tests First","variant":"primary"},
+      {"id":"skip","label":"Skip This Deploy","variant":"secondary"}
+    ]' \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  ACTION=$(echo "$RESULT" | jq -r '.actionId')
+
+  if [ "$STATUS" = "submitted" ]; then
+    case "$ACTION" in
+      deploy_anyway)
+        run_deploy --force
+        ;;
+      fix_first)
+        echo "Aborting deploy. Fix the tests and re-run."
+        exit 0
+        ;;
+      skip)
+        echo "Deploy skipped."
+        exit 0
+        ;;
+    esac
+  elif [ "$STATUS" = "cancelled" ]; then
+    REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
+    if [ "$REASON" = "user_dismissed" ]; then
+      echo "User dismissed the prompt."
+    else
+      echo "Surface cancelled (reason: $REASON). No action taken."
+    fi
+  else
+    echo "Timed out. No action taken."
+  fi
+  ```
+
+  Reserved action IDs (`selection_changed`, `content_changed`, `state_update`) are used internally for surface lifecycle events and are rejected by `--actions` validation.
+
+  ### Status and cancellation reason branching reference
+
+  Both `ui confirm` and `ui request` return a `status` field in `--json` mode. However, the `cancellationReason` field is only available in `ui request --json` output. The `ui confirm` command uses the simpler exit-code pattern (0 = confirmed, 1 = denied/cancelled/timed out) and its `--json` output includes `ok`, `confirmed`, `status`, `actionId`, `surfaceId`, and optional `decisionToken`/`summary` — but not `cancellationReason`.
 
   | Status | Meaning | Typical action |
   |--------|---------|----------------|
-  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | Check `actionId` to determine the action taken — e.g. `"confirm"` or `"deny"` for confirmations. For `ui confirm`, exit code 0 = confirmed, 1 = denied. |
-  | `cancelled` | User dismissed the surface without choosing an action (e.g. closed the dialog) | Abort gracefully. Inform the user the action was skipped. |
+  | `submitted` | User completed the interaction (confirmed, denied, or submitted form) | For `ui confirm`: exit code 0 = confirmed, 1 = denied. For `ui request`: check `actionId` or `submittedData`. |
+  | `cancelled` | Surface was cancelled | For `ui confirm`: exit code 1 — abort gracefully. For `ui request`: check `cancellationReason` to determine why. |
   | `timed_out` | No response within the timeout window | Abort safely. Do not proceed — treat as a non-confirmation. |
 
-  **Cancellation vs. failure**: A `cancelled` status means the user made a deliberate choice not to proceed — this is a normal outcome, not an error. Operational failures (IPC unavailable, invalid payload, no conversation context) surface as `ok: false` in JSON mode or a non-zero exit with an error message. Scripts should distinguish the two: cancellation is graceful, failure is exceptional.
+  **Cancellation reasons** (`ui request` only): The `cancellationReason` field distinguishes user-driven from operational cancellations. This field is only present in `ui request --json` output.
+
+  | `cancellationReason` | Category | Meaning |
+  |----------------------|----------|---------|
+  | `user_dismissed` | User-driven | User explicitly closed the surface. Treat as a deliberate "no." |
+  | `no_interactive_surface` | Operational | No interactive UI is available (headless/API channel). Consider a fallback. |
+  | `conversation_not_found` | Operational | Target conversation could not be located. Check the conversation ID. |
+  | `resolver_unavailable` | Operational | UI transport is disconnected (e.g. desktop client dropped). May be transient. |
+  | `resolver_error` | Operational | UI resolver threw an unexpected error. Log for investigation. |
+
+  **Canonical branching pattern for `ui request`** — for scripts that need to distinguish user dismissal from operational failures:
+
+  ```bash
+  RESULT=$(assistant ui request \
+    --payload '{"message":"Confirm the operation"}' \
+    --title "Operation" \
+    --json)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  case "$STATUS" in
+    submitted)
+      # Handle based on actionId or submittedData
+      ;;
+    cancelled)
+      REASON=$(echo "$RESULT" | jq -r '.cancellationReason // "unknown"')
+      if [ "$REASON" = "user_dismissed" ]; then
+        echo "User chose not to proceed."
+        exit 0
+      fi
+      # Operational cancellation — log and decide on recovery
+      echo "Surface cancelled: $REASON" >&2
+      exit 1
+      ;;
+    timed_out)
+      echo "Timed out — aborting."
+      exit 1
+      ;;
+    *)
+      echo "Unexpected status: $STATUS" >&2
+      exit 1
+      ;;
+  esac
+  ```
+
+  For `ui confirm`, use the simpler exit-code pattern (see the `ui confirm` section above) or check `status` and `confirmed` fields in `--json` mode. Do not branch on `cancellationReason` with `ui confirm` — it is not included in the output.
 
   **Decision token**: When the user affirmatively confirms (action `"confirm"`), the JSON output includes a `decisionToken` field — a short-lived, non-authoritative token encoding metadata about the decision (conversation, surface, action, timestamps). Use it for audit trails and cross-system correlation. The token is informational only and does not grant any capability. It is absent for deny, cancel, and timeout outcomes.
 

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -36,8 +36,10 @@ assistant oauth request --help
 
 **Side-effect requests require explicit user confirmation.** If the request performs a side-effect (updates data, sends an email, deletes a record, etc.), gate it with `assistant ui confirm` so the user has a hard runtime veto — do not rely solely on SKILL.md prose instructions.
 
+For simple shell branching (proceed on confirm, abort otherwise), use the exit code directly:
+
 ```bash
-# Example: gate a destructive OAuth request on user confirmation
+# Simple gate: exit code 0 = confirmed, 1 = denied/cancelled/timed_out
 if assistant ui confirm \
   --title "Send email" \
   --message "Send draft to jane@example.com — Subject: Q2 Report" \
@@ -50,6 +52,39 @@ else
   exit 0
 fi
 ```
+
+For scripts that need to inspect the result programmatically, use `--json` and branch on `status` and `confirmed`:
+
+```bash
+RESULT=$(assistant ui confirm \
+  --title "Delete calendar event" \
+  --message "Permanently delete '${EVENT_TITLE}'?" \
+  --confirm-label "Delete" \
+  --deny-label "Keep" \
+  --json)
+
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+case "$STATUS" in
+  submitted)
+    CONFIRMED=$(echo "$RESULT" | jq -r '.confirmed')
+    if [ "$CONFIRMED" = "true" ]; then
+      assistant oauth request DELETE "/v1.0/me/events/${EVENT_ID}" \
+        --provider microsoft-graph
+    else
+      echo "User chose to keep the event."
+    fi
+    ;;
+  cancelled)
+    echo "User dismissed the prompt — event not deleted."
+    ;;
+  timed_out)
+    echo "Confirmation timed out — event not deleted."
+    ;;
+esac
+```
+
+> **Note**: The `cancellationReason` field (for distinguishing user dismissal from operational failures like `no_interactive_surface`) is only available in `assistant ui request --json` output, not `ui confirm --json`. For `ui confirm`, use the exit-code pattern above for simple cases, or branch on `status` and `confirmed` for `--json` mode.
 
 For read-only requests (fetching data, listing resources), no confirmation gate is needed.
 


### PR DESCRIPTION
## Summary
Addresses all gaps found in the post-merge review of the interactive UI primitive (#26384): cancellation reason metadata on `InteractiveUiResult`, conversation hydration simplification, form payload preservation, custom `--actions` support for `assistant ui request`, and documentation updates.

## Self-review result
PASS — 6 gaps found and fixed across 3 remediation rounds

## PRs merged into feature branch
- #26442: feat: add cancellation reason metadata to interactive UI results
- #26443: fix: preserve full standalone form payload (pages/pageLabels)
- #26454: feat: support custom actions in assistant ui request
- #26502: fix: hydrate ui_request conversations from storage
- #26520: docs: clarify ui cancellation semantics and custom action usage

### Fix PRs
- #26531: fix: simplify ui_request resolver (remove unreachable hydration)
- #26530: fix: add cancellationReason to dispose path
- #26529: fix: remove duplicate comment
- #26534: fix: add cancel/dismiss to reserved action IDs
- #26536: fix: enforce reserved action ID validation at IPC layer
- #26545: fix: update reserved action ID docs and JSDoc

Part of plan: ui-request-gap-remediation.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
