### PR TITLE
docs(meet-ext): document + harden trusted-click coord math

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -360,6 +360,206 @@ describe("runJoinFlow (content-script port)", () => {
     expect(trustedClick!.y).toBe(620);
   });
 
+  test("trusted_click adds window screenX/screenY when the window is not at screen origin", async () => {
+    // Exercises a second monitor / tiled window scenario: the browser
+    // window sits at (screenX=150, screenY=80) relative to the X screen
+    // origin. The admission button's screen coordinates must include that
+    // offset, otherwise xdotool would click empty space at (clientX,
+    // clientY) on the wrong monitor. Production Xvfb always pins the
+    // window to 0,0 so this case is not hit today, but a desktop Chromium
+    // run (e.g. for a developer repro) could land here.
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertLeaveButton(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    const btn = doc.querySelector(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+    ) as HTMLElement;
+    btn.getBoundingClientRect = () =>
+      ({
+        left: 900,
+        top: 500,
+        width: 200,
+        height: 40,
+        right: 1100,
+        bottom: 540,
+        x: 900,
+        y: 500,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const events: unknown[] = [];
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-screen-offset",
+        onEvent: (e) => events.push(e),
+        doc,
+        // Window is offset from screen origin; chrome is 100px tall.
+        // Expected: x = 150 + 1000 = 1150, y = 80 + 100 + 520 = 700.
+        window: {
+          screenX: 150,
+          screenY: 80,
+          outerHeight: 820,
+          innerHeight: 720,
+        },
+      });
+    } finally {
+      restore();
+    }
+
+    const trustedClick = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "trusted_click",
+    ) as { type: string; x: number; y: number } | undefined;
+    expect(trustedClick).toBeDefined();
+    expect(trustedClick!.x).toBe(1150);
+    expect(trustedClick!.y).toBe(700);
+  });
+
+  test("trusted_click adds no chrome offset when outerHeight equals innerHeight", async () => {
+    // Kiosk / fullscreen / JSDOM-style windows report `outerHeight ==
+    // innerHeight` (no browser chrome). The computed screen coords must
+    // equal the raw client coords (plus screenX/Y, which are 0 here) —
+    // any positive chrome offset in this case is a bug.
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertLeaveButton(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    const btn = doc.querySelector(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+    ) as HTMLElement;
+    btn.getBoundingClientRect = () =>
+      ({
+        left: 900,
+        top: 500,
+        width: 200,
+        height: 40,
+        right: 1100,
+        bottom: 540,
+        x: 900,
+        y: 500,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const events: unknown[] = [];
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-no-chrome",
+        onEvent: (e) => events.push(e),
+        doc,
+        // No chrome, window at screen origin. Expected = raw rect center:
+        // x = 1000, y = 520.
+        window: {
+          screenX: 0,
+          screenY: 0,
+          outerHeight: 720,
+          innerHeight: 720,
+        },
+      });
+    } finally {
+      restore();
+    }
+
+    const trustedClick = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "trusted_click",
+    ) as { type: string; x: number; y: number } | undefined;
+    expect(trustedClick).toBeDefined();
+    expect(trustedClick!.x).toBe(1000);
+    expect(trustedClick!.y).toBe(520);
+  });
+
+  test("trusted_click documents the devtools-docked-bottom gap", async () => {
+    // KNOWN GAP — not a fix. When devtools are docked to the *bottom* of
+    // the window, Chromium reports `outerHeight > innerHeight` because of
+    // the devtools panel below the viewport. The current math assumes the
+    // entire `outerHeight - innerHeight` delta is TOP chrome and adds it
+    // to screenY, which would push the click past the admission button
+    // into (or below) the devtools surface. The production Xvfb container
+    // never opens devtools, so this is documentation-only: if the
+    // assumption ever breaks, this test pins the current (mis-)behavior
+    // so the regression is explicit rather than silent. Do not "fix" this
+    // in isolation — see the comment block in `join.ts`.
+    const { doc } = loadPrejoinDom();
+    removeMediaModal(doc);
+    insertLeaveButton(doc);
+    insertChatSurface(doc);
+    const restore = installGlobalDoc(doc);
+
+    const btn = doc.querySelector(
+      selectors.PREJOIN_JOIN_NOW_BUTTON,
+    ) as HTMLElement;
+    btn.getBoundingClientRect = () =>
+      ({
+        left: 900,
+        top: 500,
+        width: 200,
+        height: 40,
+        right: 1100,
+        bottom: 540,
+        x: 900,
+        y: 500,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const events: unknown[] = [];
+    try {
+      await runJoinFlow({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        displayName: "Vellum Bot",
+        consentMessage: "Hi, Vellum is listening.",
+        meetingId: "mtg-devtools-bottom",
+        onEvent: (e) => events.push(e),
+        doc,
+        // Simulate devtools docked to the bottom: outerHeight is inflated
+        // by 300px that sits BELOW the viewport, not above it. The
+        // current math treats it as TOP chrome — y becomes 500 + 300 +
+        // 20 = 820 instead of the correct 520.
+        window: {
+          screenX: 0,
+          screenY: 0,
+          outerHeight: 1020,
+          innerHeight: 720,
+        },
+      });
+    } finally {
+      restore();
+    }
+
+    const trustedClick = events.find(
+      (e) =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "trusted_click",
+    ) as { type: string; x: number; y: number } | undefined;
+    expect(trustedClick).toBeDefined();
+    // Pins the known-mismeasured behavior. If the math is ever updated
+    // to distinguish top vs bottom chrome, this expectation must be
+    // updated to 520 and the comment above deleted.
+    expect(trustedClick!.x).toBe(1000);
+    expect(trustedClick!.y).toBe(820);
+  });
+
   test("falls back to Ask to join when Join now is absent", async () => {
     const { doc } = loadPrejoinDom();
     removeMediaModal(doc);

--- a/skills/meet-join/meet-controller-ext/src/features/join.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/join.ts
@@ -229,12 +229,45 @@ export async function runJoinFlow(opts: RunJoinFlowOptions): Promise<void> {
   //   screenX = window.screenX + clientX
   //   screenY = window.screenY + (outerHeight - innerHeight) + clientY
   //
-  // `outerHeight - innerHeight` is the browser-chrome vertical offset
-  // (address bar + tab strip + any info-bar) that sits above the viewport.
   // We still dispatch the JS `.click()` afterwards because (a) it's free,
   // (b) the jsdom test harness exercises that path, and (c) any Meet build
   // that ever relaxes the `isTrusted` check would start working again
   // automatically.
+  //
+  // ---------------------------------------------------------------------
+  // ASSUMPTIONS — this math holds for the production Xvfb + Chromium
+  // configuration set up by `bot/src/browser/chrome-launcher.ts`:
+  //
+  //   - `--window-position=0,0` (window pinned to screen origin so
+  //     `screenX === 0` and `screenY === 0` in practice).
+  //   - No bottom chrome. We treat `outerHeight - innerHeight` as the TOP
+  //     chrome offset, which is only correct when there is no downloads
+  //     bar, no bottom-docked devtools, and no permission info-bar below
+  //     the viewport. If any of those appear, `outerHeight - innerHeight`
+  //     lumps ALL chrome together and we over-count the top offset.
+  //   - No side chrome. We ignore `outerWidth - innerWidth` entirely.
+  //     Our Xvfb container never renders side panels; a desktop Chromium
+  //     with a side panel pinned would need a matching `chromeOffsetX`.
+  //   - No fractional DPI scaling. We assume CSS px == X-server px.
+  //     Xvfb defaults to DPI 96 and we do not set a device scale factor.
+  //
+  // Drift signal: if bot-side xdotool clicks start landing above or to
+  // the side of the admission button, inspect the live `screen=(x,y)`
+  // diagnostic below against a screenshot and audit the assumptions above.
+  //
+  // MDN footnote: per the spec, `Window.screenX` / `Window.screenY` are
+  // the distance from the top-left of the *viewport* (not the browser
+  // window) to the top-left of the screen. Read literally, that would
+  // make the `(outerHeight - innerHeight)` term a double-count. In
+  // practice Chromium under Xvfb with `--window-position=0,0` reports
+  // `screenX === screenY === 0` — so the additive chrome offset is what
+  // actually shifts the coord from client-space down past the address bar
+  // / tab strip. Live evidence: `screen=(1014,536)` for the admission
+  // button matched its on-screen pixel position in PR 26602. Do not
+  // "correct" this math based on the MDN reading alone — run a headed
+  // sibling Chromium (different OS window manager) and re-instrument
+  // before changing it.
+  // ---------------------------------------------------------------------
   const rect = (admissionBtn as HTMLElement).getBoundingClientRect();
   const win = opts.window ?? (doc.defaultView ?? globalThis);
   const chromeOffsetY = Math.max(


### PR DESCRIPTION
## Summary

Defensive hardening + documentation for the trusted-click coordinate math in `runJoinFlow`. PR #26602 shipped the working xdotool bridge; this follow-up documents the assumptions the math relies on and pins them with tests.

- **Comment block** at the coord-math site calls out the assumptions explicitly: `--window-position=0,0`, no bottom chrome (downloads bar / bottom-docked devtools / permission info-bars would over-count), no side chrome, no DPI scaling. Identifies the drift signal (xdotool clicks landing off the button).
- **MDN footnote**: the spec says `Window.screenX/Y` are viewport-origin, which read literally would make `(outerHeight - innerHeight)` a double-count. Live evidence from PR #26602 (`screen=(1014,536)` matched the on-screen pixel) and the `--window-position=0,0` Xvfb setup make the chrome offset correct in practice — Chromium-in-Xvfb reports `screenX === screenY === 0` so the additive term compensates for the top chrome. Conclusion: **keep the math**, document why.
- **Tests** (3 new, all pass):
  - Non-zero `screenX/Y` — verifies the window-offset term adds correctly for a hypothetical non-pinned window.
  - `outerHeight == innerHeight` — verifies no offset added when there is no chrome (kiosk / JSDOM).
  - Devtools-docked-bottom — pins the known mis-measurement so if the assumption ever breaks the regression is explicit rather than silent.

Behavior identical for the production config. PR #26602's canonical case (`screenX=0, screenY=0, outerHeight=820, innerHeight=720`, button at `left=900, top=500, width=200, height=40`) still resolves to `(1000, 620)`.

## Test plan

- [x] `bun test src/` in `skills/meet-join/meet-controller-ext` — 76 pass (73 prior + 3 new)
- [x] `bunx tsc --noEmit` clean
- [x] Existing PR #26602 coord-math test (`(1000, 620)`) unchanged
- [x] No changes to bot package, xdotool primitive, or `trusted_click` contract
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
