### PR TITLE
feat(memory): add turn1UserQueryBias flag (default off)

### DIFF
--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -225,6 +225,15 @@ const MemoryContextLoadInjectionSchema = z
       .describe(
         "Reserved slots for skill/CLI capability nodes at conversation start",
       ),
+    turn1UserQueryBias: z
+      .boolean({
+        error:
+          "memory.retrieval.injection.contextLoad.turn1UserQueryBias must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "When true, embed the first user message as a dedicated query vector used to rank skill/CLI capability reserve slots on turn 1, instead of relying on the summary-based query. Summaries still drive organic memory retrieval.",
+      ),
   })
   .describe("Memory injection limits at conversation start");
 


### PR DESCRIPTION
## Summary
- Adds opt-in config flag `memory.retrieval.injection.contextLoad.turn1UserQueryBias` (default `false`).
- No behavior change yet — flag is not read anywhere. Wiring lands in later PRs (3/4) and the default flips in PR 6.

Part of plan: turn1-skill-query-bias.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
