### PR TITLE
fix(gateway): add dedicated proxy route for Slack OAuth install with extended timeout

### DIFF
--- a/gateway/src/http/routes/slack-control-plane-proxy.ts
+++ b/gateway/src/http/routes/slack-control-plane-proxy.ts
@@ -13,14 +13,23 @@ import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("slack-control-plane-proxy");
 
+/**
+ * The Slack OAuth install flow blocks while the user completes the Slack
+ * consent screen in their browser, which can take several minutes. Use a
+ * generous timeout so the gateway doesn't abort the connection.
+ */
+const OAUTH_INSTALL_TIMEOUT_MS = 360_000; // 6 minutes
+
 export function createSlackControlPlaneProxyHandler(config: GatewayConfig) {
   async function proxyToRuntime(
     req: Request,
     upstreamPath: string,
     upstreamSearch: string,
+    options?: { timeoutMs?: number },
   ): Promise<Response> {
     const start = performance.now();
     const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+    const timeoutMs = options?.timeoutMs ?? config.runtimeTimeoutMs;
 
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
@@ -42,7 +51,7 @@ export function createSlackControlPlaneProxyHandler(config: GatewayConfig) {
           "TimeoutError",
         ),
       );
-    }, config.runtimeTimeoutMs);
+    }, timeoutMs);
 
     let response: Response;
     try {
@@ -103,6 +112,15 @@ export function createSlackControlPlaneProxyHandler(config: GatewayConfig) {
 
     async handleShareToSlack(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/slack/share", "");
+    },
+
+    async handleSlackOAuthInstall(req: Request): Promise<Response> {
+      return proxyToRuntime(
+        req,
+        "/v1/integrations/slack/channel/oauth-install",
+        "",
+        { timeoutMs: OAUTH_INSTALL_TIMEOUT_MS },
+      );
     },
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -781,6 +781,12 @@ async function main() {
       auth: "edge",
       handler: (req) => slackControlPlaneProxy.handleShareToSlack(req),
     },
+    {
+      path: "/v1/integrations/slack/channel/oauth-install",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => slackControlPlaneProxy.handleSlackOAuthInstall(req),
+    },
 
     // ── OAuth providers ──
     {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1952,6 +1952,32 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/integrations/slack/channel/oauth-install": {
+        post: {
+          summary: "Slack OAuth install",
+          description:
+            "Authenticated gateway endpoint that initiates the Slack OAuth loopback flow to capture bot and user tokens. This endpoint blocks while the user completes the Slack consent screen (up to 6 minutes).",
+          operationId: "slackChannelOAuthInstallPost",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "OAuth install completed successfully" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/oauth/providers": {
         get: {
           summary: "List OAuth providers",


### PR DESCRIPTION
## Summary
- Adds a dedicated gateway proxy route for `POST /v1/integrations/slack/channel/oauth-install` with a 6-minute timeout (360s), preventing the catch-all runtime proxy's 30-second timeout from aborting the OAuth flow while the user completes Slack consent.
- Uses `auth: "edge"` matching other Slack control plane routes, so requests are authenticated via the gateway's edge token mechanism rather than requiring a manual bearer token in curl.
- Verified `agentmail` has no remaining imports — the bun.lock removal flagged in review is benign.

Addresses review feedback from #26592.

## Test plan
- [ ] Verify the new route is registered before the catch-all proxy in the route table
- [ ] Confirm OAuth install flow completes without gateway timeout (up to 6 min)
- [ ] Verify edge auth is enforced on the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
