### PR TITLE
chore(meet): refresh Meet DOM fixtures from live capture and bump selector version

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
@@ -5,6 +5,13 @@
   Covers the composer (textarea + send) and a rendered message list with a
   single message containing the sender/text/timestamp subnodes. Shape
   approximation — see README § "Refreshing Meet DOM fixtures".
+
+  TODO(meet-dom): The next live refresh is expected during the Phase 1.12
+  smoke test, driven by Sidd against a real Meet session. This file was
+  last verified (selector tests green) on 2026-04-19 but has not been
+  replaced with a fresh outer-HTML capture since authorship. When the
+  smoke test runs, replace this block with the captured DOM and bump
+  `GOOGLE_MEET_SELECTOR_VERSION` in `src/dom/selectors.ts`.
 -->
 <html lang="en">
   <head>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
@@ -6,6 +6,13 @@
   and a sample participant tile carrying the active-speaker and speaking
   indicators. Shape approximation — see README § "Refreshing Meet DOM
   fixtures" before relying on it as a production reference.
+
+  TODO(meet-dom): The next live refresh is expected during the Phase 1.12
+  smoke test, driven by Sidd against a real Meet session. This file was
+  last verified (selector tests green) on 2026-04-19 but has not been
+  replaced with a fresh outer-HTML capture since authorship. When the
+  smoke test runs, replace this block with the captured DOM and bump
+  `GOOGLE_MEET_SELECTOR_VERSION` in `src/dom/selectors.ts`.
 -->
 <html lang="en">
   <head>

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
@@ -6,6 +6,13 @@
   it is a minimal structure that exercises the prejoin selectors in
   `src/browser/dom-selectors.ts`. Refresh against a live Meet session when
   Meet's DOM drifts (see README § "Refreshing Meet DOM fixtures").
+
+  TODO(meet-dom): The next live refresh is expected during the Phase 1.12
+  smoke test, driven by Sidd against a real Meet session. This file was
+  last verified (selector tests green) on 2026-04-19 but has not been
+  replaced with a fresh outer-HTML capture since authorship. When the
+  smoke test runs, replace this block with the captured DOM and bump
+  `GOOGLE_MEET_SELECTOR_VERSION` in `src/dom/selectors.ts`.
 -->
 <html lang="en">
   <head>


### PR DESCRIPTION
## Summary
- Verified existing fixture → selector tests still pass (23/23 green) against the committed DOM fixtures.
- Confirmed `GOOGLE_MEET_SELECTOR_VERSION` is already `"2026-04-19"` (today) — no bump needed; it was set by a prior PR in the Phase 1.12 chain.
- Added a `TODO(meet-dom)` breadcrumb at the top of each fixture (prejoin/ingame/chat) noting the next live refresh is expected during the Phase 1.12 smoke test by Sidd, since an agent cannot drive a browser.
- Verified `skills/meet-join/bot/README.md` § "Refreshing Meet DOM fixtures" is still accurate — no change needed.

## What this PR does NOT do
- **Does not perform a live Meet recapture.** The original plan called for refreshing fixtures against a live Google Meet session, but the implementing agent has no browser access. The fixtures remain the hand-authored shape approximations from the original Phase 1.x authorship. **Sidd is still expected to run the live recapture** as the real acceptance for this plan item; the breadcrumbs now in each fixture file flag where that capture should land.

Part of plan: meet-phase-1-12-prime-time.md (PR 3 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
