### PR TITLE
feat(pkb): prefer userQueryVector for hint search when available

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -661,7 +661,7 @@ export async function runAgentLoopImpl(
         onEvent,
       );
       runMessages = graphResult.runMessages;
-      pkbQueryVector = graphResult.queryVector;
+      pkbQueryVector = graphResult.userQueryVector ?? graphResult.queryVector;
       pkbSparseVector = graphResult.sparseVector;
 
       // Persist the injected block text in message metadata so it survives

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -304,6 +304,13 @@ export class ConversationGraphMemory {
     queryVector?: number[];
     /** Optional sparse vector accompanying `queryVector`. */
     sparseVector?: QdrantSparseVector;
+    /**
+     * Dense query vector aligned to the latest user message (PR 3). Surfaced
+     * so callers (PKB hint search) can prefer it over the summary-based
+     * `queryVector`. `undefined` on the per-turn path and when no user-aligned
+     * embed was computed.
+     */
+    userQueryVector?: number[];
   }> {
     this.tracker.advanceTurn();
 
@@ -391,6 +398,7 @@ export class ConversationGraphMemory {
         metrics: result.metrics,
         queryVector: result.queryVector,
         sparseVector: result.sparseVector,
+        userQueryVector: result.userQueryVector,
       };
     }
 
@@ -412,6 +420,7 @@ export class ConversationGraphMemory {
         metrics: result.metrics,
         queryVector: result.queryVector,
         sparseVector: result.sparseVector,
+        userQueryVector: result.userQueryVector,
       };
     }
 
@@ -446,6 +455,7 @@ export class ConversationGraphMemory {
       metrics: result.metrics,
       queryVector: result.queryVector,
       sparseVector: result.sparseVector,
+      userQueryVector: result.userQueryVector,
     };
   }
 


### PR DESCRIPTION
## Summary
- PKB hint search now prefers `graphResult.userQueryVector` over `graphResult.queryVector` when both are available.
- No-op until PR 3 populates `userQueryVector` and PR 4/6 wires the caller. The `??` fallback preserves current behavior.
- Plumbed `userQueryVector` through `ConversationGraphMemory.prepareMemory`'s return type and the three `runContextLoad` return sites so the field from `ContextLoadResult` reaches the agent loop.

Part of plan: turn1-skill-query-bias.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
