### PR TITLE
feat(meet-bot): add native-messaging host shim relaying Chrome stdio to unix socket

### DIFF
--- a/skills/meet-join/bot/__tests__/nmh-protocol.test.ts
+++ b/skills/meet-join/bot/__tests__/nmh-protocol.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the native-messaging wire-format helpers.
+ *
+ * Verifies the encoder produces a correct `[u32 LE length][utf8 json]` frame
+ * and that the streaming reader recovers the original objects regardless of
+ * chunk boundaries. Also asserts the 1MB per-frame cap is enforced so a
+ * malicious or corrupt peer can't pin memory.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createFrameReader,
+  encodeFrame,
+} from "../src/native-messaging/nmh-protocol.js";
+
+describe("nmh-protocol", () => {
+  test("encode → read round-trips an object", () => {
+    const original = {
+      type: "lifecycle",
+      state: "joined",
+      meetingId: "m-123",
+      timestamp: "2026-04-18T00:00:00.000Z",
+    };
+    const frame = encodeFrame(original);
+
+    // Header is [u32 LE length] and matches the UTF-8 JSON length.
+    const declared = frame.readUInt32LE(0);
+    const payload = frame.subarray(4);
+    expect(declared).toBe(payload.byteLength);
+    expect(JSON.parse(payload.toString("utf8"))).toEqual(original);
+
+    const reader = createFrameReader();
+    const out = reader.push(frame);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual(original);
+  });
+
+  test("recovers both objects when a chunk boundary lands inside the second length header", () => {
+    const a = { type: "ready", extensionVersion: "1.0.0" };
+    const b = { type: "diagnostic", level: "info", message: "hello" };
+    const combined = Buffer.concat([encodeFrame(a), encodeFrame(b)]);
+
+    // Cut mid-second-length-header: after frame A plus 2 bytes of frame B's
+    // 4-byte length prefix. This is the tricky split — we need both halves
+    // of the header to eventually land and only THEN can we decode.
+    const frameALen = 4 + Buffer.from(JSON.stringify(a), "utf8").byteLength;
+    const cut = frameALen + 2;
+    expect(cut).toBeLessThan(combined.byteLength);
+
+    const first = combined.subarray(0, cut);
+    const second = combined.subarray(cut);
+
+    const reader = createFrameReader();
+    const out1 = reader.push(first);
+    // Frame A is complete; frame B's header is incomplete — expect only A.
+    expect(out1).toHaveLength(1);
+    expect(out1[0]).toEqual(a);
+
+    const out2 = reader.push(second);
+    expect(out2).toHaveLength(1);
+    expect(out2[0]).toEqual(b);
+  });
+
+  test("recovers the object when a chunk boundary lands inside the payload", () => {
+    const obj = {
+      type: "lifecycle",
+      state: "joining",
+      meetingId: "m-xyz",
+      timestamp: "2026-04-18T00:00:00.000Z",
+    };
+    const frame = encodeFrame(obj);
+    // Split mid-payload (after header + half of payload).
+    const payloadStart = 4;
+    const mid = payloadStart + Math.floor((frame.byteLength - payloadStart) / 2);
+    const first = frame.subarray(0, mid);
+    const second = frame.subarray(mid);
+
+    const reader = createFrameReader();
+    const out1 = reader.push(first);
+    expect(out1).toHaveLength(0);
+    const out2 = reader.push(second);
+    expect(out2).toHaveLength(1);
+    expect(out2[0]).toEqual(obj);
+  });
+
+  test("yields all three objects when three frames arrive in one push", () => {
+    const a = { type: "ready", extensionVersion: "1.0.0" };
+    const b = {
+      type: "lifecycle",
+      state: "joined",
+      meetingId: "m-1",
+      timestamp: "2026-04-18T00:00:00.000Z",
+    };
+    const c = { type: "diagnostic", level: "error", message: "boom" };
+    const combined = Buffer.concat([
+      encodeFrame(a),
+      encodeFrame(b),
+      encodeFrame(c),
+    ]);
+
+    const reader = createFrameReader();
+    const out = reader.push(combined);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual(a);
+    expect(out[1]).toEqual(b);
+    expect(out[2]).toEqual(c);
+  });
+
+  test("throws when a length header claims more than 1,000,000 bytes", () => {
+    // Forge a header claiming 2MB followed by no payload — the reader
+    // should refuse as soon as it sees the declared length, without waiting
+    // for the payload (which will never arrive).
+    const header = Buffer.alloc(4);
+    header.writeUInt32LE(2_000_000, 0);
+
+    const reader = createFrameReader();
+    expect(() => reader.push(header)).toThrow(/exceeds max/i);
+  });
+
+  test("encodeFrame throws when the serialized payload exceeds 1,000,000 bytes", () => {
+    // Build a JSON value whose UTF-8 encoding is >1MB. 1.1 million ASCII
+    // chars comfortably exceeds the cap after JSON-string-quoting.
+    const big = "x".repeat(1_100_000);
+    expect(() => encodeFrame({ blob: big })).toThrow(/exceeds max/i);
+  });
+
+  test("handles many single-byte pushes (worst-case chunking)", () => {
+    const obj = { type: "ready", extensionVersion: "1.2.3" };
+    const frame = encodeFrame(obj);
+
+    const reader = createFrameReader();
+    let collected: unknown[] = [];
+    for (let i = 0; i < frame.byteLength; i += 1) {
+      const chunk = frame.subarray(i, i + 1);
+      collected = collected.concat(reader.push(chunk));
+    }
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toEqual(obj);
+  });
+});

--- a/skills/meet-join/bot/__tests__/nmh-shim.test.ts
+++ b/skills/meet-join/bot/__tests__/nmh-shim.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Integration-style unit tests for the native-messaging shim.
+ *
+ * Each test boots an ephemeral unix-socket server on a tmp path, runs
+ * `runShim` with injected stdin/stdout streams, and asserts on the bytes
+ * crossing both directions:
+ *
+ *   - Encoded Chrome frames pushed into stdin must arrive at the server as
+ *     newline-delimited JSON.
+ *   - Newline-delimited JSON written by the server must appear on stdout as
+ *     valid length-prefixed Chrome frames.
+ *   - A missing socket causes retry exhaustion → rejection.
+ *   - A remote-close after a valid session resolves cleanly.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable, Writable } from "node:stream";
+
+import {
+  createFrameReader,
+  encodeFrame,
+} from "../src/native-messaging/nmh-protocol.js";
+import { runShim } from "../src/native-messaging/nmh-shim.js";
+
+/** Build a fresh ephemeral socket path per test. */
+function freshSocketPath(): string {
+  const suffix = randomBytes(8).toString("hex");
+  return join(tmpdir(), `nmh-test-${suffix}.sock`);
+}
+
+/** Start a unix-socket server that collects received bytes and exposes the first client. */
+interface ServerHandle {
+  server: Server;
+  onClient: Promise<Socket>;
+  received: Buffer[];
+  stop: () => Promise<void>;
+}
+
+function startServer(socketPath: string): Promise<ServerHandle> {
+  return new Promise((resolveHandle, rejectHandle) => {
+    const received: Buffer[] = [];
+    let resolveClient: (s: Socket) => void = () => {};
+    const onClient = new Promise<Socket>((r) => {
+      resolveClient = r;
+    });
+    const server = createServer((socket) => {
+      socket.on("data", (chunk) => {
+        received.push(Buffer.from(chunk));
+      });
+      resolveClient(socket);
+    });
+    server.on("error", (err) => rejectHandle(err));
+    server.listen(socketPath, () => {
+      resolveHandle({
+        server,
+        onClient,
+        received,
+        stop: () =>
+          new Promise<void>((resolveStop) => {
+            server.close(() => {
+              try {
+                unlinkSync(socketPath);
+              } catch {
+                // Socket file may already be cleaned up by the OS on close.
+              }
+              resolveStop();
+            });
+          }),
+      });
+    });
+  });
+}
+
+/** Manually-pushable readable stream for fake stdin. */
+class ManualReadable extends Readable {
+  override _read(): void {
+    // Data is pushed via `feed`/`finish` below.
+  }
+  feed(chunk: Buffer): void {
+    this.push(chunk);
+  }
+  finish(): void {
+    this.push(null);
+  }
+}
+
+/** Writable that collects all written chunks for later assertions. */
+class CollectingWritable extends Writable {
+  chunks: Buffer[] = [];
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+    this.chunks.push(buf);
+    callback();
+  }
+  collected(): Buffer {
+    return Buffer.concat(this.chunks);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Concatenate all chunks recorded by the server. */
+function concat(chunks: Buffer[]): Buffer {
+  return Buffer.concat(chunks);
+}
+
+describe("nmh-shim", () => {
+  let handle: ServerHandle | null = null;
+
+  beforeEach(() => {
+    handle = null;
+  });
+
+  afterEach(async () => {
+    if (handle !== null) {
+      await handle.stop();
+      handle = null;
+    }
+  });
+
+  test("relays encoded Chrome frames from stdin to the socket as newline-JSON", async () => {
+    const socketPath = freshSocketPath();
+    handle = await startServer(socketPath);
+
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const shimDone = runShim({
+      socketPath,
+      stdin,
+      stdout,
+      connectRetries: 3,
+      connectRetryDelayMs: 20,
+    });
+    shimDone.catch(() => {
+      // Swallow — we assert on completion below and `stop()` causes a resolve.
+    });
+
+    // Wait for the server to see a connection.
+    await handle.onClient;
+
+    const frameA = encodeFrame({ type: "join", meetingUrl: "https://meet", displayName: "Bot", consentMessage: "hi" });
+    const frameB = encodeFrame({ type: "leave", reason: "done" });
+    stdin.feed(Buffer.concat([frameA, frameB]));
+
+    // Poll until both newline-JSON lines have arrived at the server.
+    const deadline = Date.now() + 1000;
+    let text = "";
+    while (Date.now() < deadline) {
+      text = concat(handle.received).toString("utf8");
+      const lines = text.split("\n").filter((l) => l.length > 0);
+      if (lines.length >= 2) break;
+      await sleep(10);
+    }
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).toEqual({
+      type: "join",
+      meetingUrl: "https://meet",
+      displayName: "Bot",
+      consentMessage: "hi",
+    });
+    expect(JSON.parse(lines[1]!)).toEqual({ type: "leave", reason: "done" });
+
+    // Graceful shutdown.
+    stdin.finish();
+    await shimDone;
+  });
+
+  test("relays newline-JSON from the socket to stdout as encoded Chrome frames", async () => {
+    const socketPath = freshSocketPath();
+    handle = await startServer(socketPath);
+
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const shimDone = runShim({
+      socketPath,
+      stdin,
+      stdout,
+      connectRetries: 3,
+      connectRetryDelayMs: 20,
+    });
+    shimDone.catch(() => {
+      // Swallow; asserted below.
+    });
+
+    const client = await handle.onClient;
+
+    // Server writes two newline-JSON lines back to the shim.
+    const payloadA = {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    };
+    const payloadB = {
+      type: "diagnostic",
+      level: "info",
+      message: "hi",
+    };
+    client.write(`${JSON.stringify(payloadA)}\n`);
+    client.write(`${JSON.stringify(payloadB)}\n`);
+
+    // Poll until stdout has two complete frames.
+    const reader = createFrameReader();
+    const collected: unknown[] = [];
+    const deadline = Date.now() + 1000;
+    while (Date.now() < deadline && collected.length < 2) {
+      const buf = stdout.collected();
+      if (buf.byteLength > 0) {
+        // Reset reader by rebuilding — simplest; we always parse the
+        // full accumulated output.
+        const fresh = createFrameReader();
+        const parsed = fresh.push(buf);
+        collected.length = 0;
+        collected.push(...parsed);
+      }
+      if (collected.length < 2) await sleep(10);
+    }
+    expect(collected).toHaveLength(2);
+    expect(collected[0]).toEqual(payloadA);
+    expect(collected[1]).toEqual(payloadB);
+
+    // Silence the unused-reader lint.
+    void reader;
+
+    stdin.finish();
+    await shimDone;
+  });
+
+  test("exits within a few hundred ms when the socket is not reachable", async () => {
+    const socketPath = freshSocketPath(); // no server listening on this path
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const start = Date.now();
+    let caughtError: unknown = undefined;
+    try {
+      await runShim({
+        socketPath,
+        stdin,
+        stdout,
+        connectRetries: 2,
+        connectRetryDelayMs: 30,
+      });
+    } catch (err) {
+      caughtError = err;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(String((caughtError as Error).message)).toMatch(/could not connect/i);
+    // 2 retries * 30ms delay + tcp/connect overhead — generous upper bound.
+    expect(elapsed).toBeLessThan(1500);
+  });
+
+  test("resolves cleanly when the server closes the connection", async () => {
+    const socketPath = freshSocketPath();
+    handle = await startServer(socketPath);
+
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const shimDone = runShim({
+      socketPath,
+      stdin,
+      stdout,
+      connectRetries: 3,
+      connectRetryDelayMs: 20,
+    });
+
+    const client = await handle.onClient;
+    // Close the server-side socket cleanly.
+    client.end();
+
+    // `runShim` should resolve — not reject — on remote close.
+    await shimDone;
+  });
+});

--- a/skills/meet-join/bot/src/native-messaging/nmh-protocol.ts
+++ b/skills/meet-join/bot/src/native-messaging/nmh-protocol.ts
@@ -1,0 +1,109 @@
+/**
+ * Chrome Native Messaging wire-format helpers.
+ *
+ * Chrome communicates with a native-messaging host via the host's stdio. Each
+ * message is a UTF-8 JSON document prefixed by a 32-bit little-endian length
+ * header:
+ *
+ *   [u32 LE length][utf-8 json payload of exactly that length]
+ *
+ * This module provides:
+ *
+ *   - `encodeFrame(obj)` — serialize any JSON-safe value to a Buffer in that
+ *     wire format.
+ *   - `createFrameReader()` — stateful reader that accumulates arbitrarily
+ *     chunked input (split mid-header or mid-payload) and returns complete
+ *     frames as they become available.
+ *
+ * A hard cap of 1,000,000 bytes per frame matches Chrome's documented
+ * per-frame NMH limit; a forged header claiming more than this is rejected
+ * rather than allowed to exhaust memory.
+ *
+ * This layer is transport-only. It does NOT validate the JSON payload shape;
+ * that belongs to the bot's socket-server layer (see PR 7), which runs the
+ * decoded objects through the zod schemas in
+ * `skills/meet-join/contracts/native-messaging.ts`.
+ */
+
+/** Chrome's documented per-frame maximum. */
+const MAX_FRAME_SIZE = 1_000_000;
+
+/** Byte length of the little-endian u32 length prefix. */
+const HEADER_BYTES = 4;
+
+/**
+ * Encode a JSON-safe value as a native-messaging frame.
+ *
+ * Returns a Buffer containing `[u32 LE length][utf-8 json]`.
+ *
+ * Throws if the encoded payload exceeds `MAX_FRAME_SIZE` — the Chrome side
+ * would refuse to deliver it anyway, and surfacing the error here is less
+ * confusing than silently producing an un-deliverable byte stream.
+ */
+export function encodeFrame(obj: unknown): Buffer {
+  const json = JSON.stringify(obj);
+  const payload = Buffer.from(json, "utf8");
+  if (payload.byteLength > MAX_FRAME_SIZE) {
+    throw new Error(
+      `native-messaging frame payload of ${payload.byteLength} bytes exceeds max ${MAX_FRAME_SIZE}`,
+    );
+  }
+  const header = Buffer.alloc(HEADER_BYTES);
+  header.writeUInt32LE(payload.byteLength, 0);
+  return Buffer.concat([header, payload], HEADER_BYTES + payload.byteLength);
+}
+
+/**
+ * Stateful reader over a stream of native-messaging bytes.
+ *
+ * `push(chunk)` appends the chunk to an internal buffer and drains as many
+ * complete frames as are currently available. Each complete frame is parsed
+ * from UTF-8 JSON and returned as an array entry in the order received.
+ *
+ * Handles all chunk-boundary placements:
+ *   - Chunk ends inside the length header.
+ *   - Chunk ends inside the payload.
+ *   - Single chunk contains multiple complete frames plus a partial one.
+ *
+ * A frame whose length header claims more than `MAX_FRAME_SIZE` bytes causes
+ * `push()` to throw. After throwing, the internal buffer is in an indeterminate
+ * state and the reader should be discarded — callers should not retry.
+ */
+export interface FrameReader {
+  push(chunk: Buffer): unknown[];
+}
+
+export function createFrameReader(): FrameReader {
+  let buffer: Buffer = Buffer.alloc(0);
+
+  return {
+    push(chunk: Buffer): unknown[] {
+      buffer =
+        buffer.byteLength === 0
+          ? Buffer.from(chunk)
+          : Buffer.concat(
+              [buffer, chunk],
+              buffer.byteLength + chunk.byteLength,
+            );
+      const out: unknown[] = [];
+      while (true) {
+        if (buffer.byteLength < HEADER_BYTES) break;
+        const length = buffer.readUInt32LE(0);
+        if (length > MAX_FRAME_SIZE) {
+          throw new Error(
+            `native-messaging frame length ${length} exceeds max ${MAX_FRAME_SIZE}`,
+          );
+        }
+        const totalNeeded = HEADER_BYTES + length;
+        if (buffer.byteLength < totalNeeded) break;
+        const payloadStart = HEADER_BYTES;
+        const payloadEnd = totalNeeded;
+        const payload = buffer.subarray(payloadStart, payloadEnd);
+        const json = payload.toString("utf8");
+        out.push(JSON.parse(json));
+        buffer = buffer.subarray(payloadEnd);
+      }
+      return out;
+    },
+  };
+}

--- a/skills/meet-join/bot/src/native-messaging/nmh-shim.ts
+++ b/skills/meet-join/bot/src/native-messaging/nmh-shim.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+/**
+ * Native-messaging host shim — stdio <-> unix-socket bridge.
+ *
+ * Chrome spawns its configured "native-messaging host" binary and talks to it
+ * over that child's stdio using a length-prefixed JSON wire format (see
+ * `nmh-protocol.ts`). Our bot process, however, lives in a separate container
+ * and listens on a unix-domain socket. This shim is the small bridging process
+ * Chrome actually launches: it reads framed stdio from Chrome, relays each
+ * payload as newline-delimited JSON to the bot socket, and writes framed
+ * responses back to Chrome's stdio.
+ *
+ * The shim is intentionally dumb — just a format translator. Payload validation
+ * (via the zod schemas in `skills/meet-join/contracts/native-messaging.ts`)
+ * happens at the bot-socket-server layer added in PR 7, not here. Keeping the
+ * shim schema-unaware means the bot can evolve the message shapes without a
+ * coordinated redeploy of the in-Chromium shim binary.
+ *
+ * Lifecycle:
+ *   - Connect to the configured unix socket, retrying with a short backoff.
+ *   - Proxy stdin frames → socket newline-JSON.
+ *   - Proxy socket newline-JSON → stdout frames.
+ *   - Resolve cleanly on stdin EOF or remote socket close.
+ *   - Exit 1 on connect-retry exhaustion or unparseable stdin.
+ *
+ * Errors are logged to stderr, which Chrome captures and writes to its native-
+ * messaging diagnostic log — so operators can see what went wrong even when
+ * the parent Chrome process is the one that spawned us.
+ */
+
+import { connect, type Socket } from "node:net";
+
+import { createFrameReader, encodeFrame } from "./nmh-protocol.js";
+
+/**
+ * Options accepted by `runShim`. Everything is injectable for tests; the
+ * production entrypoint at the bottom of this file wires stdin/stdout and
+ * reads `NMH_SOCKET_PATH` from the environment.
+ */
+export interface RunShimOptions {
+  /** Filesystem path of the unix socket to connect to. */
+  socketPath: string;
+  /** Stream the shim reads framed Chrome messages from. Defaults to `process.stdin`. */
+  stdin?: NodeJS.ReadableStream;
+  /** Stream the shim writes framed Chrome responses to. Defaults to `process.stdout`. */
+  stdout?: NodeJS.WritableStream;
+  /** Max connection attempts before giving up (inclusive of the first try). Default 5. */
+  connectRetries?: number;
+  /** Delay in ms between connection attempts. Default 200. */
+  connectRetryDelayMs?: number;
+}
+
+const DEFAULT_CONNECT_RETRIES = 5;
+const DEFAULT_CONNECT_RETRY_DELAY_MS = 200;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Attempt a single unix-socket connection. Resolves with the connected socket
+ * or rejects with the connect error — no retries here, callers wrap this.
+ */
+function connectOnce(socketPath: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = connect({ path: socketPath });
+    const onConnect = (): void => {
+      socket.off("error", onError);
+      resolve(socket);
+    };
+    const onError = (err: Error): void => {
+      socket.off("connect", onConnect);
+      socket.destroy();
+      reject(err);
+    };
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+  });
+}
+
+/**
+ * Connect to `socketPath` with a simple retry loop. Throws a descriptive
+ * error after the final attempt fails so the shim can exit 1 with useful
+ * diagnostics on stderr.
+ */
+async function connectWithRetries(
+  socketPath: string,
+  retries: number,
+  retryDelayMs: number,
+): Promise<Socket> {
+  let lastError: unknown = undefined;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      return await connectOnce(socketPath);
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries) {
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `could not connect to native-messaging socket at ${socketPath} after ${retries} attempt(s): ${reason}`,
+  );
+}
+
+/**
+ * Run the native-messaging shim until either side closes. Resolves cleanly on
+ * stdin EOF or remote socket close. Rejects on connect-retry exhaustion or on
+ * a malformed inbound frame from Chrome.
+ */
+export async function runShim(opts: RunShimOptions): Promise<void> {
+  // Narrow the defaults to the structural NodeJS interfaces — the
+  // `process.stdin` type includes tty-specific overloads that conflict with
+  // the public `NodeJS.ReadableStream` overload set and cause the
+  // event-listener calls below to fail type inference.
+  const stdin: NodeJS.ReadableStream = opts.stdin ?? process.stdin;
+  const stdout: NodeJS.WritableStream = opts.stdout ?? process.stdout;
+  const retries = opts.connectRetries ?? DEFAULT_CONNECT_RETRIES;
+  const retryDelayMs = opts.connectRetryDelayMs ?? DEFAULT_CONNECT_RETRY_DELAY_MS;
+
+  const socket = await connectWithRetries(opts.socketPath, retries, retryDelayMs);
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        socket.end();
+      } catch {
+        // socket may already be torn down — nothing actionable.
+      }
+      if (err) reject(err);
+      else resolve();
+    };
+
+    // ----------------------- Chrome stdin → socket -----------------------
+    const frameReader = createFrameReader();
+    stdin.on("data", (chunk: Buffer | string) => {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+      let frames: unknown[];
+      try {
+        frames = frameReader.push(buf);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`nmh-shim: failed to parse Chrome frame: ${msg}\n`);
+        settle(err instanceof Error ? err : new Error(msg));
+        return;
+      }
+      for (const frame of frames) {
+        const line = `${JSON.stringify(frame)}\n`;
+        socket.write(line);
+      }
+    });
+    stdin.on("end", () => {
+      // Chrome closed its side: drain the socket and resolve cleanly.
+      settle();
+    });
+    stdin.on("error", (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`nmh-shim: stdin error: ${msg}\n`);
+      settle(err instanceof Error ? err : new Error(msg));
+    });
+
+    // ----------------------- socket → Chrome stdout -----------------------
+    let socketBuffer = "";
+    socket.on("data", (chunk: Buffer) => {
+      socketBuffer += chunk.toString("utf8");
+      // Drain complete newline-delimited JSON objects. The remainder (after
+      // the last newline) stays in the buffer for the next read.
+      let newlineIdx = socketBuffer.indexOf("\n");
+      while (newlineIdx !== -1) {
+        const line = socketBuffer.slice(0, newlineIdx);
+        socketBuffer = socketBuffer.slice(newlineIdx + 1);
+        if (line.length > 0) {
+          try {
+            const parsed: unknown = JSON.parse(line);
+            const frame = encodeFrame(parsed);
+            stdout.write(frame);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(
+              `nmh-shim: failed to encode bot→extension frame: ${msg}\n`,
+            );
+          }
+        }
+        newlineIdx = socketBuffer.indexOf("\n");
+      }
+    });
+    socket.on("error", (err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`nmh-shim: socket error: ${msg}\n`);
+      settle(err instanceof Error ? err : new Error(msg));
+    });
+    socket.on("close", () => {
+      // Remote end closed: graceful exit.
+      settle();
+    });
+  });
+}
+
+// -------------------------------------------------------------------------
+// Entrypoint guard — executed only when this file is the process entry.
+// -------------------------------------------------------------------------
+if (import.meta.main) {
+  const socketPath = process.env.NMH_SOCKET_PATH ?? "/run/nmh.sock";
+  runShim({ socketPath }).catch((err) => {
+    process.stderr.write(
+      `nmh-shim: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds nmh-shim.ts: a small supervisor-executed process Chrome will spawn as its native-messaging host. Relays framed stdio (Chrome's NMH wire format) to newline-JSON over a unix socket that the bot process will listen on (PR 7).
- Adds nmh-protocol.ts: buffer-based frame encoder + streaming reader with split-read + oversize handling.
- Tests cover round-trip, split-read boundaries, multi-frame chunks, size limits, retry-on-connect-failure, and graceful-exit.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 5 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
