### PR TITLE
feat(meet-ext): port participant scraper to content script

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/participants.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/participants.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Tests for the content-script participant scraper.
+ *
+ * Ported from `skills/meet-join/bot/__tests__/participant-scraper.test.ts`.
+ * The bot-side tests used a hand-rolled fake `Page` object that responded
+ * to the Playwright `$`/`$$eval`/`click` surface; this module runs the
+ * scraper against a real jsdom document and mutates the DOM directly to
+ * simulate Meet's participant panel changing over time.
+ *
+ * Fixture loading follows the pattern established by
+ * `src/dom/__tests__/selectors.test.ts`: load the committed HTML into a
+ * JSDOM instance and install it as the module-global `document`/`window`
+ * so the scraper's `document.querySelector*` calls resolve against it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join as joinPath } from "node:path";
+import { JSDOM } from "jsdom";
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+import type { ParticipantChangeEvent } from "../../../contracts/events.js";
+
+import { startParticipantScraper } from "../features/participants.js";
+
+const FIXTURE_DIR = joinPath(import.meta.dir, "..", "dom", "__tests__", "fixtures");
+
+interface InstalledDom {
+  dom: JSDOM;
+  uninstall: () => void;
+}
+
+/**
+ * Install a JSDOM instance as the module-global `window`/`document` so
+ * `document.querySelectorAll` inside the scraper resolves. Tests call
+ * `uninstall()` in `afterEach` to restore the previous state.
+ */
+function installDom(html: string): InstalledDom {
+  const dom = new JSDOM(html);
+  const g = globalThis as unknown as {
+    window?: unknown;
+    document?: unknown;
+    HTMLElement?: unknown;
+  };
+  const prevWindow = g.window;
+  const prevDocument = g.document;
+  const prevHTMLElement = g.HTMLElement;
+  g.window = dom.window;
+  g.document = dom.window.document;
+  // The scraper uses `nameEl instanceof HTMLElement` to check the
+  // data-self-name marker. Wire jsdom's HTMLElement into the global
+  // namespace so the instanceof check holds against jsdom-created nodes.
+  g.HTMLElement = dom.window.HTMLElement;
+  return {
+    dom,
+    uninstall: () => {
+      g.window = prevWindow;
+      g.document = prevDocument;
+      g.HTMLElement = prevHTMLElement;
+    },
+  };
+}
+
+/** Load an in-meeting fixture and install it as the active document. */
+function installIngameFixture(): InstalledDom {
+  const html = readFileSync(
+    joinPath(FIXTURE_DIR, "meet-dom-ingame.html"),
+    "utf8",
+  );
+  return installDom(html);
+}
+
+/**
+ * Minimal DOM builder for a participant panel with arbitrary rows. The
+ * bot-side tests drove the fake `Page` with plain JS objects; the
+ * content-script equivalent is to render equivalent list-item markup
+ * into a real (jsdom) document.
+ */
+interface ParticipantRowSpec {
+  id?: string | null;
+  name: string;
+  /** Use `data-self-name` instead of `data-participant-name`. */
+  isSelfByDom?: boolean;
+}
+
+function panelHtml(rows: ParticipantRowSpec[]): string {
+  const listItems = rows
+    .map((row) => {
+      const idAttr =
+        row.id === null || row.id === undefined
+          ? ""
+          : ` data-participant-id="${row.id}"`;
+      const nameAttr = row.isSelfByDom
+        ? "data-self-name"
+        : "data-participant-name";
+      return `<div role="listitem"${idAttr}><span ${nameAttr}>${row.name}</span></div>`;
+    })
+    .join("");
+  return `
+    <!doctype html>
+    <html><body>
+      <button aria-label="Show everyone"></button>
+      <div role="list" aria-label="Participants">${listItems}</div>
+    </body></html>
+  `;
+}
+
+function installPanelFixture(rows: ParticipantRowSpec[]): InstalledDom {
+  return installDom(panelHtml(rows));
+}
+
+/** Replace the participant list's children with a new row set. */
+function replaceRows(dom: JSDOM, rows: ParticipantRowSpec[]): void {
+  const list = dom.window.document.querySelector(
+    '[role="list"][aria-label="Participants"]',
+  );
+  if (!list) throw new Error("participant list not present in fixture");
+  list.innerHTML = rows
+    .map((row) => {
+      const idAttr =
+        row.id === null || row.id === undefined
+          ? ""
+          : ` data-participant-id="${row.id}"`;
+      const nameAttr = row.isSelfByDom
+        ? "data-self-name"
+        : "data-participant-name";
+      return `<div role="listitem"${idAttr}><span ${nameAttr}>${row.name}</span></div>`;
+    })
+    .join("");
+}
+
+/** Wait `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Drain a handful of microtask ticks so the synchronous initial poll fires. */
+async function drainMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/**
+ * Narrow helper — every event the scraper emits is a
+ * `participant.change`. The `ExtensionToBotMessage` union includes other
+ * variants for future use, so we cast at the point of assertion.
+ */
+function asParticipantChange(msg: ExtensionToBotMessage): ParticipantChangeEvent {
+  if (msg.type !== "participant.change") {
+    throw new Error(`expected participant.change event, got ${msg.type}`);
+  }
+  return msg;
+}
+
+describe("startParticipantScraper", () => {
+  let installed: InstalledDom | null = null;
+  let events: ExtensionToBotMessage[];
+  let handles: Array<{ stop: () => void }>;
+
+  beforeEach(() => {
+    events = [];
+    handles = [];
+  });
+
+  afterEach(() => {
+    for (const handle of handles) handle.stop();
+    if (installed) {
+      installed.uninstall();
+      installed = null;
+    }
+  });
+
+  test("emits initial snapshot with every current participant as joined", async () => {
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const initial = asParticipantChange(events[0]!);
+    expect(initial.type).toBe("participant.change");
+    expect(initial.meetingId).toBe("m-1");
+    expect(initial.left).toHaveLength(0);
+    expect(initial.joined).toHaveLength(2);
+    const joinedIds = initial.joined.map((p) => p.id).sort();
+    expect(joinedIds).toEqual(["p-alice", "p-bob"]);
+  });
+
+  test("initial snapshot reads all participants from the full in-game fixture", async () => {
+    // The committed meet-dom-ingame fixture has Alice, Bob, and "You".
+    installed = installIngameFixture();
+    const handle = startParticipantScraper({
+      meetingId: "m-ingame",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const initial = asParticipantChange(events[0]!);
+    const joinedIds = initial.joined.map((p) => p.id).sort();
+    expect(joinedIds).toEqual(["p-alice", "p-bob", "p-you"]);
+    expect(initial.left).toHaveLength(0);
+  });
+
+  test("opens the participants panel when it starts closed", async () => {
+    // No list container present — only the toggle button. The scraper
+    // should click the toggle, which our lightweight stub responds to by
+    // injecting the list container into the DOM.
+    installed = installDom(`
+      <!doctype html>
+      <html><body>
+        <button id="toggle" aria-label="Show everyone"></button>
+        <div id="holder"></div>
+      </body></html>
+    `);
+    const dom = installed.dom;
+    let toggleClicks = 0;
+    const toggle = dom.window.document.getElementById("toggle");
+    expect(toggle).not.toBeNull();
+    toggle!.addEventListener("click", () => {
+      toggleClicks += 1;
+      const holder = dom.window.document.getElementById("holder");
+      if (holder) {
+        holder.innerHTML =
+          '<div role="list" aria-label="Participants"><div role="listitem" data-participant-id="p-alice"><span data-participant-name>Alice</span></div></div>';
+      }
+    });
+
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(toggleClicks).toBe(1);
+    // After opening, the first poll sees Alice.
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const first = asParticipantChange(events[0]!);
+    expect(first.joined.map((p) => p.id)).toEqual(["p-alice"]);
+  });
+
+  test("does not re-click the toggle when the panel is already open", async () => {
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    let toggleClicks = 0;
+    const toggle = installed.dom.window.document.querySelector<HTMLElement>(
+      'button[aria-label="Show everyone"]',
+    );
+    expect(toggle).not.toBeNull();
+    toggle!.addEventListener("click", () => {
+      toggleClicks += 1;
+    });
+
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    // The list container is already present in the fixture, so the
+    // scraper should not click the toggle.
+    expect(toggleClicks).toBe(0);
+  });
+
+  test("emits only a diff event when participants change between polls", async () => {
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const dom = installed.dom;
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+
+    // Bob leaves, Carol joins.
+    replaceRows(dom, [
+      { id: "p-alice", name: "Alice" },
+      { id: "p-carol", name: "Carol" },
+    ]);
+
+    // Wait for a couple of poll intervals to elapse.
+    await sleep(80);
+
+    expect(events.length).toBe(2);
+    const diff = asParticipantChange(events[1]!);
+    expect(diff.joined.map((p) => p.id)).toEqual(["p-carol"]);
+    expect(diff.left.map((p) => p.id)).toEqual(["p-bob"]);
+    expect(diff.meetingId).toBe("m-1");
+  });
+
+  test("does not emit when the participant set is unchanged", async () => {
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+
+    // Let a few poll intervals elapse without mutating the row list.
+    await sleep(100);
+
+    expect(events.length).toBe(1);
+  });
+
+  test("stop() cancels further emissions", async () => {
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    const dom = installed.dom;
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    handle.stop();
+
+    // Mutate the DOM so a running poll *would* fire a diff event; since we
+    // stopped, the scraper must stay quiet.
+    replaceRows(dom, [
+      { id: "p-alice", name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    await sleep(100);
+
+    expect(events.length).toBe(1);
+  });
+
+  test("stop() is idempotent — calling it twice does not throw", () => {
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handle.stop();
+    expect(() => handle.stop()).not.toThrow();
+  });
+
+  test("emits an ISO timestamp in every event", async () => {
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    const before = new Date().toISOString();
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+    const after = new Date().toISOString();
+
+    const initial = asParticipantChange(events[0]!);
+    expect(initial.timestamp >= before).toBe(true);
+    expect(initial.timestamp <= after).toBe(true);
+  });
+
+  test("skips rows missing data-participant-id (the selector filters them out)", async () => {
+    // Documents a semantic difference from the bot-side fake Page: the real
+    // CSS selector `[role="listitem"][data-participant-id]` filters out
+    // partial rows. The `row.id ?? name` fallback in the scraper remains as
+    // defensive depth-in-coverage for a row whose attribute somehow reads
+    // back as null despite the selector matching — not expected in practice
+    // but cheap to keep.
+    installed = installPanelFixture([
+      // No data-participant-id → skipped by the selector.
+      { id: null, name: "Alice" },
+      { id: "p-bob", name: "Bob" },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const initial = asParticipantChange(events[0]!);
+    const joinedIds = initial.joined.map((p) => p.id).sort();
+    expect(joinedIds).toEqual(["p-bob"]);
+  });
+
+  test("restarting a scraper on the same DOM re-emits its initial snapshot", async () => {
+    // Simulates the idempotency requirement: if a caller stops and restarts
+    // the scraper on a DOM it has already seen, the *restart* should emit
+    // its initial snapshot but downstream consumers are responsible for
+    // matching against their own state. The scraper itself treats each
+    // lifecycle as independent — this test just pins that expectation.
+    installed = installPanelFixture([{ id: "p-alice", name: "Alice" }]);
+    const first = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    await sleep(50);
+    first.stop();
+    const afterFirst = events.length;
+
+    // Restart — re-emits initial snapshot once, then stays quiet while the
+    // DOM is unchanged.
+    const second = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 30,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(second);
+    await sleep(100);
+
+    // One new emission (the restart's initial snapshot), no spurious join/leave
+    // churn from the already-known participants.
+    expect(events.length - afterFirst).toBe(1);
+    const restart = asParticipantChange(events[events.length - 1]!);
+    expect(restart.left).toHaveLength(0);
+    expect(restart.joined.map((p) => p.id)).toEqual(["p-alice"]);
+  });
+
+  // --------------------------------------------------------------------
+  // isSelf detection — lets the consent monitor identify the bot's own
+  // participant id so bot-self transcripts and chat (e.g. the consent
+  // message) don't advance the watermark.
+  // --------------------------------------------------------------------
+
+  test("flags the bot's own row via Meet's data-self-name DOM marker", async () => {
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bot", name: "AI Assistant", isSelfByDom: true },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      selfName: "AI Assistant",
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = asParticipantChange(events[0]!).joined;
+    const alice = joined.find((p) => p.id === "p-alice");
+    const bot = joined.find((p) => p.id === "p-bot");
+    expect(alice?.isSelf).toBeUndefined();
+    expect(bot?.isSelf).toBe(true);
+  });
+
+  test("flags the bot's own row by display-name match when DOM marker is absent", async () => {
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bot", name: "Aria", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      selfName: "Aria",
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = asParticipantChange(events[0]!).joined;
+    const bot = joined.find((p) => p.name === "Aria");
+    expect(bot?.isSelf).toBe(true);
+    const alice = joined.find((p) => p.id === "p-alice");
+    expect(alice?.isSelf).toBeUndefined();
+  });
+
+  test("does not flag any row when selfName is omitted and no DOM marker is present", async () => {
+    installed = installPanelFixture([
+      { id: "p-alice", name: "Alice", isSelfByDom: false },
+      { id: "p-bob", name: "Bob", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = asParticipantChange(events[0]!).joined;
+    for (const p of joined) {
+      expect(p.isSelf).toBeUndefined();
+    }
+  });
+
+  test("prefers the DOM marker even when a row's name happens to equal selfName", async () => {
+    installed = installPanelFixture([
+      { id: "p-bot", name: "AI Assistant", isSelfByDom: true },
+      { id: "p-imposter", name: "AI Assistant", isSelfByDom: false },
+    ]);
+    const handle = startParticipantScraper({
+      meetingId: "m-1",
+      pollMs: 50,
+      selfName: "AI Assistant",
+      onEvent: (ev) => events.push(ev),
+    });
+    handles.push(handle);
+    await drainMicrotasks();
+    await sleep(10);
+
+    expect(events.length).toBe(1);
+    const joined = asParticipantChange(events[0]!).joined;
+    expect(joined.find((p) => p.id === "p-bot")?.isSelf).toBe(true);
+    // The name-colliding row is also flagged by the name-fallback — this
+    // is a known limitation of the fallback and the reason we prefer the
+    // DOM marker when both are available.
+    expect(joined.find((p) => p.id === "p-imposter")?.isSelf).toBe(true);
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -8,11 +8,11 @@
  *
  * ## Meeting session lifecycle
  *
- * `startMeetingSession` owns the in-page feature handles (speaker
- * scraper, chat reader today; participant scraper in a follow-up PR).
- * The returned `stop()` disposes every handle. We intentionally keep
- * this local-in-module-scope so parallel PRs can extend the factory
- * without touching the listener wiring.
+ * `startMeetingSession` owns the in-page feature handles (participant
+ * scraper, speaker scraper, chat reader). The returned `stop()` disposes
+ * every handle. We intentionally keep this local-in-module-scope so
+ * parallel PRs can extend the factory without touching the listener
+ * wiring.
  */
 import type {
   BotSendChatCommand,
@@ -27,6 +27,10 @@ import {
   sendChat,
   startChatReader,
 } from "./features/chat.js";
+import {
+  startParticipantScraper,
+  type ParticipantScraperHandle,
+} from "./features/participants.js";
 import {
   startSpeakerScraper,
   type SpeakerScraperHandle,
@@ -56,8 +60,8 @@ interface MeetingSessionHandle {
 
 /**
  * Options carried through to the session factory. `displayName` comes
- * from the bot's `join` command so the chat reader can self-filter the
- * bot's own outbound messages.
+ * from the bot's `join` command so the chat reader and participant
+ * scraper can self-filter the bot's own outbound activity.
  */
 interface MeetingSessionOptions {
   meetingId: string;
@@ -68,9 +72,9 @@ interface MeetingSessionOptions {
  * Start all per-meeting scrapers + bridges for a freshly-joined meeting.
  *
  * Called from the bot→extension `join` handler below, after any join
- * flow completes successfully. Additional features (participants) will
- * layer into the returned handle in subsequent PRs — extend this factory
- * rather than the listener wiring so session teardown stays in one place.
+ * flow completes successfully. Additional features layer into the
+ * returned handle — extend this factory rather than the listener wiring
+ * so session teardown stays in one place.
  */
 function startMeetingSession(
   opts: MeetingSessionOptions,
@@ -86,6 +90,13 @@ function startMeetingSession(
       console.warn("[meet-ext] sendMessage failed:", err);
     }
   };
+
+  const participants: ParticipantScraperHandle = startParticipantScraper({
+    meetingId: opts.meetingId,
+    selfName: opts.displayName,
+    onEvent: sendToBot,
+  });
+  handles.push(participants);
 
   const speaker: SpeakerScraperHandle = startSpeakerScraper({
     meetingId: opts.meetingId,
@@ -148,9 +159,9 @@ chrome.runtime.onMessage.addListener(
       // NOTE: PR 9 will run the actual join flow (fill name, click
       // join now, wait for leave button) before we start the session.
       // For now we wire the scrapers directly against the current DOM
-      // so PR 11's speaker scraper is exercised end-to-end once PR 9
-      // lands. Leaving this as a single call makes the PR-9 insertion
-      // a local edit.
+      // so the participant/speaker/chat features are exercised end-to-end
+      // once PR 9 lands. Leaving this as a single call makes the PR-9
+      // insertion a local edit.
       activeSession = startMeetingSession({
         meetingId,
         displayName: msg.displayName,

--- a/skills/meet-join/meet-controller-ext/src/features/participants.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/participants.ts
@@ -1,0 +1,242 @@
+/**
+ * Participant-panel scraper (content-script port).
+ *
+ * Ports `skills/meet-join/bot/src/browser/participant-scraper.ts` from the
+ * Playwright-driven page-world implementation into the Manifest V3 content
+ * script. The polling/diff logic is intentionally identical — only the
+ * substrate differs: where the bot-side code used `page.$` and `page.$$eval`
+ * to reach into the page world, this module runs *inside* the page world
+ * and reads the DOM directly via `document.querySelector*`.
+ *
+ * Design notes (mirrors the bot-side implementation):
+ *
+ *   - Meet collapses the participant panel by default. On
+ *     `startParticipantScraper` we check whether the list container is
+ *     already mounted (`INGAME_PARTICIPANT_LIST`) and only click the panel
+ *     toggle if it is not. Without this guard, clicking an already-open
+ *     panel would *close* it.
+ *   - We read participant rows via `document.querySelectorAll` and extract
+ *     `{ id, name, isSelfByDom }` from each row. The stable id comes from
+ *     `data-participant-id`; the name is pulled from the
+ *     `data-participant-name` / `data-self-name` subselector. We only fall
+ *     back to using the name as the id when the row has no stable attribute.
+ *   - The first successful poll treats *every* current participant as `joined`
+ *     (initial snapshot). Subsequent polls only emit participants whose id
+ *     set differs from the previous snapshot. That keeps downstream consumers
+ *     (conversation bridge, storage writer) from having to special-case the
+ *     "first event" vs. "delta event".
+ *   - Errors during a poll (e.g. selector timeout, panel auto-collapsed) are
+ *     swallowed so a transient DOM glitch doesn't kill the scraper. The next
+ *     poll will retry.
+ *
+ * Events flow: this module calls the caller-supplied `onEvent` callback with
+ * a `ParticipantChangeEvent`. In `content.ts` the callback is wired to
+ * `chrome.runtime.sendMessage` so the event flows
+ * content → background → native-port → bot.
+ */
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+import type { Participant } from "../../../contracts/events.js";
+import { selectors } from "../dom/selectors.js";
+
+/** Options for {@link startParticipantScraper}. */
+export interface ParticipantScraperOptions {
+  /** Meeting identifier embedded in every emitted event. */
+  meetingId: string;
+  /** Poll interval in milliseconds. Defaults to 2000. */
+  pollMs?: number;
+  /**
+   * Display name the bot joined the meeting under. When provided, the
+   * scraper flags the matching row with `isSelf: true` so downstream
+   * consumers (e.g. the consent monitor) can identify the bot's own
+   * participant id.
+   *
+   * The scraper prefers Meet's authoritative DOM signal — the name
+   * element carrying `data-self-name` rather than `data-participant-name`
+   * — and falls back to comparing the row's display name with this value
+   * when the DOM attribute is absent. The name fallback is safe for the
+   * bot (which picks a deliberately unique display name) but would be
+   * fragile for arbitrary humans.
+   */
+  selfName?: string;
+  /**
+   * Callback invoked whenever the participant set changes. In the real
+   * extension this is bound to `chrome.runtime.sendMessage`; tests pass
+   * a plain function that records events for assertion.
+   */
+  onEvent: (event: ExtensionToBotMessage) => void;
+}
+
+/** Handle returned by {@link startParticipantScraper}. */
+export interface ParticipantScraperHandle {
+  /** Cancel the polling interval. Safe to call multiple times. */
+  stop: () => void;
+}
+
+/** Shape returned by the per-row extractor. */
+interface ScrapedRow {
+  id: string | null;
+  name: string | null;
+  /**
+   * True when the row's name node was matched via `data-self-name` —
+   * Meet's own marker for the signed-in / joining user's row. Undefined
+   * when the DOM signal is absent; the caller may still flag the row by
+   * name match in that case.
+   */
+  isSelfByDom: boolean;
+}
+
+/** Default poll interval. Matches the plan: 2s. */
+const DEFAULT_POLL_MS = 2_000;
+
+/**
+ * Read every visible participant row from the participants panel. Returns
+ * an empty array if the panel container isn't mounted.
+ *
+ * Kept as a free function so the core "extract rows from the current
+ * document" logic can be reasoned about (and, in principle, unit-tested)
+ * independently of the polling harness.
+ */
+function scrapeRows(): ScrapedRow[] {
+  const nodes = document.querySelectorAll(selectors.INGAME_PARTICIPANT_NODE);
+  const rows: ScrapedRow[] = [];
+  for (const node of Array.from(nodes)) {
+    const el = node as HTMLElement;
+    const id = el.getAttribute("data-participant-id");
+    const nameEl = el.querySelector(selectors.INGAME_PARTICIPANT_NAME);
+    const name = (nameEl?.textContent ?? "").trim() || null;
+    // Meet marks the signed-in / joining user's row with `data-self-name`
+    // instead of `data-participant-name`. We use this authoritative marker
+    // to flag the bot's own row; callers may additionally match by
+    // display name.
+    const isSelfByDom =
+      nameEl instanceof HTMLElement && nameEl.hasAttribute("data-self-name");
+    rows.push({ id: id ?? null, name, isSelfByDom });
+  }
+  return rows;
+}
+
+/**
+ * Ensure the participants panel is open. Checking the list container first
+ * avoids toggling a panel that is already visible (which would close it).
+ */
+function ensurePanelOpen(): void {
+  const alreadyOpen = document.querySelector(selectors.INGAME_PARTICIPANT_LIST);
+  if (alreadyOpen) return;
+  const toggle = document.querySelector<HTMLElement>(
+    selectors.INGAME_PARTICIPANTS_PANEL_BUTTON,
+  );
+  if (toggle) toggle.click();
+}
+
+/**
+ * Start polling the participant panel and invoke `onEvent` whenever the
+ * participant set changes.
+ *
+ * The first poll emits a `ParticipantChangeEvent` with every currently-visible
+ * participant in `joined` and an empty `left`. Subsequent polls only fire when
+ * the id-set differs.
+ *
+ * @returns A handle whose `stop()` method cancels the poll interval.
+ */
+export function startParticipantScraper(
+  opts: ParticipantScraperOptions,
+): ParticipantScraperHandle {
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
+  const meetingId = opts.meetingId;
+  const selfName = opts.selfName;
+  const onEvent = opts.onEvent;
+
+  /**
+   * Snapshot of the previous poll keyed by participant id, so we can build
+   * the joined/left diffs efficiently and preserve the full participant
+   * object for departed rows (which won't be in the current DOM anymore).
+   */
+  let previous: Map<string, Participant> = new Map();
+  let firstPollComplete = false;
+  let stopped = false;
+
+  const poll = (): void => {
+    if (stopped) return;
+
+    let rows: ScrapedRow[];
+    try {
+      ensurePanelOpen();
+      rows = scrapeRows();
+    } catch {
+      // Transient DOM error (navigation, panel auto-closed, etc.). Skip this
+      // tick and try again next interval.
+      return;
+    }
+
+    const current = new Map<string, Participant>();
+    for (const row of rows) {
+      const name = row.name ?? "";
+      // Prefer the stable `data-participant-id` attribute. If Meet hasn't
+      // attached one to this row, fall back to using the name as the id.
+      // TODO(meet-dom): drop the name-as-id fallback once we confirm Meet
+      // always emits a stable id on every participant row. For MVP this
+      // keeps the scraper resilient to partially-rendered rows.
+      const id = row.id ?? name;
+      if (!id) continue;
+      // Flag the bot's own row so downstream consumers (consent monitor,
+      // watermark tracker) can filter out bot-self transcripts and chat.
+      // Prefer Meet's authoritative DOM signal (`data-self-name`); fall
+      // back to matching the configured bot display name when the DOM
+      // marker is absent.
+      const isSelf =
+        row.isSelfByDom ||
+        (selfName !== undefined && name !== "" && name === selfName);
+      const participant: Participant = isSelf
+        ? { id, name, isSelf: true }
+        : { id, name };
+      current.set(id, participant);
+    }
+
+    // First poll: everyone currently visible is a "joined" participant from
+    // the scraper's perspective. Subsequent polls compute deltas against the
+    // previous snapshot.
+    const joined: Participant[] = [];
+    const left: Participant[] = [];
+
+    if (!firstPollComplete) {
+      for (const participant of current.values()) {
+        joined.push(participant);
+      }
+    } else {
+      for (const [id, participant] of current) {
+        if (!previous.has(id)) joined.push(participant);
+      }
+      for (const [id, participant] of previous) {
+        if (!current.has(id)) left.push(participant);
+      }
+    }
+
+    previous = current;
+    firstPollComplete = true;
+
+    if (joined.length === 0 && left.length === 0) return;
+    if (stopped) return;
+
+    onEvent({
+      type: "participant.change",
+      meetingId,
+      timestamp: new Date().toISOString(),
+      joined,
+      left,
+    });
+  };
+
+  const timer = setInterval(poll, pollMs);
+  // Kick off the first poll immediately so callers don't have to wait a
+  // full interval for the initial snapshot.
+  poll();
+
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Ports bot/src/browser/participant-scraper.ts into meet-controller-ext/src/features/participants.ts, running inside the content script.
- 2s poll + diff against a previous snapshot, emits participant.change events via chrome.runtime.sendMessage.
- Content script starts/stops the scraper around the lifecycle events emitted by the join flow (PR 9).
- Tests ported from bot-side with jsdom-only substrate.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 10 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
