### PR TITLE
meet-join: SKILL.md guidance for avatar/video participation

### DIFF
--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -115,3 +115,17 @@ Avoid voice for:
 - Anything where participants have not signalled they want voice output from the assistant. When in doubt, prefer chat or silence.
 
 Barge-in is automatic: if a human speaks while the assistant is talking, the assistant's audio is cancelled mid-utterance. Treat being interrupted as normal — do not retry the cancelled utterance or apologize for it.
+
+## Video avatar
+
+`meet_enable_avatar` turns on a real-time video avatar that lip-syncs to TTS output. `meet_disable_avatar` turns it off. The avatar is **off by default** when the assistant joins a meeting — the assistant must explicitly opt in.
+
+Enable the avatar when:
+
+- The user explicitly asks the assistant to be on camera (e.g. "turn your video on", "show your avatar").
+- The meeting context expects video participation (e.g. a presentation or 1:1 where other participants are on camera and have signalled they welcome a visual presence).
+
+Avoid enabling the avatar when:
+
+- The user has not asked for it. Do not turn it on proactively.
+- The assistant is not actively speaking. Most participants read "video on" as presence and attention — the avatar is not a watching observer. Disable it during long stretches of silence and re-enable it when the assistant is about to speak again.


### PR DESCRIPTION
## Summary
- Appends a `## Video avatar` section to `skills/meet-join/SKILL.md` documenting the `meet_enable_avatar` / `meet_disable_avatar` tools (tools themselves land in PR 7).
- Includes opt-in / opt-out guidance so the assistant doesn't default to camera-on.

Part of plan: meet-phase-4-avatar.md (PR 5 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
