### PR TITLE
feat(slack): add daemon-side thread and DM backfill helpers

### DIFF
--- a/assistant/src/messaging/providers/slack/backfill.test.ts
+++ b/assistant/src/messaging/providers/slack/backfill.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the daemon-side Slack backfill helpers.
+ *
+ * Verifies:
+ *  - Pass-through of channelId, threadTs, and the `before` cursor.
+ *  - Default limit of 50 when none is supplied; explicit limits override.
+ *  - resolveConnection() is invoked once per call so any cached read/write
+ *    auth mutation lands before the adapter method runs.
+ *  - All failure modes (timeout, 401, Slack API error, missing connection)
+ *    return [] instead of propagating the error.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import type { Message } from "../../provider-types.js";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+type ResolveConnectionFn = (
+  account?: string,
+) => Promise<OAuthConnection | undefined>;
+type GetHistoryFn = (
+  connection: OAuthConnection | undefined,
+  conversationId: string,
+  options?: { limit?: number; before?: string; after?: string },
+) => Promise<Message[]>;
+type GetThreadRepliesFn = (
+  connection: OAuthConnection | undefined,
+  conversationId: string,
+  threadId: string,
+  options?: { limit?: number },
+) => Promise<Message[]>;
+
+const resolveConnectionMock = mock<ResolveConnectionFn>(async () => undefined);
+const getHistoryMock = mock<GetHistoryFn>(async () => []);
+const getThreadRepliesMock = mock<GetThreadRepliesFn>(async () => []);
+
+mock.module("./adapter.js", () => ({
+  slackProvider: {
+    id: "slack",
+    displayName: "Slack",
+    credentialService: "slack",
+    capabilities: new Set(["threads"]),
+    resolveConnection: (account?: string) => resolveConnectionMock(account),
+    getHistory: (
+      connection: OAuthConnection | undefined,
+      conversationId: string,
+      options?: { limit?: number; before?: string; after?: string },
+    ) => getHistoryMock(connection, conversationId, options),
+    getThreadReplies: (
+      connection: OAuthConnection | undefined,
+      conversationId: string,
+      threadId: string,
+      options?: { limit?: number },
+    ) => getThreadRepliesMock(connection, conversationId, threadId, options),
+    // Stub the rest of the MessagingProvider surface as no-ops; the backfill
+    // helpers should never reach for these.
+    testConnection: async () => {
+      throw new Error("not used");
+    },
+    listConversations: async () => [],
+    search: async () => ({ total: 0, messages: [], hasMore: false }),
+    sendMessage: async () => {
+      throw new Error("not used");
+    },
+  },
+}));
+
+import { backfillDm, backfillThread } from "./backfill.js";
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "1700000000.000100",
+    conversationId: "C123",
+    sender: { id: "U1", name: "Alice" },
+    text: "hello",
+    timestamp: 1700000000000,
+    platform: "slack",
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("backfillThread", () => {
+  beforeEach(() => {
+    resolveConnectionMock.mockReset();
+    resolveConnectionMock.mockImplementation(async () => undefined);
+    getThreadRepliesMock.mockReset();
+    getThreadRepliesMock.mockImplementation(async () => []);
+    getHistoryMock.mockReset();
+    getHistoryMock.mockImplementation(async () => []);
+  });
+
+  test("passes channelId/threadTs through and defaults limit to 50", async () => {
+    const reply = makeMessage({
+      id: "1700000000.000200",
+      threadId: "1700000000.000100",
+    });
+    getThreadRepliesMock.mockImplementation(async () => [reply]);
+
+    const out = await backfillThread("C123", "1700000000.000100");
+
+    expect(resolveConnectionMock).toHaveBeenCalledTimes(1);
+    expect(getThreadRepliesMock).toHaveBeenCalledTimes(1);
+    const [conn, channel, thread, opts] = getThreadRepliesMock.mock.calls[0];
+    expect(conn).toBeUndefined();
+    expect(channel).toBe("C123");
+    expect(thread).toBe("1700000000.000100");
+    expect(opts).toEqual({ limit: 50 });
+    expect(out).toEqual([reply]);
+  });
+
+  test("respects explicit limit override", async () => {
+    await backfillThread("C123", "1700000000.000100", { limit: 10 });
+    const [, , , opts] = getThreadRepliesMock.mock.calls[0];
+    expect(opts).toEqual({ limit: 10 });
+  });
+
+  test("returns [] when getThreadReplies throws (Slack API error)", async () => {
+    getThreadRepliesMock.mockImplementation(async () => {
+      throw new Error("Slack API error: channel_not_found");
+    });
+    const out = await backfillThread("C123", "1700000000.000100");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when getThreadReplies throws (auth error)", async () => {
+    getThreadRepliesMock.mockImplementation(async () => {
+      const err = new Error("Slack API HTTP 401");
+      Object.assign(err, { status: 401 });
+      throw err;
+    });
+    const out = await backfillThread("C123", "1700000000.000100");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when getThreadReplies throws (timeout)", async () => {
+    getThreadRepliesMock.mockImplementation(async () => {
+      throw new Error("ETIMEDOUT");
+    });
+    const out = await backfillThread("C123", "1700000000.000100");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when resolveConnection throws (missing connection)", async () => {
+    resolveConnectionMock.mockImplementation(async () => {
+      throw new Error("no connection available");
+    });
+    const out = await backfillThread("C123", "1700000000.000100");
+    expect(out).toEqual([]);
+    // resolveConnection failed before getThreadReplies could be reached.
+    expect(getThreadRepliesMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("backfillDm", () => {
+  beforeEach(() => {
+    resolveConnectionMock.mockReset();
+    resolveConnectionMock.mockImplementation(async () => undefined);
+    getHistoryMock.mockReset();
+    getHistoryMock.mockImplementation(async () => []);
+    getThreadRepliesMock.mockReset();
+    getThreadRepliesMock.mockImplementation(async () => []);
+  });
+
+  test("passes channelId through and defaults limit to 50, before undefined", async () => {
+    const msg = makeMessage();
+    getHistoryMock.mockImplementation(async () => [msg]);
+
+    const out = await backfillDm("D123");
+
+    expect(resolveConnectionMock).toHaveBeenCalledTimes(1);
+    expect(getHistoryMock).toHaveBeenCalledTimes(1);
+    const [conn, channel, opts] = getHistoryMock.mock.calls[0];
+    expect(conn).toBeUndefined();
+    expect(channel).toBe("D123");
+    expect(opts).toEqual({ limit: 50, before: undefined });
+    expect(out).toEqual([msg]);
+  });
+
+  test("respects explicit limit override and forwards `before` cursor", async () => {
+    await backfillDm("D123", { limit: 25, before: "1700000000.000099" });
+    const [, , opts] = getHistoryMock.mock.calls[0];
+    expect(opts).toEqual({ limit: 25, before: "1700000000.000099" });
+  });
+
+  test("returns [] when getHistory throws (Slack API error)", async () => {
+    getHistoryMock.mockImplementation(async () => {
+      throw new Error("Slack API error: not_in_channel");
+    });
+    const out = await backfillDm("D123");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when getHistory throws (auth error)", async () => {
+    getHistoryMock.mockImplementation(async () => {
+      const err = new Error("Slack API HTTP 401");
+      Object.assign(err, { status: 401 });
+      throw err;
+    });
+    const out = await backfillDm("D123");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when getHistory throws (timeout)", async () => {
+    getHistoryMock.mockImplementation(async () => {
+      throw new Error("ETIMEDOUT");
+    });
+    const out = await backfillDm("D123");
+    expect(out).toEqual([]);
+  });
+
+  test("returns [] when resolveConnection throws (missing connection)", async () => {
+    resolveConnectionMock.mockImplementation(async () => {
+      throw new Error("no connection available");
+    });
+    const out = await backfillDm("D123");
+    expect(out).toEqual([]);
+    expect(getHistoryMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/messaging/providers/slack/backfill.ts
+++ b/assistant/src/messaging/providers/slack/backfill.ts
@@ -1,0 +1,85 @@
+/**
+ * Daemon-side Slack backfill helpers.
+ *
+ * These wrap the existing slackProvider adapter methods so callers (thread
+ * recovery, DM context hydration) can fetch a small window of recent messages
+ * without re-implementing connection resolution or token routing.
+ *
+ * Best-effort semantics: any failure (timeout, auth error, missing connection,
+ * Slack API error) is logged at WARN and yields an empty array. Callers must
+ * proceed without backfill rather than propagating the error — backfill is a
+ * convenience, not a precondition.
+ */
+import { getLogger } from "../../../util/logger.js";
+import type { Message } from "../../provider-types.js";
+import { slackProvider } from "./adapter.js";
+
+const log = getLogger("slack-backfill");
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Fetch the most recent messages in a Slack thread.
+ *
+ * Resolves the cached Slack connection, then delegates to
+ * `slackProvider.getThreadReplies()`. Returns the messages mapped to the
+ * platform-agnostic `Message` shape (with `threadId` already populated from
+ * `thread_ts`). Returns `[]` on any error.
+ */
+export async function backfillThread(
+  channelId: string,
+  threadTs: string,
+  opts?: { limit?: number },
+): Promise<Message[]> {
+  const limit = opts?.limit ?? DEFAULT_LIMIT;
+  try {
+    const connection = await slackProvider.resolveConnection?.();
+    if (!slackProvider.getThreadReplies) {
+      log.warn(
+        { channelId, threadTs },
+        "Slack provider does not implement getThreadReplies — returning []",
+      );
+      return [];
+    }
+    return await slackProvider.getThreadReplies(
+      connection,
+      channelId,
+      threadTs,
+      { limit },
+    );
+  } catch (err) {
+    log.warn(
+      { channelId, threadTs, err },
+      "Slack thread backfill failed — returning []",
+    );
+    return [];
+  }
+}
+
+/**
+ * Fetch the most recent messages in a Slack DM (or any conversation).
+ *
+ * Resolves the cached Slack connection, then delegates to
+ * `slackProvider.getHistory()`. The `before` option, when provided, is passed
+ * through as Slack's `latest` cursor so callers can paginate backwards.
+ * Returns `[]` on any error.
+ */
+export async function backfillDm(
+  channelId: string,
+  opts?: { limit?: number; before?: string },
+): Promise<Message[]> {
+  const limit = opts?.limit ?? DEFAULT_LIMIT;
+  try {
+    const connection = await slackProvider.resolveConnection?.();
+    return await slackProvider.getHistory(connection, channelId, {
+      limit,
+      before: opts?.before,
+    });
+  } catch (err) {
+    log.warn(
+      { channelId, before: opts?.before, err },
+      "Slack DM backfill failed — returning []",
+    );
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- New backfill.ts exports backfillThread and backfillDm as best-effort helpers
- Wraps existing slackProvider.getThreadReplies / getHistory
- Errors return []; callers proceed without backfill
- No gateway changes; no RPC. Consumers land in PR 22 / PR 23.

Part of plan: slack-thread-aware-context.md (PR 10 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
