### PR TITLE
fix(gateway): populate source.threadId on Slack message_deleted events

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1232,4 +1232,31 @@ describe("source.threadId propagation", () => {
       expect(result!.event.source.threadId).toBeUndefined();
     });
   });
+
+  describe("normalizeSlackMessageDelete", () => {
+    it("populates source.threadId for deletes of threaded messages", () => {
+      const config = makeConfig();
+      const event = makeMessageDeletedEvent({
+        previous_message: {
+          user: "U123",
+          text: "thread reply",
+          ts: "1700000000.000100",
+          thread_ts: "parent_ts",
+        },
+      });
+      const result = normalizeSlackMessageDelete(event, "evt-tid-11", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.source.threadId).toBe("parent_ts");
+    });
+
+    it("omits source.threadId for deletes of top-level messages", () => {
+      const config = makeConfig();
+      const event = makeMessageDeletedEvent();
+      const result = normalizeSlackMessageDelete(event, "evt-tid-12", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.source.threadId).toBeUndefined();
+    });
+  });
 });

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -908,6 +908,7 @@ export function normalizeSlackMessageDelete(
         // the stored row to mark deleted.
         messageId: event.deleted_ts,
         ...(isDm ? {} : { chatType: "channel" }),
+        ...(previousThreadTs ? { threadId: previousThreadTs } : {}),
       },
       raw: event as unknown as Record<string, unknown>,
     },


### PR DESCRIPTION
## Summary
- normalizeSlackMessageDelete now exposes source.threadId, matching every other Slack normalizer
- Closes a minor cross-event consistency gap identified during plan review

Fixes gap identified during plan review for slack-thread-aware-context.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
