### PR TITLE
feat(meet): add trusted_type wire schema for future composer xdotool bridge

### DIFF
--- a/skills/meet-join/contracts/__tests__/native-messaging.test.ts
+++ b/skills/meet-join/contracts/__tests__/native-messaging.test.ts
@@ -23,6 +23,7 @@ import {
   ExtensionSendChatResultMessageSchema,
   ExtensionSpeakerChangeMessageSchema,
   ExtensionToBotMessageSchema,
+  ExtensionTrustedTypeMessageSchema,
   type BotToExtensionMessage,
   type ExtensionToBotMessage,
 } from "../index.js";
@@ -41,6 +42,8 @@ describe("EXTENSION_TO_BOT_MESSAGE_TYPES", () => {
         "speaker.change",
         "chat.inbound",
         "diagnostic",
+        "trusted_click",
+        "trusted_type",
         "send_chat_result",
       ]),
     );
@@ -186,6 +189,84 @@ describe("ExtensionDiagnosticMessageSchema", () => {
   });
 });
 
+describe("ExtensionTrustedTypeMessageSchema", () => {
+  test("parses a valid trusted_type message without delayMs", () => {
+    const input = {
+      type: "trusted_type" as const,
+      text: "hello meet",
+    };
+    const parsed = ExtensionTrustedTypeMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses a valid trusted_type message with delayMs", () => {
+    const input = {
+      type: "trusted_type" as const,
+      text: "hello meet",
+      delayMs: 12,
+    };
+    const parsed = ExtensionTrustedTypeMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty text", () => {
+    expect(() =>
+      ExtensionTrustedTypeMessageSchema.parse({
+        type: "trusted_type",
+        text: "",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects text longer than 2000 chars", () => {
+    expect(() =>
+      ExtensionTrustedTypeMessageSchema.parse({
+        type: "trusted_type",
+        text: "a".repeat(2001),
+      }),
+    ).toThrow();
+  });
+
+  test("accepts text exactly 2000 chars", () => {
+    const input = {
+      type: "trusted_type" as const,
+      text: "a".repeat(2000),
+    };
+    const parsed = ExtensionTrustedTypeMessageSchema.parse(input);
+    expect(parsed.text.length).toBe(2000);
+  });
+
+  test("rejects delayMs > 500", () => {
+    expect(() =>
+      ExtensionTrustedTypeMessageSchema.parse({
+        type: "trusted_type",
+        text: "hi",
+        delayMs: 501,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects negative delayMs", () => {
+    expect(() =>
+      ExtensionTrustedTypeMessageSchema.parse({
+        type: "trusted_type",
+        text: "hi",
+        delayMs: -1,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer delayMs", () => {
+    expect(() =>
+      ExtensionTrustedTypeMessageSchema.parse({
+        type: "trusted_type",
+        text: "hi",
+        delayMs: 12.5,
+      }),
+    ).toThrow();
+  });
+});
+
 describe("ExtensionSendChatResultMessageSchema", () => {
   test("parses an ok result without error", () => {
     const input = {
@@ -267,6 +348,15 @@ describe("ExtensionToBotMessageSchema", () => {
         message: "attached to call",
       },
       {
+        type: "trusted_type",
+        text: "hi bot",
+      },
+      {
+        type: "trusted_type",
+        text: "hi bot",
+        delayMs: 20,
+      },
+      {
         type: "send_chat_result",
         requestId: "req-1",
         ok: true,
@@ -304,6 +394,14 @@ describe("ExtensionToBotMessageSchema", () => {
         timestamp: "2026-04-15T00:00:00Z",
       }),
     ).toThrow();
+  });
+
+  test("narrows on trusted_type via the discriminated union", () => {
+    const parsed = ExtensionToBotMessageSchema.parse({
+      type: "trusted_type",
+      text: "hi",
+    });
+    expect(parsed.type).toBe("trusted_type");
   });
 });
 

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -150,6 +150,32 @@ export type ExtensionTrustedClickMessage = z.infer<
 >;
 
 /**
+ * Ask the bot to type text into the currently-focused input field via
+ * `xdotool type` inside the bot container. This is the keyboard-input
+ * analogue of {@link ExtensionTrustedClickMessageSchema}: Google Meet may
+ * gate composer input events on `event.isTrusted === true` in addition to
+ * the prejoin admission button, and synthetic `InputEvent`s dispatched from
+ * a content script cannot produce trusted events — only X-server-originated
+ * keystrokes carry that flag.
+ *
+ * The bot performs NO coordinate math and NO element targeting: the
+ * extension is responsible for focusing the correct element (e.g. by
+ * calling `.focus()` on the composer textarea) **before** emitting this
+ * message. The bot simply invokes `xdotool type` against whatever is
+ * currently focused on the Xvfb display.
+ */
+export const ExtensionTrustedTypeMessageSchema = z.object({
+  type: z.literal("trusted_type"),
+  /** Text to type via `xdotool type`. Length-capped to Meet's 2000-char chat limit. */
+  text: z.string().min(1).max(2000),
+  /** Optional per-keystroke delay (ms), passed as `xdotool --delay`. */
+  delayMs: z.number().int().min(0).max(500).optional(),
+});
+export type ExtensionTrustedTypeMessage = z.infer<
+  typeof ExtensionTrustedTypeMessageSchema
+>;
+
+/**
  * Result of a prior `send_chat` command, correlated by `requestId`.
  *
  * `ok: false` payloads should set `error` to a human-readable string so the
@@ -181,6 +207,7 @@ export const ExtensionToBotMessageSchema = z.discriminatedUnion("type", [
   ExtensionInboundChatMessageSchema,
   ExtensionDiagnosticMessageSchema,
   ExtensionTrustedClickMessageSchema,
+  ExtensionTrustedTypeMessageSchema,
   ExtensionSendChatResultMessageSchema,
 ]);
 export type ExtensionToBotMessage = z.infer<typeof ExtensionToBotMessageSchema>;
@@ -194,6 +221,7 @@ export const EXTENSION_TO_BOT_MESSAGE_TYPES = [
   "chat.inbound",
   "diagnostic",
   "trusted_click",
+  "trusted_type",
   "send_chat_result",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Adds `ExtensionTrustedTypeMessageSchema` to the native-messaging contract (extension → bot)
- Adds `"trusted_type"` to `EXTENSION_TO_BOT_MESSAGE_TYPES` tuple and the discriminated union
- Pure scaffolding — no production consumer yet (PR 9 in the plan wires it in)

Part of plan: meet-phase-1-12-prime-time.md (PR 1 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
