### PR TITLE
refactor(meet-join): move dom-selectors + fixtures into meet-controller-ext

### DIFF
--- a/skills/meet-join/meet-controller-ext/AGENTS.md
+++ b/skills/meet-join/meet-controller-ext/AGENTS.md
@@ -46,3 +46,18 @@ the sibling bot's `src/`. It is the browser-side peer of the bot and
 communicates with the bot only through the Native Messaging port, using
 message shapes defined in `../contracts/`. Treat contracts as the sole
 shared surface between bot and extension.
+
+## Google Meet DOM selectors
+
+The centralized selector module lives at `src/dom/selectors.ts` and is the
+single source of truth for every CSS/attribute selector the content script
+uses against Google Meet's web UI. Matching HTML fixtures live under
+`src/dom/__tests__/fixtures/` and are exercised by
+`src/dom/__tests__/selectors.test.ts` — if a selector is added without a
+matching fixture assertion, CI fails.
+
+When Meet's DOM drifts, refresh the fixtures and bump
+`GOOGLE_MEET_SELECTOR_VERSION` in `selectors.ts`. The step-by-step refresh
+procedure is documented in `skills/meet-join/bot/README.md` §
+"Refreshing Meet DOM fixtures" for now; that README will relocate alongside
+this package later in the migration.

--- a/skills/meet-join/meet-controller-ext/bun.lock
+++ b/skills/meet-join/meet-controller-ext/bun.lock
@@ -5,12 +5,41 @@
     "": {
       "name": "@vellumai/meet-controller-ext",
       "devDependencies": {
+        "@types/bun": "1.3.9",
         "@types/chrome": "0.1.40",
+        "@types/jsdom": "28.0.1",
+        "jsdom": "29.0.2",
         "typescript": "5.9.3",
       },
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@types/chrome": ["@types/chrome@0.1.40", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA=="],
 
     "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
@@ -19,6 +48,74 @@
 
     "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
 
+    "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
+
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
+    "undici-types": ["undici-types@7.25.0", "", {}, "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
   }
 }

--- a/skills/meet-join/meet-controller-ext/package.json
+++ b/skills/meet-join/meet-controller-ext/package.json
@@ -9,7 +9,10 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "devDependencies": {
+    "@types/bun": "1.3.9",
     "@types/chrome": "0.1.40",
+    "@types/jsdom": "28.0.1",
+    "jsdom": "29.0.2",
     "typescript": "5.9.3"
   }
 }

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet chat side panel, opened.
+
+  Covers the composer (textarea + send) and a rendered message list with a
+  single message containing the sender/text/timestamp subnodes. Shape
+  approximation — see README § "Refreshing Meet DOM fixtures".
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — Chat panel</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <aside aria-label="Side panel">
+        <header>
+          <h2>In-call messages</h2>
+        </header>
+
+        <!-- Rendered message history. -->
+        <div role="list" aria-label="Chat messages">
+          <div role="listitem" data-message-id="msg-001">
+            <span data-sender-name>Alice</span>
+            <time datetime="2026-04-15T12:34:00Z">12:34 PM</time>
+            <p data-message-text>Hello everyone, welcome to the meeting.</p>
+          </div>
+        </div>
+
+        <!-- Composer. -->
+        <div class="chat-composer" role="group">
+          <textarea
+            aria-label="Send a message"
+            placeholder="Send a message"
+            rows="1"
+          ></textarea>
+          <button type="button" aria-label="Send a message">Send</button>
+        </div>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet in-meeting UI.
+
+  Includes the meeting toolbar (camera/mic/leave + chat/people panel toggles)
+  and a sample participant tile carrying the active-speaker and speaking
+  indicators. Shape approximation — see README § "Refreshing Meet DOM
+  fixtures" before relying on it as a production reference.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — In meeting</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <main aria-label="Meeting">
+        <!-- Grid of participant video tiles. -->
+        <div class="meeting-grid" role="grid" aria-label="Video tiles">
+          <!-- Active speaker tile. -->
+          <div
+            role="gridcell"
+            data-participant-tile
+            data-participant-id="p-alice"
+            data-active-speaker="true"
+          >
+            <div class="tile-name">Alice</div>
+          </div>
+          <!-- Non-speaking tile (sanity-check that the active-speaker
+               selector does not match it). -->
+          <div
+            role="gridcell"
+            data-participant-tile
+            data-participant-id="p-bob"
+            data-active-speaker="false"
+          >
+            <div class="tile-name">Bob</div>
+          </div>
+        </div>
+
+        <!-- Bottom control bar. -->
+        <div class="meeting-toolbar" role="toolbar" aria-label="Call controls">
+          <button type="button" aria-label="Turn off microphone">
+            Microphone
+          </button>
+          <button type="button" aria-label="Turn off camera">Camera</button>
+          <button type="button" aria-label="Leave call">Leave call</button>
+          <button type="button" aria-label="Show everyone">People</button>
+          <button type="button" aria-label="Chat with everyone">Chat</button>
+        </div>
+
+        <!--
+          People side panel (opened). Meet renders this as a list of
+          participant rows with per-row name, presenter, and speaking state.
+        -->
+        <aside aria-label="Side panel">
+          <div role="list" aria-label="Participants">
+            <div
+              role="listitem"
+              data-participant-id="p-alice"
+              data-is-speaking="true"
+              data-is-presenting="true"
+            >
+              <span data-participant-name>Alice</span>
+            </div>
+            <div
+              role="listitem"
+              data-participant-id="p-bob"
+              data-is-speaking="false"
+              data-is-presenting="false"
+            >
+              <span data-participant-name>Bob</span>
+            </div>
+            <div
+              role="listitem"
+              data-participant-id="p-you"
+              data-is-speaking="false"
+              data-is-presenting="false"
+            >
+              <span data-self-name>You</span>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  </body>
+</html>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<!--
+  Fixture: Google Meet prejoin screen ("Ready to join?").
+
+  Shape approximation — this is NOT a literal snapshot of production Meet;
+  it is a minimal structure that exercises the prejoin selectors in
+  `src/browser/dom-selectors.ts`. Refresh against a live Meet session when
+  Meet's DOM drifts (see README § "Refreshing Meet DOM fixtures").
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meet — Ready to join?</title>
+  </head>
+  <body>
+    <div id="yDmH0d">
+      <div role="main" aria-label="Ready to join?">
+        <h1>Ready to join?</h1>
+
+        <div class="prejoin-video-preview">
+          <video aria-hidden="true"></video>
+        </div>
+
+        <!-- Name input (shown to unauthenticated joiners). -->
+        <label>
+          <span>Your name</span>
+          <input
+            type="text"
+            aria-label="Your name"
+            autocomplete="off"
+            maxlength="60"
+            value=""
+          />
+        </label>
+
+        <!--
+          Meet shows exactly one of the two join buttons depending on the
+          meeting's admission policy. For fixture coverage we include both so
+          either selector matches.
+        -->
+        <div class="prejoin-actions" role="group">
+          <button type="button" aria-label="Ask to join">Ask to join</button>
+          <button type="button" aria-label="Join now">Join now</button>
+        </div>
+      </div>
+
+      <!--
+        Media-permission modal Meet overlays on the prejoin screen for
+        anonymous joiners. Blocks the underlying UI until the "Use microphone
+        and camera" button (or the "Continue without" link) is clicked.
+      -->
+      <div
+        role="dialog"
+        aria-label="Do you want people to see and hear you in the meeting?"
+      >
+        <button type="button" aria-label="Use microphone and camera">
+          Use microphone and camera
+        </button>
+        <button
+          type="button"
+          aria-label="Continue without microphone and camera"
+        >
+          Continue without microphone and camera
+        </button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
@@ -11,7 +11,7 @@ import {
   participantSelectors,
   prejoinSelectors,
   selectors,
-} from "../src/browser/dom-selectors.js";
+} from "../selectors.js";
 
 /**
  * Verifies every selector exported from `dom-selectors.ts` resolves against

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -2,10 +2,19 @@
  * Centralized Google Meet DOM selectors.
  *
  * This module is the single source of truth for every CSS/attribute selector
- * the meet-bot uses to interact with Google Meet's web UI. Consolidating them
- * here means that when Meet's DOM drifts (which happens frequently, often
- * without warning) we only need to patch this one file and refresh the HTML
- * fixtures under `__tests__/fixtures/`.
+ * the meet-controller extension uses to interact with Google Meet's web UI.
+ * Consolidating them here means that when Meet's DOM drifts (which happens
+ * frequently, often without warning) we only need to patch this one file and
+ * refresh the HTML fixtures under `__tests__/fixtures/`.
+ *
+ * ## Consumers
+ *
+ * The selectors are consumed by the extension's content script (`src/content.ts`
+ * and the `src/features/*` modules), which runs in Meet's page world and reads
+ * the live DOM directly via `document.querySelector*`. This replaces the
+ * previous Playwright-driven browser-side helpers that lived in the meet-bot
+ * package — those helpers and their selectors have been retired in favor of a
+ * Manifest V3 content script that operates on the same page in-process.
  *
  * ## Conventions
  *
@@ -17,19 +26,20 @@
  *   selector and tag the constant with `// TODO(meet-dom)`. These are the
  *   candidates most likely to break on the next Meet refresh and should be
  *   re-verified each time fixtures are recaptured.
- * - Every selector MUST be exercised by a fixture in `dom-selectors.test.ts`.
+ * - Every selector MUST be exercised by a fixture in `__tests__/selectors.test.ts`.
  *   If a new selector is added without a matching fixture assertion, the test
  *   suite will fail.
  *
- * ## Downstream consumers
+ * ## Downstream consumers (inside this package)
  *
- * - PR 11 — join flow (prejoin selectors)
- * - PR 12 — participant scraper (participant selectors)
- * - PR 13 — speaker scraper (active-speaker selector)
- * - PR 14 — chat reader (chat selectors)
+ * - `src/features/join.ts` — prejoin surface selectors
+ * - `src/features/participants.ts` — participant panel selectors
+ * - `src/features/speaker.ts` — active-speaker indicator
+ * - `src/features/chat.ts` — chat panel selectors
  *
- * See `README.md` § "Refreshing Meet DOM fixtures" for the manual refresh
- * process.
+ * See `skills/meet-join/bot/README.md` § "Refreshing Meet DOM fixtures" for
+ * the manual refresh process. (That documentation will relocate alongside the
+ * extension when the bot's README is rewritten later in the migration.)
  */
 
 /**

--- a/skills/meet-join/meet-controller-ext/tsconfig.json
+++ b/skills/meet-join/meet-controller-ext/tsconfig.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "lib": ["ES2022", "DOM"],
-    "types": ["chrome"],
+    "types": ["bun", "chrome"],
     "outDir": "./dist",
     "rootDir": "."
   },


### PR DESCRIPTION
## Summary
- Moves DOM selectors + HTML fixtures from bot/src/browser/dom-selectors.ts into meet-controller-ext/src/dom/.
- Tests port with updated import paths; jsdom + @types/jsdom added as dev deps to the extension package.
- Bot-side fixture copies kept through the transition (removed in PR 15 alongside the rest of bot/src/browser/*).
- Also added @types/bun and `"bun"` to tsconfig types so the new bun:test file can typecheck from the ext package — required for step-8 acceptance and matches the pattern the later PRs (9-12) will follow when porting more bot tests into this package.

## Known breakage through the transition
- bot/src/browser/{chat-bridge,chat-reader,join-flow,participant-scraper,speaker-scraper}.ts still import `./dom-selectors.js` and will fail to resolve until PR 15 deletes them. Likewise bot/__tests__/{chat-loopback,chat-reader,join-flow,participant-scraper}.test.ts. The plan explicitly scheduled this transient breakage (PR 4 plan §6) and cleanup lands in PR 15.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 4 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
