### PR TITLE
feat(slack): persist thread metadata on inbound Slack messages

### DIFF
--- a/assistant/src/__tests__/inbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/inbound-slack-persistence.test.ts
@@ -1,0 +1,340 @@
+/**
+ * PR 11 — verifies that inbound Slack messages persist a `slackMeta`
+ * sub-object on the row's metadata column, sourced from gateway-forwarded
+ * `sourceMetadata.threadId` (the field PR 2 added) and the message's own
+ * Slack `ts` (`sourceMetadata.messageId`).
+ *
+ * The test exercises the persistence layer directly via
+ * `persistQueuedMessageBody` rather than spinning up the full HTTP stack:
+ *   - `Server.processMessage` materializes `slackInbound` into the
+ *     `metadata` parameter passed to `Conversation.persistUserMessage`,
+ *     which delegates to this function.
+ *   - The wiring between the HTTP handler and that call is type-checked
+ *     end-to-end (see `inbound-message-handler.ts:705`,
+ *     `background-dispatch.ts:188`, `server.ts:1652`).
+ *
+ * A non-Slack control case asserts that the enrichment is silent for other
+ * channels — no `slackMeta` key appears in the persisted metadata.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede module imports under test)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const addMessageCalls: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}> = [];
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => {
+    addMessageCalls.push({ conversationId, role, content, metadata });
+    return { id: `persisted-${addMessageCalls.length}` };
+  },
+  getConversation: () => null,
+  provenanceFromTrustContext: () => ({}),
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+  updateMetaFile: () => {},
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  attachmentExists: () => false,
+  linkAttachmentToMessage: () => {},
+  attachInlineAttachmentToMessage: () => {},
+  validateAttachmentUpload: () => ({ ok: true }),
+  AttachmentUploadError: class extends Error {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import type {
+  TurnChannelContext,
+  TurnInterfaceContext,
+} from "../channels/types.js";
+import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
+import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
+import type { MessageQueue } from "../daemon/conversation-queue-manager.js";
+import {
+  readSlackMetadata,
+  type SlackMessageMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestContext(
+  turnChannel: TurnChannelContext | null,
+): MessagingConversationContext {
+  const queueStub = {
+    push: () => true,
+    drain: () => [],
+    size: () => 0,
+  } as unknown as MessageQueue;
+
+  const turnIfCtx: TurnInterfaceContext | null = turnChannel
+    ? {
+        userMessageInterface: "slack",
+        assistantMessageInterface: "slack",
+      }
+    : null;
+
+  return {
+    conversationId: "conv-test",
+    messages: [],
+    processing: false,
+    abortController: null,
+    queue: queueStub,
+    getTurnChannelContext: () => turnChannel,
+    getTurnInterfaceContext: () => turnIfCtx,
+  };
+}
+
+function lastPersistedMetadata(): Record<string, unknown> {
+  expect(addMessageCalls.length).toBeGreaterThan(0);
+  const metadata = addMessageCalls.at(-1)?.metadata;
+  expect(metadata).toBeDefined();
+  return metadata!;
+}
+
+function readPersistedSlackMeta(): SlackMessageMetadata | null {
+  const metadata = lastPersistedMetadata();
+  const raw = metadata.slackMeta;
+  if (raw === undefined) return null;
+  expect(typeof raw).toBe("string");
+  return readSlackMetadata(raw as string);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PR 11 — inbound Slack message metadata persistence", () => {
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+  });
+
+  test("Slack thread reply: slackMeta.threadTs reflects sourceMetadata.threadId", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Reply inside a thread",
+      [],
+      "req-thread",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000001.111111",
+          threadTs: "1700000000.000001",
+          displayName: "Alice",
+        },
+      },
+      undefined,
+    );
+
+    const slackMeta = readPersistedSlackMeta();
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.source).toBe("slack");
+    expect(slackMeta!.eventKind).toBe("message");
+    expect(slackMeta!.channelId).toBe("C0123CHANNEL");
+    expect(slackMeta!.channelTs).toBe("1700000001.111111");
+    expect(slackMeta!.threadTs).toBe("1700000000.000001");
+    expect(slackMeta!.displayName).toBe("Alice");
+  });
+
+  test("Slack top-level message: slackMeta has no threadTs", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Top-level channel post",
+      [],
+      "req-top",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000010.222222",
+          displayName: "Bob",
+        },
+      },
+      undefined,
+    );
+
+    const slackMeta = readPersistedSlackMeta();
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.channelTs).toBe("1700000010.222222");
+    expect(slackMeta!.threadTs).toBeUndefined();
+    expect(slackMeta!.displayName).toBe("Bob");
+  });
+
+  test("Slack message without displayName omits the field", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Anonymous channel post",
+      [],
+      "req-anon",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000020.333333",
+        },
+      },
+      undefined,
+    );
+
+    const slackMeta = readPersistedSlackMeta();
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.displayName).toBeUndefined();
+  });
+
+  test("non-Slack channel (telegram): no slackMeta key in persisted metadata", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "telegram",
+      assistantMessageChannel: "telegram",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Telegram message",
+      [],
+      "req-tg",
+      undefined,
+      undefined,
+    );
+
+    const metadata = lastPersistedMetadata();
+    expect("slackMeta" in metadata).toBe(false);
+    expect(metadata.userMessageChannel).toBe("telegram");
+  });
+
+  test("non-Slack channel (telegram) ignores stale slackInbound carrier", async () => {
+    // Defense-in-depth: even if a caller mistakenly forwards `slackInbound`
+    // alongside a non-Slack channel, persistence must not emit `slackMeta`.
+    // The carrier field itself is stripped from the persisted metadata.
+    const ctx = createTestContext({
+      userMessageChannel: "telegram",
+      assistantMessageChannel: "telegram",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Telegram message with stray slackInbound",
+      [],
+      "req-tg-stray",
+      {
+        slackInbound: {
+          channelId: "C0_DOES_NOT_APPLY",
+          channelTs: "1700000030.444444",
+        },
+      },
+      undefined,
+    );
+
+    const metadata = lastPersistedMetadata();
+    expect("slackMeta" in metadata).toBe(false);
+    expect("slackInbound" in metadata).toBe(false);
+  });
+
+  test("Slack channel without slackInbound: no slackMeta key", async () => {
+    // A Slack-originated turn that lacked the inbound metadata (e.g. a
+    // signal-injected wake) must not emit a `slackMeta` field — readers
+    // already tolerate its absence (the renderer's legacy fallback).
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Slack wake without inbound metadata",
+      [],
+      "req-no-slack-inbound",
+      undefined,
+      undefined,
+    );
+
+    const metadata = lastPersistedMetadata();
+    expect("slackMeta" in metadata).toBe(false);
+  });
+
+  test("Slack channel with malformed slackInbound (missing channelTs): no slackMeta", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Malformed inbound payload",
+      [],
+      "req-malformed",
+      {
+        slackInbound: {
+          // channelTs intentionally missing — simulates a bug upstream.
+          channelId: "C0123CHANNEL",
+        } as unknown as Record<string, unknown>,
+      },
+      undefined,
+    );
+
+    const metadata = lastPersistedMetadata();
+    expect("slackMeta" in metadata).toBe(false);
+  });
+
+  test("transient slackInbound carrier never appears in persisted metadata", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "Verify carrier is stripped",
+      [],
+      "req-strip",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000040.555555",
+        },
+      },
+      undefined,
+    );
+
+    const metadata = lastPersistedMetadata();
+    expect("slackInbound" in metadata).toBe(false);
+    expect("slackMeta" in metadata).toBe(true);
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -32,11 +32,16 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { TrustContext } from "./conversation-runtime-assembly.js";
+import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
 import type {
   ServerMessage,
   UserMessageAttachment,
@@ -210,6 +215,53 @@ function extractTurnInterfaceContext(
   return { userMessageInterface, assistantMessageInterface };
 }
 
+/**
+ * Build the Slack metadata envelope persisted under the `slackMeta` key on a
+ * user message's `metadata` JSON. Returns `null` (do not include the key) when
+ * the turn is not Slack-originated or the channel ingress did not supply
+ * Slack-specific metadata.
+ *
+ * The conversation is the source of truth for the inbound channel for this
+ * turn — `userMessageChannel` is set by `Server.processMessage` from
+ * `transport.channelId`. Guarding on this ensures non-Slack flows (telegram,
+ * voice, etc.) never get a `slackMeta` key even if a stale plumbing field
+ * leaks through.
+ */
+function buildSlackMetaForPersistence(params: {
+  slackInbound: unknown;
+  turnChannel: string | undefined;
+}): string | null {
+  if (params.turnChannel !== "slack") {
+    return null;
+  }
+  const inbound = params.slackInbound;
+  if (
+    inbound === null ||
+    typeof inbound !== "object" ||
+    Array.isArray(inbound)
+  ) {
+    return null;
+  }
+  const candidate = inbound as Partial<SlackInboundMessageMetadata>;
+  if (
+    typeof candidate.channelId !== "string" ||
+    !candidate.channelId ||
+    typeof candidate.channelTs !== "string" ||
+    !candidate.channelTs
+  ) {
+    return null;
+  }
+  const slackMeta: SlackMessageMetadata = {
+    source: "slack",
+    channelId: candidate.channelId,
+    channelTs: candidate.channelTs,
+    eventKind: "message",
+    ...(candidate.threadTs ? { threadTs: candidate.threadTs } : {}),
+    ...(candidate.displayName ? { displayName: candidate.displayName } : {}),
+  };
+  return writeSlackMetadata(slackMeta);
+}
+
 // ── enqueueMessage ───────────────────────────────────────────────────
 
 export function enqueueMessage(
@@ -362,8 +414,22 @@ export async function persistQueuedMessageBody(
       }
     }
 
+    // Strip the transient `slackInbound` carrier key from the persisted
+    // metadata — it's an in-memory plumbing field, not a stored column value.
+    // The caller-supplied metadata may include it (channel ingress threads it
+    // through `Server.processMessage`); we materialize it into the typed
+    // `slackMeta` sub-key below when the turn channel is Slack.
+    const { slackInbound: rawSlackInbound, ...metadataWithoutSlackInbound } =
+      (metadata ?? {}) as Record<string, unknown> & {
+        slackInbound?: SlackInboundMessageMetadata;
+      };
+    const slackMeta = buildSlackMetaForPersistence({
+      slackInbound: rawSlackInbound,
+      turnChannel: turnCtx?.userMessageChannel,
+    });
+
     const mergedMetadata = {
-      ...(metadata ?? {}),
+      ...metadataWithoutSlackInbound,
       ...provenance,
       ...(turnCtx
         ? {
@@ -378,6 +444,7 @@ export async function persistQueuedMessageBody(
           }
         : {}),
       ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
+      ...(slackMeta ? { slackMeta } : {}),
     };
 
     // When displayContent is provided (e.g. original text before recording

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -103,6 +103,22 @@ export interface RenderedHistoryContent {
 }
 
 /**
+ * Slack-specific metadata extracted at the inbound HTTP boundary and threaded
+ * through to user-message persistence so the row can be tagged with a
+ * `slackMeta` envelope (consumed by the chronological renderer in later PRs).
+ */
+export interface SlackInboundMessageMetadata {
+  /** Slack channel id (conversation external id) — recorded as `channelId`. */
+  channelId: string;
+  /** Slack `ts` for this message — required so persistence can record `channelTs`. */
+  channelTs: string;
+  /** Parent `thread_ts` when the message lives inside a thread; absent for top-level. */
+  threadTs?: string;
+  /** Resolved sender label (display name preferred, username fallback). */
+  displayName?: string;
+}
+
+/**
  * Optional overrides for conversation creation (e.g. interview mode).
  */
 export interface ConversationCreateOptions {
@@ -141,6 +157,13 @@ export interface ConversationCreateOptions {
    * `resolveCallSiteConfig` instead of the global default.
    */
   callSite?: LLMCallSite;
+  /**
+   * Slack inbound metadata captured at the channel ingress boundary. When
+   * present (and the turn channel resolves to Slack), persistence writes a
+   * `slackMeta` sub-object into the message's `metadata` JSON for the
+   * chronological renderer to consume.
+   */
+  slackInbound?: SlackInboundMessageMetadata;
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1649,10 +1649,17 @@ export class DaemonServer {
     const resolvedContent = slashResult.content;
 
     const requestId = crypto.randomUUID();
+    // Slack inbound metadata captured at the channel ingress boundary is
+    // forwarded into the persistence call so `persistQueuedMessageBody` can
+    // emit a `slackMeta` envelope on the row's metadata column.
+    const persistMetadata = options?.slackInbound
+      ? { slackInbound: options.slackInbound }
+      : undefined;
     const messageId = await conversation.persistUserMessage(
       resolvedContent,
       attachments,
       requestId,
+      persistMetadata,
     );
 
     // Register pending interactions so channel approval interception can

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -6,7 +6,14 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
-import type { ConversationCreateOptions } from "../daemon/handlers/shared.js";
+import type {
+  ConversationCreateOptions,
+  SlackInboundMessageMetadata,
+} from "../daemon/handlers/shared.js";
+
+// Re-export so route modules (background-dispatch, etc.) can pull the type
+// from the runtime barrel without reaching into daemon internals.
+export type { SlackInboundMessageMetadata };
 import type { SkillOperationContext } from "../daemon/handlers/skills.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type {
@@ -140,6 +147,13 @@ export interface RuntimeMessageConversationOptions {
    * literals into specific call paths.
    */
   callSite?: LLMCallSite;
+  /**
+   * Slack inbound metadata captured at the channel ingress boundary. When
+   * present (and the turn channel resolves to Slack), persistence writes a
+   * `slackMeta` sub-object into the message's `metadata` JSON for the
+   * chronological renderer to consume.
+   */
+  slackInbound?: SlackInboundMessageMetadata;
 }
 
 export type MessageProcessor = (

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -698,6 +698,32 @@ export async function handleChannelInbound(
         heartbeatService?.resetTimer();
       }
 
+      // Slack inbound metadata captured for thread-aware persistence. The
+      // gateway forwards `thread_ts` under `sourceMetadata.threadId` (PR 2)
+      // and the message's own ts under `sourceMetadata.messageId`. Persistence
+      // turns this into a `slackMeta` sub-object in the row's metadata column
+      // so the chronological renderer in later PRs can reconstruct thread
+      // structure without re-fetching from Slack.
+      const slackThreadTs =
+        sourceChannel === "slack" &&
+        typeof sourceMetadata?.threadId === "string"
+          ? sourceMetadata.threadId
+          : undefined;
+      const slackInbound =
+        sourceChannel === "slack"
+          ? {
+              channelId: conversationExternalId,
+              channelTs: sourceMessageId ?? externalMessageId,
+              ...(slackThreadTs ? { threadTs: slackThreadTs } : {}),
+              ...(body.actorDisplayName ?? body.actorUsername
+                ? {
+                    displayName:
+                      body.actorDisplayName ?? body.actorUsername!,
+                  }
+                : {}),
+            }
+          : undefined;
+
       // Fire-and-forget: process the message and deliver the reply in the background.
       // The HTTP response returns immediately so the gateway webhook is not blocked.
       // The onEvent callback in processMessage registers pending interactions, and
@@ -721,6 +747,7 @@ export async function handleChannelInbound(
         assistantId: canonicalAssistantId,
         approvalCopyGenerator,
         chatType: sourceChatType,
+        slackInbound,
       });
     }
   }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -31,6 +31,7 @@ import { deliverChannelReply } from "../../gateway-client.js";
 import type {
   ApprovalCopyGenerator,
   MessageProcessor,
+  SlackInboundMessageMetadata,
 } from "../../http-types.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
 import { deliverReplyViaCallback } from "../channel-delivery-routes.js";
@@ -78,6 +79,12 @@ export interface BackgroundProcessingParams {
   sourceLanguageCode?: string;
   /** Chat type from the gateway (e.g. "private", "group", "supergroup"). */
   chatType?: string;
+  /**
+   * Slack-specific inbound metadata extracted at the HTTP boundary. Threaded
+   * through to `persistUserMessage` so the row can be tagged with a
+   * `slackMeta` envelope for the chronological renderer.
+   */
+  slackInbound?: SlackInboundMessageMetadata;
 }
 
 /**
@@ -106,6 +113,7 @@ export function processChannelMessageInBackground(
     commandIntent,
     sourceLanguageCode,
     chatType,
+    slackInbound,
   } = params;
 
   (async () => {
@@ -200,6 +208,7 @@ export function processChannelMessageInBackground(
           trustContext: trustCtx,
           isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
+          ...(slackInbound ? { slackInbound } : {}),
         },
         sourceChannel,
         sourceInterface,


### PR DESCRIPTION
## Summary
- Writes slackMeta sub-object into messages.metadata for every Slack inbound
- Sources channelTs from source.messageId; threadTs from sourceMetadata.threadId (via PR 2)
- Non-Slack channels unchanged

Part of plan: slack-thread-aware-context.md (PR 11 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
