### PR TITLE
fix(daemon): filter placeholder sentinels in history render and stream

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -10,6 +10,15 @@ let lastStreamParams: Record<string, unknown> | null = null;
 let _lastStreamOptions: Record<string, unknown> | null = null;
 let lastConstructorArgs: Record<string, unknown> | null = null;
 
+type ScriptedStreamEvent =
+  | { kind: "text"; text: string }
+  | { kind: "blockStart"; blockType?: "text" }
+  | { kind: "blockStop" };
+
+// When set, the mock fires these scripted stream events in order instead of
+// the default single "Hello" text event. Tests reset this in beforeEach.
+let scriptedStream: ScriptedStreamEvent[] | null = null;
+
 const fakeResponse = {
   content: [{ type: "text", text: "Hello" }],
   model: "claude-sonnet-4-6",
@@ -50,8 +59,25 @@ mock.module("@anthropic-ai/sdk", () => ({
           return this;
         },
         async finalMessage() {
-          // Fire text events
-          for (const cb of handlers["text"] ?? []) cb("Hello");
+          if (scriptedStream) {
+            for (const event of scriptedStream) {
+              if (event.kind === "text") {
+                for (const cb of handlers["text"] ?? []) cb(event.text);
+              } else if (event.kind === "blockStart") {
+                for (const cb of handlers["streamEvent"] ?? [])
+                  cb({
+                    type: "content_block_start",
+                    content_block: { type: event.blockType ?? "text" },
+                  });
+              } else if (event.kind === "blockStop") {
+                for (const cb of handlers["streamEvent"] ?? [])
+                  cb({ type: "content_block_stop" });
+              }
+            }
+          } else {
+            // Default: a single "Hello" text event (preserves existing tests).
+            for (const cb of handlers["text"] ?? []) cb("Hello");
+          }
           return fakeResponse;
         },
       };
@@ -145,6 +171,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     lastStreamParams = null;
     _lastStreamOptions = null;
     lastConstructorArgs = null;
+    scriptedStream = null;
     provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
   });
 
@@ -1253,6 +1280,124 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     for (let i = 1; i < sent.length; i++) {
       expect(sent[i].role).not.toBe(sent[i - 1].role);
     }
+  });
+
+  test("streams normal text through without delay when text is not a sentinel prefix", async () => {
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: "Hello world" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual(["Hello world"]);
+  });
+
+  test("suppresses placeholder sentinel streamed as a single chunk", async () => {
+    // Model echoes a sentinel in one chunk; buffer should hold it and
+    // drop it on content_block_stop since it matches exactly.
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: PLACEHOLDER_EMPTY_TURN },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual([]);
+  });
+
+  test("suppresses bare-variant sentinel streamed as a single chunk", async () => {
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: "__PLACEHOLDER__[empty assistant turn]" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual([]);
+  });
+
+  test("suppresses placeholder sentinel streamed across multiple chunks", async () => {
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: "\x00__PLACE" },
+      { kind: "text", text: "HOLDER__[empty" },
+      { kind: "text", text: " assistant turn]" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual([]);
+  });
+
+  test("flushes buffered prefix when the continuation diverges from all sentinels", async () => {
+    // "__PLACEHOLDER__" is a prefix of the sentinels, so it stays buffered.
+    // Once the next chunk diverges (bracket instead of the expected opening),
+    // the buffer must flush.
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: "__PLACEHOLDER__" },
+      { kind: "text", text: " is bold in markdown" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted.join("")).toBe("__PLACEHOLDER__ is bold in markdown");
+  });
+
+  test("flushes non-sentinel residual buffer at content_block_stop", async () => {
+    // If the stream ends mid-prefix, the residual must be flushed (the
+    // accumulated text isn't a complete sentinel, so it's real content).
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: "__PLACEHOLDER__" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual(["__PLACEHOLDER__"]);
+  });
+
+  test("resets buffer across content blocks so a sentinel in one block doesn't poison the next", async () => {
+    scriptedStream = [
+      { kind: "blockStart" },
+      { kind: "text", text: PLACEHOLDER_EMPTY_TURN },
+      { kind: "blockStop" },
+      { kind: "blockStart" },
+      { kind: "text", text: "Fresh block content" },
+      { kind: "blockStop" },
+    ];
+    const emitted: string[] = [];
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      onEvent: (event) => {
+        if (event.type === "text_delta") emitted.push(event.text);
+      },
+    });
+    expect(emitted).toEqual(["Fresh block content"]);
   });
 
   test("isPlaceholderSentinelText matches sentinel with and without the null-byte prefix", () => {

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -332,6 +332,37 @@ describe("renderHistoryContent", () => {
     expect(output.textSegments).toEqual(["Now let me try something else."]);
     expect(output.contentOrder).toEqual(["tool:0", "text:0", "tool:1"]);
   });
+
+  test("drops Anthropic placeholder sentinel text blocks from history", () => {
+    // Sentinels are injected into outbound API requests for role alternation
+    // and must never render to the UI. Guards against any leak path that
+    // bypasses cleanAssistantContent (bug-prone stored rows, historical
+    // data predating migration 222, future regressions).
+    const output = renderHistoryContent([
+      { type: "text", text: "Real response before." },
+      { type: "text", text: "\x00__PLACEHOLDER__[empty assistant turn]" },
+      { type: "text", text: "__PLACEHOLDER__[empty assistant turn]" },
+      { type: "text", text: "\x00__PLACEHOLDER__[internal blocks omitted]" },
+      { type: "text", text: "__PLACEHOLDER__[internal blocks omitted]" },
+      { type: "text", text: "Real response after." },
+    ]);
+
+    expect(output.text).toBe("Real response before. Real response after.");
+    expect(output.textSegments).toEqual([
+      "Real response before. Real response after.",
+    ]);
+    expect(output.contentOrder).toEqual(["text:0"]);
+  });
+
+  test("yields empty output when content is only a placeholder sentinel", () => {
+    const output = renderHistoryContent([
+      { type: "text", text: "\x00__PLACEHOLDER__[empty assistant turn]" },
+    ]);
+
+    expect(output.text).toBe("");
+    expect(output.textSegments).toEqual([]);
+    expect(output.contentOrder).toEqual([]);
+  });
 });
 
 describe("getAttachmentsForMessage", () => {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -7,6 +7,7 @@ import type { SecretPromptResult } from "../../permissions/secret-prompter.js";
 import type { AuthContext } from "../../runtime/auth/types.js";
 import type { DebouncerMap } from "../../util/debounce.js";
 import { getLogger } from "../../util/logger.js";
+import { isPlaceholderSentinelText } from "../../providers/anthropic/client.js";
 import { estimateBase64Bytes } from "../assistant-attachments.js";
 import { Conversation } from "../conversation.js";
 import type { TrustContext } from "../conversation-runtime-assembly.js";
@@ -328,6 +329,11 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       // path — e.g. empty segments between consecutive tool_use blocks that
       // break tool-call grouping in the UI.
       if (block.text.trim().length === 0) continue;
+      // Drop Anthropic provider placeholder sentinels. These are injected
+      // into outbound API requests to preserve role alternation and must
+      // never be rendered to users. Belt-and-suspenders with the persist-
+      // time filter in cleanAssistantContent and migration 222.
+      if (isPlaceholderSentinelText(block.text)) continue;
       textParts.push(block.text);
       ensureSegment();
       currentSegmentParts.push(block.text);

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1022,8 +1022,30 @@ export class AnthropicProvider implements Provider {
                 signal: timeoutSignal,
               }) as unknown as UnifiedStream);
 
+        // Buffer streaming text until it's clear the accumulated text isn't
+        // going to form a placeholder sentinel. Sentinels are injected into
+        // outbound requests for role alternation and are sometimes echoed by
+        // the model; holding back partial prefixes prevents them from
+        // flashing on the live UI before cleanAssistantContent strips them
+        // at persist time. Buffer is bounded by the longest sentinel (~45
+        // chars) and resets on every content_block_start.
+        const SENTINEL_TEXTS: readonly string[] = [
+          PLACEHOLDER_EMPTY_TURN,
+          PLACEHOLDER_EMPTY_TURN.slice(1),
+          PLACEHOLDER_BLOCKS_OMITTED,
+          PLACEHOLDER_BLOCKS_OMITTED.slice(1),
+        ];
+        const couldBeSentinelPrefix = (s: string): boolean =>
+          SENTINEL_TEXTS.some((sentinel) => sentinel.startsWith(s));
+        const isCompleteSentinel = (s: string): boolean =>
+          SENTINEL_TEXTS.includes(s);
+        let textBuffer = "";
+
         stream.on("text", (text) => {
-          onEvent?.({ type: "text_delta", text });
+          textBuffer += text;
+          if (couldBeSentinelPrefix(textBuffer)) return;
+          onEvent?.({ type: "text_delta", text: textBuffer });
+          textBuffer = "";
         });
 
         stream.on("thinking", (thinking) => {
@@ -1038,6 +1060,13 @@ export class AnthropicProvider implements Provider {
         let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
 
         stream.on("streamEvent", (event) => {
+          // Reset the text sentinel buffer at each content-block boundary.
+          // A new block starts fresh; at the end of a block, flush any
+          // buffered text that is NOT a complete sentinel, and drop it if
+          // it is one.
+          if (event.type === "content_block_start") {
+            textBuffer = "";
+          }
           if (
             event.type === "content_block_start" &&
             event.content_block.type === "tool_use"
@@ -1101,6 +1130,11 @@ export class AnthropicProvider implements Provider {
             currentStreamingToolName = undefined;
             currentStreamingToolUseId = undefined;
             accumulatedInputJson = "";
+            // Flush residual text buffer unless it's exactly a sentinel.
+            if (textBuffer.length > 0 && !isCompleteSentinel(textBuffer)) {
+              onEvent?.({ type: "text_delta", text: textBuffer });
+            }
+            textBuffer = "";
           }
         });
 


### PR DESCRIPTION
## Summary
- Drop Anthropic placeholder sentinels (`__PLACEHOLDER__[empty assistant turn]` / `[internal blocks omitted]`) in `renderHistoryContent` so they never reach the UI regardless of what is stored.
- Buffer streaming text in the Anthropic provider and suppress chunks that form a complete sentinel. Normal text streams without delay.
- Belt-and-suspenders layer on top of the existing `cleanAssistantContent` persist-time filter and migration 222.

## Original prompt
This 'Placeholder empty assistant turn' thing should never show up. It's pointless and confusing to the user.