### PR TITLE
feat(slack): lazily backfill DM history when assistant has no prior records

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -1,0 +1,344 @@
+/**
+ * PR 23 — verifies that the daemon lazily backfills DM history the first
+ * time a Slack DM lands in a "cold" conversation (one with fewer than the
+ * warm-storage threshold of stored slackMeta messages).
+ *
+ * Behaviour under test (see `inbound-message-handler.ts`):
+ *  - On a fresh DM, `backfillDm` is invoked exactly once and every returned
+ *    message is persisted as a `messages` row with a `slackMeta` envelope.
+ *  - Once warm storage exceeds the threshold, subsequent inbound DMs do
+ *    not re-trigger backfill.
+ *  - When `backfillDm` throws, the turn proceeds without a crash and
+ *    nothing extra is persisted.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede module imports under test)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async () => {},
+}));
+
+import type { Message } from "../messaging/provider-types.js";
+
+// `backfillDm` is the only piece of the slack provider surface this test
+// needs to control. Mocking it directly keeps the test focused on the
+// cold-start logic in the handler and avoids pulling in adapter wiring.
+type BackfillDmFn = (
+  channelId: string,
+  opts?: { limit?: number; before?: string },
+) => Promise<Message[]>;
+
+const backfillDmMock = mock<BackfillDmFn>(async () => []);
+const backfillThreadMock = mock(async () => [] as Message[]);
+
+mock.module("../messaging/providers/slack/backfill.js", () => ({
+  backfillDm: (channelId: string, opts?: { limit?: number; before?: string }) =>
+    backfillDmMock(channelId, opts),
+  backfillThread: () => backfillThreadMock(),
+}));
+
+import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { getDb, initializeDb } from "../memory/db.js";
+import { messages } from "../memory/schema/conversations.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BEARER_TOKEN = "test-token";
+const SLACK_DM_CHANNEL_ID = "D0BACKFILL";
+const SLACK_DM_USER_ID = "U_DM_USER";
+const SLACK_DM_DISPLAY_NAME = "DM Sender";
+
+function resetState(): void {
+  const db = getDb();
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+  db.run("DELETE FROM external_conversation_bindings");
+}
+
+function seedActiveMember(): void {
+  upsertContactChannel({
+    sourceChannel: "slack",
+    externalUserId: SLACK_DM_USER_ID,
+    externalChatId: SLACK_DM_CHANNEL_ID,
+    status: "active",
+    policy: "allow",
+    displayName: SLACK_DM_DISPLAY_NAME,
+  });
+}
+
+let msgCounter = 0;
+
+function buildDmRequest(
+  text: string,
+  overrides: Record<string, unknown> = {},
+): Request {
+  msgCounter++;
+  const ts = `1700000000.${String(100000 + msgCounter).padStart(6, "0")}`;
+  const body: Record<string, unknown> = {
+    sourceChannel: "slack",
+    interface: "slack",
+    conversationExternalId: SLACK_DM_CHANNEL_ID,
+    externalMessageId: `${SLACK_DM_CHANNEL_ID}:${ts}`,
+    content: text,
+    actorExternalId: SLACK_DM_USER_ID,
+    actorDisplayName: SLACK_DM_DISPLAY_NAME,
+    actorUsername: "dm_user",
+    replyCallbackUrl: "http://localhost:7830/deliver/slack",
+    sourceMetadata: {
+      messageId: ts,
+      // Critical — the cold-start trigger requires `chatType: "im"`.
+      chatType: "im",
+    },
+    ...overrides,
+  };
+  return new Request("http://localhost:8080/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": TEST_BEARER_TOKEN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function readPersistedSlackRows(): Array<{
+  role: string;
+  content: string;
+  metadata: string | null;
+}> {
+  const db = getDb();
+  return db
+    .select({
+      role: messages.role,
+      content: messages.content,
+      metadata: messages.metadata,
+    })
+    .from(messages)
+    .all();
+}
+
+function makeBackfilledMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "1700000000.090000",
+    conversationId: SLACK_DM_CHANNEL_ID,
+    sender: { id: SLACK_DM_USER_ID, name: "Backfilled Sender" },
+    text: "older message",
+    timestamp: 1700000000_000,
+    platform: "slack",
+    ...overrides,
+  };
+}
+
+function noopProcessMessage(): Promise<{ messageId: string }> {
+  // The agent loop is fire-and-forget in production, so the handler never
+  // awaits a result. Returning a sentinel is enough to satisfy the type.
+  return Promise.resolve({ messageId: "agent-stub" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PR 23 — Slack DM cold-start backfill", () => {
+  beforeEach(() => {
+    resetState();
+    seedActiveMember();
+    msgCounter = 0;
+    backfillDmMock.mockReset();
+    backfillDmMock.mockImplementation(async () => []);
+    backfillThreadMock.mockReset();
+  });
+
+  test("first DM in cold conversation triggers backfill exactly once and persists history", async () => {
+    const olderMessages: Message[] = [
+      makeBackfilledMessage({
+        id: "1700000000.000001",
+        text: "older A",
+        sender: { id: SLACK_DM_USER_ID, name: "Alice" },
+      }),
+      makeBackfilledMessage({
+        id: "1700000000.000002",
+        text: "older B",
+        sender: { id: SLACK_DM_USER_ID, name: "Alice" },
+      }),
+      makeBackfilledMessage({
+        id: "1700000000.000003",
+        text: "older C",
+        sender: { id: SLACK_DM_USER_ID, name: "Alice" },
+      }),
+    ];
+    backfillDmMock.mockImplementation(async () => olderMessages);
+
+    const req = buildDmRequest("live new DM");
+    const resp = await handleChannelInbound(
+      req,
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(backfillDmMock).toHaveBeenCalledTimes(1);
+    const [channelArg, optsArg] = backfillDmMock.mock.calls[0];
+    expect(channelArg).toBe(SLACK_DM_CHANNEL_ID);
+    expect(optsArg).toEqual({ limit: 50 });
+
+    // All three backfilled rows are persisted with a slackMeta envelope.
+    // The live new DM's row is enqueued on the agent loop's persistence path
+    // (which is mocked out here via `noopProcessMessage`), so the rows we
+    // see in storage are exactly the backfilled ones.
+    const rows = readPersistedSlackRows();
+    expect(rows.length).toBe(3);
+
+    const persistedTs = rows.map((r) => {
+      const envelope = JSON.parse(r.metadata!) as Record<string, unknown>;
+      const meta = readSlackMetadata(envelope.slackMeta as string);
+      expect(meta).not.toBeNull();
+      expect(meta!.source).toBe("slack");
+      expect(meta!.eventKind).toBe("message");
+      expect(meta!.channelId).toBe(SLACK_DM_CHANNEL_ID);
+      return meta!.channelTs;
+    });
+    expect(new Set(persistedTs)).toEqual(
+      new Set([
+        "1700000000.000001",
+        "1700000000.000002",
+        "1700000000.000003",
+      ]),
+    );
+
+    // Backfilled rows preserve their original text content so the renderer
+    // has something to display.
+    const texts = rows.map((r) => r.content).sort();
+    expect(texts).toEqual(["older A", "older B", "older C"]);
+  });
+
+  test("warm storage prevents re-trigger on subsequent DMs", async () => {
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({ id: "1700000000.000001", text: "older A" }),
+      makeBackfilledMessage({ id: "1700000000.000002", text: "older B" }),
+      makeBackfilledMessage({ id: "1700000000.000003", text: "older C" }),
+    ]);
+
+    // First inbound: cold path, fires backfill.
+    await handleChannelInbound(
+      buildDmRequest("first live DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(backfillDmMock).toHaveBeenCalledTimes(1);
+    const rowsAfterFirst = readPersistedSlackRows();
+    expect(rowsAfterFirst.length).toBe(3);
+
+    // Second inbound: storage now has three slackMeta-tagged rows from the
+    // backfill, which meets the warm threshold. Backfill MUST NOT be
+    // re-invoked.
+    const resp2 = await handleChannelInbound(
+      buildDmRequest("second live DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(resp2.status).toBe(200);
+    expect(backfillDmMock).toHaveBeenCalledTimes(1);
+    expect(readPersistedSlackRows().length).toBe(3);
+  });
+
+  test("backfill failure is non-fatal: turn proceeds without crash", async () => {
+    backfillDmMock.mockImplementation(async () => {
+      throw new Error("Slack API error: rate_limited");
+    });
+
+    const resp = await handleChannelInbound(
+      buildDmRequest("live DM despite backfill failure"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(resp.status).toBe(200);
+    expect(json.accepted).toBe(true);
+    expect(json.duplicate).toBe(false);
+    expect(backfillDmMock).toHaveBeenCalledTimes(1);
+
+    // No backfilled rows persisted because the call threw.
+    const rows = readPersistedSlackRows();
+    expect(rows.length).toBe(0);
+  });
+
+  test("non-DM Slack inbound does not trigger backfill", async () => {
+    // chatType=channel must skip the cold-start branch entirely. This guards
+    // against the trigger accidentally widening to channel messages.
+    const req = buildDmRequest("channel message", {
+      sourceMetadata: {
+        messageId: "1700000000.999999",
+        chatType: "channel",
+      },
+    });
+    await handleChannelInbound(req, noopProcessMessage, TEST_BEARER_TOKEN);
+    expect(backfillDmMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("backfill skips channelTs values already stored", async () => {
+    // First DM: backfill returns three rows.
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({ id: "1700000000.000001", text: "older A" }),
+      makeBackfilledMessage({ id: "1700000000.000002", text: "older B" }),
+    ]);
+    await handleChannelInbound(
+      buildDmRequest("first live DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(readPersistedSlackRows().length).toBe(2);
+
+    // Conversation now has 2 slackMeta rows — still under the warm
+    // threshold, so a second cold-path probe should fire. This time
+    // backfill returns an overlapping set; only the new ts is written.
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({ id: "1700000000.000001", text: "older A again" }),
+      makeBackfilledMessage({ id: "1700000000.000004", text: "older D" }),
+    ]);
+    await handleChannelInbound(
+      buildDmRequest("second live DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(backfillDmMock).toHaveBeenCalledTimes(2);
+
+    const rows = readPersistedSlackRows();
+    expect(rows.length).toBe(3);
+    const texts = rows.map((r) => r.content).sort();
+    expect(texts).toEqual(["older A", "older B", "older D"]);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -22,14 +22,18 @@ import {
 import {
   addMessage,
   getMessageById,
+  getMessages,
   updateMessageMetadata,
 } from "../../memory/conversation-crud.js";
 import * as deliveryChannels from "../../memory/delivery-channels.js";
 import * as deliveryCrud from "../../memory/delivery-crud.js";
 import * as deliveryStatus from "../../memory/delivery-status.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
+import type { Message as ProviderMessage } from "../../messaging/provider-types.js";
+import { backfillDm } from "../../messaging/providers/slack/backfill.js";
 import {
   mergeSlackMetadata,
+  readSlackMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../../messaging/providers/slack/message-metadata.js";
@@ -913,6 +917,20 @@ export async function handleChannelInbound(
             }
           : undefined;
 
+      // ── DM cold-start backfill ──
+      // First time a Slack DM lands in a conversation that has fewer than
+      // SLACK_DM_BACKFILL_WARM_THRESHOLD stored slackMeta messages, fetch a
+      // window of recent history so the agent sees prior context. One-shot:
+      // once persistence warms up past the threshold, subsequent DMs no
+      // longer trigger backfill. Failures are non-fatal — the new message
+      // proceeds without backfilled history.
+      if (sourceChannel === "slack" && sourceChatType === "im") {
+        await tryBackfillSlackDmIfCold({
+          conversationId: result.conversationId,
+          channelId: conversationExternalId,
+        });
+      }
+
       // Fire-and-forget: process the message and deliver the reply in the background.
       // The HTTP response returns immediately so the gateway webhook is not blocked.
       // The onEvent callback in processMessage registers pending interactions, and
@@ -1049,4 +1067,183 @@ async function persistSlackReactionAsMessage(params: {
   );
   deliveryCrud.linkMessage(params.eventId, persisted.id);
   deliveryStatus.markProcessed(params.eventId);
+}
+
+/**
+ * Threshold of stored Slack-tagged messages below which a conversation is
+ * considered "cold" and eligible for one-shot backfill. The number is
+ * deliberately small but greater than 1 so a single sentinel row (e.g. a
+ * stale reaction) does not disqualify a conversation that has no real
+ * message history yet.
+ */
+const SLACK_DM_BACKFILL_WARM_THRESHOLD = 3;
+
+/**
+ * Count messages in a conversation whose `metadata` carries a parseable
+ * `slackMeta` envelope. Used as the warm-storage signal for cold-start
+ * backfill: any conversation with fewer than the warm threshold is treated
+ * as a candidate for one-shot history hydration.
+ *
+ * Tolerant of legacy / malformed rows: rows without metadata, with invalid
+ * JSON, or without a `slackMeta` key are skipped. Counting is intentionally
+ * cheap (no SQL JSON probing) so it stays portable across drivers.
+ */
+function countSlackMetaMessages(conversationId: string): number {
+  const rows = getMessages(conversationId);
+  let count = 0;
+  for (const row of rows) {
+    if (!row.metadata) continue;
+    let parent: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(row.metadata) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        parent = parsed as Record<string, unknown>;
+      }
+    } catch {
+      continue;
+    }
+    if (!parent) continue;
+    const raw = parent.slackMeta;
+    if (typeof raw !== "string") continue;
+    if (readSlackMetadata(raw)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Build the set of `slackMeta.channelTs` values already stored on a
+ * conversation. Used to dedupe backfilled rows so a partial prior backfill
+ * (or a single message that was already persisted via the live ingress
+ * path) does not double-write.
+ */
+function readStoredSlackChannelTs(conversationId: string): Set<string> {
+  const seen = new Set<string>();
+  for (const row of getMessages(conversationId)) {
+    if (!row.metadata) continue;
+    let parent: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(row.metadata) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        parent = parsed as Record<string, unknown>;
+      }
+    } catch {
+      continue;
+    }
+    if (!parent) continue;
+    const raw = parent.slackMeta;
+    if (typeof raw !== "string") continue;
+    const meta = readSlackMetadata(raw);
+    if (meta) seen.add(meta.channelTs);
+  }
+  return seen;
+}
+
+/**
+ * Persist a single backfilled Slack message as a `messages` row with a
+ * `slackMeta` envelope.
+ *
+ * This is the shared insertion point for any path that hydrates history
+ * lazily (DM cold-start backfill in this PR; thread gap backfill in a
+ * follow-up PR can route through the same helper). Backfilled rows are
+ * always recorded with role `"user"` — the renderer reads `slackMeta` to
+ * format author / timestamp / thread context, so the role distinction is
+ * not used for display. Caller is responsible for dedup checks before
+ * invoking; this helper performs no idempotency check itself.
+ */
+async function persistBackfilledSlackMessage(params: {
+  conversationId: string;
+  channelId: string;
+  message: ProviderMessage;
+}): Promise<void> {
+  const { message } = params;
+  const slackMeta: SlackMessageMetadata = {
+    source: "slack",
+    channelId: params.channelId,
+    channelTs: message.id,
+    eventKind: "message",
+    ...(message.threadId ? { threadTs: message.threadId } : {}),
+    ...(message.sender.name ? { displayName: message.sender.name } : {}),
+  };
+  await addMessage(params.conversationId, "user", message.text ?? "", {
+    slackMeta: writeSlackMetadata(slackMeta),
+  });
+}
+
+/**
+ * One-shot DM cold-start backfill. When a Slack DM lands in a conversation
+ * with fewer than `SLACK_DM_BACKFILL_WARM_THRESHOLD` stored Slack-tagged
+ * messages, fetch a window of recent history via `backfillDm` and persist
+ * each returned message with a `slackMeta` envelope. Already-stored
+ * messages (matched by `slackMeta.channelTs`) are skipped to keep the
+ * operation idempotent across retries.
+ *
+ * Failure semantics: any error is logged at WARN and swallowed. The caller
+ * proceeds with only the new message.
+ */
+async function tryBackfillSlackDmIfCold(params: {
+  conversationId: string;
+  channelId: string;
+}): Promise<void> {
+  try {
+    const storedCount = countSlackMetaMessages(params.conversationId);
+    if (storedCount >= SLACK_DM_BACKFILL_WARM_THRESHOLD) {
+      return;
+    }
+
+    const fetched = await backfillDm(params.channelId, { limit: 50 });
+    if (fetched.length === 0) {
+      log.debug(
+        { conversationId: params.conversationId, channelId: params.channelId },
+        "DM backfill returned no messages",
+      );
+      return;
+    }
+
+    const seen = readStoredSlackChannelTs(params.conversationId);
+    let written = 0;
+    // Slack's conversation.history returns most-recent first. Reverse so
+    // rows insert in chronological order, giving stable createdAt ordering
+    // and a transcript that reads correctly when the renderer joins on
+    // monotonic createdAt.
+    const ordered = [...fetched].reverse();
+    for (const message of ordered) {
+      if (seen.has(message.id)) continue;
+      try {
+        await persistBackfilledSlackMessage({
+          conversationId: params.conversationId,
+          channelId: params.channelId,
+          message,
+        });
+        seen.add(message.id);
+        written++;
+      } catch (perRowErr) {
+        log.warn(
+          {
+            err: perRowErr,
+            conversationId: params.conversationId,
+            channelId: params.channelId,
+            channelTs: message.id,
+          },
+          "Failed to persist backfilled DM row; continuing",
+        );
+      }
+    }
+
+    log.info(
+      {
+        conversationId: params.conversationId,
+        channelId: params.channelId,
+        fetched: fetched.length,
+        written,
+      },
+      "DM cold-start backfill complete",
+    );
+  } catch (err) {
+    log.warn(
+      { err, conversationId: params.conversationId, channelId: params.channelId },
+      "DM cold-start backfill failed; proceeding without history",
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Triggers backfillDm on first DM in a cold conversation (<3 stored messages)
- One-shot semantics: warm storage prevents re-trigger
- Failures are non-fatal

Part of plan: slack-thread-aware-context.md (PR 23 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
