### PR TITLE
feat(meet): add xdotool-type primitive for trusted keystroke dispatch

### DIFF
--- a/skills/meet-join/bot/__tests__/xdotool-type.test.ts
+++ b/skills/meet-join/bot/__tests__/xdotool-type.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the xdotool-type primitive.
+ *
+ * We inject a fake `spawn` via `opts.spawn` so tests never actually exec
+ * xdotool. The fake-child harness mirrors the one used in
+ * `xdotool-click.test.ts` and `chrome-launcher.test.ts`: an EventEmitter
+ * with `stderr`, `.kill()`, and `__simulateExit(code, signal?)`.
+ */
+
+import { EventEmitter } from "node:events";
+import { describe, expect, test } from "bun:test";
+
+import { xdotoolType } from "../src/browser/xdotool-type.js";
+
+interface SpawnCall {
+  command: string;
+  args: string[];
+  options: { env?: NodeJS.ProcessEnv };
+}
+
+interface FakeChild extends EventEmitter {
+  stderr: EventEmitter;
+  kill: (signal?: NodeJS.Signals) => boolean;
+  __killSignals: NodeJS.Signals[];
+  __simulateExit: (code: number | null, signal?: NodeJS.Signals) => void;
+  __simulateSpawnError: (err: Error) => void;
+  __simulateStderr: (chunk: string) => void;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stderr = new EventEmitter();
+  child.__killSignals = [];
+  child.kill = (signal?: NodeJS.Signals): boolean => {
+    child.__killSignals.push(signal ?? "SIGTERM");
+    return true;
+  };
+  child.__simulateExit = (code, signal) => {
+    child.emit("exit", code, signal ?? null);
+  };
+  child.__simulateSpawnError = (err) => {
+    child.emit("error", err);
+  };
+  child.__simulateStderr = (chunk) => {
+    child.stderr.emit("data", Buffer.from(chunk, "utf8"));
+  };
+  return child;
+}
+
+function makeFakeSpawn(fakeChild: FakeChild): {
+  spawn: never;
+  calls: SpawnCall[];
+} {
+  const calls: SpawnCall[] = [];
+  const impl = (
+    command: string,
+    args: readonly string[],
+    options: { env?: NodeJS.ProcessEnv },
+  ) => {
+    calls.push({ command, args: [...args], options });
+    return fakeChild;
+  };
+  return { spawn: impl as unknown as never, calls };
+}
+
+describe("xdotoolType", () => {
+  test("spawns xdotool with type args and DISPLAY env", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolType({
+      text: "hello world",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls.length).toBe(1);
+    expect(fake.calls[0]!.command).toBe("/usr/bin/xdotool");
+    expect(fake.calls[0]!.args).toEqual([
+      "type",
+      "--delay",
+      "25",
+      "--clearmodifiers",
+      "hello world",
+    ]);
+    expect(fake.calls[0]!.options.env?.DISPLAY).toBe(":99");
+  });
+
+  test("honours custom delayMs", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolType({
+      text: "abc",
+      display: ":99",
+      delayMs: 100,
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls[0]!.args).toEqual([
+      "type",
+      "--delay",
+      "100",
+      "--clearmodifiers",
+      "abc",
+    ]);
+  });
+
+  test("honours custom binary override", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolType({
+      text: "x",
+      display: ":42",
+      binary: "/custom/xdotool",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls[0]!.command).toBe("/custom/xdotool");
+  });
+
+  test("resolves cleanly on exit code 0", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolType({
+      text: "ok",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  test("rejects with exit code + stderr detail on non-zero exit", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolType({
+      text: "boom",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateStderr("Can't open display: :99\n");
+    child.__simulateExit(1);
+    await expect(pending).rejects.toThrow(/exit code 1/i);
+    await expect(pending).rejects.toThrow(/Can't open display/i);
+  });
+
+  test("rejects with signal detail when killed", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolType({
+      text: "boom",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(null, "SIGTERM");
+    await expect(pending).rejects.toThrow(/signal SIGTERM/i);
+  });
+
+  test("rejects on spawn error", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolType({
+      text: "boom",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateSpawnError(new Error("ENOENT: xdotool"));
+    await expect(pending).rejects.toThrow(/ENOENT/);
+  });
+
+  test("times out if xdotool never exits", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+    const pending = xdotoolType({
+      text: "slow",
+      display: ":99",
+      spawn: fake.spawn,
+      timeoutMs: 10,
+    });
+    await expect(pending).rejects.toThrow(/timed out after 10ms/i);
+    expect(child.__killSignals).toContain("SIGKILL");
+  });
+});

--- a/skills/meet-join/bot/src/browser/xdotool-type.ts
+++ b/skills/meet-join/bot/src/browser/xdotool-type.ts
@@ -1,0 +1,155 @@
+/**
+ * xdotool-type: dispatches REAL X-server keystrokes inside the bot
+ * container.
+ *
+ * Google Meet (and other browser-based UIs) gate certain text-input
+ * behaviors on `event.isTrusted === true`. A content script that writes
+ * directly to `input.value` produces synthetic input events with
+ * `isTrusted: false`, which some framework-driven fields (e.g. React
+ * controlled components behind Meet's prejoin name field) silently
+ * reject or immediately overwrite. `xdotool type` dispatches keypress
+ * events through the X server so the browser sees them as trusted user
+ * input.
+ *
+ * Invocation shape (one process per type call — the text is passed as
+ * a single argv token, NOT shell-interpolated, so arbitrary user content
+ * is safe):
+ *
+ *     DISPLAY=:99 xdotool type --delay 25 --clearmodifiers "hello world"
+ *
+ * Callers are responsible for ensuring the target element has keyboard
+ * focus before invoking (e.g. via a prior `xdotoolClick` to focus the
+ * field).
+ */
+
+import {
+  spawn as nodeSpawn,
+  type ChildProcess,
+} from "node:child_process";
+
+/** Logger shape matching the one used by `chrome-launcher`. */
+export interface XdotoolTypeLogger {
+  info: (message: string) => void;
+  error: (message: string) => void;
+}
+
+const NOOP_LOGGER: XdotoolTypeLogger = {
+  info: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * Minimal shape of Node's `spawn` used by this module — kept structural so
+ * tests can inject a mock without depending on Node internals. Redeclared
+ * here (not imported from xdotool-click.ts) so the two primitives remain
+ * independently testable and independently evolvable.
+ */
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: { env?: NodeJS.ProcessEnv },
+) => ChildProcess;
+
+export interface XdotoolTypeOptions {
+  /** Literal text to type. Passed via argv — NOT shell-interpreted. */
+  text: string;
+  /** X display string (e.g. ":99"). Passed as the `DISPLAY` env var. */
+  display: string;
+  /** xdotool --delay value. Defaults to 25ms per keystroke. */
+  delayMs?: number;
+  /**
+   * xdotool binary path. Defaults to `/usr/bin/xdotool` (installed by the
+   * bot container). Override in tests.
+   */
+  binary?: string;
+  /** `node:child_process.spawn` override for tests. */
+  spawn?: SpawnFn;
+  /** Logger for visibility into invocation + failures. Defaults to no-op. */
+  logger?: XdotoolTypeLogger;
+  /**
+   * How long to wait for xdotool to exit before rejecting. Long text
+   * combined with the per-keystroke delay means typing legitimately can
+   * take a second or two — default 15s is a safety net, not a normal-path
+   * timer.
+   */
+  timeoutMs?: number;
+}
+
+const DEFAULT_DELAY_MS = 25;
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/**
+ * Type `opts.text` as trusted keystrokes on the Xvfb display.
+ *
+ * Resolves on clean exit (code 0). Rejects on non-zero exit, spawn failure,
+ * or timeout. The promise does NOT resolve with any payload — success is
+ * observed by the extension via subsequent DOM transitions on the focused
+ * input element.
+ */
+export async function xdotoolType(opts: XdotoolTypeOptions): Promise<void> {
+  const binary = opts.binary ?? "/usr/bin/xdotool";
+  const spawnFn = opts.spawn ?? nodeSpawn;
+  const logger = opts.logger ?? NOOP_LOGGER;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const delayMs = opts.delayMs ?? DEFAULT_DELAY_MS;
+
+  // `--clearmodifiers` ensures we don't accidentally inherit a stuck
+  // modifier key (Shift/Ctrl/Alt) from a prior input event. `text` is the
+  // final positional argv token; it is passed as a single argv entry so
+  // the shell is never involved and arbitrary content (including quotes,
+  // spaces, backticks) is handled safely.
+  const args = [
+    "type",
+    "--delay",
+    String(delayMs),
+    "--clearmodifiers",
+    opts.text,
+  ];
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err) reject(err);
+      else resolve();
+    };
+
+    const child = spawnFn(binary, args, {
+      env: { ...process.env, DISPLAY: opts.display },
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      logger.error(`xdotool spawn failed: ${err.message}`);
+      settle(err);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        logger.info(`xdotool type (${opts.text.length} chars) ok`);
+        settle();
+        return;
+      }
+      const reason = signal
+        ? `killed by signal ${signal}`
+        : `exit code ${code}`;
+      const detail = stderr.trim() ? ` stderr="${stderr.trim()}"` : "";
+      settle(new Error(`xdotool type failed: ${reason}${detail}`));
+    });
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // best effort; the timeout-reject below is what callers observe.
+      }
+      settle(new Error(`xdotool type timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `skills/meet-join/bot/src/browser/xdotool-type.ts` mirroring the xdotool-click primitive structure
- Adds unit tests using the fake-spawn EventEmitter harness
- Pure scaffolding — no consumer yet (PR 9 in the plan wires it into main.ts)

Part of plan: meet-phase-1-12-prime-time.md (PR 2 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
