### PR TITLE
feat(context): raise minKeepRecentUserTurns default for Slack conversations

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -1140,4 +1140,144 @@ describe("ContextWindowManager", () => {
     expect(result.compactedPersistedMessages).toBe(2);
     expect(manager.nonPersistedPrefixCount).toBe(0);
   });
+
+  test("Slack origin bumps default minKeepRecentUserTurns to 8", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- slack thread context" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    // Use targetInputTokensOverride so the binary search is forced even
+    // for a small history. Both managers see the same tight budget; the
+    // only knob that varies is conversationOriginChannel.
+    const config = makeConfig({ maxInputTokens: 12_000 });
+    const long = "s".repeat(220);
+    // 9 user turns: enough headroom for Slack's bumped floor of 8 to be
+    // distinguishable from the default floor of 1.
+    const history: Message[] = [];
+    for (let i = 1; i <= 9; i++) {
+      history.push(message("user", `u${i} ${long}`));
+      history.push(message("assistant", `a${i} ${long}`));
+    }
+
+    const slackManager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
+    const slackResult = await slackManager.maybeCompact(history, undefined, {
+      force: true,
+      targetInputTokensOverride: 200,
+      conversationOriginChannel: "slack",
+    });
+
+    const defaultManager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
+    const defaultResult = await defaultManager.maybeCompact(
+      history,
+      undefined,
+      { force: true, targetInputTokensOverride: 200 },
+    );
+
+    expect(slackResult.compacted).toBe(true);
+    expect(defaultResult.compacted).toBe(true);
+    // Default floor (1 user turn) compacts more of the history than the
+    // Slack floor (8 user turns), which preserves more recent context.
+    expect(defaultResult.compactedMessages).toBeGreaterThan(
+      slackResult.compactedMessages,
+    );
+    // Slack keeps 8 of 9 user turns: 16 kept messages, 2 compacted.
+    expect(slackResult.compactedMessages).toBe(2);
+  });
+
+  test("non-Slack origin keeps default minKeepRecentUserTurns of 1", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- standard summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    const config = makeConfig({ maxInputTokens: 12_000 });
+    const long = "n".repeat(220);
+    const history: Message[] = [];
+    for (let i = 1; i <= 9; i++) {
+      history.push(message("user", `u${i} ${long}`));
+      history.push(message("assistant", `a${i} ${long}`));
+    }
+
+    // Telegram origin must behave identically to no-channel-hint default.
+    const telegramManager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
+    const telegramResult = await telegramManager.maybeCompact(
+      history,
+      undefined,
+      {
+        force: true,
+        targetInputTokensOverride: 200,
+        conversationOriginChannel: "telegram",
+      },
+    );
+
+    const defaultManager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
+    const defaultResult = await defaultManager.maybeCompact(
+      history,
+      undefined,
+      { force: true, targetInputTokensOverride: 200 },
+    );
+
+    expect(telegramResult.compacted).toBe(true);
+    expect(defaultResult.compacted).toBe(true);
+    expect(telegramResult.compactedMessages).toBe(
+      defaultResult.compactedMessages,
+    );
+  });
+
+  test("explicit minKeepRecentUserTurns wins over Slack default", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- emergency override" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 260,
+        targetBudgetRatio: 0.28,
+      }),
+    });
+    const long = "e".repeat(220);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+    ];
+
+    // Emergency override (`minKeepRecentUserTurns: 0`) must take precedence
+    // over the Slack-bumped default of 8 — this guards the agent loop's
+    // context-too-large recovery path which always passes 0.
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      minKeepRecentUserTurns: 0,
+      conversationOriginChannel: "slack",
+    });
+    expect(result.compacted).toBe(true);
+    expect(result.compactedMessages).toBe(3);
+    expect(result.messages).toHaveLength(1);
+  });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -73,9 +73,16 @@ export interface ContextWindowCompactOptions {
    * Override the minimum number of recent user turns to preserve.
    * Set to `0` for emergency recovery that can compact the entire history
    * (except the summary message itself). When omitted, the default floor
-   * of 1 recent user turn is enforced.
+   * is `1` (or `8` when `conversationOriginChannel === "slack"`).
    */
   minKeepRecentUserTurns?: number;
+  /**
+   * Origin channel hint used when `minKeepRecentUserTurns` is omitted.
+   * Slack-originated conversations bump the default keep floor so multi-turn
+   * thread context (replies, quoted messages) is not summarized away too
+   * aggressively. Explicit `minKeepRecentUserTurns` overrides this hint.
+   */
+  conversationOriginChannel?: string;
   /**
    * Override the target input token budget used for keep-boundary
    * projected-fit checks. Allows the caller to demand a stricter fit
@@ -274,6 +281,7 @@ export class ContextWindowManager {
     const keepPlan = this.pickKeepBoundary(messages, userTurnStarts, {
       minKeepRecentUserTurns: options?.minKeepRecentUserTurns,
       targetInputTokensOverride: options?.targetInputTokensOverride,
+      conversationOriginChannel: options?.conversationOriginChannel,
     });
     if (keepPlan.keepFromIndex <= summaryOffset) {
       // All turns fit after truncation projection, but the real in-memory
@@ -548,10 +556,17 @@ export class ContextWindowManager {
     opts?: {
       minKeepRecentUserTurns?: number;
       targetInputTokensOverride?: number;
+      conversationOriginChannel?: string;
     },
   ): { keepFromIndex: number; keepTurns: number } {
+    // Slack-originated conversations rely on multi-turn thread context
+    // (reply chains, quoted messages, contextual references). Bump the
+    // default keep floor for them so compaction does not summarize away
+    // recent turns that the next reply may directly cite. Explicit
+    // `minKeepRecentUserTurns` (including emergency `0`) wins.
+    const defaultTurns = opts?.conversationOriginChannel === "slack" ? 8 : 1;
     const minFloor = Math.min(
-      Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? 1)),
+      Math.max(0, Math.floor(opts?.minKeepRecentUserTurns ?? defaultTurns)),
       userTurnStarts.length,
     );
     const targetTokens =

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -554,6 +554,8 @@ export async function runAgentLoopImpl(
       {
         lastCompactedAt: ctx.contextCompactedAt ?? undefined,
         precomputedEstimate: compactCheck.estimatedTokens,
+        conversationOriginChannel:
+          getConversationOriginChannel(ctx.conversationId) ?? undefined,
       },
     );
     if (compacted.compacted) {
@@ -1210,6 +1212,8 @@ export async function runAgentLoopImpl(
           lastCompactedAt: ctx.contextCompactedAt ?? undefined,
           force: true,
           targetInputTokensOverride: preflightBudget,
+          conversationOriginChannel:
+            getConversationOriginChannel(ctx.conversationId) ?? undefined,
         },
       );
       if (midLoopCompact.compacted) {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -47,6 +47,7 @@ import { getHookManager } from "../hooks/manager.js";
 import { enqueueAutoAnalysisOnCompaction } from "../memory/auto-analysis-enqueue.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import {
+  getConversationOriginChannel,
   updateConversationContextWindow,
   updateConversationHostAccess,
 } from "../memory/conversation-crud.js";
@@ -1219,7 +1220,12 @@ export class Conversation {
     const result = await this.contextWindowManager.maybeCompact(
       this.messages,
       this.abortController?.signal ?? undefined,
-      { force: true, lastCompactedAt: this.contextCompactedAt ?? undefined },
+      {
+        force: true,
+        lastCompactedAt: this.contextCompactedAt ?? undefined,
+        conversationOriginChannel:
+          getConversationOriginChannel(this.conversationId) ?? undefined,
+      },
     );
     if (result.compacted) {
       this.messages = result.messages;


### PR DESCRIPTION
## Summary
- Adds conversationOriginChannel hint to ContextWindowCompactOptions
- Default minKeepRecentUserTurns is 8 for Slack conversations (vs 1)
- Emergency overrides (minKeepRecentUserTurns: 0) still win

Part of plan: slack-thread-aware-context.md (PR 7 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
