### PR TITLE
fix(slack): add route policy, app_token validation, and docs fix for OAuth install

### DIFF
--- a/assistant/src/daemon/handlers/slack-channel-oauth-install.ts
+++ b/assistant/src/daemon/handlers/slack-channel-oauth-install.ts
@@ -97,6 +97,19 @@ export async function runSlackChannelOAuthInstall(): Promise<SlackOAuthInstallRe
     };
   }
 
+  const appToken = await getSecureKeyAsync(
+    credentialKey("slack_channel", "app_token"),
+  );
+  if (!appToken) {
+    return {
+      success: false,
+      hasBotToken: false,
+      hasUserToken: false,
+      error:
+        "App Token not found in credential store. Store it first via credential_store prompt (service: slack_channel, field: app_token).",
+    };
+  }
+
   log.info("Starting Slack OAuth install flow via loopback");
 
   let result;
@@ -163,7 +176,7 @@ export async function runSlackChannelOAuthInstall(): Promise<SlackOAuthInstallRe
   // which validates tokens and persists workspace metadata.
   const configResult = await setSlackChannelConfig(
     botToken,
-    undefined, // app_token already stored via credential_store prompt
+    appToken,
     userToken,
   );
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -214,6 +214,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "integrations/slack/channel/config:DELETE",
     scopes: ["settings.write"],
   },
+  {
+    endpoint: "integrations/slack/channel/oauth-install:POST",
+    scopes: ["settings.write"],
+  },
   { endpoint: "channel-verification-sessions", scopes: ["settings.write"] },
   {
     endpoint: "channel-verification-sessions:DELETE",

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -218,6 +218,7 @@ Verify that `message.channels` event subscription is enabled in your Slack app s
 ### OAuth install failed
 
 If the OAuth flow fails or times out, re-run Step 3d. Ensure:
+
 - The Client ID and Client Secret are correct (re-collect via credential_store if unsure)
 - The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (added in Step 2)
 - No other process is using port 17322

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -219,7 +219,7 @@ Verify that `message.channels` event subscription is enabled in your Slack app s
 
 If the OAuth flow fails or times out, re-run Step 3d. Ensure:
 - The Client ID and Client Secret are correct (re-collect via credential_store if unsure)
-- The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (the manifest pre-configures this)
+- The Slack app has `http://localhost:17322/oauth/callback` in its OAuth redirect URLs (added in Step 2)
 - No other process is using port 17322
 
 ## Implementation Rules


### PR DESCRIPTION
## Summary
- Register route policy for `integrations/slack/channel/oauth-install:POST` endpoint requiring `settings.write` scope — previously unprotected
- Add `app_token` validation in the OAuth install handler — retrieve from credential store and pass to `setSlackChannelConfig` instead of `undefined`
- Fix troubleshooting docs to say "(added in Step 2)" instead of "(the manifest pre-configures this)" since the manifest doesn't include redirect_urls

## Test plan
- [ ] Verify `enforcePolicy()` requires `settings.write` for the oauth-install endpoint
- [ ] Verify OAuth install handler rejects requests when `app_token` is missing from credential store
- [ ] Verify `app_token` is passed through to `setSlackChannelConfig`

Closes feedback from #26588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
