### PR TITLE
feat(meet-bot): wire chrome-launcher + nmh-socket-server into main.ts (replaces Playwright)

### DIFF
--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -83,6 +83,17 @@ RUN bun install --frozen-lockfile
 
 COPY skills/meet-join/bot/src ./src
 
+# Build the Chrome extension and install its dist/ at /app/ext/. The
+# chrome-launcher passes `--load-extension=/app/ext` so Chrome picks it
+# up on startup. We build inside the image (rather than shipping a
+# pre-built dist/ in the repo) so the extension source is the single
+# source of truth. `/app/ext-src` is throwaway; the final artefact is
+# `/app/ext/` which contains manifest.json, background.js, content.js.
+COPY skills/meet-join/meet-controller-ext /app/ext-src
+RUN cd /app/ext-src && bun install --frozen-lockfile && bun run build \
+  && cp -r /app/ext-src/dist /app/ext \
+  && rm -rf /app/ext-src
+
 # Native-messaging host registration: copy the manifest template + renderer
 # script into the image, then render the manifest with the extension's ID
 # baked in (derived from the sibling extension package's public key). The

--- a/skills/meet-join/bot/Dockerfile.dockerignore
+++ b/skills/meet-join/bot/Dockerfile.dockerignore
@@ -39,10 +39,16 @@ skills/meet-join/contracts/node_modules
 skills/meet-join/contracts/dist
 skills/meet-join/contracts/__tests__
 
-# Un-ignore the sibling extension package's manifest.json — the Dockerfile
-# copies it to /tmp at build time so the render script can extract the
-# public key and derive the extension ID that pins `allowed_origins` in the
-# rendered native-messaging host manifest. We only need the manifest
-# itself, not the ext's full source tree.
+# Un-ignore the sibling extension package. The Dockerfile needs both the
+# manifest.json (copied to /tmp so the render script can extract the
+# public key and derive the extension ID that pins `allowed_origins` in
+# the rendered native-messaging host manifest) and the full source tree
+# (copied to /app/ext-src so `bun run build` can produce the dist/ that
+# gets installed at /app/ext/ for Chrome to load via --load-extension).
 !skills/meet-join/meet-controller-ext
-!skills/meet-join/meet-controller-ext/manifest.json
+!skills/meet-join/meet-controller-ext/**
+
+# Re-ignore dev artifacts in the extension tree.
+skills/meet-join/meet-controller-ext/node_modules
+skills/meet-join/meet-controller-ext/dist
+skills/meet-join/meet-controller-ext/src/__tests__

--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -1,15 +1,17 @@
 /**
- * Tests for `runBot` — the boot path that wires pulse → xvfb → browser →
- * joinMeet → daemon client → scrapers → audio → http server.
+ * Tests for `runBot` — the boot path that wires pulse → xvfb → NMH socket
+ * server → Chrome subprocess + extension → extension-ready handshake →
+ * join command → audio → HTTP server.
  *
- * We don't spin up a real browser or daemon here. Every subsystem is
- * stubbed with a recording mock that lets us assert on:
+ * We don't spin up a real browser, real socket, or real Xvfb here. Every
+ * subsystem is stubbed with a recording mock that lets us assert on:
  *
  *   - Boot order (each subsystem only starts after its prerequisites).
- *   - Callback wiring (scraper `onEvent` calls actually enqueue into the
- *     daemon client).
+ *   - Extension-message routing (participant/speaker/chat forward to
+ *     daemon; send_chat_result resolves pending HTTP promises).
  *   - Shutdown ordering and dedup (SIGTERM + HTTP `/leave` don't double-stop).
- *   - Error paths (join failure publishes `lifecycle:error` and exits 1).
+ *   - Error paths (extension never signals ready, Chrome exits early,
+ *     daemon-client flap).
  *
  * The separate boot smoke test (`boot.test.ts`) still covers the
  * `SKIP_PULSE=1` + missing-MEET_URL path against a real `bun run src/main.ts`.
@@ -17,7 +19,14 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { LifecycleEvent, MeetBotEvent } from "../../contracts/index.js";
+import type {
+  LifecycleEvent,
+  MeetBotEvent,
+} from "../../contracts/index.js";
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
 
 import { runBot, type BotDeps, type DaemonClientLike } from "../src/main.js";
 import { BotState } from "../src/control/state.js";
@@ -32,10 +41,7 @@ interface RecordedCall {
 }
 
 interface MockHandles {
-  /**
-   * Recorded invocations in the order they were made — lets tests assert
-   * on boot order.
-   */
+  /** Recorded invocations in order — lets tests assert on boot order. */
   calls: RecordedCall[];
   /** Events enqueued on the daemon client. */
   daemonEvents: MeetBotEvent[];
@@ -52,33 +58,44 @@ interface MockHandles {
   /** Invoke the SIGINT handler captured during boot. */
   fireSigint: () => void;
   /**
-   * Fire the `onError` hook the `runBot` passed into `createDaemonClient`.
+   * Fire the `onError` hook that `runBot` passed into `createDaemonClient`.
    * Returns `null` if the daemon client hasn't been constructed yet.
    */
   fireDaemonError: (err: Error) => void;
-  /** Page object the scrapers see. */
-  page: object;
+  /** Deliver a message to the socket-server's `onExtensionMessage` listeners. */
+  fireExtensionMessage: (msg: ExtensionToBotMessage) => void;
+  /** Resolve the socket-server's pending `waitForReady` promise. */
+  fireExtensionReady: () => void;
+  /** Reject the socket-server's pending `waitForReady` promise. */
+  failExtensionReady: (err: Error) => void;
+  /** Resolve the Chrome exit promise (e.g. to simulate an unexpected exit). */
+  fireChromeExit: (code: number) => void;
   /** HTTP callbacks the server captured. */
   httpCallbacks: () => {
     onLeave: (reason: string | undefined) => void | Promise<void>;
+    onSendChat: (text: string) => Promise<void> | void;
   } | null;
-  /** Sessions created — primarily for asserting `close()` was called. */
-  sessionCloses: () => number;
-  /** Participant/speaker/chat/audio stop counters. */
+  /** Inspect queued outbound messages sent to the extension. */
+  outboundMessages: () => BotToExtensionMessage[];
+  /** Shutdown counters for each subsystem (one per subsystem). */
   stopCounts: () => {
-    participant: number;
-    speaker: number;
-    chat: number;
+    xvfb: number;
+    socketServer: number;
+    chrome: number;
     audio: number;
     httpServer: number;
   };
 }
 
 interface MakeDepsOpts {
-  /** Force `joinMeet` to reject with this error. */
-  joinError?: Error;
   /** Force `setupPulseAudio` to reject. */
   pulseError?: Error;
+  /** Force `launchChrome` to reject. */
+  chromeLaunchError?: Error;
+  /** Force `startXvfb` to reject. */
+  xvfbError?: Error;
+  /** Short-circuit `waitForReady` to reject with this error. */
+  extensionReadyError?: Error;
 }
 
 function makeDeps(opts: MakeDepsOpts = {}): {
@@ -95,22 +112,30 @@ function makeDeps(opts: MakeDepsOpts = {}): {
   let sigtermHandler: (() => void) | null = null;
   let sigintHandler: (() => void) | null = null;
 
-  let sessionClosed = 0;
-  let participantStops = 0;
-  let speakerStops = 0;
-  let chatStops = 0;
+  let xvfbStops = 0;
+  let socketStops = 0;
+  let chromeStops = 0;
   let audioStops = 0;
   let httpStops = 0;
 
   let capturedHttpCallbacks: {
     onLeave: (reason: string | undefined) => void | Promise<void>;
+    onSendChat: (text: string) => Promise<void> | void;
   } | null = null;
 
   let capturedDaemonOnError: ((err: Error) => void) | null = null;
 
-  const fakePage = { __fake: true };
+  // ---- socket server plumbing ------------------------------------------
+  const outbound: BotToExtensionMessage[] = [];
+  const extensionListeners: Array<(msg: ExtensionToBotMessage) => void> = [];
+  let readyResolve: (() => void) | null = null;
+  let readyReject: ((err: Error) => void) | null = null;
+  // ---- chrome plumbing -------------------------------------------------
+  let chromeExitResolve: ((code: number) => void) | null = null;
+  const chromeExitPromise = new Promise<number>((resolve) => {
+    chromeExitResolve = resolve;
+  });
 
-  // Full skipPulse default so only opt-in tests exercise the pulse path.
   const defaultEnv = {
     meetUrl: "https://meet.google.com/abc-defg-hij",
     meetingId: "m-1",
@@ -121,6 +146,10 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     socketDir: "/sockets",
     skipPulse: true,
     httpPort: 0,
+    extensionPath: "/app/ext",
+    nmhSocketPath: "/run/nmh.sock",
+    xvfbDisplay: ":99",
+    chromeUserDataRoot: "/tmp/chrome-profile",
   };
 
   const daemonClient: DaemonClientLike = {
@@ -137,69 +166,80 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     },
   };
 
+  let requestIdCounter = 0;
+
   const deps: BotDeps = {
     env: () => ({ ...defaultEnv }),
     setupPulseAudio: async () => {
       calls.push({ kind: "pulse.setup" });
       if (opts.pulseError) throw opts.pulseError;
     },
-    createBrowserSession: async (url) => {
-      calls.push({ kind: "browser.create", url });
+    startXvfb: async (display) => {
+      calls.push({ kind: "xvfb.start", display });
+      if (opts.xvfbError) throw opts.xvfbError;
+      return { display, process: null };
+    },
+    stopXvfb: async () => {
+      xvfbStops += 1;
+      calls.push({ kind: "xvfb.stop" });
+    },
+    createNmhSocketServer: (socketOpts) => {
+      calls.push({ kind: "socket.create", socketPath: socketOpts.socketPath });
       return {
-        browser: {} as never,
-        context: {} as never,
-        page: fakePage as never,
-        close: async () => {
-          sessionClosed += 1;
-          calls.push({ kind: "browser.close" });
+        start: async () => {
+          calls.push({ kind: "socket.start" });
         },
-      };
-    },
-    joinMeet: async (page, joinOpts) => {
-      calls.push({
-        kind: "join.meet",
-        page,
-        displayName: joinOpts.displayName,
-        consentMessage: joinOpts.consentMessage,
-      });
-      if (opts.joinError) throw opts.joinError;
-    },
-    startParticipantScraper: (_page, _onEvent, scraperOpts) => {
-      calls.push({
-        kind: "scraper.participant.start",
-        meetingId: scraperOpts.meetingId,
-        selfName: scraperOpts.selfName,
-      });
-      return {
-        stop: () => {
-          participantStops += 1;
-          calls.push({ kind: "scraper.participant.stop" });
-        },
-      };
-    },
-    startSpeakerScraper: (_page, _onEvent, scraperOpts) => {
-      calls.push({
-        kind: "scraper.speaker.start",
-        meetingId: scraperOpts.meetingId,
-      });
-      return {
-        stop: () => {
-          speakerStops += 1;
-          calls.push({ kind: "scraper.speaker.stop" });
-        },
-      };
-    },
-    startChatReader: async (_page, _onEvent, scraperOpts) => {
-      calls.push({
-        kind: "scraper.chat.start",
-        meetingId: scraperOpts.meetingId,
-        selfName: scraperOpts.selfName,
-      });
-      return {
         stop: async () => {
-          chatStops += 1;
-          calls.push({ kind: "scraper.chat.stop" });
+          socketStops += 1;
+          calls.push({ kind: "socket.stop" });
+          // Reject any lingering waitForReady so promise consumers unblock.
+          if (readyReject) {
+            readyReject(new Error("socket.stop reached before ready"));
+            readyResolve = null;
+            readyReject = null;
+          }
         },
+        sendToExtension: (msg) => {
+          outbound.push(msg);
+          calls.push({ kind: "socket.send", msg });
+        },
+        onExtensionMessage: (cb) => {
+          extensionListeners.push(cb);
+        },
+        waitForReady: (_timeoutMs) => {
+          calls.push({ kind: "socket.waitForReady" });
+          return new Promise<void>((resolve, reject) => {
+            if (opts.extensionReadyError) {
+              reject(opts.extensionReadyError);
+              return;
+            }
+            readyResolve = resolve;
+            readyReject = reject;
+          });
+        },
+      };
+    },
+    launchChrome: async (chromeOpts) => {
+      calls.push({
+        kind: "chrome.launch",
+        meetingUrl: chromeOpts.meetingUrl,
+        extensionPath: chromeOpts.extensionPath,
+        displayNumber: chromeOpts.displayNumber,
+        userDataDir: chromeOpts.userDataDir,
+      });
+      if (opts.chromeLaunchError) throw opts.chromeLaunchError;
+      return {
+        pid: 424242,
+        stop: async () => {
+          chromeStops += 1;
+          calls.push({ kind: "chrome.stop" });
+          // Resolve the exit promise now so any waiter inside runBot settles.
+          if (chromeExitResolve) {
+            chromeExitResolve(0);
+            chromeExitResolve = null;
+          }
+        },
+        exitPromise: chromeExitPromise,
       };
     },
     startAudioCapture: async (audioOpts) => {
@@ -210,9 +250,6 @@ function makeDeps(opts: MakeDepsOpts = {}): {
           calls.push({ kind: "audio.stop" });
         },
       };
-    },
-    sendChat: async (_page, text) => {
-      calls.push({ kind: "sendChat", text });
     },
     createDaemonClient: (clientOpts) => {
       calls.push({
@@ -230,6 +267,7 @@ function makeDeps(opts: MakeDepsOpts = {}): {
       });
       capturedHttpCallbacks = {
         onLeave: serverOpts.onLeave,
+        onSendChat: serverOpts.onSendChat,
       };
       return {
         app: {} as never,
@@ -243,6 +281,9 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         },
       };
     },
+    ensureDir: (path: string) => {
+      calls.push({ kind: "ensureDir", path });
+    },
     onSignal: (signal, handler) => {
       if (signal === "SIGTERM") sigtermHandler = handler;
       else sigintHandler = handler;
@@ -254,21 +295,12 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         }
       };
     },
-    joinedSettleMs: 0, // tests don't need the real 2s wait.
+    joinedSettleMs: 0,
     sleep: async (_ms: number) => {
       // no-op in tests.
     },
     exit: ((code: number) => {
-      // Record the first exit code only — subsequent calls are
-      // tolerated (production `process.exit` never returns, so the
-      // bot's real flow never sees a double-exit, but in tests the
-      // mocked `exit` returns normally and we occasionally race).
       if (exitCode === null) exitCode = code;
-      // `process.exit`'s real return type is `never`; we narrow to
-      // `never` via a non-returning path so the production code
-      // compiles. In tests we don't want to throw (that would leak
-      // unhandled rejections out of fire-and-forget `.then(exit)`
-      // chains), so just `return undefined as never`.
       return undefined as never;
     }) as BotDeps["exit"],
     logInfo: (msg) => {
@@ -276,6 +308,13 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     },
     logError: (msg) => {
       errors.push(msg);
+    },
+    extensionReadyTimeoutMs: 1_000,
+    sendChatTimeoutMs: 500,
+    leaveGraceMs: 0,
+    generateRequestId: () => {
+      requestIdCounter += 1;
+      return `req-${requestIdCounter}`;
     },
   };
 
@@ -300,19 +339,58 @@ function makeDeps(opts: MakeDepsOpts = {}): {
       }
       capturedDaemonOnError(err);
     },
-    page: fakePage,
+    fireExtensionMessage: (msg) => {
+      for (const cb of extensionListeners) cb(msg);
+    },
+    fireExtensionReady: () => {
+      if (readyResolve) {
+        readyResolve();
+        readyResolve = null;
+        readyReject = null;
+      }
+    },
+    failExtensionReady: (err: Error) => {
+      if (readyReject) {
+        readyReject(err);
+        readyResolve = null;
+        readyReject = null;
+      }
+    },
+    fireChromeExit: (code) => {
+      if (chromeExitResolve) {
+        chromeExitResolve(code);
+        chromeExitResolve = null;
+      }
+    },
     httpCallbacks: () => capturedHttpCallbacks,
-    sessionCloses: () => sessionClosed,
+    outboundMessages: () => outbound.slice(),
     stopCounts: () => ({
-      participant: participantStops,
-      speaker: speakerStops,
-      chat: chatStops,
+      xvfb: xvfbStops,
+      socketServer: socketStops,
+      chrome: chromeStops,
       audio: audioStops,
       httpServer: httpStops,
     }),
   };
 
   return { deps, handles };
+}
+
+/**
+ * Run `runBot` and fire the extension-ready handshake so the boot can
+ * progress past `waitForReady`. Returns the `runBot` promise so tests can
+ * await the full boot to complete (including settling the happy-path
+ * `audio.start` / `http.start` / logs).
+ */
+async function bootHappyPath(
+  deps: BotDeps,
+  handles: MockHandles,
+): Promise<void> {
+  const running = runBot(deps);
+  // Give the boot a tick to reach `waitForReady`, then fire ready.
+  await new Promise((r) => setTimeout(r, 5));
+  handles.fireExtensionReady();
+  await running;
 }
 
 /** Return the ordered list of `kind` tags from the recorded calls. */
@@ -328,85 +406,272 @@ describe("runBot — boot sequence", () => {
   test("wires subsystems in the correct order", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     const order = kinds(handles.calls);
-
-    // The boot order the implementation promises: browser session,
-    // daemon client (so we can report join failures), join, settle,
-    // scrapers, audio, http.
     const indexOf = (kind: string): number => order.indexOf(kind);
 
-    expect(indexOf("browser.create")).toBeGreaterThanOrEqual(0);
-    expect(indexOf("daemon.create")).toBeGreaterThan(indexOf("browser.create"));
-    expect(indexOf("join.meet")).toBeGreaterThan(indexOf("daemon.create"));
-    expect(indexOf("scraper.participant.start")).toBeGreaterThan(
-      indexOf("join.meet"),
+    // Expected boot order:
+    //   xvfb → ensureDir (socket + profile) → socket.create → socket.start
+    //   → daemon.create → chrome.launch → waitForReady → send `join`
+    //   → audio.start → http.create → http.start.
+    expect(indexOf("xvfb.start")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("socket.create")).toBeGreaterThan(indexOf("xvfb.start"));
+    expect(indexOf("socket.start")).toBeGreaterThan(indexOf("socket.create"));
+    expect(indexOf("daemon.create")).toBeGreaterThan(indexOf("socket.start"));
+    expect(indexOf("chrome.launch")).toBeGreaterThan(indexOf("daemon.create"));
+    expect(indexOf("socket.waitForReady")).toBeGreaterThan(
+      indexOf("chrome.launch"),
     );
-    expect(indexOf("scraper.speaker.start")).toBeGreaterThan(
-      indexOf("join.meet"),
-    );
-    expect(indexOf("scraper.chat.start")).toBeGreaterThan(indexOf("join.meet"));
-    expect(indexOf("audio.start")).toBeGreaterThan(
-      indexOf("scraper.chat.start"),
-    );
+    expect(indexOf("socket.send")).toBeGreaterThan(indexOf("socket.waitForReady"));
+    expect(indexOf("audio.start")).toBeGreaterThan(indexOf("socket.send"));
     expect(indexOf("http.create")).toBeGreaterThan(indexOf("audio.start"));
     expect(indexOf("http.start")).toBeGreaterThan(indexOf("http.create"));
   });
 
-  test("publishes lifecycle:joining before joinMeet and :joined after", async () => {
+  test("sends a `join` command with the env-provided URL + display name", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
+
+    const outbound = handles.outboundMessages();
+    const join = outbound.find((m) => m.type === "join");
+    expect(join).toBeDefined();
+    if (join && join.type === "join") {
+      expect(join.meetingUrl).toBe("https://meet.google.com/abc-defg-hij");
+      expect(join.displayName).toBe("Vellum Bot");
+      expect(join.consentMessage).toBe(
+        "Hi, I'm an AI assistant listening in.",
+      );
+    }
+  });
+
+  test("publishes lifecycle:joining to the daemon after sending join", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
 
     const lifecycleStates = handles.daemonEvents
       .filter((e): e is LifecycleEvent => e.type === "lifecycle")
       .map((e) => e.state);
 
-    // We expect at least `joining` and `joined`. No `error` / `left` yet.
     expect(lifecycleStates).toContain("joining");
-    expect(lifecycleStates).toContain("joined");
-    expect(lifecycleStates).not.toContain("error");
+    // No `joined` yet — the extension hasn't emitted its own joined event.
     expect(lifecycleStates).not.toContain("left");
-
-    // Ordering: joining comes before joined.
-    const joiningIdx = lifecycleStates.indexOf("joining");
-    const joinedIdx = lifecycleStates.indexOf("joined");
-    expect(joiningIdx).toBeGreaterThanOrEqual(0);
-    expect(joinedIdx).toBeGreaterThan(joiningIdx);
+    expect(lifecycleStates).not.toContain("error");
   });
 
-  test("passes the meetingId and selfName through to the scrapers", async () => {
+  test("audio capture uses socketDir/audio.sock", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
-
-    const participantCall = handles.calls.find(
-      (c) => c.kind === "scraper.participant.start",
-    );
-    const speakerCall = handles.calls.find(
-      (c) => c.kind === "scraper.speaker.start",
-    );
-    const chatCall = handles.calls.find((c) => c.kind === "scraper.chat.start");
-
-    expect(participantCall?.meetingId).toBe("m-1");
-    expect(speakerCall?.meetingId).toBe("m-1");
-    expect(chatCall?.meetingId).toBe("m-1");
-    expect(chatCall?.selfName).toBe("Vellum Bot");
-    // The participant scraper also receives the bot's display name so it
-    // can flag the bot's own row with `isSelf: true`, letting the consent
-    // monitor identify `botParticipantId` and filter self-content from
-    // the watermark.
-    expect(participantCall?.selfName).toBe("Vellum Bot");
-  });
-
-  test("passes socketDir/audio.sock into audio capture", async () => {
-    BotState.__resetForTests();
-    const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     const audioCall = handles.calls.find((c) => c.kind === "audio.start");
     expect(audioCall?.socketPath).toBe("/sockets/audio.sock");
+  });
+});
+
+describe("runBot — extension message routing", () => {
+  test("extension lifecycle:joined forwards to the daemon", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+
+    const after = handles.daemonEvents.slice(before);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.type).toBe("lifecycle");
+    if (after[0]?.type === "lifecycle") {
+      expect(after[0].state).toBe("joined");
+    }
+  });
+
+  test("participant.change forwards to the daemon verbatim", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "participant.change",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    });
+
+    const after = handles.daemonEvents.slice(before);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.type).toBe("participant.change");
+  });
+
+  test("speaker.change and chat.inbound both forward to the daemon", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "speaker.change",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      speakerId: "p-1",
+      speakerName: "Alice",
+    });
+    handles.fireExtensionMessage({
+      type: "chat.inbound",
+      meetingId: "m-1",
+      timestamp: new Date().toISOString(),
+      fromId: "p-2",
+      fromName: "Bob",
+      text: "hello",
+    });
+
+    const after = handles.daemonEvents.slice(before);
+    expect(after.map((e) => e.type)).toEqual([
+      "speaker.change",
+      "chat.inbound",
+    ]);
+  });
+
+  test("diagnostic messages go through the logger, not the daemon", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const beforeEvents = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "diagnostic",
+      level: "info",
+      message: "content-script loaded",
+    });
+    handles.fireExtensionMessage({
+      type: "diagnostic",
+      level: "error",
+      message: "selector timed out",
+    });
+
+    // No daemon events for diagnostics.
+    expect(handles.daemonEvents.length).toBe(beforeEvents);
+    expect(handles.infos.some((m) => m.includes("content-script loaded"))).toBe(
+      true,
+    );
+    expect(handles.errors.some((m) => m.includes("selector timed out"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("runBot — send_chat HTTP path", () => {
+  test("send_chat routes through the socket server with a requestId", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const cbs = handles.httpCallbacks();
+    expect(cbs).not.toBeNull();
+
+    const before = handles.outboundMessages().length;
+    const sendPromise = Promise.resolve(cbs!.onSendChat("hello world"));
+    // Give the dispatch a tick to land on the socket.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const outbound = handles.outboundMessages();
+    const fresh = outbound.slice(before);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0]?.type).toBe("send_chat");
+    const firstReq = fresh[0];
+    if (firstReq && firstReq.type === "send_chat") {
+      expect(firstReq.text).toBe("hello world");
+      expect(typeof firstReq.requestId).toBe("string");
+      // Resolve the send_chat_result for that requestId.
+      handles.fireExtensionMessage({
+        type: "send_chat_result",
+        requestId: firstReq.requestId,
+        ok: true,
+      });
+    }
+    // The HTTP callback's promise should now resolve without throwing.
+    await sendPromise;
+  });
+
+  test("a failed send_chat_result rejects the HTTP callback's promise", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const cbs = handles.httpCallbacks();
+    const before = handles.outboundMessages().length;
+    const sendPromise = Promise.resolve(cbs!.onSendChat("will fail"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    const fresh = handles.outboundMessages().slice(before);
+    expect(fresh).toHaveLength(1);
+    const first = fresh[0];
+    if (first && first.type === "send_chat") {
+      handles.fireExtensionMessage({
+        type: "send_chat_result",
+        requestId: first.requestId,
+        ok: false,
+        error: "chat panel closed",
+      });
+    }
+
+    let caught: Error | null = null;
+    try {
+      await sendPromise;
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.message).toContain("chat panel closed");
+  });
+
+  test("concurrent send_chat requests correlate independently by requestId", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const cbs = handles.httpCallbacks();
+    const before = handles.outboundMessages().length;
+
+    const firstPromise = Promise.resolve(cbs!.onSendChat("one"));
+    const secondPromise = Promise.resolve(cbs!.onSendChat("two"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    const fresh = handles.outboundMessages().slice(before);
+    expect(fresh).toHaveLength(2);
+    const first = fresh[0];
+    const second = fresh[1];
+    if (
+      first?.type === "send_chat" &&
+      second?.type === "send_chat" &&
+      first.requestId !== second.requestId
+    ) {
+      // Reply to the second one first — should only resolve the second.
+      handles.fireExtensionMessage({
+        type: "send_chat_result",
+        requestId: second.requestId,
+        ok: true,
+      });
+      await secondPromise;
+      // First still pending — resolve now.
+      handles.fireExtensionMessage({
+        type: "send_chat_result",
+        requestId: first.requestId,
+        ok: true,
+      });
+      await firstPromise;
+    } else {
+      throw new Error("expected two distinct send_chat requests");
+    }
   });
 });
 
@@ -414,84 +679,74 @@ describe("runBot — shutdown", () => {
   test("onLeave triggers the full shutdown path in the right order", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
-    // Exercise the /leave path.
     const cbs = handles.httpCallbacks();
     expect(cbs).not.toBeNull();
 
-    // onLeave schedules shutdown + exit via `void` — we catch the
-    // sentinel exit() throw via the shutdown promise.
     await new Promise<void>((resolve) => {
       void (async () => {
         try {
           await cbs!.onLeave("user requested");
         } catch {
-          // swallow __test_exit
+          // swallow
         }
         resolve();
       })();
     });
 
-    // Poll for shutdown completion — the exit-code sentinel lands after
-    // the shutdown chain resolves.
     const deadline = Date.now() + 1_000;
     while (handles.exitCode() === null && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 5));
     }
-
     expect(handles.exitCode()).toBe(0);
 
     const order = kinds(handles.calls);
-    const leaveStart = order.lastIndexOf("http.create") + 1;
-    const shutdownOrder = order.slice(leaveStart);
+    const startIdx = order.lastIndexOf("http.start") + 1;
+    const shutdownOrder = order.slice(startIdx);
 
-    // HTTP server stops first (no new commands after /leave).
-    expect(shutdownOrder.indexOf("http.stop")).toBeGreaterThanOrEqual(0);
-    // Then scrapers.
-    expect(shutdownOrder.indexOf("scraper.participant.stop")).toBeGreaterThan(
-      shutdownOrder.indexOf("http.stop"),
-    );
-    expect(shutdownOrder.indexOf("scraper.speaker.stop")).toBeGreaterThan(
-      shutdownOrder.indexOf("http.stop"),
-    );
-    expect(shutdownOrder.indexOf("scraper.chat.stop")).toBeGreaterThan(
-      shutdownOrder.indexOf("http.stop"),
-    );
-    // Audio before browser.
-    expect(shutdownOrder.indexOf("audio.stop")).toBeGreaterThan(
-      shutdownOrder.indexOf("scraper.chat.stop"),
-    );
-    expect(shutdownOrder.indexOf("browser.close")).toBeGreaterThan(
-      shutdownOrder.indexOf("audio.stop"),
-    );
-    // Daemon stop comes last, and only after `lifecycle:left` is enqueued.
-    expect(shutdownOrder.indexOf("daemon.stop")).toBeGreaterThan(
-      shutdownOrder.indexOf("browser.close"),
-    );
+    // http.stop → leave command to extension → chrome.stop → audio.stop
+    // → xvfb.stop → socket.stop → daemon.stop.
+    const httpStop = shutdownOrder.indexOf("http.stop");
+    expect(httpStop).toBeGreaterThanOrEqual(0);
 
-    // `lifecycle:left` was published before stop().
+    // A leave send message appears between http.stop and chrome.stop.
+    const leaveSendIdx = shutdownOrder.findIndex(
+      (k) => k === "socket.send",
+    );
+    expect(leaveSendIdx).toBeGreaterThan(httpStop);
+
+    const chromeStop = shutdownOrder.indexOf("chrome.stop");
+    expect(chromeStop).toBeGreaterThan(leaveSendIdx);
+    const audioStop = shutdownOrder.indexOf("audio.stop");
+    expect(audioStop).toBeGreaterThan(chromeStop);
+    const xvfbStop = shutdownOrder.indexOf("xvfb.stop");
+    expect(xvfbStop).toBeGreaterThan(audioStop);
+    const socketStop = shutdownOrder.indexOf("socket.stop");
+    expect(socketStop).toBeGreaterThan(xvfbStop);
+    const daemonStop = shutdownOrder.indexOf("daemon.stop");
+    expect(daemonStop).toBeGreaterThan(socketStop);
+
+    // lifecycle:left published before daemon stop.
     const lifecycleStates = handles.daemonEvents
       .filter((e): e is LifecycleEvent => e.type === "lifecycle")
       .map((e) => e.state);
-    expect(lifecycleStates).toContain("left");
     expect(lifecycleStates[lifecycleStates.length - 1]).toBe("left");
 
     // Shutdown counts: each subsystem stopped exactly once.
     const counts = handles.stopCounts();
     expect(counts.httpServer).toBe(1);
-    expect(counts.participant).toBe(1);
-    expect(counts.speaker).toBe(1);
-    expect(counts.chat).toBe(1);
+    expect(counts.chrome).toBe(1);
     expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
     expect(handles.daemonStopped()).toBe(true);
-    expect(handles.sessionCloses()).toBe(1);
   });
 
   test("SIGTERM triggers the same shutdown path", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     handles.fireSigterm();
 
@@ -503,24 +758,24 @@ describe("runBot — shutdown", () => {
     expect(handles.exitCode()).toBe(0);
     const counts = handles.stopCounts();
     expect(counts.httpServer).toBe(1);
-    expect(counts.participant).toBe(1);
-    expect(counts.speaker).toBe(1);
-    expect(counts.chat).toBe(1);
+    expect(counts.chrome).toBe(1);
     expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
     expect(handles.daemonStopped()).toBe(true);
   });
 
   test("SIGTERM + /leave do not double-stop subsystems", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     handles.fireSigterm();
     const cbs = handles.httpCallbacks();
     try {
       await cbs!.onLeave("redundant");
     } catch {
-      // swallow __test_exit
+      // swallow
     }
 
     const deadline = Date.now() + 1_000;
@@ -530,73 +785,76 @@ describe("runBot — shutdown", () => {
 
     const counts = handles.stopCounts();
     expect(counts.httpServer).toBe(1);
-    expect(counts.participant).toBe(1);
-    expect(counts.speaker).toBe(1);
-    expect(counts.chat).toBe(1);
+    expect(counts.chrome).toBe(1);
     expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
   });
 });
 
 describe("runBot — error paths", () => {
-  test("join failure publishes lifecycle:error and exits 1", async () => {
+  test("extension ready timeout shuts down with lifecycle:error", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps({
-      joinError: new Error("prejoin selector timed out"),
+      extensionReadyError: new Error(
+        "timed out after 1000ms waiting for extension ready handshake",
+      ),
     });
 
-    try {
-      await runBot(deps);
-    } catch (err) {
-      // The sentinel exit() throws — catch so the test continues.
-      const msg = (err as Error).message;
-      if (!msg.startsWith("__test_exit")) throw err;
-    }
+    await runBot(deps);
+
+    expect(handles.exitCode()).toBe(1);
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => ({ state: e.state, detail: e.detail }));
+    const err = lifecycleStates.find((s) => s.state === "error");
+    expect(err).toBeDefined();
+    expect(err?.detail).toContain("extension never signaled ready");
+
+    // Audio + HTTP never started.
+    const order = kinds(handles.calls);
+    expect(order).not.toContain("audio.start");
+    expect(order).not.toContain("http.start");
+  });
+
+  test("Chrome exiting unexpectedly mid-meeting shuts down with error state", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    // Simulate Chrome crashing outside of our control.
+    handles.fireChromeExit(42);
 
     const deadline = Date.now() + 1_000;
     while (handles.exitCode() === null && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 5));
     }
-
     expect(handles.exitCode()).toBe(1);
 
     const lifecycleStates = handles.daemonEvents
       .filter((e): e is LifecycleEvent => e.type === "lifecycle")
       .map((e) => ({ state: e.state, detail: e.detail }));
-    expect(lifecycleStates.some((s) => s.state === "error")).toBe(true);
-    const errorEvent = lifecycleStates.find((s) => s.state === "error");
-    expect(errorEvent?.detail).toContain("prejoin selector timed out");
-
-    // Scrapers / audio / http must not have started.
-    const order = kinds(handles.calls);
-    expect(order).not.toContain("scraper.participant.start");
-    expect(order).not.toContain("audio.start");
-    expect(order).not.toContain("http.start");
-
-    // Browser was closed; daemon was flushed.
-    expect(handles.sessionCloses()).toBe(1);
-    expect(handles.daemonStopped()).toBe(true);
+    const last = lifecycleStates[lifecycleStates.length - 1];
+    expect(last?.state).toBe("error");
+    expect(last?.detail).toContain("chrome exited unexpectedly");
+    expect(last?.detail).toContain("42");
   });
 
-  test("PulseAudio failure exits 1 without touching browser", async () => {
+  test("PulseAudio failure exits 1 without touching xvfb or chrome", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps({
       pulseError: new Error("pulseaudio: connection refused"),
     });
-    // Override skipPulse to force the setup call.
     const realEnv = deps.env;
     deps.env = () => ({ ...realEnv(), skipPulse: false });
 
-    try {
-      await runBot(deps);
-    } catch (err) {
-      const msg = (err as Error).message;
-      if (!msg.startsWith("__test_exit")) throw err;
-    }
+    await runBot(deps);
 
     expect(handles.exitCode()).toBe(1);
     const order = kinds(handles.calls);
     expect(order).toContain("pulse.setup");
-    expect(order).not.toContain("browser.create");
+    expect(order).not.toContain("xvfb.start");
+    expect(order).not.toContain("chrome.launch");
     expect(
       handles.errors.some((e) => e.includes("PulseAudio setup failed")),
     ).toBe(true);
@@ -607,35 +865,27 @@ describe("runBot — daemon-client terminal errors", () => {
   test("logs a single terminal error without shutting down", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     const stopsBefore = handles.stopCounts();
-    const exitBefore = handles.exitCode();
-
     handles.fireDaemonError(new Error("ingress returned status 503"));
-
-    // Give any fire-and-forget shutdown promise a chance to advance.
     await new Promise((r) => setTimeout(r, 20));
 
-    // No shutdown yet — single transient failures are tolerated.
     const stopsAfter = handles.stopCounts();
     expect(stopsAfter.httpServer).toBe(stopsBefore.httpServer);
-    expect(stopsAfter.participant).toBe(stopsBefore.participant);
+    expect(stopsAfter.chrome).toBe(stopsBefore.chrome);
     expect(stopsAfter.audio).toBe(stopsBefore.audio);
     expect(handles.daemonStopped()).toBe(false);
-    expect(handles.exitCode()).toBe(exitBefore);
 
-    // But the failure must have been surfaced to the log.
     expect(
       handles.errors.some((e) => e.includes("daemon ingress failure")),
     ).toBe(true);
-    expect(handles.errors.some((e) => e.includes("status 503"))).toBe(true);
   });
 
-  test("second terminal error within the window triggers graceful shutdown + exit 1", async () => {
+  test("second terminal error within the window triggers graceful shutdown", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps();
-    await runBot(deps);
+    await bootHappyPath(deps, handles);
 
     handles.fireDaemonError(
       new Error("ingress rejected batch with status 400"),
@@ -647,131 +897,18 @@ describe("runBot — daemon-client terminal errors", () => {
       await new Promise((r) => setTimeout(r, 5));
     }
 
-    // Exited 1 (error) rather than 0 (clean leave).
     expect(handles.exitCode()).toBe(1);
-
-    // Subsystems torn down exactly once — same dedup as SIGTERM / /leave.
     const counts = handles.stopCounts();
     expect(counts.httpServer).toBe(1);
-    expect(counts.participant).toBe(1);
-    expect(counts.speaker).toBe(1);
-    expect(counts.chat).toBe(1);
+    expect(counts.chrome).toBe(1);
     expect(counts.audio).toBe(1);
     expect(handles.daemonStopped()).toBe(true);
 
-    // Final lifecycle event is "error" with the daemon-ingress detail.
     const lifecycleStates = handles.daemonEvents
       .filter((e): e is LifecycleEvent => e.type === "lifecycle")
       .map((e) => ({ state: e.state, detail: e.detail }));
     const last = lifecycleStates[lifecycleStates.length - 1]!;
     expect(last.state).toBe("error");
     expect(last.detail).toContain("daemon ingress failure");
-
-    // Both failures were logged, plus the "shutting down" banner.
-    expect(
-      handles.errors.filter((e) => e.includes("daemon ingress failure")).length,
-    ).toBeGreaterThanOrEqual(2);
-    expect(handles.errors.some((e) => e.includes("shutting down"))).toBe(true);
-  });
-
-  test("daemon-error shutdown deduplicates against SIGTERM", async () => {
-    BotState.__resetForTests();
-    const { deps, handles } = makeDeps();
-    await runBot(deps);
-
-    // Tip over the error threshold…
-    handles.fireDaemonError(new Error("status 400"));
-    handles.fireDaemonError(new Error("status 400"));
-
-    // …and race a SIGTERM into the shutdown.
-    handles.fireSigterm();
-
-    const deadline = Date.now() + 1_000;
-    while (handles.exitCode() === null && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 5));
-    }
-
-    // Each subsystem stopped exactly once — the shutdown guard held.
-    const counts = handles.stopCounts();
-    expect(counts.httpServer).toBe(1);
-    expect(counts.participant).toBe(1);
-    expect(counts.speaker).toBe(1);
-    expect(counts.chat).toBe(1);
-    expect(counts.audio).toBe(1);
-  });
-});
-
-describe("runBot — event wiring", () => {
-  test("scraper onEvent callbacks enqueue events on the daemon client", async () => {
-    BotState.__resetForTests();
-
-    // Capture the participant-scraper onEvent so we can invoke it by hand.
-    let participantOnEvent:
-      | ((
-          event: import("../../contracts/index.js").ParticipantChangeEvent,
-        ) => void)
-      | null = null;
-    let speakerOnEvent:
-      | ((event: import("../../contracts/index.js").SpeakerChangeEvent) => void)
-      | null = null;
-    let chatOnEvent:
-      | ((event: import("../../contracts/index.js").InboundChatEvent) => void)
-      | null = null;
-
-    const { deps, handles } = makeDeps();
-    const baseStart = deps.startParticipantScraper;
-    const baseSpeaker = deps.startSpeakerScraper;
-    const baseChat = deps.startChatReader;
-
-    deps.startParticipantScraper = (page, onEvent, opts) => {
-      participantOnEvent = onEvent;
-      return baseStart(page, onEvent, opts);
-    };
-    deps.startSpeakerScraper = (page, onEvent, opts) => {
-      speakerOnEvent = onEvent;
-      return baseSpeaker(page, onEvent, opts);
-    };
-    deps.startChatReader = (page, onEvent, opts) => {
-      chatOnEvent = onEvent;
-      return baseChat(page, onEvent, opts);
-    };
-
-    await runBot(deps);
-
-    const before = handles.daemonEvents.length;
-    expect(participantOnEvent).not.toBeNull();
-    expect(speakerOnEvent).not.toBeNull();
-    expect(chatOnEvent).not.toBeNull();
-
-    participantOnEvent!({
-      type: "participant.change",
-      meetingId: "m-1",
-      timestamp: new Date().toISOString(),
-      joined: [{ id: "p-1", name: "Alice" }],
-      left: [],
-    });
-    speakerOnEvent!({
-      type: "speaker.change",
-      meetingId: "m-1",
-      timestamp: new Date().toISOString(),
-      speakerId: "p-1",
-      speakerName: "Alice",
-    });
-    chatOnEvent!({
-      type: "chat.inbound",
-      meetingId: "m-1",
-      timestamp: new Date().toISOString(),
-      fromId: "p-2",
-      fromName: "Bob",
-      text: "hello",
-    });
-
-    expect(handles.daemonEvents.length).toBe(before + 3);
-    const newEvents = handles.daemonEvents.slice(before);
-    expect(newEvents.map((e) => e.type)).toEqual([
-      "participant.change",
-      "speaker.change",
-      "chat.inbound",
-    ]);
   });
 });

--- a/skills/meet-join/bot/scripts/build-bot.ts
+++ b/skills/meet-join/bot/scripts/build-bot.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+/**
+ * build-bot — pre-build the sibling meet-controller-ext package's `dist/` so
+ * the bot Dockerfile can `COPY` it into `/app/ext/`.
+ *
+ * The Dockerfile itself also runs `bun run build` inside the extension
+ * source copied into the image. This script exists so local/developer
+ * builds (outside Docker) end up with the same `dist/` layout without
+ * having to remember the exact sequence.
+ */
+import { $ } from "bun";
+
+await $`cd ../meet-controller-ext && bun install --frozen-lockfile && bun run build`;
+console.log("extension built at ../meet-controller-ext/dist/");

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -7,18 +7,25 @@
  *   1. Bring up PulseAudio virtual devices (null-sinks + virtual source).
  *      Skipped under `SKIP_PULSE=1` so the boot smoke test can run on
  *      macOS developer machines.
- *   2. Start Xvfb + launch Chromium via `createBrowserSession(MEET_URL)`.
- *   3. Drive the prejoin surface with `joinMeet(page, { displayName,
- *      consentMessage })`.
- *   4. Instantiate `DaemonClient`; publish `lifecycle:joining`, wait
- *      briefly for the meeting-room UI to settle, then publish
- *      `lifecycle:joined`.
- *   5. Start the DOM scrapers (participant, speaker, chat) with callbacks
- *      that funnel events into the daemon client.
- *   6. Start the audio capture pipeline (`startAudioCapture`) so PCM is
+ *   2. Start Xvfb (virtual display) for Chrome to render into.
+ *   3. Start the NMH Unix-socket server the extension's native-messaging
+ *      shim will connect to.
+ *   4. Launch google-chrome-stable as a plain user process with the
+ *      controller extension loaded via `--load-extension`. Chrome must NOT
+ *      be driven via CDP — Meet's bot detection rejects CDP-attached
+ *      joiners. Extension-side DOM work happens via Chrome Native
+ *      Messaging rather than Playwright/Puppeteer.
+ *   5. Instantiate `DaemonClient` and wait for the extension handshake
+ *      (`{ type: "ready" }`) to land on the socket server.
+ *   6. Publish `lifecycle:joining` and send the `join` command to the
+ *      extension over the socket. The extension drives the Meet prejoin
+ *      UI and, on success, emits `lifecycle:joined` over the same pipe —
+ *      which we forward to the daemon client.
+ *   7. Start the audio capture pipeline (`startAudioCapture`) so PCM is
  *      shipped to the daemon over the Unix socket.
- *   7. Stand up the HTTP control surface so the daemon can issue `/leave`,
- *      `/send_chat` (Phase 2), `/play_audio` (Phase 3).
+ *   8. Stand up the HTTP control surface so the daemon can issue `/leave`,
+ *      `/send_chat` (routes through the socket with requestId correlation),
+ *      `/play_audio` (Phase 3).
  *
  * `SIGTERM`, `SIGINT`, and an inbound `POST /leave` all converge on a
  * single graceful-shutdown path. We guard against re-entry so multiple
@@ -33,37 +40,31 @@
  *
  * Every subsystem is injected through `runBot(deps)` so the main-test
  * suite can verify the boot order, the shutdown order, and the error
- * paths without touching PulseAudio / Playwright / network sockets.
+ * paths without touching PulseAudio / Xvfb / Chrome / real sockets.
  * `defaultDeps()` returns the real wiring; `runBot(defaultDeps())` is
  * what `void main()` invokes at the bottom of this file.
  */
 
-import type { Page } from "playwright";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
 
 import type {
-  InboundChatEvent,
   LifecycleEvent,
   LifecycleState,
   MeetBotEvent,
-  ParticipantChangeEvent,
-  SpeakerChangeEvent,
 } from "../../contracts/index.js";
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
 
-import { sendChat } from "./browser/chat-bridge.js";
-import { startChatReader, type ChatReader } from "./browser/chat-reader.js";
-import { joinMeet, type JoinMeetOptions } from "./browser/join-flow.js";
 import {
-  startParticipantScraper,
-  type ParticipantScraperHandle,
-} from "./browser/participant-scraper.js";
-import {
-  startSpeakerScraper,
-  type SpeakerScraperHandle,
-} from "./browser/speaker-scraper.js";
-import {
-  createBrowserSession,
-  type BrowserSession,
-} from "./browser/session.js";
+  launchChrome,
+  type ChromeProcessHandle,
+  type LaunchChromeOptions,
+} from "./browser/chrome-launcher.js";
+import { startXvfb, stopXvfb, type XvfbHandle } from "./browser/xvfb.js";
 import { DaemonClient } from "./control/daemon-client.js";
 import {
   createHttpServer,
@@ -77,6 +78,11 @@ import {
   type AudioCaptureOptions,
 } from "./media/audio-capture.js";
 import { setupPulseAudio } from "./media/pulse.js";
+import {
+  createNmhSocketServer,
+  type NmhSocketServer,
+  type NmhSocketServerOptions,
+} from "./native-messaging/socket-server.js";
 
 // ---------------------------------------------------------------------------
 // Env
@@ -100,6 +106,14 @@ interface BotEnv {
   skipPulse: boolean;
   /** Bind port for the HTTP control surface. Defaults to 3000. */
   httpPort: number;
+  /** Absolute path to the loaded Chrome extension directory. */
+  extensionPath: string;
+  /** Unix socket path the NMH shim connects to. */
+  nmhSocketPath: string;
+  /** X display string Xvfb listens on. */
+  xvfbDisplay: string;
+  /** User-data directory root for Chrome — suffixed with meetingId per launch. */
+  chromeUserDataRoot: string;
 }
 
 function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
@@ -113,17 +127,16 @@ function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
     socketDir: env.SOCKET_DIR ?? "/sockets",
     skipPulse: env.SKIP_PULSE === "1",
     httpPort: env.HTTP_PORT ? Number(env.HTTP_PORT) : 3000,
+    extensionPath: env.EXTENSION_PATH ?? "/app/ext",
+    nmhSocketPath: env.NMH_SOCKET_PATH ?? "/run/nmh.sock",
+    xvfbDisplay: env.XVFB_DISPLAY ?? ":99",
+    chromeUserDataRoot: env.CHROME_USER_DATA_ROOT ?? "/tmp/chrome-profile",
   };
 }
 
 // ---------------------------------------------------------------------------
 // Dep injection
 // ---------------------------------------------------------------------------
-
-/** Handle a scraper hands back to its caller for teardown. */
-interface ScraperStopHandle {
-  stop: () => void | Promise<void>;
-}
 
 /**
  * Factories the main wiring calls through. Keeping them on a single
@@ -133,31 +146,15 @@ interface ScraperStopHandle {
 export interface BotDeps {
   env: () => BotEnv;
   setupPulseAudio: () => Promise<void>;
-  createBrowserSession: (url: string) => Promise<BrowserSession>;
-  joinMeet: (page: Page, opts: JoinMeetOptions) => Promise<void>;
-  startParticipantScraper: (
-    page: Page,
-    onEvent: (event: ParticipantChangeEvent) => void,
-    opts: { meetingId: string; selfName: string },
-  ) => ParticipantScraperHandle;
-  startSpeakerScraper: (
-    page: Page,
-    onEvent: (event: SpeakerChangeEvent) => void,
-    opts: { meetingId: string },
-  ) => SpeakerScraperHandle;
-  startChatReader: (
-    page: Page,
-    onEvent: (event: InboundChatEvent) => void,
-    opts: { meetingId: string; selfName: string },
-  ) => Promise<ChatReader>;
+  /** Start Xvfb on the requested display. */
+  startXvfb: (display: string) => Promise<XvfbHandle>;
+  /** Tear down an Xvfb handle. */
+  stopXvfb: (handle: XvfbHandle) => Promise<void>;
+  /** Create (but do not start) the NMH socket server. */
+  createNmhSocketServer: (opts: NmhSocketServerOptions) => NmhSocketServer;
+  /** Spawn google-chrome-stable. Returns a handle with exitPromise + stop. */
+  launchChrome: (opts: LaunchChromeOptions) => Promise<ChromeProcessHandle>;
   startAudioCapture: (opts: AudioCaptureOptions) => Promise<AudioCaptureHandle>;
-  /**
-   * Type `text` into the Meet chat composer and submit it. Invoked by the
-   * HTTP `/send_chat` endpoint. Separated from the other browser helpers
-   * so the main-test suite can inject a mock that captures the text
-   * without spinning up Playwright.
-   */
-  sendChat: (page: Page, text: string) => Promise<void>;
   createDaemonClient: (opts: {
     daemonUrl: string;
     meetingId: string;
@@ -168,13 +165,18 @@ export interface BotDeps {
     opts: HttpServerCallbacks & { apiToken: string },
   ) => HttpServerHandle;
   /**
+   * Ensure a directory exists (recursive). Exposed as a dep so tests can
+   * intercept filesystem writes — prod calls `fs.mkdirSync(..., recursive: true)`.
+   */
+  ensureDir: (path: string) => void;
+  /**
    * Signal handler hooks. The test harness stubs these out so the
    * Bun/Node signal machinery isn't wired up during unit tests.
    */
   onSignal: (signal: "SIGTERM" | "SIGINT", handler: () => void) => () => void;
   /**
    * Short settle delay between `lifecycle:joining` and `lifecycle:joined`.
-   * Exposed as a dep so tests can pass 0 and not hang.
+   * Retained as a dep for backward-compat with tests that pass 0.
    */
   joinedSettleMs: number;
   /** Sleep shim — tests can substitute a tick-accurate implementation. */
@@ -184,6 +186,14 @@ export interface BotDeps {
   /** Logger — routed to console in production. Keep separate hooks so tests can capture. */
   logInfo: (msg: string) => void;
   logError: (msg: string) => void;
+  /** Milliseconds to wait for the extension's `ready` handshake. */
+  extensionReadyTimeoutMs: number;
+  /** Milliseconds before a `send_chat` request times out with a failure. */
+  sendChatTimeoutMs: number;
+  /** Grace period after sending `leave` for the extension to animate out. */
+  leaveGraceMs: number;
+  /** Factory for correlation ids on outbound `send_chat` commands. */
+  generateRequestId: () => string;
 }
 
 /** Minimal slice of `DaemonClient` the main wiring depends on. */
@@ -198,13 +208,11 @@ export function defaultDeps(): BotDeps {
   return {
     env: () => readEnv(process.env),
     setupPulseAudio,
-    createBrowserSession,
-    joinMeet,
-    startParticipantScraper,
-    startSpeakerScraper,
-    startChatReader,
+    startXvfb,
+    stopXvfb,
+    createNmhSocketServer: (opts) => createNmhSocketServer(opts),
+    launchChrome: (opts) => launchChrome(opts),
     startAudioCapture,
-    sendChat,
     createDaemonClient: (opts) =>
       new DaemonClient({
         daemonUrl: opts.daemonUrl,
@@ -213,6 +221,7 @@ export function defaultDeps(): BotDeps {
         onError: (err) => opts.onError(err),
       }),
     createHttpServer,
+    ensureDir: (path) => mkdirSync(path, { recursive: true }),
     onSignal: (signal, handler) => {
       process.on(signal, handler);
       return () => {
@@ -224,6 +233,10 @@ export function defaultDeps(): BotDeps {
     exit: (code) => process.exit(code),
     logInfo: (msg) => console.log(msg),
     logError: (msg) => console.error(msg),
+    extensionReadyTimeoutMs: 30_000,
+    sendChatTimeoutMs: 10_000,
+    leaveGraceMs: 2_000,
+    generateRequestId: () => randomUUID(),
   };
 }
 
@@ -281,62 +294,33 @@ export async function runBot(deps: BotDeps): Promise<void> {
   deps.logInfo("meet-bot booted");
 
   // -------------------------------------------------------------------------
-  // Legacy screenshot-only boot path (used by the boot smoke test).
+  // Smoke-test short-circuit.
   //
-  // If there's no MEET_URL at all, the boot test just wants to confirm the
-  // package can start and log the marker. Return without going further.
-  //
-  // If MEET_URL is set but MEETING_ID / DAEMON_URL / BOT_API_TOKEN / JOIN_NAME
-  // are missing, we fall back to the previous "open a browser and screenshot"
-  // behavior so existing smoke paths keep working. Full join + daemon wiring
-  // requires the full env.
+  // The boot smoke test (`boot.test.ts`) runs the package with `SKIP_PULSE=1`
+  // and no MEET_URL; it just needs to see the boot marker and exit 0. Any
+  // missing required env falls into the same "bail out cleanly" bucket — we
+  // only enter full wiring when EVERY value is set.
   // -------------------------------------------------------------------------
 
-  if (!env.meetUrl) {
-    return;
-  }
-
-  const needsFullWiring =
+  const hasFullEnv =
+    env.meetUrl &&
     env.meetingId &&
     env.joinName &&
     env.consentMessage &&
     env.daemonUrl &&
     env.botApiToken;
 
-  if (!needsFullWiring) {
-    const session = await deps.createBrowserSession(env.meetUrl);
-    try {
-      if (env.joinName && env.consentMessage) {
-        try {
-          await deps.joinMeet(session.page, {
-            displayName: env.joinName,
-            consentMessage: env.consentMessage,
-          });
-          deps.logInfo(`meet-bot joined ${env.meetUrl} as ${env.joinName}`);
-        } catch (err) {
-          deps.logError(`meet-bot: join flow failed: ${errMsg(err)}`);
-          deps.exit(1);
-          return;
-        }
-      } else {
-        await session.page.screenshot({ path: "/tmp/boot-screenshot.png" });
-        deps.logInfo(
-          `meet-bot captured boot screenshot for ${env.meetUrl} at /tmp/boot-screenshot.png`,
-        );
-      }
-    } finally {
-      await session.close();
-    }
+  if (!hasFullEnv) {
     return;
   }
 
-  // TypeScript narrowing — `needsFullWiring` already verified these.
+  // TypeScript narrowing — `hasFullEnv` already verified these.
   const meetingId = env.meetingId!;
   const joinName = env.joinName!;
   const consentMessage = env.consentMessage!;
   const daemonUrl = env.daemonUrl!;
   const botApiToken = env.botApiToken!;
-  const meetUrl = env.meetUrl;
+  const meetUrl = env.meetUrl!;
 
   BotState.setMeeting(meetingId);
 
@@ -345,34 +329,43 @@ export async function runBot(deps: BotDeps): Promise<void> {
   // still produce a usable shutdown even if the daemon client never gets
   // instantiated.
   type Subsystems = {
-    session: BrowserSession | null;
+    xvfb: XvfbHandle | null;
+    socketServer: NmhSocketServer | null;
+    chrome: ChromeProcessHandle | null;
     daemonClient: DaemonClientLike | null;
-    participantScraper: ScraperStopHandle | null;
-    speakerScraper: ScraperStopHandle | null;
-    chatReader: ScraperStopHandle | null;
     audioCapture: AudioCaptureHandle | null;
     httpServer: HttpServerHandle | null;
   };
   const subsystems: Subsystems = {
-    session: null,
+    xvfb: null,
+    socketServer: null,
+    chrome: null,
     daemonClient: null,
-    participantScraper: null,
-    speakerScraper: null,
-    chatReader: null,
     audioCapture: null,
     httpServer: null,
   };
 
-  // Dedup guard: signals, HTTP /leave, and boot errors can all race to
-  // trigger shutdown. Only the first one wins.
+  // Pending `send_chat` requests, correlated by requestId so the extension's
+  // `send_chat_result` can resolve the awaiting HTTP route.
+  const pendingSendChat = new Map<
+    string,
+    {
+      resolve: () => void;
+      reject: (err: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  // Dedup guard: signals, HTTP /leave, daemon-error flaps, and boot errors
+  // can all race to trigger shutdown. Only the first one wins.
   let shutdownInProgress = false;
   let shutdownDonePromise: Promise<void> | null = null;
 
   /**
    * Graceful shutdown. Tears down subsystems in the reverse order of
-   * startup: HTTP server (so no new commands arrive) → scrapers → audio
-   * → browser → daemon client (flushed last so `lifecycle:left` is
-   * delivered). Safe to call multiple times.
+   * startup: HTTP → tell the extension to leave → Chrome → audio →
+   * Xvfb → socket server → daemon client (flushed last so
+   * `lifecycle:left`/`error` is delivered). Safe to call multiple times.
    */
   async function shutdown(
     finalState: "left" | "error",
@@ -386,32 +379,79 @@ export async function runBot(deps: BotDeps): Promise<void> {
     shutdownDonePromise = (async () => {
       BotState.setPhase(finalState === "error" ? "error" : "leaving");
 
+      // Reject any pending send_chat promises so the HTTP handlers unblock
+      // with a clear error rather than hanging until their own timer fires.
+      for (const [requestId, pending] of pendingSendChat.entries()) {
+        clearTimeout(pending.timer);
+        pending.reject(
+          new Error(`send_chat: bot shutting down (requestId=${requestId})`),
+        );
+      }
+      pendingSendChat.clear();
+
       /** Run a subsystem teardown without letting its failure poison the rest. */
       const stopSafely = async (
         label: string,
-        handle: { stop: () => void | Promise<void> } | null,
+        fn: (() => void | Promise<void>) | null,
       ): Promise<void> => {
-        if (!handle) return;
+        if (!fn) return;
         try {
-          await handle.stop();
+          await fn();
         } catch (err) {
           deps.logError(`meet-bot: ${label} stop failed: ${errMsg(err)}`);
         }
       };
 
-      // Teardown order (reverse of boot): HTTP first so no new commands
-      // arrive, then the scrapers (halts scraper-generated events), then
-      // audio (so parec sees clean EOF before Chrome tears down), then
-      // the browser. The daemon client is stopped last so the terminal
-      // lifecycle event gets flushed.
-      await stopSafely("http server", subsystems.httpServer);
-      await stopSafely("participant scraper", subsystems.participantScraper);
-      await stopSafely("speaker scraper", subsystems.speakerScraper);
-      await stopSafely("chat reader", subsystems.chatReader);
-      await stopSafely("audio capture", subsystems.audioCapture);
+      // Teardown order (reverse of boot):
+      //   1. HTTP first so no new commands arrive.
+      //   2. Best-effort `leave` to the extension so it animates out.
+      //   3. Chrome (SIGTERM → SIGKILL after 5s).
+      //   4. Audio capture (parec sees EOF before Pulse tears down).
+      //   5. Xvfb (no more rendering to do).
+      //   6. Socket server (closes the listener, unlinks the socket).
+      //   7. Daemon client (flushed last so the terminal lifecycle event
+      //      gets delivered).
       await stopSafely(
-        "browser session",
-        subsystems.session ? { stop: () => subsystems.session!.close() } : null,
+        "http server",
+        subsystems.httpServer
+          ? () => subsystems.httpServer!.stop()
+          : null,
+      );
+      // Send `leave` best-effort; swallow errors because the extension
+      // may already be gone. Give it a short grace period to animate out.
+      if (subsystems.socketServer) {
+        try {
+          subsystems.socketServer.sendToExtension({
+            type: "leave",
+            reason: detail ?? (finalState === "error" ? "error" : "shutdown"),
+          });
+          await deps.sleep(deps.leaveGraceMs);
+        } catch (err) {
+          // Extension may already be disconnected; fine.
+          deps.logError(
+            `meet-bot: leave command to extension failed: ${errMsg(err)}`,
+          );
+        }
+      }
+      await stopSafely(
+        "chrome",
+        subsystems.chrome ? () => subsystems.chrome!.stop() : null,
+      );
+      await stopSafely(
+        "audio capture",
+        subsystems.audioCapture
+          ? () => subsystems.audioCapture!.stop()
+          : null,
+      );
+      await stopSafely(
+        "xvfb",
+        subsystems.xvfb ? () => deps.stopXvfb(subsystems.xvfb!) : null,
+      );
+      await stopSafely(
+        "socket server",
+        subsystems.socketServer
+          ? () => subsystems.socketServer!.stop()
+          : null,
       );
 
       publishLifecycle(
@@ -421,7 +461,12 @@ export async function runBot(deps: BotDeps): Promise<void> {
         deps,
         detail,
       );
-      await stopSafely("daemon client", subsystems.daemonClient);
+      await stopSafely(
+        "daemon client",
+        subsystems.daemonClient
+          ? () => subsystems.daemonClient!.stop()
+          : null,
+      );
 
       BotState.setPhase(finalState);
     })();
@@ -475,19 +520,51 @@ export async function runBot(deps: BotDeps): Promise<void> {
   // error we publish `lifecycle:error`, drain the daemon client, and
   // exit 1.
   try {
-    // ---------------------------------------------------------------------
-    // Step 2 — Xvfb + browser.
-    // ---------------------------------------------------------------------
     BotState.setPhase("joining");
-    subsystems.session = await deps.createBrowserSession(meetUrl);
 
     // ---------------------------------------------------------------------
-    // Step 3 — join the meeting.
+    // Step 2 — Xvfb.
+    // ---------------------------------------------------------------------
+    subsystems.xvfb = await deps.startXvfb(env.xvfbDisplay);
+
+    // ---------------------------------------------------------------------
+    // Step 3 — NMH socket server.
     //
-    // We need the daemon client up to *report* a join failure, so
-    // instantiate it before invoking joinMeet. That way a selector
-    // timeout (host never admits the bot, prejoin URL expired, etc.)
-    // still produces a `lifecycle:error` event on the wire.
+    // Ensure the socket's parent directory exists and the Chrome user-data
+    // directory is ready before spawning anything. The socket lives under
+    // `/run/` in production which may not exist in all base images.
+    // ---------------------------------------------------------------------
+    const socketDir = dirname(env.nmhSocketPath);
+    deps.ensureDir(socketDir);
+
+    const userDataDir = `${env.chromeUserDataRoot}-${meetingId}`;
+    deps.ensureDir(userDataDir);
+
+    subsystems.socketServer = deps.createNmhSocketServer({
+      socketPath: env.nmhSocketPath,
+      logger: {
+        info: (m) => deps.logInfo(m),
+        warn: (m) => deps.logError(m),
+      },
+    });
+
+    // Inbound messages from the extension. This single handler routes every
+    // validated frame: lifecycle + telemetry forward to the daemon,
+    // diagnostics get logged, send_chat_result completes pending HTTP
+    // requests. The `ready` handshake is handled separately by
+    // `socketServer.waitForReady`; we log it here too for visibility.
+    subsystems.socketServer.onExtensionMessage((msg) =>
+      handleExtensionMessage(msg),
+    );
+
+    await subsystems.socketServer.start();
+
+    // ---------------------------------------------------------------------
+    // Step 4 — daemon client.
+    //
+    // Instantiate BEFORE Chrome + extension so any lifecycle events the
+    // extension produces during early join can be forwarded to the daemon
+    // immediately.
     // ---------------------------------------------------------------------
     subsystems.daemonClient = deps.createDaemonClient({
       daemonUrl,
@@ -496,16 +573,65 @@ export async function runBot(deps: BotDeps): Promise<void> {
       onError: onDaemonTerminalError,
     });
 
+    // ---------------------------------------------------------------------
+    // Step 5 — Chrome.
+    //
+    // The handle's `exitPromise` is watched below; if Chrome dies before
+    // we've intentionally shut down, treat it as an unexpected failure.
+    // ---------------------------------------------------------------------
+    subsystems.chrome = await deps.launchChrome({
+      meetingUrl: meetUrl,
+      displayNumber: env.xvfbDisplay,
+      extensionPath: env.extensionPath,
+      userDataDir,
+      logger: {
+        info: (m) => deps.logInfo(m),
+        error: (m) => deps.logError(m),
+      },
+    });
+
+    // Watch for an unexpected Chrome exit. If Chrome dies on its own before
+    // the bot has decided to shut down, we escalate to an error shutdown.
+    void subsystems.chrome.exitPromise.then((code) => {
+      if (shutdownInProgress) return;
+      void shutdown("error", `chrome exited unexpectedly with code ${code}`).then(
+        () => {
+          detachSigterm();
+          detachSigint();
+          deps.exit(1);
+        },
+      );
+    });
+
+    // ---------------------------------------------------------------------
+    // Step 6 — wait for the extension, then issue `join`.
+    // ---------------------------------------------------------------------
+    try {
+      await subsystems.socketServer.waitForReady(deps.extensionReadyTimeoutMs);
+    } catch (err) {
+      const msg = errMsg(err);
+      deps.logError(`meet-bot: ${msg}`);
+      await shutdown("error", "extension never signaled ready");
+      detachSigterm();
+      detachSigint();
+      deps.exit(1);
+      return;
+    }
+
+    // Publish `lifecycle:joining` directly so the daemon sees the transition
+    // even if the extension's own `joining` message is delayed by tab load.
     publishLifecycle(subsystems.daemonClient, meetingId, "joining", deps);
 
     try {
-      await deps.joinMeet(subsystems.session.page, {
+      subsystems.socketServer.sendToExtension({
+        type: "join",
+        meetingUrl: meetUrl,
         displayName: joinName,
         consentMessage,
       });
     } catch (err) {
       const msg = errMsg(err);
-      deps.logError(`meet-bot: join flow failed: ${msg}`);
+      deps.logError(`meet-bot: failed to send join to extension: ${msg}`);
       await shutdown("error", msg);
       detachSigterm();
       detachSigint();
@@ -513,45 +639,21 @@ export async function runBot(deps: BotDeps): Promise<void> {
       return;
     }
 
-    // ---------------------------------------------------------------------
-    // Step 4 — settle, then publish `lifecycle:joined`.
-    // ---------------------------------------------------------------------
+    // Short settle before wiring up the audio pipeline so the page has a
+    // moment to render after admission. The extension will emit its own
+    // `lifecycle:joined` which we forward; this sleep only keeps historical
+    // test timing semantics (`joinedSettleMs`) intact.
     await deps.sleep(deps.joinedSettleMs);
-    BotState.setPhase("joined");
-    publishLifecycle(subsystems.daemonClient, meetingId, "joined", deps);
 
     // ---------------------------------------------------------------------
-    // Step 5 — scrapers.
-    // ---------------------------------------------------------------------
-    const enqueue = (ev: MeetBotEvent): void => {
-      if (subsystems.daemonClient) subsystems.daemonClient.enqueue(ev);
-    };
-
-    subsystems.participantScraper = deps.startParticipantScraper(
-      subsystems.session.page,
-      (event) => enqueue(event),
-      { meetingId, selfName: joinName },
-    );
-    subsystems.speakerScraper = deps.startSpeakerScraper(
-      subsystems.session.page,
-      (event) => enqueue(event),
-      { meetingId },
-    );
-    subsystems.chatReader = await deps.startChatReader(
-      subsystems.session.page,
-      (event) => enqueue(event),
-      { meetingId, selfName: joinName },
-    );
-
-    // ---------------------------------------------------------------------
-    // Step 6 — audio capture.
+    // Step 7 — audio capture.
     // ---------------------------------------------------------------------
     subsystems.audioCapture = await deps.startAudioCapture({
       socketPath: `${env.socketDir}/audio.sock`,
     });
 
     // ---------------------------------------------------------------------
-    // Step 7 — HTTP control surface.
+    // Step 8 — HTTP control surface.
     // ---------------------------------------------------------------------
     subsystems.httpServer = deps.createHttpServer({
       apiToken: botApiToken,
@@ -562,18 +664,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
           deps.exit(0);
         });
       },
-      onSendChat: async (text) => {
-        // Surfacing errors back to the HTTP server lets it respond 502 to
-        // the daemon when Playwright can't reach the chat panel (selector
-        // drift, panel closed, Meet DOM still loading, etc.). The HTTP
-        // server is responsible for validation and the 2000-char limit —
-        // at this layer we just drive the browser.
-        const page = subsystems.session?.page;
-        if (!page) {
-          throw new Error("send_chat: browser session is not ready");
-        }
-        await deps.sendChat(page, text);
-      },
+      onSendChat: (text) => sendChatViaExtension(text),
       onPlayAudio: () => {
         // Phase 3 will replace the 501 stub with a real implementation.
       },
@@ -588,6 +679,115 @@ export async function runBot(deps: BotDeps): Promise<void> {
     detachSigterm();
     detachSigint();
     deps.exit(1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers defined in-scope so they capture the subsystems / pending map.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Route a single validated inbound message from the extension. Lifecycle
+   * + telemetry forward to the daemon, diagnostics get logged, and
+   * `send_chat_result` completes the pending HTTP request.
+   */
+  function handleExtensionMessage(msg: ExtensionToBotMessage): void {
+    switch (msg.type) {
+      case "ready":
+        deps.logInfo(`meet-bot: extension ready (version=${msg.extensionVersion})`);
+        return;
+      case "lifecycle": {
+        const state: LifecycleState = msg.state;
+        // Drive local bot-state on `joined` / terminal states; the
+        // `joining` emitted by the extension is informational — we already
+        // set BotState before `waitForReady` returned.
+        if (state === "joined") BotState.setPhase("joined");
+        if (state === "error") BotState.setPhase("error");
+        if (state === "left") BotState.setPhase("leaving");
+        publishLifecycle(
+          subsystems.daemonClient,
+          msg.meetingId,
+          state,
+          deps,
+          msg.detail,
+        );
+        return;
+      }
+      case "participant.change":
+      case "speaker.change":
+      case "chat.inbound":
+        if (subsystems.daemonClient) subsystems.daemonClient.enqueue(msg);
+        return;
+      case "diagnostic":
+        if (msg.level === "error") deps.logError(`[ext] ${msg.message}`);
+        else deps.logInfo(`[ext] ${msg.message}`);
+        return;
+      case "send_chat_result": {
+        const pending = pendingSendChat.get(msg.requestId);
+        if (!pending) {
+          // Late reply for a request we already gave up on, or a fabricated
+          // requestId. Log and drop.
+          deps.logError(
+            `meet-bot: send_chat_result for unknown requestId=${msg.requestId}`,
+          );
+          return;
+        }
+        clearTimeout(pending.timer);
+        pendingSendChat.delete(msg.requestId);
+        if (msg.ok) {
+          pending.resolve();
+        } else {
+          pending.reject(
+            new Error(
+              msg.error
+                ? `send_chat failed: ${msg.error}`
+                : "send_chat failed (extension did not provide a reason)",
+            ),
+          );
+        }
+        return;
+      }
+    }
+  }
+
+  /**
+   * Dispatch a `send_chat` command to the extension and wait for the
+   * matching `send_chat_result`. Resolves on `ok: true`, rejects on
+   * `ok: false` or on a 10s timeout. Called from the HTTP `/send_chat`
+   * route.
+   */
+  async function sendChatViaExtension(text: string): Promise<void> {
+    if (!subsystems.socketServer) {
+      throw new Error("send_chat: socket server not started");
+    }
+    const requestId = deps.generateRequestId();
+    const waitForResult = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingSendChat.delete(requestId);
+        reject(
+          new Error(
+            `send_chat: extension did not reply within ${deps.sendChatTimeoutMs}ms (requestId=${requestId})`,
+          ),
+        );
+      }, deps.sendChatTimeoutMs);
+      pendingSendChat.set(requestId, { resolve, reject, timer });
+    });
+
+    const cmd: BotToExtensionMessage = {
+      type: "send_chat",
+      text,
+      requestId,
+    };
+    try {
+      subsystems.socketServer.sendToExtension(cmd);
+    } catch (err) {
+      const pending = pendingSendChat.get(requestId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        pendingSendChat.delete(requestId);
+      }
+      throw err;
+    }
+    await waitForResult;
   }
 }
 

--- a/skills/meet-join/meet-controller-ext/bun.lock
+++ b/skills/meet-join/meet-controller-ext/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@vellumai/meet-controller-ext",
+      "dependencies": {
+        "zod": "4.3.6",
+      },
       "devDependencies": {
         "@types/bun": "1.3.9",
         "@types/chrome": "0.1.40",
@@ -113,6 +116,8 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/skills/meet-join/meet-controller-ext/package.json
+++ b/skills/meet-join/meet-controller-ext/package.json
@@ -9,6 +9,9 @@
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },
+  "dependencies": {
+    "zod": "4.3.6"
+  },
   "devDependencies": {
     "@types/bun": "1.3.9",
     "@types/chrome": "0.1.40",


### PR DESCRIPTION
## Summary
- Rewrites main.ts to orchestrate: PulseAudio -> Xvfb -> NMH socket server -> Chrome subprocess + extension -> extension ready handshake -> send 'join' -> audio capture -> HTTP server.
- Playwright launch + scraper wiring dropped; extension does all DOM work and reports via native-messaging.
- send_chat path now routes command/response through the socket server with requestId correlation and a 10s timeout.
- Shutdown order: HTTP -> extension 'leave' -> Chrome SIGTERM/SIGKILL -> audio -> Xvfb -> socket server -> daemon client (flushed last).
- Dockerfile now builds the extension during image-build and installs it at /app/ext.
- Old Playwright files (session.ts, join-flow.ts, browser scrapers) left in place for PR 15 to delete.

Part of plan: meet-phase-1-11-chrome-extension.md (PR 14 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
