### PR TITLE
fix(memory): remove dead turn1UserQueryBias flag

### DIFF
--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -225,15 +225,6 @@ const MemoryContextLoadInjectionSchema = z
       .describe(
         "Reserved slots for skill/CLI capability nodes at conversation start",
       ),
-    turn1UserQueryBias: z
-      .boolean({
-        error:
-          "memory.retrieval.injection.contextLoad.turn1UserQueryBias must be a boolean",
-      })
-      .default(true)
-      .describe(
-        "When true (default), embed the first user message as a dedicated query vector used to rank skill/CLI capability reserve slots on turn 1, instead of relying on the summary-based query. Summaries still drive organic memory retrieval. Set false to revert to summary-dominant ranking.",
-      ),
   })
   .describe("Memory injection limits at conversation start");
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for turn1-skill-query-bias.md.

**Gap:** Dead feature flag. PR 6 (#26568) removed the only code path that read `turn1UserQueryBias` from `conversation-graph-memory.ts` when it flipped the default to `true` and removed the legacy `unshift` branch. The schema entry remained with a describe string promising `"Set false to revert to summary-dominant ranking"`, but the flag had no effect.

**Fix:** Delete the flag entirely from the schema. The dual-query behavior is now permanent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
