### PR TITLE
feat(meet): sweep orphaned meet-bot containers on assistant startup

### DIFF
--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -14,12 +14,16 @@ import {
 
 import {
   buildCreateBody,
+  type ContainerListEntry,
   demultiplexDockerLogs,
   DockerApiError,
   DockerRunner,
   dockerSocketUnreachableMessage,
   extractBoundPorts,
   HOST_GATEWAY_ALIAS,
+  MEET_BOT_LABEL,
+  MEET_BOT_MEETING_ID_LABEL,
+  reapOrphanedMeetBots,
   resetSocketReachabilityCacheForTests,
   resolveWorkspaceSubpath,
 } from "../docker-runner.js";
@@ -666,5 +670,256 @@ describe("DockerRunner workspace-mount mode branching", () => {
     expect(mock.captured).toHaveLength(7);
     const pingCalls = mock.captured.filter((c) => c.url.includes("/_ping"));
     expect(pingCalls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Container-create labels (orphan-reaper scheme)
+// ---------------------------------------------------------------------------
+
+describe("buildCreateBody labels", () => {
+  test("omits Labels when none supplied", () => {
+    const body = buildCreateBody({ image: "x:y" });
+    expect(body.Labels).toBeUndefined();
+  });
+
+  test("emits Labels payload when supplied (orphan-reaper label scheme)", () => {
+    const body = buildCreateBody({
+      image: "vellum-meet-bot:dev",
+      labels: {
+        [MEET_BOT_LABEL]: "true",
+        [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+      },
+    });
+    expect(body.Labels).toEqual({
+      "vellum.meet.bot": "true",
+      "vellum.meet.meetingId": "meeting-a",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listContainers + kill
+// ---------------------------------------------------------------------------
+
+describe("DockerRunner.listContainers", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("passes label filter + all=false in query string", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({
+      status: 200,
+      body: [
+        {
+          Id: "c1",
+          Labels: { "vellum.meet.bot": "true", "vellum.meet.meetingId": "a" },
+        },
+      ],
+    });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    const result = await runner.listContainers({
+      labels: { "vellum.meet.bot": "true" },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].Id).toBe("c1");
+
+    const [req] = mock.captured;
+    expect(req.method).toBe("GET");
+    expect(req.url).toContain("/containers/json");
+    expect(req.url).toContain("filters=");
+    // Decode the filters JSON and verify the label filter round-trips.
+    const encoded = new URL(req.url, "http://localhost").searchParams.get(
+      "filters",
+    );
+    const parsed = JSON.parse(encoded ?? "{}");
+    expect(parsed.label).toEqual(["vellum.meet.bot=true"]);
+  });
+});
+
+describe("DockerRunner.kill", () => {
+  let mock: MockDocker;
+
+  afterEach(async () => {
+    await mock?.close();
+  });
+
+  test("POSTs /containers/<id>/kill with signal query", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 204, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await runner.kill("cid", "SIGTERM");
+
+    expect(mock.captured).toHaveLength(1);
+    expect(mock.captured[0].method).toBe("POST");
+    expect(mock.captured[0].url).toContain("/containers/cid/kill");
+    expect(mock.captured[0].url).toContain("signal=SIGTERM");
+  });
+
+  test("defaults to SIGKILL when no signal is supplied", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 204, body: null });
+
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await runner.kill("cid");
+    expect(mock.captured[0].url).toContain("signal=SIGKILL");
+  });
+
+  test("swallows 404 and 409 (already-dead container)", async () => {
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 404, body: "no such container" });
+    const runner = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner.kill("gone")).resolves.toBeUndefined();
+
+    await mock.close();
+    mock = await startMockDocker();
+    mock.queueResponse({ status: 409, body: "container is not running" });
+    const runner2 = new DockerRunner({ socketPath: mock.socketPath });
+    await expect(runner2.kill("stopped")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reapOrphanedMeetBots
+// ---------------------------------------------------------------------------
+
+interface FakeDocker {
+  listContainers: (opts: {
+    labels?: Record<string, string>;
+    all?: boolean;
+  }) => Promise<ContainerListEntry[]>;
+  kill: (containerId: string, signal?: string) => Promise<void>;
+}
+
+function silentLogger() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+describe("reapOrphanedMeetBots", () => {
+  test("kills containers whose meetingId is not in the active set, keeps the rest", async () => {
+    const killCalls: Array<{ id: string; signal: string | undefined }> = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-a",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+          },
+        },
+        {
+          Id: "c-b",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        killCalls.push({ id, signal });
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(["meeting-b"]),
+      logger: silentLogger(),
+    });
+
+    expect(result.killed).toEqual(["c-a"]);
+    expect(result.kept).toEqual(["c-b"]);
+    // SIGTERM went out synchronously during the sweep. The delayed SIGKILL
+    // is scheduled via unref'd setTimeout — we assert only the SIGTERM here.
+    expect(killCalls.filter((c) => c.signal === "SIGTERM")).toEqual([
+      { id: "c-a", signal: "SIGTERM" },
+    ]);
+  });
+
+  test("returns empty result when there are no orphans", async () => {
+    const docker: FakeDocker = {
+      listContainers: async () => [],
+      kill: async () => {
+        throw new Error("should not be called");
+      },
+    };
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      logger: silentLogger(),
+    });
+    expect(result).toEqual({ killed: [], kept: [] });
+  });
+
+  test("continues sweeping when one container's kill throws", async () => {
+    const killed: string[] = [];
+    const docker: FakeDocker = {
+      listContainers: async () => [
+        {
+          Id: "c-a",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-a",
+          },
+        },
+        {
+          Id: "c-b",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-b",
+          },
+        },
+        {
+          Id: "c-c",
+          Labels: {
+            [MEET_BOT_LABEL]: "true",
+            [MEET_BOT_MEETING_ID_LABEL]: "meeting-c",
+          },
+        },
+      ],
+      kill: async (id, signal) => {
+        if (signal !== "SIGTERM") return; // delayed SIGKILL — ignore
+        if (id === "c-b") throw new Error("engine glitch");
+        killed.push(id);
+      },
+    };
+
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      logger: silentLogger(),
+    });
+
+    // c-b threw during SIGTERM; c-a and c-c still reached kill successfully.
+    expect(killed).toEqual(["c-a", "c-c"]);
+    expect(result.killed).toEqual(["c-a", "c-c"]);
+    expect(result.kept).toEqual([]);
+  });
+
+  test("returns empty result and logs a warning if listContainers throws", async () => {
+    const docker: FakeDocker = {
+      listContainers: async () => {
+        throw new Error("engine unreachable");
+      },
+      kill: async () => {
+        throw new Error("should not be called");
+      },
+    };
+    const result = await reapOrphanedMeetBots({
+      docker,
+      activeMeetingIds: new Set(),
+      logger: silentLogger(),
+    });
+    expect(result).toEqual({ killed: [], kept: [] });
   });
 });

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -133,6 +133,14 @@ export interface DockerRunOptions {
   ports?: PortMapping[];
   name?: string;
   network?: string;
+  /**
+   * Docker labels applied at container-create time. Meet-bot containers
+   * are tagged with `vellum.meet.bot=true` and
+   * `vellum.meet.meetingId=<id>` so the orphan reaper (see
+   * {@link reapOrphanedMeetBots}) can discover and clean them up after a
+   * crashed prior run without misidentifying unrelated containers.
+   */
+  labels?: Record<string, string>;
 }
 
 /** Minimal shape of the Docker `containers/<id>/json` response we rely on. */
@@ -149,6 +157,20 @@ export interface ContainerInspect {
       Array<{ HostIp?: string; HostPort?: string }> | null
     >;
   };
+  [key: string]: unknown;
+}
+
+/**
+ * Minimal shape of a single entry in Docker's `GET /containers/json`
+ * response body. We only rely on the id + labels for the orphan-reaper
+ * sweep; everything else is optional.
+ */
+export interface ContainerListEntry {
+  Id: string;
+  Names?: string[];
+  Labels?: Record<string, string>;
+  State?: string;
+  Status?: string;
   [key: string]: unknown;
 }
 
@@ -475,6 +497,65 @@ export class DockerRunner {
     }
   }
 
+  /**
+   * Send a signal to a running container. Wraps
+   * `POST /containers/<id>/kill?signal=<sig>`. Defaults to `SIGKILL`.
+   * 404 / 409 ("container is not running") are swallowed — the caller's
+   * intent ("make sure this container is dead") is already satisfied.
+   */
+  async kill(containerId: string, signal: string = "SIGKILL"): Promise<void> {
+    const path = `/${DOCKER_API_VERSION}/containers/${containerId}/kill?signal=${encodeURIComponent(signal)}`;
+    try {
+      await this.request<void>("POST", path, null);
+    } catch (err) {
+      if (
+        err instanceof DockerApiError &&
+        (err.status === 404 || err.status === 409)
+      ) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * List containers, optionally filtered by labels. Wraps
+   * `GET /containers/json?filters=...`. Docker's filter syntax is a JSON
+   * map of filter-name → array of filter values; for labels the value is
+   * either `"<key>"` (any value) or `"<key>=<value>"` (exact match).
+   *
+   * @param opts.labels Label filters. Array values are exact-match
+   *   (`<key>=<value>`); pass just a key (via `{ "<key>": null }` –style
+   *   contract) to filter on label presence. Here we only need equality
+   *   matches so the input is `Record<string, string>`.
+   * @param opts.all When true, includes non-running containers (matches
+   *   Docker's `all=true` query param). Defaults to false (running only).
+   */
+  async listContainers(
+    opts: {
+      labels?: Record<string, string>;
+      all?: boolean;
+    } = {},
+  ): Promise<ContainerListEntry[]> {
+    const params: string[] = [];
+    if (opts.all) params.push("all=true");
+    if (opts.labels && Object.keys(opts.labels).length > 0) {
+      const labelFilters = Object.entries(opts.labels).map(
+        ([k, v]) => `${k}=${v}`,
+      );
+      const filters = { label: labelFilters };
+      params.push(`filters=${encodeURIComponent(JSON.stringify(filters))}`);
+    }
+    const query = params.length > 0 ? `?${params.join("&")}` : "";
+    const path = `/${DOCKER_API_VERSION}/containers/json${query}`;
+    const entries = await this.request<ContainerListEntry[]>(
+      "GET",
+      path,
+      null,
+    );
+    return entries ?? [];
+  }
+
   /** Force-remove a container. Wraps `DELETE /containers/<id>?force=true`. */
   async remove(containerId: string): Promise<void> {
     const path = `/${DOCKER_API_VERSION}/containers/${containerId}?force=true&v=true`;
@@ -625,6 +706,22 @@ export interface ResolvedMounts {
 export const HOST_GATEWAY_ALIAS = "host.docker.internal:host-gateway";
 
 /**
+ * Docker-label key applied to every meet-bot container at create time. Set
+ * to the literal string `"true"`. Used together with
+ * {@link MEET_BOT_MEETING_ID_LABEL} for orphan discovery in
+ * {@link reapOrphanedMeetBots}.
+ */
+export const MEET_BOT_LABEL = "vellum.meet.bot";
+
+/**
+ * Docker-label key that carries the meeting ID for the running bot. Pairs
+ * with {@link MEET_BOT_LABEL} so the reaper can compare each labeled
+ * container's meeting ID against the currently-active session set and only
+ * kill the ones that belong to no live session.
+ */
+export const MEET_BOT_MEETING_ID_LABEL = "vellum.meet.meetingId";
+
+/**
  * Resolve a workspace-relative `subpath` against the absolute `workspaceDir`
  * using POSIX join semantics. Leading slashes in `subpath` are tolerated;
  * POSIX rules are used so the result is portable across test platforms.
@@ -701,12 +798,16 @@ export function buildCreateBody(
     ...(opts.network ? { NetworkMode: opts.network } : {}),
   };
 
-  return {
+  const body: Record<string, unknown> = {
     Image: opts.image,
     Env: env,
     ExposedPorts: exposedPorts,
     HostConfig: hostConfig,
   };
+  if (opts.labels && Object.keys(opts.labels).length > 0) {
+    body.Labels = { ...opts.labels };
+  }
+  return body;
 }
 
 /**
@@ -737,4 +838,128 @@ export function extractBoundPorts(inspection: ContainerInspect): BoundPort[] {
     }
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan reaper
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of {@link DockerRunner} that {@link reapOrphanedMeetBots}
+ * depends on. Isolated as a structural type so tests can pass a hand-rolled
+ * fake without instantiating the full runner.
+ */
+export interface DockerClientForReaper {
+  listContainers(opts: {
+    labels?: Record<string, string>;
+    all?: boolean;
+  }): Promise<ContainerListEntry[]>;
+  kill(containerId: string, signal?: string): Promise<void>;
+}
+
+/** Grace window (ms) between SIGTERM and SIGKILL during the reaper sweep. */
+export const REAPER_TERM_KILL_GRACE_MS = 10_000;
+
+/**
+ * Sweep orphaned meet-bot containers left behind by a crashed prior run.
+ *
+ * **Label scheme.** Every meet-bot container created by this daemon is
+ * tagged at `/containers/create` time with two Docker labels:
+ *
+ *   - `vellum.meet.bot=true` — identifies the container as a meet-bot
+ *     managed by this codebase (distinguishes from any other containers
+ *     the user might be running).
+ *   - `vellum.meet.meetingId=<id>` — carries the originating meeting ID
+ *     so the reaper can match each labeled container against the currently-
+ *     active in-process session set and only kill the ones that belong to
+ *     no live session.
+ *
+ * **Kill protocol.** Each orphan receives a `SIGTERM`, then after a
+ * {@link REAPER_TERM_KILL_GRACE_MS}-ms grace window the reaper issues a
+ * `SIGKILL` as the hard fallback. Both calls go through the docker client's
+ * `/kill` endpoint so the container's exit is recorded in the engine's
+ * state table; the subsequent `docker events` stream fires normally and
+ * downstream consumers (monitoring, log retention) see a clean shutdown
+ * rather than a disappearing container. Per-container errors are caught and
+ * logged so one misbehaving container can't abort the sweep.
+ *
+ * @param opts.docker Docker client — typically a {@link DockerRunner}.
+ * @param opts.activeMeetingIds Meeting IDs that currently map to a live
+ *   in-process session. On boot this is an empty set (no sessions yet),
+ *   but the signature accepts any set so the same helper can be called
+ *   from a later "cleanup unexpected orphans" sweep during runtime.
+ * @param opts.logger Structured logger — one INFO line per kill.
+ * @returns Summary of which container ids were killed vs kept.
+ */
+/**
+ * Structural subset of a pino-style structured logger — the reaper only
+ * emits info/warn/debug lines and doesn't want a hard dep on pino's type
+ * export from this module. The daemon's real logger (`pino.Logger`) is
+ * assignable to this shape.
+ */
+export interface ReaperLogger {
+  info(obj: Record<string, unknown>, msg?: string): void;
+  warn(obj: Record<string, unknown>, msg?: string): void;
+  error?(obj: Record<string, unknown>, msg?: string): void;
+  debug(obj: Record<string, unknown>, msg?: string): void;
+}
+
+export async function reapOrphanedMeetBots(opts: {
+  docker: DockerClientForReaper;
+  activeMeetingIds: ReadonlySet<string>;
+  logger: ReaperLogger;
+}): Promise<{ killed: string[]; kept: string[] }> {
+  const { docker, activeMeetingIds, logger } = opts;
+  const killed: string[] = [];
+  const kept: string[] = [];
+
+  let containers: ContainerListEntry[];
+  try {
+    containers = await docker.listContainers({
+      labels: { [MEET_BOT_LABEL]: "true" },
+      all: false,
+    });
+  } catch (err) {
+    logger.warn({ err }, "reapOrphanedMeetBots: listContainers failed");
+    return { killed, kept };
+  }
+
+  for (const container of containers) {
+    const containerId = container.Id;
+    const labels = container.Labels ?? {};
+    const meetingId = labels[MEET_BOT_MEETING_ID_LABEL];
+
+    if (meetingId && activeMeetingIds.has(meetingId)) {
+      kept.push(containerId);
+      continue;
+    }
+
+    try {
+      await docker.kill(containerId, "SIGTERM");
+      // Best-effort grace window: schedule a SIGKILL after the grace
+      // period, in case the bot ignores SIGTERM. We don't await the
+      // timeout — reaper callers want a bounded sweep duration, not an
+      // extra 10s per orphan.
+      setTimeout(() => {
+        docker.kill(containerId, "SIGKILL").catch((err: unknown) => {
+          logger.debug(
+            { err, containerId, meetingId },
+            "reapOrphanedMeetBots: delayed SIGKILL failed (container likely already dead)",
+          );
+        });
+      }, REAPER_TERM_KILL_GRACE_MS).unref?.();
+      logger.info(
+        { containerId, meetingId, reason: "orphan" },
+        "orphan meet-bot reaped",
+      );
+      killed.push(containerId);
+    } catch (err) {
+      logger.warn(
+        { err, containerId, meetingId },
+        "reapOrphanedMeetBots: kill failed — continuing sweep",
+      );
+    }
+  }
+
+  return { killed, kept };
 }

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -96,7 +96,13 @@ import {
   type InsertMessageFn,
   MeetConversationBridge,
 } from "./conversation-bridge.js";
-import { DockerRunner, type DockerRunResult } from "./docker-runner.js";
+import {
+  DockerRunner,
+  MEET_BOT_LABEL,
+  MEET_BOT_MEETING_ID_LABEL,
+  reapOrphanedMeetBots,
+  type DockerRunResult,
+} from "./docker-runner.js";
 import {
   meetEventDispatcher,
   type MeetEventUnsubscribe,
@@ -437,7 +443,13 @@ export interface MeetSessionManagerDeps {
   /** Factory for the Docker runner — swapped in tests. */
   dockerRunnerFactory?: () => Pick<
     DockerRunner,
-    "run" | "stop" | "remove" | "inspect" | "logs"
+    | "run"
+    | "stop"
+    | "remove"
+    | "inspect"
+    | "logs"
+    | "kill"
+    | "listContainers"
   >;
   /** Override the function that fetches credentials. */
   getProviderKey?: (provider: string) => Promise<string | undefined>;
@@ -544,6 +556,13 @@ export interface MeetSessionManagerDeps {
     hint: string;
     source: string;
   }) => Promise<void>;
+  /**
+   * Disables the one-shot startup orphan-reaper sweep. Only used by unit
+   * tests that don't want a background reaper call polluting docker-client
+   * mocks. Production and integration paths leave this as the default
+   * (sweep enabled).
+   */
+  disableStartupOrphanReaper?: boolean;
 }
 
 class MeetSessionManagerImpl {
@@ -603,6 +622,7 @@ class MeetSessionManagerImpl {
       bargeInWatcherFactory:
         deps.bargeInWatcherFactory ?? defaultBargeInWatcherFactory,
       wakeAgent: deps.wakeAgent ?? defaultWakeAgent,
+      disableStartupOrphanReaper: deps.disableStartupOrphanReaper ?? false,
     };
 
     // The ingress route (PR 9) looks up per-meeting tokens through this
@@ -615,6 +635,24 @@ class MeetSessionManagerImpl {
       if (session) return session.botApiToken;
       return this.pendingBotTokens.get(meetingId) ?? null;
     });
+
+    // One-shot startup orphan sweep. On a fresh boot no sessions exist, so
+    // the active-id set is empty — any `vellum.meet.bot`-labeled container
+    // still running came from a crashed prior daemon run and must be
+    // reaped. Fire-and-forget so construction stays synchronous; the
+    // reaper logs its own outcome and catches per-container errors so a
+    // transient docker-engine hiccup never tears down the session-manager
+    // singleton. Tests opt out via {@link MeetSessionManagerDeps.disableStartupOrphanReaper}.
+    if (!this.deps.disableStartupOrphanReaper) {
+      const reaperDocker = this.deps.dockerRunnerFactory();
+      void reapOrphanedMeetBots({
+        docker: reaperDocker,
+        activeMeetingIds: new Set<string>(),
+        logger: log,
+      }).catch((err: unknown) => {
+        log.warn({ err }, "Startup orphan-reaper sweep threw — continuing");
+      });
+    }
   }
 
   /** Reset internal state. Tests only. */
@@ -864,6 +902,13 @@ class MeetSessionManagerImpl {
         ],
         name: `vellum-meet-${meetingId}`,
         network: meet.dockerNetwork,
+        // Labels consumed by the orphan reaper on the next daemon boot.
+        // See {@link reapOrphanedMeetBots} in `docker-runner.ts` for the
+        // full label scheme + reaper contract.
+        labels: {
+          [MEET_BOT_LABEL]: "true",
+          [MEET_BOT_MEETING_ID_LABEL]: meetingId,
+        },
       });
     } catch (err) {
       log.error(
@@ -1699,7 +1744,15 @@ export const MeetSessionManager = new MeetSessionManagerImpl();
 export function _createMeetSessionManagerForTests(
   deps?: MeetSessionManagerDeps,
 ): MeetSessionManagerImpl {
-  return new MeetSessionManagerImpl(deps);
+  // Default to disabling the startup orphan-reaper sweep in tests — most
+  // tests supply a narrow mock runner that only implements the
+  // `run`/`stop`/`remove`/`inspect`/`logs` surface used by the
+  // join/leave path. Tests that want to exercise the reaper can override
+  // by passing `disableStartupOrphanReaper: false`.
+  return new MeetSessionManagerImpl({
+    disableStartupOrphanReaper: true,
+    ...deps,
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `reapOrphanedMeetBots()` that scans for `vellum.meet.bot=true`-labeled containers and SIGTERM/SIGKILLs any whose meetingId is not in the active set
- Ensures bot containers are labeled with `vellum.meet.bot` + `vellum.meet.meetingId` at create time
- Wired into the session-manager startup hook so orphans from a crashed prior run are reaped within ~10s of daemon boot

Part of plan: meet-phase-1-12-prime-time.md (PR 7 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
