### PR TITLE
feat(slack): render reaction events inline in the chronological transcript

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -246,6 +246,51 @@ describe("renderSlackTranscript — reaction cap", () => {
   });
 });
 
+// ── mixed message + reaction chronology ─────────────────────────────────────
+
+describe("renderSlackTranscript — mixed message + reaction chronology", () => {
+  test("reaction renders inline at correct chronological position", () => {
+    // Order of events as they happened in time:
+    //   14:25 — alice posts the parent
+    //   14:26 — bob posts a follow-up message
+    //   14:28 — carol reacts to alice's parent
+    //   14:30 — dan posts another message
+    // Inputs are intentionally shuffled so the renderer must sort.
+    const aliasParent = parentAlias(TS_14_25);
+    const out = renderSlackTranscript([
+      reactionMsg(TS_14_28, "@carol", "👍", TS_14_25, "added"),
+      userMsg(TS_14_30, "@dan", "later"),
+      userMsg(TS_14_25, "@alice", "lunch?"),
+      userMsg(TS_14_26, "@bob", "yes"),
+    ]);
+    expect(out.map((r) => r.content)).toEqual([
+      "[14:25 @alice]: lunch?",
+      "[14:26 @bob]: yes",
+      `[14:28 @carol reacted 👍 to ${aliasParent}]`,
+      "[14:30 @dan]: later",
+    ]);
+  });
+
+  test("removed reactions interleave with messages by their own ts", () => {
+    // A reaction is added at 14:26 then removed at 14:30; bob posts a message
+    // at 14:28 in between. The "removed" line must land between bob's message
+    // and dan's later message, not collapsed beside the "added" line.
+    const aliasParent = parentAlias(TS_14_25);
+    const out = renderSlackTranscript([
+      userMsg(TS_14_25, "@alice", "lunch?"),
+      reactionMsg("1699971960.000010", "@carol", "👍", TS_14_25, "added"),
+      userMsg(TS_14_28, "@bob", "yes"),
+      reactionMsg(TS_14_30, "@carol", "👍", TS_14_25, "removed"),
+    ]);
+    expect(out.map((r) => r.content)).toEqual([
+      "[14:25 @alice]: lunch?",
+      `[14:26 @carol reacted 👍 to ${aliasParent}]`,
+      "[14:28 @bob]: yes",
+      `[14:30 @carol removed 👍 from ${aliasParent}]`,
+    ]);
+  });
+});
+
 // ── sort stability ───────────────────────────────────────────────────────────
 
 describe("renderSlackTranscript — sort", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -16,27 +16,7 @@
 
 import { createHash } from "node:crypto";
 
-// TODO(slack-thread-ctx PR 1): replace this local type with an import from
-// `./message-metadata.js` once PR 1 lands. The shape is duplicated here so
-// PR 6 can compile in isolation; both files agree on the schema.
-type SlackEventKind = "message" | "reaction";
-
-interface SlackMessageMetadata {
-  readonly source: "slack";
-  readonly channelId: string;
-  readonly channelTs: string;
-  readonly threadTs?: string;
-  readonly displayName?: string;
-  readonly eventKind: SlackEventKind;
-  readonly reaction?: {
-    readonly emoji: string;
-    readonly actorDisplayName?: string;
-    readonly targetChannelTs: string;
-    readonly op: "added" | "removed";
-  };
-  readonly editedAt?: number;
-  readonly deletedAt?: number;
-}
+import type { SlackMessageMetadata } from "./message-metadata.js";
 
 export interface RenderableSlackMessage {
   role: "user" | "assistant";


### PR DESCRIPTION
## Summary
- Extends renderSlackTranscript for reaction event kind
- [@actor reacted/removed <emoji> to M<alias>] formatting
- Cap enforced per target message

Part of plan: slack-thread-aware-context.md (PR 18 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
