### PR TITLE
feat(slack): lazily backfill unknown thread ancestors and persist

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -1,0 +1,757 @@
+/**
+ * PR 22 — verifies that an inbound Slack thread reply triggers a lazy
+ * backfill of the missing thread ancestors when the conversation has no
+ * record of the parent message, persists each backfilled message with a
+ * derived `slackMeta` envelope, de-dupes against rows already stored, and
+ * gates re-triggers behind a 10-minute idempotency cache so bursts of
+ * replies in the same thread do not flood the Slack API.
+ *
+ * Tests exercise the helper {@link triggerSlackThreadBackfillIfNeeded}
+ * directly against the real database (via the test-preload temp workspace).
+ * Only `backfillThread` is mocked, since the contract under test is "given
+ * what Slack returns, what does the daemon write to the DB".
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede module imports under test). Note: backfillThread is
+// stubbed via spyOn (below) rather than mock.module so the stub does not leak
+// into other test files (e.g. backfill.test.ts) that import the same module.
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+  listCredentialMetadata: () => [],
+}));
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { v4 as uuid } from "uuid";
+
+import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { getDb,initializeDb } from "../memory/db.js";
+import type { Message as MessagingMessage } from "../messaging/provider-types.js";
+import * as slackBackfill from "../messaging/providers/slack/backfill.js";
+import {
+  readSlackMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
+import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
+import {
+  _backfillTriggerCache,
+  triggerSlackThreadBackfillIfNeeded,
+} from "../runtime/routes/inbound-message-handler.js";
+
+initializeDb();
+
+// Spy on backfillThread so the stub is scoped to this test file only.
+// Restoring after the file's tests run keeps cross-file leakage to zero —
+// other tests (e.g. backfill.test.ts) keep seeing the real implementation.
+const backfillThreadMock = spyOn(slackBackfill, "backfillThread");
+backfillThreadMock.mockResolvedValue([]);
+
+afterAll(() => {
+  backfillThreadMock.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+//
+// These helpers go directly against the SQLite layer rather than calling into
+// `conversation-crud.js`. The reason is test isolation: several other test
+// files in the suite mock `conversation-crud.js` partially (only the exports
+// they need), and Bun does not always reset such mocks between files. When
+// our test runs in the same process after one of those, calls like
+// `getMessages` come back as `undefined`. Going around the module entirely
+// keeps this test resilient to any future module-level mocks elsewhere.
+
+const SLACK_CHANNEL_ID = "C0THREAD";
+
+function resetState(): void {
+  const db = getDb();
+  db.$client.exec("DELETE FROM messages");
+  db.$client.exec("DELETE FROM conversations");
+  _backfillTriggerCache.clear();
+  backfillThreadMock.mockReset();
+  backfillThreadMock.mockImplementation(async () => []);
+}
+
+let convCounter = 0;
+
+function makeConversationId(): string {
+  convCounter++;
+  return `conv-test-${convCounter}-${uuid()}`;
+}
+
+function createTestConversation(): { id: string } {
+  const db = getDb();
+  const id = makeConversationId();
+  const now = Date.now();
+  db.$client
+    .prepare(
+      `INSERT INTO conversations (
+        id, title, created_at, updated_at, total_input_tokens, total_output_tokens,
+        total_estimated_cost, context_compacted_message_count, conversation_type,
+        source, memory_scope_id, host_access, is_auto_title
+      ) VALUES (?, NULL, ?, ?, 0, 0, 0, 0, 'standard', 'user', 'default', 0, 1)`,
+    )
+    .run(id, now, now);
+  return { id };
+}
+
+let messageCounter = 0;
+
+function insertMessage(
+  conversationId: string,
+  role: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): void {
+  const db = getDb();
+  const id = uuid();
+  // Use a strictly increasing timestamp so the ORDER BY in
+  // readMessagesByConversation is deterministic — Date.now() ties when
+  // multiple inserts happen inside the same millisecond.
+  messageCounter++;
+  const now = Date.now() + messageCounter;
+  const metadataStr = metadata ? JSON.stringify(metadata) : null;
+  db.$client
+    .prepare(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(id, conversationId, role, content, now, metadataStr);
+}
+
+interface RawMessageRow {
+  role: string;
+  content: string;
+  metadata: string | null;
+}
+
+function readMessagesByConversation(conversationId: string): RawMessageRow[] {
+  const db = getDb();
+  return db.$client
+    .prepare(
+      "SELECT role, content, metadata FROM messages WHERE conversation_id = ? ORDER BY created_at ASC",
+    )
+    .all(conversationId) as RawMessageRow[];
+}
+
+function makeBackfillMessage(
+  overrides: Partial<MessagingMessage> = {},
+): MessagingMessage {
+  return {
+    id: "1234.0",
+    conversationId: SLACK_CHANNEL_ID,
+    sender: { id: "U_USER", name: "Alice" },
+    text: "thread parent",
+    timestamp: 1700000000_000,
+    threadId: undefined,
+    platform: "slack",
+    ...overrides,
+  };
+}
+
+interface PersistedRow {
+  role: string;
+  content: string;
+  channelTs: string | undefined;
+  threadTs: string | undefined;
+  displayName: string | undefined;
+}
+
+function readPersistedSlackRows(conversationId: string): PersistedRow[] {
+  const rows = readMessagesByConversation(conversationId);
+  const out: PersistedRow[] = [];
+  for (const row of rows) {
+    const blank: PersistedRow = {
+      role: row.role,
+      content: row.content,
+      channelTs: undefined,
+      threadTs: undefined,
+      displayName: undefined,
+    };
+    if (!row.metadata) {
+      out.push(blank);
+      continue;
+    }
+    let envelope: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(row.metadata) as unknown;
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        Array.isArray(parsed)
+      ) {
+        out.push(blank);
+        continue;
+      }
+      envelope = parsed as Record<string, unknown>;
+    } catch {
+      out.push(blank);
+      continue;
+    }
+    const slackMetaRaw = envelope.slackMeta;
+    if (typeof slackMetaRaw !== "string") {
+      out.push(blank);
+      continue;
+    }
+    const slackMeta = readSlackMetadata(slackMetaRaw);
+    out.push({
+      role: row.role,
+      content: row.content,
+      channelTs: slackMeta?.channelTs,
+      threadTs: slackMeta?.threadTs,
+      displayName: slackMeta?.displayName,
+    });
+  }
+  return out;
+}
+
+function seedSlackRow(
+  conversationId: string,
+  channelTs: string,
+  threadTs: string | undefined,
+  text: string,
+): void {
+  insertMessage(conversationId, "user", text, {
+    slackMeta: writeSlackMetadata({
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID,
+      channelTs,
+      eventKind: "message",
+      ...(threadTs ? { threadTs } : {}),
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    backfillThreadMock.mockReset();
+    _backfillTriggerCache.clear();
+  });
+
+  test("inbound thread reply with unseen parent triggers backfill and persists ancestors with slackMeta", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "parent",
+        threadId: undefined,
+        sender: { id: "U_PARENT", name: "Parent User" },
+      }),
+      makeBackfillMessage({
+        id: "1234.1",
+        text: "first reply",
+        threadId: "1234.0",
+        sender: { id: "U_REPLY1", name: "Reply One" },
+      }),
+      makeBackfillMessage({
+        id: "1234.2",
+        text: "second reply",
+        threadId: "1234.0",
+        sender: { id: "U_REPLY2", name: "Reply Two" },
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
+    expect(calledChannel).toBe(SLACK_CHANNEL_ID);
+    expect(calledThread).toBe("1234.0");
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(3);
+
+    const byChannelTs = new Map(
+      persisted.map((p) => [p.channelTs ?? "<no-ts>", p]),
+    );
+    expect(byChannelTs.get("1234.0")?.content).toBe("parent");
+    expect(byChannelTs.get("1234.0")?.displayName).toBe("Parent User");
+    expect(byChannelTs.get("1234.0")?.threadTs).toBeUndefined();
+
+    expect(byChannelTs.get("1234.1")?.content).toBe("first reply");
+    expect(byChannelTs.get("1234.1")?.threadTs).toBe("1234.0");
+    expect(byChannelTs.get("1234.1")?.displayName).toBe("Reply One");
+
+    expect(byChannelTs.get("1234.2")?.content).toBe("second reply");
+    expect(byChannelTs.get("1234.2")?.threadTs).toBe("1234.0");
+    expect(byChannelTs.get("1234.2")?.displayName).toBe("Reply Two");
+  });
+
+  test("backfill is NOT triggered when the parent is already persisted", async () => {
+    const conv = createTestConversation();
+
+    // Seed the parent message before the trigger runs — simulates a
+    // conversation where the daemon has already seen the thread parent.
+    seedSlackRow(conv.id, "1234.0", undefined, "already here");
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).not.toHaveBeenCalled();
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(1);
+    expect(persisted[0].channelTs).toBe("1234.0");
+  });
+
+  test("idempotency cache: a second call inside the TTL window does not re-fetch", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({ id: "1234.0", text: "parent" }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    // Second call for the same conversation+thread — must short-circuit on
+    // the in-memory cache without hitting backfillThread again.
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+
+    const persisted = readPersistedSlackRows(conv.id);
+    // Only one parent row (no duplicate from the second trigger).
+    expect(persisted.filter((p) => p.channelTs === "1234.0").length).toBe(1);
+  });
+
+  test("backfill error: turn proceeds, no crash, no rows written", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => {
+      throw new Error("Slack API error: thread_not_found");
+    });
+
+    // Must not throw — error handling is internal.
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    expect(readPersistedSlackRows(conv.id).length).toBe(0);
+  });
+
+  test("backfill returns duplicates that are already stored — only new rows are inserted", async () => {
+    const conv = createTestConversation();
+
+    // Pre-seed sibling 1234.1 so the backfill response includes one row that
+    // already exists (and must not be re-inserted) plus two genuinely new
+    // ones (parent 1234.0 and sibling 1234.2).
+    seedSlackRow(conv.id, "1234.1", "1234.0", "already here");
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "parent",
+        threadId: undefined,
+      }),
+      makeBackfillMessage({
+        id: "1234.1",
+        text: "duplicate sibling — must be skipped",
+        threadId: "1234.0",
+      }),
+      makeBackfillMessage({
+        id: "1234.2",
+        text: "new sibling",
+        threadId: "1234.0",
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(3);
+
+    const oneRow = persisted.find((p) => p.channelTs === "1234.1");
+    // The pre-seeded row's content remains; the duplicate from backfill was
+    // skipped (otherwise the count would be 4 or the content would change).
+    expect(oneRow?.content).toBe("already here");
+
+    expect(persisted.find((p) => p.channelTs === "1234.0")?.content).toBe(
+      "parent",
+    );
+    expect(persisted.find((p) => p.channelTs === "1234.2")?.content).toBe(
+      "new sibling",
+    );
+  });
+
+  test("empty backfill response leaves the conversation untouched but still seeds the cache", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => []);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    expect(readPersistedSlackRows(conv.id).length).toBe(0);
+
+    // Cache should now be populated for this conversation+thread, so an
+    // immediate retry must not re-run the API call.
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("two distinct threads in the same conversation each trigger their own backfill", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async (_channel, threadTs) => [
+      makeBackfillMessage({
+        id: threadTs as string,
+        text: `parent of ${threadTs as string}`,
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "5678.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(2);
+    expect(
+      persisted.map((p) => p.channelTs).sort(),
+    ).toEqual(["1234.0", "5678.0"]);
+  });
+
+  test("backfilled message without text is persisted with empty content", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "",
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(1);
+    expect(persisted[0].content).toBe("");
+    expect(persisted[0].channelTs).toBe("1234.0");
+  });
+
+  test("backfill skips messages with no id rather than crashing", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({ id: "", text: "no id" }),
+      makeBackfillMessage({ id: "1234.0", text: "valid parent" }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(1);
+    expect(persisted[0].channelTs).toBe("1234.0");
+  });
+
+  test("messages with malformed metadata in the conversation are tolerated when scanning", async () => {
+    const conv = createTestConversation();
+
+    // Insert a message with malformed (non-JSON) metadata directly. The
+    // scan must not throw on parse errors.
+    insertMessage(conv.id, "user", "malformed", { foo: "bar" });
+    const db = getDb();
+    db.$client
+      .prepare("UPDATE messages SET metadata = 'not-json' WHERE conversation_id = ?")
+      .run(conv.id);
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({ id: "1234.0", text: "parent" }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    const persisted = readPersistedSlackRows(conv.id);
+    // Two rows: the malformed row + the newly backfilled parent.
+    expect(persisted.length).toBe(2);
+    expect(
+      persisted.find((p) => p.channelTs === "1234.0")?.content,
+    ).toBe("parent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration through handleChannelInbound — the wiring contract
+// ---------------------------------------------------------------------------
+
+const TEST_BEARER_TOKEN = "test-token";
+const HTTP_SLACK_CHANNEL_ID = "C0HTTPTHREAD";
+const HTTP_SLACK_USER_ID = "U_HTTP_USER";
+const HTTP_SLACK_DISPLAY_NAME = "Charlie Threader";
+
+function resetHttpState(): void {
+  const db = getDb();
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+  _backfillTriggerCache.clear();
+  backfillThreadMock.mockReset();
+  backfillThreadMock.mockImplementation(async () => []);
+}
+
+function seedHttpActiveMember(): void {
+  upsertContactChannel({
+    sourceChannel: "slack",
+    externalUserId: HTTP_SLACK_USER_ID,
+    externalChatId: HTTP_SLACK_CHANNEL_ID,
+    status: "active",
+    policy: "allow",
+    displayName: HTTP_SLACK_DISPLAY_NAME,
+  });
+}
+
+let httpMsgCounter = 0;
+
+function buildThreadReplyRequest(
+  threadId: string,
+  messageId: string,
+  overrides: Record<string, unknown> = {},
+): Request {
+  httpMsgCounter++;
+  const body: Record<string, unknown> = {
+    sourceChannel: "slack",
+    interface: "slack",
+    conversationExternalId: HTTP_SLACK_CHANNEL_ID,
+    externalMessageId: `${HTTP_SLACK_CHANNEL_ID}:${messageId}:${httpMsgCounter}`,
+    content: "thread reply text",
+    actorExternalId: HTTP_SLACK_USER_ID,
+    actorDisplayName: HTTP_SLACK_DISPLAY_NAME,
+    actorUsername: "charlie",
+    replyCallbackUrl: "http://localhost:7830/deliver/slack",
+    sourceMetadata: {
+      messageId,
+      threadId,
+      chatType: "channel",
+    },
+    ...overrides,
+  };
+
+  return new Request("http://localhost:8080/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": TEST_BEARER_TOKEN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("handleChannelInbound — Slack thread backfill wiring", () => {
+  beforeEach(() => {
+    resetHttpState();
+    seedHttpActiveMember();
+    httpMsgCounter = 0;
+  });
+
+  afterEach(() => {
+    backfillThreadMock.mockReset();
+    _backfillTriggerCache.clear();
+  });
+
+  test("inbound thread reply with no stored parent triggers backfill from the HTTP path", async () => {
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "parent",
+        threadId: undefined,
+        sender: { id: "U_PARENT", name: "Original Poster" },
+      }),
+      makeBackfillMessage({
+        id: "1234.1",
+        text: "earlier sibling",
+        threadId: "1234.0",
+        sender: { id: "U_SIB", name: "Earlier Sibling" },
+      }),
+    ]);
+
+    const processMessage = async (): Promise<{ messageId: string }> => {
+      return { messageId: "agent-result-id" };
+    };
+
+    const req = buildThreadReplyRequest("1234.0", "1234.3");
+    const resp = await handleChannelInbound(
+      req,
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.duplicate).toBe(false);
+
+    // The backfill is fire-and-forget; settle the microtask queue so the
+    // void-promise has time to write to the DB before we assert.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
+    expect(calledChannel).toBe(HTTP_SLACK_CHANNEL_ID);
+    expect(calledThread).toBe("1234.0");
+
+    const db = getDb();
+    const rows = db.$client
+      .prepare("SELECT metadata FROM messages")
+      .all() as Array<{ metadata: string | null }>;
+
+    const channelTimestamps = new Set<string>();
+    for (const row of rows) {
+      if (!row.metadata) continue;
+      try {
+        const envelope = JSON.parse(row.metadata) as Record<string, unknown>;
+        if (typeof envelope.slackMeta === "string") {
+          const slackMeta = readSlackMetadata(envelope.slackMeta);
+          if (slackMeta) channelTimestamps.add(slackMeta.channelTs);
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    expect(channelTimestamps.has("1234.0")).toBe(true);
+    expect(channelTimestamps.has("1234.1")).toBe(true);
+  });
+
+  test("second thread reply within the TTL window does not re-trigger backfill", async () => {
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({ id: "5678.0", text: "parent" }),
+    ]);
+
+    const processMessage = async (): Promise<{ messageId: string }> => ({
+      messageId: "agent-result-id",
+    });
+
+    const r1 = await handleChannelInbound(
+      buildThreadReplyRequest("5678.0", "5678.1"),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(r1.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const r2 = await handleChannelInbound(
+      buildThreadReplyRequest("5678.0", "5678.2"),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+    expect(r2.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("backfill error from the HTTP path does not crash the request", async () => {
+    backfillThreadMock.mockImplementation(async () => {
+      throw new Error("Slack API offline");
+    });
+
+    const processMessage = async (): Promise<{ messageId: string }> => ({
+      messageId: "agent-result-id",
+    });
+
+    const resp = await handleChannelInbound(
+      buildThreadReplyRequest("9999.0", "9999.1"),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    expect(resp.status).toBe(200);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.accepted).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -30,7 +30,10 @@ import * as deliveryCrud from "../../memory/delivery-crud.js";
 import * as deliveryStatus from "../../memory/delivery-status.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
 import type { Message as ProviderMessage } from "../../messaging/provider-types.js";
-import { backfillDm } from "../../messaging/providers/slack/backfill.js";
+import {
+  backfillDm,
+  backfillThread,
+} from "../../messaging/providers/slack/backfill.js";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
@@ -931,6 +934,21 @@ export async function handleChannelInbound(
         });
       }
 
+      // ── Thread-ancestor backfill ──
+      // When a Slack reply arrives for a thread the daemon never saw the
+      // parent of, fetch the thread's recent history from Slack and persist
+      // the missing messages so the chronological renderer (PR 18) has the
+      // full conversation. Fire-and-forget: failures are swallowed and
+      // never block the agent loop, the outbound HTTP response, or message
+      // dispatch.
+      if (slackThreadTs) {
+        void triggerSlackThreadBackfillIfNeeded({
+          conversationId: result.conversationId,
+          channelId: conversationExternalId,
+          threadTs: slackThreadTs,
+        });
+      }
+
       // Fire-and-forget: process the message and deliver the reply in the background.
       // The HTTP response returns immediately so the gateway webhook is not blocked.
       // The onEvent callback in processMessage registers pending interactions, and
@@ -1114,9 +1132,9 @@ function countSlackMetaMessages(conversationId: string): number {
 
 /**
  * Build the set of `slackMeta.channelTs` values already stored on a
- * conversation. Used to dedupe backfilled rows so a partial prior backfill
- * (or a single message that was already persisted via the live ingress
- * path) does not double-write.
+ * conversation. Used by both DM cold-start backfill and thread-ancestor
+ * backfill to dedupe rows so a partial prior backfill (or a single message
+ * that was already persisted via the live ingress path) does not double-write.
  */
 function readStoredSlackChannelTs(conversationId: string): Set<string> {
   const seen = new Set<string>();
@@ -1144,13 +1162,12 @@ function readStoredSlackChannelTs(conversationId: string): Set<string> {
  * Persist a single backfilled Slack message as a `messages` row with a
  * `slackMeta` envelope.
  *
- * This is the shared insertion point for any path that hydrates history
- * lazily (DM cold-start backfill in this PR; thread gap backfill in a
- * follow-up PR can route through the same helper). Backfilled rows are
- * always recorded with role `"user"` — the renderer reads `slackMeta` to
- * format author / timestamp / thread context, so the role distinction is
- * not used for display. Caller is responsible for dedup checks before
- * invoking; this helper performs no idempotency check itself.
+ * Shared insertion point for both DM cold-start backfill and thread-ancestor
+ * backfill. Backfilled rows are always recorded with role `"user"` — the
+ * renderer reads `slackMeta` to format author / timestamp / thread context,
+ * so the role distinction is not used for display. Caller is responsible
+ * for dedup checks before invoking; this helper performs no idempotency
+ * check itself.
  */
 async function persistBackfilledSlackMessage(params: {
   conversationId: string;
@@ -1164,7 +1181,7 @@ async function persistBackfilledSlackMessage(params: {
     channelTs: message.id,
     eventKind: "message",
     ...(message.threadId ? { threadTs: message.threadId } : {}),
-    ...(message.sender.name ? { displayName: message.sender.name } : {}),
+    ...(message.sender?.name ? { displayName: message.sender.name } : {}),
   };
   await addMessage(params.conversationId, "user", message.text ?? "", {
     slackMeta: writeSlackMetadata(slackMeta),
@@ -1244,6 +1261,159 @@ async function tryBackfillSlackDmIfCold(params: {
     log.warn(
       { err, conversationId: params.conversationId, channelId: params.channelId },
       "DM cold-start backfill failed; proceeding without history",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Slack thread backfill on gap detection
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory TTL cache keyed by `<conversationId>:<threadTs>`. Tracks recent
+ * thread-backfill triggers so a burst of replies inside the same Slack
+ * thread (e.g. a guardian rapidly typing several lines) does not re-fetch
+ * the same parent messages from Slack repeatedly. Entries naturally fall
+ * out after the TTL — if the thread is still active later, a fresh
+ * backfill becomes a cheap "are the parents already stored?" DB lookup
+ * that short-circuits before the Slack API is touched.
+ *
+ * Exported only for tests; production callers should use
+ * {@link triggerSlackThreadBackfillIfNeeded}.
+ */
+export const _backfillTriggerCache = new Map<string, number>();
+
+const BACKFILL_TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const BACKFILL_TRIGGER_CACHE_MAX = 1_000;
+
+function pruneBackfillCacheIfNeeded(): void {
+  if (_backfillTriggerCache.size < BACKFILL_TRIGGER_CACHE_MAX) return;
+  const now = Date.now();
+  for (const [key, ts] of _backfillTriggerCache) {
+    if (now - ts >= BACKFILL_TRIGGER_TTL_MS) {
+      _backfillTriggerCache.delete(key);
+    }
+  }
+  // If still over the cap after TTL sweep, drop the oldest entries (LRU-ish).
+  if (_backfillTriggerCache.size >= BACKFILL_TRIGGER_CACHE_MAX) {
+    const entries = [..._backfillTriggerCache.entries()].sort(
+      (a, b) => a[1] - b[1],
+    );
+    const toRemove = entries.slice(
+      0,
+      entries.length - BACKFILL_TRIGGER_CACHE_MAX + 1,
+    );
+    for (const [key] of toRemove) {
+      _backfillTriggerCache.delete(key);
+    }
+  }
+}
+
+function isBackfillRecentlyTriggered(cacheKey: string): boolean {
+  const ts = _backfillTriggerCache.get(cacheKey);
+  if (ts === undefined) return false;
+  if (Date.now() - ts >= BACKFILL_TRIGGER_TTL_MS) {
+    _backfillTriggerCache.delete(cacheKey);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Lazily backfill missing Slack thread ancestors for an inbound thread reply.
+ *
+ * When a reply arrives for a thread the daemon has never seen (e.g. the bot
+ * was just added to the channel, or the parent message pre-dates the
+ * conversation), the daemon fetches the thread's recent history via
+ * {@link backfillThread}, persists each unseen message as a `messages` row
+ * with a `slackMeta` envelope, and skips duplicates whose `ts` already
+ * appears in the conversation.
+ *
+ * Behavior contracts:
+ * - **No-op when the parent is already stored.** Looks up the conversation's
+ *   messages and short-circuits if any row has `slackMeta.channelTs ===
+ *   threadTs`. This keeps subsequent replies in the same thread cheap.
+ * - **TTL idempotency cache.** A 10-minute in-memory cache prevents bursts
+ *   of replies in the same thread from re-running the DB lookup or the
+ *   Slack API call.
+ * - **Failure-tolerant.** Any error (Slack API failure, DB error, malformed
+ *   payload) is logged at `warn` and swallowed — the inbound turn must
+ *   never block on backfill.
+ */
+export async function triggerSlackThreadBackfillIfNeeded(params: {
+  conversationId: string;
+  channelId: string;
+  threadTs: string;
+}): Promise<void> {
+  const { conversationId, channelId, threadTs } = params;
+  const cacheKey = `${conversationId}:${threadTs}`;
+
+  try {
+    if (isBackfillRecentlyTriggered(cacheKey)) {
+      return;
+    }
+
+    const storedChannelTs = readStoredSlackChannelTs(conversationId);
+    if (storedChannelTs.has(threadTs)) {
+      // Parent is already in the conversation; mark the cache so a burst of
+      // replies in this thread does not redo the DB scan for each one.
+      _backfillTriggerCache.set(cacheKey, Date.now());
+      pruneBackfillCacheIfNeeded();
+      return;
+    }
+
+    // Mark the trigger before issuing the network call. Doing this first
+    // means a second concurrent reply in the same thread short-circuits
+    // immediately even while the first call is still awaiting the Slack
+    // API. The cost is a slightly larger window where a transient Slack
+    // failure suppresses a retry, which the next reply outside the TTL
+    // (or a daemon restart) will re-attempt anyway.
+    _backfillTriggerCache.set(cacheKey, Date.now());
+    pruneBackfillCacheIfNeeded();
+
+    const fetched = await backfillThread(channelId, threadTs);
+    if (fetched.length === 0) {
+      log.debug(
+        { conversationId, channelId, threadTs },
+        "Slack thread backfill returned no messages",
+      );
+      return;
+    }
+
+    let persisted = 0;
+    for (const message of fetched) {
+      if (!message.id) continue;
+      if (storedChannelTs.has(message.id)) continue;
+      try {
+        await persistBackfilledSlackMessage({
+          conversationId,
+          channelId,
+          message,
+        });
+        storedChannelTs.add(message.id);
+        persisted++;
+      } catch (err) {
+        log.warn(
+          { err, conversationId, channelId, threadTs, channelTs: message.id },
+          "Failed to persist backfilled Slack thread message",
+        );
+      }
+    }
+
+    log.info(
+      {
+        conversationId,
+        channelId,
+        threadTs,
+        persisted,
+        fetched: fetched.length,
+      },
+      "Slack thread backfill persisted ancestor messages",
+    );
+  } catch (err) {
+    log.warn(
+      { err, conversationId, channelId, threadTs },
+      "Slack thread backfill failed; proceeding without it",
     );
   }
 }


### PR DESCRIPTION
## Summary
- Triggers backfillThread when inbound has threadId with no stored parent
- Persists backfilled messages with slackMeta; dedups against existing
- TTL-cached idempotency prevents re-backfill bursts
- Failures are non-fatal

Part of plan: slack-thread-aware-context.md (PR 22 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
