### PR TITLE
fix(meet-ext): chat composer aria-label prefix match + contenteditable fallback

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
@@ -27,14 +27,18 @@
           </div>
         </div>
 
-        <!-- Composer. -->
+        <!-- Composer. Live Meet decorates the aria-label with "to everyone"
+             (and similar context qualifiers) — see selectors.ts § chatSelectors
+             for the prefix-match selector rationale. -->
         <div class="chat-composer" role="group">
           <textarea
-            aria-label="Send a message"
-            placeholder="Send a message"
+            aria-label="Send a message to everyone"
+            placeholder="Send a message to everyone"
             rows="1"
           ></textarea>
-          <button type="button" aria-label="Send a message">Send</button>
+          <button type="button" aria-label="Send a message to everyone">
+            Send
+          </button>
         </div>
       </aside>
     </div>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/selectors.test.ts
@@ -163,17 +163,74 @@ describe("in-meeting selectors", () => {
 describe("chat panel selectors", () => {
   const doc = loadFixture("meet-dom-chat.html");
 
-  test("INPUT resolves the composer textarea", () => {
+  test("INPUT resolves the composer textarea (decorated aria-label)", () => {
     const nodes = doc.querySelectorAll(chatSelectors.INPUT);
     expect(nodes.length).toBe(1);
     expect((nodes[0] as HTMLTextAreaElement).tagName).toBe("TEXTAREA");
+    // Fixture reflects the decorated form shipped by live Meet — the prefix
+    // match must still resolve it.
+    expect((nodes[0] as HTMLElement).getAttribute("aria-label")).toBe(
+      "Send a message to everyone",
+    );
   });
 
-  test("SEND_BUTTON resolves the send button", () => {
+  test("INPUT prefix match resolves the bare aria-label variant too", () => {
+    // Some Meet builds drop the "to everyone" decoration. Verify the same
+    // selector matches the bare label — this is the forward/backward-compat
+    // property the `^=` prefix match buys us.
+    const bareHtml = `
+      <div>
+        <textarea aria-label="Send a message" rows="1"></textarea>
+      </div>
+    `;
+    const bareDoc = new JSDOM(bareHtml).window.document;
+    const nodes = bareDoc.querySelectorAll(chatSelectors.INPUT);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).tagName).toBe("TEXTAREA");
+  });
+
+  test("INPUT selector also matches contenteditable div composers", () => {
+    // Meet has been migrating some surfaces from <textarea> to contenteditable
+    // <div>. The selector admits both so future drift doesn't silently break
+    // the query (the `chat.ts` typing logic is a separate concern — see the
+    // selector comment and the PR body).
+    const ceHtml = `
+      <div>
+        <div
+          contenteditable="true"
+          role="textbox"
+          aria-label="Send a message to everyone"
+        ></div>
+      </div>
+    `;
+    const ceDoc = new JSDOM(ceHtml).window.document;
+    const nodes = ceDoc.querySelectorAll(chatSelectors.INPUT);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).tagName).toBe("DIV");
+    expect((nodes[0] as HTMLElement).getAttribute("contenteditable")).toBe(
+      "true",
+    );
+  });
+
+  test("SEND_BUTTON resolves the send button (decorated aria-label)", () => {
     const nodes = doc.querySelectorAll(chatSelectors.SEND_BUTTON);
     expect(nodes.length).toBe(1);
     expect((nodes[0] as HTMLElement).tagName).toBe("BUTTON");
-    expect((nodes[0] as HTMLElement).textContent?.trim()).toBe("Send");
+    expect((nodes[0] as HTMLElement).getAttribute("aria-label")).toBe(
+      "Send a message to everyone",
+    );
+  });
+
+  test("SEND_BUTTON prefix match resolves the bare aria-label variant too", () => {
+    const bareHtml = `
+      <div>
+        <button type="button" aria-label="Send a message">Send</button>
+      </div>
+    `;
+    const bareDoc = new JSDOM(bareHtml).window.document;
+    const nodes = bareDoc.querySelectorAll(chatSelectors.SEND_BUTTON);
+    expect(nodes.length).toBe(1);
+    expect((nodes[0] as HTMLElement).tagName).toBe("BUTTON");
   });
 
   test("MESSAGE_NODE resolves each rendered message", () => {

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -50,7 +50,7 @@
  * lets us trace any fixture vs. production mismatch to a concrete date and
  * decide whether to recapture.
  */
-export const GOOGLE_MEET_SELECTOR_VERSION = "2026-04-15";
+export const GOOGLE_MEET_SELECTOR_VERSION = "2026-04-19";
 
 /**
  * Prejoin-surface selectors — the "Ready to join?" screen shown before the bot
@@ -106,11 +106,32 @@ export const chatSelectors = {
   /** Toggle button in the meeting toolbar that opens the chat side panel. */
   PANEL_BUTTON: 'button[aria-label="Chat with everyone"]',
 
-  /** Textarea for composing an outgoing chat message. */
-  INPUT: 'textarea[aria-label="Send a message"]',
+  /**
+   * Composer for outgoing chat messages. Matches by aria-label prefix because
+   * Meet decorates the label with context — e.g. `aria-label="Send a message
+   * to everyone"` when the chat is broadcast to all participants. The `^=`
+   * prefix match covers both the bare and decorated forms, mirroring the
+   * approach used for `ASK_TO_JOIN_BUTTON`.
+   *
+   * We also accept `div[contenteditable="true"]` variants since some Meet
+   * builds render the composer as a contenteditable div rather than a
+   * textarea. Note that `chat.ts` currently writes via `.value`, which is a
+   * textarea-only affordance — if Meet has migrated to contenteditable, the
+   * selector will resolve but `sendChat` will silently no-op. That's a
+   * follow-up (tracked in the PR body) and out of scope for this selector
+   * drift fix.
+   */
+  // TODO(meet-dom): aria-label is localized. Future versions may need to
+  // match multiple locales or fall back to role=textbox + placeholder.
+  INPUT:
+    'textarea[aria-label^="Send a message"], div[contenteditable="true"][aria-label^="Send a message"]',
 
-  /** Send button adjacent to the chat composer. */
-  SEND_BUTTON: 'button[aria-label="Send a message"]',
+  /**
+   * Send button adjacent to the chat composer. Prefix match handles Meet's
+   * decorated labels (e.g. "Send a message to everyone") the same way INPUT
+   * does.
+   */
+  SEND_BUTTON: 'button[aria-label^="Send a message"]',
 
   /**
    * Container that holds the list of chat messages. Used to detect whether the


### PR DESCRIPTION
## Summary

- Meet's chat composer aria-label is now decorated (`"Send a message to everyone"`), breaking the exact-match selector `textarea[aria-label="Send a message"]` that the bot's consent post depends on. Switch `chatSelectors.INPUT` and `chatSelectors.SEND_BUTTON` to `aria-label^=` prefix matches, mirroring the PR #26600 pattern for `ASK_TO_JOIN_BUTTON`.
- Broaden `INPUT` to also match `div[contenteditable="true"]` so a future textarea->contenteditable migration doesn't silently fail the query. Refresh the chat fixture to the decorated aria-label and add selector-test coverage for the decorated, bare, and contenteditable variants. Bump `GOOGLE_MEET_SELECTOR_VERSION` to today.
- Scope is strictly selectors + fixtures + selector tests per the drift-fix mandate — `chat.ts` is unchanged.

## Known gap / follow-up

Not verified against a live Meet DOM (no bot rebuild was run). The selector is chosen defensively to cover both the likely decoration pattern and a potential contenteditable migration. If Meet has in fact flipped the composer to a contenteditable `<div>`, this PR fixes the **selector** but `chat.ts`'s `input.value = text` line is a textarea-only affordance and will silently no-op on a contenteditable div — Meet's React handler won't see the new text. Fixing that end-to-end is a separate PR: either a contenteditable typing path (`document.execCommand('insertText', …)` or a `beforeinput` dispatch pattern) or a trusted-typing xdotool bridge parallel to the trusted-click bridge from PR #26602. Flagging explicitly since the PR won't close the user-visible bug if contenteditable is the real drift.

## Test plan

- [x] `cd skills/meet-join/meet-controller-ext && bun test src/` — 76 pass, 0 fail.
- [x] `cd skills/meet-join/bot && bun test __tests__/` — 144 pass, 0 fail.
- [x] `bunx tsc --noEmit` in `meet-controller-ext` — clean.
- [ ] Live-verify against `meet.google.com` with the bot image (blocked on Docker + admittance partner; deferred to post-merge smoke test).