### PR TITLE
feat(slack): add typed message metadata helpers for thread-aware context

### DIFF
--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  mergeSlackMetadata,
+  readSlackMetadata,
+  writeSlackMetadata,
+  type SlackMessageMetadata,
+} from "./message-metadata.js";
+
+describe("readSlackMetadata", () => {
+  test("tolerates null and undefined", () => {
+    expect(readSlackMetadata(null)).toBeNull();
+    expect(readSlackMetadata(undefined)).toBeNull();
+  });
+
+  test("returns null on JSON parse error", () => {
+    expect(readSlackMetadata("not-json")).toBeNull();
+    expect(readSlackMetadata("{")).toBeNull();
+  });
+
+  test("returns null when the payload is not an object", () => {
+    expect(readSlackMetadata(JSON.stringify("string"))).toBeNull();
+    expect(readSlackMetadata(JSON.stringify(42))).toBeNull();
+    expect(readSlackMetadata(JSON.stringify(null))).toBeNull();
+    expect(readSlackMetadata(JSON.stringify([{ source: "slack" }]))).toBeNull();
+  });
+
+  test("rejects metadata whose source is not slack", () => {
+    const raw = JSON.stringify({
+      source: "telegram",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
+    expect(readSlackMetadata(raw)).toBeNull();
+  });
+
+  test("rejects payloads missing required fields", () => {
+    const noChannelId = JSON.stringify({
+      source: "slack",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
+    const noChannelTs = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      eventKind: "message",
+    });
+    const badEventKind = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "totally-bogus",
+    });
+    expect(readSlackMetadata(noChannelId)).toBeNull();
+    expect(readSlackMetadata(noChannelTs)).toBeNull();
+    expect(readSlackMetadata(badEventKind)).toBeNull();
+  });
+
+  test("parses a fully populated message metadata payload", () => {
+    const meta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      threadTs: "1699999999.000000",
+      displayName: "Alice",
+      eventKind: "message",
+      editedAt: 1700000123,
+    };
+    const parsed = readSlackMetadata(JSON.stringify(meta));
+    expect(parsed).toEqual(meta);
+  });
+
+  test("parses a reaction metadata payload", () => {
+    const meta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000050.000200",
+      eventKind: "reaction",
+      reaction: {
+        emoji: "thumbsup",
+        actorDisplayName: "Bob",
+        targetChannelTs: "1700000000.000100",
+        op: "added",
+      },
+    };
+    const parsed = readSlackMetadata(JSON.stringify(meta));
+    expect(parsed).toEqual(meta);
+  });
+});
+
+describe("writeSlackMetadata", () => {
+  test("round-trips through readSlackMetadata", () => {
+    const meta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      threadTs: "1699999999.000000",
+      displayName: "Alice",
+      eventKind: "message",
+    };
+    const raw = writeSlackMetadata(meta);
+    expect(typeof raw).toBe("string");
+    expect(readSlackMetadata(raw)).toEqual(meta);
+  });
+
+  test("round-trips reaction metadata", () => {
+    const meta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000050.000200",
+      eventKind: "reaction",
+      reaction: {
+        emoji: "eyes",
+        targetChannelTs: "1700000000.000100",
+        op: "removed",
+      },
+    };
+    const raw = writeSlackMetadata(meta);
+    expect(readSlackMetadata(raw)).toEqual(meta);
+  });
+});
+
+describe("mergeSlackMetadata", () => {
+  const baseMeta: SlackMessageMetadata = {
+    source: "slack",
+    channelId: "C123",
+    channelTs: "1700000000.000100",
+    threadTs: "1699999999.000000",
+    displayName: "Alice",
+    eventKind: "message",
+  };
+
+  test("preserves unrelated existing fields", () => {
+    const existing = writeSlackMetadata(baseMeta);
+    const merged = mergeSlackMetadata(existing, { editedAt: 1700000123 });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed).toEqual({ ...baseMeta, editedAt: 1700000123 });
+  });
+
+  test("overrides fields present in both existing and patch", () => {
+    const existing = writeSlackMetadata(baseMeta);
+    const merged = mergeSlackMetadata(existing, { displayName: "Alicia" });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed?.displayName).toBe("Alicia");
+    expect(parsed?.channelId).toBe(baseMeta.channelId);
+  });
+
+  test("ignores undefined patch fields rather than wiping existing values", () => {
+    const existing = writeSlackMetadata(baseMeta);
+    const merged = mergeSlackMetadata(existing, { displayName: undefined });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed?.displayName).toBe(baseMeta.displayName);
+  });
+
+  test("supports marking a message deleted while keeping prior fields", () => {
+    const existing = writeSlackMetadata(baseMeta);
+    const merged = mergeSlackMetadata(existing, { deletedAt: 1700000200 });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed).toEqual({ ...baseMeta, deletedAt: 1700000200 });
+  });
+
+  test("constructs valid metadata when existing is null and patch supplies required fields", () => {
+    const merged = mergeSlackMetadata(null, {
+      source: "slack",
+      channelId: "C999",
+      channelTs: "1700000300.000400",
+      eventKind: "message",
+      displayName: "Carol",
+    });
+    expect(readSlackMetadata(merged)).toEqual({
+      source: "slack",
+      channelId: "C999",
+      channelTs: "1700000300.000400",
+      eventKind: "message",
+      displayName: "Carol",
+    });
+  });
+
+  test("constructs valid metadata when existing fails to parse as slack", () => {
+    const merged = mergeSlackMetadata("garbage", {
+      source: "slack",
+      channelId: "C111",
+      channelTs: "1700000400.000500",
+      eventKind: "message",
+    });
+    expect(readSlackMetadata(merged)).toEqual({
+      source: "slack",
+      channelId: "C111",
+      channelTs: "1700000400.000500",
+      eventKind: "message",
+    });
+  });
+
+  test("forces source to slack even if patch attempts to override it", () => {
+    const existing = writeSlackMetadata(baseMeta);
+    const merged = mergeSlackMetadata(existing, {
+      // @ts-expect-error - intentional bad input to verify the guard
+      source: "telegram",
+      displayName: "Mallory",
+    });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed?.source).toBe("slack");
+    expect(parsed?.displayName).toBe("Mallory");
+  });
+
+  test("preserves nested reaction metadata across a patch", () => {
+    const reactionMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000050.000200",
+      eventKind: "reaction",
+      reaction: {
+        emoji: "thumbsup",
+        targetChannelTs: "1700000000.000100",
+        op: "added",
+      },
+    };
+    const existing = writeSlackMetadata(reactionMeta);
+    const merged = mergeSlackMetadata(existing, {
+      displayName: "Bob",
+    });
+    const parsed = readSlackMetadata(merged);
+    expect(parsed?.reaction).toEqual(reactionMeta.reaction);
+    expect(parsed?.displayName).toBe("Bob");
+  });
+});

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -1,0 +1,112 @@
+/**
+ * Typed Slack message metadata stored in the `messages.metadata` column for
+ * thread-aware context rendering.
+ *
+ * The full metadata column may contain other unrelated keys; Slack-specific
+ * metadata lives under a `slackMeta` sub-key written via `writeSlackMetadata`
+ * and read via `readSlackMetadata`. `mergeSlackMetadata` performs partial
+ * updates (for edits, deletions, display-name refreshes) without disturbing
+ * unrelated fields.
+ *
+ * This file is a pure library addition — no consumers wire into it yet; that
+ * happens in later PRs of the slack-thread-aware-context plan.
+ */
+
+export type SlackEventKind = "message" | "reaction";
+
+export interface SlackReactionMetadata {
+  readonly emoji: string;
+  readonly actorDisplayName?: string;
+  readonly targetChannelTs: string;
+  readonly op: "added" | "removed";
+}
+
+export interface SlackMessageMetadata {
+  readonly source: "slack";
+  readonly channelId: string;
+  readonly channelTs: string; // Slack's own ts for this record
+  readonly threadTs?: string; // parent ts, absent for top-level
+  readonly displayName?: string; // cached sender name
+  readonly eventKind: SlackEventKind; // "message" or "reaction"
+  readonly reaction?: SlackReactionMetadata;
+  readonly editedAt?: number;
+  readonly deletedAt?: number;
+}
+
+/**
+ * Parse a JSON string into `SlackMessageMetadata`. Returns `null` on parse
+ * error, when the payload is not an object, or when `source !== "slack"`.
+ *
+ * Tolerates `null` and `undefined` inputs (returns `null`) so callers can pass
+ * raw column values without pre-checks.
+ */
+export function readSlackMetadata(
+  raw: string | null | undefined,
+): SlackMessageMetadata | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed)
+  ) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.source !== "slack") {
+    return null;
+  }
+  if (typeof obj.channelId !== "string" || typeof obj.channelTs !== "string") {
+    return null;
+  }
+  if (obj.eventKind !== "message" && obj.eventKind !== "reaction") {
+    return null;
+  }
+  return obj as unknown as SlackMessageMetadata;
+}
+
+/**
+ * Serialize `SlackMessageMetadata` to a JSON string suitable for storage in
+ * the `messages.metadata` column (or as a sub-value within a larger metadata
+ * envelope).
+ */
+export function writeSlackMetadata(meta: SlackMessageMetadata): string {
+  return JSON.stringify(meta);
+}
+
+/**
+ * Apply a partial patch to existing serialized Slack metadata. Used for
+ * incremental updates such as marking a message edited or deleted, or
+ * refreshing a cached display name.
+ *
+ * If `existing` is `null`/`undefined` or fails to parse as Slack metadata,
+ * the patch must contain enough fields to construct a valid
+ * `SlackMessageMetadata` (`source`, `channelId`, `channelTs`, `eventKind`).
+ * The function does not validate that case beyond what `JSON.stringify`
+ * accepts — readers will reject invalid output via `readSlackMetadata`.
+ *
+ * Unrelated fields on the existing metadata are preserved; the patch's
+ * defined fields override them. `undefined` fields in the patch are ignored
+ * (use a sentinel like `0` if a numeric field needs an explicit reset).
+ */
+export function mergeSlackMetadata(
+  existing: string | null | undefined,
+  patch: Partial<SlackMessageMetadata>,
+): string {
+  const base = readSlackMetadata(existing) ?? {};
+  const cleanedPatch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) {
+      cleanedPatch[key] = value;
+    }
+  }
+  const merged = { ...base, ...cleanedPatch, source: "slack" as const };
+  return JSON.stringify(merged);
+}


### PR DESCRIPTION
## Summary
- Introduces SlackMessageMetadata type and read/write/merge helpers
- Foundation for thread-aware context rendering across later PRs
- Pure library addition with no wiring; consumers land in PR 11+

Part of plan: slack-thread-aware-context.md (PR 1 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
