### PR TITLE
chore(meet): add join-latency benchmark script and document qemu/arm64 perf baseline

### DIFF
--- a/skills/meet-join/README.md
+++ b/skills/meet-join/README.md
@@ -1,0 +1,67 @@
+# meet-join
+
+Skill for joining Google Meet calls as a bot, transcribing audio, and
+bridging the meeting into an assistant conversation. See
+[`SKILL.md`](./SKILL.md) for the user-facing skill contract and
+[`AGENTS.md`](./AGENTS.md) for the development / isolation rules.
+
+## Layout
+
+- `bot/` — the containerized Meet bot. Debian + Bun + Chromium +
+  PulseAudio + Xvfb. Built from [`bot/Dockerfile`](./bot/Dockerfile).
+- `meet-controller-ext/` — the Chrome extension that drives the prejoin
+  DOM and reports lifecycle / transcript / participant events back to
+  the bot over Native Messaging.
+- `daemon/` — assistant-side code that owns session state, ingests
+  bot-emitted events, and republishes them on `assistantEventHub`.
+- `contracts/` — shared wire-level types used by the bot and daemon.
+- `routes/`, `tools/` — HTTP routes and tool registrations that wire
+  the skill into the assistant.
+
+## Performance on arm64 hosts
+
+The bot image is built and run with `--platform linux/amd64` because
+Meet's BotGuard accepts a plain-subprocess Chromium launch, and
+Chromium for Linux/amd64 is the platform with the richest working set
+of base-image packages (Debian ships a current `chromium` for amd64
+but lags for arm64, and `google-chrome-stable` dropped
+`--load-extension` support that the extension-based join architecture
+depends on). On an arm64 host (Apple Silicon Mac, Graviton, Ampere)
+the image therefore runs under qemu user-mode emulation, which
+carries a meaningful CPU tax on bot-boot steps like Bun startup and
+Chromium V8 initialization.
+
+To quantify the overhead per image build and spot regressions, use
+[`bot/scripts/bench-join-latency.sh`](./bot/scripts/bench-join-latency.sh)
+(docs: [`bench-join-latency.md`](./bot/scripts/bench-join-latency.md)).
+The script runs N container launches against a test Meet URL and
+reports per-run CSV plus mean / median / p95 for two intervals:
+
+- `booted_delta`: container start → `meet-bot booted` (PulseAudio up,
+  pre-Chromium). Measures base container-startup + qemu interpreter
+  warmup.
+- `ready_delta`: container start → `meet-bot ready (meetingId=…)`
+  (extension loaded, join command dispatched). Adds Chromium launch
+  and Meet prejoin DOM time; the closest stdout proxy we have for
+  "about to click Join".
+
+### Baseline numbers
+
+*To be filled in after a live smoke-test run on the reference dev
+hardware (Apple Silicon M-series under macOS Docker Desktop with
+qemu-user-static). Expect order-of-magnitude overhead on `booted_delta`
+vs. a native amd64 host and 3–5× on `ready_delta`.*
+
+```
+# image=vellum-meet-bot:<tag> iterations=<n> meet_url=<test-room>
+# booted_delta (start → meet-bot booted): n=<n> mean=<m>ms median=<m>ms p95=<m>ms
+# ready_delta  (start → meet-bot ready):  n=<n> mean=<m>ms median=<m>ms p95=<m>ms
+```
+
+If the arm64 cost becomes a blocker (latency visible to the user, CI
+runtime blowup, flaky smoke tests), the path forward is a native arm64
+image: Chromium from an alternate source (e.g. `chromium-browser` via
+`snap` is off the table in containers, but `playwright`-style chromium
+builds or the `browser-use` community images ship arm64 variants).
+That work is deliberately deferred until we have baseline numbers
+showing it's worth the complexity.

--- a/skills/meet-join/bot/scripts/bench-join-latency.md
+++ b/skills/meet-join/bot/scripts/bench-join-latency.md
@@ -1,0 +1,102 @@
+# `bench-join-latency.sh`
+
+Measures meet-bot join latency on an arm64 host running the amd64 bot image
+under qemu emulation. Primary purpose: establish a baseline for how much
+qemu overhead costs us per join so we can decide whether a native arm64
+image is worth building, and so regressions in bot boot time show up in a
+single CSV.
+
+## Usage
+
+```bash
+BOT_IMAGE=vellum-meet-bot:latest \
+  ./bench-join-latency.sh https://meet.google.com/xxx-yyyy-zzz 5
+```
+
+### Arguments
+
+| Position | Name         | Default | Description                                    |
+|----------|--------------|---------|------------------------------------------------|
+| `$1`     | `MEET_URL`   | —       | Full Google Meet URL. Required.                |
+| `$2`     | `ITERATIONS` | `5`     | Number of bot runs to average.                 |
+
+### Environment
+
+| Variable        | Default                | Description                                                                                                                                                                                         |
+|-----------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `BOT_IMAGE`     | —                      | Container image reference. Required.                                                                                                                                                                |
+| `MEETING_ID`    | generated per run      | Override the per-run meeting id. Normally the bench generates a fresh UUID per iteration so sessions don't collide.                                                                                 |
+| `JOIN_NAME`     | `Bench Bot`            | Display name the bot presents in the prejoin UI.                                                                                                                                                    |
+| `BENCH_TIMEOUT` | `120`                  | Per-iteration timeout in seconds. Covers worst-case cold-cache qemu boot + Chromium launch.                                                                                                         |
+| `DAEMON_URL`    | `http://127.0.0.1:1/`  | Bot ingress URL. Intentionally defaulted to an unreachable address — the bench doesn't need events to land, only the bot to boot and dispatch the join. A real daemon would make the bench noisier. |
+
+## Output
+
+The script prints a CSV to stdout (header + one row per iteration) and
+aggregate stats to stderr:
+
+```csv
+iteration,start_ms,booted_ms,ready_ms,total_ms,booted_delta_ms,ready_delta_ms
+1,1713550000123,1713550004712,1713550011498,12031,4589,11375
+2,1713550012200,1713550016344,1713550022881,10901,4144,10681
+...
+```
+
+Aggregate stats are written to stderr and include `mean`, `median`, and
+`p95` for each of:
+
+- `booted_delta` — `start` → `meet-bot booted` (container cold-start +
+  PulseAudio init; dominated by qemu interpreter startup + shared-library
+  relocation).
+- `ready_delta` — `start` → `meet-bot ready (meetingId=…)` (adds Xvfb,
+  Chromium launch, extension load, and join-command dispatch).
+
+## Markers & what they do/don't mean
+
+The bot's lifecycle events (`lifecycle:joining`, `lifecycle:joined`) are
+shipped to the daemon over HTTP rather than logged to stderr. For a
+standalone bench where no daemon is running, we anchor on two stdout
+lines the bot prints unconditionally:
+
+| Marker string                      | Phase                                                                                                                                                                                       |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `meet-bot booted`                  | PulseAudio is up. Pre-Xvfb, pre-Chromium.                                                                                                                                                   |
+| `meet-bot ready (meetingId=…)`     | Extension loaded, HTTP server started, join command dispatched to the extension. Closest stdout proxy for "about to hit the admission button". Strictly earlier than `lifecycle:joined`.  |
+
+If you instrument a real daemon receiving the bot's HTTP pipe and want
+a true `start` → `lifecycle:joined` measurement, you'll want to extend
+this script (or write a sibling) that tails the daemon's SSE stream for
+`meet.joined` instead. For the arm64/qemu baseline, the bot-boot window
+is the dominant cost and the right thing to chart.
+
+## Interpreting numbers
+
+On a native amd64 host, `booted_delta` should land in the low hundreds
+of milliseconds and `ready_delta` in the 2–4 second range (mostly
+Chromium startup + Meet prejoin DOM wait).
+
+On an arm64 host under `--platform linux/amd64` qemu emulation, both
+numbers grow substantially. The dominant cost is interpreter overhead
+on CPU-heavy steps — Bun's startup, Chromium's V8 initialization, and
+extension JS compilation. Expect roughly an order-of-magnitude slowdown
+for `booted_delta`, and a 3–5x slowdown for `ready_delta` (because the
+Meet prejoin DOM wait is I/O-bound and partially insulated from
+emulation cost). Actual ratios depend on host chip (M1 vs M3, Graviton
+vs Ampere), host load, and whether the image layers are warm in the
+local Docker cache.
+
+See `skills/meet-join/README.md` for baseline numbers captured on the
+reference dev hardware.
+
+## Caveats
+
+- **Cold-cache first iteration.** The first iteration typically
+  includes qemu register-bank setup and shared-library warmup. Bench
+  runs with `iterations ≥ 3` and rely on the median rather than the
+  mean when the first sample is visibly high.
+- **Host load.** Chromium and Bun are CPU-bound under emulation, so a
+  busy host machine skews latency sharply. Close other heavy apps
+  before collecting a baseline.
+- **Meet prejoin behavior varies.** Admission policies (guest knock-to-enter,
+  in-domain auto-admit) change the DOM path the extension walks; use
+  the same meeting type across runs when comparing numbers.

--- a/skills/meet-join/bot/scripts/bench-join-latency.sh
+++ b/skills/meet-join/bot/scripts/bench-join-latency.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# bench-join-latency.sh
+#
+# Measure meet-bot join latency on an arm64 host running the amd64 bot image
+# under qemu emulation. Runs the bot image N times against the given Meet URL,
+# records wall-clock time from container start to the key bot-boot markers,
+# and emits a CSV plus aggregate stats (mean / median / p95).
+#
+# The bot's lifecycle events (`lifecycle:joining`, `lifecycle:joined`) are
+# shipped over an HTTP pipe to the daemon rather than being logged to stderr,
+# so this script grep-anchors on the two stdout markers that are emitted in
+# the clear at the relevant boot phases:
+#
+#   - "meet-bot booted"     — PulseAudio is up, pre-Xvfb/pre-browser boot
+#                              checkpoint. Treated as JOIN_SENT proxy:
+#                              everything after this is qemu-emulated CPU
+#                              work (Chromium launch, extension load,
+#                              prejoin DOM wait).
+#   - "meet-bot ready (meetingId=..."  — extension has loaded, join command
+#                                         dispatched, HTTP server started.
+#                                         Treated as ADMITTED proxy.
+#
+# The two proxies are NOT identical to the on-wire `meet.joining` / `meet.joined`
+# events — those fire strictly later (joined is posted after the extension
+# confirms admission via `lifecycle:joined`). But for the qemu/arm64
+# emulation-overhead baseline this script exists to measure, the bot-boot
+# window is the dominant cost and the right thing to chart.
+#
+# Usage:
+#   BOT_IMAGE=vellum-meet-bot:latest \
+#     bench-join-latency.sh https://meet.google.com/xxx-yyyy-zzz [iterations]
+#
+# Env:
+#   BOT_IMAGE     (required)  Container image reference.
+#   MEETING_ID    (optional)  Overrides the generated per-run UUID.
+#   JOIN_NAME     (optional)  Display name (default "Bench Bot").
+#   BENCH_TIMEOUT (optional)  Per-iteration timeout seconds (default 120).
+#   DAEMON_URL    (optional)  Dummy ingress URL. A dead URL is fine — the
+#                             bot's daemon-client retries in the background
+#                             and we don't need the events to land, we only
+#                             need the bot to boot and dispatch the join.
+#                             Default: http://127.0.0.1:1/ (always fails).
+#
+# Exits non-zero if BOT_IMAGE is unset or the Meet URL is missing.
+#
+set -euo pipefail
+
+MEET_URL="${1:-}"
+ITERATIONS="${2:-5}"
+
+if [[ -z "${MEET_URL}" ]]; then
+  echo "usage: $0 <meet-url> [iterations]" >&2
+  exit 2
+fi
+if [[ -z "${BOT_IMAGE:-}" ]]; then
+  echo "BOT_IMAGE env var is required (e.g. vellum-meet-bot:latest)" >&2
+  exit 2
+fi
+
+JOIN_NAME="${JOIN_NAME:-Bench Bot}"
+BENCH_TIMEOUT="${BENCH_TIMEOUT:-120}"
+DAEMON_URL="${DAEMON_URL:-http://127.0.0.1:1/}"
+
+# Portable milliseconds-since-epoch. `date +%s%3N` works on GNU coreutils
+# (Linux, or macOS with `gdate` from `brew install coreutils`). Otherwise
+# fall back to perl which is ubiquitous on macOS and every Linux distro
+# we care about.
+now_ms() {
+  if date +%s%3N >/dev/null 2>&1 && [[ "$(date +%N 2>/dev/null)" != "N" ]]; then
+    date +%s%3N
+  elif command -v gdate >/dev/null 2>&1; then
+    gdate +%s%3N
+  else
+    perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'
+  fi
+}
+
+# Tiny random UUID-ish string for MEETING_ID when the caller didn't pin one.
+gen_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    # Fallback: 32 hex chars from /dev/urandom.
+    head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'
+  fi
+}
+
+# Scan a log file for the first line containing the marker, return the
+# wall-clock ms at which it appeared. Returns empty string if the marker
+# is never seen before EOF.
+wait_for_marker() {
+  local log_path="$1"
+  local marker="$2"
+  local deadline_ms="$3"
+  while :; do
+    if grep -qF -- "${marker}" "${log_path}" 2>/dev/null; then
+      now_ms
+      return 0
+    fi
+    if (( $(now_ms) > deadline_ms )); then
+      echo ""
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+echo "# bench-join-latency.sh" >&2
+echo "# image=${BOT_IMAGE} iterations=${ITERATIONS} meet_url=${MEET_URL}" >&2
+echo "# timeout=${BENCH_TIMEOUT}s daemon_url=${DAEMON_URL}" >&2
+echo "iteration,start_ms,booted_ms,ready_ms,total_ms,booted_delta_ms,ready_delta_ms"
+
+# Arrays for aggregate math.
+declare -a booted_deltas=()
+declare -a ready_deltas=()
+
+for ((i = 1; i <= ITERATIONS; i++)); do
+  meeting_id="${MEETING_ID:-$(gen_id)}"
+  log_file="$(mktemp -t bench-join-latency-XXXXXX.log)"
+  # Ensure log cleanup even if we exit mid-loop.
+  trap 'rm -f "${log_file}"' EXIT
+
+  start_ms="$(now_ms)"
+  deadline_ms=$(( start_ms + BENCH_TIMEOUT * 1000 ))
+
+  # Launch the bot in the background with stdout+stderr tee'd to a temp file
+  # so we can grep for markers while the container is still running.
+  # `--init` ensures PID 1 handles SIGTERM cleanly.
+  container_id="$(
+    docker run -d --rm \
+      --platform linux/amd64 \
+      --init \
+      -e "MEET_URL=${MEET_URL}" \
+      -e "MEETING_ID=${meeting_id}" \
+      -e "JOIN_NAME=${JOIN_NAME}" \
+      -e "CONSENT_MESSAGE=This meeting is being recorded by a bot for benchmark purposes." \
+      -e "DAEMON_URL=${DAEMON_URL}" \
+      -e "BOT_API_TOKEN=bench-token-unused" \
+      "${BOT_IMAGE}"
+  )"
+
+  # Tail the container's combined log stream into our temp file in the
+  # background. `docker logs -f` blocks until the container exits.
+  docker logs -f "${container_id}" >"${log_file}" 2>&1 &
+  logs_pid=$!
+
+  booted_ms="$(wait_for_marker "${log_file}" "meet-bot booted" "${deadline_ms}" || true)"
+  ready_ms="$(wait_for_marker "${log_file}" "meet-bot ready (meetingId=" "${deadline_ms}" || true)"
+
+  # SIGTERM the container; the bot's signal handler will drain & exit.
+  docker kill --signal=SIGTERM "${container_id}" >/dev/null 2>&1 || true
+  # Best-effort wait for graceful exit, bounded so a wedged container
+  # doesn't stall the bench. If it doesn't exit in 15s, force-kill.
+  for _ in $(seq 1 150); do
+    if ! docker inspect "${container_id}" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+  docker kill "${container_id}" >/dev/null 2>&1 || true
+  wait "${logs_pid}" 2>/dev/null || true
+
+  end_ms="$(now_ms)"
+
+  total_ms=$(( end_ms - start_ms ))
+  booted_delta=""
+  ready_delta=""
+  if [[ -n "${booted_ms}" ]]; then
+    booted_delta=$(( booted_ms - start_ms ))
+    booted_deltas+=("${booted_delta}")
+  fi
+  if [[ -n "${ready_ms}" ]]; then
+    ready_delta=$(( ready_ms - start_ms ))
+    ready_deltas+=("${ready_delta}")
+  fi
+
+  printf "%d,%d,%s,%s,%d,%s,%s\n" \
+    "${i}" \
+    "${start_ms}" \
+    "${booted_ms:-}" \
+    "${ready_ms:-}" \
+    "${total_ms}" \
+    "${booted_delta:-}" \
+    "${ready_delta:-}"
+
+  rm -f "${log_file}"
+  trap - EXIT
+done
+
+# ---------------------------------------------------------------------------
+# Aggregate stats
+# ---------------------------------------------------------------------------
+
+aggregate() {
+  local label="$1"
+  shift
+  local -a vals=("$@")
+  local n="${#vals[@]}"
+  if (( n == 0 )); then
+    echo "# ${label}: no samples" >&2
+    return
+  fi
+  # Sort ascending for median / p95.
+  local sorted
+  sorted="$(printf "%s\n" "${vals[@]}" | sort -n)"
+  local sum=0
+  local v
+  while IFS= read -r v; do
+    sum=$(( sum + v ))
+  done <<<"${sorted}"
+  local mean=$(( sum / n ))
+  # 1-indexed median / p95 offsets.
+  local median_idx p95_idx
+  median_idx=$(( (n + 1) / 2 ))
+  # Ceil(0.95 * n), clamped to >= 1 and <= n.
+  p95_idx=$(( (95 * n + 99) / 100 ))
+  if (( p95_idx < 1 )); then p95_idx=1; fi
+  if (( p95_idx > n )); then p95_idx=$n; fi
+  local median p95
+  median="$(echo "${sorted}" | sed -n "${median_idx}p")"
+  p95="$(echo "${sorted}" | sed -n "${p95_idx}p")"
+  echo "# ${label}: n=${n} mean=${mean}ms median=${median}ms p95=${p95}ms" >&2
+}
+
+aggregate "booted_delta (start → meet-bot booted)" "${booted_deltas[@]}"
+aggregate "ready_delta  (start → meet-bot ready)" "${ready_deltas[@]}"


### PR DESCRIPTION
## Summary
- Adds `bot/scripts/bench-join-latency.sh` — runs N meet-bot joins, records time-to-admitted, emits CSV + aggregates
- Adds companion `bench-join-latency.md` for usage
- README section on arm64/qemu perf with baseline placeholder (Sidd to fill from a live run)

Part of plan: meet-phase-1-12-prime-time.md (PR 11 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
