### PR TITLE
fix(macos): mark defaultRePairTimeout nonisolated for Swift 6

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -727,7 +727,7 @@ public final class GatewayConnectionManager {
     /// Default timeout for `attemptRePair`. Long enough for a real bootstrap
     /// (guardian token poll + provision) to land, short enough that the
     /// Re-pair menu item becomes clickable again after a stuck attempt.
-    public static let defaultRePairTimeout: TimeInterval = 90.0
+    public nonisolated static let defaultRePairTimeout: TimeInterval = 90.0
 
     /// Attempts to recover from a stuck `isAuthFailed` state by re-running
     /// the bootstrap flow (clear stored credentials + re-provision). Runs the


### PR DESCRIPTION
## Summary
- Mark `GatewayConnectionManager.defaultRePairTimeout` as `nonisolated` to silence a Swift 6 actor-isolation warning.
- The constant is used as a default value for `attemptRePair(timeout:)`. Default parameter expressions are evaluated in the caller's (potentially nonisolated) context, so referencing a `@MainActor`-isolated static from that position fails under Swift 6.
- Safe because the property is an immutable `TimeInterval` literal with no mutable or main-actor-only state.

## Original prompt
Fix the Swift 6 warning:
```
GatewayConnectionManager.swift:751:58: warning: main actor-isolated static property 'defaultRePairTimeout' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
