### PR TITLE
chore(meet): document LaunchDarkly provisioning prerequisite for meet flag enablement

### DIFF
--- a/meta/feature-flags/PENDING_PLATFORM_PRS.md
+++ b/meta/feature-flags/PENDING_PLATFORM_PRS.md
@@ -1,0 +1,17 @@
+# Pending Platform PRs for Feature Flags
+
+This file tracks assistant feature flags that have been declared in
+`feature-flag-registry.json` but do not yet have a corresponding
+LaunchDarkly/Terraform entry in the `vellum-assistant-platform` repo. Per
+`CLAUDE.md` (see the Assistant Feature Flags section) and
+`meta/feature-flags/AGENTS.md`, a new flag in this registry requires a
+companion PR in `vellum-assistant-platform` to provision the flag on the
+platform for remote sync.
+
+Remove an entry from this file once its companion platform PR is merged.
+
+## Open entries
+
+| Flag key | Registry declaration date | Owner | Status | Required platform work |
+|---|---|---|---|---|
+| `meet` | 2026-04-19 | sidd@vellum.ai | Platform PR not yet opened (as of 2026-04-19) | Terraform entry in `../vellum-assistant-platform/terraform/launchdarkly.tf` (or equivalent) with `defaultEnabled: false` and a description pointing at `skills/meet-join/SKILL.md`. |

--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -77,3 +77,20 @@ for the empirical repro.
 
 Do not re-introduce Playwright or any CDP-based automation library into
 `bot/`. See `bot/AGENTS.md` for the bot-side architecture.
+
+## Release gating
+
+The `meet` feature flag defaults to **off** in
+`meta/feature-flags/feature-flag-registry.json`. Turning it on in
+production requires both of the following to be true:
+
+1. All Blocking and Important PRs in the Phase 1.12 plan have landed on
+   `main` and been live-verified (no regressions against a real Meet).
+2. The LaunchDarkly provisioning PR in `vellum-assistant-platform` has
+   merged, creating the Terraform entry for `meet` so the platform can
+   remote-sync the flag to managed assistants. This companion PR is
+   tracked in `meta/feature-flags/PENDING_PLATFORM_PRS.md` — the entry
+   there should be removed once the platform PR lands.
+
+Until both conditions are met, the flag must stay off for all users
+outside the local development environment.


### PR DESCRIPTION
## Summary
- New `meta/feature-flags/PENDING_PLATFORM_PRS.md` tracking the required Terraform companion PR for the `meet` flag
- Release-gating section in `skills/meet-join/AGENTS.md` noting production-enablement prerequisites

## TODO for Sidd
Open the companion PR in `vellum-assistant-platform` to add the `meet` flag to the LaunchDarkly Terraform configuration. Remove the entry from `PENDING_PLATFORM_PRS.md` once merged.

Part of plan: meet-phase-1-12-prime-time.md (PR 14 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
