### PR TITLE
fix(memory): always embed userQuery; fix sparse pair; update stale comment

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -662,7 +662,12 @@ export async function runAgentLoopImpl(
       );
       runMessages = graphResult.runMessages;
       pkbQueryVector = graphResult.userQueryVector ?? graphResult.queryVector;
-      pkbSparseVector = graphResult.sparseVector;
+      // Reset sparse vector when the dense vector came from `userQueryVector` —
+      // there is no matching user-query sparse vector today, and pairing a
+      // user-query dense with a summary-aligned sparse is incorrect.
+      pkbSparseVector = graphResult.userQueryVector
+        ? undefined
+        : graphResult.sparseVector;
 
       // Persist the injected block text in message metadata so it survives
       // conversation reloads (eviction, restart, fork). loadFromDb re-injects

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -368,12 +368,15 @@ describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
     expect(reservedIds.has(heartbeatNodeId)).toBe(true);
   });
 
-  test("short-circuits the dedicated embed when userQuery dominates summary length", async () => {
+  test("always embeds userQuery when provided (no length-based short-circuit)", async () => {
     embedRouter = keywordEmbedRouter;
     searchRouter = vectorSearchRouter;
 
-    // Summary is short, user query is much longer (>= half summary length)
-    // so the short-circuit kicks in and we only pay for the summary embed.
+    // Summary is short and the user query is much longer — in the pre-PR-6
+    // world the length-ratio guard would have skipped the dedicated embed
+    // here. After PR 6 removed the firstUserText unshift, summaries and the
+    // user query are disjoint signals, so we always pay for both embeds
+    // when a userQuery is present.
     const result = await loadContextMemory({
       scopeId: "default",
       recentSummaries: ["hi"],
@@ -382,7 +385,35 @@ describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
       config: DUAL_QUERY_CONFIG,
     });
 
-    expect(result.userQueryVector).toBeUndefined();
+    expect(result.userQueryVector).toBeDefined();
+    expect(embedCallCount).toBe(2);
+  });
+
+  test("skips the dedicated embed when userQuery is missing or empty", async () => {
+    embedRouter = keywordEmbedRouter;
+    searchRouter = vectorSearchRouter;
+
+    // No userQuery → only the summary embed runs.
+    const missing = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(missing.userQueryVector).toBeUndefined();
+    expect(embedCallCount).toBe(1);
+
+    // Reset and verify the same holds for a whitespace-only userQuery.
+    embedCallCount = 0;
+
+    const blank = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries: [LONG_HEARTBEAT_SUMMARY],
+      userQuery: "   ",
+      config: DUAL_QUERY_CONFIG,
+    });
+
+    expect(blank.userQueryVector).toBeUndefined();
     expect(embedCallCount).toBe(1);
   });
 });

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -413,14 +413,12 @@ export async function loadContextMemory(
   let embeddingProvider: string | null = null;
   let embeddingModel: string | null = null;
   let contextQueryText: string | null = null;
-  let truncatedSummaryLength = 0;
   if (opts.recentSummaries.length > 0) {
     try {
       const queryText = opts.recentSummaries.join("\n\n");
       const truncated =
         queryText.length > 3000 ? queryText.slice(0, 3000) : queryText;
       contextQueryText = truncated;
-      truncatedSummaryLength = truncated.length;
       const result = await embedWithRetry(opts.config, [truncated], {
         signal: opts.signal,
       });
@@ -432,22 +430,18 @@ export async function loadContextMemory(
     }
   }
 
-  // 1b. (PR 3) Dedicated user-query embedding. When `opts.userQuery` is
-  //     provided and materially shorter than the summary query, embed it
-  //     independently and use the resulting vector for capability-reserve
-  //     ranking + as a merged candidate pool. Skipped when the user query
-  //     already dominates the summary text to avoid paying for a redundant
-  //     embed call.
+  // 1b. (PR 3) Dedicated user-query embedding. Always run the dedicated
+  //     user-query embed when a user query is present. Summaries and the
+  //     user query are now disjoint signals (the unshift was removed in
+  //     PR 6), so there is no redundancy between the two vectors — the
+  //     length-ratio short-circuit that previously lived here was written
+  //     against pre-PR-6 semantics and would drop the embed precisely in
+  //     the workloads that benefit most (short summaries + substantive
+  //     user question).
   let userQueryVector: number[] | null = null;
   const userQueryCandidateIds = new Map<string, number>(); // nodeId → score
   const trimmedUserQuery = opts.userQuery?.trim() ?? "";
-  const shouldEmbedUserQuery =
-    trimmedUserQuery.length > 0 &&
-    // Short-circuit: when there is a summary query, only embed user query if
-    // it's less than half the summary length (otherwise it already dominates).
-    // If there's no summary query, always embed the user query on its own.
-    (truncatedSummaryLength === 0 ||
-      trimmedUserQuery.length < truncatedSummaryLength / 2);
+  const shouldEmbedUserQuery = trimmedUserQuery.length > 0;
   if (shouldEmbedUserQuery) {
     try {
       const result = await embedWithRetry(opts.config, [trimmedUserQuery], {
@@ -519,7 +513,7 @@ export async function loadContextMemory(
   });
   for (const node of topSignificance) {
     if (!semanticCandidateIds.has(node.id)) {
-      semanticCandidateIds.set(node.id, 0); // no semantic score, ranked by significance
+      semanticCandidateIds.set(node.id, 0); // no score from either Qdrant query, ranked by significance only
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes three gaps identified during plan review for turn1-skill-query-bias.md.

**Gap A — length-ratio short-circuit invalidated.** The guard `userQuery.length < summaryLength / 2` was valid when `firstUserText` was unshifted into `recentSummaries` (the summary embed contained the user query). PR 6 removed the unshift, so summaries and the user query are now disjoint signals. The guard now drops the user-query embed precisely in the workloads that benefit most (short summaries + substantive user question). Dropped the length check; always embed a non-empty user query. Regression test updated to match — it now asserts `embedCallCount === 2` whenever `userQuery` is present, and preserves the `=== 1` assertion for the empty-userQuery path.

**Gap B — sparse vector mispair.** `pkbQueryVector` prefers `userQueryVector` over `queryVector`, but `pkbSparseVector` was always `sparseVector` (summary-aligned). Pairing a user-query dense vector with a summary-aligned sparse vector is incorrect by construction. Reset `pkbSparseVector` to `undefined` when `userQueryVector` is used.

**Gap C — stale comment.** The `semanticCandidateIds.set(node.id, 0)` comment in `retriever.ts` no longer describes the general state now that the map can carry user-query scores. Tightened to 'no score from either Qdrant query, ranked by significance only'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
