### PR TITLE
feat(daemon): render Slack channel context chronologically with thread tags

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -228,6 +228,8 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
     "threads.md",
     "buffer.md",
   ],
+  loadSlackChannelRenderableHistory: () => [],
+  applySlackChannelChronologicalRender: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -218,6 +218,8 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
     "threads.md",
     "buffer.md",
   ],
+  loadSlackChannelRenderableHistory: () => [],
+  applySlackChannelChronologicalRender: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -19,6 +19,7 @@ import type {
 } from "../daemon/conversation-runtime-assembly.js";
 import {
   applyRuntimeInjections,
+  applySlackChannelChronologicalRender,
   buildSubagentStatusBlock,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
@@ -27,12 +28,19 @@ import {
   injectNowScratchpad,
   injectSubagentStatus,
   isGroupChatType,
+  loadSlackChannelRenderableHistory,
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
   stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
 import { buildPkbReminder } from "../daemon/pkb-reminder-builder.js";
+import type { MessageRow } from "../memory/conversation-crud.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
+import { parentAlias } from "../messaging/providers/slack/render-transcript.js";
 import type { Message } from "../providers/types.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -2074,5 +2082,471 @@ describe("applyRuntimeInjections — PKB relevance hints", () => {
     expect(rebuiltReminder).toContain("- topics/alpha.md");
     expect(rebuiltReminder).toContain("- topics/beta.md");
     expect(rebuiltReminder).not.toContain("- topics/gamma.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR 17 — Slack channel chronological rendering
+// ---------------------------------------------------------------------------
+
+describe("loadSlackChannelRenderableHistory + applySlackChannelChronologicalRender", () => {
+  // Slack ts values are seconds-since-epoch with microsecond precision.
+  // Pick a few stable anchors so thread aliases (sha-derived) stay
+  // predictable across the scenarios.
+  const T0 = "1700000000.000001"; // 2023-11-14 22:13:20 UTC — top-level message in thread A
+  const T0_REPLY1 = "1700000005.000001"; // reply in thread A
+  const T0_REPLY2 = "1700000020.000001"; // later reply in thread A
+  const T1 = "1700000010.000002"; // top-level message starting thread B
+  const T2 = "1700000030.000003"; // newer top-level message
+  const ALIAS_T0 = parentAlias(T0);
+  const ALIAS_T1 = parentAlias(T1);
+  const ALIAS_T2 = parentAlias(T2);
+
+  const SLACK_CHANNEL_ID = "C0123CHANNEL";
+
+  function buildSlackMeta(
+    overrides: Partial<SlackMessageMetadata>,
+  ): SlackMessageMetadata {
+    return {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID,
+      channelTs: overrides.channelTs ?? T0,
+      eventKind: "message",
+      ...overrides,
+    } as SlackMessageMetadata;
+  }
+
+  function userRow(opts: {
+    id: string;
+    createdAt: number;
+    text: string;
+    slackMeta?: SlackMessageMetadata;
+    extraOuterMetadata?: Record<string, unknown>;
+  }): MessageRow {
+    const outer: Record<string, unknown> = {
+      ...(opts.extraOuterMetadata ?? {}),
+    };
+    if (opts.slackMeta) outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    return {
+      id: opts.id,
+      conversationId: "conv-1",
+      role: "user",
+      content: JSON.stringify([{ type: "text", text: opts.text }]),
+      createdAt: opts.createdAt,
+      metadata: Object.keys(outer).length > 0 ? JSON.stringify(outer) : null,
+    };
+  }
+
+  function assistantRow(opts: {
+    id: string;
+    createdAt: number;
+    text: string;
+    slackMeta?: SlackMessageMetadata;
+  }): MessageRow {
+    const outer: Record<string, unknown> = {};
+    if (opts.slackMeta) outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    return {
+      id: opts.id,
+      conversationId: "conv-1",
+      role: "assistant",
+      content: JSON.stringify([{ type: "text", text: opts.text }]),
+      createdAt: opts.createdAt,
+      metadata: Object.keys(outer).length > 0 ? JSON.stringify(outer) : null,
+    };
+  }
+
+  // Helper: assemble a Slack-channel turn through the public assembly path
+  // so the tests exercise the same code the daemon uses.
+  async function runSlackChannelAssembly(rows: MessageRow[]): Promise<Message[]> {
+    const slackChannelHistory = loadSlackChannelRenderableHistory(
+      "conv-1",
+      () => rows,
+    );
+    const lastUserMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "current turn" }],
+    };
+    const slackChannelCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    return applyRuntimeInjections([lastUserMessage], {
+      channelCapabilities: slackChannelCaps,
+      slackChannelHistory,
+    });
+  }
+
+  // Extract the rendered text content from a chronological transcript
+  // result. Each Message produced by the slack-channel render carries
+  // exactly one rendered text block, but the FINAL message also receives
+  // injection blocks (e.g. <channel_capabilities>) prepended by the rest
+  // of `applyRuntimeInjections`. The rendered transcript line is always
+  // the LAST text block of each Message.
+  function texts(messages: Message[]): string[] {
+    return messages.map((m) => {
+      for (let i = m.content.length - 1; i >= 0; i--) {
+        const block = m.content[i];
+        if (block.type === "text") return block.text;
+      }
+      return "";
+    });
+  }
+
+  // ── Scenario 1: reply in mid-thread ──────────────────────────────────
+  // Alice posts to thread A, Bob replies in thread B (cross-thread). Then
+  // Alice posts a follow-up reply in thread A. Cross-thread visibility:
+  // Bob's mid-thread reply must remain visible alongside thread A.
+  test("scenario 1 — mid-thread reply preserves cross-thread visibility", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "Top-level in thread A",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m2",
+        createdAt: 1700000010_000,
+        text: "Top-level starting thread B",
+        slackMeta: buildSlackMeta({ channelTs: T1, displayName: "bob" }),
+      }),
+      userRow({
+        id: "m3",
+        createdAt: 1700000015_000,
+        text: "Reply in thread B (cross-thread relative to A)",
+        slackMeta: buildSlackMeta({
+          channelTs: "1700000015.000001",
+          threadTs: T1,
+          displayName: "bob",
+        }),
+      }),
+      userRow({
+        id: "m4",
+        createdAt: 1700000020_000,
+        text: "Reply in thread A from alice",
+        slackMeta: buildSlackMeta({
+          channelTs: T0_REPLY2,
+          threadTs: T0,
+          displayName: "alice",
+        }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const lines = texts(result);
+
+    expect(lines.length).toBe(4);
+    // Chronological order is preserved.
+    expect(lines[0]).toContain("Top-level in thread A");
+    expect(lines[1]).toContain("Top-level starting thread B");
+    expect(lines[2]).toContain("Reply in thread B");
+    expect(lines[3]).toContain("Reply in thread A");
+    // Cross-thread visibility: thread B's reply is in the rendered output
+    // alongside thread A's reply.
+    expect(lines[2]).toContain(`→ ${ALIAS_T1}`);
+    expect(lines[3]).toContain(`→ ${ALIAS_T0}`);
+    // Sender labels appear.
+    expect(lines[0]).toContain("alice");
+    expect(lines[1]).toContain("bob");
+  });
+
+  // ── Scenario 2: reply to a top-level (starts new thread) ─────────────
+  test("scenario 2 — reply to top-level renders thread tag pointing at parent", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "Top-level message",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m2",
+        createdAt: 1700000005_000,
+        text: "Reply that starts a new thread",
+        slackMeta: buildSlackMeta({
+          channelTs: T0_REPLY1,
+          threadTs: T0,
+          displayName: "bob",
+        }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const lines = texts(result);
+
+    expect(lines.length).toBe(2);
+    // Top-level has no thread tag.
+    expect(lines[0]).not.toContain("→ M");
+    // Reply points at the parent's deterministic alias.
+    expect(lines[1]).toContain(`→ ${ALIAS_T0}`);
+    expect(lines[1]).toContain("Reply that starts a new thread");
+  });
+
+  // ── Scenario 3: reply to the most-recent top-level message ───────────
+  test("scenario 3 — reply to last top-level still renders thread tag", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "Older top-level",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m2",
+        createdAt: 1700000010_000,
+        text: "Newer top-level",
+        slackMeta: buildSlackMeta({ channelTs: T1, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m3",
+        createdAt: 1700000020_000,
+        text: "Reply to the newer top-level",
+        slackMeta: buildSlackMeta({
+          channelTs: "1700000020.000099",
+          threadTs: T1,
+          displayName: "bob",
+        }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const lines = texts(result);
+
+    expect(lines.length).toBe(3);
+    // The reply targets the newer top-level alias, not the older one.
+    expect(lines[2]).toContain(`→ ${ALIAS_T1}`);
+    expect(lines[2]).not.toContain(`→ ${ALIAS_T0}`);
+  });
+
+  // ── Scenario 4: brand-new top-level message ──────────────────────────
+  test("scenario 4 — new top-level message has no thread tag", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "Existing top-level",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m2",
+        createdAt: 1700000030_000,
+        text: "Brand-new top-level message",
+        slackMeta: buildSlackMeta({ channelTs: T2, displayName: "carol" }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const lines = texts(result);
+
+    expect(lines.length).toBe(2);
+    // Both lines render without a thread tag — they are siblings, not
+    // members of the same thread.
+    expect(lines[0]).not.toContain("→ M");
+    expect(lines[1]).not.toContain("→ M");
+    expect(lines[1]).toContain("Brand-new top-level message");
+    // Sanity: each top-level message has a deterministic alias even if
+    // the rendered output doesn't surface it on a top-level line. This
+    // confirms the alias function is reachable for downstream consumers
+    // (focus block in PR 24).
+    expect(ALIAS_T2.length).toBe(7);
+  });
+
+  // ── Scenario 5: legacy mixed with post-upgrade rows ──────────────────
+  // Pre-upgrade rows have no `slackMeta` sub-key. Post-upgrade rows have
+  // it. Both kinds must appear in the rendered transcript with legacy
+  // rows rendered flat (no thread tag) and post-upgrade rows carrying
+  // their thread tags. The renderer's chronological sort must intermix
+  // them on the appropriate timeline.
+  test("scenario 5 — legacy rows mixed with post-upgrade rows render chronologically", async () => {
+    const rows: MessageRow[] = [
+      // Legacy user row with a displayName hint only — no slackMeta.
+      userRow({
+        id: "m1",
+        createdAt: 1699999000_000,
+        text: "Legacy user message",
+        extraOuterMetadata: { displayName: "legacy_alice" },
+      }),
+      // Legacy assistant row.
+      assistantRow({
+        id: "m2",
+        createdAt: 1699999500_000,
+        text: "Legacy assistant reply",
+      }),
+      // Post-upgrade row anchored to a thread parent that has no record
+      // in storage (legacy parent) — the renderer still emits the alias
+      // because the metadata is intact.
+      userRow({
+        id: "m3",
+        createdAt: 1700000000_000,
+        text: "Post-upgrade thread reply",
+        slackMeta: buildSlackMeta({
+          channelTs: T0_REPLY1,
+          threadTs: T0,
+          displayName: "alice",
+        }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const lines = texts(result);
+
+    // All three rows survive the rendering pipeline. Legacy rows are NOT
+    // dropped from context.
+    expect(lines.length).toBe(3);
+    // Chronological order preserved across legacy/post-upgrade rows.
+    expect(lines[0]).toContain("Legacy user message");
+    expect(lines[1]).toContain("Legacy assistant reply");
+    expect(lines[2]).toContain("Post-upgrade thread reply");
+    // Legacy rows render flat — no thread tag arrow.
+    expect(lines[0]).not.toContain("→ M");
+    expect(lines[1]).not.toContain("→ M");
+    // Post-upgrade row carries its thread tag.
+    expect(lines[2]).toContain(`→ ${ALIAS_T0}`);
+    // Sender labels: legacy user pulls displayName from outer metadata,
+    // legacy assistant uses the role label.
+    expect(lines[0]).toContain("legacy_alice");
+    expect(lines[1]).toContain("assistant");
+  });
+
+  // ── Branch isolation: non-Slack channels untouched ───────────────────
+  test("non-slack conversations bypass chronological rendering", async () => {
+    const lastUserMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "vellum question" }],
+    };
+    const result = await applyRuntimeInjections([lastUserMessage], {
+      channelCapabilities: {
+        channel: "vellum",
+        dashboardCapable: true,
+        supportsDynamicUi: true,
+        supportsVoiceInput: true,
+      },
+      // Even if we accidentally pass slack history, the branch must be a
+      // no-op for non-slack channels.
+      slackChannelHistory: [
+        {
+          role: "user",
+          content: "should not appear",
+          metadata: null,
+          senderLabel: "ghost",
+          createdAt: 1700000000_000,
+        },
+      ],
+    });
+    expect(result.length).toBe(1);
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("vellum question");
+    expect(allText).not.toContain("should not appear");
+  });
+
+  // ── Branch isolation: DMs (chatType === "im") use the existing path ──
+  test("slack DMs (chatType im) bypass chronological rendering — wired in PR 21", async () => {
+    const lastUserMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: "DM question" }],
+    };
+    const result = await applyRuntimeInjections([lastUserMessage], {
+      channelCapabilities: {
+        channel: "slack",
+        dashboardCapable: false,
+        supportsDynamicUi: false,
+        supportsVoiceInput: false,
+        chatType: "im",
+      },
+      slackChannelHistory: [
+        {
+          role: "user",
+          content: "should not appear in DM",
+          metadata: null,
+          senderLabel: "ghost",
+          createdAt: 1700000000_000,
+        },
+      ],
+    });
+    expect(result.length).toBe(1);
+    const allText = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("DM question");
+    expect(allText).not.toContain("should not appear in DM");
+  });
+
+  // ── transport_hints suppression for slack channels ────────────────────
+  test("slack channel conversations skip <transport_hints> injection", async () => {
+    const slackChannelCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "Original message",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+    ];
+    const slackChannelHistory = loadSlackChannelRenderableHistory(
+      "conv-1",
+      () => rows,
+    );
+
+    const result = await applyRuntimeInjections(
+      [{ role: "user", content: [{ type: "text", text: "current turn" }] }],
+      {
+        channelCapabilities: slackChannelCaps,
+        slackChannelHistory,
+        transportHints: ["thread context: ..."],
+      },
+    );
+
+    const allText = result
+      .flatMap((m) => m.content)
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).not.toContain("<transport_hints>");
+  });
+
+  // ── transport_hints kept for non-slack channels ───────────────────────
+  test("non-slack conversations still receive <transport_hints>", async () => {
+    const result = await applyRuntimeInjections(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      {
+        channelCapabilities: {
+          channel: "telegram",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "private",
+        },
+        transportHints: ["please answer concisely"],
+      },
+    );
+    const allText = result
+      .flatMap((m) => m.content)
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("<transport_hints>");
+    expect(allText).toContain("please answer concisely");
+  });
+
+  // ── Helper: pure render function dropped to a no-op when history empty ─
+  test("applySlackChannelChronologicalRender is a no-op when history is empty", () => {
+    const original: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+    const result = applySlackChannelChronologicalRender(original, []);
+    expect(result).toBe(original);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -123,6 +123,8 @@ import {
   getPkbAutoInjectList,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
+  isSlackChannelConversation,
+  loadSlackChannelRenderableHistory,
   readNowScratchpad,
   readPkbContext,
   stripInjectionsForCompaction,
@@ -892,6 +894,15 @@ export async function runAgentLoopImpl(
           getSubagentManager().getChildrenOf(ctx.conversationId),
         );
 
+    // For Slack non-DM channels, load the stored thread metadata once per
+    // turn so the assembly path can replace the in-memory message array
+    // with a chronological transcript that exposes sibling threads.
+    const slackChannelHistory = isSlackChannelConversation(
+      ctx.channelCapabilities,
+    )
+      ? loadSlackChannelRenderableHistory(ctx.conversationId)
+      : null;
+
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
       activeSurface,
@@ -915,6 +926,7 @@ export async function runAgentLoopImpl(
       transportHints: ctx.transportHints ?? null,
       isNonInteractive: !isInteractiveResolved,
       subagentStatusBlock,
+      slackChannelHistory,
     } as const;
 
     let currentInjectionMode: InjectionMode = "full";

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -10,10 +10,19 @@ import { join, resolve } from "node:path";
 
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
+import {
+  getMessages as defaultGetMessages,
+  type MessageRow,
+} from "../memory/conversation-crud.js";
 import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import {
+  type RenderableSlackMessage,
+  renderSlackTranscript,
+} from "../messaging/providers/slack/render-transcript.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
-import type { Message } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
@@ -1155,6 +1164,156 @@ export function stripTransportHints(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ["<transport_hints>"]);
 }
 
+// ---------------------------------------------------------------------------
+// Slack channel chronological rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the channel capabilities describe a Slack non-DM channel: a
+ * group/channel/mpim where the assistant renders context across all
+ * threads instead of relying on per-turn `<transport_hints>` from the
+ * gateway. DMs (`chatType === "im"`) are intentionally excluded so the
+ * renderer does not emit thread tags for one-on-one conversations.
+ */
+export function isSlackChannelConversation(
+  channelCapabilities?: ChannelCapabilities | null,
+): boolean {
+  return (
+    channelCapabilities?.channel === "slack" &&
+    channelCapabilities.chatType !== "im"
+  );
+}
+
+/** Pull plain text out of a stored row's JSON content array. */
+function extractTextFromStoredContent(rawContent: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    // Non-JSON content (older rows or non-array content) is treated as raw
+    // text so the renderer still receives a meaningful string.
+    return rawContent;
+  }
+  if (!Array.isArray(parsed)) {
+    return typeof parsed === "string" ? parsed : rawContent;
+  }
+  const blocks = parsed as ContentBlock[];
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (
+      block &&
+      typeof block === "object" &&
+      "type" in block &&
+      block.type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      texts.push((block as { text: string }).text);
+    }
+  }
+  return texts.join("\n");
+}
+
+/**
+ * Convert a single stored row into a `RenderableSlackMessage`.
+ *
+ * When `slackMeta` is present and parses cleanly the result carries the
+ * full Slack metadata; otherwise the message is treated as a legacy
+ * pre-upgrade row (`metadata: null`) and the renderer's flat fallback
+ * applies.
+ */
+function rowToRenderableSlackMessage(row: MessageRow): RenderableSlackMessage {
+  const role = row.role === "assistant" ? "assistant" : "user";
+  const content = extractTextFromStoredContent(row.content);
+
+  // Parse the outer metadata envelope once and reuse the result for both
+  // `slackMeta` lookup and the legacy displayName fallback.
+  let outerMeta: Record<string, unknown> | null = null;
+  if (row.metadata) {
+    try {
+      const parsed = JSON.parse(row.metadata);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        outerMeta = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed outer metadata — treat as legacy.
+    }
+  }
+
+  const slackMetaRaw =
+    outerMeta && typeof outerMeta.slackMeta === "string"
+      ? outerMeta.slackMeta
+      : null;
+  const meta = readSlackMetadata(slackMetaRaw);
+
+  let senderLabel: string;
+  if (meta?.displayName && meta.displayName.length > 0) {
+    senderLabel = meta.displayName;
+  } else if (role === "assistant") {
+    senderLabel = "assistant";
+  } else {
+    const candidate = outerMeta?.displayName ?? outerMeta?.senderName;
+    senderLabel =
+      typeof candidate === "string" && candidate.length > 0
+        ? candidate
+        : "user";
+  }
+
+  return {
+    role,
+    content,
+    metadata: meta,
+    senderLabel,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Replace the Slack-channel history portion of `runMessages` with the
+ * chronologically-rendered transcript.
+ *
+ * The renderer's output is a `{role, content}[]` of one tagged line per
+ * stored row. We map each line back into a `Message` (single text block),
+ * then drop the original `runMessages` and rebuild the array so the model
+ * sees one user-role line per stored Slack event followed by the active
+ * inbound message.
+ *
+ * When the active inbound user message is also represented in
+ * `slackHistory` (it normally is — inbound persistence in PR 11 happens
+ * before this assembly step), the renderer emits a tagged line for it as
+ * the last entry; downstream injections (turn context, transport, etc.)
+ * still attach to that final user message exactly as they would for a
+ * non-Slack channel.
+ *
+ * Pure: no I/O, no clock reads.
+ */
+export function applySlackChannelChronologicalRender(
+  runMessages: Message[],
+  slackHistory: RenderableSlackMessage[],
+): Message[] {
+  if (slackHistory.length === 0) return runMessages;
+  const rendered = renderSlackTranscript(slackHistory);
+  if (rendered.length === 0) return runMessages;
+  return rendered.map<Message>((line) => ({
+    role: line.role,
+    content: [{ type: "text", text: line.content }],
+  }));
+}
+
+/**
+ * Load DB rows for a Slack channel conversation and convert them into
+ * `RenderableSlackMessage[]` ordered by `createdAt`.
+ *
+ * The loader is exposed as a parameter so tests can substitute a stub. In
+ * production it defaults to `getMessages` from `conversation-crud.ts`.
+ */
+export function loadSlackChannelRenderableHistory(
+  conversationId: string,
+  loader: (id: string) => MessageRow[] = defaultGetMessages,
+): RenderableSlackMessage[] {
+  const rows = loader(conversationId);
+  return rows.map(rowToRenderableSlackMessage);
+}
+
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   "<channel_capabilities>",
@@ -1280,11 +1439,36 @@ export async function applyRuntimeInjections(
     subagentStatusBlock?: string | null;
     isNonInteractive?: boolean;
     transportHints?: string[] | null;
+    /**
+     * Pre-loaded Slack-channel history for chronological rendering.
+     *
+     * When `channelCapabilities` describes a Slack non-DM channel and this
+     * array is non-empty, `runMessages` is replaced with a chronological
+     * transcript built from the stored Slack metadata. The `transportHints`
+     * pipeline is skipped in that case so the model sees one consistent
+     * channel-wide view instead of a duplicated active-thread hint.
+     *
+     * Callers load the history via `loadSlackChannelRenderableHistory`
+     * before invoking this function so the assembly path stays free of
+     * direct DB calls and remains easy to test.
+     */
+    slackChannelHistory?: RenderableSlackMessage[] | null;
     mode?: InjectionMode;
   },
 ): Promise<Message[]> {
   const mode = options.mode ?? "full";
+  const slackChannel = isSlackChannelConversation(options.channelCapabilities);
   let result = runMessages;
+  if (
+    slackChannel &&
+    options.slackChannelHistory &&
+    options.slackChannelHistory.length > 0
+  ) {
+    result = applySlackChannelChronologicalRender(
+      result,
+      options.slackChannelHistory,
+    );
+  }
 
   // For non-interactive conversations (scheduled jobs, work items), instruct the
   // model to never ask for clarification — there is no human present to answer.
@@ -1455,8 +1639,15 @@ export async function applyRuntimeInjections(
     }
   }
 
+  // Slack channel conversations build their own chronological transcript
+  // (see `applySlackChannelChronologicalRender` above) and intentionally
+  // do not receive the per-turn `<transport_hints>` block — the rendered
+  // history already covers the active thread, so duplicating it would
+  // confuse the model. Other channels (DMs, telegram, email, etc.) keep
+  // the existing injection.
   if (
     mode === "full" &&
+    !slackChannel &&
     options.transportHints &&
     options.transportHints.length > 0
   ) {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -16,27 +16,7 @@
 
 import { createHash } from "node:crypto";
 
-// TODO(slack-thread-ctx PR 1): replace this local type with an import from
-// `./message-metadata.js` once PR 1 lands. The shape is duplicated here so
-// PR 6 can compile in isolation; both files agree on the schema.
-type SlackEventKind = "message" | "reaction";
-
-interface SlackMessageMetadata {
-  readonly source: "slack";
-  readonly channelId: string;
-  readonly channelTs: string;
-  readonly threadTs?: string;
-  readonly displayName?: string;
-  readonly eventKind: SlackEventKind;
-  readonly reaction?: {
-    readonly emoji: string;
-    readonly actorDisplayName?: string;
-    readonly targetChannelTs: string;
-    readonly op: "added" | "removed";
-  };
-  readonly editedAt?: number;
-  readonly deletedAt?: number;
-}
+import type { SlackMessageMetadata } from "./message-metadata.js";
 
 export interface RenderableSlackMessage {
   role: "user" | "assistant";


### PR DESCRIPTION
## Summary
- Routes Slack channel conversations through renderSlackTranscript
- Handles pre-upgrade rows via metadata:null fallback (chronological with no thread tag)
- Skips transport_hints injection for Slack channels (DMs + other channels untouched)

Part of plan: slack-thread-aware-context.md (PR 17 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
