### PR TITLE
fix: replace PKB with Personal Knowledge Base in user-facing text

### DIFF
--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -6,7 +6,7 @@ export const FilingConfigSchema = z
       .boolean({ error: "filing.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Whether periodic PKB filing is enabled — processes buffer.md into topic files and reviews knowledge base organization",
+        "Whether periodic Personal Knowledge Base filing is enabled — processes buffer.md into topic files and reviews knowledge base organization",
       ),
     intervalMs: z
       .number({ error: "filing.intervalMs must be a number" })
@@ -36,7 +36,7 @@ export const FilingConfigSchema = z
       ),
   })
   .describe(
-    "Periodic PKB (personal knowledge base) filing — processes the buffer into topic files and maintains knowledge organization",
+    "Periodic Personal Knowledge Base filing — processes the buffer into topic files and maintains knowledge organization",
   )
   .superRefine((config, ctx) => {
     const startNull = config.activeHoursStart == null;

--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -7,7 +7,7 @@ import { buildPkbReminder } from "./pkb-reminder-builder.js";
 // matching string in conversation-runtime-assembly.ts must change too.
 const ORIGINAL_REMINDER =
   "<system_reminder>" +
-  "\nRead any unread PKB files that might be even partially relevant to this conversation" +
+  "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
   "\nUse `remember` for anything you learn immediately" +
   "\n</system_reminder>";
 
@@ -20,7 +20,7 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(["projects/alpha.md"]);
     const expected =
       "<system_reminder>" +
-      "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
       "\nUse `remember` for anything you learn immediately" +
@@ -40,7 +40,7 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(hints);
     const expected =
       "<system_reminder>" +
-      "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- a.md" +
       "\n- sub/b.md" +

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -13,7 +13,7 @@ export function buildPkbReminder(hints: ReadonlyArray<string>): string {
   if (hints.length === 0) {
     return (
       "<system_reminder>" +
-      "\nRead any unread PKB files that might be even partially relevant to this conversation" +
+      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
       "\nUse `remember` for anything you learn immediately" +
       "\n</system_reminder>"
     );
@@ -22,7 +22,7 @@ export function buildPkbReminder(hints: ReadonlyArray<string>): string {
   const bullets = hints.map((h) => `- ${h}`).join("\n");
   return (
     "<system_reminder>" +
-    "\nRead any unread PKB files that might be even partially relevant to this conversation." +
+    "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
     "\nBased on the current context, these files look especially relevant:" +
     `\n${bullets}` +
     "\nUse `remember` for anything you learn immediately" +


### PR DESCRIPTION
## Summary
- Replace "PKB" abbreviation with "Personal Knowledge Base" in system reminder text (`pkb-reminder-builder.ts`)
- Update config schema descriptions in `filing.ts` to use the full name
- Update test fixtures to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
