### PR TITLE
feat(memory): enable turn1UserQueryBias by default, remove legacy unshift

### DIFF
--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -230,9 +230,9 @@ const MemoryContextLoadInjectionSchema = z
         error:
           "memory.retrieval.injection.contextLoad.turn1UserQueryBias must be a boolean",
       })
-      .default(false)
+      .default(true)
       .describe(
-        "When true, embed the first user message as a dedicated query vector used to rank skill/CLI capability reserve slots on turn 1, instead of relying on the summary-based query. Summaries still drive organic memory retrieval.",
+        "When true (default), embed the first user message as a dedicated query vector used to rank skill/CLI capability reserve slots on turn 1, instead of relying on the summary-based query. Summaries still drive organic memory retrieval. Set false to revert to summary-dominant ranking.",
       ),
   })
   .describe("Memory injection limits at conversation start");

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -338,23 +338,12 @@ export class ConversationGraphMemory {
       if (!this.initialized || this.needsReload) {
         const recentSummaries = this.fetchRecentSummaries();
         const firstUserText = extractUserText(lastMessage);
-        const turn1Bias =
-          config.memory.retrieval.injection.contextLoad.turn1UserQueryBias;
-
-        let userQuery: string | undefined;
-        if (firstUserText) {
-          if (turn1Bias) {
-            userQuery = firstUserText;
-          } else {
-            recentSummaries.unshift(firstUserText);
-          }
-        }
 
         return await this.runContextLoad(
           messages,
           config,
           recentSummaries,
-          userQuery,
+          firstUserText ?? undefined,
           abortSignal,
           onEvent,
         );


### PR DESCRIPTION
## Summary
- Flips the `turn1UserQueryBias` config default from `false` to `true`. The first user message is now embedded as a dedicated query vector on every turn-1 retrieval by default.
- Removes the legacy `recentSummaries.unshift(firstUserText)` branch from `ConversationGraphMemory.prepareMemory`. `firstUserText` now always flows through the `userQuery` option.
- Updates the flag description to reflect the new default and note the opt-out path.

Part of plan: turn1-skill-query-bias.md (PR 6 of 6 — final)