### PR TITLE
feat(gateway): add normalizeSlackMessageDelete and forward deletions

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -6,12 +6,14 @@ import {
   normalizeSlackChannelMessage,
   normalizeSlackAppMention,
   normalizeSlackMessageEdit,
+  normalizeSlackMessageDelete,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackAppMentionEvent,
   type SlackMessageChangedEvent,
+  type SlackMessageDeletedEvent,
   type SlackFile,
 } from "./normalize.js";
 import type { GatewayConfig } from "../config.js";
@@ -735,5 +737,146 @@ describe("normalizeSlackMessageEdit", () => {
     const result = normalizeSlackMessageEdit(event, "Ev4", config, "UBOT");
 
     expect(result).toBeNull();
+  });
+});
+
+// --- normalizeSlackMessageDelete ---
+
+function makeMessageDeletedEvent(
+  overrides?: Partial<SlackMessageDeletedEvent>,
+): SlackMessageDeletedEvent {
+  return {
+    type: "message",
+    subtype: "message_deleted",
+    channel: "C456",
+    channel_type: "channel",
+    hidden: true,
+    ts: "1700000000.999999",
+    deleted_ts: "1700000000.000100",
+    previous_message: {
+      user: "U123",
+      text: "the original message",
+      ts: "1700000000.000100",
+    },
+    ...overrides,
+  };
+}
+
+describe("normalizeSlackMessageDelete", () => {
+  it("normalizes a DM delete with the message_deleted sentinel", () => {
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent({
+      channel: "D789",
+      channel_type: "im",
+      previous_message: {
+        user: "U123",
+        text: "hi",
+        ts: "1700000000.000100",
+      },
+    });
+    const result = normalizeSlackMessageDelete(event, "evt-del-dm", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.message.callbackData).toBe("message_deleted");
+    expect(result!.event.message.content).toBe("");
+    expect(result!.event.message.externalMessageId).toBe("evt-del-dm");
+    expect(result!.event.message.conversationExternalId).toBe("D789");
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
+    expect(result!.event.source.updateId).toBe("evt-del-dm");
+    // DMs should not be tagged as channel chat
+    expect(result!.event.source.chatType).toBeUndefined();
+    // No thread_ts on the previous message means no threadTs propagated
+    expect(result!.threadTs).toBeUndefined();
+    expect(result!.channel).toBe("D789");
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+  });
+
+  it("normalizes a channel delete with the message_deleted sentinel", () => {
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent();
+    const result = normalizeSlackMessageDelete(event, "evt-del-ch", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe("message_deleted");
+    expect(result!.event.message.content).toBe("");
+    expect(result!.event.message.externalMessageId).toBe("evt-del-ch");
+    // source.messageId carries the original deleted message's ts
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
+    expect(result!.event.source.chatType).toBe("channel");
+    expect(result!.event.message.conversationExternalId).toBe("C456");
+    expect(result!.channel).toBe("C456");
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+  });
+
+  it("preserves threadTs from the previous_message thread root", () => {
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent({
+      previous_message: {
+        user: "U123",
+        text: "thread reply",
+        ts: "1700000000.000100",
+        thread_ts: "1700000000.000050",
+      },
+    });
+    const result = normalizeSlackMessageDelete(event, "evt-del-thr", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000050");
+  });
+
+  it("returns null when deleted_ts is missing", () => {
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent({
+      deleted_ts: undefined as unknown as string,
+    });
+    const result = normalizeSlackMessageDelete(event, "evt-del-bad", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to a synthetic actor when previous_message.user is missing", () => {
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent({
+      previous_message: {
+        text: "[no user]",
+        ts: "1700000000.000100",
+      },
+    });
+    const result = normalizeSlackMessageDelete(
+      event,
+      "evt-del-no-user",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.actor.actorExternalId).toBe("slack-system");
+  });
+
+  it("returns null when channel routing rejects without a default", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeMessageDeletedEvent();
+    const result = normalizeSlackMessageDelete(event, "evt-del-noroute", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to default assistant for DM deletes when channel is unrouted", () => {
+    const config = makeConfig({ unmappedPolicy: "reject" });
+    const event = makeMessageDeletedEvent({
+      channel: "D789",
+      channel_type: "im",
+    });
+    const result = normalizeSlackMessageDelete(
+      event,
+      "evt-del-dm-default",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.routing.assistantId).toBe("ast-1");
   });
 });

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -254,6 +254,28 @@ export interface SlackMessageChangedEvent {
 }
 
 /**
+ * Slack `message_deleted` event shape — subtype `message_deleted` carries
+ * the original message's `ts` in `event.deleted_ts` and the prior content
+ * in `event.previous_message`.
+ */
+export interface SlackMessageDeletedEvent {
+  type: "message";
+  subtype: "message_deleted";
+  channel: string;
+  channel_type?: "im" | "channel" | "group" | "mpim";
+  hidden?: boolean;
+  ts: string;
+  event_ts?: string;
+  deleted_ts: string;
+  previous_message?: {
+    user?: string;
+    text: string;
+    ts: string;
+    thread_ts?: string;
+  };
+}
+
+/**
  * Strip leading bot-mention tokens (`<@U...>`) from the message text.
  * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
  * app_mention event's text field. We remove all leading occurrences
@@ -759,6 +781,78 @@ export function normalizeSlackMessageEdit(
     // For DMs without a thread, omit threadTs so the reply goes directly in conversation.
     // For channels (or DMs already in a thread), fall back to edited.ts.
     ...(isDm && !edited.thread_ts ? {} : { threadTs: edited.thread_ts ?? edited.ts }),
+    channel: event.channel,
+  };
+}
+
+/**
+ * Normalize a Slack `message_deleted` event into the gateway's canonical
+ * inbound event shape.
+ *
+ * The deleted message's `ts` arrives as `event.deleted_ts` and the prior
+ * content (including any `thread_ts`) lives in `event.previous_message`.
+ * The daemon detects deletes via the `message_deleted` sentinel placed in
+ * `callbackData` and uses `source.messageId` (= `deleted_ts`) to look up
+ * the stored row. `message.content` is intentionally empty — the daemon
+ * just marks the row deleted and does not re-process content.
+ *
+ * Each delete event gets a unique `externalMessageId` (= eventId) so the
+ * dedup pipeline does not collide if Slack re-delivers the event.
+ *
+ * Returns null if the event cannot be routed.
+ */
+export function normalizeSlackMessageDelete(
+  event: SlackMessageDeletedEvent,
+  eventId: string,
+  config: GatewayConfig,
+): NormalizedSlackEvent | null {
+  if (!event.deleted_ts) return null;
+
+  // Use the previous author for actor identity when available; otherwise fall
+  // back to a synthetic identifier so routing/trust still has something to key on.
+  const actorId = event.previous_message?.user ?? "slack-system";
+
+  const isDm = event.channel_type === "im";
+  let routing = resolveAssistant(config, event.channel, actorId);
+  if (isRejection(routing) && isDm && config.defaultAssistantId) {
+    routing = {
+      assistantId: config.defaultAssistantId,
+      routeSource: "default" as const,
+    };
+  }
+  if (isRejection(routing)) return null;
+
+  const previousThreadTs = event.previous_message?.thread_ts;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: "",
+        conversationExternalId: event.channel,
+        // Unique per delete event to avoid dedup collisions
+        externalMessageId: eventId,
+        // Sentinel value the daemon uses to detect deletions
+        callbackData: "message_deleted",
+      },
+      actor: {
+        actorExternalId: actorId,
+      },
+      source: {
+        updateId: eventId,
+        // Original message's ts — the lookup key the daemon uses to find
+        // the stored row to mark deleted.
+        messageId: event.deleted_ts,
+        ...(isDm ? {} : { chatType: "channel" }),
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    // Preserve thread context so downstream handling stays scoped to the
+    // original conversation thread when applicable.
+    ...(previousThreadTs ? { threadTs: previousThreadTs } : {}),
     channel: event.channel,
   };
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -7,6 +7,7 @@ import {
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
   normalizeSlackMessageEdit,
+  normalizeSlackMessageDelete,
   normalizeSlackBlockActions,
   normalizeSlackReactionAdded,
   resolveSlackUser,
@@ -14,6 +15,7 @@ import {
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackMessageChangedEvent,
+  type SlackMessageDeletedEvent,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
   type NormalizedSlackEvent,
@@ -349,6 +351,7 @@ export class SlackSocketModeClient {
           | SlackDirectMessageEvent
           | SlackChannelMessageEvent
           | SlackMessageChangedEvent
+          | SlackMessageDeletedEvent
           | SlackReactionAddedEvent;
         // Interactive payloads are delivered directly as the payload
         type?: string;
@@ -415,6 +418,7 @@ export class SlackSocketModeClient {
     const dmEvent = event as SlackDirectMessageEvent;
     const channelEvent = event as SlackChannelMessageEvent;
     const messageChangedEvent = event as SlackMessageChangedEvent;
+    const messageDeletedEvent = event as SlackMessageDeletedEvent;
 
     const isAppMention = event.type === "app_mention";
     const isMessageChangedRaw =
@@ -441,9 +445,29 @@ export class SlackSocketModeClient {
         (!!messageChangedEvent.message?.ts &&
           this.store.hasThread(messageChangedEvent.message.ts)) ||
         isSubscribedChannel);
+    // Admit message_deleted in DMs, tracked bot threads, or any channel the
+    // bot is explicitly subscribed to via a conversation_id routing entry so
+    // the daemon can mark the corresponding stored row deleted. The
+    // routing-entry check mirrors message_changed's scoping above.
+    const isMessageDeleted =
+      event.type === "message" &&
+      messageDeletedEvent.subtype === "message_deleted" &&
+      !!messageDeletedEvent.deleted_ts &&
+      (messageDeletedEvent.channel_type === "im" ||
+        (!!messageDeletedEvent.previous_message?.thread_ts &&
+          this.store.hasThread(messageDeletedEvent.previous_message.thread_ts)) ||
+        (!!messageDeletedEvent.deleted_ts &&
+          this.store.hasThread(messageDeletedEvent.deleted_ts)) ||
+        (!!messageDeletedEvent.channel &&
+          this.config.gatewayConfig.routingEntries.some(
+            (entry) =>
+              entry.type === "conversation_id" &&
+              entry.key === messageDeletedEvent.channel,
+          )));
     const isDm =
       event.type === "message" &&
       !isMessageChanged &&
+      !isMessageDeleted &&
       dmEvent.channel_type === "im";
     const mentionsBot =
       this.config.botUserId &&
@@ -451,6 +475,7 @@ export class SlackSocketModeClient {
     const isActiveThreadReply =
       event.type === "message" &&
       !isMessageChanged &&
+      !isMessageDeleted &&
       !isDm &&
       !mentionsBot &&
       !!channelEvent.thread_ts &&
@@ -463,18 +488,20 @@ export class SlackSocketModeClient {
       !!reactionEvent.item?.ts &&
       this.store.hasThread(reactionEvent.item.ts);
 
-    // Process app_mention events, DMs, message edits, scoped reactions, and replies in active bot threads
+    // Process app_mention events, DMs, message edits, message deletes, scoped reactions, and replies in active bot threads
     const matchedFilter = isAppMention
       ? "app_mention"
       : isDm
         ? "dm"
         : isMessageChanged
           ? "message_changed"
-          : isReactionAdded
-            ? "reaction_added"
-            : isActiveThreadReply
-              ? "active_thread_reply"
-              : null;
+          : isMessageDeleted
+            ? "message_deleted"
+            : isReactionAdded
+              ? "reaction_added"
+              : isActiveThreadReply
+                ? "active_thread_reply"
+                : null;
 
     if (!matchedFilter) {
       log.debug(
@@ -524,6 +551,7 @@ export class SlackSocketModeClient {
       isActiveThreadReply,
       isReactionAdded,
       isMessageChanged,
+      isMessageDeleted,
       isDm,
     );
   }
@@ -534,12 +562,14 @@ export class SlackSocketModeClient {
       | SlackDirectMessageEvent
       | SlackChannelMessageEvent
       | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
       | SlackReactionAddedEvent,
     eventId: string,
     isAppMention: boolean,
     isActiveThreadReply: boolean,
     isReactionAdded: boolean,
     isMessageChanged: boolean,
+    isMessageDeleted: boolean,
     isDm: boolean,
   ): void {
     let normalized: NormalizedSlackEvent | null;
@@ -563,6 +593,12 @@ export class SlackSocketModeClient {
         eventId,
         this.config.gatewayConfig,
         this.config.botUserId,
+      );
+    } else if (isMessageDeleted) {
+      normalized = normalizeSlackMessageDelete(
+        event as SlackMessageDeletedEvent,
+        eventId,
+        this.config.gatewayConfig,
       );
     } else if (isActiveThreadReply) {
       normalized = normalizeSlackChannelMessage(


### PR DESCRIPTION
## Summary
- Adds normalizeSlackMessageDelete, emitted with callbackData: "message_deleted" sentinel
- source.messageId carries the original deleted message's ts (lookup key for daemon)
- Admits deletes on any subscribed channel; daemon applies in PR 15

Part of plan: slack-thread-aware-context.md (PR 5 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
