### PR TITLE
fix(slack): reconcile channelTs on outbound assistant messages

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -9,11 +9,13 @@ type DeliveryCall = {
 };
 
 const deliveryCalls: DeliveryCall[] = [];
-const conversationMessages: Array<{
+type MockMessageRow = {
   id: string;
   role: string;
   content: string;
-}> = [];
+  metadata?: string | null;
+};
+const conversationMessages: MockMessageRow[] = [];
 const attachmentsByMessageId = new Map<
   string,
   Array<{
@@ -24,6 +26,14 @@ const attachmentsByMessageId = new Map<
     kind?: string;
   }>
 >();
+type UpdateMessageMetadataCall = {
+  messageId: string;
+  updates: Record<string, unknown>;
+};
+const updateMessageMetadataCalls: UpdateMessageMetadataCall[] = [];
+
+/** Per-test override for the synthetic Slack `ts` returned by deliverChannelReply. */
+let nextDeliveryTs: string | null = null;
 
 let renderedHistoryContent: {
   text: string;
@@ -58,6 +68,13 @@ mock.module("../runtime/gateway-client.js", () => ({
       throw new Error("Simulated delivery failure (502)");
     }
     deliveryCalls.push({ callbackUrl, payload, bearerToken });
+    if (nextDeliveryTs !== null) {
+      const ts = nextDeliveryTs;
+      // Only the first segment of a multi-segment delivery should carry
+      // back a meaningful ts for `channelTs` reconciliation. Tests that
+      // need specific ts values per-segment can re-set this between calls.
+      return { ok: true, ts };
+    }
     return { ok: true };
   },
 }));
@@ -86,6 +103,21 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
   getMessages: () => conversationMessages,
+  getMessageById: (messageId: string) =>
+    conversationMessages.find((m) => m.id === messageId) ?? null,
+  updateMessageMetadata: (
+    messageId: string,
+    updates: Record<string, unknown>,
+  ) => {
+    updateMessageMetadataCalls.push({ messageId, updates });
+    const row = conversationMessages.find((m) => m.id === messageId);
+    if (!row) return;
+    const existing =
+      row.metadata && typeof row.metadata === "string"
+        ? (JSON.parse(row.metadata) as Record<string, unknown>)
+        : {};
+    row.metadata = JSON.stringify({ ...existing, ...updates });
+  },
 }));
 
 mock.module("../memory/attachments-store.js", () => ({
@@ -106,6 +138,8 @@ describe("channel-reply-delivery", () => {
     deliveryFailAtIndex = -1;
     conversationMessages.length = 0;
     attachmentsByMessageId.clear();
+    updateMessageMetadataCalls.length = 0;
+    nextDeliveryTs = null;
     renderedHistoryContent = {
       text: "",
       textSegments: [],
@@ -457,5 +491,269 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload.text).toBe("Beta.");
     expect(deliveryCalls[1].payload.text).toBe("Gamma.");
     expect(delivered).toEqual([2, 3]);
+  });
+
+  // ── slackMeta.channelTs reconciliation (post-send) ─────────────────────
+  // These tests close the gap where outbound assistant messages were
+  // persisted with a partial slackMeta lacking `channelTs`. The renderer
+  // (`readSlackMetadata`) rejects rows missing `channelTs`, so without
+  // reconciliation every outbound assistant row falls through to the
+  // legacy/flat fallback and is excluded from thread-tag rendering and the
+  // active-thread focus block.
+  describe("slackMeta.channelTs reconciliation", () => {
+    /** Build the outer envelope mirroring `handleMessageComplete`'s write. */
+    function partialSlackEnvelope(
+      channelId: string,
+      threadTs?: string,
+    ): string {
+      // Note: this matches the partial write — channelTs is intentionally
+      // absent so `readSlackMetadata` returns null until reconciliation runs.
+      const inner: Record<string, unknown> = {
+        source: "slack",
+        eventKind: "message",
+        channelId,
+        ...(threadTs ? { threadTs } : {}),
+      };
+      return JSON.stringify({
+        userMessageChannel: "slack",
+        assistantMessageChannel: "slack",
+        slackMeta: JSON.stringify(inner),
+      });
+    }
+
+    function pushPartialAssistantRow(
+      conversationId: string,
+      messageId: string,
+      channelId: string,
+      threadTs?: string,
+    ): void {
+      conversationMessages.push({
+        id: messageId,
+        role: "assistant",
+        content: '[{"type":"text","text":"hello"}]',
+        metadata: partialSlackEnvelope(channelId, threadTs),
+      });
+      // Set up renderer to produce one segment so onMessageTs fires once.
+      renderedHistoryContent = {
+        text: "hello",
+        textSegments: ["hello"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+    }
+
+    it("writes channelTs into slackMeta from the gateway-returned ts (top-level reply)", async () => {
+      pushPartialAssistantRow("conv-recon-top", "msg-recon-top", "C123");
+      nextDeliveryTs = "1700000123.000456";
+
+      await deliverReplyViaCallback(
+        "conv-recon-top",
+        "C123",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-recon",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(1);
+      const call = updateMessageMetadataCalls[0];
+      expect(call.messageId).toBe("msg-recon-top");
+      const merged = call.updates.slackMeta as string;
+      expect(typeof merged).toBe("string");
+      const parsed = JSON.parse(merged) as Record<string, unknown>;
+      expect(parsed.source).toBe("slack");
+      expect(parsed.channelId).toBe("C123");
+      expect(parsed.eventKind).toBe("message");
+      expect(parsed.channelTs).toBe("1700000123.000456");
+      expect(parsed.threadTs).toBeUndefined();
+    });
+
+    it("preserves an existing threadTs when reconciling channelTs (threaded reply)", async () => {
+      pushPartialAssistantRow(
+        "conv-recon-thread",
+        "msg-recon-thread",
+        "C456",
+        "1234.5678",
+      );
+      nextDeliveryTs = "1700000200.000700";
+
+      await deliverReplyViaCallback(
+        "conv-recon-thread",
+        "C456",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-recon-thread",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(1);
+      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
+      const parsed = JSON.parse(merged) as Record<string, unknown>;
+      expect(parsed.threadTs).toBe("1234.5678");
+      expect(parsed.channelTs).toBe("1700000200.000700");
+    });
+
+    it("does NOT call updateMessageMetadata when the assistant row has no slackMeta", async () => {
+      // vellum/telegram/non-slack outbound: the row's metadata envelope has
+      // no slackMeta sub-key. The reconciler must short-circuit silently.
+      conversationMessages.push({
+        id: "msg-vellum",
+        role: "assistant",
+        content: '[{"type":"text","text":"hi"}]',
+        metadata: JSON.stringify({
+          userMessageChannel: "vellum",
+          assistantMessageChannel: "vellum",
+        }),
+      });
+      renderedHistoryContent = {
+        text: "hi",
+        textSegments: ["hi"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700000300.000800";
+
+      await deliverReplyViaCallback(
+        "conv-vellum",
+        "chat-vellum",
+        "http://gateway/deliver/telegram",
+        "token",
+        "assistant-vellum",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(0);
+    });
+
+    it("does NOT call updateMessageMetadata when slackMeta already has channelTs", async () => {
+      // Idempotency: a re-delivery (e.g. from channel-retry-sweep) must not
+      // overwrite a channelTs that is already in place.
+      const existingMeta = JSON.stringify({
+        source: "slack",
+        eventKind: "message",
+        channelId: "C789",
+        channelTs: "1699999999.000111",
+      });
+      conversationMessages.push({
+        id: "msg-already",
+        role: "assistant",
+        content: '[{"type":"text","text":"hi"}]',
+        metadata: JSON.stringify({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+          slackMeta: existingMeta,
+        }),
+      });
+      renderedHistoryContent = {
+        text: "hi",
+        textSegments: ["hi"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700000400.000999";
+
+      await deliverReplyViaCallback(
+        "conv-already",
+        "C789",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-already",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(0);
+    });
+
+    it("only reconciles from the FIRST segment's ts when the reply is split", async () => {
+      pushPartialAssistantRow("conv-multi", "msg-multi", "C999");
+      // Two-segment delivery: only the first segment's ts is the canonical
+      // channelTs for the persisted row. Subsequent segments correspond to
+      // independent Slack messages.
+      renderedHistoryContent = {
+        text: "AlphaBeta",
+        textSegments: ["Alpha", "Beta"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0", "tool:0", "text:1"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700000500.000111";
+
+      await deliverReplyViaCallback(
+        "conv-multi",
+        "C999",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-multi",
+      );
+
+      // Two delivery POSTs but only one metadata write — the first ts wins.
+      expect(deliveryCalls.length).toBe(2);
+      expect(updateMessageMetadataCalls.length).toBe(1);
+      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
+      const parsed = JSON.parse(merged) as Record<string, unknown>;
+      expect(parsed.channelTs).toBe("1700000500.000111");
+    });
+
+    it("composes with caller-supplied onMessageTs without losing either side-effect", async () => {
+      pushPartialAssistantRow("conv-compose", "msg-compose", "C111");
+      nextDeliveryTs = "1700000600.000222";
+      const callerTsSeen: string[] = [];
+
+      await deliverReplyViaCallback(
+        "conv-compose",
+        "C111",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-compose",
+        {
+          onMessageTs: (ts) => callerTsSeen.push(ts),
+        },
+      );
+
+      // Caller's onMessageTs still fires for the delivered segment.
+      expect(callerTsSeen).toEqual(["1700000600.000222"]);
+      // And reconciliation still wrote channelTs.
+      expect(updateMessageMetadataCalls.length).toBe(1);
+      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
+      const parsed = JSON.parse(merged) as Record<string, unknown>;
+      expect(parsed.channelTs).toBe("1700000600.000222");
+    });
+
+    it("after reconciliation, readSlackMetadata returns a valid envelope", async () => {
+      // End-to-end: this is the assertion that the ORIGINAL gap test
+      // (`outbound-slack-persistence.test.ts:209`) was inverted on. Once
+      // reconciliation runs, readSlackMetadata must accept the merged value.
+      pushPartialAssistantRow("conv-readback", "msg-readback", "C222");
+      nextDeliveryTs = "1700000700.000333";
+
+      await deliverReplyViaCallback(
+        "conv-readback",
+        "C222",
+        "http://gateway/deliver/slack",
+        "token",
+        "assistant-readback",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(1);
+      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
+      // Imported here so the production read path (the same one the renderer
+      // uses) is what actually validates the merged envelope.
+      const { readSlackMetadata } = await import(
+        "../messaging/providers/slack/message-metadata.js"
+      );
+      const parsed = readSlackMetadata(merged);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.channelTs).toBe("1700000700.000333");
+      expect(parsed?.channelId).toBe("C222");
+      expect(parsed?.source).toBe("slack");
+      expect(parsed?.eventKind).toBe("message");
+    });
   });
 });

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3278,8 +3278,12 @@ describe("assembleSlackChronologicalMessages", () => {
       eventKind: "message",
       displayName: "@alice",
     };
-    // Outbound assistant rows in production lack channelTs (filled in by a
-    // later reconciliation PR), so they go through the legacy fallback path.
+    // Outbound assistant rows in DMs may go through the legacy fallback
+    // when no slackMeta envelope is present at all (e.g. a row written
+    // before the post-send reconciliation lands, or pre-upgrade history).
+    // This fixture pins down the legacy interleave behaviour and matches
+    // how `assembleSlackChronologicalMessages` falls back to chronological
+    // ordering by createdAt for null-slackMeta rows.
     const rows: SlackTranscriptInputRow[] = [
       row("user", "hi assistant", MS_14_25, metadataEnvelope(userMeta1)),
       row("assistant", "hi back!", MS_14_26, metadataEnvelope(null)),
@@ -3381,5 +3385,149 @@ describe("assembleSlackChronologicalMessages", () => {
   test("empty rows yields an empty array (Slack DM with no history)", () => {
     const result = assembleSlackChronologicalMessages([], DM_CAPS);
     expect(result).toEqual([]);
+  });
+
+  test("post-reconciliation: assistant rows with channelTs participate in thread tagging", () => {
+    // Once `deliverReplyViaCallback` reconciles `channelTs` from the
+    // gateway's response, assistant rows carry a fully-formed slackMeta
+    // envelope. They must then render through the Slack chronological
+    // path (not the legacy fallback) so reply rows pointing at the
+    // assistant's prior message get a `→ Mxxxxxx` parent-alias arrow.
+    //
+    // This is the cross-thread visibility that the slack-thread-aware-
+    // context plan promises: a follow-up user reply to the assistant's
+    // earlier post should render with a parent-alias arrow that the model
+    // can use to reason about which prior assistant message it threads off.
+    const SLACK_CHANNEL_ID_2 = "C0THREAD";
+    const ASSISTANT_TS = "1700001000.000111";
+    const REPLY_TS = "1700001020.000222";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+
+    const assistantMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_2,
+      channelTs: ASSISTANT_TS,
+      eventKind: "message",
+    };
+    const userReplyMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_2,
+      channelTs: REPLY_TS,
+      threadTs: ASSISTANT_TS, // Reply to the assistant's earlier message.
+      displayName: "@alice",
+      eventKind: "message",
+    };
+
+    // 1700001000 UTC = 2023-11-14 22:30:00 UTC
+    const MS_ASSISTANT = 1700001000_000;
+    const MS_REPLY = 1700001020_000;
+
+    const rows: SlackTranscriptInputRow[] = [
+      row(
+        "assistant",
+        "Earlier reply",
+        MS_ASSISTANT,
+        metadataEnvelope(assistantMeta),
+      ),
+      row("user", "Following up", MS_REPLY, metadataEnvelope(userReplyMeta)),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, SLACK_CAPS_CHANNEL);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+
+    // The user follow-up MUST carry a `→ Mxxxxxx` parent-alias arrow that
+    // points at the assistant's prior message. Before reconciliation, the
+    // assistant row was treated as legacy/null-metadata and excluded from
+    // alias issuance — the user reply rendered without the arrow.
+    const replyText = (result![1].content[0] as { text: string }).text;
+    expect(replyText).toMatch(/→ M[0-9a-f]{6}/);
+    expect(replyText).toContain(parentAlias(ASSISTANT_TS));
+  });
+
+  test("post-reconciliation: assistant row appears in active-thread focus block", () => {
+    // The active-thread focus block at
+    // `conversation-runtime-assembly.ts:1387` filters out rows with null
+    // metadata. Before reconciliation, outbound assistant rows were null-
+    // metadata at the renderable layer and silently dropped from the focus
+    // block — even when they were part of the active thread the user just
+    // replied to. Once channelTs is filled in, the assistant row's
+    // `threadTs` matches the active thread and the row is included.
+    const SLACK_CHANNEL_ID_3 = "C0FOCUS2";
+    const PARENT_TS = "1700002000.000001";
+    const ASSISTANT_REPLY_TS = "1700002005.000111";
+    const USER_REPLY_TS = "1700002010.000222";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+
+    const parentMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_3,
+      channelTs: PARENT_TS,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    const assistantInThreadMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_3,
+      channelTs: ASSISTANT_REPLY_TS,
+      threadTs: PARENT_TS, // Assistant's reply lives inside the active thread.
+      eventKind: "message",
+    };
+    const userInThreadMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_3,
+      channelTs: USER_REPLY_TS,
+      threadTs: PARENT_TS, // Latest user row — drives active-thread detection.
+      displayName: "@alice",
+      eventKind: "message",
+    };
+
+    const rows: SlackTranscriptInputRow[] = [
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Parent message" }]),
+        createdAt: 1700002000_000,
+        metadata: metadataEnvelope(parentMeta),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Assistant earlier reply" },
+        ]),
+        createdAt: 1700002005_000,
+        metadata: metadataEnvelope(assistantInThreadMeta),
+      },
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Follow-up" }]),
+        createdAt: 1700002010_000,
+        metadata: metadataEnvelope(userInThreadMeta),
+      },
+    ];
+
+    const focusBlock = assembleSlackActiveThreadFocusBlock(
+      rows,
+      SLACK_CAPS_CHANNEL,
+    );
+    expect(focusBlock).not.toBeNull();
+    expect(focusBlock!).toContain("<active_thread>");
+    expect(focusBlock!).toContain("Parent message");
+    // The assistant's earlier reply must appear in the focus block now —
+    // before reconciliation it was excluded because its slackMeta failed
+    // `readSlackMetadata` validation (no channelTs).
+    expect(focusBlock!).toContain("Assistant earlier reply");
+    expect(focusBlock!).toContain("Follow-up");
   });
 });

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -5,10 +5,11 @@
  *
  * Persistence happens BEFORE the Slack adapter sends the message, so Slack's
  * authoritative `ts` (-> `channelTs`) is not yet known at this layer. The
- * partial `slackMeta` written here is intentionally missing `channelTs`; a
- * later PR (PR 21) reconciles the field by writing it back once the send
- * response returns. These tests document that ordering and verify the
- * `channelTs` absence at the persistence boundary.
+ * partial `slackMeta` written here is intentionally missing `channelTs`; the
+ * post-send reconciliation step in `deliverReplyViaCallback` writes
+ * `channelTs` back into the row once the gateway returns the Slack-assigned
+ * ts. These tests document the persistence-side ordering — see
+ * `channel-reply-delivery.test.ts` for the reconciliation behaviour.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -202,9 +203,12 @@ describe("outbound assistant Slack metadata persistence", () => {
     expect(slackMeta.threadTs).toBe("1234.5678");
 
     // Persistence runs BEFORE the Slack adapter posts the message, so the
-    // authoritative `ts` (-> `channelTs`) is not yet known. A later PR will
-    // reconcile this field. Until then, `readSlackMetadata` rejects the
-    // partial metadata since `channelTs` is still required by the schema.
+    // authoritative `ts` (-> `channelTs`) is not yet known at this layer.
+    // The post-send reconciliation in `deliverReplyViaCallback` fills the
+    // field once the gateway returns the Slack-assigned ts (covered by
+    // `channel-reply-delivery.test.ts`). Until that runs, the partial
+    // metadata is intentionally rejected by `readSlackMetadata` so callers
+    // that try to use it before reconciliation get a clear null.
     expect(slackMeta.channelTs).toBeUndefined();
     expect(readSlackMetadata(slackMetaRaw as string)).toBeNull();
   });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -777,12 +777,14 @@ export async function handleMessageComplete(
   };
 
   // When the assistant is replying through Slack, stamp a `slackMeta`
-  // sub-object so PR 17's transcript-rendering / thread-aware-context
-  // lookup can identify this row's thread without joining tables.
+  // sub-object so the transcript-rendering / thread-aware-context lookup
+  // can identify this row's thread without joining tables.
   // Persistence happens BEFORE the Slack adapter sends the message, so
   // Slack's authoritative `ts` (-> `channelTs`) is not yet known and is
-  // intentionally omitted here. A later PR (PR 21) reconciles `channelTs`
-  // by writing it back once the send response returns.
+  // intentionally omitted here. The post-send reconciliation step in
+  // `deliverReplyViaCallback` writes `channelTs` back into this row once
+  // the gateway returns the Slack-assigned ts, restoring a fully-formed
+  // metadata envelope before any subsequent turn reads the row.
   if (deps.turnChannelContext.assistantMessageChannel === "slack") {
     const channelId = deps.ctx.trustContext?.requesterChatId;
     if (channelId) {
@@ -794,8 +796,9 @@ export async function handleMessageComplete(
         ...(threadTs ? { threadTs } : {}),
       };
       assistantChannelMetadata.slackMeta = writeSlackMetadata(
-        // `channelTs` is filled in by the post-send reconciliation step in a
-        // later PR; cast through the Partial to satisfy the writer's type.
+        // `channelTs` is filled in by the post-send reconciliation step in
+        // `deliverReplyViaCallback`; cast through the Partial to satisfy
+        // the writer's type at this pre-send boundary.
         partialSlackMeta as SlackMessageMetadata,
       );
     }

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,6 +1,12 @@
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
-import { getMessages } from "../memory/conversation-crud.js";
+import {
+  getMessageById,
+  getMessages,
+  updateMessageMetadata,
+} from "../memory/conversation-crud.js";
+import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { getLogger } from "../util/logger.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
@@ -8,6 +14,8 @@ import {
   isSlackCallbackUrl,
   textToSlackBlocks,
 } from "./slack-block-formatting.js";
+
+const log = getLogger("channel-reply-delivery");
 
 const INTER_SEGMENT_DELAY_MS = 150;
 
@@ -206,6 +214,22 @@ export async function deliverReplyViaCallback(
       kind: a.kind,
     }));
 
+    // Compose an `onMessageTs` that reconciles `slackMeta.channelTs` on the
+    // persisted assistant row once Slack returns the authoritative ts. The
+    // assistant row was written BEFORE the gateway POST in
+    // `handleMessageComplete`, so the partial `slackMeta` it carries is
+    // missing `channelTs` and would otherwise be rejected by
+    // `readSlackMetadata`, dropping the row out of chronological/thread-tag
+    // rendering. We only act on the FIRST ts (top-level segment); any
+    // subsequent split segments become independent Slack messages with
+    // their own ts and are not represented as separate DB rows.
+    const reconcileOnMessageTs = makeChannelTsReconciler(msgs[i].id);
+    const callerOnMessageTs = options?.onMessageTs;
+    const composedOnMessageTs = (ts: string): void => {
+      reconcileOnMessageTs(ts);
+      callerOnMessageTs?.(ts);
+    };
+
     await deliverRenderedReplyViaCallback({
       callbackUrl,
       chatId: externalChatId,
@@ -219,8 +243,88 @@ export async function deliverReplyViaCallback(
       ephemeral: options?.ephemeral,
       user: options?.user,
       messageTs: options?.messageTs,
-      onMessageTs: options?.onMessageTs,
+      onMessageTs: composedOnMessageTs,
     });
     break;
   }
+}
+
+/**
+ * Build a one-shot `onMessageTs` handler that reconciles the persisted
+ * assistant message's `slackMeta.channelTs` from Slack's authoritative `ts`.
+ *
+ * Behavior:
+ * - Acts only on the first invocation per delivery (subsequent segments
+ *   correspond to independent Slack messages with their own ts and are not
+ *   represented as separate DB rows).
+ * - No-op when the row was not persisted with a `slackMeta` envelope (the
+ *   channel was not Slack at write-time, e.g. vellum/telegram outbound).
+ * - No-op when the row's existing `slackMeta` already parses cleanly via
+ *   `readSlackMetadata` (channelTs already present, e.g. from a prior
+ *   reconciliation).
+ * - Failures are logged and swallowed so a transient DB error cannot break
+ *   the outbound delivery itself.
+ */
+function makeChannelTsReconciler(messageId: string): (ts: string) => void {
+  let applied = false;
+  return (ts: string): void => {
+    if (applied) return;
+    applied = true;
+    if (!ts) return;
+    try {
+      // Re-read the row's current metadata so a concurrent edit-propagation
+      // write (e.g. `editedAt`) is not clobbered. `updateMessageMetadata`
+      // shallow-merges into the top-level envelope, and the slackMeta
+      // sub-object is merged manually below so we can preserve fields on
+      // the partial pre-send envelope (`mergeSlackMetadata` would call
+      // `readSlackMetadata` which rejects the partial form for lacking
+      // channelTs — exactly the state we are reconciling).
+      const row = getMessageById(messageId);
+      if (row === null || row.metadata === null) return;
+      let envelope: Record<string, unknown>;
+      try {
+        envelope = JSON.parse(row.metadata) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      const slackMetaRaw =
+        typeof envelope.slackMeta === "string" ? envelope.slackMeta : null;
+      if (slackMetaRaw === null) return;
+      // If the existing slackMeta already parses cleanly via the strict
+      // reader, channelTs is already present (a prior reconciliation ran,
+      // or backfill stamped the field) — nothing to do.
+      if (readSlackMetadata(slackMetaRaw) !== null) return;
+      // Lenient parse of the partial slackMeta so we can preserve every
+      // field already written by `handleMessageComplete` (source,
+      // eventKind, channelId, threadTs, ...) while patching channelTs in.
+      let existingSlackMeta: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(slackMetaRaw) as unknown;
+        if (
+          parsed === null ||
+          typeof parsed !== "object" ||
+          Array.isArray(parsed)
+        ) {
+          return;
+        }
+        existingSlackMeta = parsed as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      const mergedSlackMeta = JSON.stringify({
+        ...existingSlackMeta,
+        channelTs: ts,
+        // Force `source: "slack"` for parity with `mergeSlackMetadata`'s
+        // invariant — the reader rejects anything else and we never want a
+        // reconciled row to slip through with a stale source.
+        source: "slack",
+      });
+      updateMessageMetadata(messageId, { slackMeta: mergedSlackMeta });
+    } catch (err) {
+      log.warn(
+        { err, messageId },
+        "Failed to reconcile slackMeta.channelTs on outbound assistant row",
+      );
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- Outbound assistant Slack messages now carry a complete slackMeta (including channelTs), so they render with thread tags and appear in the active-thread focus block.
- Closes the gap identified during self-review: assistant's own prior replies were silently falling through to the legacy-flat-render path.

Fixes gap identified during plan review for slack-thread-aware-context.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
