### PR TITLE
feat(macos): show typing indicator after tool completion while streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -59,6 +59,20 @@ extension ChatBubble {
 
             // Inline image previews from completed tool calls (e.g. image generation)
             inlineToolCallImages(from: message.toolCalls)
+
+            // When all tools are complete but the assistant is still streaming
+            // without any text content yet, show a typing indicator below the
+            // progress card so the user knows content is on the way.
+            if message.isStreaming && !hasText
+                && !message.toolCalls.isEmpty
+                && message.toolCalls.allSatisfy({ $0.isComplete }) {
+                HStack(spacing: 0) {
+                    TypingIndicatorView()
+                    Spacer(minLength: 0)
+                }
+                .padding(.top, VSpacing.xxs)
+                .transition(.opacity)
+            }
         } else if !effectiveConfirmations.isEmpty, !inlineToolProgressRenderedInContent {
             // No tool display needed — only show permission chips.
             // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.


### PR DESCRIPTION
## Summary
- Add a typing indicator below the progress card when all tools are complete but the message is still streaming without text content
- Fills the visual gap between 'Completed N steps' and the eventual response, so the user knows the assistant is still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
