### PR TITLE
feat(daemon): render Slack DM context chronologically from persisted messages

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -15,10 +15,12 @@ mock.module("../memory/pkb/pkb-search.js", () => ({
 import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type {
   ChannelCapabilities,
+  SlackTranscriptInputRow,
   UnifiedTurnContextOptions,
 } from "../daemon/conversation-runtime-assembly.js";
 import {
   applyRuntimeInjections,
+  assembleSlackChronologicalMessages,
   buildSubagentStatusBlock,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
@@ -33,6 +35,10 @@ import {
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
 import { buildPkbReminder } from "../daemon/pkb-reminder-builder.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
 import type { Message } from "../providers/types.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -2074,5 +2080,223 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     expect(rebuiltReminder).toContain("- topics/alpha.md");
     expect(rebuiltReminder).toContain("- topics/beta.md");
     expect(rebuiltReminder).not.toContain("- topics/gamma.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleSlackChronologicalMessages — DM chronological rendering (PR 21)
+// ---------------------------------------------------------------------------
+
+describe("assembleSlackChronologicalMessages", () => {
+  // Anchor times mirror the renderer's HH:MM (UTC) output.
+  // 14:25:00 UTC on 2023-11-14 = epoch second 1699971900.
+  const TS_14_25 = "1699971900.000100"; // 14:25 UTC
+  const TS_14_28 = "1699972080.000300"; // 14:28 UTC
+  const MS_14_25 = 1699971900_000;
+  const MS_14_26 = 1699971960_000;
+  const MS_14_28 = 1699972080_000;
+  const MS_14_30 = 1699972200_000;
+
+  const DM_CHANNEL_ID = "D0DM0001";
+  const DM_CAPS: ChannelCapabilities = {
+    channel: "slack",
+    dashboardCapable: false,
+    supportsDynamicUi: false,
+    supportsVoiceInput: false,
+    chatType: "im",
+  };
+
+  /**
+   * Build the persisted-row metadata JSON envelope. `slackMeta` is stored as
+   * a JSON string sub-key inside the outer metadata object, mirroring the
+   * production write path in `conversation-messaging.ts`.
+   */
+  function metadataEnvelope(slackMeta: SlackMessageMetadata | null): string {
+    const envelope: Record<string, unknown> = {
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    };
+    if (slackMeta) {
+      envelope.slackMeta = writeSlackMetadata(slackMeta);
+    }
+    return JSON.stringify(envelope);
+  }
+
+  /** Build a row that mirrors how `addMessage` persists user/assistant content. */
+  function row(
+    role: "user" | "assistant",
+    text: string,
+    createdAt: number,
+    metadata: string | null,
+  ): SlackTranscriptInputRow {
+    return {
+      role,
+      content: JSON.stringify([{ type: "text", text }]),
+      createdAt,
+      metadata,
+    };
+  }
+
+  test("returns null when channel is not Slack", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "private",
+    };
+    const result = assembleSlackChronologicalMessages([], caps);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for Slack channels (chatType !== 'im')", () => {
+    // PR 17 owns the channel branch; PR 21 must not accidentally swallow it.
+    const channelCaps: ChannelCapabilities = {
+      ...DM_CAPS,
+      chatType: "channel",
+    };
+    const result = assembleSlackChronologicalMessages([], channelCaps);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when chatType is missing entirely", () => {
+    // Defensive: omitted chatType should fall through to the legacy path
+    // rather than triggering DM rendering on ambiguous metadata.
+    const looseCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+    const result = assembleSlackChronologicalMessages([], looseCaps);
+    expect(result).toBeNull();
+  });
+
+  test("DM-only fixture: pure chronological render with no thread tags", () => {
+    // Two-turn DM: user → assistant → user. All rows carry slackMeta but
+    // none have threadTs (DMs never have threadTs). Output must be a flat
+    // chronological transcript with no `→ Mxxxxxx` parent-alias arrows.
+    const userMeta1: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_25,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    const userMeta2: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_28,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    // Outbound assistant rows in production lack channelTs (filled in by a
+    // later reconciliation PR), so they go through the legacy fallback path.
+    const rows: SlackTranscriptInputRow[] = [
+      row("user", "hi assistant", MS_14_25, metadataEnvelope(userMeta1)),
+      row("assistant", "hi back!", MS_14_26, metadataEnvelope(null)),
+      row("user", "another one", MS_14_28, metadataEnvelope(userMeta2)),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    expect(result).not.toBeNull();
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "[14:25 @alice]: hi assistant" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[14:26 @assistant]: hi back!" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "[14:28 @alice]: another one" }],
+      },
+    ]);
+    // Sanity: no thread-tag arrow ever appears in DM output.
+    for (const msg of result!) {
+      const text = (msg.content[0] as { type: "text"; text: string }).text;
+      expect(text).not.toMatch(/→ M[0-9a-f]{6}/);
+    }
+  });
+
+  test("legacy-DM fixture: pre-upgrade rows (no slackMeta) interleave with post-upgrade rows", () => {
+    // Mix:
+    //  - Two pre-upgrade rows (created before PR 16 wired slackMeta into
+    //    DM persistence). Their metadata column has no slackMeta sub-key —
+    //    the renderer's flat fallback orders them by createdAt.
+    //  - One post-upgrade user row with slackMeta.
+    //  - One assistant row that lacks slackMeta entirely (no metadata
+    //    column at all — also goes through the legacy fallback).
+    //
+    // All four rows must appear in the output, sorted chronologically.
+    const postUpgradeUserMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_28,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+
+    const rows: SlackTranscriptInputRow[] = [
+      // Pre-upgrade user row from before slackMeta was persisted on DMs.
+      row("user", "old hi", MS_14_25, metadataEnvelope(null)),
+      // Pre-upgrade assistant row.
+      row("assistant", "old reply", MS_14_26, metadataEnvelope(null)),
+      // Post-upgrade user row with slackMeta.
+      row(
+        "user",
+        "fresh hi",
+        MS_14_28,
+        metadataEnvelope(postUpgradeUserMeta),
+      ),
+      // Assistant row with no metadata column at all (defensive: null
+      // metadata must still survive the assembly path).
+      row("assistant", "fresh reply", MS_14_30, null),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    expect(result).not.toBeNull();
+    expect(result!.map((m) => (m.content[0] as { text: string }).text)).toEqual(
+      [
+        "[14:25 @user]: old hi",
+        "[14:26 @assistant]: old reply",
+        "[14:28 @alice]: fresh hi",
+        "[14:30 @assistant]: fresh reply",
+      ],
+    );
+    expect(result!.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+
+  test("malformed slackMeta sub-key falls back to legacy flat render", () => {
+    // Defensive: if the slackMeta sub-key is present but isn't a valid
+    // serialized SlackMessageMetadata, the row is treated as legacy rather
+    // than dropped from context.
+    const badEnvelope = JSON.stringify({
+      userMessageChannel: "slack",
+      slackMeta: "not valid json {{{",
+    });
+    const rows: SlackTranscriptInputRow[] = [
+      row("user", "hello", MS_14_25, badEnvelope),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "[14:25 @user]: hello" }],
+      },
+    ]);
+  });
+
+  test("empty rows yields an empty array (Slack DM with no history)", () => {
+    const result = assembleSlackChronologicalMessages([], DM_CAPS);
+    expect(result).toEqual([]);
   });
 });

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -12,8 +12,13 @@ import { type ChannelId, parseInterfaceId } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
 import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import {
+  type RenderableSlackMessage,
+  renderSlackTranscript,
+} from "../messaging/providers/slack/render-transcript.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
-import type { Message } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
@@ -1153,6 +1158,126 @@ function injectTransportHints(message: Message, hints: string[]): Message {
 /** Strip `<transport_hints>` blocks injected by `injectTransportHints`. */
 export function stripTransportHints(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ["<transport_hints>"]);
+}
+
+// ---------------------------------------------------------------------------
+// Slack chronological transcript assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural shape of a persisted message row used by the Slack
+ * chronological-transcript assembly path. Decouples the assembly logic from
+ * the DB-row type so it can be unit-tested with plain literals.
+ */
+export interface SlackTranscriptInputRow {
+  role: "user" | "assistant";
+  /** Raw persisted content column. JSON-encoded `ContentBlock[]` in production. */
+  content: string;
+  /** Epoch ms when the row was created. */
+  createdAt: number;
+  /** Raw `metadata` column value (JSON string with optional `slackMeta` sub-key). */
+  metadata: string | null;
+}
+
+/**
+ * Extract the user-facing plain text from a persisted message row's content
+ * column. The persisted shape is a JSON-encoded `ContentBlock[]`; only `text`
+ * blocks contribute to the rendered transcript line. Tool-use / tool-result /
+ * thinking blocks are intentionally elided — they would clutter the
+ * Slack-style transcript and the model can already recall them from the
+ * surrounding turn structure.
+ *
+ * Falls back to the raw column value when JSON parsing fails so legacy /
+ * non-JSON-encoded rows still surface their text content.
+ */
+function extractPlainText(rawContent: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    return rawContent;
+  }
+  if (!Array.isArray(parsed)) {
+    return typeof parsed === "string" ? parsed : rawContent;
+  }
+  const parts: string[] = [];
+  for (const block of parsed as ContentBlock[]) {
+    if (block && typeof block === "object" && block.type === "text") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Convert a persisted row into the {@link RenderableSlackMessage} shape
+ * consumed by `renderSlackTranscript`.
+ *
+ * Legacy pre-upgrade rows (no `slackMeta` sub-key, malformed metadata, etc.)
+ * yield `metadata: null`; the renderer then takes its flat-render fallback
+ * path and the row stays in chronological order via `createdAt`.
+ *
+ * Sender labels:
+ * - assistant rows: always `"@assistant"`.
+ * - user rows: prefer `slackMeta.displayName`, otherwise fall back to a
+ *   generic `"@user"` label so the renderer's tag template still parses.
+ */
+function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
+  let slackMeta: ReturnType<typeof readSlackMetadata> = null;
+  if (row.metadata) {
+    try {
+      const outer = JSON.parse(row.metadata) as { slackMeta?: unknown };
+      if (typeof outer.slackMeta === "string") {
+        slackMeta = readSlackMetadata(outer.slackMeta);
+      }
+    } catch {
+      // Malformed metadata — fall through to legacy/null treatment.
+    }
+  }
+
+  const senderLabel =
+    row.role === "assistant"
+      ? "@assistant"
+      : (slackMeta?.displayName ?? "@user");
+
+  return {
+    role: row.role,
+    content: extractPlainText(row.content),
+    metadata: slackMeta,
+    senderLabel,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Build a chronological Slack transcript for Slack DM conversations and
+ * project it onto the LLM-facing `Message[]` shape.
+ *
+ * Returns `null` when the channel is not a Slack DM (caller should fall
+ * through to the default message history). Legacy pre-upgrade rows without
+ * `slackMeta` are tolerated: the renderer's flat fallback orders them by
+ * `createdAt` alongside post-upgrade rows.
+ *
+ * NOTE on transport hints: PR 21 deliberately does NOT remove DM
+ * transport-hint injection here — that cleanup happens in PR 25 once the
+ * gateway stops sending Slack hints altogether.
+ */
+export function assembleSlackChronologicalMessages(
+  rows: SlackTranscriptInputRow[],
+  capabilities: ChannelCapabilities,
+): Message[] | null {
+  // PR 21 handles DMs only. PR 17 adds the symmetric channel branch
+  // (`chatType !== "im"`) — keep the guard tight so the channel path never
+  // accidentally runs through the DM-only renderer wiring.
+  if (capabilities.channel !== "slack" || capabilities.chatType !== "im") {
+    return null;
+  }
+  const renderable = rows.map(rowToRenderable);
+  const rendered = renderSlackTranscript(renderable);
+  return rendered.map((r) => ({
+    role: r.role,
+    content: [{ type: "text" as const, text: r.content }],
+  }));
 }
 
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */


### PR DESCRIPTION
## Summary
- Routes Slack DM context through renderSlackTranscript
- Legacy DM rows preserved via metadata:null fallback (same as PR 17 for channels)
- DM transport-hint injection retained (removed in PR 25)

Part of plan: slack-thread-aware-context.md (PR 21 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
