### PR TITLE
fix(db): add migration 042 to fix column names from migration 041

### DIFF
--- a/assistant/src/workspace/migrations/042-fix-backfill-google-gmail-settings-scope.ts
+++ b/assistant/src/workspace/migrations/042-fix-backfill-google-gmail-settings-scope.ts
@@ -1,0 +1,58 @@
+import { rawGet, rawRun } from "../../memory/raw-query.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const GMAIL_SETTINGS_BASIC_SCOPE =
+  "https://www.googleapis.com/auth/gmail.settings.basic";
+
+/**
+ * Re-run the gmail.settings.basic scope backfill with correct SQLite column names.
+ *
+ * Migration 041 used Drizzle property names (`defaultScopes`, `provider`,
+ * `updatedAt`) instead of the actual SQLite column names (`default_scopes`,
+ * `provider_key`, `updated_at`). The SQL silently failed because the catch
+ * block swallowed the error, and the migration was marked complete without
+ * actually backfilling the scope.
+ *
+ * This migration performs the same backfill with the correct column names.
+ */
+export const fixBackfillGoogleGmailSettingsScopeMigration: WorkspaceMigration =
+  {
+    id: "042-fix-backfill-google-gmail-settings-scope",
+    description:
+      "Re-run gmail.settings.basic scope backfill with correct SQLite column names",
+    run(_workspaceDir: string): void {
+      let row: { default_scopes: string } | null;
+      try {
+        row = rawGet<{ default_scopes: string }>(
+          `SELECT default_scopes FROM oauth_providers WHERE provider_key = 'google'`,
+        );
+      } catch {
+        // DB not initialized yet — nothing to backfill.
+        return;
+      }
+
+      if (!row) return; // No google provider row — seed will create it fresh.
+
+      let scopes: string[];
+      try {
+        const parsed = JSON.parse(row.default_scopes);
+        scopes = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        scopes = [];
+      }
+
+      if (scopes.includes(GMAIL_SETTINGS_BASIC_SCOPE)) return; // Already present.
+
+      scopes.push(GMAIL_SETTINGS_BASIC_SCOPE);
+
+      rawRun(
+        `UPDATE oauth_providers SET default_scopes = ?, updated_at = ? WHERE provider_key = 'google'`,
+        JSON.stringify(scopes),
+        new Date().toISOString(),
+      );
+    },
+    down(_workspaceDir: string): void {
+      // Forward-only: removing the scope would break Gmail settings functionality
+      // for users who have already started using it.
+    },
+  };

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -39,6 +39,7 @@ import { unifyLlmCallSiteConfigsMigration } from "./038-unify-llm-callsite-confi
 import { dropLegacyLlmKeysMigration } from "./039-drop-legacy-llm-keys.js";
 import { seedLatencyCallSiteDefaultsMigration } from "./040-seed-latency-callsite-defaults.js";
 import { backfillGoogleGmailSettingsScopeMigration } from "./041-backfill-google-gmail-settings-scope.js";
+import { fixBackfillGoogleGmailSettingsScopeMigration } from "./042-fix-backfill-google-gmail-settings-scope.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -89,4 +90,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropLegacyLlmKeysMigration,
   seedLatencyCallSiteDefaultsMigration,
   backfillGoogleGmailSettingsScopeMigration,
+  fixBackfillGoogleGmailSettingsScopeMigration,
 ];


### PR DESCRIPTION
Migration 041 used Drizzle property names (defaultScopes, provider, updatedAt) instead of SQLite column names (default_scopes, provider_key, updated_at). The query silently failed because the catch block swallowed the error. This adds migration 042 with the correct column names to properly backfill the data.

See https://github.com/vellum-ai/vellum-assistant/pull/26420
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
