### PR TITLE
fix(macos): improve TCC sandbox profile deny list and fix Contacts path

### DIFF
--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -18,16 +18,18 @@ const HASH_DISPLAY_LENGTH = 12;
  * from triggering Photos, Contacts, Calendar, etc. dialogs during filesystem
  * traversal (e.g. `find ~ -name .git`).
  *
- * Paths are relative to $HOME. Only directories that trigger TCC prompts for
- * non-App-Sandbox apps are listed — ~/Desktop and ~/Documents are
- * TCC-protected only under App Sandbox, which the daemon does not use.
+ * Paths are relative to $HOME. Includes both TCC-protected directories that
+ * trigger prompts for all apps and directories like ~/Desktop and ~/Documents
+ * that are TCC-protected under App Sandbox or Full Disk Access checks.
  */
 export const MACOS_TCC_PROTECTED_PATHS = [
+  "Desktop",
+  "Documents",
   "Pictures/Photos Library.photoslibrary",
   "Library/Photos",
   "Library/Calendars",
   "Library/Reminders",
-  "Library/AddressBook",
+  "Library/Application Support/AddressBook",
   "Library/Messages",
   "Library/Mail",
   "Library/Safari",


### PR DESCRIPTION
## Summary
- Add ~/Desktop and ~/Documents to the Files & Folders TCC deny list
- Fix Contacts path from Library/AddressBook to Library/Application Support/AddressBook
- Update comment to reflect the broader scope of denied paths

See https://github.com/vellum-ai/vellum-assistant/pull/26414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
