### PR TITLE
fix(meet-bot): stamp authoritative meetingId on ext events + add join timeout + pass error details

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -96,6 +96,13 @@ interface MakeDepsOpts {
   xvfbError?: Error;
   /** Short-circuit `waitForReady` to reject with this error. */
   extensionReadyError?: Error;
+  /**
+   * Deadline for the extension to reach `lifecycle:joined`. Defaults to
+   * a very large value in tests so the happy-path suite doesn't trip the
+   * timer while sitting at `phase=joining`. Only the Gap B test should
+   * override this to a small value.
+   */
+  extensionJoinedTimeoutMs?: number;
 }
 
 function makeDeps(opts: MakeDepsOpts = {}): {
@@ -310,6 +317,7 @@ function makeDeps(opts: MakeDepsOpts = {}): {
       errors.push(msg);
     },
     extensionReadyTimeoutMs: 1_000,
+    extensionJoinedTimeoutMs: opts.extensionJoinedTimeoutMs ?? 60_000,
     sendChatTimeoutMs: 500,
     leaveGraceMs: 0,
     generateRequestId: () => {
@@ -910,5 +918,236 @@ describe("runBot — daemon-client terminal errors", () => {
     const last = lifecycleStates[lifecycleStates.length - 1]!;
     expect(last.state).toBe("error");
     expect(last.detail).toContain("daemon ingress failure");
+  });
+});
+
+/** -----------------------------------------------------------------------
+ * Gap A: meetingId rewrite at the bot boundary
+ * -----------------------------------------------------------------------
+ * The Chrome extension stamps every event with `meetingId = location.pathname`
+ * (the Meet URL code, e.g. `abc-defg-hij`), but the daemon keys each bot
+ * session by the UUID passed via the `MEETING_ID` env. The bot must overwrite
+ * `meetingId` with the authoritative UUID before forwarding to the daemon so
+ * events correlate to the right session even if the extension misreports.
+ */
+describe("runBot — Gap A: meetingId rewrite at bot boundary", () => {
+  test("participant.change has meetingId rewritten to the env UUID", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    // Simulate the extension's URL-code-based meetingId — not the env UUID.
+    handles.fireExtensionMessage({
+      type: "participant.change",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    });
+
+    const fresh = handles.daemonEvents.slice(before);
+    expect(fresh).toHaveLength(1);
+    const event = fresh[0];
+    expect(event?.type).toBe("participant.change");
+    // Must be rewritten to the env UUID ("m-1" in test deps), not the
+    // extension-supplied URL code.
+    if (event?.type === "participant.change") {
+      expect(event.meetingId).toBe("m-1");
+    }
+  });
+
+  test("speaker.change + chat.inbound both have meetingId rewritten", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "speaker.change",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      speakerId: "p-1",
+      speakerName: "Alice",
+    });
+    handles.fireExtensionMessage({
+      type: "chat.inbound",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      fromId: "p-2",
+      fromName: "Bob",
+      text: "hello",
+    });
+
+    const fresh = handles.daemonEvents.slice(before);
+    expect(fresh).toHaveLength(2);
+    for (const event of fresh) {
+      if (event.type === "speaker.change" || event.type === "chat.inbound") {
+        expect(event.meetingId).toBe("m-1");
+      }
+    }
+  });
+
+  test("lifecycle events have meetingId rewritten to the env UUID", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+
+    const fresh = handles.daemonEvents.slice(before);
+    expect(fresh).toHaveLength(1);
+    const event = fresh[0];
+    expect(event?.type).toBe("lifecycle");
+    if (event?.type === "lifecycle") {
+      expect(event.meetingId).toBe("m-1");
+      expect(event.state).toBe("joined");
+    }
+  });
+});
+
+/** -----------------------------------------------------------------------
+ * Gap B: extension-joined deadline
+ * -----------------------------------------------------------------------
+ * `waitForReady` only proves the extension is alive, not that Chrome landed
+ * on a Meet tab. A restore-session dialog or redirect loop leaves the
+ * content script unmounted and the `join` relay is silently dropped. Bound
+ * the wait with `extensionJoinedTimeoutMs` so the bot doesn't sit in
+ * `phase=joining` forever.
+ */
+describe("runBot — Gap B: extension-joined deadline", () => {
+  test("fires shutdown with error when extension never reaches joined", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
+    const running = runBot(deps);
+    // Let the boot reach `waitForReady`, then fire ready but never fire
+    // `lifecycle:joined`. The timer should trip and shutdown should fire.
+    await new Promise((r) => setTimeout(r, 5));
+    handles.fireExtensionReady();
+    await running;
+
+    // Wait longer than `extensionJoinedTimeoutMs` for the timer to fire.
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(handles.exitCode()).toBe(1);
+
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => ({ state: e.state, detail: e.detail }));
+    const errState = lifecycleStates.find((s) => s.state === "error");
+    expect(errState).toBeDefined();
+    expect(errState?.detail).toContain(
+      "extension did not reach joined state within 50ms",
+    );
+
+    // Full shutdown should have run.
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.chrome).toBe(1);
+    expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
+  });
+
+  test("lifecycle:joined from extension clears the timer (no shutdown)", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
+    const running = runBot(deps);
+    await new Promise((r) => setTimeout(r, 5));
+    handles.fireExtensionReady();
+    await running;
+
+    // Fire `joined` before the timer deadline — should prevent shutdown.
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+
+    // Give the timer plenty of time to fire if it wasn't cleared.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // No shutdown should have occurred.
+    expect(handles.exitCode()).toBeNull();
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(0);
+    expect(counts.chrome).toBe(0);
+    expect(counts.audio).toBe(0);
+    expect(handles.daemonStopped()).toBe(false);
+  });
+
+  test("lifecycle:error from extension clears the timer (no duplicate shutdown)", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
+    const running = runBot(deps);
+    await new Promise((r) => setTimeout(r, 5));
+    handles.fireExtensionReady();
+    await running;
+
+    // Fire `error` — handler updates state and clears the timer, but does
+    // not itself initiate shutdown (that's the extension's signal the
+    // meet-side died; shutdown is a separate path we're validating is
+    // idempotent).
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      state: "error",
+      detail: "prejoin captcha",
+    });
+
+    // Give the timer plenty of time to fire if it wasn't cleared.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The error lifecycle event was forwarded.
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => e.state);
+    expect(lifecycleStates).toContain("error");
+
+    // But no timer-driven shutdown should have fired.
+    // exitCode remains null because nothing else triggered shutdown.
+    expect(handles.exitCode()).toBeNull();
+  });
+});
+
+/** -----------------------------------------------------------------------
+ * Gap C: error detail forwarded to the daemon
+ * -----------------------------------------------------------------------
+ * Previously `waitForReady` / send-join failures reported a generic string
+ * to the daemon, losing the underlying error's message. The specific cause
+ * must reach the conversation log.
+ */
+describe("runBot — Gap C: error detail forwarding", () => {
+  test("waitForReady rejection forwards the underlying error message to daemon", async () => {
+    BotState.__resetForTests();
+    const specific = "timed out after 1234ms waiting for extension ready handshake";
+    const { deps, handles } = makeDeps({
+      extensionReadyError: new Error(specific),
+    });
+
+    await runBot(deps);
+
+    expect(handles.exitCode()).toBe(1);
+
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => ({ state: e.state, detail: e.detail }));
+    const errState = lifecycleStates.find((s) => s.state === "error");
+    expect(errState).toBeDefined();
+    // Detail must contain BOTH the generic context AND the specific cause.
+    expect(errState?.detail).toContain("extension never signaled ready");
+    expect(errState?.detail).toContain(specific);
   });
 });

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -188,6 +188,19 @@ export interface BotDeps {
   logError: (msg: string) => void;
   /** Milliseconds to wait for the extension's `ready` handshake. */
   extensionReadyTimeoutMs: number;
+  /**
+   * Milliseconds to wait for the extension to reach `lifecycle:joined` (or
+   * emit `lifecycle:error`) after the bot dispatches the `join` command.
+   * If nothing arrives in this window, assume Chrome never landed on a
+   * Meet tab (restore-session dialog, redirect loop, non-Meet URL, etc.)
+   * and shut down with `lifecycle:error` rather than sitting in
+   * `phase=joining` indefinitely.
+   *
+   * The default (120s) gives the prejoin flow enough slack for the Meet
+   * "ask to join" → host admission cycle, on top of the separate 30s
+   * `extensionReadyTimeoutMs` that bounds the earlier handshake.
+   */
+  extensionJoinedTimeoutMs: number;
   /** Milliseconds before a `send_chat` request times out with a failure. */
   sendChatTimeoutMs: number;
   /** Grace period after sending `leave` for the extension to animate out. */
@@ -234,6 +247,7 @@ export function defaultDeps(): BotDeps {
     logInfo: (msg) => console.log(msg),
     logError: (msg) => console.error(msg),
     extensionReadyTimeoutMs: 30_000,
+    extensionJoinedTimeoutMs: 120_000,
     sendChatTimeoutMs: 10_000,
     leaveGraceMs: 2_000,
     generateRequestId: () => randomUUID(),
@@ -361,6 +375,18 @@ export async function runBot(deps: BotDeps): Promise<void> {
   let shutdownInProgress = false;
   let shutdownDonePromise: Promise<void> | null = null;
 
+  // Timer armed after `join` is dispatched that trips shutdown if the
+  // extension never reaches `lifecycle:joined` / `lifecycle:error`. Cleared
+  // from the lifecycle-message handler and on shutdown. See the timer
+  // setup site below for full rationale.
+  let extensionJoinedTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearExtensionJoinedTimer = (): void => {
+    if (extensionJoinedTimer) {
+      clearTimeout(extensionJoinedTimer);
+      extensionJoinedTimer = null;
+    }
+  };
+
   /**
    * Graceful shutdown. Tears down subsystems in the reverse order of
    * startup: HTTP → tell the extension to leave → Chrome → audio →
@@ -378,6 +404,9 @@ export async function runBot(deps: BotDeps): Promise<void> {
     shutdownInProgress = true;
     shutdownDonePromise = (async () => {
       BotState.setPhase(finalState === "error" ? "error" : "leaving");
+
+      // Any in-flight join-deadline timer is now moot.
+      clearExtensionJoinedTimer();
 
       // Reject any pending send_chat promises so the HTTP handlers unblock
       // with a clear error rather than hanging until their own timer fires.
@@ -611,7 +640,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
     } catch (err) {
       const msg = errMsg(err);
       deps.logError(`meet-bot: ${msg}`);
-      await shutdown("error", "extension never signaled ready");
+      await shutdown("error", `extension never signaled ready: ${msg}`);
       detachSigterm();
       detachSigint();
       deps.exit(1);
@@ -632,12 +661,31 @@ export async function runBot(deps: BotDeps): Promise<void> {
     } catch (err) {
       const msg = errMsg(err);
       deps.logError(`meet-bot: failed to send join to extension: ${msg}`);
-      await shutdown("error", msg);
+      await shutdown("error", `failed to send join to extension: ${msg}`);
       detachSigterm();
       detachSigint();
       deps.exit(1);
       return;
     }
+
+    // Arm the extension-joined deadline. `waitForReady` guarantees the
+    // extension is alive, but it doesn't guarantee Chrome actually landed
+    // on a Meet tab — a restore-session dialog or a redirect loop leaves
+    // the content script unmounted and the background bridge silently
+    // drops the `join` relay. Without this timer the bot would sit in
+    // `phase=joining` indefinitely. The lifecycle message handler clears
+    // `extensionJoinedTimer` on `joined` / `error`; the clear is idempotent
+    // so repeated events are safe.
+    extensionJoinedTimer = setTimeout(() => {
+      if (shutdownInProgress) return;
+      const detail = `extension did not reach joined state within ${deps.extensionJoinedTimeoutMs}ms`;
+      deps.logError(`meet-bot: ${detail}`);
+      void shutdown("error", detail).then(() => {
+        detachSigterm();
+        detachSigint();
+        deps.exit(1);
+      });
+    }, deps.extensionJoinedTimeoutMs);
 
     // Short settle before wiring up the audio pipeline so the page has a
     // moment to render after admission. The extension will emit its own
@@ -703,9 +751,20 @@ export async function runBot(deps: BotDeps): Promise<void> {
         if (state === "joined") BotState.setPhase("joined");
         if (state === "error") BotState.setPhase("error");
         if (state === "left") BotState.setPhase("leaving");
+        // Clear the extension-joined deadline as soon as the extension
+        // reaches a terminal post-prejoin state. Idempotent.
+        if (state === "joined" || state === "error") {
+          clearExtensionJoinedTimer();
+        }
+        // Rewrite meetingId to the authoritative UUID from env. The
+        // extension derives its `meetingId` from `location.pathname` (the
+        // Meet URL code, e.g. `abc-defg-hij`), but the daemon keys
+        // sessions by the UUID passed via `MEETING_ID` env. Stamping here
+        // at the bot boundary keeps the extension simple while ensuring
+        // every daemon-facing event correlates to the correct session.
         publishLifecycle(
           subsystems.daemonClient,
-          msg.meetingId,
+          meetingId,
           state,
           deps,
           msg.detail,
@@ -715,7 +774,11 @@ export async function runBot(deps: BotDeps): Promise<void> {
       case "participant.change":
       case "speaker.change":
       case "chat.inbound":
-        if (subsystems.daemonClient) subsystems.daemonClient.enqueue(msg);
+        // Belt-and-suspenders: overwrite meetingId with the authoritative
+        // UUID before forwarding. See lifecycle case above for rationale.
+        if (subsystems.daemonClient) {
+          subsystems.daemonClient.enqueue({ ...msg, meetingId });
+        }
         return;
       case "diagnostic":
         if (msg.level === "error") deps.logError(`[ext] ${msg.message}`);


### PR DESCRIPTION
## Summary
Three fixes identified during Phase 1.11 post-landing review.

**1. meetingId mismatch.** Extension derived meetingId from location.pathname (Meet URL code); daemon keys sessions by a UUID from MEETING_ID env. Bot now stamps the authoritative UUID onto lifecycle/participant.change/speaker.change/chat.inbound events before forwarding to the daemon client.

**2. Join timeout.** waitForReady had a 30s timeout but there was no deadline for the extension to reach lifecycle:joined after receiving the join command. Bot could hang indefinitely if Chrome didn't land on a Meet tab. Added extensionJoinedTimeoutMs (default 120s); timer cleared on joined/error.

**3. Error detail lost.** Shutdown details for waitForReady/send-join failures dropped the underlying error message. Now forwarded to the daemon so the specific cause reaches the conversation log.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
