### PR TITLE
feat(meet-ext): port speaker scraper to content script

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/speaker.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/speaker.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for the DOM active-speaker scraper, content-script flavor.
+ *
+ * The content-script scraper runs directly against `document` and
+ * `MutationObserver` — there is no Playwright bridge — so the test
+ * harness is much thinner than the bot-side one: install jsdom globals
+ * before each test, mutate the fixture DOM to simulate Meet promoting /
+ * demoting participants, and assert the scraper turns those transitions
+ * into `SpeakerChangeEvent`s.
+ *
+ * Every mutation in this file goes through jsdom's real MutationObserver,
+ * so the test exercises the same observer wiring that runs in the Meet
+ * page world.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import {
+  SpeakerChangeEventSchema,
+  type SpeakerChangeEvent,
+} from "../../../contracts/index.js";
+
+import { startSpeakerScraper } from "../features/speaker.js";
+
+const FIXTURE_PATH = join(
+  import.meta.dir,
+  "..",
+  "dom",
+  "__tests__",
+  "fixtures",
+  "meet-dom-ingame.html",
+);
+
+interface JsdomHarness {
+  dom: JSDOM;
+  /** Replace the current active-speaker tile by id; `null` clears. */
+  setActiveSpeaker: (participantId: string | null) => void;
+  /** Restore the original globals and close the jsdom window. */
+  close: () => void;
+}
+
+/**
+ * Stand up a jsdom document seeded with the ingame fixture and install
+ * its `window`, `document`, and `MutationObserver` onto `globalThis` so
+ * the content-script scraper (which reads globals directly) sees a real
+ * DOM substrate. We keep the globals live for the whole test because
+ * jsdom's MutationObserver callbacks fire as microtasks that still
+ * expect `document` to be defined.
+ */
+function makeJsdomHarness(): JsdomHarness {
+  const html = readFileSync(FIXTURE_PATH, "utf8");
+  const dom = new JSDOM(html, { runScripts: "outside-only" });
+  const { window } = dom;
+
+  const previousGlobals = {
+    window: (globalThis as { window?: unknown }).window,
+    document: (globalThis as { document?: unknown }).document,
+    MutationObserver: (globalThis as { MutationObserver?: unknown })
+      .MutationObserver,
+  };
+  (globalThis as { window?: unknown }).window = window;
+  (globalThis as { document?: unknown }).document = window.document;
+  (globalThis as { MutationObserver?: unknown }).MutationObserver =
+    window.MutationObserver;
+
+  const setActiveSpeaker = (participantId: string | null): void => {
+    const tiles = window.document.querySelectorAll("[data-participant-tile]");
+    for (const tile of Array.from(tiles)) {
+      const id = tile.getAttribute("data-participant-id");
+      tile.setAttribute(
+        "data-active-speaker",
+        id === participantId ? "true" : "false",
+      );
+    }
+  };
+
+  return {
+    dom,
+    setActiveSpeaker,
+    close: () => {
+      (globalThis as { window?: unknown }).window = previousGlobals.window;
+      (globalThis as { document?: unknown }).document =
+        previousGlobals.document;
+      (globalThis as { MutationObserver?: unknown }).MutationObserver =
+        previousGlobals.MutationObserver;
+      dom.window.close();
+    },
+  };
+}
+
+/**
+ * Yield a macrotask so jsdom's MutationObserver callbacks (scheduled as
+ * microtasks) and any follow-up work can run before the test asserts.
+ */
+async function tick(ms = 5): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("startSpeakerScraper", () => {
+  let harness: JsdomHarness;
+  let events: SpeakerChangeEvent[];
+  let stopScraper: (() => void) | null = null;
+
+  beforeEach(() => {
+    harness = makeJsdomHarness();
+    events = [];
+    stopScraper = null;
+  });
+
+  afterEach(() => {
+    stopScraper?.();
+    harness.close();
+  });
+
+  test("emits the initial active speaker when the fixture already has one", async () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    // No async setup — the scraper emits the initial snapshot
+    // synchronously — but we still tick to line up with the mutation
+    // tests for consistency.
+    await tick(5);
+
+    expect(events.length).toBe(1);
+    const event = events[0]!;
+    expect(event.type).toBe("speaker.change");
+    expect(event.meetingId).toBe("meeting-1");
+    expect(event.speakerId).toBe("p-alice");
+    expect(event.speakerName).toBe("Alice");
+    // Schema compliance: timestamp must be a non-empty ISO string.
+    expect(typeof event.timestamp).toBe("string");
+    expect(event.timestamp.length).toBeGreaterThan(0);
+    // Full shape must round-trip through the wire-protocol schema.
+    expect(() => SpeakerChangeEventSchema.parse(event)).not.toThrow();
+  });
+
+  test("emits a new event when the active-speaker attribute moves to a different tile", async () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    await tick(5);
+
+    // Clear the initial Alice emission so the test focuses on transitions.
+    expect(events.length).toBe(1);
+    events.length = 0;
+
+    // Alice → Bob.
+    harness.setActiveSpeaker("p-bob");
+    await tick(10);
+
+    // Bob → Alice.
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+
+    expect(events.map((e) => e.speakerId)).toEqual(["p-bob", "p-alice"]);
+    expect(events.map((e) => e.speakerName)).toEqual(["Bob", "Alice"]);
+    for (const event of events) {
+      expect(() => SpeakerChangeEventSchema.parse(event)).not.toThrow();
+    }
+  });
+
+  test("dedupes consecutive identical activations", async () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    await tick(5);
+    expect(events.length).toBe(1);
+    events.length = 0;
+
+    // Re-emit Alice repeatedly. Meet can toggle attributes on the same
+    // tile (e.g. true→true via a DOM patch) without actually changing
+    // who's speaking; we must not amplify those into events.
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+
+    expect(events.length).toBe(0);
+  });
+
+  test("emits nothing over a static fixture (no changes)", async () => {
+    // Start with NO active speaker so even the initial-emit path is a
+    // no-op; this isolates the "no spurious events" guarantee.
+    harness.setActiveSpeaker(null);
+
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    // Wait a while to catch any spurious timers or latent observer work.
+    await tick(220);
+
+    expect(events).toEqual([]);
+  });
+
+  test("stop() silences further events even when the DOM keeps changing", async () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    await tick(5);
+    events.length = 0;
+
+    stop();
+
+    // Further attribute flips must not produce any more events.
+    harness.setActiveSpeaker("p-bob");
+    await tick(10);
+    harness.setActiveSpeaker("p-alice");
+    await tick(10);
+
+    expect(events).toEqual([]);
+  });
+
+  test("stop() is idempotent", () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "meeting-1",
+      onEvent: () => {},
+    });
+    stopScraper = stop;
+
+    stop();
+    expect(() => stop()).not.toThrow();
+  });
+
+  test("stamps the meetingId and a valid timestamp on every event", async () => {
+    const { stop } = startSpeakerScraper({
+      meetingId: "my-meeting-xyz",
+      onEvent: (event) => events.push(event),
+    });
+    stopScraper = stop;
+
+    await tick(5);
+    harness.setActiveSpeaker("p-bob");
+    await tick(10);
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    for (const event of events) {
+      expect(event.meetingId).toBe("my-meeting-xyz");
+      const parsed = new Date(event.timestamp);
+      expect(Number.isNaN(parsed.getTime())).toBe(false);
+    }
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -1,2 +1,142 @@
-// Content script entry. PRs 9-12 will add feature modules here.
+/**
+ * Meet content-script entry.
+ *
+ * Runs in the Google Meet page world at `document_idle`. Listens for
+ * {@link BotToExtensionMessage} frames forwarded by the background
+ * service worker's native-messaging bridge, and runs per-meeting
+ * feature modules once the bot asks us to join.
+ *
+ * ## Meeting session lifecycle
+ *
+ * `startMeetingSession` owns the in-page feature handles (speaker
+ * scraper today; participant scraper, chat bridge, etc. in follow-up
+ * PRs). The returned `stop()` disposes every handle. We intentionally
+ * keep this local-in-module-scope so parallel PRs can extend the
+ * factory without touching the listener wiring.
+ */
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+import { BotToExtensionMessageSchema } from "../../contracts/native-messaging.js";
+
+import {
+  startSpeakerScraper,
+  type SpeakerScraperHandle,
+} from "./features/speaker.js";
+
 console.log("[meet-ext] content script loaded on", location.href);
+
+/**
+ * Extract the meeting id from the current page URL.
+ *
+ * Google Meet URLs take the form `https://meet.google.com/<id>` where
+ * `<id>` is a short code like `abc-defg-hij`. We strip the leading slash
+ * and any trailing query so downstream consumers get a clean opaque
+ * identifier. Falls back to the full pathname when we cannot find a
+ * segment — the content script would never be injected on a non-meet
+ * URL, so any ambiguity here surfaces as a diagnostic rather than a
+ * silent mismatch.
+ */
+function deriveMeetingId(): string {
+  const path = location.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
+  return path || location.pathname;
+}
+
+interface MeetingSessionHandle {
+  stop: () => void;
+}
+
+/**
+ * Start all per-meeting scrapers + bridges for a freshly-joined meeting.
+ *
+ * Called from the bot→extension `join` handler below, after any join
+ * flow completes successfully. Additional features (participants, chat)
+ * will layer into the returned handle in subsequent PRs — extend this
+ * factory rather than the listener wiring so session teardown stays in
+ * one place.
+ */
+function startMeetingSession(meetingId: string): MeetingSessionHandle {
+  const handles: Array<{ stop: () => void }> = [];
+
+  const sendToBot = (event: ExtensionToBotMessage): void => {
+    try {
+      // Fire-and-forget — the background bridge validates and forwards
+      // to the native port. No response expected.
+      void chrome.runtime.sendMessage(event);
+    } catch (err) {
+      console.warn("[meet-ext] sendMessage failed:", err);
+    }
+  };
+
+  const speaker: SpeakerScraperHandle = startSpeakerScraper({
+    meetingId,
+    onEvent: sendToBot,
+  });
+  handles.push(speaker);
+
+  let stopped = false;
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      for (const handle of handles) {
+        try {
+          handle.stop();
+        } catch (err) {
+          console.warn("[meet-ext] handle.stop threw:", err);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Currently-active meeting session, if any. We keep at most one at a
+ * time — a fresh `join` command while a prior session is live tears
+ * down the old handles before installing new ones.
+ */
+let activeSession: MeetingSessionHandle | null = null;
+
+chrome.runtime.onMessage.addListener(
+  (
+    raw: unknown,
+    _sender: chrome.runtime.MessageSender,
+    _sendResponse: (response?: unknown) => void,
+  ): boolean => {
+    const parsed = BotToExtensionMessageSchema.safeParse(raw);
+    if (!parsed.success) {
+      // The background bridge fans out every bot→extension frame to
+      // every Meet tab, including frames intended for sibling tabs. A
+      // parse miss is expected noise; log at debug rather than warn.
+      console.debug(
+        "[meet-ext] ignoring non-bot-command message:",
+        parsed.error.message,
+      );
+      return false;
+    }
+    const msg: BotToExtensionMessage = parsed.data;
+
+    if (msg.type === "join") {
+      const meetingId = deriveMeetingId();
+      activeSession?.stop();
+      // NOTE: PR 9 will run the actual join flow (fill name, click
+      // join now, wait for leave button) before we start the session.
+      // For now we wire the scrapers directly against the current DOM
+      // so PR 11's speaker scraper is exercised end-to-end once PR 9
+      // lands. Leaving this as a single call makes the PR-9 insertion
+      // a local edit.
+      activeSession = startMeetingSession(meetingId);
+      return false;
+    }
+
+    if (msg.type === "leave") {
+      activeSession?.stop();
+      activeSession = null;
+      return false;
+    }
+
+    // `send_chat` lands in PR 12.
+    return false;
+  },
+);

--- a/skills/meet-join/meet-controller-ext/src/features/speaker.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/speaker.ts
@@ -1,0 +1,166 @@
+/**
+ * DOM active-speaker scraper, content-script flavor.
+ *
+ * Watches Google Meet's participant-tile grid for changes to the
+ * active-speaker indicator ({@link INGAME_ACTIVE_SPEAKER_INDICATOR}) and
+ * emits a {@link SpeakerChangeEvent} every time the active speaker
+ * transitions to a new participant.
+ *
+ * ## Strategy
+ *
+ * This module is the in-page descendant of the former Playwright-driven
+ * `bot/src/browser/speaker-scraper.ts`. Because the Manifest V3 content
+ * script already runs inside Meet's page world, we can install the
+ * `MutationObserver` directly against `document.body` and skip the
+ * `page.evaluate` / `page.exposeFunction` bridge. That removes the reason
+ * the bot-side scraper carried a Node-side polling fallback — the bridge
+ * no longer exists, so there is nothing to fall back from.
+ *
+ * Meet toggles `data-active-speaker="true"` on exactly one participant
+ * tile at a time. Every observed attribute change triggers a single
+ * `document.querySelector(INGAME_ACTIVE_SPEAKER_INDICATOR)` lookup to find
+ * the current active tile; we dedupe by `speakerId` so a repeat activation
+ * of the same speaker produces no event.
+ *
+ * ## Contract
+ *
+ * - Only emits events on transitions. A static fixture (no active-speaker
+ *   changes) must produce zero events, no matter how long we observe.
+ * - The initial active speaker (if any) is reported as the first event so
+ *   downstream state can be primed at scraper start.
+ * - Emits `SpeakerChangeEvent` with `timestamp` as an ISO-8601 string so
+ *   the payload validates against `SpeakerChangeEventSchema`.
+ * - `stop()` is idempotent and must not throw; subsequent invocations are
+ *   no-ops.
+ */
+
+import type { SpeakerChangeEvent } from "../../../contracts/index.js";
+
+import { INGAME_ACTIVE_SPEAKER_INDICATOR } from "../dom/selectors.js";
+
+/**
+ * Payload captured from the active-speaker tile. Kept deliberately small
+ * so the outbound `SpeakerChangeEvent` is a thin wrapper around it.
+ */
+export interface SpeakerTileSnapshot {
+  speakerId: string;
+  speakerName: string;
+}
+
+export interface SpeakerScraperOptions {
+  /** Meeting ID stamped onto every emitted event. */
+  meetingId: string;
+  /**
+   * Callback invoked with every {@link SpeakerChangeEvent} the scraper
+   * detects. In production this forwards via `chrome.runtime.sendMessage`
+   * so the background service worker can relay it over the native port;
+   * tests supply an in-memory collector.
+   */
+  onEvent: (event: SpeakerChangeEvent) => void;
+}
+
+export interface SpeakerScraperHandle {
+  /**
+   * Stop the scraper. Disconnects the observer. Idempotent — calling
+   * twice is safe.
+   */
+  stop: () => void;
+}
+
+/**
+ * Extract a {@link SpeakerTileSnapshot} from the current DOM. Returns
+ * `null` when no tile has `data-active-speaker="true"` or when the
+ * active tile lacks a stable participant id.
+ */
+function extractActiveSpeaker(doc: Document): SpeakerTileSnapshot | null {
+  const tile = doc.querySelector(INGAME_ACTIVE_SPEAKER_INDICATOR);
+  if (!tile) return null;
+  const speakerId = tile.getAttribute("data-participant-id") ?? "";
+  if (!speakerId) return null;
+  // Prefer the in-tile name label; fall back to the tile's aria / text
+  // content. Keeping this mirror-image simple — callers downstream can
+  // normalize or enrich with participant-panel info.
+  const nameEl =
+    tile.querySelector("[data-participant-name]") ??
+    tile.querySelector("[data-self-name]") ??
+    tile.querySelector(".tile-name");
+  const speakerName =
+    nameEl?.textContent?.trim() ??
+    tile.getAttribute("aria-label")?.trim() ??
+    "";
+  return { speakerId, speakerName };
+}
+
+/**
+ * Begin observing active-speaker transitions on the current page and
+ * invoke `opts.onEvent` with a fully-formed {@link SpeakerChangeEvent}
+ * on each transition.
+ *
+ * Returns `{ stop }` — the caller owns teardown.
+ */
+export function startSpeakerScraper(
+  opts: SpeakerScraperOptions,
+): SpeakerScraperHandle {
+  const { meetingId, onEvent } = opts;
+
+  // Track the last-emitted speaker so we can dedupe consecutive identical
+  // activations. `null` means we haven't emitted anything yet.
+  let lastSpeakerId: string | null = null;
+  let stopped = false;
+
+  /**
+   * Dedupe + forward. All observer callbacks (initial + every mutation)
+   * funnel through here so we can't double-emit even if Meet patches the
+   * same tile multiple times in quick succession.
+   */
+  const handleSnapshot = (snapshot: SpeakerTileSnapshot | null): void => {
+    if (stopped) return;
+    if (!snapshot) return;
+    if (snapshot.speakerId === lastSpeakerId) return;
+
+    lastSpeakerId = snapshot.speakerId;
+
+    // `SpeakerChangeEventSchema` types `timestamp` as a non-empty string,
+    // so we format "now" as ISO-8601. Downstream consumers can
+    // `Date.parse(event.timestamp)` to recover millis if needed.
+    const event: SpeakerChangeEvent = {
+      type: "speaker.change",
+      meetingId,
+      timestamp: new Date().toISOString(),
+      speakerId: snapshot.speakerId,
+      speakerName: snapshot.speakerName,
+    };
+
+    try {
+      onEvent(event);
+    } catch {
+      // Never let a caller's error crash the scraper — the caller's
+      // observability pipeline is responsible for reporting onEvent
+      // failures.
+    }
+  };
+
+  // Emit the initial active speaker (if any) so downstream state is
+  // primed. Dedupe below means this is a no-op unless the page already
+  // has a speaker highlighted at scraper-start.
+  handleSnapshot(extractActiveSpeaker(document));
+
+  const observer = new MutationObserver(() => {
+    handleSnapshot(extractActiveSpeaker(document));
+  });
+
+  observer.observe(document.body, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-active-speaker"],
+    childList: true,
+  });
+
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      observer.disconnect();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Ports bot/src/browser/speaker-scraper.ts into meet-controller-ext/src/features/speaker.ts, MutationObserver-based.
- Emits speaker.change events via chrome.runtime.sendMessage.
- Content script hooks scraper into the lifecycle-joined path.
- Tests ported from bot side with jsdom substrate.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 11 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
