### PR TITLE
feat(memory): pass firstUserText via userQuery when turn1UserQueryBias enabled

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -330,18 +330,24 @@ export class ConversationGraphMemory {
       // Decide which retrieval mode to use
       if (!this.initialized || this.needsReload) {
         const recentSummaries = this.fetchRecentSummaries();
-
-        // Extract the first user message as an additional retrieval signal
-        // so context-load biases toward what the user is asking about
         const firstUserText = extractUserText(lastMessage);
+        const turn1Bias =
+          config.memory.retrieval.injection.contextLoad.turn1UserQueryBias;
+
+        let userQuery: string | undefined;
         if (firstUserText) {
-          recentSummaries.unshift(firstUserText);
+          if (turn1Bias) {
+            userQuery = firstUserText;
+          } else {
+            recentSummaries.unshift(firstUserText);
+          }
         }
 
         return await this.runContextLoad(
           messages,
           config,
           recentSummaries,
+          userQuery,
           abortSignal,
           onEvent,
         );
@@ -365,12 +371,14 @@ export class ConversationGraphMemory {
     messages: Message[],
     config: AssistantConfig,
     recentSummaries: string[],
+    userQuery: string | undefined,
     signal: AbortSignal,
     onEvent: (msg: ServerMessage) => void,
   ) {
     const result = await loadContextMemory({
       scopeId: this.scopeId,
       recentSummaries,
+      userQuery,
       config,
       signal,
     });


### PR DESCRIPTION
## Summary
- Reads the `turn1UserQueryBias` config flag in `ConversationGraphMemory.prepareMemory`.
- When the flag is true, routes `firstUserText` through the new `userQuery` option on `loadContextMemory` (added in PR 2; consumed in PR 3).
- When the flag is false (default), preserves the existing `recentSummaries.unshift(firstUserText)` behavior exactly.

Part of plan: turn1-skill-query-bias.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
