### PR TITLE
feat(gateway): admit reactions on all stored channels and add reaction_removed

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import {
   normalizeSlackBlockActions,
   normalizeSlackReactionAdded,
+  normalizeSlackReactionRemoved,
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
   normalizeSlackAppMention,
@@ -9,6 +10,7 @@ import {
   normalizeSlackMessageDelete,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
+  type SlackReactionRemovedEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackAppMentionEvent,
@@ -68,6 +70,26 @@ function makeReactionAddedEvent(
 ): SlackReactionAddedEvent {
   return {
     type: "reaction_added",
+    user: overrides?.user ?? "U123",
+    reaction: overrides?.reaction ?? "thumbsup",
+    item: {
+      type: "message",
+      channel: overrides?.channelId ?? "C456",
+      ts: overrides?.messageTs ?? "1234567890.123456",
+    },
+  };
+}
+
+function makeReactionRemovedEvent(
+  overrides?: Partial<{
+    user: string;
+    reaction: string;
+    channelId: string;
+    messageTs: string;
+  }>,
+): SlackReactionRemovedEvent {
+  return {
+    type: "reaction_removed",
     user: overrides?.user ?? "U123",
     reaction: overrides?.reaction ?? "thumbsup",
     item: {
@@ -260,6 +282,205 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe(
       "reaction:white_check_mark",
+    );
+  });
+
+  it("normalizes reactions on a non-bot-thread channel message", () => {
+    // Filter expansion: PR 3 admits reactions on any subscribed channel,
+    // not just tracked bot-thread messages. The normalizer itself doesn't
+    // gate on thread tracking — that filter lives in socket-mode.ts.
+    // Verify the normalizer happily produces a valid event for an arbitrary
+    // public-channel message ts when routing matches the channel.
+    const config = makeConfig({
+      defaultAssistantId: undefined,
+      unmappedPolicy: "reject",
+      routingEntries: [
+        { type: "conversation_id", key: "C500", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionAddedEvent({
+      channelId: "C500",
+      messageTs: "1700000000.999999",
+    });
+    const result = normalizeSlackReactionAdded(event, "evt-expand", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe("reaction:thumbsup");
+    expect(result!.channel).toBe("C500");
+    expect(result!.threadTs).toBe("1700000000.999999");
+    expect(result!.routing.assistantId).toBe("ast-1");
+    expect(result!.event.message.externalMessageId).toBe(
+      "C500:1700000000.999999:thumbsup:U123",
+    );
+  });
+});
+
+describe("normalizeSlackReactionRemoved", () => {
+  it("normalizes a reaction_removed event with reaction_removed: prefix", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent();
+    const result = normalizeSlackReactionRemoved(event, "evt-r-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.message.callbackData).toBe(
+      "reaction_removed:thumbsup",
+    );
+    expect(result!.event.message.content).toBe("reaction_removed:thumbsup");
+    expect(result!.event.message.conversationExternalId).toBe("C456");
+    expect(result!.event.message.externalMessageId).toBe(
+      "C456:1234567890.123456:thumbsup:U123:removed",
+    );
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+    expect(result!.event.source.messageId).toBe("1234567890.123456");
+    expect(result!.channel).toBe("C456");
+    expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
+  it("uses the reaction name in callbackData", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent({ reaction: "white_check_mark" });
+    const result = normalizeSlackReactionRemoved(event, "evt-r-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe(
+      "reaction_removed:white_check_mark",
+    );
+  });
+
+  it("returns null when user is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent({ user: "" });
+    const result = normalizeSlackReactionRemoved(event, "evt-r-3", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when item channel is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent();
+    event.item.channel = "";
+    const result = normalizeSlackReactionRemoved(event, "evt-r-4", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when item ts is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent();
+    event.item.ts = "";
+    const result = normalizeSlackReactionRemoved(event, "evt-r-5", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores reactions removed by the bot itself", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent({ user: "UBOT" });
+    const result = normalizeSlackReactionRemoved(
+      event,
+      "evt-r-6",
+      config,
+      "UBOT",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when routing rejects on a public channel", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeReactionRemovedEvent();
+    const result = normalizeSlackReactionRemoved(event, "evt-r-7", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to default assistant for unrouted DM channels", () => {
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+    });
+    const event = makeReactionRemovedEvent({
+      channelId: "D999",
+      messageTs: "111.222",
+    });
+    const result = normalizeSlackReactionRemoved(event, "evt-r-8", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.channel).toBe("D999");
+    expect(result!.event.message.externalMessageId).toBe(
+      "D999:111.222:thumbsup:U123:removed",
+    );
+  });
+
+  it("normalizes reaction_removed in a DM channel", () => {
+    const config = makeConfig();
+    const event = makeReactionRemovedEvent({
+      channelId: "D789",
+      messageTs: "1700000000.000001",
+    });
+    const result = normalizeSlackReactionRemoved(event, "evt-r-9", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.channel).toBe("D789");
+    expect(result!.event.message.callbackData).toBe(
+      "reaction_removed:thumbsup",
+    );
+    expect(result!.event.message.externalMessageId).toBe(
+      "D789:1700000000.000001:thumbsup:U123:removed",
+    );
+  });
+
+  it("normalizes reaction_removed on a non-bot-thread channel message", () => {
+    // Filter expansion: PR 3 admits reactions on any subscribed channel,
+    // not just tracked bot-thread messages. Verify the removed normalizer
+    // produces a valid event for an arbitrary public-channel message ts.
+    const config = makeConfig({
+      defaultAssistantId: undefined,
+      unmappedPolicy: "reject",
+      routingEntries: [
+        { type: "conversation_id", key: "C500", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionRemovedEvent({
+      channelId: "C500",
+      messageTs: "1700000000.999999",
+    });
+    const result = normalizeSlackReactionRemoved(event, "evt-r-10", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.routing.assistantId).toBe("ast-1");
+    expect(result!.event.message.externalMessageId).toBe(
+      "C500:1700000000.999999:thumbsup:U123:removed",
+    );
+  });
+
+  it("produces a different externalMessageId than reaction_added for the same emoji+user+message", () => {
+    // Critical for dedup: an add followed by a remove of the same emoji by
+    // the same user on the same message must not collide on externalMessageId.
+    const config = makeConfig();
+    const addEvent = makeReactionAddedEvent({
+      reaction: "fire",
+      messageTs: "111.222",
+    });
+    const removeEvent = makeReactionRemovedEvent({
+      reaction: "fire",
+      messageTs: "111.222",
+    });
+    const addResult = normalizeSlackReactionAdded(addEvent, "evt-add", config);
+    const removeResult = normalizeSlackReactionRemoved(
+      removeEvent,
+      "evt-remove",
+      config,
+    );
+
+    expect(addResult).not.toBeNull();
+    expect(removeResult).not.toBeNull();
+    expect(addResult!.event.message.externalMessageId).not.toBe(
+      removeResult!.event.message.externalMessageId,
     );
   });
 });

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -583,6 +583,23 @@ export interface SlackReactionAddedEvent {
 }
 
 /**
+ * Slack `reaction_removed` event shape — same payload as `reaction_added`,
+ * differentiated only by the `type` discriminator.
+ */
+export interface SlackReactionRemovedEvent {
+  type: "reaction_removed";
+  user: string;
+  reaction: string;
+  item: {
+    type: string;
+    channel: string;
+    ts: string;
+  };
+  item_user?: string;
+  event_ts?: string;
+}
+
+/**
  * Normalize a Slack `block_actions` interactive payload into the gateway's
  * canonical inbound event shape, matching Telegram's `callback_query` pattern.
  *
@@ -648,16 +665,15 @@ export function normalizeSlackBlockActions(
 }
 
 /**
- * Normalize a Slack `reaction_added` event into the gateway's canonical
- * inbound event shape. The reaction emoji name is placed in `callbackData`
- * so downstream handlers can process it like a callback action.
- *
- * Returns null if the event is missing required fields or cannot be routed.
+ * Shared normalizer for Slack reaction events. Both `reaction_added` and
+ * `reaction_removed` carry the same payload shape and differ only in the
+ * downstream callback prefix and externalMessageId suffix.
  */
-export function normalizeSlackReactionAdded(
-  event: SlackReactionAddedEvent,
+function normalizeSlackReaction(
+  event: SlackReactionAddedEvent | SlackReactionRemovedEvent,
   eventId: string,
   config: GatewayConfig,
+  op: "added" | "removed",
   botUserId?: string,
 ): NormalizedSlackEvent | null {
   if (!event.user || !event.item?.channel || !event.item?.ts) return null;
@@ -682,7 +698,16 @@ export function normalizeSlackReactionAdded(
   }
   if (isRejection(routing)) return null;
 
-  const callbackData = `reaction:${event.reaction}`;
+  const prefix = op === "added" ? "reaction" : "reaction_removed";
+  const callbackData = `${prefix}:${event.reaction}`;
+  // Include reactor user ID to prevent dedup collisions when multiple
+  // users react with the same emoji on the same message. Append the op
+  // suffix so an add and a subsequent remove of the same emoji by the
+  // same user produce distinct externalMessageIds.
+  const externalMessageId =
+    op === "added"
+      ? `${channel}:${event.item.ts}:${event.reaction}:${event.user}`
+      : `${channel}:${event.item.ts}:${event.reaction}:${event.user}:removed`;
 
   return {
     event: {
@@ -692,9 +717,7 @@ export function normalizeSlackReactionAdded(
       message: {
         content: callbackData,
         conversationExternalId: channel,
-        // Include reactor user ID to prevent dedup collisions when multiple
-        // users react with the same emoji on the same message.
-        externalMessageId: `${channel}:${event.item.ts}:${event.reaction}:${event.user}`,
+        externalMessageId,
         callbackData,
       },
       actor: {
@@ -710,6 +733,40 @@ export function normalizeSlackReactionAdded(
     threadTs: event.item.ts,
     channel,
   };
+}
+
+/**
+ * Normalize a Slack `reaction_added` event into the gateway's canonical
+ * inbound event shape. The reaction emoji name is placed in `callbackData`
+ * (prefixed with `reaction:`) so downstream handlers can process it like a
+ * callback action.
+ *
+ * Returns null if the event is missing required fields or cannot be routed.
+ */
+export function normalizeSlackReactionAdded(
+  event: SlackReactionAddedEvent,
+  eventId: string,
+  config: GatewayConfig,
+  botUserId?: string,
+): NormalizedSlackEvent | null {
+  return normalizeSlackReaction(event, eventId, config, "added", botUserId);
+}
+
+/**
+ * Normalize a Slack `reaction_removed` event into the gateway's canonical
+ * inbound event shape. The emoji name is placed in `callbackData` with a
+ * `reaction_removed:` prefix so downstream handlers can distinguish removals
+ * from additions.
+ *
+ * Returns null if the event is missing required fields or cannot be routed.
+ */
+export function normalizeSlackReactionRemoved(
+  event: SlackReactionRemovedEvent,
+  eventId: string,
+  config: GatewayConfig,
+  botUserId?: string,
+): NormalizedSlackEvent | null {
+  return normalizeSlackReaction(event, eventId, config, "removed", botUserId);
 }
 
 /**

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -10,6 +10,7 @@ import {
   normalizeSlackMessageDelete,
   normalizeSlackBlockActions,
   normalizeSlackReactionAdded,
+  normalizeSlackReactionRemoved,
   resolveSlackUser,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
@@ -18,6 +19,7 @@ import {
   type SlackMessageDeletedEvent,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
+  type SlackReactionRemovedEvent,
   type NormalizedSlackEvent,
 } from "./normalize.js";
 
@@ -251,6 +253,22 @@ export class SlackSocketModeClient {
     this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
   }
 
+  /**
+   * Returns true when the gateway has a configured `conversation_id` routing
+   * entry for the given channel — i.e. the bot is subscribed to that channel.
+   *
+   * Used by the reaction filter to admit reactions on any subscribed channel,
+   * not just those in tracked bot threads.
+   */
+  private isChannelSubscribed(channel: string): boolean {
+    for (const entry of this.config.gatewayConfig.routingEntries) {
+      if (entry.type === "conversation_id" && entry.key === channel) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private async connect(): Promise<void> {
     if (!this.running) return;
     if (this.connecting) return;
@@ -352,7 +370,8 @@ export class SlackSocketModeClient {
           | SlackChannelMessageEvent
           | SlackMessageChangedEvent
           | SlackMessageDeletedEvent
-          | SlackReactionAddedEvent;
+          | SlackReactionAddedEvent
+          | SlackReactionRemovedEvent;
         // Interactive payloads are delivered directly as the payload
         type?: string;
         trigger_id?: string;
@@ -481,12 +500,31 @@ export class SlackSocketModeClient {
       !!channelEvent.thread_ts &&
       this.store.hasThread(channelEvent.thread_ts);
 
-    // Only forward reaction_added events on messages in tracked bot threads
-    const reactionEvent = event as SlackReactionAddedEvent;
+    // Forward reaction events on:
+    //   1. messages in tracked bot threads (preserves original behavior), or
+    //   2. messages in any channel the bot is subscribed to (a configured
+    //      conversation_id routing entry, or any DM channel since DMs always
+    //      route to the default assistant).
+    // Both reaction_added and reaction_removed are admitted under the same
+    // filter; the daemon dispatches by callbackData prefix.
+    const reactionEvent = event as
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent;
+    const reactionTargetChannel = reactionEvent.item?.channel;
+    const reactionAdmitChannel =
+      !!reactionTargetChannel &&
+      (reactionTargetChannel.startsWith("D") ||
+        this.isChannelSubscribed(reactionTargetChannel) ||
+        (!!reactionEvent.item?.ts &&
+          this.store.hasThread(reactionEvent.item.ts)));
     const isReactionAdded =
       event.type === "reaction_added" &&
       !!reactionEvent.item?.ts &&
-      this.store.hasThread(reactionEvent.item.ts);
+      reactionAdmitChannel;
+    const isReactionRemoved =
+      event.type === "reaction_removed" &&
+      !!reactionEvent.item?.ts &&
+      reactionAdmitChannel;
 
     // Process app_mention events, DMs, message edits, message deletes, scoped reactions, and replies in active bot threads
     const matchedFilter = isAppMention
@@ -499,9 +537,11 @@ export class SlackSocketModeClient {
             ? "message_deleted"
             : isReactionAdded
               ? "reaction_added"
-              : isActiveThreadReply
-                ? "active_thread_reply"
-                : null;
+              : isReactionRemoved
+                ? "reaction_removed"
+                : isActiveThreadReply
+                  ? "active_thread_reply"
+                  : null;
 
     if (!matchedFilter) {
       log.debug(
@@ -550,6 +590,7 @@ export class SlackSocketModeClient {
       isAppMention,
       isActiveThreadReply,
       isReactionAdded,
+      isReactionRemoved,
       isMessageChanged,
       isMessageDeleted,
       isDm,
@@ -563,11 +604,13 @@ export class SlackSocketModeClient {
       | SlackChannelMessageEvent
       | SlackMessageChangedEvent
       | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent,
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
     eventId: string,
     isAppMention: boolean,
     isActiveThreadReply: boolean,
     isReactionAdded: boolean,
+    isReactionRemoved: boolean,
     isMessageChanged: boolean,
     isMessageDeleted: boolean,
     isDm: boolean,
@@ -576,6 +619,13 @@ export class SlackSocketModeClient {
     if (isReactionAdded) {
       normalized = normalizeSlackReactionAdded(
         event as SlackReactionAddedEvent,
+        eventId,
+        this.config.gatewayConfig,
+        this.config.botUserId,
+      );
+    } else if (isReactionRemoved) {
+      normalized = normalizeSlackReactionRemoved(
+        event as SlackReactionRemovedEvent,
         eventId,
         this.config.gatewayConfig,
         this.config.botUserId,


### PR DESCRIPTION
## Summary
- Expands reaction_added filter to any subscribed channel (was bot-threads-only)
- Adds reaction_removed normalizer + admission
- Reactions reuse unified SlackInboundEvent shape; daemon dispatches by callbackData prefix

Part of plan: slack-thread-aware-context.md (PR 3 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
