### PR TITLE
feat(gateway): admit message.changed on all subscribed Slack channels

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -5,11 +5,13 @@ import {
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
   normalizeSlackAppMention,
+  normalizeSlackMessageEdit,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackAppMentionEvent,
+  type SlackMessageChangedEvent,
   type SlackFile,
 } from "./normalize.js";
 import type { GatewayConfig } from "../config.js";
@@ -587,5 +589,151 @@ describe("attachment extraction in normalize functions", () => {
       expect(result!.slackFiles).toBeDefined();
       expect(result!.slackFiles!.get("F020")!.id).toBe("F020");
     });
+  });
+});
+
+function makeMessageChangedEvent(
+  overrides?: Partial<{
+    channel: string;
+    channelType: SlackMessageChangedEvent["channel_type"];
+    eventTs: string;
+    messageTs: string;
+    user: string;
+    text: string;
+    threadTs?: string;
+  }>,
+): SlackMessageChangedEvent {
+  return {
+    type: "message",
+    subtype: "message_changed",
+    channel: overrides?.channel ?? "C456",
+    channel_type: overrides?.channelType ?? "channel",
+    ts: overrides?.eventTs ?? "1700000000.000200",
+    event_ts: overrides?.eventTs ?? "1700000000.000200",
+    message: {
+      user: overrides?.user ?? "U123",
+      text: overrides?.text ?? "edited content",
+      ts: overrides?.messageTs ?? "1700000000.000100",
+      ...(overrides?.threadTs ? { thread_ts: overrides.threadTs } : {}),
+    },
+    previous_message: {
+      user: overrides?.user ?? "U123",
+      text: "original content",
+      ts: overrides?.messageTs ?? "1700000000.000100",
+    },
+  };
+}
+
+describe("normalizeSlackMessageEdit", () => {
+  it("normalizes an edit in a subscribed channel (not DM, not bot thread)", () => {
+    // Bot is subscribed to the channel via a conversation_id routing entry —
+    // this is the case PR 4 expanded the gateway filter to admit.
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
+      ],
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeMessageChangedEvent({
+      channel: "C456",
+      channelType: "channel",
+      messageTs: "1700000000.000100",
+      eventTs: "1700000000.000200",
+      user: "U123",
+    });
+    const eventId = "Ev0XYZ";
+
+    const result = normalizeSlackMessageEdit(event, eventId, config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.conversationExternalId).toBe("C456");
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+    expect(result!.event.source.chatType).toBe("channel");
+    expect(result!.routing.assistantId).toBe("ast-2");
+    expect(result!.routing.routeSource).toBe("conversation_id");
+
+    // PR 3 invariant: source.messageId is the original Slack ts (the lookup
+    // key the daemon uses to find the prior message), and externalMessageId
+    // is the per-edit eventId. They MUST be distinct so successive edits do
+    // not collide in the dedup pipeline.
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
+    expect(result!.event.message.externalMessageId).toBe(eventId);
+    expect(result!.event.source.messageId).not.toBe(
+      result!.event.message.externalMessageId,
+    );
+  });
+
+  it("uses message ts as threadTs for top-level channel edits", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
+      ],
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeMessageChangedEvent({
+      channel: "C456",
+      channelType: "channel",
+      messageTs: "1700000000.000100",
+    });
+    const result = normalizeSlackMessageEdit(event, "Ev1", config);
+
+    expect(result).not.toBeNull();
+    // For channel edits without a thread_ts, fall back to the message ts so
+    // any reply lands on the same root message.
+    expect(result!.threadTs).toBe("1700000000.000100");
+    expect(result!.channel).toBe("C456");
+  });
+
+  it("preserves thread_ts on a threaded channel edit", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
+      ],
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeMessageChangedEvent({
+      channel: "C456",
+      channelType: "channel",
+      messageTs: "1700000000.000150",
+      threadTs: "1700000000.000050",
+    });
+    const result = normalizeSlackMessageEdit(event, "Ev2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000050");
+    expect(result!.event.source.messageId).toBe("1700000000.000150");
+  });
+
+  it("returns null when channel has no routing entry and not a DM", () => {
+    // Without a route and without DM fallback, an edit in an unknown channel
+    // is unroutable — normalize must return null so the gateway drops it.
+    const config = makeConfig({
+      routingEntries: [],
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeMessageChangedEvent({
+      channel: "C999",
+      channelType: "channel",
+    });
+    const result = normalizeSlackMessageEdit(event, "Ev3", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores edits authored by the bot itself", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
+      ],
+    });
+    const event = makeMessageChangedEvent({ user: "UBOT" });
+    const result = normalizeSlackMessageEdit(event, "Ev4", config, "UBOT");
+
+    expect(result).toBeNull();
   });
 });

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -420,15 +420,27 @@ export class SlackSocketModeClient {
     const isMessageChangedRaw =
       event.type === "message" &&
       messageChangedEvent.subtype === "message_changed";
-    // Only accept message_changed in DMs or tracked bot threads — otherwise
-    // Slack unfurls (link previews) in random channels trigger the bot.
+    // Accept message_changed in DMs, tracked bot threads, or any channel
+    // the bot is explicitly subscribed to via a conversation_id routing
+    // entry. The routing-entry check keeps Slack unfurl (link preview)
+    // events in random channels from triggering the bot, while still
+    // surfacing edits made to any message in a configured channel so the
+    // daemon can correlate them with prior context.
+    const isSubscribedChannel =
+      !!messageChangedEvent.channel &&
+      this.config.gatewayConfig.routingEntries.some(
+        (entry) =>
+          entry.type === "conversation_id" &&
+          entry.key === messageChangedEvent.channel,
+      );
     const isMessageChanged =
       isMessageChangedRaw &&
       (messageChangedEvent.channel_type === "im" ||
         (!!messageChangedEvent.message?.thread_ts &&
           this.store.hasThread(messageChangedEvent.message.thread_ts)) ||
         (!!messageChangedEvent.message?.ts &&
-          this.store.hasThread(messageChangedEvent.message.ts)));
+          this.store.hasThread(messageChangedEvent.message.ts)) ||
+        isSubscribedChannel);
     const isDm =
       event.type === "message" &&
       !isMessageChanged &&


### PR DESCRIPTION
## Summary
- Expands message_changed filter beyond DMs + bot threads to any subscribed channel
- Gateway forwarding of edits is additive; daemon consumer lands in PR 14

Part of plan: slack-thread-aware-context.md (PR 4 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
