### PR TITLE
feat(meet-join): scaffold meet-controller-ext Chrome extension package

### DIFF
--- a/skills/meet-join/meet-controller-ext/.gitignore
+++ b/skills/meet-join/meet-controller-ext/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/skills/meet-join/meet-controller-ext/AGENTS.md
+++ b/skills/meet-join/meet-controller-ext/AGENTS.md
@@ -1,0 +1,48 @@
+# meet-controller-ext — Agent Instructions
+
+Chrome extension (Manifest V3) that controls Google Meet on behalf of the
+Vellum meet-bot. It runs inside the same Chromium the bot drives via
+Playwright; the bot launches Chromium with `--load-extension=/app/ext`
+pointed at this package's `dist/` output (wiring added in PR 13).
+
+## Where it fits
+
+- Lives at `skills/meet-join/meet-controller-ext/` alongside the sibling
+  `bot/` and `contracts/` packages.
+- The bot's Dockerfile copies the built `dist/` into `/app/ext` and tells
+  Chromium to load it at launch time (PR 13).
+- The extension talks to the bot via Chrome Native Messaging: the bot
+  registers a native host manifest (PR 6) whose `allowed_origins` pin this
+  extension's ID, and the service worker `connectNative()`s to it (PR 8).
+- Meet DOM automation (chat, participants, speaker detection, virtual-mic
+  priming) moves from Playwright page-world scripts into this extension's
+  content script across PRs 9-12.
+
+## Build
+
+```
+bun install
+bun run build
+```
+
+Produces `dist/manifest.json`, `dist/background.js`, `dist/content.js`.
+
+## The `key` field
+
+`manifest.json` pins the extension's public key so Chromium computes a
+**stable extension ID** across installs. That stable ID is what the
+Native Messaging host manifest's `allowed_origins` entry targets (PR 6).
+Regenerating the key rotates the ID and requires a matching NMH update.
+
+- The private key is **not** committed to the repo. Only the base64
+  DER-encoded public key belongs in `manifest.json`.
+- To derive the extension ID from the public key: SHA-256 the DER bytes,
+  take the first 32 hex chars, then map `0..f` to `a..p`.
+
+## Isolation rule
+
+This package must **not** import from `assistant/`, `gateway/`, or from
+the sibling bot's `src/`. It is the browser-side peer of the bot and
+communicates with the bot only through the Native Messaging port, using
+message shapes defined in `../contracts/`. Treat contracts as the sole
+shared surface between bot and extension.

--- a/skills/meet-join/meet-controller-ext/bun.lock
+++ b/skills/meet-join/meet-controller-ext/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/meet-controller-ext",
+      "devDependencies": {
+        "@types/chrome": "0.1.40",
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/chrome": ["@types/chrome@0.1.40", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA=="],
+
+    "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
+
+    "@types/filewriter": ["@types/filewriter@0.0.33", "", {}, "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="],
+
+    "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/skills/meet-join/meet-controller-ext/manifest.json
+++ b/skills/meet-join/meet-controller-ext/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Vellum Meet Controller",
+  "version": "0.0.1",
+  "description": "Controls Google Meet on behalf of the Vellum assistant.",
+  "permissions": ["nativeMessaging", "scripting", "tabs"],
+  "host_permissions": ["https://meet.google.com/*"],
+  "background": { "service_worker": "background.js", "type": "module" },
+  "content_scripts": [
+    {
+      "matches": ["https://meet.google.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7HeRDjffv54OgiXEqgqmwhpIo9cruNnF3vscK/Ubn8vENJPp4TSUP2ZVfoWBUVONT5HtKvkYsJJjavokdGMuaRKm9xfdri/WWB+qJRePsGEdTYtNxD5Vrw+c5X6g3S0irNLbqTWGM9++Xn67hYSOKHdDVeKWZGbC6PdqYrTOaB1YHLKp+MulWMgoE4bDc+aWc58LOmhngAbRWreofNM/9Xomazm2TJ5/2zYikaEpRCT1JC3zpLTGfuRroZ2Ln5ut3zphp1aa1z4smViwsFVLUnhLKgWwSv2xPkRRHv5CE5FBDXjvgHNernlD9hn3EZisq3u4Z09C6D2qayC5/IxecQIDAQAB"
+}

--- a/skills/meet-join/meet-controller-ext/package.json
+++ b/skills/meet-join/meet-controller-ext/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vellumai/meet-controller-ext",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "bun run scripts/build.ts",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/chrome": "0.1.40",
+    "typescript": "5.9.3"
+  }
+}

--- a/skills/meet-join/meet-controller-ext/scripts/build.ts
+++ b/skills/meet-join/meet-controller-ext/scripts/build.ts
@@ -1,0 +1,19 @@
+import { cp } from "node:fs/promises";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+
+const outdir = "dist";
+if (existsSync(outdir)) rmSync(outdir, { recursive: true });
+mkdirSync(outdir, { recursive: true });
+
+const result = await Bun.build({
+  entrypoints: ["src/background.ts", "src/content.ts"],
+  outdir,
+  target: "browser",
+  format: "esm",
+});
+if (!result.success) {
+  console.error(result.logs);
+  process.exit(1);
+}
+await cp("manifest.json", `${outdir}/manifest.json`);
+console.log(`Built extension to ${outdir}/`);

--- a/skills/meet-join/meet-controller-ext/src/background.ts
+++ b/skills/meet-join/meet-controller-ext/src/background.ts
@@ -1,0 +1,2 @@
+// Service worker entry. PR 8 will wire native-messaging here.
+console.log("[meet-ext] background booted");

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -1,0 +1,2 @@
+// Content script entry. PRs 9-12 will add feature modules here.
+console.log("[meet-ext] content script loaded on", location.href);

--- a/skills/meet-join/meet-controller-ext/tsconfig.json
+++ b/skills/meet-join/meet-controller-ext/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["chrome"],
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Adds a new workspace package skills/meet-join/meet-controller-ext/ for the Chrome extension that will drive Meet DOM from inside the browser.
- Manifest V3 with a stable public key pinning the extension ID.
- Minimal background + content script stubs; real wiring lands in PRs 8-12.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 3 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
