### PR TITLE
feat(meet-bot): add unix socket server for native-messaging shim traffic

### DIFF
--- a/skills/meet-join/bot/__tests__/socket-server.test.ts
+++ b/skills/meet-join/bot/__tests__/socket-server.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Unit tests for the Chrome native-messaging Unix-socket server.
+ *
+ * These tests open real unix sockets in the OS temp directory (no TCP, no
+ * external services) and simulate the native-messaging shim with a plain
+ * `net.createConnection` client. The goal is to exercise the full pump —
+ * framing, schema validation, cutover semantics, shutdown cleanup — without
+ * mocking away the transport.
+ *
+ * Coverage:
+ *   - Handshake: `{type:"ready"}` from the client resolves `waitForReady`.
+ *   - Inbound dispatch: a valid lifecycle frame reaches `onExtensionMessage`.
+ *   - Outbound: `sendToExtension` writes a newline-terminated JSON line.
+ *   - Drop paths: wrong-schema and malformed JSON warn but keep the server alive.
+ *   - Cutover: a second client connect displaces the first.
+ *   - Shutdown: `stop()` unlinks the socket file.
+ *   - Timeout: `waitForReady` rejects past its deadline.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createConnection, type Socket } from "node:net";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createNmhSocketServer,
+  type NmhSocketLogger,
+  type NmhSocketServer,
+} from "../src/native-messaging/socket-server.js";
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+
+/** -------------------- helpers --------------------------------------- */
+
+/**
+ * Build a fresh unique socket path under `tmpdir()`. Every test calls this
+ * so concurrent test runs can't stomp on each other's socket files.
+ */
+function freshSocketPath(): string {
+  const rnd = Math.random().toString(36).slice(2, 10);
+  return join(tmpdir(), `socket-server-test-${rnd}-${process.pid}.sock`);
+}
+
+/**
+ * Capture logger — records every info/warn line for post-hoc assertions.
+ */
+interface CapturingLogger extends NmhSocketLogger {
+  infoMessages: string[];
+  warnMessages: string[];
+}
+function captureLogger(): CapturingLogger {
+  const info: string[] = [];
+  const warn: string[] = [];
+  return {
+    infoMessages: info,
+    warnMessages: warn,
+    info: (m) => info.push(m),
+    warn: (m) => warn.push(m),
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll `predicate` until true or the deadline elapses. Test utility to
+ * avoid fragile fixed sleeps on async side-effects.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  { timeoutMs = 2000, intervalMs = 5 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error(`waitFor: predicate did not become true in ${timeoutMs}ms`);
+}
+
+/**
+ * Connect a client to the server at `path` and resolve once the connection
+ * is established. The returned socket has `setEncoding("utf8")` so data
+ * events deliver strings directly.
+ */
+async function connectClient(path: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection({ path });
+    const onError = (err: Error): void => {
+      sock.off("connect", onConnect);
+      reject(err);
+    };
+    const onConnect = (): void => {
+      sock.off("error", onError);
+      sock.setEncoding("utf8");
+      resolve(sock);
+    };
+    sock.once("error", onError);
+    sock.once("connect", onConnect);
+  });
+}
+
+/**
+ * Write a JSON value followed by a newline. Matches the framing the server
+ * expects from the real shim.
+ */
+function writeJsonLine(sock: Socket, value: unknown): void {
+  sock.write(`${JSON.stringify(value)}\n`);
+}
+
+/** Registry of servers/clients so tests can be torn down deterministically. */
+interface TestFixtures {
+  server?: NmhSocketServer;
+  clients: Socket[];
+}
+
+const active: TestFixtures = { clients: [] };
+
+afterEach(async () => {
+  for (const c of active.clients) {
+    try {
+      c.destroy();
+    } catch {
+      // Best-effort.
+    }
+  }
+  active.clients = [];
+  if (active.server) {
+    try {
+      await active.server.stop();
+    } catch {
+      // Best-effort.
+    }
+    active.server = undefined;
+  }
+});
+
+function track<T extends NmhSocketServer>(srv: T): T {
+  active.server = srv;
+  return srv;
+}
+function trackClient(c: Socket): Socket {
+  active.clients.push(c);
+  return c;
+}
+
+/** -------------------- tests ----------------------------------------- */
+
+describe("createNmhSocketServer — handshake", () => {
+  test("resolves waitForReady after the client sends a ready frame", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const client = trackClient(await connectClient(path));
+    const readyPromise = server.waitForReady(2000);
+
+    const ready: ExtensionToBotMessage = {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    };
+    writeJsonLine(client, ready);
+
+    await readyPromise;
+    // Idempotent: a second call should resolve immediately.
+    await server.waitForReady(10);
+  });
+});
+
+describe("createNmhSocketServer — inbound dispatch", () => {
+  test("fires onExtensionMessage for a valid lifecycle frame", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const received: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => received.push(m));
+
+    const client = trackClient(await connectClient(path));
+    const lifecycle: ExtensionToBotMessage = {
+      type: "lifecycle",
+      state: "joining",
+      meetingId: "m-abc",
+      timestamp: new Date().toISOString(),
+    };
+    writeJsonLine(client, lifecycle);
+
+    await waitFor(() => received.length === 1);
+    const msg = received[0]!;
+    expect(msg.type).toBe("lifecycle");
+    if (msg.type === "lifecycle") {
+      expect(msg.state).toBe("joining");
+      expect(msg.meetingId).toBe("m-abc");
+    }
+  });
+
+  test("supports multiple onExtensionMessage listeners (fan-out)", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const a: ExtensionToBotMessage[] = [];
+    const b: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => a.push(m));
+    server.onExtensionMessage((m) => b.push(m));
+
+    const client = trackClient(await connectClient(path));
+    writeJsonLine(client, {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    } satisfies ExtensionToBotMessage);
+
+    await waitFor(() => a.length === 1 && b.length === 1);
+  });
+
+  test("handles multiple frames delivered in a single TCP chunk", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const received: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => received.push(m));
+
+    const client = trackClient(await connectClient(path));
+    // Two frames concatenated in a single write — the server must split on
+    // `\n` rather than treating the blob as a single JSON document.
+    const first = {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    } satisfies ExtensionToBotMessage;
+    const second = {
+      type: "lifecycle",
+      state: "joined",
+      meetingId: "m-xyz",
+      timestamp: new Date().toISOString(),
+    } satisfies ExtensionToBotMessage;
+    client.write(`${JSON.stringify(first)}\n${JSON.stringify(second)}\n`);
+
+    await waitFor(() => received.length === 2);
+    expect(received[0]!.type).toBe("ready");
+    expect(received[1]!.type).toBe("lifecycle");
+  });
+});
+
+describe("createNmhSocketServer — outbound", () => {
+  test("sendToExtension writes a newline-terminated JSON line", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const client = trackClient(await connectClient(path));
+
+    // Accumulate whatever the client receives from the server.
+    let clientRecv = "";
+    client.on("data", (chunk) => {
+      clientRecv += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+
+    // Wait a tick so the server sees the accept before we try to send.
+    await sleep(20);
+
+    const join: BotToExtensionMessage = {
+      type: "join",
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Bot",
+      consentMessage: "Recording for the user.",
+    };
+    server.sendToExtension(join);
+
+    await waitFor(() => clientRecv.includes("\n"));
+    // The payload must end in exactly one newline.
+    expect(clientRecv.endsWith("\n")).toBe(true);
+    const line = clientRecv.slice(0, -1);
+    const parsed = JSON.parse(line);
+    expect(parsed).toEqual(join);
+  });
+
+  test("sendToExtension throws when no client is connected", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    expect(() =>
+      server.sendToExtension({
+        type: "leave",
+        reason: "test",
+      }),
+    ).toThrow(/no extension client connected/);
+  });
+});
+
+describe("createNmhSocketServer — defensive parsing", () => {
+  test("drops schema-invalid JSON and keeps serving", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const received: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => received.push(m));
+
+    const client = trackClient(await connectClient(path));
+    // Well-formed JSON, wrong schema — the `type` is not a valid discriminator.
+    client.write(`${JSON.stringify({ type: "nope", extraneous: 1 })}\n`);
+    // Then a valid ready frame to prove the server is still processing input.
+    writeJsonLine(client, {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    } satisfies ExtensionToBotMessage);
+
+    await waitFor(() => received.length === 1);
+    expect(received[0]!.type).toBe("ready");
+    expect(
+      logger.warnMessages.some((m) => m.includes("schema-invalid")),
+    ).toBe(true);
+  });
+
+  test("drops malformed JSON and keeps serving", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const received: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => received.push(m));
+
+    const client = trackClient(await connectClient(path));
+    client.write("not-json\n");
+    writeJsonLine(client, {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    } satisfies ExtensionToBotMessage);
+
+    await waitFor(() => received.length === 1);
+    expect(received[0]!.type).toBe("ready");
+    expect(
+      logger.warnMessages.some((m) => m.includes("malformed JSON")),
+    ).toBe(true);
+  });
+});
+
+describe("createNmhSocketServer — cutover", () => {
+  test("second client connect displaces the first and the server keeps serving", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    const received: ExtensionToBotMessage[] = [];
+    server.onExtensionMessage((m) => received.push(m));
+
+    // First client connects and sends a ready frame.
+    const first = trackClient(await connectClient(path));
+    let firstClosed = false;
+    first.on("close", () => {
+      firstClosed = true;
+    });
+    writeJsonLine(first, {
+      type: "ready",
+      extensionVersion: "1.0.0",
+    } satisfies ExtensionToBotMessage);
+    await waitFor(() => received.length === 1);
+
+    // Second client connects — the server must accept it and close the first.
+    const second = trackClient(await connectClient(path));
+    await waitFor(() => firstClosed === true);
+    expect(
+      logger.warnMessages.some((m) => m.includes("closing previous client")),
+    ).toBe(true);
+
+    // Verify the second client is now the active one by sending from it
+    // and observing dispatch.
+    writeJsonLine(second, {
+      type: "lifecycle",
+      state: "joined",
+      meetingId: "m-new",
+      timestamp: new Date().toISOString(),
+    } satisfies ExtensionToBotMessage);
+
+    await waitFor(() => received.length === 2);
+    expect(received[1]!.type).toBe("lifecycle");
+  });
+});
+
+describe("createNmhSocketServer — shutdown", () => {
+  test("stop() unlinks the socket file and subsequent sendToExtension throws", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    // Connect a client, then stop — the socket file must be gone afterwards.
+    trackClient(await connectClient(path));
+    await sleep(20);
+    expect(existsSync(path)).toBe(true);
+
+    await server.stop();
+    // Clear the registry so the afterEach hook doesn't try to stop again.
+    active.server = undefined;
+
+    expect(existsSync(path)).toBe(false);
+
+    // After stop, no client is connected, so sendToExtension throws.
+    expect(() =>
+      server.sendToExtension({ type: "leave", reason: "post-stop" }),
+    ).toThrow(/no extension client connected/);
+  });
+
+  test("stop() is idempotent", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    await server.stop();
+    // A second stop() must not throw.
+    await server.stop();
+    active.server = undefined;
+  });
+});
+
+describe("createNmhSocketServer — waitForReady timeout", () => {
+  test("rejects when no ready frame arrives within the budget", async () => {
+    const logger = captureLogger();
+    const path = freshSocketPath();
+    const server = track(createNmhSocketServer({ socketPath: path, logger }));
+    await server.start();
+
+    // Connect a client but never send ready.
+    trackClient(await connectClient(path));
+
+    let thrown: unknown;
+    try {
+      await server.waitForReady(40);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("timed out");
+  });
+});

--- a/skills/meet-join/bot/src/native-messaging/socket-server.ts
+++ b/skills/meet-join/bot/src/native-messaging/socket-server.ts
@@ -1,0 +1,348 @@
+/**
+ * Unix-socket server that carries the Chrome Native Messaging bridge between
+ * the meet-bot process and its in-browser extension.
+ *
+ * Chrome can't talk to a long-lived bot process directly from an extension,
+ * so we run a small **native-messaging shim** (a separate stdio host Chrome
+ * launches) that forwards Chrome's length-prefixed frames over this Unix
+ * socket. From the bot's perspective the transport is plain newline-delimited
+ * JSON: each `\n`-terminated line is a single message, validated against the
+ * {@link ExtensionToBotMessageSchema} / {@link BotToExtensionMessageSchema}
+ * pair from {@link ../../../contracts/native-messaging.js}.
+ *
+ * Design notes:
+ *
+ * - **Single-client policy.** Chrome restarts (or the shim reconnecting after
+ *   a browser crash) must not wedge the server. When a new client connects
+ *   while one is already active, we log a warning, close the old one, and
+ *   accept the new connection. The bot's view of "the extension" is
+ *   always "the most recent connection".
+ * - **Newline framing.** Both directions use JSON lines. We maintain a
+ *   per-connection buffer and split on `\n` on each `data` event so that
+ *   TCP-style coalesced frames are handled correctly.
+ * - **Defensive parsing.** Malformed JSON or schema-invalid payloads are
+ *   logged via `logger.warn` and dropped; the server must never crash on
+ *   bad input. The shim is untrusted in the sense that extension bugs
+ *   shouldn't be able to take down the bot.
+ * - **Outbound validation.** `sendToExtension` re-validates every frame so
+ *   a caller can't smuggle an invalid shape past the wire — catching the
+ *   bug at the source instead of on the extension side.
+ * - **Ready handshake.** The extension sends `{ type: "ready" }` once its
+ *   background service worker is up. Callers await `waitForReady` before
+ *   issuing the first `join` command so commands don't get dropped while
+ *   the shim is still negotiating.
+ */
+
+import { createServer, type Server, type Socket } from "node:net";
+import { unlink } from "node:fs/promises";
+
+import {
+  BotToExtensionMessageSchema,
+  ExtensionToBotMessageSchema,
+  type BotToExtensionMessage,
+  type ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+
+/** Minimal logger surface the server needs. */
+export interface NmhSocketLogger {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+export interface NmhSocketServerOptions {
+  /** Filesystem path of the Unix-domain socket to listen on. */
+  socketPath: string;
+  /** Logger for diagnostics (ignored for malformed payloads — we just drop). */
+  logger: NmhSocketLogger;
+}
+
+export interface NmhSocketServer {
+  /**
+   * Unlink any stale socket file at `socketPath` and begin listening. Resolves
+   * once the `net.Server` has bound.
+   */
+  start(): Promise<void>;
+  /**
+   * Stop the listener, close any active client, and unlink the socket file.
+   * Idempotent — safe to call multiple times.
+   */
+  stop(): Promise<void>;
+  /**
+   * Send a command to the extension. Throws synchronously if no client is
+   * connected or if the payload fails schema validation.
+   */
+  sendToExtension(msg: BotToExtensionMessage): void;
+  /**
+   * Register a callback fired for every valid inbound message. Multiple
+   * callbacks are supported (fan-out).
+   */
+  onExtensionMessage(cb: (msg: ExtensionToBotMessage) => void): void;
+  /**
+   * Resolve once the first `{ type: "ready" }` frame has been received.
+   * Rejects if `timeoutMs` elapses first. Idempotent: if the handshake has
+   * already been seen the returned promise resolves immediately.
+   */
+  waitForReady(timeoutMs: number): Promise<void>;
+}
+
+/**
+ * Create (but do not start) the Unix-socket server. Call `start()` to bind.
+ */
+export function createNmhSocketServer(
+  opts: NmhSocketServerOptions,
+): NmhSocketServer {
+  const { socketPath, logger } = opts;
+
+  /** Registered inbound listeners (fan-out). */
+  const listeners: Array<(msg: ExtensionToBotMessage) => void> = [];
+
+  /** The currently active connection, if any. */
+  let activeSocket: Socket | null = null;
+  /** Per-connection buffer for partial lines. Reset on every new connection. */
+  let inboundBuffer = "";
+
+  let server: Server | null = null;
+  let started = false;
+  let stopped = false;
+
+  /** True once the first `{type:"ready"}` frame has been received. */
+  let ready = false;
+  /** Waiters created before the handshake lands. */
+  const readyWaiters: Array<{
+    resolve: () => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  /**
+   * Flush every queued `waitForReady` waiter with the handshake result. On
+   * success we resolve each waiter; on server teardown we reject them so
+   * callers don't hang forever.
+   */
+  function flushReadyWaiters(err?: Error): void {
+    while (readyWaiters.length > 0) {
+      const w = readyWaiters.shift()!;
+      clearTimeout(w.timer);
+      if (err) {
+        w.reject(err);
+      } else {
+        w.resolve();
+      }
+    }
+  }
+
+  /**
+   * Handle a single parsed-and-validated inbound message: mark the handshake
+   * as complete on `ready`, then fan out to every registered listener.
+   */
+  function dispatchInbound(msg: ExtensionToBotMessage): void {
+    if (msg.type === "ready" && !ready) {
+      ready = true;
+      flushReadyWaiters();
+    }
+    for (const cb of listeners) {
+      try {
+        cb(msg);
+      } catch (err) {
+        // A listener throwing shouldn't take down the socket pump. Log and
+        // keep going so the remaining callbacks still fire.
+        logger.warn(
+          `nmh-socket-server: listener threw for message type=${msg.type}: ${formatError(err)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Consume a newly-arrived chunk of bytes: split on `\n`, parse each line
+   * as JSON, validate with the extension→bot schema, and dispatch. Malformed
+   * JSON and schema-invalid payloads warn and drop.
+   */
+  function handleData(chunk: Buffer | string): void {
+    inboundBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let newlineIdx = inboundBuffer.indexOf("\n");
+    while (newlineIdx !== -1) {
+      const line = inboundBuffer.slice(0, newlineIdx);
+      inboundBuffer = inboundBuffer.slice(newlineIdx + 1);
+      newlineIdx = inboundBuffer.indexOf("\n");
+      // Tolerate the `\r\n` form in case a producer is careless about line
+      // endings — strip the trailing CR rather than failing to parse.
+      const trimmed = line.endsWith("\r") ? line.slice(0, -1) : line;
+      if (trimmed.length === 0) continue;
+
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(trimmed);
+      } catch (err) {
+        logger.warn(
+          `nmh-socket-server: dropping malformed JSON frame: ${formatError(err)}`,
+        );
+        continue;
+      }
+
+      const validated = ExtensionToBotMessageSchema.safeParse(parsedJson);
+      if (!validated.success) {
+        logger.warn(
+          `nmh-socket-server: dropping schema-invalid frame: ${validated.error.message}`,
+        );
+        continue;
+      }
+
+      dispatchInbound(validated.data);
+    }
+  }
+
+  /**
+   * Replace `activeSocket` with `next`, tearing down the previous one with
+   * a warning so the operator can see that the shim reconnected.
+   */
+  function acceptClient(next: Socket): void {
+    if (activeSocket) {
+      logger.warn(
+        "nmh-socket-server: closing previous client; a new connection arrived",
+      );
+      try {
+        activeSocket.destroy();
+      } catch {
+        // Best-effort; the previous socket might already be gone.
+      }
+    }
+    activeSocket = next;
+    // Per-connection state resets on every new accept — a stale half-line
+    // from the old socket must not bleed into the new one.
+    inboundBuffer = "";
+
+    next.setEncoding("utf8");
+    next.on("data", (chunk) => {
+      // Node types `data` as `string | Buffer` depending on whether
+      // `setEncoding` was called. We set utf8 above, so this is always a
+      // string in practice.
+      handleData(chunk as string);
+    });
+    next.on("error", (err) => {
+      // `error` on a Unix socket is usually ECONNRESET from the peer
+      // vanishing. We don't want this to crash the server.
+      logger.warn(`nmh-socket-server: client error: ${err.message}`);
+    });
+    next.on("close", () => {
+      if (activeSocket === next) {
+        activeSocket = null;
+        inboundBuffer = "";
+      }
+    });
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return;
+      started = true;
+
+      // Clear a stale socket file from a previous crashed run. Ignore
+      // "file doesn't exist" (the common case on a fresh start).
+      await unlink(socketPath).catch((err: NodeJS.ErrnoException) => {
+        if (err?.code !== "ENOENT") {
+          logger.warn(
+            `nmh-socket-server: could not unlink stale socket: ${err.message}`,
+          );
+        }
+      });
+
+      const srv = createServer((socket) => {
+        acceptClient(socket);
+      });
+      server = srv;
+
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error): void => {
+          srv.off("listening", onListening);
+          reject(err);
+        };
+        const onListening = (): void => {
+          srv.off("error", onError);
+          resolve();
+        };
+        srv.once("error", onError);
+        srv.once("listening", onListening);
+        srv.listen(socketPath);
+      });
+
+      logger.info(`nmh-socket-server: listening on ${socketPath}`);
+    },
+
+    async stop(): Promise<void> {
+      if (stopped) return;
+      stopped = true;
+
+      // Reject any pending ready waiters so callers blocked in
+      // `waitForReady` don't hang forever after shutdown.
+      flushReadyWaiters(
+        new Error("nmh-socket-server: stopped before handshake completed"),
+      );
+
+      if (activeSocket) {
+        try {
+          activeSocket.destroy();
+        } catch {
+          // Best-effort.
+        }
+        activeSocket = null;
+      }
+
+      const srv = server;
+      server = null;
+      if (srv) {
+        await new Promise<void>((resolve) => {
+          srv.close(() => resolve());
+        });
+      }
+
+      await unlink(socketPath).catch((err: NodeJS.ErrnoException) => {
+        // Missing file on stop is fine (e.g. start() never completed).
+        if (err?.code !== "ENOENT") {
+          logger.warn(
+            `nmh-socket-server: could not unlink socket on stop: ${err.message}`,
+          );
+        }
+      });
+    },
+
+    sendToExtension(msg: BotToExtensionMessage): void {
+      if (!activeSocket) {
+        throw new Error(
+          "nmh-socket-server: no extension client connected; cannot send",
+        );
+      }
+      // Re-validate outbound so a caller-side bug (e.g. assembling a
+      // command with a missing field) surfaces here rather than being
+      // dropped by the extension side silently.
+      const parsed = BotToExtensionMessageSchema.parse(msg);
+      activeSocket.write(`${JSON.stringify(parsed)}\n`);
+    },
+
+    onExtensionMessage(cb: (msg: ExtensionToBotMessage) => void): void {
+      listeners.push(cb);
+    },
+
+    waitForReady(timeoutMs: number): Promise<void> {
+      if (ready) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = readyWaiters.findIndex((w) => w.timer === timer);
+          if (idx !== -1) readyWaiters.splice(idx, 1);
+          reject(
+            new Error(
+              `nmh-socket-server: timed out after ${timeoutMs}ms waiting for extension ready handshake`,
+            ),
+          );
+        }, timeoutMs);
+        readyWaiters.push({ resolve, reject, timer });
+      });
+    },
+  };
+}
+
+/** Render an unknown throwable as a short string suitable for a log line. */
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}


### PR DESCRIPTION
## Summary
- Adds createNmhSocketServer: the bot-process side of the Chrome Native Messaging bridge. Listens on a unix socket, parses newline-delimited JSON frames, validates with the PR 1 Zod schemas, exposes waitForReady/sendToExtension/onExtensionMessage.
- Single-client policy with graceful cutover; tolerates shim reconnect.
- Tests cover handshake, valid/invalid frames, cutover, timeout, cleanup.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 7 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
