### PR TITLE
feat(memory): add userQuery/userQueryVector fields to ContextLoad types

### DIFF
--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -109,6 +109,17 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
     expect(result.queryVector).toBeUndefined();
     expect(result.sparseVector).toBeUndefined();
   });
+
+  test("ignores userQuery when dual-query logic is not yet implemented (PR 2 baseline)", async () => {
+    const result = await loadContextMemory({
+      scopeId: "test-scope",
+      recentSummaries: ["summary"],
+      userQuery: "ignore me for now",
+      config: TEST_CONFIG,
+    });
+    expect(result.userQueryVector).toBeUndefined();
+    expect(result.queryVector).toBeDefined();
+  });
 });
 
 describe("retrieveForTurn — query/sparse vector surfacing", () => {

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -348,6 +348,13 @@ export interface ContextLoadOpts {
   serendipitySlots?: number;
   /** Maximum nodes to return (default 40). */
   maxNodes?: number;
+  /**
+   * Optional dedicated user-message query text. When present and non-empty,
+   * `loadContextMemory` (PR 3) embeds this text independently of
+   * `recentSummaries` and uses the resulting vector to rank capability
+   * reserve slots. Leave `undefined` to preserve pre-PR-3 behavior.
+   */
+  userQuery?: string;
 }
 
 export interface ContextLoadResult {
@@ -369,6 +376,14 @@ export interface ContextLoadResult {
    * retrieval that produces a sparse vector at the call site.
    */
   sparseVector?: QdrantSparseVector;
+  /**
+   * Dense query vector computed from `opts.userQuery` (PR 3). Surfaced so
+   * downstream callers (PKB hint search) can prefer it over the
+   * summary-based `queryVector` for user-intent-aligned retrieval.
+   * `undefined` when `userQuery` was not provided, was effectively empty,
+   * or the dedicated embed call was skipped/failed.
+   */
+  userQueryVector?: number[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extends `ContextLoadOpts` with optional `userQuery?: string`.
- Extends `ContextLoadResult` with optional `userQueryVector?: number[]`.
- Pure type scaffolding — no behavior wired up yet. Dual-query logic lands in PR 3.
- Adds baseline regression test asserting `userQuery` is currently ignored.

Part of plan: turn1-skill-query-bias.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
