### PR TITLE
feat(meet-ext): background service worker — native-messaging bridge

### DIFF
--- a/skills/meet-join/meet-controller-ext/bun.lock
+++ b/skills/meet-join/meet-controller-ext/bun.lock
@@ -5,12 +5,15 @@
     "": {
       "name": "@vellumai/meet-controller-ext",
       "devDependencies": {
+        "@types/bun": "1.3.9",
         "@types/chrome": "0.1.40",
         "typescript": "5.9.3",
       },
     },
   },
   "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@types/chrome": ["@types/chrome@0.1.40", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA=="],
 
     "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
@@ -19,6 +22,12 @@
 
     "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
 
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }
 }

--- a/skills/meet-join/meet-controller-ext/package.json
+++ b/skills/meet-join/meet-controller-ext/package.json
@@ -6,9 +6,11 @@
   "type": "module",
   "scripts": {
     "build": "bun run scripts/build.ts",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/__tests__/"
   },
   "devDependencies": {
+    "@types/bun": "1.3.9",
     "@types/chrome": "0.1.40",
     "typescript": "5.9.3"
   }

--- a/skills/meet-join/meet-controller-ext/src/__tests__/native-port.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/native-port.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the native-messaging port wrapper.
+ *
+ * These tests stub the portions of the `chrome.runtime` API the wrapper
+ * touches (`connectNative` + `Port.onMessage` / `onDisconnect` / `postMessage`
+ * / `disconnect`) so we can assert the protocol validation and
+ * auto-reconnect semantics without a real browser.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_RECONNECT_BASE_MS,
+  NATIVE_HOST_NAME,
+  openNativePort,
+} from "../messaging/native-port.js";
+
+/** Recorded call to {@link chrome.runtime.connectNative}. */
+interface ConnectCall {
+  app: string;
+  port: FakePort;
+}
+
+/** Minimal in-memory stand-in for {@link chrome.runtime.Port}. */
+interface FakePort {
+  name: string;
+  postMessage(msg: unknown): void;
+  disconnect(): void;
+  messageListeners: Array<(msg: unknown, port: FakePort) => void>;
+  disconnectListeners: Array<(port: FakePort) => void>;
+  sent: unknown[];
+  disconnected: boolean;
+  onMessage: {
+    addListener(cb: (msg: unknown, port: FakePort) => void): void;
+  };
+  onDisconnect: {
+    addListener(cb: (port: FakePort) => void): void;
+  };
+}
+
+interface FakeChrome {
+  connectCalls: ConnectCall[];
+  runtime: {
+    connectNative: (app: string) => FakePort;
+    lastError?: { message: string } | undefined;
+  };
+}
+
+function installFakeChrome(): FakeChrome {
+  const connectCalls: ConnectCall[] = [];
+  const fake: FakeChrome = {
+    connectCalls,
+    runtime: {
+      connectNative(app: string): FakePort {
+        const port: FakePort = {
+          name: app,
+          messageListeners: [],
+          disconnectListeners: [],
+          sent: [],
+          disconnected: false,
+          postMessage(msg: unknown) {
+            if (this.disconnected) {
+              throw new Error("port is disconnected");
+            }
+            this.sent.push(msg);
+          },
+          disconnect() {
+            this.disconnected = true;
+          },
+          onMessage: {
+            addListener: (cb) => {
+              port.messageListeners.push(cb);
+            },
+          },
+          onDisconnect: {
+            addListener: (cb) => {
+              port.disconnectListeners.push(cb);
+            },
+          },
+        };
+        connectCalls.push({ app, port });
+        return port;
+      },
+      lastError: undefined,
+    },
+  };
+  // Cast through unknown because the real @types/chrome Port is richer than
+  // our fake; we only implement the surface `openNativePort` uses.
+  (globalThis as unknown as { chrome: unknown }).chrome = fake;
+  return fake;
+}
+
+function uninstallFakeChrome(): void {
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
+}
+
+function emit(port: FakePort, msg: unknown): void {
+  for (const cb of port.messageListeners) cb(msg, port);
+}
+
+function disconnect(port: FakePort): void {
+  port.disconnected = true;
+  for (const cb of port.disconnectListeners) cb(port);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("openNativePort", () => {
+  let fake: FakeChrome;
+
+  beforeEach(() => {
+    fake = installFakeChrome();
+  });
+
+  afterEach(() => {
+    uninstallFakeChrome();
+  });
+
+  test("calls connectNative with the Vellum host name", () => {
+    const handle = openNativePort({});
+    expect(fake.connectCalls.length).toBe(1);
+    expect(fake.connectCalls[0]!.app).toBe(NATIVE_HOST_NAME);
+    expect(NATIVE_HOST_NAME).toBe("com.vellum.meet");
+    handle.close();
+  });
+
+  test("parses valid inbound messages and invokes onMessage", () => {
+    const handle = openNativePort({});
+    const received: unknown[] = [];
+    handle.onMessage((msg) => received.push(msg));
+
+    const port = fake.connectCalls[0]!.port;
+    const joinCommand = {
+      type: "join",
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, I'm here to take notes.",
+    };
+    emit(port, joinCommand);
+
+    expect(received.length).toBe(1);
+    expect(received[0]).toEqual(joinCommand);
+    handle.close();
+  });
+
+  test("rejects invalid inbound shape, reports via onDisconnect, and reconnects", async () => {
+    const baseMs = 25;
+    const handle = openNativePort({
+      reconnectBaseMs: baseMs,
+      reconnectMaxMs: 1_000,
+    });
+    const disconnects: string[] = [];
+    handle.onDisconnect((reason) => disconnects.push(reason));
+
+    const port = fake.connectCalls[0]!.port;
+    // Missing `type` discriminator is a protocol error.
+    emit(port, { meetingUrl: "https://meet.google.com/abc" });
+
+    expect(disconnects.length).toBe(1);
+    expect(disconnects[0]).toContain("protocol error");
+    // The wrapper should have torn down the port so callers can't double-send.
+    expect(port.disconnected).toBe(true);
+    // Initial connect + no reconnect yet (backoff pending).
+    expect(fake.connectCalls.length).toBe(1);
+
+    // Wait past the backoff to observe the reconnect.
+    await sleep(baseMs + 20);
+    expect(fake.connectCalls.length).toBe(2);
+    handle.close();
+  });
+
+  test("post() throws synchronously on invalid outbound messages", () => {
+    const handle = openNativePort({});
+    // `ready` requires `extensionVersion` per ExtensionReadyMessageSchema.
+    expect(() => {
+      // Cast through unknown to let us hand in an invalid shape.
+      handle.post({ type: "ready" } as unknown as Parameters<
+        typeof handle.post
+      >[0]);
+    }).toThrow();
+    // No frame should have been forwarded to the underlying port.
+    expect(fake.connectCalls[0]!.port.sent.length).toBe(0);
+    handle.close();
+  });
+
+  test("post() forwards valid outbound messages verbatim", () => {
+    const handle = openNativePort({});
+    const msg = {
+      type: "ready" as const,
+      extensionVersion: "0.0.1",
+    };
+    handle.post(msg);
+    const port = fake.connectCalls[0]!.port;
+    expect(port.sent.length).toBe(1);
+    expect(port.sent[0]).toEqual(msg);
+    handle.close();
+  });
+
+  test("reconnects with exponential backoff capped at reconnectMaxMs", async () => {
+    const baseMs = 20;
+    const maxMs = 40;
+    const handle = openNativePort({
+      reconnectBaseMs: baseMs,
+      reconnectMaxMs: maxMs,
+    });
+
+    // Trigger first disconnect; reconnect fires after `baseMs`.
+    disconnect(fake.connectCalls[0]!.port);
+    await sleep(baseMs + 20);
+    expect(fake.connectCalls.length).toBe(2);
+
+    // Second disconnect; backoff is `baseMs * 2` but capped at `maxMs`.
+    disconnect(fake.connectCalls[1]!.port);
+    await sleep(maxMs + 20);
+    expect(fake.connectCalls.length).toBe(3);
+
+    handle.close();
+  });
+
+  test("close() prevents further reconnect attempts", async () => {
+    const baseMs = 20;
+    const handle = openNativePort({ reconnectBaseMs: baseMs });
+    const port = fake.connectCalls[0]!.port;
+    handle.close();
+    // Even after a disconnect fires, close() should have torn everything down.
+    disconnect(port);
+    await sleep(baseMs + 20);
+    expect(fake.connectCalls.length).toBe(1);
+  });
+});
+
+test("DEFAULT_RECONNECT_BASE_MS is 500ms", () => {
+  expect(DEFAULT_RECONNECT_BASE_MS).toBe(500);
+});

--- a/skills/meet-join/meet-controller-ext/src/background.ts
+++ b/skills/meet-join/meet-controller-ext/src/background.ts
@@ -1,2 +1,20 @@
-// Service worker entry. PR 8 will wire native-messaging here.
+/**
+ * Extension service-worker entry. Opens the native-messaging port to the
+ * meet-bot, wires content scripts into it via {@link startContentBridge}, and
+ * emits the `ready` handshake so the bot knows the extension is alive.
+ */
+import { startContentBridge } from "./messaging/content-bridge.js";
+import { openNativePort } from "./messaging/native-port.js";
+
 console.log("[meet-ext] background booted");
+
+const port = openNativePort({});
+startContentBridge(port);
+
+// Emit the ready handshake as soon as the port is open. The bot uses this as
+// the signal that the in-container extension is attached and ready to
+// receive join/leave/send_chat commands.
+port.post({
+  type: "ready",
+  extensionVersion: chrome.runtime.getManifest().version,
+});

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -1,0 +1,87 @@
+/**
+ * Router that glues together Meet content scripts and the native-messaging
+ * port. The background service worker owns the single native port; content
+ * scripts ride a standard `chrome.runtime` message channel to interact with
+ * it.
+ *
+ * Direction of flow:
+ *
+ *   - **Content → Bot**: `chrome.runtime.onMessage` messages that validate as
+ *     {@link ExtensionToBotMessage} are forwarded to the native port. Invalid
+ *     frames are logged and dropped; we never surface the error back to the
+ *     content script because there is no shared recovery path.
+ *   - **Bot → Content**: every validated {@link BotToExtensionMessage} fanned
+ *     out to every Meet tab (`https://meet.google.com/*`). If no tab matches,
+ *     we warn and drop the frame — the content script has not yet mounted
+ *     during early startup and there is nothing to deliver to.
+ */
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+import { ExtensionToBotMessageSchema } from "../../../contracts/native-messaging.js";
+
+import type { NativePort } from "./native-port.js";
+
+/** URL pattern used to locate Meet tabs when fanning out bot commands. */
+export const MEET_TAB_URL_PATTERN = "https://meet.google.com/*";
+
+/** Wire up the content-script ↔ native-port router for the life of the SW. */
+export function startContentBridge(port: NativePort): void {
+  // Content scripts post messages up to the service worker via
+  // chrome.runtime.sendMessage; we validate and forward to the native host.
+  chrome.runtime.onMessage.addListener(
+    (
+      raw: unknown,
+      _sender: chrome.runtime.MessageSender,
+      _sendResponse: (response?: unknown) => void,
+    ): boolean => {
+      const result = ExtensionToBotMessageSchema.safeParse(raw);
+      if (!result.success) {
+        console.warn(
+          "[meet-ext] dropped invalid content->bot message:",
+          result.error.message,
+        );
+        return false;
+      }
+      try {
+        port.post(result.data as ExtensionToBotMessage);
+      } catch (err) {
+        console.warn("[meet-ext] failed to forward to native port:", err);
+      }
+      return false;
+    },
+  );
+
+  // Bot commands from the native port fan out to every open Meet tab. The
+  // content script mounts on `document_idle`, so during very early startup no
+  // tab will match — we log and drop rather than throw because the bot
+  // treats commands as fire-and-forget.
+  port.onMessage((msg: BotToExtensionMessage) => {
+    void fanOutToMeetTabs(msg);
+  });
+}
+
+async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
+  let tabs: chrome.tabs.Tab[];
+  try {
+    tabs = await chrome.tabs.query({ url: MEET_TAB_URL_PATTERN });
+  } catch (err) {
+    console.warn("[meet-ext] tabs.query failed:", err);
+    return;
+  }
+  if (tabs.length === 0) {
+    console.warn(
+      `[meet-ext] no Meet tab open; dropping bot->content message type=${msg.type}`,
+    );
+    return;
+  }
+  for (const tab of tabs) {
+    if (typeof tab.id !== "number") continue;
+    try {
+      await chrome.tabs.sendMessage(tab.id, msg);
+    } catch (err) {
+      console.warn(`[meet-ext] tabs.sendMessage to tab ${tab.id} failed:`, err);
+    }
+  }
+}

--- a/skills/meet-join/meet-controller-ext/src/messaging/native-port.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/native-port.ts
@@ -1,0 +1,177 @@
+/**
+ * Thin wrapper around `chrome.runtime.connectNative("com.vellum.meet")` that
+ *
+ *   - validates every inbound frame as {@link BotToExtensionMessage} and every
+ *     outbound frame as {@link ExtensionToBotMessage};
+ *   - surfaces protocol-level errors via `onDisconnect(reason)` and attempts
+ *     auto-reconnect with exponential backoff;
+ *   - throws synchronously on malformed outbound messages so bugs in the
+ *     extension surface at the call site rather than as silent drops on the
+ *     native side.
+ *
+ * Backoff strategy: start at `reconnectBaseMs`, double after each disconnect
+ * (capped at `reconnectMaxMs`), and reset back to `reconnectBaseMs` on the
+ * first successful inbound message.
+ */
+import {
+  BotToExtensionMessageSchema,
+  ExtensionToBotMessageSchema,
+  type BotToExtensionMessage,
+  type ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+
+/** Name of the native-messaging host the extension connects to. */
+export const NATIVE_HOST_NAME = "com.vellum.meet";
+
+/** Default starting backoff between reconnect attempts. */
+export const DEFAULT_RECONNECT_BASE_MS = 500;
+
+/** Default maximum backoff between reconnect attempts. */
+export const DEFAULT_RECONNECT_MAX_MS = 5_000;
+
+/** Options accepted by {@link openNativePort}. */
+export interface OpenNativePortOptions {
+  /** Starting backoff (milliseconds) after a disconnect. Defaults to 500ms. */
+  reconnectBaseMs?: number;
+  /** Maximum backoff (milliseconds) after repeated disconnects. Defaults to 5000ms. */
+  reconnectMaxMs?: number;
+}
+
+/** Handle returned by {@link openNativePort}. */
+export interface NativePort {
+  /** Send a validated message to the native host. Throws if `msg` is invalid. */
+  post(msg: ExtensionToBotMessage): void;
+  /** Register a callback for every validated inbound {@link BotToExtensionMessage}. */
+  onMessage(cb: (msg: BotToExtensionMessage) => void): void;
+  /**
+   * Register a callback fired whenever the underlying port disconnects, whether
+   * via transport failure, protocol error, or explicit {@link NativePort.close}.
+   */
+  onDisconnect(cb: (reason: string) => void): void;
+  /** Close the port without attempting reconnect. Idempotent. */
+  close(): void;
+}
+
+/**
+ * Open a native-messaging port to {@link NATIVE_HOST_NAME} with inbound /
+ * outbound Zod validation and exponential-backoff reconnect.
+ */
+export function openNativePort(opts: OpenNativePortOptions = {}): NativePort {
+  const baseMs = opts.reconnectBaseMs ?? DEFAULT_RECONNECT_BASE_MS;
+  const maxMs = opts.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
+
+  const messageCallbacks: Array<(msg: BotToExtensionMessage) => void> = [];
+  const disconnectCallbacks: Array<(reason: string) => void> = [];
+
+  let closed = false;
+  let currentPort: chrome.runtime.Port | null = null;
+  let currentBackoff = baseMs;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function emitDisconnect(reason: string): void {
+    for (const cb of disconnectCallbacks) {
+      try {
+        cb(reason);
+      } catch (err) {
+        console.warn("[meet-ext] onDisconnect callback threw", err);
+      }
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (closed) return;
+    if (reconnectTimer !== null) return;
+    const delay = currentBackoff;
+    currentBackoff = Math.min(currentBackoff * 2, maxMs);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      if (closed) return;
+      connect();
+    }, delay);
+  }
+
+  function connect(): void {
+    if (closed) return;
+    let port: chrome.runtime.Port;
+    try {
+      port = chrome.runtime.connectNative(NATIVE_HOST_NAME);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      emitDisconnect(`connectNative failed: ${reason}`);
+      scheduleReconnect();
+      return;
+    }
+    currentPort = port;
+
+    port.onMessage.addListener((raw: unknown) => {
+      const result = BotToExtensionMessageSchema.safeParse(raw);
+      if (!result.success) {
+        const reason = `protocol error: ${result.error.message}`;
+        // Drop this frame, tear down the port, and attempt reconnect. The
+        // native host is misbehaving; reopening the pipe is the safest
+        // response since we have no channel to negotiate recovery.
+        try {
+          port.disconnect();
+        } catch {
+          // Already gone; ignore.
+        }
+        currentPort = null;
+        emitDisconnect(reason);
+        scheduleReconnect();
+        return;
+      }
+      // Successful receipt — reset backoff to base.
+      currentBackoff = baseMs;
+      for (const cb of messageCallbacks) {
+        try {
+          cb(result.data);
+        } catch (err) {
+          console.warn("[meet-ext] onMessage callback threw", err);
+        }
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      currentPort = null;
+      const lastError = chrome.runtime.lastError;
+      const reason = lastError?.message ?? "native port disconnected";
+      emitDisconnect(reason);
+      scheduleReconnect();
+    });
+  }
+
+  connect();
+
+  return {
+    post(msg: ExtensionToBotMessage): void {
+      // Validate synchronously so programmer errors throw at the call site.
+      const parsed = ExtensionToBotMessageSchema.parse(msg);
+      if (!currentPort) {
+        throw new Error("native port not connected");
+      }
+      currentPort.postMessage(parsed);
+    },
+    onMessage(cb: (msg: BotToExtensionMessage) => void): void {
+      messageCallbacks.push(cb);
+    },
+    onDisconnect(cb: (reason: string) => void): void {
+      disconnectCallbacks.push(cb);
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (currentPort) {
+        try {
+          currentPort.disconnect();
+        } catch {
+          // Already gone; ignore.
+        }
+        currentPort = null;
+      }
+    },
+  };
+}

--- a/skills/meet-join/meet-controller-ext/tsconfig.json
+++ b/skills/meet-join/meet-controller-ext/tsconfig.json
@@ -9,10 +9,15 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "lib": ["ES2022", "DOM"],
-    "types": ["chrome"],
-    "outDir": "./dist",
-    "rootDir": "."
+    "types": ["chrome", "bun"],
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "../contracts/index.ts",
+    "../contracts/native-messaging.ts",
+    "../contracts/events.ts",
+    "../contracts/commands.ts"
+  ],
+  "exclude": ["node_modules", "dist", "../contracts/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- Adds background service worker that opens a Native Messaging port to com.vellum.meet and posts a ready handshake on boot.
- native-port.ts wraps chrome.runtime.connectNative with Zod-validated messages and auto-reconnect (exponential backoff).
- content-bridge.ts routes messages between content scripts and the native port.
- Tests cover connect, valid/invalid inbound + outbound, auto-reconnect, handshake.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 8 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
