### PR TITLE
feat(meet-bot): register native-messaging host manifest in Chrome search path

### DIFF
--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -83,6 +83,23 @@ RUN bun install --frozen-lockfile
 
 COPY skills/meet-join/bot/src ./src
 
+# Native-messaging host registration: copy the manifest template + renderer
+# script into the image, then render the manifest with the extension's ID
+# baked in (derived from the sibling extension package's public key). The
+# rendered file lands at Chrome's well-known search path so Chromium picks
+# it up automatically when it boots inside the container.
+COPY skills/meet-join/bot/native-messaging ./native-messaging
+COPY skills/meet-join/bot/scripts/render-nmh-manifest.ts ./scripts/render-nmh-manifest.ts
+COPY skills/meet-join/meet-controller-ext/manifest.json /tmp/ext-manifest.json
+
+RUN mkdir -p /etc/opt/chrome/native-messaging-hosts \
+  && bun scripts/render-nmh-manifest.ts \
+       /etc/opt/chrome/native-messaging-hosts/com.vellum.meet.json \
+       --ext-manifest /tmp/ext-manifest.json \
+       --template /app/bot/native-messaging/com.vellum.meet.json \
+  && chmod +x /app/bot/src/native-messaging/nmh-shim.ts \
+  && rm /tmp/ext-manifest.json
+
 # The PulseAudio bootstrap script is shelled out to at container start by
 # `src/media/pulse.ts`; ensure the executable bit is set in the image so the
 # runtime `bash` invocation succeeds. The script is NOT run at build time —

--- a/skills/meet-join/bot/Dockerfile.dockerignore
+++ b/skills/meet-join/bot/Dockerfile.dockerignore
@@ -38,3 +38,11 @@ skills/meet-join/bot/__tests__
 skills/meet-join/contracts/node_modules
 skills/meet-join/contracts/dist
 skills/meet-join/contracts/__tests__
+
+# Un-ignore the sibling extension package's manifest.json — the Dockerfile
+# copies it to /tmp at build time so the render script can extract the
+# public key and derive the extension ID that pins `allowed_origins` in the
+# rendered native-messaging host manifest. We only need the manifest
+# itself, not the ext's full source tree.
+!skills/meet-join/meet-controller-ext
+!skills/meet-join/meet-controller-ext/manifest.json

--- a/skills/meet-join/bot/__tests__/render-nmh-manifest.test.ts
+++ b/skills/meet-join/bot/__tests__/render-nmh-manifest.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the native-messaging-host manifest renderer.
+ *
+ * Covers:
+ *   - Chrome extension-ID derivation (SHA-256 of SPKI DER → first 16 bytes
+ *     expanded to nibbles → 'a' + nibble).
+ *   - `{{EXT_ID}}` placeholder substitution in the template string.
+ *   - Agreement with the committed `meet-controller-ext/manifest.json.key`,
+ *     so a key rotation in that manifest deliberately breaks this test and
+ *     forces the operator to regenerate the ID reference.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  computeExtensionId,
+  renderManifest,
+} from "../scripts/render-nmh-manifest.js";
+
+/**
+ * Reference implementation used to corroborate `computeExtensionId`.
+ *
+ * This intentionally mirrors the Chrome spec
+ * (https://developer.chrome.com/docs/extensions/mv3/manifest/key) rather
+ * than importing from the module under test: we want the test to fail if
+ * someone later "optimizes" the production implementation in a way that
+ * silently diverges from Chrome's computation.
+ */
+function referenceExtensionId(keyBase64: string): string {
+  const der = Buffer.from(keyBase64, "base64");
+  const hash = createHash("sha256").update(der).digest("hex");
+  const first32 = hash.slice(0, 32);
+  let id = "";
+  for (const c of first32) {
+    const v = parseInt(c, 16);
+    id += String.fromCharCode(97 + v);
+  }
+  return id;
+}
+
+describe("computeExtensionId", () => {
+  test("matches a hand-computed reference value for a known public key", () => {
+    // Generated locally from a throwaway RSA-2048 keypair — value fixed so
+    // the test is independent of the committed extension manifest.
+    const key =
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7HeRDjffv54OgiXEqgqmwhpIo9cruNnF3vscK/Ubn8vENJPp4TSUP2ZVfoWBUVONT5HtKvkYsJJjavokdGMuaRKm9xfdri/WWB+qJRePsGEdTYtNxD5Vrw+c5X6g3S0irNLbqTWGM9++Xn67hYSOKHdDVeKWZGbC6PdqYrTOaB1YHLKp+MulWMgoE4bDc+aWc58LOmhngAbRWreofNM/9Xomazm2TJ5/2zYikaEpRCT1JC3zpLTGfuRroZ2Ln5ut3zphp1aa1z4smViwsFVLUnhLKgWwSv2xPkRRHv5CE5FBDXjvgHNernlD9hn3EZisq3u4Z09C6D2qayC5/IxecQIDAQAB";
+    const expected = "ckneaobnfimaenmllkigpibjgkaeolnf";
+    expect(computeExtensionId(key)).toBe(expected);
+    // Belt-and-suspenders: the reference implementation agrees.
+    expect(referenceExtensionId(key)).toBe(expected);
+  });
+
+  test("matches the reference implementation for the committed ext manifest key", async () => {
+    const extManifestPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "meet-controller-ext",
+      "manifest.json",
+    );
+    const raw = await readFile(extManifestPath, "utf8");
+    const manifest = JSON.parse(raw) as { key: string };
+    expect(typeof manifest.key).toBe("string");
+    const expected = referenceExtensionId(manifest.key);
+    expect(computeExtensionId(manifest.key)).toBe(expected);
+    // Output shape: 32 lowercase characters in the a..p range.
+    expect(expected).toMatch(/^[a-p]{32}$/);
+  });
+
+  test("rejects empty input", () => {
+    expect(() => computeExtensionId("")).toThrow(/non-empty/);
+    expect(() => computeExtensionId("   ")).toThrow(/non-empty/);
+  });
+});
+
+describe("renderManifest", () => {
+  test("substitutes {{EXT_ID}} into a template string", () => {
+    const template = JSON.stringify({
+      name: "com.vellum.meet",
+      allowed_origins: ["chrome-extension://{{EXT_ID}}/"],
+    });
+    const rendered = renderManifest(template, "abcdefghijklmnopabcdefghijklmnop");
+    const parsed = JSON.parse(rendered) as { allowed_origins: string[] };
+    expect(parsed.allowed_origins).toEqual([
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop/",
+    ]);
+  });
+
+  test("replaces every occurrence of the placeholder", () => {
+    const template =
+      "{{EXT_ID}} and again {{EXT_ID}} and yet again {{EXT_ID}}";
+    const rendered = renderManifest(template, "ID");
+    expect(rendered).toBe("ID and again ID and yet again ID");
+  });
+
+  test("is a no-op when the placeholder is absent", () => {
+    const template = '{"name":"com.vellum.meet"}';
+    expect(renderManifest(template, "anything")).toBe(template);
+  });
+});
+
+describe("render integration", () => {
+  test("template + computed id yields a well-formed NMH manifest", async () => {
+    const templatePath = resolve(
+      import.meta.dir,
+      "..",
+      "native-messaging",
+      "com.vellum.meet.json",
+    );
+    const extManifestPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "meet-controller-ext",
+      "manifest.json",
+    );
+    const template = await readFile(templatePath, "utf8");
+    const extManifest = JSON.parse(
+      await readFile(extManifestPath, "utf8"),
+    ) as { key: string };
+    const extId = computeExtensionId(extManifest.key);
+    const rendered = renderManifest(template, extId);
+    const parsed = JSON.parse(rendered) as {
+      name: string;
+      type: string;
+      path: string;
+      allowed_origins: string[];
+    };
+    expect(parsed.name).toBe("com.vellum.meet");
+    expect(parsed.type).toBe("stdio");
+    expect(parsed.path).toBe("/app/bot/src/native-messaging/nmh-shim.ts");
+    expect(parsed.allowed_origins).toEqual([
+      `chrome-extension://${extId}/`,
+    ]);
+  });
+});

--- a/skills/meet-join/bot/native-messaging/com.vellum.meet.json
+++ b/skills/meet-join/bot/native-messaging/com.vellum.meet.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.vellum.meet",
+  "description": "Vellum Meet Controller native host",
+  "path": "/app/bot/src/native-messaging/nmh-shim.ts",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://{{EXT_ID}}/"]
+}

--- a/skills/meet-join/bot/scripts/render-nmh-manifest.ts
+++ b/skills/meet-join/bot/scripts/render-nmh-manifest.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env bun
+/**
+ * render-nmh-manifest — emit a Chrome native-messaging host manifest with
+ * `{{EXT_ID}}` replaced by the extension ID derived from the sibling
+ * `meet-controller-ext` package's public key.
+ *
+ * Invoked at image-build time from `skills/meet-join/bot/Dockerfile` so the
+ * rendered file lands at Chrome's well-known search path
+ * (`/etc/opt/chrome/native-messaging-hosts/com.vellum.meet.json`) inside the
+ * bot image. The Chrome extension's `allowed_origins` entry pins the bot's
+ * native host to only accept connections from the extension whose SPKI
+ * public-key matches the `key` field committed to
+ * `meet-controller-ext/manifest.json`.
+ *
+ * Entry points:
+ *   - CLI: `bun scripts/render-nmh-manifest.ts <output-path> [--ext-manifest <path>]`
+ *   - Library: exported `computeExtensionId` and `renderManifest` helpers.
+ *
+ * The extension-ID math follows Chrome's documented derivation:
+ *   https://developer.chrome.com/docs/extensions/mv3/manifest/key
+ * Concretely: SHA-256 the DER-encoded SubjectPublicKeyInfo (the base64 body
+ * of `manifest.json.key`), take the first 16 bytes of the hash, split each
+ * byte into its high and low nibbles, and emit `'a' + nibble` — yielding a
+ * 32-character lowercase a-p string.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Default location of the sibling extension's manifest relative to THIS
+ * script. Used by the CLI when `--ext-manifest` is not supplied so local
+ * dev invocations (outside Docker) work without extra flags.
+ */
+const DEFAULT_EXT_MANIFEST_PATH = resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "meet-controller-ext",
+  "manifest.json",
+);
+
+/**
+ * Default location of the bot's NMH template relative to THIS script.
+ */
+const DEFAULT_TEMPLATE_PATH = resolve(
+  import.meta.dir,
+  "..",
+  "native-messaging",
+  "com.vellum.meet.json",
+);
+
+/**
+ * Compute the Chrome extension ID that Chromium will derive from a given
+ * base64-encoded SPKI public key. See file header for the algorithm.
+ *
+ * @throws if `keyBase64` is empty or cannot be base64-decoded into a
+ *   non-empty byte sequence.
+ */
+export function computeExtensionId(keyBase64: string): string {
+  if (typeof keyBase64 !== "string" || keyBase64.trim().length === 0) {
+    throw new Error("computeExtensionId: keyBase64 must be a non-empty string");
+  }
+  const der = Buffer.from(keyBase64, "base64");
+  if (der.byteLength === 0) {
+    throw new Error("computeExtensionId: base64 decode produced zero bytes");
+  }
+  const hash = createHash("sha256").update(der).digest();
+  // Take the first 16 bytes (32 hex chars worth of nibbles) and map each
+  // nibble to 'a'..'p' (0 -> 'a', 15 -> 'p').
+  let id = "";
+  for (let i = 0; i < 16; i += 1) {
+    const byte = hash[i]!;
+    const hi = (byte >> 4) & 0xf;
+    const lo = byte & 0xf;
+    id += String.fromCharCode(97 + hi);
+    id += String.fromCharCode(97 + lo);
+  }
+  return id;
+}
+
+/**
+ * Substitute `{{EXT_ID}}` placeholders in a template string with the given
+ * extension ID. Returns the rendered string; does not touch the filesystem.
+ */
+export function renderManifest(template: string, extId: string): string {
+  return template.replaceAll("{{EXT_ID}}", extId);
+}
+
+interface CliArgs {
+  outputPath: string;
+  extManifestPath: string;
+  templatePath: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  // argv is process.argv.slice(2); first positional is the output path.
+  const positional: string[] = [];
+  let extManifestPath = DEFAULT_EXT_MANIFEST_PATH;
+  let templatePath = DEFAULT_TEMPLATE_PATH;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    if (arg === "--ext-manifest") {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        throw new Error("--ext-manifest requires a path argument");
+      }
+      extManifestPath = next;
+      i += 1;
+    } else if (arg.startsWith("--ext-manifest=")) {
+      extManifestPath = arg.slice("--ext-manifest=".length);
+    } else if (arg === "--template") {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        throw new Error("--template requires a path argument");
+      }
+      templatePath = next;
+      i += 1;
+    } else if (arg.startsWith("--template=")) {
+      templatePath = arg.slice("--template=".length);
+    } else if (arg.startsWith("--")) {
+      throw new Error(`unknown flag: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length === 0) {
+    throw new Error(
+      "usage: render-nmh-manifest <output-path> [--ext-manifest <path>] [--template <path>]",
+    );
+  }
+  if (positional.length > 1) {
+    throw new Error(
+      `expected exactly one positional output path; got ${positional.length}`,
+    );
+  }
+  return {
+    outputPath: positional[0]!,
+    extManifestPath,
+    templatePath,
+  };
+}
+
+async function main(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const extManifestRaw = await readFile(args.extManifestPath, "utf8");
+  const extManifest = JSON.parse(extManifestRaw) as { key?: unknown };
+  if (typeof extManifest.key !== "string" || extManifest.key.length === 0) {
+    throw new Error(
+      `ext manifest at ${args.extManifestPath} is missing a non-empty "key" field`,
+    );
+  }
+  const extId = computeExtensionId(extManifest.key);
+  const template = await readFile(args.templatePath, "utf8");
+  const rendered = renderManifest(template, extId);
+  await mkdir(dirname(args.outputPath), { recursive: true });
+  await writeFile(args.outputPath, rendered, "utf8");
+  process.stderr.write(
+    `render-nmh-manifest: wrote ${args.outputPath} (EXT_ID=${extId})\n`,
+  );
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(
+      `render-nmh-manifest: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/skills/meet-join/bot/tsconfig.json
+++ b/skills/meet-join/bot/tsconfig.json
@@ -15,6 +15,6 @@
     "rootDir": ".",
     "types": ["bun-types"]
   },
-  "include": ["src/**/*", "__tests__/**/*"],
+  "include": ["src/**/*", "__tests__/**/*", "scripts/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Adds native-messaging/com.vellum.meet.json template with {{EXT_ID}} placeholder.
- Adds scripts/render-nmh-manifest.ts: computes the Chrome extension ID from the ext's public key and substitutes into the manifest.
- Dockerfile installs the rendered manifest at /etc/opt/chrome/native-messaging-hosts/com.vellum.meet.json and chmods the shim as executable.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 6 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
