### PR TITLE
feat(memory): embed userQuery separately for capability-reserve ranking

### DIFF
--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -18,12 +18,23 @@ import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // Configurable embed-mock state — reset between tests.
 let embedShouldThrow = false;
 let embedVector: number[] = [0.1, 0.2, 0.3];
+let embedCallCount = 0;
+// Optional input-aware router. When set, overrides the default single-vector
+// mock behavior: takes the first text input and returns a matching vector.
+let embedRouter: ((text: string) => number[]) | null = null;
 
 mock.module("../embed.js", () => ({
-  embedWithRetry: async () => {
+  embedWithRetry: async (
+    _config: unknown,
+    texts: unknown[],
+    _opts?: unknown,
+  ) => {
+    embedCallCount++;
     if (embedShouldThrow) throw new Error("embedding backend down");
+    const firstText = typeof texts[0] === "string" ? texts[0] : "";
+    const vector = embedRouter ? embedRouter(firstText) : embedVector;
     return {
-      vectors: [embedVector],
+      vectors: [vector],
       provider: "test-provider",
       model: "test-model",
     };
@@ -34,8 +45,16 @@ mock.module("../embedding-backend.js", () => ({
   selectedBackendSupportsMultimodal: async () => false,
 }));
 
+// Optional input-aware search router. When set, chooses a candidate list
+// based on the query vector's identity (vector equality on the first 3 dims).
+type SearchHit = { nodeId: string; score: number };
+let searchRouter: ((vector: number[]) => SearchHit[]) | null = null;
+
 mock.module("./graph-search.js", () => ({
-  searchGraphNodes: async () => [],
+  searchGraphNodes: async (vector: number[]) => {
+    if (searchRouter) return searchRouter(vector);
+    return [];
+  },
 }));
 
 // Returning `null` from getConfiguredProvider causes rerankAndDedup and
@@ -52,11 +71,44 @@ mock.module("../../providers/provider-send-message.js", () => ({
 
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
-import { initializeDb, resetDb } from "../db.js";
+import { initializeDb, resetDb, resetTestTables } from "../db.js";
 import { InContextTracker } from "./injection.js";
 import { loadContextMemory, retrieveForTurn } from "./retriever.js";
+import { createNode } from "./store.js";
+import type { NewNode } from "./types.js";
 
 const TEST_CONFIG: AssistantConfig = { ...DEFAULT_CONFIG };
+
+function makeCapabilityNode(content: string, capId: string): NewNode {
+  const now = Date.now();
+  return {
+    content,
+    type: "procedural",
+    created: now,
+    lastAccessed: now,
+    lastConsolidated: now,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 1,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: now,
+    sourceConversations: [`capability:skill:${capId}`],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    scopeId: "default",
+  };
+}
 
 describe("loadContextMemory — query/sparse vector surfacing", () => {
   beforeAll(() => {
@@ -66,6 +118,9 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
   beforeEach(() => {
     embedShouldThrow = false;
     embedVector = [0.1, 0.2, 0.3];
+    embedCallCount = 0;
+    embedRouter = null;
+    searchRouter = null;
     resetDb();
     initializeDb();
   });
@@ -110,16 +165,6 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
     expect(result.sparseVector).toBeUndefined();
   });
 
-  test("ignores userQuery when dual-query logic is not yet implemented (PR 2 baseline)", async () => {
-    const result = await loadContextMemory({
-      scopeId: "test-scope",
-      recentSummaries: ["summary"],
-      userQuery: "ignore me for now",
-      config: TEST_CONFIG,
-    });
-    expect(result.userQueryVector).toBeUndefined();
-    expect(result.queryVector).toBeDefined();
-  });
 });
 
 describe("retrieveForTurn — query/sparse vector surfacing", () => {
@@ -130,6 +175,9 @@ describe("retrieveForTurn — query/sparse vector surfacing", () => {
   beforeEach(() => {
     embedShouldThrow = false;
     embedVector = [0.1, 0.2, 0.3];
+    embedCallCount = 0;
+    embedRouter = null;
+    searchRouter = null;
     resetDb();
     initializeDb();
   });
@@ -183,5 +231,158 @@ describe("retrieveForTurn — query/sparse vector surfacing", () => {
 
     expect(result.queryVector).toBeUndefined();
     expect(result.sparseVector).toBeUndefined();
+  });
+});
+
+describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
+  // Capture seeded capability node IDs so the searchGraphNodes mock can
+  // reference them by ID (the mock runs at call time, not seed time).
+  let inboxNodeId = "";
+  let heartbeatNodeId = "";
+  let watchNodeId = "";
+
+  // Build a config where capabilityReserve=1 so the ranking code actually
+  // prunes (it only prunes when capabilityNodes.length > capabilityReserve).
+  const DUAL_QUERY_CONFIG: AssistantConfig = structuredClone(DEFAULT_CONFIG);
+  DUAL_QUERY_CONFIG.memory.retrieval.injection.contextLoad.capabilityReserve =
+    1;
+
+  // Keyword-routed embed: any text that contains a topic keyword returns a
+  // one-hot vector identifying that topic. Anything else falls back to a
+  // neutral default vector. This lets tests assert which vector ended up
+  // driving the capability-reserve decision.
+  function keywordEmbedRouter(text: string): number[] {
+    const lowered = text.toLowerCase();
+    if (lowered.includes("inbox")) return [1, 0, 0];
+    if (lowered.includes("heartbeat") || lowered.includes("readiness"))
+      return [0, 1, 0];
+    if (lowered.includes("bridgerton") || lowered.includes("watch"))
+      return [0, 0, 1];
+    return [0.1, 0.1, 0.1];
+  }
+
+  // Vector-routed search: returns the capability node aligned with the query
+  // vector as the top hit, with the others as weak filler.
+  function vectorSearchRouter(vector: number[]): SearchHit[] {
+    const [a = 0, b = 0, c = 0] = vector;
+    if (a === 1 && b === 0 && c === 0) {
+      return [
+        { nodeId: inboxNodeId, score: 0.9 },
+        { nodeId: heartbeatNodeId, score: 0.1 },
+        { nodeId: watchNodeId, score: 0.05 },
+      ];
+    }
+    if (a === 0 && b === 1 && c === 0) {
+      return [
+        { nodeId: heartbeatNodeId, score: 0.9 },
+        { nodeId: inboxNodeId, score: 0.1 },
+        { nodeId: watchNodeId, score: 0.05 },
+      ];
+    }
+    if (a === 0 && b === 0 && c === 1) {
+      return [
+        { nodeId: watchNodeId, score: 0.9 },
+        { nodeId: inboxNodeId, score: 0.1 },
+        { nodeId: heartbeatNodeId, score: 0.05 },
+      ];
+    }
+    // Neutral default — return nothing so it can't accidentally dominate.
+    return [];
+  }
+
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    embedShouldThrow = false;
+    embedVector = [0.1, 0.2, 0.3];
+    embedCallCount = 0;
+    embedRouter = null;
+    searchRouter = null;
+    resetTestTables(
+      "memory_graph_triggers",
+      "memory_graph_edges",
+      "memory_graph_nodes",
+    );
+
+    const inbox = createNode(
+      makeCapabilityNode(
+        'The "Inbox Cleanup" skill (inbox-cleanup) is available. Run a high-recall, multi-pass email inbox cleanup. Use when: when user asks to clean up email inbox.',
+        "inbox-cleanup",
+      ),
+    );
+    const heartbeat = createNode(
+      makeCapabilityNode(
+        'The "Heartbeat" skill (heartbeat) is available. Body temperature and readiness check-ins. Use when: user asks about daily readiness.',
+        "heartbeat",
+      ),
+    );
+    const watch = createNode(
+      makeCapabilityNode(
+        'The "Watch Together" skill (watch-together) is available. Co-watch video. Use when: user asks about watching Bridgerton or other shows.',
+        "watch-together",
+      ),
+    );
+    inboxNodeId = inbox.id;
+    heartbeatNodeId = heartbeat.id;
+    watchNodeId = watch.id;
+  });
+
+  // Use a long summary so the user-query short-circuit guard does not fire.
+  const LONG_HEARTBEAT_SUMMARY =
+    "User mentioned their heartbeat check-in this morning and we discussed " +
+    "daily readiness routines, body temperature monitoring, and how the " +
+    "heartbeat skill has been helping them track readiness patterns over " +
+    "the last several weeks. We also touched on journaling and sleep data.";
+
+  test("userQuery drives capability-reserve ranking over summary", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    const result = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      userQuery: "clean up my inbox",
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(result.userQueryVector).toEqual([1, 0, 0]);
+    const reservedIds = new Set(result.nodes.map((s) => s.node.id));
+    expect(reservedIds.has(inboxNodeId)).toBe(true);
+    expect(reservedIds.has(heartbeatNodeId)).toBe(false);
+  });
+
+  test("without userQuery, summary-based ranking picks the heartbeat capability", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    const result = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(result.userQueryVector).toBeUndefined();
+    const reservedIds = new Set(result.nodes.map((s) => s.node.id));
+    expect(reservedIds.has(heartbeatNodeId)).toBe(true);
+  });
+
+  test("short-circuits the dedicated embed when userQuery dominates summary length", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    // Summary is short, user query is much longer (>= half summary length)
+    // so the short-circuit kicks in and we only pay for the summary embed.
+    const result = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: ["hi"],
+      userQuery:
+        "this is a dramatically longer user query that easily dominates the summary text length",
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(result.userQueryVector).toBeUndefined();
+    expect(embedCallCount).toBe(1);
   });
 });

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -413,12 +413,14 @@ export async function loadContextMemory(
   let embeddingProvider: string | null = null;
   let embeddingModel: string | null = null;
   let contextQueryText: string | null = null;
+  let truncatedSummaryLength = 0;
   if (opts.recentSummaries.length > 0) {
     try {
       const queryText = opts.recentSummaries.join("\n\n");
       const truncated =
         queryText.length > 3000 ? queryText.slice(0, 3000) : queryText;
       contextQueryText = truncated;
+      truncatedSummaryLength = truncated.length;
       const result = await embedWithRetry(opts.config, [truncated], {
         signal: opts.signal,
       });
@@ -427,6 +429,37 @@ export async function loadContextMemory(
       embeddingModel = result.model;
     } catch (err) {
       log.warn({ err }, "Failed to embed summaries for context load");
+    }
+  }
+
+  // 1b. (PR 3) Dedicated user-query embedding. When `opts.userQuery` is
+  //     provided and materially shorter than the summary query, embed it
+  //     independently and use the resulting vector for capability-reserve
+  //     ranking + as a merged candidate pool. Skipped when the user query
+  //     already dominates the summary text to avoid paying for a redundant
+  //     embed call.
+  let userQueryVector: number[] | null = null;
+  const userQueryCandidateIds = new Map<string, number>(); // nodeId → score
+  const trimmedUserQuery = opts.userQuery?.trim() ?? "";
+  const shouldEmbedUserQuery =
+    trimmedUserQuery.length > 0 &&
+    // Short-circuit: when there is a summary query, only embed user query if
+    // it's less than half the summary length (otherwise it already dominates).
+    // If there's no summary query, always embed the user query on its own.
+    (truncatedSummaryLength === 0 ||
+      trimmedUserQuery.length < truncatedSummaryLength / 2);
+  if (shouldEmbedUserQuery) {
+    try {
+      const result = await embedWithRetry(opts.config, [trimmedUserQuery], {
+        signal: opts.signal,
+      });
+      userQueryVector = result.vectors[0] ?? null;
+      if (!embeddingProvider) {
+        embeddingProvider = result.provider;
+        embeddingModel = result.model;
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to embed userQuery for context load");
     }
   }
 
@@ -452,6 +485,31 @@ export async function loadContextMemory(
     }
   }
   const pureSemanticHits = semanticCandidateIds.size;
+
+  // 2b. (PR 3) Run a parallel Qdrant search against the user-query vector and
+  //     merge the results into the organic scoring pool (max-score union).
+  //     This keeps PR 3 strictly additive: candidates that only match the
+  //     user-query vector still participate in downstream scoring, and
+  //     candidates that match both vectors retain the higher score.
+  if (userQueryVector) {
+    try {
+      const results = await searchGraphNodes(
+        userQueryVector,
+        maxNodes * 3,
+        [opts.scopeId],
+        undefined,
+      );
+      for (const r of results) {
+        userQueryCandidateIds.set(r.nodeId, r.score);
+        const existing = semanticCandidateIds.get(r.nodeId);
+        if (existing === undefined || r.score > existing) {
+          semanticCandidateIds.set(r.nodeId, r.score);
+        }
+      }
+    } catch (err) {
+      log.warn({ err }, "Qdrant search failed for userQuery vector");
+    }
+  }
 
   // Also include top-significance nodes as a fallback
   const topSignificance = queryNodes({
@@ -614,9 +672,25 @@ export async function loadContextMemory(
       return true;
     });
 
-  // Rank by semantic similarity when a query vector exists
+  // Rank by semantic similarity when a query vector exists.
+  // (PR 3) When a dedicated user-query vector is available, prefer its
+  // scores over the summary vector's for capability-reserve ranking —
+  // capability picks should align with the user's current intent, not
+  // the conversation-summary topic.
   let selectedCapabilities: MemoryNode[];
-  if (queryVector && capabilityNodes.length > capabilityReserve) {
+  if (userQueryCandidateIds.size > 0 && capabilityNodes.length > capabilityReserve) {
+    selectedCapabilities = capabilityNodes
+      .map((node) => ({
+        node,
+        sim:
+          userQueryCandidateIds.get(node.id) ??
+          semanticCandidateIds.get(node.id) ??
+          0,
+      }))
+      .sort((a, b) => b.sim - a.sim)
+      .slice(0, capabilityReserve)
+      .map((e) => e.node);
+  } else if (queryVector && capabilityNodes.length > capabilityReserve) {
     selectedCapabilities = capabilityNodes
       .map((node) => ({ node, sim: semanticCandidateIds.get(node.id) ?? 0 }))
       .sort((a, b) => b.sim - a.sim)
@@ -732,6 +806,7 @@ export async function loadContextMemory(
     },
     queryVector: queryVector ?? undefined,
     sparseVector,
+    userQueryVector: userQueryVector ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- When `opts.userQuery` is provided to `loadContextMemory`, embed it independently of `recentSummaries` and use the resulting vector to rank skill/CLI capability-reserve slots.
- Merges user-query candidates into the organic scoring pool (additive, max-score union) so the change is strictly additive.
- Short-circuits the extra embed when the user query already dominates the summary text.
- Surfaces `userQueryVector` on `ContextLoadResult` for downstream callers.
- Adds a regression test proving that a short user message about topic X beats a long summary about topic Y for a capability-reserve slot, plus a short-circuit test.

Part of plan: turn1-skill-query-bias.md (PR 3 of 6)