### PR TITLE
fix(slack): restore guardian approvals, await backfill, enforce ACL on deletes

### DIFF
--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -23,6 +23,7 @@ mock.module("../config/env.js", () => ({
 
 import { eq } from "drizzle-orm";
 
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb, initializeDb } from "../memory/db.js";
 import { linkMessage, recordInbound } from "../memory/delivery-crud.js";
 import { messages } from "../memory/schema.js";
@@ -35,6 +36,12 @@ import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 initializeDb();
 
 const TEST_BEARER_TOKEN = "test-token";
+// Slack `message_deleted` events stamp the deleted message's original author
+// as the actor (gateway: `event.previous_message.user`). The author must be a
+// recognised member for the inbound ACL to admit the event — gating delete
+// behind ACL is the contract under test.
+const SLACK_DELETE_ACTOR_ID = "U_DELETE_ACTOR";
+const SLACK_DELETE_ACTOR_DISPLAY_NAME = "Delete Actor";
 
 function resetState(): void {
   const db = getDb();
@@ -42,6 +49,19 @@ function resetState(): void {
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
   db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+function seedActiveDeleteActor(externalChatId: string): void {
+  upsertContactChannel({
+    sourceChannel: "slack",
+    externalUserId: SLACK_DELETE_ACTOR_ID,
+    externalChatId,
+    status: "active",
+    policy: "allow",
+    displayName: SLACK_DELETE_ACTOR_DISPLAY_NAME,
+  });
 }
 
 interface SeededMessage {
@@ -109,6 +129,7 @@ function buildSlackDeleteRequest(opts: {
   externalChatId: string;
   deletedTs: string;
   eventId?: string;
+  actorExternalId?: string;
 }): Request {
   const eventId = opts.eventId ?? `evt-del-${opts.deletedTs}`;
   return new Request("http://localhost:8080/channels/inbound", {
@@ -125,7 +146,7 @@ function buildSlackDeleteRequest(opts: {
       externalMessageId: eventId,
       content: "",
       callbackData: "message_deleted",
-      actorExternalId: "slack-system",
+      actorExternalId: opts.actorExternalId ?? SLACK_DELETE_ACTOR_ID,
       sourceMetadata: {
         // The original (deleted) message's ts — the lookup key.
         messageId: opts.deletedTs,
@@ -137,6 +158,7 @@ function buildSlackDeleteRequest(opts: {
 describe("Slack delete propagation", () => {
   beforeEach(() => {
     resetState();
+    seedActiveDeleteActor("C0123CHANNEL");
   });
 
   test("marks slackMeta.deletedAt and leaves content untouched", async () => {
@@ -276,7 +298,7 @@ describe("Slack delete propagation", () => {
         externalMessageId: "evt-del-no-source",
         content: "",
         callbackData: "message_deleted",
-        actorExternalId: "slack-system",
+        actorExternalId: SLACK_DELETE_ACTOR_ID,
         // sourceMetadata intentionally omitted
       }),
     });
@@ -292,6 +314,47 @@ describe("Slack delete propagation", () => {
       .from(messages)
       .where(eq(messages.id, seeded.messageId))
       .get();
+    const parsed = JSON.parse(row!.metadata!) as Record<string, unknown>;
+    const slackMeta = readSlackMetadata(parsed.slackMeta as string);
+    expect(slackMeta!.deletedAt).toBeUndefined();
+  });
+
+  test("delete from non-member actor is rejected by ACL and does not apply", async () => {
+    // Use a channel where NO active member is seeded so the actor cannot
+    // resolve via the channel's externalChatId either. This is the
+    // regression check for the gap where the delete short-circuit ran
+    // before ingress ACL — under the fix the ACL must reject the delete
+    // so no row is mutated. Also clear the C0123CHANNEL seed for the
+    // alt channel below since beforeEach wires the seed on C0123CHANNEL
+    // only.
+    const altChannel = "C0_NON_MEMBER_CHAN";
+    const seeded = seedSlackMessage({
+      externalChatId: altChannel,
+      originalTs: "7777.7777",
+      content: "Original audited text",
+      withSlackMeta: true,
+    });
+
+    const req = buildSlackDeleteRequest({
+      externalChatId: seeded.externalChatId,
+      deletedTs: seeded.originalTs,
+      actorExternalId: "U_NON_MEMBER",
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    // ACL denies the inbound — the response must not carry `deleted: true`.
+    expect(json.deleted).not.toBe(true);
+
+    // The original row remains unmodified — content untouched and no
+    // deletedAt marker stamped on slackMeta.
+    const db = getDb();
+    const row = db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, seeded.messageId))
+      .get();
+    expect(row!.content).toBe("Original audited text");
     const parsed = JSON.parse(row!.metadata!) as Record<string, unknown>;
     const slackMeta = readSlackMetadata(parsed.slackMeta as string);
     expect(slackMeta!.deletedAt).toBeUndefined();

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -39,10 +39,19 @@ mock.module("../runtime/gateway-client.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { upsertContactChannel } from "../contacts/contacts-write.js";
+import {
+  createGuardianBinding,
+  upsertContactChannel,
+} from "../contacts/contacts-write.js";
+import type { Conversation } from "../daemon/conversation.js";
 import { getDb, initializeDb } from "../memory/db.js";
+import {
+  createApprovalRequest,
+  getPendingApprovalForRequest,
+} from "../memory/guardian-approvals.js";
 import { messages } from "../memory/schema/conversations.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 import {
   isSlackReactionEvent,
@@ -375,5 +384,155 @@ describe("Slack reaction event persistence", () => {
       .where(eq(channelInboundEvents.id, eventId))
       .get();
     expect(eventRow?.messageId).toBe(messageRows[0].id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guardian approval-by-reaction integration test
+// ---------------------------------------------------------------------------
+//
+// Verifies that a guardian's `reaction:` event on a pending approval prompt
+// applies the decision via `handleApprovalInterception` and short-circuits
+// the reaction-persistence path so no transcript-line row is written. This
+// is the regression check for the gap where the reaction short-circuit ran
+// before approval interception, silently breaking guardian approval-by-reaction.
+
+const GUARDIAN_USER_ID = "U_GUARDIAN_REACT";
+const GUARDIAN_DISPLAY_NAME = "Guardian Reactor";
+const GUARDIAN_REACTION_TOOL = "execute_shell";
+const GUARDIAN_REACTION_INPUT = { command: "rm -rf /tmp/test" };
+
+function seedGuardianForChannel(): void {
+  createGuardianBinding({
+    channel: "slack",
+    guardianExternalUserId: GUARDIAN_USER_ID,
+    guardianDeliveryChatId: SLACK_CHANNEL_ID,
+    guardianPrincipalId: GUARDIAN_USER_ID,
+  });
+}
+
+function seedPendingGuardianApprovalForReaction(
+  requestId: string,
+  conversationId: string,
+): void {
+  createApprovalRequest({
+    runId: `run-${requestId}`,
+    requestId,
+    conversationId,
+    channel: "slack",
+    requesterExternalUserId: "requester-user-1",
+    requesterChatId: SLACK_CHANNEL_ID,
+    guardianExternalUserId: GUARDIAN_USER_ID,
+    guardianChatId: SLACK_CHANNEL_ID,
+    toolName: GUARDIAN_REACTION_TOOL,
+    expiresAt: Date.now() + 300_000,
+  });
+
+  // Register a pending interaction so applyGuardianDecision finds the
+  // requester-side hook to drive `allow`.
+  const handleConfirmationResponse = mock(() => {});
+  const mockSession = {
+    handleConfirmationResponse,
+    ensureActorScopedHistory: async () => {},
+  } as unknown as Conversation;
+  pendingInteractions.register(requestId, {
+    conversation: mockSession,
+    conversationId,
+    kind: "confirmation",
+    confirmationDetails: {
+      toolName: GUARDIAN_REACTION_TOOL,
+      input: GUARDIAN_REACTION_INPUT,
+      riskLevel: "high",
+      allowlistOptions: [
+        { label: "test", description: "test", pattern: "test" },
+      ],
+      scopeOptions: [{ label: "everywhere", scope: "everywhere" }],
+    },
+  });
+}
+
+describe("guardian approval-by-reaction integration via handleChannelInbound", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM channel_inbound_events");
+    db.run("DELETE FROM conversations");
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    db.run("DELETE FROM channel_guardian_approval_requests");
+    pendingInteractions.clear();
+    msgCounter = 0;
+  });
+
+  test("guardian reaction on pending approval applies decision and persists no transcript row", async () => {
+    seedGuardianForChannel();
+    const requestId = "req-guardian-react-1";
+    // Conversation must exist so the approval row's conversation_id FK
+    // resolves; reuse an inbound seed by sending a no-op message that the
+    // ACL allows. Easier: insert directly via the DB layer.
+    const db = getDb();
+    const conversationId = "conv-react-test-1";
+    const now = Date.now();
+    db.$client
+      .prepare(
+        `INSERT INTO conversations (
+          id, title, created_at, updated_at, total_input_tokens, total_output_tokens,
+          total_estimated_cost, context_compacted_message_count, conversation_type,
+          source, memory_scope_id, host_access, is_auto_title
+        ) VALUES (?, NULL, ?, ?, 0, 0, 0, 0, 'standard', 'user', 'default', 0, 1)`,
+      )
+      .run(conversationId, now, now);
+
+    seedPendingGuardianApprovalForReaction(requestId, conversationId);
+
+    const reactedTs = "1700000099.000001";
+    const body = {
+      sourceChannel: "slack",
+      interface: "slack",
+      conversationExternalId: SLACK_CHANNEL_ID,
+      externalMessageId: `${SLACK_CHANNEL_ID}:${reactedTs}:guardian-react`,
+      content: "reaction:white_check_mark",
+      callbackData: "reaction:white_check_mark",
+      actorExternalId: GUARDIAN_USER_ID,
+      actorDisplayName: GUARDIAN_DISPLAY_NAME,
+      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      sourceMetadata: {
+        messageId: reactedTs,
+        chatType: "channel",
+      },
+    };
+    const req = new Request("http://localhost:8080/channels/inbound", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gateway-Origin": TEST_BEARER_TOKEN,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(resp.status).toBe(200);
+    expect(json.accepted).toBe(true);
+    expect(json.approval).toBe("guardian_decision_applied");
+
+    // The pending approval row is resolved (no longer pending).
+    expect(getPendingApprovalForRequest(requestId)).toBeNull();
+
+    // No transcript row was written for the reaction itself — pre-upgrade
+    // semantics carried no transcript trace for resolved approvals.
+    const reactionRows = readPersistedMessages().filter((row) => {
+      if (!row.metadata) return false;
+      try {
+        const env = JSON.parse(row.metadata) as Record<string, unknown>;
+        if (typeof env.slackMeta !== "string") return false;
+        const meta = readSlackMetadata(env.slackMeta);
+        return meta?.eventKind === "reaction";
+      } catch {
+        return false;
+      }
+    });
+    expect(reactionRows.length).toBe(0);
   });
 });

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -754,4 +754,94 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     const json = (await resp.json()) as Record<string, unknown>;
     expect(json.accepted).toBe(true);
   });
+
+  test("backfill is awaited: parent is stored before handleChannelInbound returns", async () => {
+    // Replace the resolved promise with a manually-controlled deferred so we
+    // can prove that the inbound handler awaits the backfill rather than
+    // racing it against the agent-loop dispatch. If `await` were missing,
+    // `handleChannelInbound` would resolve before the parent row hit the
+    // database and the immediate post-response read below would miss it.
+    let resolveBackfill: (() => void) | null = null;
+    const backfillCompleted = new Promise<void>((resolve) => {
+      resolveBackfill = resolve;
+    });
+
+    backfillThreadMock.mockImplementation(async () => {
+      await backfillCompleted;
+      return [
+        makeBackfillMessage({
+          id: "8888.0",
+          text: "thread parent",
+          threadId: undefined,
+          sender: { id: "U_PARENT_AWAIT", name: "Parent Author" },
+        }),
+      ];
+    });
+
+    let agentLoopFired = false;
+    const processMessage = async (): Promise<{ messageId: string }> => {
+      // The agent loop runs *after* backfill. Confirm the parent row is
+      // already visible at this point — that proves the backfill landed
+      // before dispatch.
+      agentLoopFired = true;
+      return { messageId: "agent-result-id" };
+    };
+
+    const inboundPromise = handleChannelInbound(
+      buildThreadReplyRequest("8888.0", "8888.1"),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    // Give the handler enough microtasks to reach the awaited backfill.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // Backfill is suspended at the awaited deferred — the parent row should
+    // not yet be persisted, and the agent loop must not have fired.
+    const db = getDb();
+    const rowsBeforeResolve = db.$client
+      .prepare("SELECT metadata FROM messages")
+      .all() as Array<{ metadata: string | null }>;
+    const tsBefore = rowsBeforeResolve
+      .map((row) => {
+        if (!row.metadata) return undefined;
+        try {
+          const env = JSON.parse(row.metadata) as Record<string, unknown>;
+          if (typeof env.slackMeta !== "string") return undefined;
+          const meta = readSlackMetadata(env.slackMeta);
+          return meta?.channelTs;
+        } catch {
+          return undefined;
+        }
+      })
+      .filter((ts): ts is string => ts !== undefined);
+    expect(tsBefore.includes("8888.0")).toBe(false);
+    expect(agentLoopFired).toBe(false);
+
+    // Release the backfill mock; the awaited handler should now finish.
+    resolveBackfill!();
+    const resp = await inboundPromise;
+    expect(resp.status).toBe(200);
+
+    const rowsAfter = db.$client
+      .prepare("SELECT metadata FROM messages")
+      .all() as Array<{ metadata: string | null }>;
+    const tsAfter = rowsAfter
+      .map((row) => {
+        if (!row.metadata) return undefined;
+        try {
+          const env = JSON.parse(row.metadata) as Record<string, unknown>;
+          if (typeof env.slackMeta !== "string") return undefined;
+          const meta = readSlackMetadata(env.slackMeta);
+          return meta?.channelTs;
+        } catch {
+          return undefined;
+        }
+      })
+      .filter((ts): ts is string => ts !== undefined);
+
+    // The parent row is present before the response is delivered, so the
+    // agent loop dispatched after this point sees it.
+    expect(tsAfter.includes("8888.0")).toBe(true);
+  });
 });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -186,15 +186,85 @@ export async function handleChannelInbound(
     );
   }
 
+  // Canonicalize the assistant ID so all DB-facing operations use the
+  // consistent 'self' key regardless of what the gateway sent.
+  const canonicalAssistantId = canonicalChannelAssistantId(assistantId);
+  if (canonicalAssistantId !== assistantId) {
+    log.debug(
+      { raw: assistantId, canonical: canonicalAssistantId },
+      "Canonicalized channel assistant ID",
+    );
+  }
+
+  // Coerce actorExternalId to a string at the boundary — the field
+  // comes from unvalidated JSON and may be a number, object, or other
+  // non-string type. Non-string truthy values would throw inside
+  // canonicalizeInboundIdentity when it calls .trim().
+  const rawSenderId =
+    body.actorExternalId != null ? String(body.actorExternalId) : undefined;
+
+  // Canonicalize the sender identity so all trust lookups, member matching,
+  // and guardian binding comparisons use a normalized form. Phone-like
+  // channels (voice, whatsapp) are normalized to E.164; non-phone
+  // channels pass through the platform-stable ID unchanged.
+  const canonicalSenderId = rawSenderId
+    ? canonicalizeInboundIdentity(sourceChannel, rawSenderId)
+    : null;
+
+  // Track whether the original payload included a sender identity. A
+  // whitespace-only actorExternalId canonicalizes to null but still
+  // represents an explicit (malformed) identity claim that must enter the
+  // ACL deny path rather than bypassing it.
+  const hasSenderIdentityClaim = rawSenderId !== undefined;
+
+  // ── Guardian channel activation ──
+  // When a bare /start arrives on a channel with no guardian, auto-initiate
+  // guardian verification so the first user can claim the channel.
+  const guardianActivationResponse = await handleGuardianActivationIntercept({
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    canonicalSenderId,
+    actorDisplayName: body.actorDisplayName,
+    actorUsername: body.actorUsername,
+    sourceMetadata: body.sourceMetadata,
+    replyCallbackUrl: body.replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+    externalMessageId,
+  });
+  if (guardianActivationResponse) return guardianActivationResponse;
+
+  // ── Ingress ACL enforcement ──
+  const aclResult = await enforceIngressAcl({
+    canonicalSenderId,
+    hasSenderIdentityClaim,
+    rawSenderId,
+    sourceChannel,
+    conversationExternalId,
+    canonicalAssistantId,
+    trimmedContent,
+    sourceMetadata: body.sourceMetadata,
+    actorDisplayName: body.actorDisplayName,
+    actorUsername: body.actorUsername,
+    replyCallbackUrl: body.replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+    externalMessageId,
+  });
+  if (aclResult.earlyResponse) return aclResult.earlyResponse;
+  const { resolvedMember, guardianVerifyCode } = aclResult;
+
   // ── Slack delete propagation ──
   // Slack message_deleted events are forwarded by the gateway with the
   // sentinel `callbackData = "message_deleted"` and `sourceMetadata.messageId`
   // set to the original (deleted) message's ts. Short-circuit the rest of
   // the pipeline: the agent loop should not run for delete notifications,
-  // and routing the event through guardian/ACL/approval paths would be
-  // incorrect. We mark the stored row as deleted in slackMeta but leave
-  // `content` untouched for audit purposes — rendering elides based on
-  // the deletedAt marker.
+  // and routing the event through approval / agent paths would be incorrect.
+  // We mark the stored row as deleted in slackMeta but leave `content`
+  // untouched for audit purposes — rendering elides based on the deletedAt
+  // marker. Gated behind ingress ACL so non-members cannot drive deletes
+  // (matches the edit-intercept policy).
   if (sourceChannel === "slack" && body.callbackData === "message_deleted") {
     const deletedMessageTs =
       typeof sourceMetadata?.messageId === "string"
@@ -307,75 +377,6 @@ export async function handleChannelInbound(
       messageId: original.messageId,
     });
   }
-
-  // Canonicalize the assistant ID so all DB-facing operations use the
-  // consistent 'self' key regardless of what the gateway sent.
-  const canonicalAssistantId = canonicalChannelAssistantId(assistantId);
-  if (canonicalAssistantId !== assistantId) {
-    log.debug(
-      { raw: assistantId, canonical: canonicalAssistantId },
-      "Canonicalized channel assistant ID",
-    );
-  }
-
-  // Coerce actorExternalId to a string at the boundary — the field
-  // comes from unvalidated JSON and may be a number, object, or other
-  // non-string type. Non-string truthy values would throw inside
-  // canonicalizeInboundIdentity when it calls .trim().
-  const rawSenderId =
-    body.actorExternalId != null ? String(body.actorExternalId) : undefined;
-
-  // Canonicalize the sender identity so all trust lookups, member matching,
-  // and guardian binding comparisons use a normalized form. Phone-like
-  // channels (voice, whatsapp) are normalized to E.164; non-phone
-  // channels pass through the platform-stable ID unchanged.
-  const canonicalSenderId = rawSenderId
-    ? canonicalizeInboundIdentity(sourceChannel, rawSenderId)
-    : null;
-
-  // Track whether the original payload included a sender identity. A
-  // whitespace-only actorExternalId canonicalizes to null but still
-  // represents an explicit (malformed) identity claim that must enter the
-  // ACL deny path rather than bypassing it.
-  const hasSenderIdentityClaim = rawSenderId !== undefined;
-
-  // ── Guardian channel activation ──
-  // When a bare /start arrives on a channel with no guardian, auto-initiate
-  // guardian verification so the first user can claim the channel.
-  const guardianActivationResponse = await handleGuardianActivationIntercept({
-    sourceChannel,
-    conversationExternalId,
-    rawSenderId,
-    canonicalSenderId,
-    actorDisplayName: body.actorDisplayName,
-    actorUsername: body.actorUsername,
-    sourceMetadata: body.sourceMetadata,
-    replyCallbackUrl: body.replyCallbackUrl,
-    mintBearerToken,
-    assistantId,
-    externalMessageId,
-  });
-  if (guardianActivationResponse) return guardianActivationResponse;
-
-  // ── Ingress ACL enforcement ──
-  const aclResult = await enforceIngressAcl({
-    canonicalSenderId,
-    hasSenderIdentityClaim,
-    rawSenderId,
-    sourceChannel,
-    conversationExternalId,
-    canonicalAssistantId,
-    trimmedContent,
-    sourceMetadata: body.sourceMetadata,
-    actorDisplayName: body.actorDisplayName,
-    actorUsername: body.actorUsername,
-    replyCallbackUrl: body.replyCallbackUrl,
-    mintBearerToken,
-    assistantId,
-    externalMessageId,
-  });
-  if (aclResult.earlyResponse) return aclResult.earlyResponse;
-  const { resolvedMember, guardianVerifyCode } = aclResult;
 
   if (hasAttachments) {
     const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
@@ -508,14 +509,73 @@ export async function handleChannelInbound(
     });
   }
 
-  // ── Slack reaction persistence ──
+  // ── Slack reaction handling ──
   // Reactions arrive as regular `SlackInboundEvent`s with `callbackData`
-  // prefixed `reaction:` (added) or `reaction_removed:` (removed). Persist
-  // them as `messages` rows so the chronological renderer (PR 18) can
-  // surface them inline. Reactions never trigger an agent response, so we
-  // short-circuit before escalation, approval interception, and agent-loop
-  // dispatch.
+  // prefixed `reaction:` (added) or `reaction_removed:` (removed).
+  //
+  // Two paths from here:
+  //   1. Guardian approval-by-reaction. A `reaction:` (added) event from
+  //      the guardian on an active approval prompt is consumed by
+  //      `handleApprovalInterception` to apply the decision. In that case
+  //      we do NOT persist the reaction as a transcript line — pre-upgrade
+  //      semantics carried no transcript trace for resolved reactions.
+  //   2. All other reactions (non-guardian, no pending approval, stale,
+  //      and any `reaction_removed:` event regardless of actor) fall
+  //      through to `persistSlackReactionAsMessage` so the chronological
+  //      renderer (PR 18) can surface them inline. Reactions never
+  //      trigger an agent response, so we short-circuit before
+  //      escalation and agent-loop dispatch in both cases.
   if (isSlackReactionEvent(body)) {
+    // Approval interception runs only for reactions (added) — `reaction_removed`
+    // never expresses an approval intent, so un-reacting is left as a pure
+    // transcript signal. Gated by the same `replyCallbackUrl && !duplicate`
+    // preconditions used by the standard approval interception call below.
+    const isReactionAdded = body.callbackData?.startsWith("reaction:") === true;
+    if (isReactionAdded && replyCallbackUrl && !result.duplicate) {
+      const trustCtxForReaction: TrustContext = resolveTrustContext({
+        assistantId: canonicalAssistantId,
+        sourceChannel,
+        conversationExternalId,
+        actorExternalId: rawSenderId,
+        actorUsername: body.actorUsername,
+        actorDisplayName: body.actorDisplayName,
+      });
+
+      const approvalMessageTs =
+        typeof sourceMetadata?.messageId === "string"
+          ? sourceMetadata.messageId
+          : undefined;
+
+      const reactionApprovalResult = await handleApprovalInterception({
+        conversationId: result.conversationId,
+        callbackData: body.callbackData,
+        content: trimmedContent,
+        conversationExternalId,
+        sourceChannel,
+        actorExternalId: canonicalSenderId ?? rawSenderId,
+        replyCallbackUrl,
+        bearerToken: mintBearerToken(),
+        trustCtx: trustCtxForReaction,
+        assistantId: canonicalAssistantId,
+        approvalCopyGenerator,
+        approvalConversationGenerator,
+        approvalMessageTs,
+      });
+
+      // A real guardian decision was applied — short-circuit and skip the
+      // reaction-persistence path so we do not double-record it as a
+      // transcript line. All other interception outcomes (stale_ignored,
+      // non-guardian, no pending approval) fall through to persistence.
+      if (reactionApprovalResult.type === "guardian_decision_applied") {
+        return Response.json({
+          accepted: true,
+          duplicate: false,
+          eventId: result.eventId,
+          approval: reactionApprovalResult.type,
+        });
+      }
+    }
+
     const reactedMessageTs =
       typeof sourceMetadata?.messageId === "string"
         ? sourceMetadata.messageId
@@ -934,11 +994,15 @@ export async function handleChannelInbound(
       // When a Slack reply arrives for a thread the daemon never saw the
       // parent of, fetch the thread's recent history from Slack and persist
       // the missing messages so the chronological renderer (PR 18) has the
-      // full conversation. Fire-and-forget: failures are swallowed and
-      // never block the agent loop, the outbound HTTP response, or message
-      // dispatch.
+      // full conversation. Awaited (mirrors the DM cold-start path above)
+      // so the agent loop dispatched immediately afterwards observes the
+      // backfilled parent — without this, `loadSlackChronologicalMessages`
+      // can race the persist and miss thread context. Backfill is bounded
+      // (parent + ~50 messages) and the agent latency is dominated by the
+      // LLM call, so the added latency is negligible. Failures are
+      // swallowed inside the helper so they never block dispatch.
       if (slackThreadTs) {
-        void triggerSlackThreadBackfillIfNeeded({
+        await triggerSlackThreadBackfillIfNeeded({
           conversationId: result.conversationId,
           channelId: conversationExternalId,
           threadTs: slackThreadTs,


### PR DESCRIPTION
## Summary
Fixes three gaps found during self-review of the Slack thread-aware context plan:
- Restore guardian approval-by-reaction by running handleApprovalInterception before the reaction persistence short-circuit.
- Await thread-ancestor backfill so the agent loop sees the parent message.
- Move Slack message_deleted processing below enforceIngressAcl.

Fixes gaps identified during plan review for slack-thread-aware-context.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
