### PR TITLE
fix(meet-bot): swap to chromium + live-Meet DOM fixes

### DIFF
--- a/scripts/build-meet-bot-image.sh
+++ b/scripts/build-meet-bot-image.sh
@@ -16,9 +16,10 @@
 # than `.dockerignore`) so it takes precedence over the existing repo-root
 # `.dockerignore` file, which targets other images.
 #
-# --platform linux/amd64 is required because google-chrome-stable ships
-# amd64 only — on arm64 Macs Docker would otherwise pick arm64 and fail to
-# install Chrome.
+# --platform linux/amd64 is required because the inner DinD engine only
+# runs bot containers under that platform and Chromium's amd64 apt package
+# is the tested baseline. On arm64 Macs Docker would otherwise pick arm64
+# and the meet-bot image would not match the assistant container's platform.
 #
 # Usage:
 #   ./scripts/build-meet-bot-image.sh

--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -1,17 +1,19 @@
 # meet-bot container image.
 #
 # Runs the Meet bot inside a Debian-based Bun image with Xvfb (virtual
-# display), PulseAudio (virtual audio devices), google-chrome-stable (for
-# Chrome extension support required by the Chrome extension based
-# meet-join architecture), and ffmpeg for future audio capture/encoding
-# needs.
+# display), PulseAudio (virtual audio devices), chromium (Debian package, for
+# the `--load-extension` support required by the extension-based meet-join
+# architecture — google-chrome-stable silently strips that flag as of
+# Chrome 128+), and ffmpeg for future audio capture/encoding needs.
 #
 # The real Meet-join + audio-capture logic lands in later PRs of the
 # meet-phase-1 plan; this image just needs to build cleanly and boot
 # `bun src/main.ts` to completion so CI can smoke-test the structure.
 #
-# NOTE: google-chrome-stable ships amd64 only. This image must be built
-# with --platform linux/amd64 — enforced in scripts/build-meet-bot-image.sh.
+# NOTE: Meet's BotGuard accepts chromium launched as a plain subprocess
+# (no CDP attachment) but rejects Chrome-with-CDP. The image inherits the
+# `--platform linux/amd64` build constraint for parity with other amd64
+# dependencies — enforced in `scripts/build-meet-bot-image.sh`.
 #
 # Build context: the REPO ROOT (not `skills/meet-join/bot/`). The bot package
 # depends on the sibling workspace package `skills/meet-join/contracts` via
@@ -35,39 +37,37 @@ FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4
 # System dependencies. Keep this list grouped and sorted so future PRs can
 # add/remove packages cleanly.
 #
-#   Xvfb + PulseAudio: virtual display and audio stack for headless Chrome.
-#   dbus-x11:          required at runtime by Chrome.
+#   Xvfb + PulseAudio: virtual display and audio stack for headless Chromium.
+#   ca-certificates:   TLS trust store for any outbound HTTPS the bot makes
+#                      at runtime.
+#   dbus-x11:          required at runtime by Chromium.
 #   ffmpeg:            audio/video encoding for transcript + recording paths.
-#   fonts-liberation/libvulkan1/xdg-utils: google-chrome-stable runtime deps.
-#   libnss3/libgbm1/libasound2: Chrome shared-library dependencies.
-#   wget + gnupg:      required to fetch Google's apt signing key and configure
-#                      the google-chrome repo (see next RUN).
+#   fonts-liberation/libvulkan1/xdg-utils: chromium runtime deps.
+#   libnss3/libgbm1/libasound2: Chromium shared-library dependencies.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     dbus-x11 \
     ffmpeg \
     fonts-liberation \
-    gnupg \
     libasound2 \
     libgbm1 \
     libnss3 \
     libvulkan1 \
     pulseaudio \
     pulseaudio-utils \
-    wget \
     xdg-utils \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Install google-chrome-stable from Google's official apt repo. We use Chrome
-# (not Chromium) because the Chrome extension based meet-join architecture
-# requires Chrome's extension support. Per CLAUDE.md's Docker dependencies
-# rule, package versions are NOT pinned — rely on the base-image digest for
-# reproducibility.
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
-    | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
-  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-    > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update && apt-get install -y --no-install-recommends google-chrome-stable \
+# Install Debian's chromium (NOT google-chrome-stable). As of Chrome 128+,
+# google-chrome-stable silently strips the `--load-extension` command-line
+# flag ("--load-extension is not allowed in Google Chrome, ignoring"), which
+# blocks our extension-based architecture. Chromium keeps the flag working
+# and is otherwise indistinguishable to Meet's BotGuard when launched as a
+# plain subprocess without CDP attachment. Per CLAUDE.md's Docker
+# dependencies rule, package versions are NOT pinned — rely on the
+# base-image digest for reproducibility.
+RUN apt-get update && apt-get install -y --no-install-recommends chromium \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app/bot
@@ -80,6 +80,14 @@ COPY skills/meet-join/contracts /app/contracts
 # source files change.
 COPY skills/meet-join/bot/package.json skills/meet-join/bot/bun.lock skills/meet-join/bot/tsconfig.json ./
 RUN bun install --frozen-lockfile
+
+# The contracts/ directory has no package.json and no node_modules of its own,
+# but its TS files import `zod`. Both the bot (at runtime) and the extension
+# build (which imports contracts via relative paths) need zod resolvable from
+# /app/contracts/. Symlink the bot's node_modules in so Node/Bun's upward
+# module resolution finds zod when walking up from /app/contracts/*.ts.
+RUN mkdir -p /app/contracts/node_modules \
+  && ln -sf /app/bot/node_modules/zod /app/contracts/node_modules/zod
 
 COPY skills/meet-join/bot/src ./src
 
@@ -103,9 +111,9 @@ COPY skills/meet-join/bot/native-messaging ./native-messaging
 COPY skills/meet-join/bot/scripts/render-nmh-manifest.ts ./scripts/render-nmh-manifest.ts
 COPY skills/meet-join/meet-controller-ext/manifest.json /tmp/ext-manifest.json
 
-RUN mkdir -p /etc/opt/chrome/native-messaging-hosts \
+RUN mkdir -p /etc/chromium/native-messaging-hosts \
   && bun scripts/render-nmh-manifest.ts \
-       /etc/opt/chrome/native-messaging-hosts/com.vellum.meet.json \
+       /etc/chromium/native-messaging-hosts/com.vellum.meet.json \
        --ext-manifest /tmp/ext-manifest.json \
        --template /app/bot/native-messaging/com.vellum.meet.json \
   && chmod +x /app/bot/src/native-messaging/nmh-shim.ts \

--- a/skills/meet-join/bot/__tests__/chrome-launcher.test.ts
+++ b/skills/meet-join/bot/__tests__/chrome-launcher.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the chrome-launcher primitive.
  *
  * We inject a fake `spawn` via `opts.spawn` so the tests never actually exec
- * google-chrome-stable. Each fake child process exposes `.kill(signal)`,
+ * chromium. Each fake child process exposes `.kill(signal)`,
  * `.on("exit", cb)`, and `.stdout`/`.stderr` event emitters, mirroring the
  * shape of a real `ChildProcess`.
  *
@@ -105,14 +105,14 @@ const BASE_OPTS = {
 };
 
 describe("launchChrome", () => {
-  test("defaults chromeBinary to /usr/bin/google-chrome-stable", async () => {
+  test("defaults chromeBinary to /usr/bin/chromium", async () => {
     const child = makeFakeChild();
     const fake = makeFakeSpawn(child);
 
     await launchChrome({ ...BASE_OPTS, spawn: fake.spawn });
 
     expect(fake.calls.length).toBe(1);
-    expect(fake.calls[0]!.command).toBe("/usr/bin/google-chrome-stable");
+    expect(fake.calls[0]!.command).toBe("/usr/bin/chromium");
   });
 
   test("argv contains extension, user-data-dir, --no-sandbox, and meeting URL", async () => {

--- a/skills/meet-join/bot/src/browser/chrome-launcher.ts
+++ b/skills/meet-join/bot/src/browser/chrome-launcher.ts
@@ -1,5 +1,12 @@
 /**
- * chrome-launcher: spawns google-chrome-stable as a PLAIN USER PROCESS.
+ * chrome-launcher: spawns chromium as a PLAIN USER PROCESS.
+ *
+ * We launch Debian's `chromium` package rather than `google-chrome-stable`
+ * because Chrome 128+ silently strips the `--load-extension` command-line
+ * flag ("--load-extension is not allowed in Google Chrome, ignoring"),
+ * which blocks our extension-based architecture. Chromium still honors
+ * the flag and is otherwise indistinguishable to Meet's BotGuard when
+ * launched as a plain subprocess.
  *
  * Deliberately does NOT use CDP or any CDP-based automation framework.
  * The launcher also does NOT pass any of:
@@ -11,9 +18,8 @@
  * anonymous joiners with "You can't join this video call" before the prejoin
  * surface renders. The empirical reproduction lives in the Phase 1.11 plan
  * at .private/plans/archived/meet-phase-1-11-chrome-extension.md. Browser
- * control happens via a Chrome extension loaded with --load-extension that
- * communicates with this bot process via Chrome Native Messaging; it does
- * NOT depend on CDP.
+ * control happens via a loaded extension that communicates with this bot
+ * process via Chrome Native Messaging; it does NOT depend on CDP.
  */
 
 import {
@@ -36,8 +42,8 @@ export interface LaunchChromeOptions {
   /** Absolute path to the Chrome user-data directory for this session. */
   userDataDir: string;
   /**
-   * Chrome binary path. Defaults to `/usr/bin/google-chrome-stable` (installed
-   * by the bot container). Override in tests.
+   * Browser binary path. Defaults to `/usr/bin/chromium` (Debian's chromium
+   * package, installed by the bot container). Override in tests.
    */
   chromeBinary?: string;
   /**
@@ -105,6 +111,8 @@ function buildChromeArgs(opts: {
     "--no-default-browser-check",
     "--disable-default-apps",
     "--use-fake-ui-for-media-stream",
+    "--enable-logging=stderr",
+    "--v=0",
     `--user-data-dir=${opts.userDataDir}`,
     `--load-extension=${opts.extensionPath}`,
     opts.meetingUrl,
@@ -120,7 +128,7 @@ function buildChromeArgs(opts: {
 export async function launchChrome(
   opts: LaunchChromeOptions,
 ): Promise<ChromeProcessHandle> {
-  const chromeBinary = opts.chromeBinary ?? "/usr/bin/google-chrome-stable";
+  const chromeBinary = opts.chromeBinary ?? "/usr/bin/chromium";
   const logger = opts.logger ?? NOOP_LOGGER;
   const spawnFn = opts.spawn ?? nodeSpawn;
   const sigkillGraceMs = opts.sigkillGraceMs ?? DEFAULT_SIGKILL_GRACE_MS;

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -79,19 +79,22 @@ export const prejoinSelectors = {
 
   /**
    * "Ask to join" button shown when the meeting is locked and the bot needs
-   * the host to admit it. Matches by aria-label for stability across locales
-   * (callers should be aware of localization — see TODO below).
+   * the host to admit it. Matches by aria-label prefix because Meet decorates
+   * the label with context — e.g. `aria-label="Ask to join without camera"`
+   * when the bot's camera is unavailable. The `^=` prefix match covers both
+   * the bare and decorated forms.
    */
   // TODO(meet-dom): aria-label is localized. Future versions may need to
   // match multiple locales or fall back to role=button + text content.
-  ASK_TO_JOIN_BUTTON: 'button[aria-label="Ask to join"]',
+  ASK_TO_JOIN_BUTTON: 'button[aria-label^="Ask to join"]',
 
   /**
    * "Join now" button shown when the meeting is open or the bot is already
    * trusted (e.g. same-domain policy). Distinct from Ask-to-join so the caller
-   * can branch on which flow Meet presented.
+   * can branch on which flow Meet presented. Prefix match covers the bare
+   * label plus Meet's "Join now without camera" etc. variants.
    */
-  JOIN_NOW_BUTTON: 'button[aria-label="Join now"]',
+  JOIN_NOW_BUTTON: 'button[aria-label^="Join now"]',
 } as const;
 
 /**

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -152,31 +152,74 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
 
   // Step 3 — populate the name input if present. Meet doesn't render it for
   // signed-in users, in which case the account's name is used instead.
+  //
+  // Meet's UI is React-based; React tracks input values via the native
+  // HTMLInputElement setter and ignores assignments that bypass it. Using
+  // the native setter followed by a bubbling `input` event is the canonical
+  // pattern for programmatically setting a controlled input in React —
+  // without it, Meet's internal state never registers the name change and
+  // the join button remains gated as if the field were still empty.
   const nameInput = doc.querySelector(selectors.PREJOIN_NAME_INPUT);
   if (nameInput) {
-    (nameInput as HTMLInputElement).focus();
-    (nameInput as HTMLInputElement).value = displayName;
-    nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+    const input = nameInput as HTMLInputElement;
+    input.focus();
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    if (setter) {
+      setter.call(input, displayName);
+    } else {
+      input.value = displayName;
+    }
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
   }
 
-  // Step 4 — click the admission button. Prefer "Join now" because it is the
-  // happy-path branch for signed-in / same-domain sessions; fall back to
-  // "Ask to join" for locked meetings. We re-query the live DOM rather than
-  // relying on `firstVisible` because Meet may have mounted additional
-  // buttons between step 2 and here.
-  const joinNow = doc.querySelector(selectors.PREJOIN_JOIN_NOW_BUTTON);
-  if (joinNow) {
-    (joinNow as HTMLElement).click();
-  } else {
-    const askToJoin = doc.querySelector(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
-    if (!askToJoin) {
-      fail(
-        onEvent,
-        "meet-ext: no join button present after prejoin surface mounted",
-      );
-    }
-    (askToJoin as HTMLElement).click();
+  // Step 4 — wait for the admission button, then click it. Prefer "Join now"
+  // because it is the happy-path branch for signed-in / same-domain sessions;
+  // fall back to "Ask to join" for locked meetings. Meet re-renders the
+  // join button after we populate the name input, so a synchronous query
+  // here races against that render. Poll with a short budget — the button
+  // is visible in the DOM within a few hundred ms of the input event.
+  let admissionBtn: Element | null = null;
+  const joinDeadline = Date.now() + 10_000;
+  while (Date.now() < joinDeadline) {
+    admissionBtn =
+      doc.querySelector(selectors.PREJOIN_JOIN_NOW_BUTTON) ??
+      doc.querySelector(selectors.PREJOIN_ASK_TO_JOIN_BUTTON);
+    if (admissionBtn) break;
+    await new Promise((r) => setTimeout(r, 200));
   }
+  if (!admissionBtn) {
+    // Dump every button's aria-label / text so fixture refreshes can catch
+    // selector drift quickly — Meet's DOM changes without notice.
+    const buttons = Array.from(doc.querySelectorAll("button")).slice(0, 30);
+    const inventory = buttons.map((b) => {
+      const label = b.getAttribute("aria-label") ?? "";
+      const text = (b.textContent ?? "").trim().slice(0, 40);
+      const disabled = (b as HTMLButtonElement).disabled;
+      return `[aria="${label}" text="${text}" disabled=${disabled}]`;
+    });
+    fail(
+      onEvent,
+      `meet-ext: no join button matched selectors after 10s. buttons: ${inventory.join(" ")}`,
+    );
+  }
+  const btnLabel = admissionBtn.getAttribute("aria-label") ?? "";
+  // NOTE: Meet gates the prejoin admission button on `event.isTrusted`, so a
+  // programmatic `.click()` from a content script is silently ignored by the
+  // real Meet UI — admission requires an X-server mouse click (handled by
+  // a separate trusted-click bridge to the bot process). We still dispatch
+  // the JS click here because (a) it's free, (b) the jsdom test harness
+  // exercises this path, and (c) any Meet build that ever relaxes the
+  // `isTrusted` check would start working again automatically.
+  (admissionBtn as HTMLElement).click();
+  onEvent({
+    type: "diagnostic",
+    level: "info",
+    message: `meet-ext: clicked admission button aria-label="${btnLabel}"`,
+  });
 
   // Step 5 — wait for the in-meeting UI. The "Leave call" button only mounts
   // once the bot is in the meeting, so it is our canonical admission signal.

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -62,26 +62,58 @@ export function startContentBridge(port: NativePort): void {
   });
 }
 
+/**
+ * Retry schedule for content-script delivery. The background SW wins the
+ * race with the content script at startup — Chrome mounts content scripts
+ * on `document_idle`, which fires after the native-messaging handshake
+ * resolves. `sendMessage` to a not-yet-mounted content script rejects
+ * with "Could not establish connection. Receiving end does not exist",
+ * so we retry with exponential backoff for up to ~10s.
+ */
+const DELIVERY_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000, 2000, 2000, 2000];
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function fanOutToMeetTabs(msg: BotToExtensionMessage): Promise<void> {
-  let tabs: chrome.tabs.Tab[];
-  try {
-    tabs = await chrome.tabs.query({ url: MEET_TAB_URL_PATTERN });
-  } catch (err) {
-    console.warn("[meet-ext] tabs.query failed:", err);
-    return;
-  }
-  if (tabs.length === 0) {
-    console.warn(
-      `[meet-ext] no Meet tab open; dropping bot->content message type=${msg.type}`,
-    );
-    return;
-  }
-  for (const tab of tabs) {
-    if (typeof tab.id !== "number") continue;
+  for (let attempt = 0; attempt <= DELIVERY_RETRY_DELAYS_MS.length; attempt++) {
+    let tabs: chrome.tabs.Tab[];
     try {
-      await chrome.tabs.sendMessage(tab.id, msg);
+      tabs = await chrome.tabs.query({ url: MEET_TAB_URL_PATTERN });
     } catch (err) {
-      console.warn(`[meet-ext] tabs.sendMessage to tab ${tab.id} failed:`, err);
+      console.warn("[meet-ext] tabs.query failed:", err);
+      return;
     }
+    if (tabs.length === 0) {
+      if (attempt === DELIVERY_RETRY_DELAYS_MS.length) {
+        console.warn(
+          `[meet-ext] no Meet tab open after ${attempt} retries; dropping bot->content message type=${msg.type}`,
+        );
+        return;
+      }
+      await sleep(DELIVERY_RETRY_DELAYS_MS[attempt]!);
+      continue;
+    }
+    let anyDelivered = false;
+    let lastError: unknown;
+    for (const tab of tabs) {
+      if (typeof tab.id !== "number") continue;
+      try {
+        await chrome.tabs.sendMessage(tab.id, msg);
+        anyDelivered = true;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    if (anyDelivered) return;
+    if (attempt === DELIVERY_RETRY_DELAYS_MS.length) {
+      console.warn(
+        `[meet-ext] tabs.sendMessage failed after ${attempt} retries; dropping bot->content message type=${msg.type}:`,
+        lastError,
+      );
+      return;
+    }
+    await sleep(DELIVERY_RETRY_DELAYS_MS[attempt]!);
   }
 }


### PR DESCRIPTION
## Summary

Five related fixes needed to actually join a live Meet from the bot container. Discovered smoke-testing the Phase 1.11 architecture end-to-end against `meet.google.com` — each gap blocked the bot before it could reach the waiting-room state.

- **Chromium instead of google-chrome-stable.** Chrome 128+ silently strips `--load-extension` (`"--load-extension is not allowed in Google Chrome, ignoring"`), which broke the entire extension-based control plane. Debian's `chromium` honors the flag and is indistinguishable to BotGuard when launched as a plain subprocess. NMH manifest path changed to `/etc/chromium/native-messaging-hosts/`.
- **ca-certificates** added to the base image — needed for outbound HTTPS (the Chrome signing-key fetch was failing silently on TLS verification before).
- **zod symlink for /app/contracts.** The bot and the extension build both resolve `zod` from `/app/contracts/*.ts` via upward module resolution, but `/app/contracts/` has no `node_modules` of its own. Symlink the bot's `node_modules/zod` in.
- **Content-script delivery race.** Background SW wins the race with the content script — `tabs.sendMessage` for a just-landed Meet tab rejected with "Receiving end does not exist" and the `join` command was lost. Added exponential-backoff retry (up to ~10s) in `fanOutToMeetTabs`.
- **Prejoin selector drift.** Real Meet aria-labels are decorated (e.g. `"Ask to join without camera"` when no camera). Switched to `aria-label^=` prefix matches.
- **React-native input setter.** `input.value = x` bypasses React's tracked setter, so Meet's internal state stayed empty and the join button remained gated. Use the canonical native-setter pattern plus `input`+`change` events.
- **DOM inventory on failure.** When no admission button matches after 10s, dump every button's aria-label/text/disabled state into the diagnostic message so future selector drift is triageable from a single log line.
- **Polling loop for join button.** Meet re-renders the button after the name input changes; poll for up to 10s instead of a single synchronous query.
- **Chrome stderr logging** kept on by default for observability — no rebuild needed for future debugging.

## Known gap

Meet gates the prejoin admission button on `event.isTrusted`, so the JS `.click()` in `runJoinFlow` is silently ignored by the live site. A real X-server click (via xdotool, bridged through the native port) lands in a follow-up PR. This PR gets the bot to "click dispatched, Meet ignores it" consistently — admission itself remains blocked on that follow-up.

Smoke-tested live: with a manual `xdotool` click layered on top of this PR, Velissa successfully joined `https://meet.google.com/vcc-wvij-kbz` alongside Sidd's account.

## Test plan

- [x] `bun test __tests__/` in `skills/meet-join/bot/` — 135 pass
- [x] `bun test src/` in `skills/meet-join/meet-controller-ext/` — 72 pass
- [x] `bash scripts/build-meet-bot-image.sh` — clean build, no wget/gpg errors
- [x] Boot container with real MEET_URL, daemon stub — extension handshake completes, join command delivered, admission click fires with correct aria-label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
