### PR TITLE
fix(slack): wire DM conversations through chronological rendering

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -230,7 +230,9 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   ],
   isSlackChannelConversation: () => false,
   loadSlackChronologicalMessages: () => null,
+  loadSlackActiveThreadFocusBlock: () => null,
   assembleSlackChronologicalMessages: () => null,
+  assembleSlackActiveThreadFocusBlock: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -220,7 +220,9 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   ],
   isSlackChannelConversation: () => false,
   loadSlackChronologicalMessages: () => null,
+  loadSlackActiveThreadFocusBlock: () => null,
   assembleSlackChronologicalMessages: () => null,
+  assembleSlackActiveThreadFocusBlock: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2447,11 +2447,12 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).not.toContain("should not appear");
   });
 
-  // ── Branch isolation: DMs (chatType === "im") bypass channel rendering ──
-  // The runtime-assembly hook keys the override on `isSlackChannelConversation`
-  // (channel === slack AND chatType !== im), so DMs intentionally fall
-  // through even when the caller passes a chronological transcript.
-  test("slack DMs (chatType im) bypass channel chronological rendering", async () => {
+  // ── DMs (chatType === "im") use chronological rendering ────────────────
+  // The runtime-assembly hook overrides `runMessages` for any Slack
+  // conversation (channels and DMs alike). DMs render flat (no thread
+  // tags), but they DO swap in the pre-assembled chronological transcript
+  // so the model sees one consistent persisted view.
+  test("slack DMs (chatType im) use chronological rendering", async () => {
     const lastUserMessage: Message = {
       role: "user",
       content: [{ type: "text", text: "DM question" }],
@@ -2467,17 +2468,27 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       slackChronologicalMessages: [
         {
           role: "user",
-          content: [{ type: "text", text: "should not appear in DM" }],
+          content: [
+            { type: "text", text: "[14:25 @alice]: earlier DM line" },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "[14:26 @assistant]: prior reply" }],
         },
       ],
     });
-    expect(result.length).toBe(1);
-    const allText = result[0].content
+    // The chronological transcript REPLACES the default runMessages, so
+    // the inbound `DM question` text does not appear — only the rendered
+    // transcript lines do (plus any non-Slack injections).
+    const allText = result
+      .flatMap((m) => m.content)
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
       .map((b) => b.text)
       .join("\n");
-    expect(allText).toContain("DM question");
-    expect(allText).not.toContain("should not appear in DM");
+    expect(allText).toContain("earlier DM line");
+    expect(allText).toContain("prior reply");
+    expect(allText).not.toContain("DM question");
   });
 
   // ── transport_hints suppression for slack channels ────────────────────
@@ -2988,6 +2999,29 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     );
     expect(result).toBeNull();
   });
+
+  test("loadSlackActiveThreadFocusBlock returns null for Slack DMs (no threads)", () => {
+    // DMs do not have threads, so the focus block is always a no-op.
+    // The loader short-circuits before invoking the row loader so the
+    // DB read is skipped entirely.
+    let loaderCalls = 0;
+    const result = loadSlackActiveThreadFocusBlock(
+      "conv-1",
+      {
+        channel: "slack",
+        dashboardCapable: false,
+        supportsDynamicUi: false,
+        supportsVoiceInput: false,
+        chatType: "im",
+      },
+      () => {
+        loaderCalls += 1;
+        return [];
+      },
+    );
+    expect(result).toBeNull();
+    expect(loaderCalls).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -3048,6 +3082,25 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
       chatType: "private",
     });
     expect(result).toBeNull();
+  });
+
+  test("returns null for Slack DMs (chatType im) regardless of rows", () => {
+    // DMs do not have threads. Even if a caller mistakenly passes thread-
+    // looking metadata, the assembler short-circuits before scanning rows.
+    const dmCaps: ChannelCapabilities = { ...SLACK_CAPS, chatType: "im" };
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "thread-shaped row in a DM",
+        1_000,
+        buildMeta({
+          channelTs: REPLY_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+    ];
+    expect(assembleSlackActiveThreadFocusBlock(rows, dmCaps)).toBeNull();
   });
 
   test("returns null when no rows have slackMeta", () => {
@@ -3234,10 +3287,10 @@ describe("assembleSlackChronologicalMessages", () => {
   });
 
   test("renders for Slack channels (chatType !== 'im')", () => {
-    // The channel branch and the DM branch share this assembler. The
-    // wiring in `applyRuntimeInjections` decides whether to actually
-    // override `runMessages` based on `isSlackChannelConversation`; the
-    // assembler itself returns rendered messages for any Slack channel.
+    // The channel branch and the DM branch share this assembler.
+    // `applyRuntimeInjections` swaps in the chronological transcript for
+    // any Slack conversation (channels and DMs alike); the assembler
+    // itself returns rendered messages for any Slack channel.
     const channelCaps: ChannelCapabilities = {
       ...DM_CAPS,
       chatType: "channel",
@@ -3248,8 +3301,9 @@ describe("assembleSlackChronologicalMessages", () => {
 
   test("renders when chatType is missing entirely", () => {
     // The assembler treats a missing chatType as a non-DM Slack channel
-    // (it does not infer DM from absence). Callers can still gate via
-    // `isSlackChannelConversation` if they need stricter handling.
+    // (it does not infer DM from absence). Callers that need to
+    // distinguish DMs from channels (e.g. to skip thread-only injections)
+    // can still gate via `isSlackChannelConversation`.
     const looseCaps: ChannelCapabilities = {
       channel: "slack",
       dashboardCapable: false,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -123,7 +123,6 @@ import {
   getPkbAutoInjectList,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
-  isSlackChannelConversation,
   loadSlackActiveThreadFocusBlock,
   loadSlackChronologicalMessages,
   readNowScratchpad,
@@ -895,13 +894,14 @@ export async function runAgentLoopImpl(
           getSubagentManager().getChildrenOf(ctx.conversationId),
         );
 
-    // For Slack non-DM channels, build a chronological transcript from
-    // the persisted message rows so the model sees one channel-wide view
-    // (sibling threads included) instead of the gateway's per-turn
-    // active-thread hint.
-    const slackChronologicalMessages = isSlackChannelConversation(
-      ctx.channelCapabilities,
-    )
+    // For any Slack conversation (channels and DMs alike), build a
+    // chronological transcript from the persisted message rows so the
+    // model sees one channel-wide view instead of the gateway's per-turn
+    // hints. DMs render as a flat sequence (no thread tags), channels
+    // include sibling threads.
+    const isSlackConversation =
+      ctx.channelCapabilities?.channel === "slack";
+    const slackChronologicalMessages = isSlackConversation
       ? loadSlackChronologicalMessages(
           ctx.conversationId,
           ctx.channelCapabilities!,
@@ -913,9 +913,9 @@ export async function runAgentLoopImpl(
     // to the final user turn listing the thread's parent + replies. Helps
     // the model orient when the channel transcript is long and
     // interleaved. Replays strip the block via RUNTIME_INJECTION_PREFIXES.
-    const slackActiveThreadFocusBlock = isSlackChannelConversation(
-      ctx.channelCapabilities,
-    )
+    // DMs short-circuit to null inside `loadSlackActiveThreadFocusBlock`
+    // since DMs do not have threads.
+    const slackActiveThreadFocusBlock = isSlackConversation
       ? loadSlackActiveThreadFocusBlock(
           ctx.conversationId,
           ctx.channelCapabilities!,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1169,11 +1169,14 @@ export function stripTransportHints(messages: Message[]): Message[] {
 // ---------------------------------------------------------------------------
 
 /**
- * True when the channel capabilities describe a Slack non-DM channel: a
- * group/channel/mpim where the assistant renders context across all
- * threads instead of relying on per-turn `<transport_hints>` from the
- * gateway. DMs (`chatType === "im"`) are intentionally excluded so the
- * renderer does not emit thread tags for one-on-one conversations.
+ * True when the channel capabilities describe a Slack non-DM conversation
+ * (group/channel/mpim). Used to gate thread-only behavior such as the
+ * `<active_thread>` focus block. DMs (`chatType === "im"`) are excluded
+ * because they have no threads.
+ *
+ * The chronological-transcript override applies to ALL Slack
+ * conversations (channels and DMs) — gate that on
+ * `channelCapabilities.channel === "slack"` rather than this helper.
  */
 export function isSlackChannelConversation(
   channelCapabilities?: ChannelCapabilities | null,
@@ -1279,11 +1282,9 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
  * `slackMeta` are tolerated: the renderer's flat fallback orders them by
  * `createdAt` alongside post-upgrade rows.
  *
- * For non-DM Slack channels, `<transport_hints>` injection is suppressed
- * by `applyRuntimeInjections` so the model sees one consistent
- * channel-wide chronological view instead of a duplicated active-thread
- * hint. DM transport-hint injection cleanup happens in a later PR once the
- * gateway stops sending Slack hints altogether.
+ * For ALL Slack conversations (channels and DMs), `<transport_hints>`
+ * injection is suppressed by `applyRuntimeInjections` so the model sees
+ * one consistent persisted view instead of a duplicated gateway hint.
  */
 export function assembleSlackChronologicalMessages(
   rows: SlackTranscriptInputRow[],
@@ -1438,6 +1439,7 @@ function buildActiveThreadBlockFromRenderable(
  * Pure assembly entrypoint mirroring `assembleSlackChronologicalMessages`.
  * Returns the rendered `<active_thread>` block as a string, or `null` when:
  *   - the channel is not Slack, OR
+ *   - the channel is a Slack DM (DMs do not have threads), OR
  *   - the latest user row is top-level (not in a thread), OR
  *   - no rows belong to the active thread.
  */
@@ -1446,6 +1448,9 @@ export function assembleSlackActiveThreadFocusBlock(
   capabilities: ChannelCapabilities,
 ): string | null {
   if (capabilities.channel !== "slack") return null;
+  // DMs do not have threads, so the focus block is always a no-op.
+  // Short-circuit explicitly to avoid scanning rows on every turn.
+  if (capabilities.chatType === "im") return null;
   const renderable = rows.map(rowToRenderable);
   const activeThreadTs = detectActiveThreadTs(renderable);
   if (!activeThreadTs) return null;
@@ -1455,7 +1460,8 @@ export function assembleSlackActiveThreadFocusBlock(
 /**
  * Loader convenience over `assembleSlackActiveThreadFocusBlock` mirroring
  * `loadSlackChronologicalMessages`. Returns `null` when the channel is not
- * Slack so callers can skip the injection entirely.
+ * Slack, or when it is a Slack DM (DMs have no threads), so callers can
+ * skip the injection entirely without paying for a DB read.
  */
 export function loadSlackActiveThreadFocusBlock(
   conversationId: string,
@@ -1463,6 +1469,7 @@ export function loadSlackActiveThreadFocusBlock(
   loader: (id: string) => MessageRow[] = defaultGetMessages,
 ): string | null {
   if (capabilities.channel !== "slack") return null;
+  if (capabilities.chatType === "im") return null;
   const rows: SlackTranscriptInputRow[] = loader(conversationId).map((row) => ({
     role: row.role === "assistant" ? "assistant" : "user",
     content: row.content,
@@ -1603,13 +1610,16 @@ export async function applyRuntimeInjections(
     transportHints?: string[] | null;
     /**
      * Pre-rendered Slack chronological transcript that replaces the
-     * default `runMessages` history for Slack non-DM channels.
+     * default `runMessages` history for any Slack conversation (channels
+     * and DMs alike).
      *
-     * When `channelCapabilities` describes a Slack non-DM channel and this
+     * When `channelCapabilities` describes a Slack conversation and this
      * array is non-empty, it overrides `runMessages` so the model sees one
      * chronologically-ordered transcript built from the stored Slack
-     * metadata. The `transportHints` pipeline is skipped in that case so
-     * the channel-wide view isn't duplicated by the active-thread hint.
+     * metadata. Channel renders include sibling-thread tags; DM renders
+     * are flat (DMs have no threads). The `transportHints` pipeline is
+     * skipped for any Slack conversation so the persisted view isn't
+     * duplicated by gateway-side hints.
      *
      * Callers build this via `loadSlackChronologicalMessages` (or the
      * underlying `assembleSlackChronologicalMessages`) before invoking
@@ -1644,8 +1654,14 @@ export async function applyRuntimeInjections(
   // (telegram, email, etc.) keep the generic hint pipeline.
   const slackConversation = options.channelCapabilities?.channel === "slack";
   let result = runMessages;
+  // Slack channels AND DMs both override `runMessages` with a pre-rendered
+  // chronological transcript built from persisted message rows. The shared
+  // assembler (`assembleSlackChronologicalMessages`) renders thread tags
+  // for channels and a flat sequence for DMs, so the same branch handles
+  // both. The active-thread focus block below stays gated on `slackChannel`
+  // since DMs do not have threads.
   if (
-    slackChannel &&
+    slackConversation &&
     options.slackChronologicalMessages &&
     options.slackChronologicalMessages.length > 0
   ) {


### PR DESCRIPTION
## Summary
- Slack DM conversations now go through the chronological renderer (PR 6) with persisted slackMeta, matching PR 21's acceptance criteria.
- Widens the agent-loop gate from Slack-channel-only to any Slack conversation.
- Active-thread focus block short-circuits for DMs (no threads on DMs).

Fixes gap identified during plan review for slack-thread-aware-context.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
