### PR TITLE
feat(meet-ext): port join flow to content script

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for the content-script port of the Meet join flow.
+ *
+ * We load the committed `meet-dom-prejoin.html` fixture into a JSDOM document
+ * and drive {@link runJoinFlow} against it via the `doc` overload. The join
+ * flow's job is to orchestrate DOM interactions deterministically; mocking the
+ * wait helpers is unnecessary because JSDOM honors the `MutationObserver` we
+ * use in `dom/wait.ts`.
+ *
+ * We follow the testing style of `skills/meet-join/bot/__tests__/join-flow.test.ts`
+ * (the Playwright-era predecessor on `main`) — one test per prejoin branch,
+ * plus an admission-timeout case. The bot-side test is scheduled for deletion
+ * in PR 15 once the content-script flow fully replaces it.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { JSDOM } from "jsdom";
+
+import { selectors } from "../dom/selectors.js";
+import { runJoinFlow } from "../features/join.js";
+
+/** Path to the committed prejoin fixture. */
+const PREJOIN_FIXTURE = pathJoin(
+  import.meta.dir,
+  "..",
+  "dom",
+  "__tests__",
+  "fixtures",
+  "meet-dom-prejoin.html",
+);
+
+/** Globals we borrow from the JSDOM window so JSDOM-realm checks pass. */
+const JSDOM_GLOBALS = [
+  "MutationObserver",
+  "Event",
+  "HTMLInputElement",
+  "HTMLElement",
+  "Element",
+  "Node",
+] as const;
+
+/**
+ * Build a JSDOM document from the committed prejoin fixture. Returns the
+ * document plus the JSDOM window so tests can scope any additional
+ * DOM mutations (e.g. removing the media-permission modal) cleanly.
+ */
+function loadPrejoinDom(): { dom: JSDOM; doc: Document; win: JSDOM["window"] } {
+  const html = readFileSync(PREJOIN_FIXTURE, "utf8");
+  // `runScripts: "outside-only"` keeps fixture scripts quiescent while still
+  // exposing `window.Event`, `MutationObserver`, etc. inside the document.
+  const dom = new JSDOM(html, { runScripts: "outside-only" });
+  return { dom, doc: dom.window.document, win: dom.window };
+}
+
+// ---------------------------------------------------------------------------
+// Global fixtures
+// ---------------------------------------------------------------------------
+//
+// Two concerns are handled globally rather than per-test:
+//
+//   1. JSDOM realms: `runJoinFlow` reads `MutationObserver` / `Event` from
+//      `globalThis`. Bun's runtime doesn't ship with a DOM, so we install
+//      those names from a scratch JSDOM window during `beforeAll` and restore
+//      the prior globals in `afterAll`. Per-test DOMs reuse the same class
+//      constructors because they're identical across fresh JSDOM windows.
+//   2. Timeout compression: the production join flow uses 5s / 30s / 90s
+//      waits. Those would dominate wall-clock test time. We patch the global
+//      `setTimeout` before each test to fire any timer >=500ms immediately,
+//      then restore it in `afterEach`. Short timers (reconnect-backoff style)
+//      are left untouched so anything keyed on the JS event loop continues
+//      to work.
+
+let sharedWindow: JSDOM["window"] | null = null;
+const previousGlobals: Record<string, unknown> = {};
+
+beforeAll(() => {
+  const dom = new JSDOM("<html><body></body></html>", {
+    runScripts: "outside-only",
+  });
+  sharedWindow = dom.window;
+  for (const key of JSDOM_GLOBALS) {
+    previousGlobals[key] = (globalThis as unknown as Record<string, unknown>)[
+      key
+    ];
+    (globalThis as unknown as Record<string, unknown>)[key] = (
+      sharedWindow as unknown as Record<string, unknown>
+    )[key];
+  }
+});
+
+afterAll(() => {
+  for (const key of JSDOM_GLOBALS) {
+    (globalThis as unknown as Record<string, unknown>)[key] =
+      previousGlobals[key];
+  }
+  sharedWindow = null;
+});
+
+// The global `setTimeout` varies across runtimes (`typeof setTimeout` resolves
+// to the Node / Bun overload with a `.__promisify__` attachment). Casting
+// through `unknown` keeps our collapsing wrapper compatible with the signature
+// `runJoinFlow` calls without dragging in a runtime-specific shape.
+type GlobalSetTimeout = (
+  cb: (...args: unknown[]) => void,
+  ms?: number,
+  ...args: unknown[]
+) => ReturnType<typeof setTimeout>;
+
+let originalSetTimeout: GlobalSetTimeout | null = null;
+
+beforeEach(() => {
+  originalSetTimeout = globalThis.setTimeout as unknown as GlobalSetTimeout;
+  const patched: GlobalSetTimeout = (cb, ms, ...args) => {
+    const real = originalSetTimeout as GlobalSetTimeout;
+    // Collapse long production timeouts to a single tick so tests don't spin
+    // for 30s / 90s waiting on a selector that will never appear. 500ms is
+    // above every short timer in the code under test (there are none today)
+    // and below every production timeout we need to collapse.
+    if (typeof ms === "number" && ms >= 500) {
+      return real(cb, 0, ...args);
+    }
+    return real(cb, ms, ...args);
+  };
+  (globalThis as unknown as { setTimeout: GlobalSetTimeout }).setTimeout =
+    patched;
+});
+
+afterEach(() => {
+  if (originalSetTimeout !== null) {
+    (globalThis as unknown as { setTimeout: GlobalSetTimeout }).setTimeout =
+      originalSetTimeout;
+    originalSetTimeout = null;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Attach a click spy to the first element matching `sel` in `doc`. Returns
+ * the spy's call list so the test can assert the click landed. The click
+ * still propagates through the JSDOM default handler so `dispatchEvent`-style
+ * side effects continue to fire.
+ */
+function spyOnClick(doc: Document, sel: string): string[] {
+  const el = doc.querySelector(sel) as HTMLElement | null;
+  if (!el) throw new Error(`fixture missing selector: ${sel}`);
+  const calls: string[] = [];
+  const original = el.click.bind(el);
+  el.click = () => {
+    calls.push(sel);
+    original();
+  };
+  return calls;
+}
+
+/**
+ * Insert a Meet "Leave call" button into the DOM to simulate admission. We
+ * run this *synchronously* before calling {@link runJoinFlow} so the step-5
+ * wait short-circuits on the initial `querySelector` check rather than
+ * racing against the observer. The separation-of-concerns test goals here
+ * are "does the flow locate the leave button?" — not "does the observer fire
+ * on a late mutation?" — so pre-insertion is the cleaner assertion target.
+ */
+function insertLeaveButton(doc: Document): HTMLButtonElement {
+  const leave = doc.createElement("button");
+  leave.setAttribute("type", "button");
+  leave.setAttribute("aria-label", "Leave call");
+  leave.textContent = "Leave call";
+  doc.body.appendChild(leave);
+  return leave as HTMLButtonElement;
+}
+
+/**
+ * Remove the media-permission modal so step 1 times out (signed-in happy
+ * path). Keeping the modal in the fixture is useful for its own test, but
+ * every other branch wants the modal-dismissal step to be a no-op.
+ */
+function removeMediaModal(doc: Document): void {
+  const modal = doc.querySelector(selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON);
+  const dialog = modal?.closest('[role="dialog"]');
+  dialog?.remove();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runJoinFlow (content-script port)", () => {
+  test("populates the name input and clicks Join now", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    const clicks = spyOnClick(doc, selectors.PREJOIN_JOIN_NOW_BUTTON);
+    insertLeaveButton(doc);
+
+    const events: unknown[] = [];
+    await runJoinFlow({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+      meetingId: "mtg-1",
+      onEvent: (e) => events.push(e),
+      doc,
+    });
+
+    // Name input populated with the displayName.
+    const input = doc.querySelector(
+      selectors.PREJOIN_NAME_INPUT,
+    ) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("Vellum Bot");
+
+    // Join now was clicked exactly once.
+    expect(clicks).toEqual([selectors.PREJOIN_JOIN_NOW_BUTTON]);
+
+    // No diagnostic errors on the happy path.
+    const errorDiagnostics = events.filter(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "diagnostic" &&
+        (e as { level?: string }).level === "error",
+    );
+    expect(errorDiagnostics.length).toBe(0);
+
+    // The INGAME_LEAVE_BUTTON selector matches after admission.
+    const leave = doc.querySelector(selectors.INGAME_LEAVE_BUTTON);
+    expect(leave).not.toBeNull();
+  });
+
+  test("falls back to Ask to join when Join now is absent", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    // Simulate a locked meeting: remove the Join now button so the fallback
+    // branch fires.
+    doc.querySelector(selectors.PREJOIN_JOIN_NOW_BUTTON)?.remove();
+    const clicks = spyOnClick(doc, selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+    insertLeaveButton(doc);
+
+    await runJoinFlow({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+      meetingId: "mtg-2",
+      onEvent: () => {},
+      doc,
+    });
+
+    expect(clicks).toEqual([selectors.PREJOIN_ASK_TO_JOIN_BUTTON]);
+  });
+
+  test("dismisses the media-permission modal when Meet renders it", async () => {
+    const { doc } = loadPrejoinDom();
+    // Modal IS present (keep it) — assert the dismiss click fires.
+    const modalClicks = spyOnClick(
+      doc,
+      selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+    );
+    const joinClicks = spyOnClick(doc, selectors.PREJOIN_JOIN_NOW_BUTTON);
+    insertLeaveButton(doc);
+
+    await runJoinFlow({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+      meetingId: "mtg-3",
+      onEvent: () => {},
+      doc,
+    });
+
+    expect(modalClicks).toEqual([
+      selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+    ]);
+    expect(joinClicks).toEqual([selectors.PREJOIN_JOIN_NOW_BUTTON]);
+  });
+
+  test("skips the name fill when the input is not rendered (signed-in flow)", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    // Signed-in flow: no "Your name" input, but the join buttons are still
+    // there.
+    doc.querySelector(selectors.PREJOIN_NAME_INPUT)?.remove();
+    const clicks = spyOnClick(doc, selectors.PREJOIN_JOIN_NOW_BUTTON);
+    insertLeaveButton(doc);
+
+    await runJoinFlow({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      displayName: "Vellum Bot",
+      consentMessage: "Hi, Vellum is listening.",
+      meetingId: "mtg-4",
+      onEvent: () => {},
+      doc,
+    });
+
+    // No name input means nothing to assert on `.value` — instead verify the
+    // flow still clicked Join now, demonstrating the branch didn't fail.
+    expect(clicks).toEqual([selectors.PREJOIN_JOIN_NOW_BUTTON]);
+  });
+
+  test("emits a diagnostic and rejects when admission times out", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    // Deliberately do NOT insert a leave button — the INGAME_LEAVE_BUTTON
+    // never mounts, so step 5 should reject. The beforeEach setTimeout patch
+    // collapses the 90s wait to a single tick so the test runs quickly.
+
+    const events: unknown[] = [];
+    await expect(
+      runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-5",
+        onEvent: (e) => events.push(e),
+        doc,
+      }),
+    ).rejects.toThrow(/in-meeting UI did not appear/i);
+
+    // A diagnostic error was emitted before the throw.
+    const diag = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "diagnostic" &&
+        (e as { level?: string }).level === "error",
+    );
+    expect(diag).toBeDefined();
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -3,8 +3,9 @@
  *
  * Runs in the Google Meet page world at `document_idle`. Listens for
  * {@link BotToExtensionMessage} frames forwarded by the background
- * service worker's native-messaging bridge, and runs per-meeting
- * feature modules once the bot asks us to join.
+ * service worker's native-messaging bridge, drives the Meet prejoin UI
+ * on `join`, and runs per-meeting feature modules once the bot is in
+ * the meeting room.
  *
  * ## Meeting session lifecycle
  *
@@ -13,6 +14,14 @@
  * The returned `stop()` disposes every handle. We intentionally keep
  * this local-in-module-scope so parallel PRs can extend the factory
  * without touching the listener wiring.
+ *
+ * On `join` we emit a `lifecycle { state: "joining" }` event up-front so
+ * the daemon sees the transition even if `runJoinFlow` throws during
+ * its first DOM query, then emit `joined` after the flow resolves and
+ * the session factory has been installed. An unhandled rejection from
+ * `runJoinFlow` surfaces as `lifecycle { state: "error" }` with the
+ * error's message in `detail` — the session factory is NOT installed
+ * in that case because the scrapers require an admitted meeting.
  */
 import type {
   BotSendChatCommand,
@@ -27,6 +36,7 @@ import {
   sendChat,
   startChatReader,
 } from "./features/chat.js";
+import { runJoinFlow } from "./features/join.js";
 import {
   startSpeakerScraper,
   type SpeakerScraperHandle,
@@ -50,6 +60,30 @@ function deriveMeetingId(): string {
   return path || location.pathname;
 }
 
+/**
+ * Build a timestamped, meeting-scoped lifecycle message.
+ *
+ * Extracted to a helper so every lifecycle emit site (joining, joined,
+ * error) stays in lockstep on the timestamp/meetingId shape required by
+ * `ExtensionLifecycleMessageSchema`.
+ */
+function lifecycleMessage(
+  state: "joining" | "joined" | "left" | "error",
+  meetingId: string,
+  detail?: string,
+): ExtensionToBotMessage {
+  const msg: ExtensionToBotMessage = {
+    type: "lifecycle",
+    state,
+    meetingId,
+    timestamp: new Date().toISOString(),
+  };
+  if (detail !== undefined) {
+    (msg as { detail?: string }).detail = detail;
+  }
+  return msg;
+}
+
 interface MeetingSessionHandle {
   stop: () => void;
 }
@@ -67,10 +101,11 @@ interface MeetingSessionOptions {
 /**
  * Start all per-meeting scrapers + bridges for a freshly-joined meeting.
  *
- * Called from the bot→extension `join` handler below, after any join
- * flow completes successfully. Additional features (participants) will
- * layer into the returned handle in subsequent PRs — extend this factory
- * rather than the listener wiring so session teardown stays in one place.
+ * Called from the bot→extension `join` handler below, after `runJoinFlow`
+ * has driven the prejoin UI and confirmed admission. Additional features
+ * (participants) will layer into the returned handle in subsequent PRs —
+ * extend this factory rather than the listener wiring so session teardown
+ * stays in one place.
  */
 function startMeetingSession(
   opts: MeetingSessionOptions,
@@ -143,18 +178,7 @@ chrome.runtime.onMessage.addListener(
     const msg: BotToExtensionMessage = parsed.data;
 
     if (msg.type === "join") {
-      const meetingId = deriveMeetingId();
-      activeSession?.stop();
-      // NOTE: PR 9 will run the actual join flow (fill name, click
-      // join now, wait for leave button) before we start the session.
-      // For now we wire the scrapers directly against the current DOM
-      // so PR 11's speaker scraper is exercised end-to-end once PR 9
-      // lands. Leaving this as a single call makes the PR-9 insertion
-      // a local edit.
-      activeSession = startMeetingSession({
-        meetingId,
-        displayName: msg.displayName,
-      });
+      void handleJoin(msg.meetingUrl, msg.displayName, msg.consentMessage);
       return false;
     }
 
@@ -172,6 +196,73 @@ chrome.runtime.onMessage.addListener(
     return false;
   },
 );
+
+/**
+ * Drive the Meet prejoin UI, then start per-meeting scrapers.
+ *
+ * Lifecycle fanout:
+ *
+ *   - `joining` is emitted synchronously so the daemon sees the
+ *     transition even if `runJoinFlow` throws on its first DOM query.
+ *   - `joined` is emitted after the flow resolves and the session
+ *     factory has been installed.
+ *   - `error` is emitted if the flow rejects; the session factory is
+ *     NOT installed because the scrapers require an admitted meeting.
+ *
+ * The prior session (if any) is torn down synchronously before the
+ * new flow kicks off so overlapping joins cannot double-install
+ * scrapers against the same DOM.
+ */
+async function handleJoin(
+  meetingUrl: string,
+  displayName: string,
+  consentMessage: string,
+): Promise<void> {
+  const meetingId = deriveMeetingId();
+  activeSession?.stop();
+  activeSession = null;
+
+  // Emit "joining" up front so the daemon records the transition even
+  // if runJoinFlow throws before any event reaches onEvent.
+  try {
+    chrome.runtime.sendMessage(lifecycleMessage("joining", meetingId));
+  } catch (err) {
+    console.warn("[meet-ext] lifecycle(joining) send failed:", err);
+  }
+
+  try {
+    await runJoinFlow({
+      meetingUrl,
+      displayName,
+      consentMessage,
+      meetingId,
+      onEvent: (event) => {
+        try {
+          chrome.runtime.sendMessage(event);
+        } catch (err) {
+          console.warn("[meet-ext] runJoinFlow event send failed:", err);
+        }
+      },
+    });
+  } catch (err) {
+    const detail =
+      err instanceof Error ? err.message : String(err ?? "unknown error");
+    try {
+      chrome.runtime.sendMessage(lifecycleMessage("error", meetingId, detail));
+    } catch (sendErr) {
+      console.warn("[meet-ext] lifecycle(error) send failed:", sendErr);
+    }
+    return;
+  }
+
+  // Join succeeded — install per-meeting scrapers and emit "joined".
+  activeSession = startMeetingSession({ meetingId, displayName });
+  try {
+    chrome.runtime.sendMessage(lifecycleMessage("joined", meetingId));
+  } catch (err) {
+    console.warn("[meet-ext] lifecycle(joined) send failed:", err);
+  }
+}
 
 /**
  * Execute a {@link BotSendChatCommand} and emit a matching

--- a/skills/meet-join/meet-controller-ext/src/dom/wait.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/wait.ts
@@ -1,0 +1,139 @@
+/**
+ * DOM wait helpers for the content script.
+ *
+ * The meet-controller extension runs inside Meet's page world as a Manifest V3
+ * content script — it does not have access to Playwright-style `waitForSelector`
+ * APIs. These helpers replicate the small subset of that behavior the join /
+ * chat flows need, implemented on top of `MutationObserver` so they work in
+ * any browser context without extra dependencies.
+ *
+ * Design notes:
+ *
+ *   - Every wait checks the document synchronously once before attaching an
+ *     observer; this keeps the happy path (the element is already in the DOM)
+ *     cheap and avoids racing against the first mutation.
+ *   - The observer is always disconnected before the returned promise settles,
+ *     whether the wait succeeded, timed out, or was rejected by an internal
+ *     failure. Leaking observers on a Meet page is expensive because the DOM
+ *     mutates constantly.
+ *   - Errors use a stable message shape (`"timeout waiting for " + selector`)
+ *     so the caller can build descriptive diagnostics without having to match
+ *     on regex.
+ *   - A `document`-scoped argument is exposed so tests can substitute a JSDOM
+ *     document; production callers use the real `document` default.
+ */
+
+/**
+ * Resolve with the first element matching `sel`. Rejects with
+ * `Error("timeout waiting for " + sel)` if no match appears within `timeoutMs`.
+ *
+ * Implementation strategy:
+ *   1. Check the document synchronously — if the element is already there,
+ *      return it without touching MutationObserver.
+ *   2. Otherwise, attach a MutationObserver scoped to `{ childList: true,
+ *      subtree: true, attributes: true }` at the document root, and re-run
+ *      `querySelector` on each mutation batch. Attributes are observed so
+ *      waits that key on aria-label changes (Meet toggles these during state
+ *      transitions) fire on the next batch rather than waiting for a child
+ *      insertion that may never come.
+ *   3. Disconnect the observer in every settle path (match, timeout).
+ */
+export function waitForSelector(
+  sel: string,
+  timeoutMs: number,
+  doc: Document = document,
+): Promise<Element> {
+  return new Promise<Element>((resolve, reject) => {
+    // Synchronous check — if it's already there, return immediately. This
+    // short-circuits the happy path without touching MutationObserver.
+    const existing = doc.querySelector(sel);
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    let settled = false;
+    const observer = new MutationObserver(() => {
+      if (settled) return;
+      const match = doc.querySelector(sel);
+      if (match) {
+        settled = true;
+        observer.disconnect();
+        clearTimeout(timer);
+        resolve(match);
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      observer.disconnect();
+      reject(new Error("timeout waiting for " + sel));
+    }, timeoutMs);
+
+    observer.observe(doc, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
+  });
+}
+
+/**
+ * Resolve with `{ selector, element }` for the first selector in `selectors`
+ * whose element appears in the DOM. Rejects with
+ * `Error("timeout waiting for any of " + selectors.join(", "))` if no match
+ * appears within `timeoutMs`.
+ *
+ * Semantics match Playwright's `Promise.race` over individual `waitForSelector`
+ * calls in the bot's original join flow — used to branch on whichever of the
+ * prejoin surfaces (name input, Join now, Ask to join) Meet renders first.
+ */
+export function waitForAny(
+  selectors: string[],
+  timeoutMs: number,
+  doc: Document = document,
+): Promise<{ selector: string; element: Element }> {
+  return new Promise<{ selector: string; element: Element }>(
+    (resolve, reject) => {
+      // Synchronous check — return the first selector that already matches.
+      for (const selector of selectors) {
+        const existing = doc.querySelector(selector);
+        if (existing) {
+          resolve({ selector, element: existing });
+          return;
+        }
+      }
+
+      let settled = false;
+      const observer = new MutationObserver(() => {
+        if (settled) return;
+        for (const selector of selectors) {
+          const match = doc.querySelector(selector);
+          if (match) {
+            settled = true;
+            observer.disconnect();
+            clearTimeout(timer);
+            resolve({ selector, element: match });
+            return;
+          }
+        }
+      });
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        observer.disconnect();
+        reject(
+          new Error("timeout waiting for any of " + selectors.join(", ")),
+        );
+      }, timeoutMs);
+
+      observer.observe(doc, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+    },
+  );
+}

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -1,0 +1,197 @@
+/**
+ * Content-script port of the Google Meet join flow.
+ *
+ * Ports `skills/meet-join/bot/src/browser/join-flow.ts` (which drives Meet
+ * via Playwright from outside the browser) to run inside a Manifest V3
+ * content script attached to `https://meet.google.com/*`. The selector
+ * catalog, timeouts, and branch structure are intentionally kept in sync
+ * with the bot-side implementation so the two are trivially cross-referenced
+ * when Meet's DOM drifts.
+ *
+ * Call graph:
+ *
+ *   1. Dismiss the media-permission modal if Meet rendered one. The modal
+ *      blocks the underlying prejoin UI for anonymous joiners; a missing
+ *      modal is the signed-in happy path and is not an error.
+ *   2. Wait for either the prejoin name input OR a join button — signed-in
+ *      flows skip the name input entirely, so treating it as mandatory would
+ *      hang the extension for 30s on a page that's otherwise interactable.
+ *   3. Populate the display name if the input is present.
+ *   4. Click Join now (preferred — signed-in / same-domain flow) or fall back
+ *      to Ask to join (locked meeting, host admits).
+ *   5. Wait for the in-meeting UI. The red "Leave call" button is the
+ *      canonical marker — it only mounts once the bot is in the meeting.
+ *   6. Post `consentMessage` in chat. PR 12 wires this up; for PR 9 we leave
+ *      a TODO and return early.
+ *
+ * Error strategy: every step throws a descriptive `Error` on timeout. Before
+ * re-throwing, we emit an `ExtensionDiagnosticMessage` via `opts.onEvent` so
+ * the bot-side stderr captures the failure reason. We intentionally do NOT
+ * capture screenshots — `page.screenshot` has no content-script analogue,
+ * and diagnostics already surface through the native port's stderr.
+ */
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+import { selectors } from "../dom/selectors.js";
+import { waitForAny, waitForSelector } from "../dom/wait.js";
+
+/** How long to wait for the prejoin surface to mount. */
+const PREJOIN_TIMEOUT_MS = 30_000;
+
+/**
+ * How long to wait for Meet's media-permission modal. Short by design — if
+ * Meet didn't render the modal (signed-in flows, older UI variants) we want
+ * to fall through to the prejoin wait quickly rather than spending the full
+ * prejoin budget on a dialog that will never appear.
+ */
+const MEDIA_PROMPT_TIMEOUT_MS = 5_000;
+
+/**
+ * How long to wait for the meeting-room UI after clicking the join button.
+ * The "Ask to join" flow can block on the host manually admitting the bot,
+ * so the cap is intentionally generous.
+ */
+const MEETING_ROOM_TIMEOUT_MS = 90_000;
+
+/** Options accepted by {@link runJoinFlow}. */
+export interface RunJoinFlowOptions {
+  /** Full Meet join URL. Currently used only for diagnostic context. */
+  meetingUrl: string;
+  /** Display name Meet will render next to the bot's tile. */
+  displayName: string;
+  /**
+   * Consent notice to post once the bot is in the meeting. Plumbed through
+   * for PR 12 (chat posting). Not used in PR 9.
+   */
+  consentMessage: string;
+  /** Opaque identifier for the meeting the extension is in. */
+  meetingId: string;
+  /**
+   * Sink for extension→bot events emitted during the join flow. Currently we
+   * only emit `diagnostic` messages on failure; lifecycle transitions are
+   * emitted by the content-script entry point (`content.ts`).
+   */
+  onEvent: (msg: ExtensionToBotMessage) => void;
+  /**
+   * Document to operate against. Defaults to the live `document` so the
+   * production content script can call `runJoinFlow(opts)` without passing
+   * it through; tests override with a JSDOM-backed document.
+   */
+  doc?: Document;
+}
+
+/**
+ * Emit a diagnostic `error` message to the bot, then throw `new Error(message)`.
+ *
+ * Surfaces descriptive failures in the bot's stderr-equivalent log stream
+ * without silently swallowing them; the thrown error propagates to the
+ * content-script entry point which emits a `lifecycle { state: "error" }`
+ * event for the daemon.
+ */
+function fail(
+  onEvent: (msg: ExtensionToBotMessage) => void,
+  message: string,
+): never {
+  onEvent({
+    type: "diagnostic",
+    level: "error",
+    message,
+  });
+  throw new Error(message);
+}
+
+/**
+ * Drive the Meet prejoin surface to completion.
+ *
+ * Resolves once the in-meeting UI has mounted. Does NOT post the consent
+ * message — that is deferred to PR 12 (see the TODO at step 6).
+ */
+export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
+  const { displayName, onEvent } = opts;
+  const doc = opts.doc ?? document;
+
+  // Step 1 — dismiss the media-permission modal if Meet rendered one. Best
+  // effort; a missing modal is the signed-in happy path.
+  try {
+    const modal = await waitForSelector(
+      selectors.PREJOIN_MEDIA_PROMPT_ACCEPT_BUTTON,
+      MEDIA_PROMPT_TIMEOUT_MS,
+      doc,
+    );
+    (modal as HTMLElement).click();
+  } catch {
+    // No modal — proceed directly to the prejoin surface.
+  }
+
+  // Step 2 — race the prejoin surface selectors. Signed-in flows skip the
+  // name input entirely, so waiting for the input alone would hang the
+  // extension for the full prejoin budget on an otherwise interactable page.
+  let firstVisible: { selector: string; element: Element };
+  try {
+    firstVisible = await waitForAny(
+      [
+        selectors.PREJOIN_NAME_INPUT,
+        selectors.PREJOIN_JOIN_NOW_BUTTON,
+        selectors.PREJOIN_ASK_TO_JOIN_BUTTON,
+      ],
+      PREJOIN_TIMEOUT_MS,
+      doc,
+    );
+  } catch {
+    fail(
+      onEvent,
+      `meet-ext: prejoin surface did not appear within ${PREJOIN_TIMEOUT_MS}ms (url: ${opts.meetingUrl})`,
+    );
+  }
+  // Silence an unused-variable warning in strict mode — we only look up
+  // `firstVisible` to observe that the race resolved, then branch on live DOM.
+  void firstVisible;
+
+  // Step 3 — populate the name input if present. Meet doesn't render it for
+  // signed-in users, in which case the account's name is used instead.
+  const nameInput = doc.querySelector(selectors.PREJOIN_NAME_INPUT);
+  if (nameInput) {
+    (nameInput as HTMLInputElement).focus();
+    (nameInput as HTMLInputElement).value = displayName;
+    nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  // Step 4 — click the admission button. Prefer "Join now" because it is the
+  // happy-path branch for signed-in / same-domain sessions; fall back to
+  // "Ask to join" for locked meetings. We re-query the live DOM rather than
+  // relying on `firstVisible` because Meet may have mounted additional
+  // buttons between step 2 and here.
+  const joinNow = doc.querySelector(selectors.PREJOIN_JOIN_NOW_BUTTON);
+  if (joinNow) {
+    (joinNow as HTMLElement).click();
+  } else {
+    const askToJoin = doc.querySelector(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+    if (!askToJoin) {
+      fail(
+        onEvent,
+        "meet-ext: no join button present after prejoin surface mounted",
+      );
+    }
+    (askToJoin as HTMLElement).click();
+  }
+
+  // Step 5 — wait for the in-meeting UI. The "Leave call" button only mounts
+  // once the bot is in the meeting, so it is our canonical admission signal.
+  try {
+    await waitForSelector(
+      selectors.INGAME_LEAVE_BUTTON,
+      MEETING_ROOM_TIMEOUT_MS,
+      doc,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    fail(
+      onEvent,
+      `meet-ext: in-meeting UI did not appear within ${MEETING_ROOM_TIMEOUT_MS}ms (host may not have admitted the bot): ${msg}`,
+    );
+  }
+
+  // Step 6 — TODO(meet-ext): post consent via sendChat (added in PR 12).
+  // For PR 9 we stop here and let the content-script entry emit the
+  // `lifecycle { state: "joined" }` event.
+  return;
+}


### PR DESCRIPTION
## Summary
- Ports bot/src/browser/join-flow.ts to meet-controller-ext/src/features/join.ts, running inside a content script instead of driving via Playwright.
- Adds dom/wait.ts with waitForSelector + waitForAny helpers (MutationObserver-based, no Playwright).
- Content script handles incoming 'join' messages from the background and emits lifecycle events back.
- Consent message post deferred to PR 12 (TODO in step 6).

Part of plan: meet-phase-1-11-chrome-extension.md (PR 9 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
