### PR TITLE
fix(daemon): strip historical web_search_tool_result before replay

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -313,6 +313,37 @@ describe("classifyConversationError", () => {
     });
   });
 
+  describe("stale web-search encrypted_content errors", () => {
+    const cases = [
+      "messages.205.content.0: Invalid `encrypted_content` in `search_result` block",
+      "Invalid encrypted_content in search_result block",
+      "Invalid `encrypted_content` in `web_search_result` block",
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg.slice(0, 50)}…" as PROVIDER_WEB_SEARCH / stale_web_search_content`, () => {
+        const result = classifyConversationError(new Error(msg), baseCtx);
+        expect(result.code).toBe("PROVIDER_WEB_SEARCH");
+        expect(result.retryable).toBe(true);
+        expect(result.errorCategory).toBe("stale_web_search_content");
+        expect(result.userMessage).toBe(
+          "Stale web-search results in conversation history. Please try again.",
+        );
+      });
+    }
+
+    it("classifies 400 ProviderError with stale encrypted_content payload", () => {
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"{\\"type\\":\\"error\\",\\"error\\":{\\"type\\":\\"invalid_request_error\\",\\"message\\":\\"messages.205.content.0: Invalid `encrypted_content` in `search_result` block\\"}}","provider_name":"Anthropic","is_byok":false}}}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_WEB_SEARCH");
+      expect(result.errorCategory).toBe("stale_web_search_content");
+    });
+  });
+
   describe("provider not configured errors", () => {
     it("classifies ProviderNotConfiguredError as PROVIDER_NOT_CONFIGURED", () => {
       const err = new ProviderNotConfiguredError("anthropic", []);

--- a/assistant/src/__tests__/web-search-history.test.ts
+++ b/assistant/src/__tests__/web-search-history.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from "bun:test";
+
+import { stripHistoricalWebSearchResults } from "../daemon/web-search-history.js";
+import type { Message } from "../providers/types.js";
+
+describe("stripHistoricalWebSearchResults", () => {
+  test("no-op when there are no web_search_tool_result blocks", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(result).toEqual(messages);
+    expect(stats.blocksStripped).toBe(0);
+    expect(stats.serverToolUsesDropped).toBe(0);
+    expect(stats.messagesModified).toBe(0);
+  });
+
+  test(
+    "replaces historical web_search_tool_result with text summary including title+url",
+    () => {
+      const messages: Message[] = [
+        { role: "user", content: [{ type: "text", text: "Search cats" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me look" },
+            {
+              type: "server_tool_use",
+              id: "stu_1",
+              name: "web_search",
+              input: { query: "cats" },
+            },
+            {
+              type: "web_search_tool_result",
+              tool_use_id: "stu_1",
+              content: [
+                {
+                  type: "web_search_result",
+                  url: "https://cats.com",
+                  title: "Cats!",
+                  encrypted_content: "expired_token_1",
+                },
+                {
+                  type: "web_search_result",
+                  url: "https://felines.org",
+                  title: "Feline facts",
+                  encrypted_content: "expired_token_2",
+                },
+              ],
+            },
+            { type: "text", text: "Here's what I found." },
+          ],
+        },
+      ];
+
+      const { messages: result, stats } = stripHistoricalWebSearchResults(
+        messages,
+      );
+
+      expect(stats.blocksStripped).toBe(1);
+      expect(stats.serverToolUsesDropped).toBe(1);
+      expect(stats.messagesModified).toBe(1);
+
+      const assistantMsg = result[1];
+      const types = assistantMsg.content.map((b) => b.type);
+      expect(types).toEqual(["text", "text", "text"]);
+
+      const summary = assistantMsg.content[1];
+      expect(summary.type).toBe("text");
+      if (summary.type === "text") {
+        expect(summary.text).toContain("cats");
+        expect(summary.text).toContain("Cats!");
+        expect(summary.text).toContain("https://cats.com");
+        expect(summary.text).toContain("Feline facts");
+        expect(summary.text).toContain("https://felines.org");
+        expect(summary.text).not.toContain("expired_token_1");
+      }
+    },
+  );
+
+  test("drops server_tool_use paired with converted results", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_A",
+            name: "web_search",
+            input: { query: "alpha" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_A",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://a.example",
+                title: "A",
+                encrypted_content: "tok_A",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(stats.blocksStripped).toBe(1);
+    expect(stats.serverToolUsesDropped).toBe(1);
+    expect(result[0].content).toHaveLength(1);
+    expect(result[0].content[0].type).toBe("text");
+  });
+
+  test("preserves unrelated server_tool_use blocks when other searches stripped", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_A",
+            name: "web_search",
+            input: { query: "alpha" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_A",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://a.example",
+                title: "A",
+                encrypted_content: "tok_A",
+              },
+            ],
+          },
+          {
+            type: "server_tool_use",
+            id: "stu_B",
+            name: "web_search",
+            input: { query: "beta" },
+          },
+        ],
+      },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(stats.serverToolUsesDropped).toBe(1);
+    const types = result[0].content.map((b) => b.type);
+    expect(types).toEqual(["text", "server_tool_use"]);
+    const preserved = result[0].content[1];
+    expect(preserved.type).toBe("server_tool_use");
+    if (preserved.type === "server_tool_use") {
+      expect(preserved.id).toBe("stu_B");
+    }
+  });
+
+  test("handles web_search_tool_result with error content gracefully", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_1",
+            name: "web_search",
+            input: { query: "x" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_1",
+            content: {
+              type: "web_search_tool_result_error",
+              error_code: "unavailable",
+            },
+          },
+        ],
+      },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(stats.blocksStripped).toBe(1);
+    expect(result[0].content).toHaveLength(1);
+    const summary = result[0].content[0];
+    expect(summary.type).toBe("text");
+    if (summary.type === "text") {
+      expect(summary.text).toContain("unavailable");
+    }
+  });
+
+  test("falls back when query cannot be found", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_missing",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://x.example",
+                title: "X",
+                encrypted_content: "tok",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(stats.blocksStripped).toBe(1);
+    expect(stats.serverToolUsesDropped).toBe(0);
+    const summary = result[0].content[0];
+    expect(summary.type).toBe("text");
+    if (summary.type === "text") {
+      expect(summary.text).toContain("Prior web_search results");
+      expect(summary.text).toContain("https://x.example");
+    }
+  });
+
+  test("handles multiple searches in one assistant message", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_1",
+            name: "web_search",
+            input: { query: "first" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_1",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://first.example",
+                title: "First",
+                encrypted_content: "tok_1",
+              },
+            ],
+          },
+          { type: "text", text: "interlude" },
+          {
+            type: "server_tool_use",
+            id: "stu_2",
+            name: "web_search",
+            input: { query: "second" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_2",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://second.example",
+                title: "Second",
+                encrypted_content: "tok_2",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: result, stats } = stripHistoricalWebSearchResults(
+      messages,
+    );
+
+    expect(stats.blocksStripped).toBe(2);
+    expect(stats.serverToolUsesDropped).toBe(2);
+    expect(stats.messagesModified).toBe(1);
+
+    const types = result[0].content.map((b) => b.type);
+    expect(types).toEqual(["text", "text", "text"]);
+
+    const first = result[0].content[0];
+    const second = result[0].content[2];
+    if (first.type === "text") expect(first.text).toContain("first");
+    if (second.type === "text") expect(second.text).toContain("second");
+  });
+
+  test("does not mutate the input messages array", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_1",
+            name: "web_search",
+            input: { query: "q" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_1",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "E",
+                encrypted_content: "tok",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const beforeTypes = messages[0].content.map((b) => b.type);
+
+    stripHistoricalWebSearchResults(messages);
+
+    const afterTypes = messages[0].content.map((b) => b.type);
+    expect(afterTypes).toEqual(beforeTypes);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -133,6 +133,7 @@ import { resolveTrustClass } from "./conversation-tool-setup.js";
 import { recordUsage } from "./conversation-usage.js";
 import { formatTurnTimestamp } from "./date-context.js";
 import { deepRepairHistory, repairHistory } from "./history-repair.js";
+import { stripHistoricalWebSearchResults } from "./web-search-history.js";
 import type {
   DynamicPageSurfaceData,
   ServerMessage,
@@ -1083,6 +1084,20 @@ export async function runAgentLoopImpl(
       runMessages = preRunRepair.messages;
     }
 
+    // Replace historical web_search_tool_result blocks with text summaries.
+    // The opaque `encrypted_content` tokens Anthropic attaches to each result
+    // expire / are route-scoped; replaying a stale token is rejected with
+    // `Invalid encrypted_content in search_result block`. Titles + URLs
+    // preserve enough context for the model on follow-up turns.
+    const webSearchStrip = stripHistoricalWebSearchResults(runMessages);
+    if (webSearchStrip.stats.blocksStripped > 0) {
+      rlog.info(
+        { phase: "pre_run", ...webSearchStrip.stats },
+        "Converted historical web_search_tool_result blocks to text summaries",
+      );
+      runMessages = webSearchStrip.messages;
+    }
+
     let preRunHistoryLength = runMessages.length;
 
     const shouldGenerateTitle = isReplaceableTitle(
@@ -1298,7 +1313,9 @@ export async function runAgentLoopImpl(
       );
       const retryRepair = deepRepairHistory(runMessages);
       runMessages = retryRepair.messages;
-      preRepairMessages = retryRepair.messages;
+      const retryStrip = stripHistoricalWebSearchResults(runMessages);
+      runMessages = retryStrip.messages;
+      preRepairMessages = runMessages;
       preRunHistoryLength = runMessages.length;
       state.orderingErrorDetected = false;
       state.deferredOrderingError = null;

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -86,6 +86,14 @@ const WEB_SEARCH_ORDERING_PATTERNS = [
   /web_search.*tool_result/i,
 ];
 
+// Stale/invalid opaque `encrypted_content` token in replayed web-search results.
+// Anthropic's tokens have bounded validity; the daemon replaces historical
+// `web_search_tool_result` blocks with text summaries to avoid this, but this
+// classifier remains as defense-in-depth for any path that bypasses the strip.
+const STALE_WEB_SEARCH_CONTENT_PATTERNS = [
+  /invalid\s+`?encrypted_content`?\s+in\s+`?(?:web_)?search_result`?\s+block/i,
+];
+
 // Streaming corruption patterns (Anthropic SDK throws non-HTTP errors for SSE issues)
 const STREAMING_ERROR_PATTERNS = [
   /unexpected event order/i,
@@ -302,6 +310,15 @@ function classifyCore(
           errorCategory: "web_search_ordering",
         };
       }
+      if (isStaleWebSearchContent(message)) {
+        return {
+          code: "PROVIDER_WEB_SEARCH",
+          userMessage:
+            "Stale web-search results in conversation history. Please try again.",
+          retryable: true,
+          errorCategory: "stale_web_search_content",
+        };
+      }
       if (isOrderingError(message)) {
         return {
           code: "PROVIDER_ORDERING",
@@ -352,6 +369,15 @@ export function isContextTooLarge(message: string): boolean {
 /** Check whether an error message indicates a web-search-specific ordering failure. */
 export function isWebSearchOrderingError(message: string): boolean {
   return WEB_SEARCH_ORDERING_PATTERNS.some((p) => p.test(message));
+}
+
+/**
+ * Check whether an error message indicates a stale/invalid `encrypted_content`
+ * opaque token in a replayed `web_search_tool_result`. See
+ * `stripHistoricalWebSearchResults()` for the proactive mitigation.
+ */
+export function isStaleWebSearchContent(message: string): boolean {
+  return STALE_WEB_SEARCH_CONTENT_PATTERNS.some((p) => p.test(message));
 }
 
 /** Check whether an error message indicates a tool_use/tool_result ordering failure. */
@@ -412,6 +438,15 @@ function classifyByMessage(
         "An internal error occurred with web search. Please try again.",
       retryable: true,
       errorCategory: "web_search_ordering",
+    };
+  }
+  if (isStaleWebSearchContent(message)) {
+    return {
+      code: "PROVIDER_WEB_SEARCH",
+      userMessage:
+        "Stale web-search results in conversation history. Please try again.",
+      retryable: true,
+      errorCategory: "stale_web_search_content",
     };
   }
 

--- a/assistant/src/daemon/web-search-history.ts
+++ b/assistant/src/daemon/web-search-history.ts
@@ -1,0 +1,126 @@
+import type {
+  ContentBlock,
+  Message,
+  ServerToolUseContent,
+  TextContent,
+  WebSearchToolResultContent,
+} from "../providers/types.js";
+
+export interface StripStats {
+  blocksStripped: number;
+  serverToolUsesDropped: number;
+  messagesModified: number;
+}
+
+export interface StripResult {
+  messages: Message[];
+  stats: StripStats;
+}
+
+/**
+ * Replaces every `web_search_tool_result` block in the message list with a
+ * plain `text` summary of its results, and drops the paired `server_tool_use`
+ * that produced it.
+ *
+ * Anthropic's `encrypted_content` tokens attached to each `web_search_result`
+ * are opaque server tokens with bounded validity (they expire and/or are
+ * route-scoped). Replaying a stale token produces
+ * `messages.N.content.M: Invalid encrypted_content in search_result block`.
+ * For historical turns the model does not need the opaque token to re-read
+ * the body — a title+url summary is sufficient to preserve context.
+ *
+ * Intended to run on `runMessages` immediately before the agent loop starts a
+ * new turn, at which point every `web_search_tool_result` in the list is by
+ * definition from a prior turn.
+ */
+export function stripHistoricalWebSearchResults(
+  messages: Message[],
+): StripResult {
+  const stats: StripStats = {
+    blocksStripped: 0,
+    serverToolUsesDropped: 0,
+    messagesModified: 0,
+  };
+
+  const next: Message[] = messages.map((msg) => {
+    const droppedServerToolUseIds = new Set<string>();
+    const transformed: ContentBlock[] = [];
+
+    for (const block of msg.content) {
+      if (block.type !== "web_search_tool_result") continue;
+      const wsr = block as WebSearchToolResultContent;
+      const query = findQueryForToolUseId(msg.content, wsr.tool_use_id);
+      transformed.push(formatAsText(wsr, query));
+      droppedServerToolUseIds.add(wsr.tool_use_id);
+      stats.blocksStripped++;
+    }
+
+    if (droppedServerToolUseIds.size === 0) return msg;
+
+    const rewritten: ContentBlock[] = [];
+    let wsrIndex = 0;
+    for (const block of msg.content) {
+      if (block.type === "server_tool_use") {
+        const stu = block as ServerToolUseContent;
+        if (droppedServerToolUseIds.has(stu.id)) {
+          stats.serverToolUsesDropped++;
+          continue;
+        }
+        rewritten.push(block);
+      } else if (block.type === "web_search_tool_result") {
+        rewritten.push(transformed[wsrIndex++]);
+      } else {
+        rewritten.push(block);
+      }
+    }
+
+    stats.messagesModified++;
+    return { ...msg, content: rewritten };
+  });
+
+  return { messages: next, stats };
+}
+
+function findQueryForToolUseId(
+  blocks: ContentBlock[],
+  toolUseId: string,
+): string | null {
+  for (const b of blocks) {
+    if (b.type !== "server_tool_use") continue;
+    const stu = b as ServerToolUseContent;
+    if (stu.id !== toolUseId) continue;
+    const q = stu.input?.query;
+    return typeof q === "string" ? q : null;
+  }
+  return null;
+}
+
+function formatAsText(
+  block: WebSearchToolResultContent,
+  query: string | null,
+): TextContent {
+  const header = query
+    ? `[Prior web_search results for "${query}":`
+    : "[Prior web_search results:";
+
+  const content = block.content;
+  if (!Array.isArray(content)) {
+    return { type: "text", text: `${header} (results unavailable)]` };
+  }
+
+  const entries = content
+    .filter(
+      (r): r is { type: string; title?: unknown; url?: unknown } =>
+        typeof r === "object" &&
+        r != null &&
+        (r as { type?: string }).type === "web_search_result",
+    )
+    .map((r, i) => {
+      const title = typeof r.title === "string" ? r.title : "(untitled)";
+      const url = typeof r.url === "string" ? r.url : "";
+      return url ? `${i + 1}. ${title}\n   ${url}` : `${i + 1}. ${title}`;
+    });
+
+  const body = entries.length > 0 ? entries.join("\n") : "(no results)";
+  return { type: "text", text: `${header}\n${body}]` };
+}


### PR DESCRIPTION
## Summary
- Replace historical `web_search_tool_result` content blocks with text summaries (title + URL) before each agent-loop turn, so Anthropic's expiring opaque `encrypted_content` tokens are never replayed from prior turns.
- Drop paired `server_tool_use` blocks so the rewritten assistant message stays well-formed.
- Classify the specific Anthropic rejection (`Invalid encrypted_content in search_result block`) as `PROVIDER_WEB_SEARCH` / `stale_web_search_content` instead of the generic `PROVIDER_API` — defense-in-depth telemetry in case any call path bypasses the strip.
- Long-running conversations (419 msgs, Mar 25 → Apr 19 in my local case) with old web searches no longer trap themselves behind a blanket provider rejection.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
