### PR TITLE
feat(meet-bot): xdotool trusted-click bridge

### DIFF
--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -44,6 +44,10 @@ FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4
 #   ffmpeg:            audio/video encoding for transcript + recording paths.
 #   fonts-liberation/libvulkan1/xdg-utils: chromium runtime deps.
 #   libnss3/libgbm1/libasound2: Chromium shared-library dependencies.
+#   xdotool:           posts trusted X-server mouse events for buttons that
+#                      Meet gates on `event.isTrusted` (the prejoin admission
+#                      button is the main one — JS `.click()` from the
+#                      extension is silently ignored).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     dbus-x11 \
@@ -56,6 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pulseaudio \
     pulseaudio-utils \
     xdg-utils \
+    xdotool \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 

--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -92,6 +92,8 @@ interface MakeDepsOpts {
   pulseError?: Error;
   /** Force `launchChrome` to reject. */
   chromeLaunchError?: Error;
+  /** Force `xdotoolClick` to reject. */
+  xdotoolClickError?: Error;
   /** Force `startXvfb` to reject. */
   xvfbError?: Error;
   /** Short-circuit `waitForReady` to reject with this error. */
@@ -248,6 +250,15 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         },
         exitPromise: chromeExitPromise,
       };
+    },
+    xdotoolClick: async (clickOpts) => {
+      calls.push({
+        kind: "xdotool.click",
+        x: clickOpts.x,
+        y: clickOpts.y,
+        display: clickOpts.display,
+      });
+      if (opts.xdotoolClickError) throw opts.xdotoolClickError;
     },
     startAudioCapture: async (audioOpts) => {
       calls.push({ kind: "audio.start", socketPath: audioOpts.socketPath });
@@ -547,6 +558,52 @@ describe("runBot — extension message routing", () => {
       "speaker.change",
       "chat.inbound",
     ]);
+  });
+
+  test("trusted_click invokes xdotoolClick with the screen coords + configured display", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    handles.fireExtensionMessage({
+      type: "trusted_click",
+      x: 1014,
+      y: 536,
+    });
+    // xdotoolClick is fire-and-forget (no promise surface here), so give
+    // it one microtask to settle and the logInfo to land.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const clickCall = handles.calls.find((c) => c.kind === "xdotool.click");
+    expect(clickCall).toBeDefined();
+    expect(clickCall!.x).toBe(1014);
+    expect(clickCall!.y).toBe(536);
+    expect(clickCall!.display).toBe(":99");
+    // Success should surface via logInfo.
+    expect(
+      handles.infos.some((m) => m.includes("trusted_click dispatched at (1014,536)")),
+    ).toBe(true);
+  });
+
+  test("trusted_click xdotool failures surface via logError but don't shut down", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      xdotoolClickError: new Error("xdotool exit code 1"),
+    });
+    await bootHappyPath(deps, handles);
+
+    handles.fireExtensionMessage({ type: "trusted_click", x: 5, y: 10 });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(
+      handles.errors.some((m) =>
+        m.includes("trusted_click failed: xdotool exit code 1"),
+      ),
+    ).toBe(true);
+    // Bot stays alive — no shutdown triggered.
+    const counts = handles.stopCounts();
+    expect(counts.chrome).toBe(0);
+    expect(counts.xvfb).toBe(0);
   });
 
   test("diagnostic messages go through the logger, not the daemon", async () => {

--- a/skills/meet-join/bot/__tests__/xdotool-click.test.ts
+++ b/skills/meet-join/bot/__tests__/xdotool-click.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the xdotool-click primitive.
+ *
+ * We inject a fake `spawn` via `opts.spawn` so tests never actually exec
+ * xdotool. The shape of the fake child mirrors the one used in
+ * `chrome-launcher.test.ts`: an EventEmitter with `stderr`, `.kill()`, and
+ * a `__simulateExit(code, signal?)` helper.
+ */
+
+import { EventEmitter } from "node:events";
+import { describe, expect, test } from "bun:test";
+
+import { xdotoolClick } from "../src/browser/xdotool-click.js";
+
+interface SpawnCall {
+  command: string;
+  args: string[];
+  options: { env?: NodeJS.ProcessEnv };
+}
+
+interface FakeChild extends EventEmitter {
+  stderr: EventEmitter;
+  kill: (signal?: NodeJS.Signals) => boolean;
+  __killSignals: NodeJS.Signals[];
+  __simulateExit: (code: number | null, signal?: NodeJS.Signals) => void;
+  __simulateSpawnError: (err: Error) => void;
+  __simulateStderr: (chunk: string) => void;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stderr = new EventEmitter();
+  child.__killSignals = [];
+  child.kill = (signal?: NodeJS.Signals): boolean => {
+    child.__killSignals.push(signal ?? "SIGTERM");
+    return true;
+  };
+  child.__simulateExit = (code, signal) => {
+    child.emit("exit", code, signal ?? null);
+  };
+  child.__simulateSpawnError = (err) => {
+    child.emit("error", err);
+  };
+  child.__simulateStderr = (chunk) => {
+    child.stderr.emit("data", Buffer.from(chunk, "utf8"));
+  };
+  return child;
+}
+
+function makeFakeSpawn(fakeChild: FakeChild): {
+  spawn: never;
+  calls: SpawnCall[];
+} {
+  const calls: SpawnCall[] = [];
+  const impl = (
+    command: string,
+    args: readonly string[],
+    options: { env?: NodeJS.ProcessEnv },
+  ) => {
+    calls.push({ command, args: [...args], options });
+    return fakeChild;
+  };
+  return { spawn: impl as unknown as never, calls };
+}
+
+describe("xdotoolClick", () => {
+  test("spawns xdotool with mousemove+click args and DISPLAY env", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolClick({
+      x: 120,
+      y: 240,
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls.length).toBe(1);
+    expect(fake.calls[0]!.command).toBe("/usr/bin/xdotool");
+    expect(fake.calls[0]!.args).toEqual([
+      "mousemove",
+      "120",
+      "240",
+      "click",
+      "1",
+    ]);
+    expect(fake.calls[0]!.options.env?.DISPLAY).toBe(":99");
+  });
+
+  test("honours custom binary override", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolClick({
+      x: 0,
+      y: 0,
+      display: ":42",
+      binary: "/custom/xdotool",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls[0]!.command).toBe("/custom/xdotool");
+  });
+
+  test("resolves cleanly on exit code 0", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolClick({ x: 5, y: 5, display: ":99", spawn: fake.spawn });
+    child.__simulateExit(0);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  test("rejects with exit code + stderr detail on non-zero exit", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolClick({
+      x: 10,
+      y: 20,
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateStderr("Can't open display: :99\n");
+    child.__simulateExit(1);
+    await expect(pending).rejects.toThrow(/exit code 1/i);
+    await expect(pending).rejects.toThrow(/Can't open display/i);
+  });
+
+  test("rejects with signal detail when killed", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolClick({
+      x: 10,
+      y: 20,
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(null, "SIGTERM");
+    await expect(pending).rejects.toThrow(/signal SIGTERM/i);
+  });
+
+  test("rejects on spawn error", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolClick({
+      x: 10,
+      y: 20,
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateSpawnError(new Error("ENOENT: xdotool"));
+    await expect(pending).rejects.toThrow(/ENOENT/);
+  });
+
+  test("times out if xdotool never exits", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolClick({
+      x: 10,
+      y: 20,
+      display: ":99",
+      spawn: fake.spawn,
+      timeoutMs: 10,
+    });
+    await expect(pending).rejects.toThrow(/timed out after 10ms/i);
+    expect(child.__killSignals).toContain("SIGKILL");
+  });
+});

--- a/skills/meet-join/bot/src/browser/xdotool-click.ts
+++ b/skills/meet-join/bot/src/browser/xdotool-click.ts
@@ -1,0 +1,145 @@
+/**
+ * xdotool-click: dispatches a REAL X-server mouse click inside the bot
+ * container.
+ *
+ * Google Meet gates several critical buttons (the prejoin admission button
+ * in particular) on `event.isTrusted === true`. A content script's
+ * `element.click()` produces `isTrusted: false` and Meet silently ignores
+ * it — verified empirically against a live Meet URL during Phase 1.11
+ * smoke-testing. xdotool dispatches events through the X server, which
+ * stamps them with `isTrusted: true`, so Meet processes them as real user
+ * interactions.
+ *
+ * Invocation shape (one process per click — `mousemove` and `click` are
+ * fused into a single argv so the pointer doesn't have a visible "dwell"
+ * frame between the two):
+ *
+ *     DISPLAY=:99 xdotool mousemove X Y click 1
+ *
+ * Callers pass screen-space coordinates (the extension is responsible for
+ * translating `clientX/clientY` via `window.screenX/screenY + chromeOffset`
+ * before emitting the `trusted_click` native-messaging frame).
+ */
+
+import {
+  spawn as nodeSpawn,
+  type ChildProcess,
+} from "node:child_process";
+
+/** Logger shape matching the one used by `chrome-launcher`. */
+export interface XdotoolClickLogger {
+  info: (message: string) => void;
+  error: (message: string) => void;
+}
+
+const NOOP_LOGGER: XdotoolClickLogger = {
+  info: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * Minimal shape of Node's `spawn` used by this module — kept structural so
+ * tests can inject a mock without depending on Node internals.
+ */
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: { env?: NodeJS.ProcessEnv },
+) => ChildProcess;
+
+export interface XdotoolClickOptions {
+  /** Screen-space X coordinate on the Xvfb virtual display. */
+  x: number;
+  /** Screen-space Y coordinate on the Xvfb virtual display. */
+  y: number;
+  /** X display string (e.g. ":99"). Passed as the `DISPLAY` env var. */
+  display: string;
+  /**
+   * xdotool binary path. Defaults to `/usr/bin/xdotool` (installed by the
+   * bot container). Override in tests.
+   */
+  binary?: string;
+  /** `node:child_process.spawn` override for tests. */
+  spawn?: SpawnFn;
+  /** Logger for visibility into invocation + failures. Defaults to no-op. */
+  logger?: XdotoolClickLogger;
+  /**
+   * How long to wait for xdotool to exit before rejecting. xdotool itself
+   * is a very short-lived process (single mousemove + click on the local
+   * X server), so this is a safety net rather than a normal-path timer.
+   */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Dispatch a single trusted left-click at `(x, y)` on the Xvfb display.
+ *
+ * Resolves on clean exit (code 0). Rejects on non-zero exit, spawn failure,
+ * or timeout. The promise intentionally does NOT resolve with any payload —
+ * success is observed by the extension via subsequent DOM transitions (the
+ * waitForSelector for `INGAME_LEAVE_BUTTON` is the authoritative signal).
+ */
+export async function xdotoolClick(opts: XdotoolClickOptions): Promise<void> {
+  const binary = opts.binary ?? "/usr/bin/xdotool";
+  const spawnFn = opts.spawn ?? nodeSpawn;
+  const logger = opts.logger ?? NOOP_LOGGER;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Fuse mousemove + click into a single argv so the pointer doesn't hover
+  // visibly between the two invocations, and so we only pay one fork/exec
+  // cost per click. `click 1` is the X-server button number for left click.
+  const args = ["mousemove", String(opts.x), String(opts.y), "click", "1"];
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err) reject(err);
+      else resolve();
+    };
+
+    const child = spawnFn(binary, args, {
+      env: { ...process.env, DISPLAY: opts.display },
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      logger.error(`xdotool spawn failed: ${err.message}`);
+      settle(err);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        logger.info(`xdotool click at (${opts.x},${opts.y}) ok`);
+        settle();
+        return;
+      }
+      const reason = signal
+        ? `killed by signal ${signal}`
+        : `exit code ${code}`;
+      const detail = stderr.trim() ? ` stderr="${stderr.trim()}"` : "";
+      settle(new Error(`xdotool click failed: ${reason}${detail}`));
+    });
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // best effort; the timeout-reject below is what callers observe.
+      }
+      settle(
+        new Error(
+          `xdotool click timed out after ${timeoutMs}ms at (${opts.x},${opts.y})`,
+        ),
+      );
+    }, timeoutMs);
+  });
+}

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -64,6 +64,7 @@ import {
   type ChromeProcessHandle,
   type LaunchChromeOptions,
 } from "./browser/chrome-launcher.js";
+import { xdotoolClick } from "./browser/xdotool-click.js";
 import { startXvfb, stopXvfb, type XvfbHandle } from "./browser/xvfb.js";
 import { DaemonClient } from "./control/daemon-client.js";
 import {
@@ -152,8 +153,14 @@ export interface BotDeps {
   stopXvfb: (handle: XvfbHandle) => Promise<void>;
   /** Create (but do not start) the NMH socket server. */
   createNmhSocketServer: (opts: NmhSocketServerOptions) => NmhSocketServer;
-  /** Spawn google-chrome-stable. Returns a handle with exitPromise + stop. */
+  /** Spawn chromium. Returns a handle with exitPromise + stop. */
   launchChrome: (opts: LaunchChromeOptions) => Promise<ChromeProcessHandle>;
+  /**
+   * Dispatch a real X-server click at the given screen coordinates. Used to
+   * clear Meet's `event.isTrusted` gate on the prejoin admission button.
+   * See `browser/xdotool-click.ts` for rationale.
+   */
+  xdotoolClick: (opts: { x: number; y: number; display: string }) => Promise<void>;
   startAudioCapture: (opts: AudioCaptureOptions) => Promise<AudioCaptureHandle>;
   createDaemonClient: (opts: {
     daemonUrl: string;
@@ -225,6 +232,7 @@ export function defaultDeps(): BotDeps {
     stopXvfb,
     createNmhSocketServer: (opts) => createNmhSocketServer(opts),
     launchChrome: (opts) => launchChrome(opts),
+    xdotoolClick: (opts) => xdotoolClick(opts),
     startAudioCapture,
     createDaemonClient: (opts) =>
       new DaemonClient({
@@ -784,6 +792,28 @@ export async function runBot(deps: BotDeps): Promise<void> {
         if (msg.level === "error") deps.logError(`[ext] ${msg.message}`);
         else deps.logInfo(`[ext] ${msg.message}`);
         return;
+      case "trusted_click": {
+        // Fire-and-forget: the extension confirms success by observing the
+        // subsequent DOM transition (waitForSelector on the in-meeting UI).
+        // We surface any xdotool failure as a logError so operators see
+        // them even though the extension can't synchronously react.
+        deps
+          .xdotoolClick({
+            x: msg.x,
+            y: msg.y,
+            display: env.xvfbDisplay,
+          })
+          .then(() =>
+            deps.logInfo(
+              `meet-bot: trusted_click dispatched at (${msg.x},${msg.y})`,
+            ),
+          )
+          .catch((err: unknown) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            deps.logError(`meet-bot: trusted_click failed: ${detail}`);
+          });
+        return;
+      }
       case "send_chat_result": {
         const pending = pendingSendChat.get(msg.requestId);
         if (!pending) {

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -122,6 +122,34 @@ export type ExtensionDiagnosticMessage = z.infer<
 >;
 
 /**
+ * Ask the bot to dispatch a REAL X-server mouse click at the given screen
+ * coordinates (via xdotool inside the bot container). Google Meet gates
+ * several critical buttons (the prejoin admission button in particular)
+ * on `event.isTrusted === true`, which JS `.click()` from a content script
+ * cannot produce — only X-server-originated events carry that flag. The
+ * extension emits this message when it needs a trusted click; the bot
+ * runs xdotool and the extension confirms success by observing the DOM
+ * transition (no separate response message — the DOM is the source of
+ * truth and avoids an otherwise-unused correlation path).
+ *
+ * Coordinates are **screen-space** (absolute pixels on Xvfb's virtual
+ * display), NOT viewport-relative — the extension is responsible for
+ * translating `clientX/clientY` using `window.screenX/screenY` plus the
+ * Chromium chrome offset (`outerHeight - innerHeight`). The bot performs
+ * NO coordinate translation; it passes the values straight to xdotool.
+ */
+export const ExtensionTrustedClickMessageSchema = z.object({
+  type: z.literal("trusted_click"),
+  /** Screen-space X coordinate on the Xvfb virtual display. */
+  x: z.number().int().min(0).max(10_000),
+  /** Screen-space Y coordinate on the Xvfb virtual display. */
+  y: z.number().int().min(0).max(10_000),
+});
+export type ExtensionTrustedClickMessage = z.infer<
+  typeof ExtensionTrustedClickMessageSchema
+>;
+
+/**
  * Result of a prior `send_chat` command, correlated by `requestId`.
  *
  * `ok: false` payloads should set `error` to a human-readable string so the
@@ -152,6 +180,7 @@ export const ExtensionToBotMessageSchema = z.discriminatedUnion("type", [
   ExtensionSpeakerChangeMessageSchema,
   ExtensionInboundChatMessageSchema,
   ExtensionDiagnosticMessageSchema,
+  ExtensionTrustedClickMessageSchema,
   ExtensionSendChatResultMessageSchema,
 ]);
 export type ExtensionToBotMessage = z.infer<typeof ExtensionToBotMessageSchema>;
@@ -164,6 +193,7 @@ export const EXTENSION_TO_BOT_MESSAGE_TYPES = [
   "speaker.change",
   "chat.inbound",
   "diagnostic",
+  "trusted_click",
   "send_chat_result",
 ] as const;
 

--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -299,6 +299,67 @@ describe("runJoinFlow (content-script port)", () => {
     expect(leave).not.toBeNull();
   });
 
+  test("emits a trusted_click message with computed screen coords before clicking", async () => {
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertLeaveButton(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    // Stub the admission button's geometry so the coordinate math is
+    // deterministic — jsdom returns zero rects by default.
+    const btn = doc.querySelector(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+    ) as HTMLElement;
+    btn.getBoundingClientRect = () =>
+      ({
+        left: 900,
+        top: 500,
+        width: 200,
+        height: 40,
+        right: 1100,
+        bottom: 540,
+        x: 900,
+        y: 500,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const events: unknown[] = [];
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-click-coords",
+        onEvent: (e) => events.push(e),
+        doc,
+        // window with explicit chrome offset: chrome=100px tall, at screen
+        // origin (0,0). Expected screen coords = center of the stubbed rect
+        // plus chrome offset: x = 900+100 = 1000, y = 500+100+20 = 620.
+        window: {
+          screenX: 0,
+          screenY: 0,
+          outerHeight: 820,
+          innerHeight: 720,
+        },
+      });
+    } finally {
+      restore();
+    }
+
+    const trustedClick = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "trusted_click",
+    ) as { type: string; x: number; y: number } | undefined;
+    expect(trustedClick).toBeDefined();
+    expect(trustedClick!.x).toBe(1000);
+    expect(trustedClick!.y).toBe(620);
+  });
+
   test("falls back to Ask to join when Join now is absent", async () => {
     const { doc } = loadPrejoinDom();
     removeMediaModal(doc);

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -81,6 +81,18 @@ export interface RunJoinFlowOptions {
    * it through; tests override with a JSDOM-backed document.
    */
   doc?: Document;
+  /**
+   * Window used to compute screen-space coordinates for `trusted_click`.
+   * Production uses the live `window`; tests override with a JSDOM window
+   * (which has `screenX=0`, `screenY=0`, and `outerHeight === innerHeight`
+   * so the click coords resolve to plain client coords).
+   */
+  window?: {
+    screenX: number;
+    screenY: number;
+    outerHeight: number;
+    innerHeight: number;
+  };
 }
 
 /**
@@ -207,18 +219,43 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
     );
   }
   const btnLabel = admissionBtn.getAttribute("aria-label") ?? "";
-  // NOTE: Meet gates the prejoin admission button on `event.isTrusted`, so a
-  // programmatic `.click()` from a content script is silently ignored by the
-  // real Meet UI — admission requires an X-server mouse click (handled by
-  // a separate trusted-click bridge to the bot process). We still dispatch
-  // the JS click here because (a) it's free, (b) the jsdom test harness
-  // exercises this path, and (c) any Meet build that ever relaxes the
-  // `isTrusted` check would start working again automatically.
+  // Meet gates the prejoin admission button on `event.isTrusted`, so a
+  // programmatic `.click()` from a content script is silently ignored by
+  // the real Meet UI. Admission requires a REAL X-server mouse click,
+  // which the bot dispatches via xdotool when it receives this
+  // `trusted_click` message. We compute screen coordinates locally here
+  // because the bot has no DOM access; the math is:
+  //
+  //   screenX = window.screenX + clientX
+  //   screenY = window.screenY + (outerHeight - innerHeight) + clientY
+  //
+  // `outerHeight - innerHeight` is the browser-chrome vertical offset
+  // (address bar + tab strip + any info-bar) that sits above the viewport.
+  // We still dispatch the JS `.click()` afterwards because (a) it's free,
+  // (b) the jsdom test harness exercises that path, and (c) any Meet build
+  // that ever relaxes the `isTrusted` check would start working again
+  // automatically.
+  const rect = (admissionBtn as HTMLElement).getBoundingClientRect();
+  const win = opts.window ?? (doc.defaultView ?? globalThis);
+  const chromeOffsetY = Math.max(
+    0,
+    (win as typeof globalThis).outerHeight - (win as typeof globalThis).innerHeight,
+  );
+  const screenX = Math.round(
+    ((win as typeof globalThis).screenX ?? 0) + rect.left + rect.width / 2,
+  );
+  const screenY = Math.round(
+    ((win as typeof globalThis).screenY ?? 0) +
+      chromeOffsetY +
+      rect.top +
+      rect.height / 2,
+  );
+  onEvent({ type: "trusted_click", x: screenX, y: screenY });
   (admissionBtn as HTMLElement).click();
   onEvent({
     type: "diagnostic",
     level: "info",
-    message: `meet-ext: clicked admission button aria-label="${btnLabel}"`,
+    message: `meet-ext: clicked admission button aria-label="${btnLabel}" screen=(${screenX},${screenY})`,
   });
 
   // Step 5 — wait for the in-meeting UI. The "Leave call" button only mounts


### PR DESCRIPTION
## Summary

Wires a trusted-click bridge so the bot can actually self-admit from Meet's prejoin screen. Meet's admission button is gated on `event.isTrusted`, which a content-script `.click()` cannot produce — the live site silently ignores those clicks. xdotool, dispatching through the X server, produces trusted events that Meet accepts.

- **Contract** — new `trusted_click` extension→bot message with screen-space `x`/`y`. Fire-and-forget (DOM transition is the authoritative success signal).
- **Bot** — new `src/browser/xdotool-click.ts` primitive (spawn via fake for tests, timeout-bounded, propagates stderr + exit codes). Wired into `handleExtensionMessage` as a new case that dispatches through a new `BotDeps.xdotoolClick` dep.
- **Extension** — `runJoinFlow` computes screen coords from `getBoundingClientRect + window.screenX/screenY + (outerHeight - innerHeight)`, emits `trusted_click`, then falls back to the JS `.click()` (cheap, still exercised by tests, self-heals if Meet ever relaxes the `isTrusted` gate).
- **Dockerfile** — adds `xdotool` to the apt install list.

## Verification

- Unit tests: 7 new (xdotool-click primitive), 2 new (main.ts routing), 1 new (extension coord math). 144 bot tests + 73 ext tests pass.
- Live: bot auto-admitted into `meet.google.com/vcc-wvij-kbz` from the prejoin screen without manual intervention. Logs:
  ```
  [ext] meet-ext: clicked admission button aria-label="Ask to join without camera" screen=(1014,536)
  meet-bot: trusted_click dispatched at (1014,536)
  ```
  Screenshot of Velissa in the meeting post-admit available on request.

## Test plan

- [x] `bun test __tests__/xdotool-click.test.ts` (new)
- [x] `bun test __tests__/main.test.ts` (new trusted_click cases)
- [x] `bun test src/__tests__/join.test.ts` (new coord-math case)
- [x] Full bot + ext suites green (144+73 = 217)
- [x] Live Meet join: container auto-admits without manual xdotool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
