### PR TITLE
feat(meet-ext): port chat reader + sender to content script

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Unit tests for `src/features/chat.ts` — jsdom-only.
+ *
+ * The content-script version of the chat reader/sender operates directly on
+ * `document` rather than going through Playwright, so we can exercise it end
+ * to end by installing a JSDOM document as the process-wide `document` /
+ * `window` pair before each test. JSDOM provides a real MutationObserver, so
+ * DOM mutations fire through the observer just as they would inside Meet.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+
+import { chatSelectors } from "../dom/selectors.js";
+import {
+  MEET_CHAT_MAX_LENGTH,
+  postConsentMessage,
+  sendChat,
+  startChatReader,
+} from "../features/chat.js";
+
+const FIXTURE_DIR = join(import.meta.dir, "..", "dom", "__tests__", "fixtures");
+const CHAT_FIXTURE = readFileSync(
+  join(FIXTURE_DIR, "meet-dom-chat.html"),
+  "utf8",
+);
+
+interface InstalledDom {
+  dom: JSDOM;
+  /** Count of times the chat panel toggle button was clicked. */
+  panelToggleClicks: () => number;
+  /** Remove the message list so ensurePanelOpen takes the click path. */
+  closePanel: () => void;
+  /** Append a rendered message <div> to the chat list. */
+  appendMessage: (opts: {
+    id: string;
+    sender: string;
+    text: string;
+    datetime?: string;
+    isSelf?: boolean;
+  }) => void;
+}
+
+/**
+ * Install a JSDOM document on `globalThis` so `chat.ts`'s bare `document` /
+ * `window` references resolve to the fixture. Also injects the panel toggle
+ * button (the chat fixture alone doesn't carry it — it lives in the in-game
+ * fixture) so `ensurePanelOpen` has something to click.
+ */
+function installChatDom(): InstalledDom {
+  const dom = new JSDOM(CHAT_FIXTURE, { runScripts: "outside-only" });
+  const window = dom.window;
+  const document = window.document;
+
+  // The chat fixture doesn't include the toolbar panel toggle; inject one so
+  // `ensurePanelOpen`'s click path has a target.
+  if (!document.querySelector(chatSelectors.PANEL_BUTTON)) {
+    const toggle = document.createElement("button");
+    toggle.setAttribute("type", "button");
+    toggle.setAttribute("aria-label", "Chat with everyone");
+    toggle.textContent = "Chat";
+    document.body.appendChild(toggle);
+  }
+
+  let toggleClicks = 0;
+  const attachToggleHandler = (): void => {
+    const toggle = document.querySelector(chatSelectors.PANEL_BUTTON);
+    if (!toggle) return;
+    toggle.addEventListener("click", () => {
+      toggleClicks += 1;
+      // If the message list has been removed, recreate it so a subsequent
+      // query succeeds.
+      if (!document.querySelector(chatSelectors.MESSAGE_LIST)) {
+        const aside = document.querySelector("aside");
+        const list = document.createElement("div");
+        list.setAttribute("role", "list");
+        list.setAttribute("aria-label", "Chat messages");
+        aside?.insertBefore(list, aside.firstChild);
+      }
+    });
+  };
+  attachToggleHandler();
+
+  // Swap the process-wide globals that `chat.ts` closes over. Keep
+  // originals so `restore()` can put them back.
+  const originals: Record<string, unknown> = {};
+  const wire = (key: string, value: unknown): void => {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    (globalThis as Record<string, unknown>)[key] = value;
+  };
+  wire("document", document);
+  wire("window", window);
+  wire("MutationObserver", window.MutationObserver);
+  wire("Event", window.Event);
+  wire("HTMLTextAreaElement", window.HTMLTextAreaElement);
+  wire("HTMLButtonElement", window.HTMLButtonElement);
+
+  const appendMessage: InstalledDom["appendMessage"] = ({
+    id,
+    sender,
+    text,
+    datetime,
+    isSelf,
+  }) => {
+    const list = document.querySelector(chatSelectors.MESSAGE_LIST);
+    if (!list) throw new Error("message list is not mounted");
+    const node = document.createElement("div");
+    node.setAttribute("role", "listitem");
+    node.setAttribute("data-message-id", id);
+    if (isSelf) node.setAttribute("data-is-self", "true");
+    const senderEl = document.createElement("span");
+    senderEl.setAttribute("data-sender-name", "");
+    senderEl.textContent = sender;
+    const timeEl = document.createElement("time");
+    timeEl.setAttribute("datetime", datetime ?? new Date().toISOString());
+    timeEl.textContent = "12:00 PM";
+    const textEl = document.createElement("p");
+    textEl.setAttribute("data-message-text", "");
+    textEl.textContent = text;
+    node.appendChild(senderEl);
+    node.appendChild(timeEl);
+    node.appendChild(textEl);
+    list.appendChild(node);
+  };
+
+  const closePanel: InstalledDom["closePanel"] = () => {
+    const list = document.querySelector(chatSelectors.MESSAGE_LIST);
+    list?.remove();
+  };
+
+  // Restore original globals on teardown. Stored on the JSDOM instance so
+  // `afterEach` can fish them back out.
+  (dom as unknown as { __restore: () => void }).__restore = () => {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) {
+        delete (globalThis as Record<string, unknown>)[k];
+      } else {
+        (globalThis as Record<string, unknown>)[k] = v;
+      }
+    }
+  };
+
+  return {
+    dom,
+    panelToggleClicks: () => toggleClicks,
+    closePanel,
+    appendMessage,
+  };
+}
+
+/** Wait for JSDOM's MutationObserver callbacks to flush. */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("startChatReader", () => {
+  let reader: { stop: () => void } | null = null;
+  let installed: InstalledDom | null = null;
+
+  beforeEach(() => {
+    reader = null;
+    installed = installChatDom();
+  });
+
+  afterEach(() => {
+    if (reader) {
+      reader.stop();
+      reader = null;
+    }
+    if (installed) {
+      (
+        installed.dom as unknown as { __restore: () => void }
+      ).__restore();
+      installed = null;
+    }
+  });
+
+  test("emits chat.inbound for pre-existing and newly-appended messages in order", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "meeting-abc",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // Fixture ships with one pre-existing message from Alice — the backfill
+    // path should surface it synchronously.
+    expect(events.length).toBe(1);
+    expect(events[0]!.type).toBe("chat.inbound");
+    const first = events[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(first.meetingId).toBe("meeting-abc");
+    expect(first.fromName).toBe("Alice");
+    expect(first.text).toBe("Hello everyone, welcome to the meeting.");
+
+    installed!.appendMessage({
+      id: "msg-002",
+      sender: "Bob",
+      text: "Good morning.",
+      datetime: "2026-04-15T12:35:00Z",
+    });
+    await flushMicrotasks();
+
+    expect(events.length).toBe(2);
+    const second = events[1] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(second.fromName).toBe("Bob");
+    expect(second.text).toBe("Good morning.");
+
+    expect(
+      events.map(
+        (e) =>
+          (e as Extract<ExtensionToBotMessage, { type: "chat.inbound" }>)
+            .fromName,
+      ),
+    ).toEqual(["Alice", "Bob"]);
+  });
+
+  test("drops messages whose sender matches selfName", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Alice",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // The fixture's pre-existing message is from "Alice" — since Alice is
+    // our self-name, it must be filtered out.
+    expect(events.length).toBe(0);
+
+    installed!.appendMessage({
+      id: "msg-002",
+      sender: "Bob",
+      text: "Hi there.",
+    });
+    await flushMicrotasks();
+    expect(events.length).toBe(1);
+    const ev = events[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(ev.fromName).toBe("Bob");
+  });
+
+  test("respects an authoritative data-is-self attribute", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      // Intentional mismatch — we're asserting the attribute alone drops
+      // the message.
+      selfName: "SomebodyElse",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // Drain the fixture's pre-existing Alice message first.
+    events.length = 0;
+
+    installed!.appendMessage({
+      id: "msg-self",
+      sender: "Renamed Bot",
+      text: "from the bot",
+      isSelf: true,
+    });
+    await flushMicrotasks();
+    expect(events.length).toBe(0);
+  });
+
+  test("dedupes messages with the same domId", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // Drop the fixture's pre-existing message from the comparison.
+    events.length = 0;
+
+    installed!.appendMessage({
+      id: "msg-dup",
+      sender: "Bob",
+      text: "ping",
+      datetime: "2026-04-15T12:36:00Z",
+    });
+    installed!.appendMessage({
+      id: "msg-dup",
+      sender: "Bob",
+      text: "ping",
+      datetime: "2026-04-15T12:36:00Z",
+    });
+    await flushMicrotasks();
+
+    expect(events.length).toBe(1);
+    const ev = events[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(ev.fromName).toBe("Bob");
+    expect(ev.text).toBe("ping");
+  });
+
+  test("clicks the panel toggle when the chat panel is closed", async () => {
+    installed!.closePanel();
+    expect(installed!.panelToggleClicks()).toBe(0);
+
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    // Exactly one click to open the panel; once open, no further clicks.
+    expect(installed!.panelToggleClicks()).toBe(1);
+
+    installed!.appendMessage({
+      id: "msg-after-open",
+      sender: "Carol",
+      text: "hello post-open",
+    });
+    await flushMicrotasks();
+    expect(events.length).toBe(1);
+    const ev = events[0] as Extract<
+      ExtensionToBotMessage,
+      { type: "chat.inbound" }
+    >;
+    expect(ev.fromName).toBe("Carol");
+  });
+
+  test("does not click the panel toggle when the panel is already open", () => {
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Bot",
+      onEvent: () => {},
+    });
+    expect(installed!.panelToggleClicks()).toBe(0);
+  });
+
+  test("stamps meetingId on every event", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "custom-meeting-xyz",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    installed!.appendMessage({
+      id: "msg-99",
+      sender: "Dave",
+      text: "yo",
+    });
+    await flushMicrotasks();
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    for (const e of events) {
+      expect(
+        (e as Extract<ExtensionToBotMessage, { type: "chat.inbound" }>)
+          .meetingId,
+      ).toBe("custom-meeting-xyz");
+    }
+  });
+
+  test("stop() is idempotent", async () => {
+    const events: ExtensionToBotMessage[] = [];
+    reader = startChatReader({
+      meetingId: "m1",
+      selfName: "Bot",
+      onEvent: (ev) => events.push(ev),
+    });
+
+    reader.stop();
+    reader.stop(); // second call must not throw
+
+    installed!.appendMessage({
+      id: "msg-after-stop",
+      sender: "Frank",
+      text: "post-stop",
+    });
+    await flushMicrotasks();
+    expect(
+      events.map(
+        (e) =>
+          (e as Extract<ExtensionToBotMessage, { type: "chat.inbound" }>)
+            .fromName,
+      ),
+    ).not.toContain("Frank");
+
+    // Null out so afterEach doesn't call stop again.
+    reader = null;
+  });
+});
+
+describe("sendChat", () => {
+  let installed: InstalledDom | null = null;
+
+  beforeEach(() => {
+    installed = installChatDom();
+  });
+
+  afterEach(() => {
+    if (installed) {
+      (
+        installed.dom as unknown as { __restore: () => void }
+      ).__restore();
+      installed = null;
+    }
+  });
+
+  test("populates the textarea and clicks the send button", async () => {
+    const doc = installed!.dom.window.document;
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
+    const sendButton = doc.querySelector<HTMLButtonElement>(
+      chatSelectors.SEND_BUTTON,
+    );
+    expect(input).not.toBeNull();
+    expect(sendButton).not.toBeNull();
+
+    let sendClicks = 0;
+    sendButton!.addEventListener("click", () => {
+      sendClicks += 1;
+    });
+
+    let inputEvents = 0;
+    input!.addEventListener("input", () => {
+      inputEvents += 1;
+    });
+
+    await sendChat("hello world");
+
+    expect(input!.value).toBe("hello world");
+    // The input event must fire so React's controlled-input handler sees
+    // the new value.
+    expect(inputEvents).toBeGreaterThanOrEqual(1);
+    expect(sendClicks).toBe(1);
+  });
+
+  test("accepts exactly 2000 characters", async () => {
+    const doc = installed!.dom.window.document;
+    const sendButton = doc.querySelector<HTMLButtonElement>(
+      chatSelectors.SEND_BUTTON,
+    );
+    let sendClicks = 0;
+    sendButton!.addEventListener("click", () => {
+      sendClicks += 1;
+    });
+
+    const text = "a".repeat(MEET_CHAT_MAX_LENGTH);
+    await sendChat(text);
+    expect(sendClicks).toBe(1);
+  });
+
+  test("throws when text exceeds the 2000-character cap", async () => {
+    const text = "b".repeat(MEET_CHAT_MAX_LENGTH + 1);
+    await expect(sendChat(text)).rejects.toThrow(/2000/);
+  });
+
+  test("throws when the chat input is missing", async () => {
+    const doc = installed!.dom.window.document;
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
+    input?.remove();
+
+    await expect(sendChat("hi")).rejects.toThrow(/chat input not found/);
+  });
+
+  test("throws when the send button is missing", async () => {
+    const doc = installed!.dom.window.document;
+    const button = doc.querySelector<HTMLButtonElement>(
+      chatSelectors.SEND_BUTTON,
+    );
+    button?.remove();
+
+    await expect(sendChat("hi")).rejects.toThrow(/send button not found/);
+  });
+});
+
+describe("postConsentMessage", () => {
+  let installed: InstalledDom | null = null;
+
+  beforeEach(() => {
+    installed = installChatDom();
+  });
+
+  afterEach(() => {
+    if (installed) {
+      (
+        installed.dom as unknown as { __restore: () => void }
+      ).__restore();
+      installed = null;
+    }
+  });
+
+  test("opens the panel (if closed) and sends the message", async () => {
+    installed!.closePanel();
+    expect(installed!.panelToggleClicks()).toBe(0);
+
+    const doc = installed!.dom.window.document;
+    let sendClicks = 0;
+    doc
+      .querySelector<HTMLButtonElement>(chatSelectors.SEND_BUTTON)!
+      .addEventListener("click", () => {
+        sendClicks += 1;
+      });
+
+    await postConsentMessage("consent please");
+
+    expect(installed!.panelToggleClicks()).toBe(1);
+    expect(sendClicks).toBe(1);
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
+    expect(input!.value).toBe("consent please");
+  });
+
+  test("does not click the panel toggle when already open", async () => {
+    expect(installed!.panelToggleClicks()).toBe(0);
+    await postConsentMessage("already open");
+    expect(installed!.panelToggleClicks()).toBe(0);
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -1,2 +1,132 @@
-// Content script entry. PRs 9-12 will add feature modules here.
+/**
+ * Content script entry point.
+ *
+ * Runs inside every `https://meet.google.com/*` tab (declared in
+ * `manifest.json`). Responsible for:
+ *
+ * - Forwarding inbound Meet chat messages to the background service worker
+ *   (which relays them over the native-messaging port as
+ *   `chat.inbound` events).
+ * - Handling `send_chat` commands dispatched from the background and
+ *   replying with `send_chat_result`.
+ *
+ * The join-flow wiring (PR 9) and participant/speaker scrapers (PRs 10-11)
+ * will hook into the same lifecycle path and share this file. Until that
+ * lands, the chat reader starts unconditionally on mount — the content
+ * script is only injected into Meet pages, so there's no risk of firing
+ * outside a meeting context.
+ */
+import type {
+  BotSendChatCommand,
+  BotToExtensionMessage,
+  ExtensionSendChatResultMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+import { BotToExtensionMessageSchema } from "../../contracts/native-messaging.js";
+
+import { sendChat, startChatReader } from "./features/chat.js";
+
 console.log("[meet-ext] content script loaded on", location.href);
+
+/**
+ * Extract the Meet meeting ID from the current URL.
+ *
+ * Meet URLs have the shape `https://meet.google.com/<code>?...`; the code
+ * segment is the meeting's opaque identifier. We use it to stamp every
+ * outbound event. Falls back to an empty string if the path is somehow
+ * unexpected — the contract schemas enforce a non-empty ID so the bot will
+ * drop the frame rather than pollute the event stream with bogus IDs.
+ */
+function currentMeetingId(): string {
+  // Meet paths: `/<code>` for new meetings, `/<code>?authuser=...`, etc.
+  const segment = location.pathname.split("/").filter(Boolean)[0] ?? "";
+  return segment;
+}
+
+/**
+ * Start the chat reader and keep the handle in module scope. When PR 9
+ * lands the join-flow hook, this will move under a `joined` lifecycle
+ * transition; until then, firing on content-script mount is safe because
+ * the content script is only injected on Meet URLs.
+ */
+const meetingId = currentMeetingId();
+if (meetingId) {
+  startChatReader({
+    meetingId,
+    // TODO(meet-ext): plumb the real bot display name through from the
+    // join command (PR 9). For now, self-filter by an empty string — the
+    // DOM-level `data-is-self="true"` path still handles the common case,
+    // and the name-based fallback kicks in once PR 9 threads the name
+    // through.
+    selfName: "",
+    onEvent: (ev: ExtensionToBotMessage) => {
+      try {
+        chrome.runtime.sendMessage(ev);
+      } catch (err) {
+        console.warn("[meet-ext] failed to forward chat event:", err);
+      }
+    },
+  });
+}
+
+/**
+ * Background -> content router. The background fans out validated
+ * {@link BotToExtensionMessage} frames to every Meet tab via
+ * `chrome.tabs.sendMessage`; this listener validates the frame against
+ * the shared schema and dispatches to the feature handler.
+ */
+chrome.runtime.onMessage.addListener(
+  (
+    raw: unknown,
+    _sender: chrome.runtime.MessageSender,
+    _sendResponse: (response?: unknown) => void,
+  ): boolean => {
+    const result = BotToExtensionMessageSchema.safeParse(raw);
+    if (!result.success) {
+      // Not for us, or malformed. Either way there's nothing to do — the
+      // background is the validator on the outbound path, so a mismatch
+      // here almost always means the frame is a content-script-only ping
+      // (e.g. a future in-extension message). Log at debug level and drop.
+      return false;
+    }
+    const msg = result.data;
+    if (msg.type === "send_chat") {
+      void handleSendChat(msg);
+    }
+    // No synchronous response — all replies go back through
+    // `chrome.runtime.sendMessage` (which routes via the content bridge to
+    // the native port).
+    return false;
+  },
+);
+
+/**
+ * Execute a {@link BotSendChatCommand} and emit a matching
+ * {@link ExtensionSendChatResultMessage} back to the background. Errors
+ * are caught and surfaced via `ok: false` so the bot can correlate the
+ * failure with the originating request.
+ */
+async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
+  let reply: ExtensionSendChatResultMessage;
+  try {
+    await sendChat(cmd.text);
+    reply = {
+      type: "send_chat_result",
+      requestId: cmd.requestId,
+      ok: true,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    reply = {
+      type: "send_chat_result",
+      requestId: cmd.requestId,
+      ok: false,
+      error: message,
+    };
+  }
+  try {
+    chrome.runtime.sendMessage(reply);
+  } catch (err) {
+    console.warn("[meet-ext] failed to send send_chat_result:", err);
+  }
+}

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -1,0 +1,246 @@
+/**
+ * In-meeting chat reader + sender for the content script.
+ *
+ * Ports `skills/meet-join/bot/src/browser/chat-reader.ts` and
+ * `chat-bridge.ts` from the Playwright-driven bot into the extension. The
+ * content script runs inside Meet's page world, so we operate on `document`
+ * directly instead of going through Playwright's `page.evaluate` /
+ * `exposeFunction` bridge. That simplifies the reader (we keep a single
+ * in-process observer — no polling fallback needed) and the sender (we drive
+ * the textarea via `value` + synthetic `input` event instead of Playwright's
+ * `fill`).
+ *
+ * The exported surface matches what the rest of the extension (content.ts)
+ * and the join flow (PR 9) expect:
+ *
+ * - {@link startChatReader} — installs a `MutationObserver` on the chat
+ *   message list and emits `chat.inbound` events for every inbound message.
+ * - {@link sendChat} — types `text` into the composer and clicks send.
+ *   Enforces Meet's 2000-character limit.
+ * - {@link postConsentMessage} — thin wrapper over `sendChat` that ensures
+ *   the chat panel is open first. Invoked by the join flow once the bot
+ *   lands in the meeting room.
+ *
+ * ## Self-filter
+ *
+ * Meet renders the bot's own outbound messages back into the chat list. We
+ * drop anything whose rendered sender name matches `opts.selfName`, and we
+ * treat an authoritative `data-is-self="true"` attribute as a stronger
+ * signal when Meet exposes it.
+ *
+ * ## Dedupe
+ *
+ * The in-page observer tracks seen message DOM IDs, and we layer a second
+ * seen-set on top of the bot-side callback so panel close/reopen cycles
+ * (which reset the in-page set when the observer is reinstalled) don't
+ * double-emit the same message.
+ */
+
+import type {
+  ExtensionInboundChatMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+import { chatSelectors } from "../dom/selectors.js";
+
+/**
+ * Meet's chat composer enforces a 2000-character cap server-side. We mirror
+ * that cap here so callers get a fast, local error instead of a silent drop
+ * or a panel toast. Must stay in sync with `MEET_CHAT_MAX_LENGTH` in
+ * `skills/meet-join/bot/src/control/http-server.ts`.
+ */
+export const MEET_CHAT_MAX_LENGTH = 2000;
+
+/** Options passed to {@link startChatReader}. */
+export interface ChatReaderOptions {
+  /** Meeting ID stamped on every emitted event. */
+  meetingId: string;
+  /** The bot's display name — used to drop the bot's own messages. */
+  selfName: string;
+  /**
+   * Callback invoked for every validated {@link ExtensionToBotMessage}
+   * produced by the reader. Currently only `chat.inbound` events flow
+   * through here; the event type is widened to {@link ExtensionToBotMessage}
+   * so content.ts can forward directly to `chrome.runtime.sendMessage`
+   * without re-wrapping.
+   */
+  onEvent: (ev: ExtensionToBotMessage) => void;
+}
+
+/** Handle returned by {@link startChatReader}. */
+export interface ChatReader {
+  /**
+   * Tear down the observer. Safe to call multiple times — subsequent calls
+   * are no-ops.
+   */
+  stop: () => void;
+}
+
+/**
+ * Install a `MutationObserver` over Meet's chat panel and invoke
+ * `opts.onEvent` for every new inbound chat message.
+ *
+ * Opens the chat panel if it is currently collapsed (otherwise the message
+ * list is not mounted and the observer has nothing to watch).
+ */
+export function startChatReader(opts: ChatReaderOptions): ChatReader {
+  ensurePanelOpen();
+
+  // Bot-side dedupe keyed on the rendered `data-message-id`. The in-page
+  // seen set is reset every time the panel close/reopens and the observer
+  // re-attaches, so we keep our own set to survive those cycles.
+  const seenDomIds = new Set<string>();
+
+  const extract = (node: Element): void => {
+    const messages = node.matches(chatSelectors.MESSAGE_NODE)
+      ? [node]
+      : Array.from(node.querySelectorAll(chatSelectors.MESSAGE_NODE));
+    for (const msg of messages) {
+      const domId =
+        msg.getAttribute("data-message-id") ?? msg.getAttribute("id") ?? "";
+      if (!domId) continue;
+      if (seenDomIds.has(domId)) continue;
+
+      const senderEl = msg.querySelector(chatSelectors.MESSAGE_SENDER);
+      const textEl = msg.querySelector(chatSelectors.MESSAGE_TEXT);
+
+      const fromName = (senderEl?.textContent ?? "").trim();
+      const text = (textEl?.textContent ?? "").trim();
+      if (!fromName || !text) continue;
+
+      // Authoritative self-flag wins; otherwise match by display name.
+      const isSelf =
+        msg.getAttribute("data-is-self") === "true" ||
+        senderEl?.getAttribute("data-is-self") === "true" ||
+        fromName === opts.selfName;
+      if (isSelf) {
+        // Record the DOM id anyway so we don't re-inspect the node on the
+        // next mutation.
+        seenDomIds.add(domId);
+        continue;
+      }
+
+      // Sender-side id when Meet exposes one; otherwise fall back to the
+      // display name (stable enough within a meeting).
+      const fromId = senderEl?.getAttribute("data-sender-id") ?? fromName;
+
+      seenDomIds.add(domId);
+
+      const event: ExtensionInboundChatMessage = {
+        type: "chat.inbound",
+        meetingId: opts.meetingId,
+        // Emit bot-observation time, not Meet's sender-side timestamp. Keeps
+        // event ordering consistent with the rest of the pipeline.
+        timestamp: new Date().toISOString(),
+        fromId,
+        fromName,
+        text,
+      };
+      try {
+        opts.onEvent(event);
+      } catch {
+        // Don't let a subscriber throw kill the observer loop.
+      }
+    }
+  };
+
+  // Backfill any messages already in the DOM when the reader attaches —
+  // otherwise we'd miss the pre-existing chat history.
+  for (const existing of document.querySelectorAll(
+    chatSelectors.MESSAGE_NODE,
+  )) {
+    extract(existing);
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      for (const node of m.addedNodes) {
+        if (node.nodeType === 1) extract(node as Element);
+      }
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  let stopped = false;
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      observer.disconnect();
+    },
+  };
+}
+
+/**
+ * Type `text` into Meet's chat composer and submit it.
+ *
+ * Throws synchronously if `text` exceeds {@link MEET_CHAT_MAX_LENGTH}. If
+ * the composer input or send button is missing, throws a descriptive error.
+ * Assumes the chat panel is open — callers that need to lazily open it
+ * should use {@link postConsentMessage}.
+ */
+export async function sendChat(text: string): Promise<void> {
+  if (text.length > MEET_CHAT_MAX_LENGTH) {
+    throw new Error(
+      `text exceeds Meet chat limit of ${MEET_CHAT_MAX_LENGTH} characters (got ${text.length})`,
+    );
+  }
+
+  const input = document.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
+  if (!input) {
+    throw new Error(
+      `sendChat: chat input not found (selector: ${chatSelectors.INPUT})`,
+    );
+  }
+
+  // Meet's composer is a React-controlled textarea. Simply setting `.value`
+  // doesn't update React's internal state — we have to dispatch a synthetic
+  // `input` event so React's onChange handler picks up the new value. This
+  // mirrors the technique the bot-side `page.fill` ultimately uses under the
+  // hood through Playwright's element-handle bindings.
+  input.value = text;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+
+  const sendButton = document.querySelector<HTMLButtonElement>(
+    chatSelectors.SEND_BUTTON,
+  );
+  if (!sendButton) {
+    throw new Error(
+      `sendChat: send button not found (selector: ${chatSelectors.SEND_BUTTON})`,
+    );
+  }
+  sendButton.click();
+}
+
+/**
+ * Ensure the chat panel is open and then call {@link sendChat}.
+ *
+ * Invoked by the join flow to drop the consent notice once the bot is in
+ * the meeting. Safe to call exactly once per session — if the composer is
+ * already visible, we skip the panel-toggle click (clicking again would
+ * close the panel).
+ */
+export async function postConsentMessage(text: string): Promise<void> {
+  ensurePanelOpen();
+  await sendChat(text);
+}
+
+/**
+ * Click the chat toggle once if the panel isn't already open. Detects open
+ * state via the message-list container (mounted even when empty), not
+ * individual message nodes which require at least one message to exist.
+ */
+function ensurePanelOpen(): void {
+  if (document.querySelector(chatSelectors.MESSAGE_LIST)) return;
+  const toggle = document.querySelector<HTMLButtonElement>(
+    chatSelectors.PANEL_BUTTON,
+  );
+  if (toggle) {
+    try {
+      toggle.click();
+    } catch {
+      // Click can fail if the button is detached mid-flight; let the caller
+      // surface the downstream selector error when the composer isn't
+      // findable.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Ports chat-reader + chat-bridge from bot/src/browser/ into meet-controller-ext/src/features/chat.ts (jsdom substrate, no Playwright).
- Content script handles send_chat commands and returns send_chat_result.
- join.ts now posts the consent message at step 6 (TODO removed).
- Tests cover inbound scraping, self-filtering, sendChat round-trip, 2000-char cap.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 12 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
