### PR TITLE
feat(meet-join): add native-messaging wire protocol schemas for extension ↔ bot

### DIFF
--- a/skills/meet-join/contracts/__tests__/native-messaging.test.ts
+++ b/skills/meet-join/contracts/__tests__/native-messaging.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for the native-messaging wire protocol.
+ *
+ * Every message variant in each union is exercised with a parse
+ * round-trip assertion. Each union also has a negative test verifying
+ * an unknown `type` value is rejected.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  BOT_TO_EXTENSION_MESSAGE_TYPES,
+  BotJoinCommandSchema,
+  BotLeaveCommandSchema,
+  BotSendChatCommandSchema,
+  BotToExtensionMessageSchema,
+  EXTENSION_TO_BOT_MESSAGE_TYPES,
+  ExtensionDiagnosticMessageSchema,
+  ExtensionInboundChatMessageSchema,
+  ExtensionLifecycleMessageSchema,
+  ExtensionParticipantChangeMessageSchema,
+  ExtensionReadyMessageSchema,
+  ExtensionSendChatResultMessageSchema,
+  ExtensionSpeakerChangeMessageSchema,
+  ExtensionToBotMessageSchema,
+  type BotToExtensionMessage,
+  type ExtensionToBotMessage,
+} from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Type-constant coverage
+// ---------------------------------------------------------------------------
+
+describe("EXTENSION_TO_BOT_MESSAGE_TYPES", () => {
+  test("includes every discriminator used by ExtensionToBotMessageSchema", () => {
+    expect(new Set(EXTENSION_TO_BOT_MESSAGE_TYPES)).toEqual(
+      new Set([
+        "ready",
+        "lifecycle",
+        "participant.change",
+        "speaker.change",
+        "chat.inbound",
+        "diagnostic",
+        "send_chat_result",
+      ]),
+    );
+  });
+});
+
+describe("BOT_TO_EXTENSION_MESSAGE_TYPES", () => {
+  test("includes every discriminator used by BotToExtensionMessageSchema", () => {
+    expect(new Set(BOT_TO_EXTENSION_MESSAGE_TYPES)).toEqual(
+      new Set(["join", "leave", "send_chat"]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extension → Bot — per-variant parse
+// ---------------------------------------------------------------------------
+
+describe("ExtensionReadyMessageSchema", () => {
+  test("parses a ready handshake", () => {
+    const input = { type: "ready", extensionVersion: "1.2.3" } as const;
+    const parsed = ExtensionReadyMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty extensionVersion", () => {
+    expect(() =>
+      ExtensionReadyMessageSchema.parse({ type: "ready", extensionVersion: "" }),
+    ).toThrow();
+  });
+});
+
+describe("ExtensionLifecycleMessageSchema", () => {
+  test("parses every lifecycle state", () => {
+    for (const state of ["joining", "joined", "left", "error"] as const) {
+      const input = {
+        type: "lifecycle" as const,
+        state,
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      };
+      const parsed = ExtensionLifecycleMessageSchema.parse(input);
+      expect(parsed).toEqual(input);
+    }
+  });
+
+  test("parses an error lifecycle with detail", () => {
+    const input = {
+      type: "lifecycle" as const,
+      state: "error" as const,
+      detail: "pre-join screen timed out",
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+    };
+    const parsed = ExtensionLifecycleMessageSchema.parse(input);
+    expect(parsed.detail).toBe("pre-join screen timed out");
+  });
+
+  test("rejects unknown lifecycle state", () => {
+    expect(() =>
+      ExtensionLifecycleMessageSchema.parse({
+        type: "lifecycle",
+        state: "dialing",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("ExtensionParticipantChangeMessageSchema", () => {
+  test("parses a participant change", () => {
+    const input = {
+      type: "participant.change" as const,
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    };
+    const parsed = ExtensionParticipantChangeMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+});
+
+describe("ExtensionSpeakerChangeMessageSchema", () => {
+  test("parses a speaker change", () => {
+    const input = {
+      type: "speaker.change" as const,
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      speakerId: "spk-alice",
+      speakerName: "Alice",
+    };
+    const parsed = ExtensionSpeakerChangeMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+});
+
+describe("ExtensionInboundChatMessageSchema", () => {
+  test("parses an inbound chat", () => {
+    const input = {
+      type: "chat.inbound" as const,
+      meetingId: "meet-1",
+      timestamp: "2026-04-15T00:00:00Z",
+      fromId: "p-alice",
+      fromName: "Alice",
+      text: "hi bot",
+    };
+    const parsed = ExtensionInboundChatMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+});
+
+describe("ExtensionDiagnosticMessageSchema", () => {
+  test("parses an info diagnostic", () => {
+    const input = {
+      type: "diagnostic" as const,
+      level: "info" as const,
+      message: "waited for pre-join screen",
+    };
+    const parsed = ExtensionDiagnosticMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses an error diagnostic", () => {
+    const input = {
+      type: "diagnostic" as const,
+      level: "error" as const,
+      message: "chat input selector not found",
+    };
+    const parsed = ExtensionDiagnosticMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects unknown diagnostic level", () => {
+    expect(() =>
+      ExtensionDiagnosticMessageSchema.parse({
+        type: "diagnostic",
+        level: "warn",
+        message: "mid-severity",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("ExtensionSendChatResultMessageSchema", () => {
+  test("parses an ok result without error", () => {
+    const input = {
+      type: "send_chat_result" as const,
+      requestId: "req-1",
+      ok: true,
+    };
+    const parsed = ExtensionSendChatResultMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses a failure result with error detail", () => {
+    const input = {
+      type: "send_chat_result" as const,
+      requestId: "req-2",
+      ok: false,
+      error: "chat input not focusable",
+    };
+    const parsed = ExtensionSendChatResultMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects missing requestId", () => {
+    expect(() =>
+      ExtensionSendChatResultMessageSchema.parse({
+        type: "send_chat_result",
+        ok: true,
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExtensionToBotMessageSchema — discriminated union round-trip
+// ---------------------------------------------------------------------------
+
+describe("ExtensionToBotMessageSchema", () => {
+  test("round-trips every extension→bot message shape", () => {
+    const fixtures: ExtensionToBotMessage[] = [
+      { type: "ready", extensionVersion: "1.0.0" },
+      {
+        type: "lifecycle",
+        state: "joining",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      },
+      {
+        type: "lifecycle",
+        state: "error",
+        detail: "boom",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:01Z",
+      },
+      {
+        type: "participant.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:02Z",
+        joined: [{ id: "p-1", name: "Alice" }],
+        left: [],
+      },
+      {
+        type: "speaker.change",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:03Z",
+        speakerId: "spk-1",
+        speakerName: "Alice",
+      },
+      {
+        type: "chat.inbound",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:04Z",
+        fromId: "p-alice",
+        fromName: "Alice",
+        text: "hey bot",
+      },
+      {
+        type: "diagnostic",
+        level: "info",
+        message: "attached to call",
+      },
+      {
+        type: "send_chat_result",
+        requestId: "req-1",
+        ok: true,
+      },
+      {
+        type: "send_chat_result",
+        requestId: "req-2",
+        ok: false,
+        error: "not allowed",
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      const parsed = ExtensionToBotMessageSchema.parse(
+        JSON.parse(JSON.stringify(fixture)),
+      );
+      expect(parsed).toEqual(fixture);
+    }
+  });
+
+  test("rejects an unknown message type", () => {
+    expect(() =>
+      ExtensionToBotMessageSchema.parse({
+        type: "heartbeat",
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a message missing the discriminator", () => {
+    expect(() =>
+      ExtensionToBotMessageSchema.parse({
+        meetingId: "meet-1",
+        timestamp: "2026-04-15T00:00:00Z",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bot → Extension — per-variant parse
+// ---------------------------------------------------------------------------
+
+describe("BotJoinCommandSchema", () => {
+  test("parses a full join command", () => {
+    const input = {
+      type: "join" as const,
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage:
+        "Hi, I'm here on behalf of Sidd to take notes. Reply STOP to have me leave.",
+    };
+    const parsed = BotJoinCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty meetingUrl", () => {
+    expect(() =>
+      BotJoinCommandSchema.parse({
+        type: "join",
+        meetingUrl: "",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing displayName", () => {
+    expect(() =>
+      BotJoinCommandSchema.parse({
+        type: "join",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        consentMessage: "Hi",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("BotLeaveCommandSchema", () => {
+  test("parses a leave with reason", () => {
+    const input = { type: "leave" as const, reason: "host ended meeting" };
+    const parsed = BotLeaveCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty reason", () => {
+    expect(() =>
+      BotLeaveCommandSchema.parse({ type: "leave", reason: "" }),
+    ).toThrow();
+  });
+});
+
+describe("BotSendChatCommandSchema", () => {
+  test("parses a send_chat", () => {
+    const input = {
+      type: "send_chat" as const,
+      text: "thanks, team",
+      requestId: "req-1",
+    };
+    const parsed = BotSendChatCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty text", () => {
+    expect(() =>
+      BotSendChatCommandSchema.parse({
+        type: "send_chat",
+        text: "",
+        requestId: "req-1",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing requestId", () => {
+    expect(() =>
+      BotSendChatCommandSchema.parse({
+        type: "send_chat",
+        text: "hi",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BotToExtensionMessageSchema — discriminated union round-trip
+// ---------------------------------------------------------------------------
+
+describe("BotToExtensionMessageSchema", () => {
+  test("round-trips every bot→extension message shape", () => {
+    const fixtures: BotToExtensionMessage[] = [
+      {
+        type: "join",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, I'm here to take notes.",
+      },
+      { type: "leave", reason: "user requested" },
+      { type: "send_chat", text: "hi", requestId: "req-1" },
+    ];
+
+    for (const fixture of fixtures) {
+      const parsed = BotToExtensionMessageSchema.parse(
+        JSON.parse(JSON.stringify(fixture)),
+      );
+      expect(parsed).toEqual(fixture);
+    }
+  });
+
+  test("rejects an unknown command type", () => {
+    expect(() =>
+      BotToExtensionMessageSchema.parse({
+        type: "mute",
+        target: "self",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a command missing the discriminator", () => {
+    expect(() =>
+      BotToExtensionMessageSchema.parse({
+        meetingUrl: "https://meet.google.com/abc",
+      }),
+    ).toThrow();
+  });
+});

--- a/skills/meet-join/contracts/index.ts
+++ b/skills/meet-join/contracts/index.ts
@@ -1,12 +1,14 @@
 /**
  * Neutral wire-protocol contracts between the meet-bot (out-of-process
- * container that joins a meeting) and the assistant daemon.
+ * container that joins a meeting) and the assistant daemon, plus the
+ * native-messaging protocol used inside the bot container between the
+ * in-browser extension and the bot process.
  *
  * These files are intentionally free of imports from `assistant/`,
  * `skills/meet-join/bot/`, or any implementation module so that both sides
  * can depend on them without circular references.
  *
- * Two directions:
+ * Three directions:
  *
  * - **Events** — bot → daemon. Transcript chunks, speaker changes,
  *   participant join/leave, inbound chat, lifecycle transitions. See
@@ -14,7 +16,13 @@
  * - **Commands** — daemon → bot. Send chat, play audio (metadata only —
  *   PCM is delivered out of band), leave, status request. See
  *   {@link MeetBotCommand} and {@link MeetBotCommandSchema}.
+ * - **Native messaging** — extension ↔ bot. Lifecycle, meeting telemetry,
+ *   diagnostics, and join/leave/send-chat commands carried over Chrome's
+ *   native-messaging stdio pipe. See {@link ExtensionToBotMessage} /
+ *   {@link ExtensionToBotMessageSchema} and {@link BotToExtensionMessage} /
+ *   {@link BotToExtensionMessageSchema}.
  */
 
 export * from "./events.js";
 export * from "./commands.js";
+export * from "./native-messaging.js";

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -1,0 +1,236 @@
+/**
+ * Wire-protocol contracts for the Chrome Native Messaging stdio pipe that
+ * connects the meet-bot's in-container extension (running inside Chromium)
+ * to the bot process.
+ *
+ * Chrome's native-messaging transport carries length-prefixed JSON frames.
+ * This module defines the JSON payload shapes on top of that transport in
+ * two directions:
+ *
+ * - **Extension → Bot**: handshake, lifecycle transitions, meeting telemetry
+ *   (participant/speaker/chat), diagnostics, and command results. See
+ *   {@link ExtensionToBotMessage} and {@link ExtensionToBotMessageSchema}.
+ * - **Bot → Extension**: join / leave / send_chat commands. See
+ *   {@link BotToExtensionMessage} and {@link BotToExtensionMessageSchema}.
+ *
+ * These schemas are intentionally independent of the broader
+ * daemon ↔ bot {@link MeetBotEvent}/{@link MeetBotCommand} protocol, though
+ * some shapes (participant/speaker/chat) are reused verbatim from `events.ts`
+ * so the extension and the bot agree on a single canonical structure.
+ */
+
+import { z } from "zod";
+
+import {
+  InboundChatEventSchema,
+  ParticipantChangeEventSchema,
+  SpeakerChangeEventSchema,
+} from "./events.js";
+
+// ---------------------------------------------------------------------------
+// Extension → Bot
+// ---------------------------------------------------------------------------
+
+/**
+ * Initial handshake emitted by the extension once its background service
+ * worker has connected to the native-messaging host.
+ */
+export const ExtensionReadyMessageSchema = z.object({
+  type: z.literal("ready"),
+  /** SemVer of the extension build, for compatibility logging. */
+  extensionVersion: z.string().min(1),
+});
+export type ExtensionReadyMessage = z.infer<typeof ExtensionReadyMessageSchema>;
+
+/** Lifecycle state values reported by the extension to the bot. */
+export const ExtensionLifecycleStateSchema = z.enum([
+  "joining",
+  "joined",
+  "left",
+  "error",
+]);
+export type ExtensionLifecycleState = z.infer<
+  typeof ExtensionLifecycleStateSchema
+>;
+
+/**
+ * Lifecycle transition mirrored from the extension's join flow. This is the
+ * extension-side counterpart to the daemon-facing `LifecycleEvent` in
+ * {@link ./events.js} — it carries the same state transitions but flows
+ * over the native-messaging pipe rather than the daemon channel.
+ */
+export const ExtensionLifecycleMessageSchema = z.object({
+  type: z.literal("lifecycle"),
+  state: ExtensionLifecycleStateSchema,
+  /** Optional human-readable detail (required-ish for `error`). */
+  detail: z.string().optional(),
+  /** Opaque identifier for the meeting the extension is in. */
+  meetingId: z.string().min(1),
+  /** ISO-8601 timestamp of when the transition occurred in the extension. */
+  timestamp: z.string().min(1),
+});
+export type ExtensionLifecycleMessage = z.infer<
+  typeof ExtensionLifecycleMessageSchema
+>;
+
+/**
+ * Participant join/leave delta reported by the extension. Payload shape
+ * mirrors {@link ParticipantChangeEventSchema} so the bot can fan out to
+ * the daemon without reshaping.
+ */
+export const ExtensionParticipantChangeMessageSchema =
+  ParticipantChangeEventSchema;
+export type ExtensionParticipantChangeMessage = z.infer<
+  typeof ExtensionParticipantChangeMessageSchema
+>;
+
+/**
+ * Active-speaker change reported by the extension. Payload shape mirrors
+ * {@link SpeakerChangeEventSchema}.
+ */
+export const ExtensionSpeakerChangeMessageSchema = SpeakerChangeEventSchema;
+export type ExtensionSpeakerChangeMessage = z.infer<
+  typeof ExtensionSpeakerChangeMessageSchema
+>;
+
+/**
+ * Inbound chat message observed by the extension. Payload shape mirrors
+ * {@link InboundChatEventSchema}.
+ */
+export const ExtensionInboundChatMessageSchema = InboundChatEventSchema;
+export type ExtensionInboundChatMessage = z.infer<
+  typeof ExtensionInboundChatMessageSchema
+>;
+
+/** Severity for an extension-side diagnostic message. */
+export const ExtensionDiagnosticLevelSchema = z.enum(["info", "error"]);
+export type ExtensionDiagnosticLevel = z.infer<
+  typeof ExtensionDiagnosticLevelSchema
+>;
+
+/**
+ * Diagnostic log line emitted by the extension that the bot should surface
+ * (e.g. re-emit as a structured log entry).
+ */
+export const ExtensionDiagnosticMessageSchema = z.object({
+  type: z.literal("diagnostic"),
+  level: ExtensionDiagnosticLevelSchema,
+  message: z.string().min(1),
+});
+export type ExtensionDiagnosticMessage = z.infer<
+  typeof ExtensionDiagnosticMessageSchema
+>;
+
+/**
+ * Result of a prior `send_chat` command, correlated by `requestId`.
+ *
+ * `ok: false` payloads should set `error` to a human-readable string so the
+ * bot can surface a meaningful failure reason.
+ */
+export const ExtensionSendChatResultMessageSchema = z.object({
+  type: z.literal("send_chat_result"),
+  /** Correlation id from the originating `send_chat` command. */
+  requestId: z.string().min(1),
+  /** Whether the extension successfully posted the chat message. */
+  ok: z.boolean(),
+  /** Human-readable failure reason when `ok === false`. */
+  error: z.string().optional(),
+});
+export type ExtensionSendChatResultMessage = z.infer<
+  typeof ExtensionSendChatResultMessageSchema
+>;
+
+/**
+ * Every payload the extension may send to the bot over the native-messaging
+ * pipe. Consumers should parse incoming frames with this schema to both
+ * validate and narrow on `type`.
+ */
+export const ExtensionToBotMessageSchema = z.discriminatedUnion("type", [
+  ExtensionReadyMessageSchema,
+  ExtensionLifecycleMessageSchema,
+  ExtensionParticipantChangeMessageSchema,
+  ExtensionSpeakerChangeMessageSchema,
+  ExtensionInboundChatMessageSchema,
+  ExtensionDiagnosticMessageSchema,
+  ExtensionSendChatResultMessageSchema,
+]);
+export type ExtensionToBotMessage = z.infer<typeof ExtensionToBotMessageSchema>;
+
+/** All extension→bot `type` discriminator values as a const tuple. */
+export const EXTENSION_TO_BOT_MESSAGE_TYPES = [
+  "ready",
+  "lifecycle",
+  "participant.change",
+  "speaker.change",
+  "chat.inbound",
+  "diagnostic",
+  "send_chat_result",
+] as const;
+
+export type ExtensionToBotMessageType =
+  (typeof EXTENSION_TO_BOT_MESSAGE_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Bot → Extension
+// ---------------------------------------------------------------------------
+
+/**
+ * Ask the extension to drive the Meet join flow for the given meeting.
+ *
+ * `consentMessage` is the verbal/written consent that the extension will
+ * post in chat on joining, so participants understand the bot is present
+ * on the user's behalf.
+ */
+export const BotJoinCommandSchema = z.object({
+  type: z.literal("join"),
+  /** Full Meet join URL. */
+  meetingUrl: z.string().min(1),
+  /** Display name the bot should use when joining. */
+  displayName: z.string().min(1),
+  /** Consent string the extension will post in chat on joining. */
+  consentMessage: z.string().min(1),
+});
+export type BotJoinCommand = z.infer<typeof BotJoinCommandSchema>;
+
+/** Ask the extension to cleanly leave the current meeting. */
+export const BotLeaveCommandSchema = z.object({
+  type: z.literal("leave"),
+  /** Human-readable reason, surfaced in logs/telemetry. */
+  reason: z.string().min(1),
+});
+export type BotLeaveCommand = z.infer<typeof BotLeaveCommandSchema>;
+
+/**
+ * Ask the extension to type a chat message. The extension replies with a
+ * `send_chat_result` carrying the same `requestId`.
+ */
+export const BotSendChatCommandSchema = z.object({
+  type: z.literal("send_chat"),
+  /** Chat message text to post. */
+  text: z.string().min(1),
+  /** Correlation id the extension must echo back in `send_chat_result`. */
+  requestId: z.string().min(1),
+});
+export type BotSendChatCommand = z.infer<typeof BotSendChatCommandSchema>;
+
+/**
+ * Every command the bot may send to the extension over the native-messaging
+ * pipe. Consumers should parse incoming frames with this schema to both
+ * validate and narrow on `type`.
+ */
+export const BotToExtensionMessageSchema = z.discriminatedUnion("type", [
+  BotJoinCommandSchema,
+  BotLeaveCommandSchema,
+  BotSendChatCommandSchema,
+]);
+export type BotToExtensionMessage = z.infer<typeof BotToExtensionMessageSchema>;
+
+/** All bot→extension `type` discriminator values as a const tuple. */
+export const BOT_TO_EXTENSION_MESSAGE_TYPES = [
+  "join",
+  "leave",
+  "send_chat",
+] as const;
+
+export type BotToExtensionMessageType =
+  (typeof BOT_TO_EXTENSION_MESSAGE_TYPES)[number];

--- a/skills/meet-join/contracts/tsconfig.json
+++ b/skills/meet-join/contracts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Adds Zod schemas for ExtensionToBotMessage + BotToExtensionMessage flowing over the Native Messaging stdio pipe.
- Reuses existing event schemas (participant.change, speaker.change, chat.inbound) where applicable.
- Parse round-trip + negative-case tests for every variant.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 1 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
