### PR TITLE
feat(slack): update stored message content on Slack message.changed events

### DIFF
--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Edit-propagation tests for Slack `message.changed` events.
+ *
+ * Validates that the edit intercept stage:
+ *  - Updates `messages.content` and stamps `slackMeta.editedAt` when the
+ *    original message can be located.
+ *  - Is idempotent across successive edits (subsequent edits keep updating).
+ *  - Treats missing-target edits as a silent no-op (no throw, no row change).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { addMessage } from "../memory/conversation-crud.js";
+import { getDb, initializeDb } from "../memory/db.js";
+import { linkMessage, recordInbound } from "../memory/delivery-crud.js";
+import { messages } from "../memory/schema.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { handleEditIntercept } from "../runtime/routes/inbound-stages/edit-intercept.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM conversations");
+}
+
+interface SeededFixture {
+  conversationId: string;
+  messageId: string;
+  channelTs: string;
+  conversationExternalId: string;
+}
+
+/**
+ * Seed a Slack message in a fresh conversation. Mirrors what the new-message
+ * pipeline does at runtime: `recordInbound` writes the channel_inbound_events
+ * row (storing `sourceMessageId = ts`), `addMessage` writes the user message,
+ * and `linkMessage` connects them so edit lookups succeed.
+ *
+ * Note: the gateway sets `externalMessageId = client_msg_id ?? ts` for new
+ * Slack messages, so this fixture mirrors a message where `client_msg_id`
+ * equals the `ts` (i.e. the simplest case). The lookup mechanism keys on
+ * `sourceMessageId`, which always carries the `ts`, so the test exercises
+ * the same path that production hits regardless of `client_msg_id` presence.
+ */
+async function seedSlackMessage(opts: {
+  conversationExternalId: string;
+  channelTs: string;
+  initialContent: string;
+}): Promise<SeededFixture> {
+  const { conversationExternalId, channelTs, initialContent } = opts;
+
+  const inboundResult = recordInbound("slack", conversationExternalId, channelTs, {
+    sourceMessageId: channelTs,
+  });
+
+  const inserted = await addMessage(
+    inboundResult.conversationId,
+    "user",
+    initialContent,
+    { userMessageChannel: "slack" },
+    { skipIndexing: true },
+  );
+
+  linkMessage(inboundResult.eventId, inserted.id);
+
+  return {
+    conversationId: inboundResult.conversationId,
+    messageId: inserted.id,
+    channelTs,
+    conversationExternalId,
+  };
+}
+
+function readMessageRow(messageId: string): { content: string; metadata: string | null } {
+  const db = getDb();
+  const row = db
+    .select({ content: messages.content, metadata: messages.metadata })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (!row) {
+    throw new Error(`message ${messageId} not found`);
+  }
+  return { content: row.content, metadata: row.metadata };
+}
+
+let editEventCounter = 0;
+function nextEditEventId(): string {
+  editEventCounter += 1;
+  return `edit-event-${Date.now()}-${editEventCounter}`;
+}
+
+describe("Slack edit propagation", () => {
+  beforeEach(() => {
+    resetTables();
+    editEventCounter = 0;
+  });
+
+  test("updates content and stamps slackMeta.editedAt when original is found", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+
+    const before = readMessageRow(seeded.messageId);
+    expect(before.content).toBe("original text");
+
+    const t0 = Date.now();
+    const resp = await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      content: "new text",
+    });
+
+    expect(resp.status).toBe(200);
+    const respJson = (await resp.json()) as Record<string, unknown>;
+    expect(respJson.accepted).toBe(true);
+    expect(respJson.duplicate).toBe(false);
+
+    const after = readMessageRow(seeded.messageId);
+    expect(after.content).toBe("new text");
+
+    expect(after.metadata).not.toBeNull();
+    const outer = JSON.parse(after.metadata!);
+    expect(outer.userMessageChannel).toBe("slack");
+    expect(typeof outer.slackMeta).toBe("string");
+
+    const slackMeta = readSlackMetadata(outer.slackMeta);
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.source).toBe("slack");
+    expect(slackMeta!.channelId).toBe(seeded.conversationExternalId);
+    expect(slackMeta!.channelTs).toBe(seeded.channelTs);
+    expect(slackMeta!.eventKind).toBe("message");
+    expect(typeof slackMeta!.editedAt).toBe("number");
+    expect(slackMeta!.editedAt!).toBeGreaterThanOrEqual(t0);
+  });
+
+  test("is idempotent across successive edits", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+
+    await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      content: "first edit",
+    });
+
+    const afterFirst = readMessageRow(seeded.messageId);
+    expect(afterFirst.content).toBe("first edit");
+    const firstSlackMeta = readSlackMetadata(
+      (JSON.parse(afterFirst.metadata!) as Record<string, unknown>).slackMeta as
+        | string
+        | null,
+    );
+    expect(firstSlackMeta).not.toBeNull();
+    const firstEditedAt = firstSlackMeta!.editedAt!;
+
+    // Ensure the second edit's timestamp is observably after the first so the
+    // assertion below proves the field was re-stamped, not stale.
+    await Bun.sleep(2);
+
+    await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      content: "second edit",
+    });
+
+    const afterSecond = readMessageRow(seeded.messageId);
+    expect(afterSecond.content).toBe("second edit");
+    const secondSlackMeta = readSlackMetadata(
+      (JSON.parse(afterSecond.metadata!) as Record<string, unknown>).slackMeta as
+        | string
+        | null,
+    );
+    expect(secondSlackMeta).not.toBeNull();
+    expect(secondSlackMeta!.editedAt!).toBeGreaterThan(firstEditedAt);
+    // Other fields stay stable across edits.
+    expect(secondSlackMeta!.channelId).toBe(seeded.conversationExternalId);
+    expect(secondSlackMeta!.channelTs).toBe(seeded.channelTs);
+    expect(secondSlackMeta!.eventKind).toBe("message");
+  });
+
+  // The lookup retries 5 times with 2s backoff (~10s total) before giving up,
+  // so this test legitimately needs to outrun the default 5s per-test timeout.
+  test(
+    "missing-target edit is a no-op (no throw, no row changed)",
+    async () => {
+      const seeded = await seedSlackMessage({
+        conversationExternalId: "C0123CHANNEL",
+        channelTs: "1234.5678",
+        initialContent: "original text",
+      });
+      const beforeUnknown = readMessageRow(seeded.messageId);
+
+      const resp = await handleEditIntercept({
+        sourceChannel: "slack",
+        conversationExternalId: seeded.conversationExternalId,
+        // sourceMessageId points at a ts that was never stored.
+        externalMessageId: nextEditEventId(),
+        sourceMessageId: "9999.0000",
+        canonicalAssistantId: "self",
+        assistantId: "self",
+        content: "new text",
+      });
+
+      expect(resp.status).toBe(200);
+      const respJson = (await resp.json()) as Record<string, unknown>;
+      expect(respJson.accepted).toBe(true);
+      expect(respJson.duplicate).toBe(false);
+
+      const afterUnknown = readMessageRow(seeded.messageId);
+      expect(afterUnknown.content).toBe(beforeUnknown.content);
+      expect(afterUnknown.metadata).toBe(beforeUnknown.metadata);
+    },
+    30_000,
+  );
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1457,6 +1457,39 @@ export function updateMessageMetadata(
 }
 
 /**
+ * Atomically update both `content` and (shallow-merged) `metadata` for a
+ * message. Used by edit-propagation paths that need to update the message
+ * body and stamp metadata (e.g. `slackMeta.editedAt`) in a single
+ * transaction so a partial write cannot leak.
+ *
+ * `metadataUpdates` is shallow-merged into the existing top-level metadata
+ * object. To merge into a nested sub-key (e.g. `slackMeta`), the caller
+ * must compute the merged sub-value first and pass `{ slackMeta: merged }`.
+ */
+export function updateMessageContentAndMetadata(
+  messageId: string,
+  newContent: string,
+  metadataUpdates: Record<string, unknown>,
+): void {
+  const db = getDb();
+  db.transaction((tx) => {
+    const row = tx
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .get();
+    const existing = row?.metadata ? JSON.parse(row.metadata) : {};
+    tx.update(messages)
+      .set({
+        content: newContent,
+        metadata: JSON.stringify({ ...existing, ...metadataUpdates }),
+      })
+      .where(eq(messages.id, messageId))
+      .run();
+  });
+}
+
+/**
  * Re-link all attachments from a set of source messages to a target message.
  * Used during message consolidation so that attachments linked to deleted
  * messages survive the ON DELETE CASCADE on message_attachments.

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -7,13 +7,25 @@
  * webhook arrives before the original message has been linked via
  * linkMessage (the original agent loop may still be in progress).
  *
+ * For Slack edits, the stage additionally stamps `slackMeta.editedAt` into
+ * the message's metadata via a single transactional content+metadata update,
+ * so downstream renderers can surface the edited marker.
+ *
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
 import type { ChannelId } from "../../../channels/types.js";
 import { touchContactInteraction } from "../../../contacts/contacts-write.js";
-import { updateMessageContent } from "../../../memory/conversation-crud.js";
+import {
+  getMessageById,
+  updateMessageContent,
+  updateMessageContentAndMetadata,
+} from "../../../memory/conversation-crud.js";
 import * as deliveryCrud from "../../../memory/delivery-crud.js";
+import {
+  mergeSlackMetadata,
+  readSlackMetadata,
+} from "../../../messaging/providers/slack/message-metadata.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("runtime-http");
@@ -106,16 +118,45 @@ export async function handleEditIntercept(
   }
 
   if (original) {
-    updateMessageContent(original.messageId, content ?? "");
+    if (sourceChannel === "slack") {
+      // Slack edits stamp `slackMeta.editedAt` so the chronological
+      // transcript renderer can surface the edited marker. The merge
+      // tolerates rows that pre-date PR 11's slackMeta enrichment by
+      // synthesizing the minimum-required fields from the lookup data.
+      applySlackEditMetadata({
+        messageId: original.messageId,
+        conversationExternalId,
+        sourceMessageId,
+        newContent: content ?? "",
+      });
+    } else {
+      updateMessageContent(original.messageId, content ?? "");
+    }
     log.info(
       { assistantId, sourceMessageId, messageId: original.messageId },
       "Updated message content from edited_message",
     );
   } else {
-    log.warn(
-      { assistantId, sourceChannel, conversationExternalId, sourceMessageId },
-      "Could not find original message for edit after retries, ignoring",
-    );
+    // For Slack, treat missing-target edits as `debug` (the row may have
+    // been compacted, never stored, or pre-date this upgrade); for other
+    // channels, retain the louder `warn` since their edit pipelines
+    // historically expect the row to exist.
+    if (sourceChannel === "slack") {
+      log.debug(
+        {
+          assistantId,
+          sourceChannel,
+          channelId: conversationExternalId,
+          externalMessageId: sourceMessageId,
+        },
+        "Slack edit target not found, ignoring",
+      );
+    } else {
+      log.warn(
+        { assistantId, sourceChannel, conversationExternalId, sourceMessageId },
+        "Could not find original message for edit after retries, ignoring",
+      );
+    }
   }
 
   return Response.json({
@@ -123,4 +164,73 @@ export async function handleEditIntercept(
     duplicate: false,
     eventId: editResult.eventId,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a Slack edit to the stored message: update content and stamp
+ * `slackMeta.editedAt` in the same transaction.
+ *
+ * If the row already has a valid `slackMeta` sub-object (post-PR-11
+ * messages), the merge preserves all existing fields and only sets/refreshes
+ * `editedAt`. If the row pre-dates `slackMeta` enrichment, the helper
+ * synthesizes the minimum-required fields (`source`, `channelId`,
+ * `channelTs`, `eventKind`) from the values that brought us here so the
+ * resulting metadata is still readable by `readSlackMetadata`.
+ */
+function applySlackEditMetadata(params: {
+  messageId: string;
+  conversationExternalId: string;
+  sourceMessageId: string;
+  newContent: string;
+}): void {
+  const { messageId, conversationExternalId, sourceMessageId, newContent } =
+    params;
+
+  const row = getMessageById(messageId);
+  const outerMetadata: Record<string, unknown> =
+    row?.metadata != null ? safeParseRecord(row.metadata) : {};
+  const existingSlackMeta =
+    typeof outerMetadata.slackMeta === "string"
+      ? outerMetadata.slackMeta
+      : undefined;
+
+  const editedAt = Date.now();
+  const parsedExisting = readSlackMetadata(existingSlackMeta ?? null);
+
+  // For pre-PR-11 rows (no valid existing slackMeta), `mergeSlackMetadata`
+  // would produce a record missing the required fields and fail subsequent
+  // `readSlackMetadata` calls. Seed defaults from the lookup-derived facts
+  // so the post-merge value is always a valid `SlackMessageMetadata`.
+  const mergedSlackMeta = mergeSlackMetadata(existingSlackMeta ?? null, {
+    ...(parsedExisting
+      ? {}
+      : {
+          source: "slack" as const,
+          channelId: conversationExternalId,
+          channelTs: sourceMessageId,
+          eventKind: "message" as const,
+        }),
+    editedAt,
+  });
+
+  updateMessageContentAndMetadata(messageId, newContent, {
+    slackMeta: mergedSlackMeta,
+  });
+}
+
+/** Tolerant JSON.parse that returns `{}` for invalid or non-object payloads. */
+function safeParseRecord(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary
- Detects isEdit=true; looks up original via channel_inbound_events.externalMessageId = source.messageId
- Updates messages.content and stamps slackMeta.editedAt
- Missing-target edits are a no-op with debug log

Part of plan: slack-thread-aware-context.md (PR 14 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
