### PR TITLE
feat(slack): automate bot+user token capture via OAuth loopback

### DIFF
--- a/assistant/src/daemon/handlers/slack-channel-oauth-install.ts
+++ b/assistant/src/daemon/handlers/slack-channel-oauth-install.ts
@@ -1,0 +1,184 @@
+/**
+ * Runs an OAuth2 loopback flow to install the user's Slack app and capture
+ * bot + user tokens in a single exchange.
+ *
+ * Prerequisites: client_id, client_secret, and app_token must already be
+ * stored in the credential vault (service: slack_channel).
+ *
+ * The handler reads client credentials from secure storage, starts a
+ * loopback OAuth server on port 17322, opens the browser to Slack's
+ * authorize URL, and waits for the user to click "Allow". Slack's
+ * oauth.v2.access response contains both the bot token (access_token)
+ * and user token (authed_user.access_token). Both are stored via
+ * setSlackChannelConfig.
+ */
+
+import { credentialKey } from "../../security/credential-key.js";
+import { startOAuth2Flow } from "../../security/oauth2.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { openInHostBrowser } from "../../util/browser.js";
+import { getLogger } from "../../util/logger.js";
+import { setSlackChannelConfig } from "./config-slack-channel.js";
+
+const log = getLogger("slack-channel-oauth-install");
+
+/** Port pre-registered for Slack in seed-providers.ts. */
+const SLACK_LOOPBACK_PORT = 17322;
+
+/** Bot scopes matching the manifest in SKILL.md. */
+const BOT_SCOPES = [
+  "app_mentions:read",
+  "assistant:write",
+  "channels:history",
+  "channels:join",
+  "channels:read",
+  "chat:write",
+  "files:read",
+  "files:write",
+  "groups:history",
+  "groups:read",
+  "im:history",
+  "im:read",
+  "im:write",
+  "mpim:history",
+  "mpim:read",
+  "reactions:read",
+  "reactions:write",
+  "users:read",
+];
+
+/** User scopes matching the manifest in SKILL.md. */
+const USER_SCOPES = [
+  "channels:history",
+  "channels:read",
+  "groups:history",
+  "groups:read",
+  "im:history",
+  "im:read",
+  "mpim:history",
+  "mpim:read",
+  "users:read",
+  "search:read",
+  "reactions:read",
+];
+
+export interface SlackOAuthInstallResult {
+  success: boolean;
+  hasBotToken: boolean;
+  hasUserToken: boolean;
+  error?: string;
+}
+
+export async function runSlackChannelOAuthInstall(): Promise<SlackOAuthInstallResult> {
+  // Read client credentials from secure storage
+  const clientId = await getSecureKeyAsync(
+    credentialKey("slack_channel", "client_id"),
+  );
+  if (!clientId) {
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error:
+        "Client ID not found in credential store. Store it first via credential_store prompt (service: slack_channel, field: client_id).",
+    };
+  }
+
+  const clientSecret = await getSecureKeyAsync(
+    credentialKey("slack_channel", "client_secret"),
+  );
+  if (!clientSecret) {
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error:
+        "Client Secret not found in credential store. Store it first via credential_store prompt (service: slack_channel, field: client_secret).",
+    };
+  }
+
+  log.info("Starting Slack OAuth install flow via loopback");
+
+  let result;
+  try {
+    result = await startOAuth2Flow(
+      {
+        authorizeUrl: "https://slack.com/oauth/v2/authorize",
+        tokenExchangeUrl: "https://slack.com/api/oauth.v2.access",
+        scopes: BOT_SCOPES,
+        clientId,
+        clientSecret,
+        scopeSeparator: ",",
+        authorizeParams: {
+          user_scope: USER_SCOPES.join(","),
+        },
+      },
+      {
+        openUrl: (url) => openInHostBrowser(url),
+      },
+      {
+        callbackTransport: "loopback",
+        loopbackPort: SLACK_LOOPBACK_PORT,
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err: msg }, "Slack OAuth install flow failed");
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error: `OAuth flow failed: ${msg}`,
+    };
+  }
+
+  // Slack's oauth.v2.access returns:
+  //   access_token: "xoxb-..." (bot token)
+  //   authed_user: { access_token: "xoxp-..." } (user token)
+  const raw = result.rawTokenResponse;
+  const botToken = raw.access_token as string | undefined;
+  const authedUser = raw.authed_user as { access_token?: string } | undefined;
+  const userToken = authedUser?.access_token as string | undefined;
+
+  if (!botToken) {
+    log.error(
+      { rawKeys: Object.keys(raw) },
+      "Slack OAuth response missing bot access_token",
+    );
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error:
+        "Slack OAuth response did not include a bot token (access_token). The app may not have bot scopes configured.",
+    };
+  }
+
+  log.info(
+    { hasBotToken: true, hasUserToken: !!userToken },
+    "Slack OAuth tokens received, storing via setSlackChannelConfig",
+  );
+
+  // Store bot token (and user token if present) via the Slack channel handler,
+  // which validates tokens and persists workspace metadata.
+  const configResult = await setSlackChannelConfig(
+    botToken,
+    undefined, // app_token already stored via credential_store prompt
+    userToken,
+  );
+
+  if (!configResult.success) {
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error: configResult.error ?? "Failed to store Slack tokens",
+    };
+  }
+
+  return {
+    success: true,
+    hasBotToken: true,
+    hasUserToken: !!userToken,
+  };
+}

--- a/assistant/src/runtime/routes/integrations/slack/channel.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channel.ts
@@ -1,9 +1,10 @@
 /**
  * Route handlers for Slack channel configuration.
  *
- * GET    /v1/integrations/slack/channel/config — get current config status
- * POST   /v1/integrations/slack/channel/config — validate and store credentials
- * DELETE /v1/integrations/slack/channel/config — clear credentials
+ * GET    /v1/integrations/slack/channel/config        — get current config status
+ * POST   /v1/integrations/slack/channel/config        — validate and store credentials
+ * DELETE /v1/integrations/slack/channel/config        — clear credentials
+ * POST   /v1/integrations/slack/channel/oauth-install — run OAuth loopback to capture bot+user tokens
  */
 
 import {
@@ -11,6 +12,7 @@ import {
   getSlackChannelConfig,
   setSlackChannelConfig,
 } from "../../../../daemon/handlers/config-slack-channel.js";
+import { runSlackChannelOAuthInstall } from "../../../../daemon/handlers/slack-channel-oauth-install.js";
 import type { RouteDefinition } from "../../../http-router.js";
 
 // ---------------------------------------------------------------------------
@@ -55,6 +57,21 @@ export async function handleClearSlackChannelConfig(): Promise<Response> {
   return Response.json(result);
 }
 
+/**
+ * POST /v1/integrations/slack/channel/oauth-install
+ *
+ * Runs an OAuth2 loopback flow to install the Slack app and capture
+ * bot + user tokens. Requires client_id, client_secret, and app_token
+ * to be pre-stored in the credential vault.
+ *
+ * Blocks until the user completes the OAuth flow or the 5-minute timeout.
+ */
+export async function handleSlackChannelOAuthInstall(): Promise<Response> {
+  const result = await runSlackChannelOAuthInstall();
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -75,6 +92,11 @@ export function slackChannelRouteDefinitions(): RouteDefinition[] {
       endpoint: "integrations/slack/channel/config",
       method: "DELETE",
       handler: () => handleClearSlackChannelConfig(),
+    },
+    {
+      endpoint: "integrations/slack/channel/oauth-install",
+      method: "POST",
+      handler: () => handleSlackChannelOAuthInstall(),
     },
   ];
 }

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -64,7 +64,7 @@ Run this `bash` command, setting `BOT_NAME` and `BOT_DESC` to the user's chosen 
 
 ```
 bash {
-  command: "BOT_NAME='<user_name>' BOT_DESC='<user_description>' bun -e \"const name = process.env.BOT_NAME; const desc = process.env.BOT_DESC; const manifest = { display_information: { name, description: desc, background_color: '#1a1a2e' }, features: { app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false }, bot_user: { display_name: name, always_online: true } }, oauth_config: { redirect_urls: ['http://localhost:17322/oauth/callback'], scopes: { bot: ['app_mentions:read','assistant:write','channels:history','channels:join','channels:read','chat:write','files:read','files:write','groups:history','groups:read','im:history','im:read','im:write','mpim:history','mpim:read','reactions:read','reactions:write','users:read'], user: ['channels:history','channels:read','groups:history','groups:read','im:history','im:read','mpim:history','mpim:read','users:read','search:read','reactions:read'] } }, settings: { event_subscriptions: { bot_events: ['app_mention','message.channels','message.groups','message.im','message.mpim','reaction_added'] }, interactivity: { is_enabled: true }, org_deploy_enabled: false, socket_mode_enabled: true, token_rotation_enabled: false } }; const url = 'https://api.slack.com/apps?new_app=1&manifest_json=' + encodeURIComponent(JSON.stringify(manifest)); console.log(url);\""
+  command: "BOT_NAME='<user_name>' BOT_DESC='<user_description>' bun -e \"const name = process.env.BOT_NAME; const desc = process.env.BOT_DESC; const manifest = { display_information: { name, description: desc, background_color: '#1a1a2e' }, features: { app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false }, bot_user: { display_name: name, always_online: true } }, oauth_config: { scopes: { bot: ['app_mentions:read','assistant:write','channels:history','channels:join','channels:read','chat:write','files:read','files:write','groups:history','groups:read','im:history','im:read','im:write','mpim:history','mpim:read','reactions:read','reactions:write','users:read'], user: ['channels:history','channels:read','groups:history','groups:read','im:history','im:read','mpim:history','mpim:read','users:read','search:read','reactions:read'] } }, settings: { event_subscriptions: { bot_events: ['app_mention','message.channels','message.groups','message.im','message.mpim','reaction_added'] }, interactivity: { is_enabled: true }, org_deploy_enabled: false, socket_mode_enabled: true, token_rotation_enabled: false } }; const url = 'https://api.slack.com/apps?new_app=1&manifest_json=' + encodeURIComponent(JSON.stringify(manifest)); console.log(url);\""
   activity: "to generate the Slack app manifest link"
 }
 ```
@@ -75,11 +75,21 @@ The command outputs a ready-to-click URL. Present it to the user: "Click this li
 
 Wait for the user to confirm they've created the app before proceeding.
 
-## Step 2: Collect Credentials & Install via OAuth
+## Step 2: Add Redirect URL
 
-After the app is created, the user lands on the app's **Basic Information** page. We need three values from this page, then we'll automate the rest.
+After creating the app, tell the user to navigate to **OAuth & Permissions** in the sidebar, then scroll to **Redirect URLs** and:
 
-### Step 2a: App Token
+1. Click **Add New Redirect URL**
+2. Enter: `http://localhost:17322/oauth/callback`
+3. Click **Add**, then click **Save URLs**
+
+This enables the automated OAuth install in Step 3. Wait for the user to confirm before proceeding.
+
+## Step 3: Collect Credentials & Install via OAuth
+
+The user should navigate back to **Basic Information**. We need three values from this page, then we'll automate the rest.
+
+### Step 3a: App Token
 
 Tell the user to scroll to **App-Level Tokens** on the Basic Information page, then:
 
@@ -94,19 +104,19 @@ Collect the app token securely:
 
 If it succeeds, continue. If it returns an error, ask the user to re-enter the token.
 
-### Step 2b: Client ID
+### Step 3b: Client ID
 
 Tell the user to scroll to **App Credentials** on the same Basic Information page. The Client ID is displayed there.
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_id"`, `label: "Client ID"`, `description: "From Basic Information > App Credentials"`
 
-### Step 2c: Client Secret
+### Step 3c: Client Secret
 
 The Client Secret is right below the Client ID on the same page (the user may need to click "Show" to reveal it).
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_secret"`, `label: "Client Secret"`, `placeholder: "starts with a long alphanumeric string"`, `description: "From Basic Information > App Credentials (click Show to reveal)"`
 
-### Step 2d: Run OAuth Install
+### Step 3d: Run OAuth Install
 
 Now that all three credentials are stored, trigger the automated OAuth install. This opens the user's browser to Slack's authorization page — they just click **Allow**.
 
@@ -126,10 +136,10 @@ This endpoint reads the stored Client ID and Client Secret, opens a browser to S
 
 Parse the JSON response:
 
-- If `success: true` — bot and user tokens were captured and stored automatically. Continue to Step 3.
+- If `success: true` — bot and user tokens were captured and stored automatically. Continue to Step 4.
 - If `success: false` — show the `error` field and troubleshoot. Common issues:
-  - "Client ID not found" / "Client Secret not found" — re-collect the missing credential via Step 2b/2c.
-  - "OAuth flow failed: OAuth2 loopback callback timed out" — the user didn't complete authorization in time. Re-run Step 2d.
+  - "Client ID not found" / "Client Secret not found" — re-collect the missing credential via Step 3b/3c.
+  - "OAuth flow failed: OAuth2 loopback callback timed out" — the user didn't complete authorization in time. Re-run Step 3d.
   - "OAuth flow failed: OAuth2 authorization denied" — the user clicked Cancel or the workspace requires admin approval.
 
 After the OAuth install succeeds, show the user their setup progress:
@@ -142,7 +152,7 @@ After the OAuth install succeeds, show the user their setup progress:
 
 Almost there — let's do a quick test!"
 
-## Step 3: Test Your Connection
+## Step 4: Test Your Connection
 
 Now let's test the connection by verifying the user can receive messages from the bot. This confirms everything works and links the user's Slack identity for future message delivery.
 
@@ -150,9 +160,9 @@ Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user explicitly wants to skip this step, proceed to Step 4, but let them know they can always verify later by saying "verify me on slack".
+If the user explicitly wants to skip this step, proceed to Step 5, but let them know they can always verify later by saying "verify me on slack".
 
-## Step 4: Report Success
+## Step 5: Report Success
 
 Summarize with the completed checklist.
 
@@ -207,7 +217,7 @@ Verify that `message.channels` event subscription is enabled in your Slack app s
 
 ### OAuth install failed
 
-If the OAuth flow fails or times out, re-run Step 2d. Ensure:
+If the OAuth flow fails or times out, re-run Step 3d. Ensure:
 - The Client ID and Client Secret are correct (re-collect via credential_store if unsure)
 - The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (the manifest pre-configures this)
 - No other process is using port 17322

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -11,17 +11,22 @@ metadata:
 
 You are helping your user connect a Slack bot to the Vellum Assistant via Socket Mode. Walk through each step below.
 
-**CRITICAL: Follow these steps strictly in order. Do NOT combine steps, skip ahead, or ask for multiple tokens at once. Each step must be completed and confirmed before moving to the next. The bot token does NOT exist until the app is installed — you cannot collect it early.**
+**Before starting, set expectations:** "We're creating a custom Slack app for your assistant — this gives you your own bot identity, avatar, and name in Slack. There are a few steps to get through, but most of it is automated."
+
+**CRITICAL: Follow these steps strictly in order. Do NOT combine steps or skip ahead.**
 
 ## Value Classification
 
-| Value      | Type       | Storage method            | Secret? |
-| ---------- | ---------- | ------------------------- | ------- |
-| App Token  | Credential | `credential_store` prompt | **Yes** |
-| Bot Token  | Credential | `credential_store` prompt | **Yes** |
-| User Token | Credential | `credential_store` prompt | **Yes** |
+| Value         | Type       | Storage method            | Secret? |
+| ------------- | ---------- | ------------------------- | ------- |
+| App Token     | Credential | `credential_store` prompt | **Yes** |
+| Client ID     | Credential | `credential_store` prompt | **Yes** |
+| Client Secret | Credential | `credential_store` prompt | **Yes** |
+| Bot Token     | Credential | OAuth (automatic)         | **Yes** |
+| User Token    | Credential | OAuth (automatic)         | **Yes** |
 
-- All tokens are secrets. Always collect via `credential_store` prompt — never accept them pasted in plaintext chat.
+- App Token, Client ID, and Client Secret are collected via `credential_store` prompt — never accept them pasted in plaintext chat.
+- Bot Token and User Token are captured automatically via the OAuth install flow.
 
 # Setup Steps
 
@@ -43,7 +48,7 @@ Then branch on the state of `app_token` and `bot_token` first (those are the req
 
 - If `app_token` and `bot_token` are **both** present:
   - If `user_token` is also present — Slack is fully configured with full triage visibility. Offer to show status or reconfigure.
-  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 3.5) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
+  - If `user_token` is missing — Slack is connected with **bot-only visibility**. Offer to collect the user token now (Step 3) to enable full triage visibility across all channels the user is in. The user token is optional; if they decline, leave the setup as-is.
 - If exactly **one** of `app_token` or `bot_token` is present — offer to resume setup from the missing step. (If a `user_token` is also present, leave it in place; it will be re-validated against the bot's workspace once setup completes.)
 - If **neither** `app_token` nor `bot_token` is present — continue to Step 1. (If a `user_token` is present without a paired bot/app, it is orphaned from a prior incomplete setup. Tell the user it will be replaced during this run, and proceed.)
 
@@ -59,7 +64,7 @@ Run this `bash` command, setting `BOT_NAME` and `BOT_DESC` to the user's chosen 
 
 ```
 bash {
-  command: "BOT_NAME='<user_name>' BOT_DESC='<user_description>' bun -e \"const name = process.env.BOT_NAME; const desc = process.env.BOT_DESC; const manifest = { display_information: { name, description: desc, background_color: '#1a1a2e' }, features: { app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false }, bot_user: { display_name: name, always_online: true } }, oauth_config: { scopes: { bot: ['app_mentions:read','assistant:write','channels:history','channels:join','channels:read','chat:write','files:read','files:write','groups:history','groups:read','im:history','im:read','im:write','mpim:history','mpim:read','reactions:read','reactions:write','users:read'], user: ['channels:history','channels:read','groups:history','groups:read','im:history','im:read','mpim:history','mpim:read','users:read','search:read','reactions:read'] } }, settings: { event_subscriptions: { bot_events: ['app_mention','message.channels','message.groups','message.im','message.mpim','reaction_added'] }, interactivity: { is_enabled: true }, org_deploy_enabled: false, socket_mode_enabled: true, token_rotation_enabled: false } }; const url = 'https://api.slack.com/apps?new_app=1&manifest_json=' + encodeURIComponent(JSON.stringify(manifest)); console.log(url);\""
+  command: "BOT_NAME='<user_name>' BOT_DESC='<user_description>' bun -e \"const name = process.env.BOT_NAME; const desc = process.env.BOT_DESC; const manifest = { display_information: { name, description: desc, background_color: '#1a1a2e' }, features: { app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false }, bot_user: { display_name: name, always_online: true } }, oauth_config: { redirect_urls: ['http://localhost:17322/oauth/callback'], scopes: { bot: ['app_mentions:read','assistant:write','channels:history','channels:join','channels:read','chat:write','files:read','files:write','groups:history','groups:read','im:history','im:read','im:write','mpim:history','mpim:read','reactions:read','reactions:write','users:read'], user: ['channels:history','channels:read','groups:history','groups:read','im:history','im:read','mpim:history','mpim:read','users:read','search:read','reactions:read'] } }, settings: { event_subscriptions: { bot_events: ['app_mention','message.channels','message.groups','message.im','message.mpim','reaction_added'] }, interactivity: { is_enabled: true }, org_deploy_enabled: false, socket_mode_enabled: true, token_rotation_enabled: false } }; const url = 'https://api.slack.com/apps?new_app=1&manifest_json=' + encodeURIComponent(JSON.stringify(manifest)); console.log(url);\""
   activity: "to generate the Slack app manifest link"
 }
 ```
@@ -70,11 +75,13 @@ The command outputs a ready-to-click URL. Present it to the user: "Click this li
 
 Wait for the user to confirm they've created the app before proceeding.
 
-## Step 2: Generate App Token & Collect It
+## Step 2: Collect Credentials & Install via OAuth
 
-**Do NOT skip ahead to the bot token. The app token must be collected first — the bot token does not exist yet.**
+After the app is created, the user lands on the app's **Basic Information** page. We need three values from this page, then we'll automate the rest.
 
-Tell the user to navigate to **Settings > Basic Information > App-Level Tokens** in their newly created Slack app, then:
+### Step 2a: App Token
+
+Tell the user to scroll to **App-Level Tokens** on the Basic Information page, then:
 
 1. Click **Generate Token and Scopes**
 2. Token name: "Socket Mode" (or any name they prefer)
@@ -85,66 +92,57 @@ Collect the app token securely:
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "app_token"`, `label: "App-Level Token"`, `placeholder: "xapp-..."`, `description: "Paste the App-Level Token you just generated"`
 
-The `slack_channel` secure prompt already routes through the same Slack settings handler used by Settings. Treat that tool result as authoritative:
+If it succeeds, continue. If it returns an error, ask the user to re-enter the token.
 
-- If it succeeds, continue.
-- If it returns an error, ask the user to re-enter the token.
-- If it returns a warning that the connection is incomplete, that is expected until the bot token is collected.
+### Step 2b: Client ID
 
-## Step 3: Install App & Collect Bot Token
+Tell the user to scroll to **App Credentials** on the same Basic Information page. The Client ID is displayed there.
 
-**IMPORTANT: The bot token only becomes available AFTER the app is installed. The user MUST install the app first — do NOT ask for the bot token before this step. The bot token is found under Install App (NOT under OAuth & Permissions).**
+- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_id"`, `label: "Client ID"`, `description: "From Basic Information > App Credentials"`
 
-Tell the user to navigate to **Settings > Install App** in the sidebar, then click **Install to Workspace** and authorize the requested permissions (already pre-configured from the manifest).
+### Step 2c: Client Secret
 
-**Note:** This app requests user scopes so your assistant can read messages in channels the bot isn't a member of. Some Slack workspaces require admin approval for user-scope installs. If the install page shows "Request approval" instead of "Allow", you'll need your workspace admin to approve it before continuing.
+The Client Secret is right below the Client ID on the same page (the user may need to click "Show" to reveal it).
 
-After installation, the **Bot User OAuth Token** will appear on the same Install App page. Collect it securely:
+- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "client_secret"`, `label: "Client Secret"`, `placeholder: "starts with a long alphanumeric string"`, `description: "From Basic Information > App Credentials (click Show to reveal)"`
 
-- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "bot_token"`, `label: "Bot User OAuth Token"`, `placeholder: "xoxb-..."`, `description: "Paste the Bot User OAuth Token shown after installing"`
+### Step 2d: Run OAuth Install
 
-After the bot-token prompt succeeds, the same Slack settings handler used by Settings has already:
+Now that all three credentials are stored, trigger the automated OAuth install. This opens the user's browser to Slack's authorization page — they just click **Allow**.
 
-- validated the bot token with Slack
-- stored workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`)
-- activated Socket Mode when both tokens are present
+Tell the user: "Opening your browser now — just select your workspace and click **Allow** to install the app."
 
-Use the most recent `credential_store` result as the source of truth:
+Then call the daemon's OAuth install endpoint:
 
-- If it reports the Slack channel is connected, continue.
-- If it reports an error, stop and fix that error before moving on.
-- If it reports an incomplete setup warning, collect the missing token instead of improvising extra validation commands.
+```
+bash {
+  command: "curl -s -X POST http://localhost:${RUNTIME_HTTP_PORT}/v1/integrations/slack/channel/oauth-install -H 'Content-Type: application/json'"
+  activity: "to run the Slack OAuth install flow"
+  timeout: 360000
+}
+```
 
-Show the user their setup progress:
+This endpoint reads the stored Client ID and Client Secret, opens a browser to Slack's OAuth consent screen, and automatically captures the bot token and user token when the user clicks **Allow**. It blocks until the user completes authorization (up to 5 minutes).
+
+Parse the JSON response:
+
+- If `success: true` — bot and user tokens were captured and stored automatically. Continue to Step 3.
+- If `success: false` — show the `error` field and troubleshoot. Common issues:
+  - "Client ID not found" / "Client Secret not found" — re-collect the missing credential via Step 2b/2c.
+  - "OAuth flow failed: OAuth2 loopback callback timed out" — the user didn't complete authorization in time. Re-run Step 2d.
+  - "OAuth flow failed: OAuth2 authorization denied" — the user clicked Cancel or the workspace requires admin approval.
+
+After the OAuth install succeeds, show the user their setup progress:
 
 "Setup progress:
 ✅ App created
-✅ Tokens configured
+✅ Tokens configured (bot + user tokens captured automatically)
 ✅ Connection active
 ⬜ Connection tested
 
 Almost there — let's do a quick test!"
 
-## Step 3.5: Collect User OAuth Token (Optional, Recommended)
-
-**This step is optional but recommended.** The User OAuth Token lets the assistant READ messages in every channel the user is in — including channels the bot isn't a member of — for triage purposes. Writes (posting, reacting, editing) always go through the bot token; the assistant will never post, react, or edit as the user.
-
-Tell the user to go back to the **Install App** page in their Slack app settings and scroll down past the Bot User OAuth Token. Look for the **User OAuth Token** (starts with `xoxp-`).
-
-**If there is no User OAuth Token shown on the Install App page**, the workspace admin may have restricted user-scope installs. Skip this step — setup works without it (bot-only visibility). Continue to Step 4.
-
-Otherwise, collect the user token securely:
-
-- Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "user_token"`, `label: "User OAuth Token"`, `placeholder: "xoxp-..."`, `description: "Optional — lets the assistant read messages in channels the bot isn't a member of. Writes always go through the bot."`
-
-The handler validates the token against Slack (auth.test) **and** confirms the token is for the same workspace as the bot. Treat the tool result as authoritative:
-
-- If it succeeds, continue to Step 4.
-- If it returns an error (invalid token or workspace mismatch), ask the user to re-copy the User OAuth Token from the Install App page and try again.
-
-If the user explicitly declines to provide a user token, continue to Step 4. They can add it later by re-running this skill.
-
-## Step 4: Test Your Connection
+## Step 3: Test Your Connection
 
 Now let's test the connection by verifying the user can receive messages from the bot. This confirms everything works and links the user's Slack identity for future message delivery.
 
@@ -152,9 +150,9 @@ Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user explicitly wants to skip this step, proceed to Step 5, but let them know they can always verify later by saying "verify me on slack".
+If the user explicitly wants to skip this step, proceed to Step 4, but let them know they can always verify later by saying "verify me on slack".
 
-## Step 5: Report Success
+## Step 4: Report Success
 
 Summarize with the completed checklist.
 
@@ -186,8 +184,8 @@ Identity: skipped"
 
 For `{triage_line}`, use:
 
-- If `user_token` was collected: `✅ Triage visibility: full (can read all your channels)`
-- If `user_token` was skipped: `⬜ Triage visibility: bot-only (only channels the bot is a member of) — you can collect a user token anytime to enable full triage`
+- If `hasUserToken` was `true` in the OAuth response: `✅ Triage visibility: full (can read all your channels)`
+- If `hasUserToken` was `false`: `⬜ Triage visibility: bot-only (only channels the bot is a member of) — you can collect a user token anytime to enable full triage`
 
 ## Troubleshooting
 
@@ -207,13 +205,19 @@ Re-enter the token via credential_store prompt. The handler validates tokens on 
 
 Verify that `message.channels` event subscription is enabled in your Slack app settings under **Event Subscriptions > Subscribe to bot events**. The manifest pre-configures this, but it can be accidentally removed.
 
+### OAuth install failed
+
+If the OAuth flow fails or times out, re-run Step 2d. Ensure:
+- The Client ID and Client Secret are correct (re-collect via credential_store if unsure)
+- The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (the manifest pre-configures this)
+- No other process is using port 17322
+
 ## Implementation Rules
 
-- All token collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
+- App Token, Client ID, and Client Secret collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, or other mechanisms. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
+- Bot Token and User Token are captured automatically by the OAuth install flow. Do NOT ask the user to copy-paste these tokens.
 - **Do NOT combine multiple steps into a single message.** Each step must be its own turn in the conversation. Wait for the user to confirm completion before moving on.
-- **Do NOT ask for both tokens at once.** Collect the app token (Step 2) first, then install the app (Step 3), then collect the bot token. The bot token literally does not exist until the app is installed.
-- **Do NOT tell the user to find the bot token under "OAuth & Permissions".** The bot token appears on the **Install App** page after installation.
-- **Do NOT tell the user to set up a redirect URL.** Socket Mode does not require redirect URLs, OAuth redirect URLs, or any publicly reachable endpoints. The manifest already configures Socket Mode — no additional URL configuration is needed.
+- **Do NOT tell the user to manually copy the bot token.** The OAuth flow captures it automatically.
 
 ## Clearing Credentials
 


### PR DESCRIPTION
## Summary
- Adds `POST /v1/integrations/slack/channel/oauth-install` endpoint that reads stored client credentials, runs an OAuth loopback flow on port 17322, and auto-captures bot + user tokens from Slack's `oauth.v2.access` response
- Rewrites the `slack-app-setup` SKILL.md to use the OAuth flow — reduces setup from ~10+ manual steps to ~4 user actions (manifest click, 3 credential prompts, click Allow)
- Adds `redirect_urls` to the Slack app manifest so the OAuth callback can reach the loopback server

## Test plan
- [ ] Run `bunx tsc --noEmit` — passes
- [ ] Run `bun test src/runtime/routes/integrations/slack/__tests__/channel.test.ts` — passes
- [ ] Run `bun test src/__tests__/skills.test.ts` — passes
- [ ] End-to-end: trigger Slack setup skill, create app via manifest, collect app_token + client_id + client_secret via credential prompts, verify OAuth flow opens browser and captures tokens on Allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
