### PR TITLE
feat(slack): persist thread metadata on outbound assistant messages

### DIFF
--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests that `handleMessageComplete` stamps a `slackMeta` sub-object on the
+ * persisted assistant message metadata when the turn's
+ * `assistantMessageChannel === "slack"`.
+ *
+ * Persistence happens BEFORE the Slack adapter sends the message, so Slack's
+ * authoritative `ts` (-> `channelTs`) is not yet known at this layer. The
+ * partial `slackMeta` written here is intentionally missing `channelTs`; a
+ * later PR (PR 21) reconciles the field by writing it back once the send
+ * response returns. These tests document that ordering and verify the
+ * `channelTs` absence at the persistence boundary.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Shared mock plumbing (must precede module-under-test imports) ──────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+// `addMessage` is the only DB-touching call we need to inspect. We capture
+// its arguments per test invocation so each case can assert on the metadata
+// that was actually persisted.
+interface AddMessageCall {
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+const addMessageCalls: AddMessageCall[] = [];
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => {
+    addMessageCalls.push({ conversationId, role, content, metadata });
+    return { id: `mock-msg-${addMessageCalls.length}` };
+  },
+  getConversation: () => null,
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  // The handler treats provenance as a flat spread; returning {} keeps the
+  // metadata snapshot focused on the fields under test.
+  provenanceFromTrustContext: () => ({}),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+mock.module("../memory/memory-recall-log-store.js", () => ({
+  backfillMemoryRecallLogMessageId: () => {},
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import type { AgentEvent } from "../agent/loop.js";
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  handleMessageComplete,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { setThreadTs } from "../memory/slack-thread-store.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDeps(
+  conversationId: string,
+  overrides: {
+    assistantMessageChannel?: "slack" | "vellum" | "telegram";
+    requesterChatId?: string;
+  } = {},
+): EventHandlerDeps {
+  const assistantMessageChannel = overrides.assistantMessageChannel ?? "slack";
+  return {
+    ctx: {
+      conversationId,
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      currentTurnSurfaces: [],
+      trustContext: {
+        sourceChannel: assistantMessageChannel,
+        trustClass: "guardian",
+        requesterChatId: overrides.requesterChatId,
+      },
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (_msg: ServerMessage) => {},
+    reqId: "test-req-id",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: assistantMessageChannel,
+      assistantMessageChannel,
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface:
+        assistantMessageChannel === "vellum" ? "macos" : assistantMessageChannel,
+      assistantMessageInterface:
+        assistantMessageChannel === "vellum" ? "macos" : assistantMessageChannel,
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+}
+
+function makeMessageCompleteEvent(
+  text: string,
+): Extract<AgentEvent, { type: "message_complete" }> {
+  return {
+    type: "message_complete",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+/** Find the most recently persisted assistant-role message in the capture log. */
+function lastAssistantPersisted(): AddMessageCall {
+  for (let i = addMessageCalls.length - 1; i >= 0; i--) {
+    if (addMessageCalls[i].role === "assistant") return addMessageCalls[i];
+  }
+  throw new Error("No assistant message was persisted via addMessage");
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("outbound assistant Slack metadata persistence", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+    state = createEventHandlerState();
+    state.turnStartedAt = 1_700_000_000_000;
+  });
+
+  afterEach(() => {
+    addMessageCalls.length = 0;
+  });
+
+  test("stamps slackMeta with threadTs when the conversation has a Slack thread mapping", async () => {
+    const conversationId = "conv-slack-threaded";
+    const channelId = "C123CHANNEL";
+    // Seed an in-memory Slack thread mapping (mirrors the inbound path that
+    // calls setThreadTs when a thread_ts arrives).
+    setThreadTs(conversationId, channelId, "1234.5678");
+
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "slack",
+      requesterChatId: channelId,
+    });
+    await handleMessageComplete(state, deps, makeMessageCompleteEvent("hi"));
+
+    const persisted = lastAssistantPersisted();
+    const slackMetaRaw = persisted.metadata?.slackMeta;
+    expect(typeof slackMetaRaw).toBe("string");
+
+    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
+      string,
+      unknown
+    >;
+    expect(slackMeta.source).toBe("slack");
+    expect(slackMeta.eventKind).toBe("message");
+    expect(slackMeta.channelId).toBe(channelId);
+    expect(slackMeta.threadTs).toBe("1234.5678");
+
+    // Persistence runs BEFORE the Slack adapter posts the message, so the
+    // authoritative `ts` (-> `channelTs`) is not yet known. A later PR will
+    // reconcile this field. Until then, `readSlackMetadata` rejects the
+    // partial metadata since `channelTs` is still required by the schema.
+    expect(slackMeta.channelTs).toBeUndefined();
+    expect(readSlackMetadata(slackMetaRaw as string)).toBeNull();
+  });
+
+  test("stamps slackMeta WITHOUT threadTs for top-level Slack replies", async () => {
+    const conversationId = "conv-slack-toplevel";
+    const channelId = "C456NOTHREAD";
+    // No setThreadTs() call — the conversation has no thread mapping, so
+    // the assistant's reply targets the channel root, not a thread.
+
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "slack",
+      requesterChatId: channelId,
+    });
+    await handleMessageComplete(state, deps, makeMessageCompleteEvent("hello"));
+
+    const persisted = lastAssistantPersisted();
+    const slackMetaRaw = persisted.metadata?.slackMeta;
+    expect(typeof slackMetaRaw).toBe("string");
+
+    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
+      string,
+      unknown
+    >;
+    expect(slackMeta.source).toBe("slack");
+    expect(slackMeta.eventKind).toBe("message");
+    expect(slackMeta.channelId).toBe(channelId);
+    // threadTs is intentionally absent — top-level reply.
+    expect(slackMeta.threadTs).toBeUndefined();
+    // channelTs is still absent for the same persistence-vs-send reason.
+    expect(slackMeta.channelTs).toBeUndefined();
+  });
+
+  test("does NOT stamp slackMeta on non-Slack outbound assistant messages", async () => {
+    const conversationId = "conv-vellum";
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "vellum",
+    });
+    await handleMessageComplete(
+      state,
+      deps,
+      makeMessageCompleteEvent("vellum reply"),
+    );
+
+    const persisted = lastAssistantPersisted();
+    expect(persisted.metadata).toBeDefined();
+    // Non-Slack channels must leave the existing metadata shape untouched.
+    expect(persisted.metadata?.slackMeta).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -26,6 +26,11 @@ import {
   recordRequestLog,
 } from "../memory/llm-request-log-store.js";
 import { backfillMemoryRecallLogMessageId } from "../memory/memory-recall-log-store.js";
+import { getThreadTs } from "../memory/slack-thread-store.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
 import type { ContentBlock, ImageContent } from "../providers/types.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -761,7 +766,7 @@ export async function handleMessageComplete(
     } as unknown as ContentBlock);
   }
 
-  const assistantChannelMetadata = {
+  const assistantChannelMetadata: Record<string, unknown> = {
     ...provenanceFromTrustContext(deps.ctx.trustContext),
     userMessageChannel: deps.turnChannelContext.userMessageChannel,
     assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
@@ -770,6 +775,31 @@ export async function handleMessageComplete(
       deps.turnInterfaceContext.assistantMessageInterface,
     sentAt: state.turnStartedAt,
   };
+
+  // When the assistant is replying through Slack, stamp a `slackMeta`
+  // sub-object so PR 17's transcript-rendering / thread-aware-context
+  // lookup can identify this row's thread without joining tables.
+  // Persistence happens BEFORE the Slack adapter sends the message, so
+  // Slack's authoritative `ts` (-> `channelTs`) is not yet known and is
+  // intentionally omitted here. A later PR (PR 21) reconciles `channelTs`
+  // by writing it back once the send response returns.
+  if (deps.turnChannelContext.assistantMessageChannel === "slack") {
+    const channelId = deps.ctx.trustContext?.requesterChatId;
+    if (channelId) {
+      const threadTs = getThreadTs(deps.ctx.conversationId);
+      const partialSlackMeta: Partial<SlackMessageMetadata> = {
+        source: "slack",
+        eventKind: "message",
+        channelId,
+        ...(threadTs ? { threadTs } : {}),
+      };
+      assistantChannelMetadata.slackMeta = writeSlackMetadata(
+        // `channelTs` is filled in by the post-send reconciliation step in a
+        // later PR; cast through the Partial to satisfy the writer's type.
+        partialSlackMeta as SlackMessageMetadata,
+      );
+    }
+  }
   const assistantMsg = await addMessage(
     deps.ctx.conversationId,
     "assistant",

--- a/assistant/src/memory/slack-thread-store.ts
+++ b/assistant/src/memory/slack-thread-store.ts
@@ -63,6 +63,17 @@ export function setThreadTs(
 }
 
 /**
+ * Read-side accessor for the in-memory thread mapping. Returns the
+ * `threadTs` previously associated with this conversation via
+ * {@link setThreadTs}, or `null` if no mapping exists. Does not bump
+ * `lastUsedAt` or otherwise mutate the entry — pure lookup.
+ */
+export function getThreadTs(conversationId: string): string | null {
+  const mapping = threadMappings.get(conversationId);
+  return mapping ? mapping.threadTs : null;
+}
+
+/**
  * Extract the threadTs from a Slack reply callback URL, if present.
  * The gateway encodes threadTs as a query parameter on the callback URL.
  */


### PR DESCRIPTION
## Summary
- Adds slackMeta to outbound assistant message.metadata when assistantMessageChannel === slack
- Reads threadTs from slack-thread-store (new getThreadTs getter)
- channelTs absent at persistence time; send happens after (documented)

Part of plan: slack-thread-aware-context.md (PR 12 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
