### PR TITLE
fix(slack): use slack_channel service key in INGRESS_SECRET_TARGETS

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -100,17 +100,17 @@ const INGRESS_SECRET_TARGETS: Record<string, IngressSecretTarget> = {
     label: "SendGrid API Key",
   },
   "Slack Bot Token": {
-    service: "slack",
+    service: "slack_channel",
     field: "bot_token",
     label: "Slack Bot Token",
   },
   "Slack User Token": {
-    service: "slack",
+    service: "slack_channel",
     field: "user_token",
     label: "Slack User Token",
   },
   "Slack Webhook": {
-    service: "slack",
+    service: "slack_channel",
     field: "webhook_url",
     label: "Slack Webhook URL",
   },


### PR DESCRIPTION
## Summary
- Changed Slack Bot Token, User Token, and Webhook entries in `INGRESS_SECRET_TARGETS` from `service: "slack"` to `service: "slack_channel"`
- Fixes a loop where the assistant stored tokens under the wrong key during Slack setup, then had to re-prompt to store them under the correct key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
