### PR TITLE
meet: TTS viseme/amplitude tap for lip-sync input

### DIFF
--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -100,6 +100,35 @@ export interface TtsSynthesisResult {
 }
 
 // ---------------------------------------------------------------------------
+// Alignment / viseme events
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-phoneme alignment event emitted by TTS providers that expose
+ * character- or phoneme-level alignment metadata alongside the audio
+ * stream (e.g. ElevenLabs Turbo with alignment).
+ *
+ * Consumers (e.g. the Meet avatar lip-sync path) map these events to
+ * blendshape weights at the rendered timestamp. Providers that do not
+ * expose alignment metadata simply never invoke the callback; the
+ * caller is expected to fall back to an amplitude-envelope approximation
+ * derived from the PCM stream.
+ */
+export interface TtsAlignmentEvent {
+  /**
+   * Phoneme label or character — free-form string that the consumer maps
+   * to renderer-specific blendshape weights. Providers typically emit
+   * IPA-style phoneme labels, viseme codes, or individual characters
+   * depending on their alignment granularity.
+   */
+  phoneme: string;
+  /** Normalized intensity in the range [0, 1]. */
+  weight: number;
+  /** Milliseconds from the start of the synthesized utterance. */
+  timestamp: number;
+}
+
+// ---------------------------------------------------------------------------
 // Provider capabilities
 // ---------------------------------------------------------------------------
 
@@ -110,6 +139,15 @@ export interface TtsProviderCapabilities {
 
   /** Audio formats the provider can produce (e.g. `["mp3", "wav", "opus"]`). */
   supportedFormats: string[];
+
+  /**
+   * Whether the provider can emit {@link TtsAlignmentEvent}s via the optional
+   * `onAlignment` callback of `synthesizeStream`. Consumers use this to pick
+   * between a viseme-driven lip-sync path and an RMS-amplitude fallback.
+   *
+   * Optional for backwards compatibility — treat `undefined` as `false`.
+   */
+  alignment?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,9 +183,16 @@ export interface TtsProvider {
    * The `onChunk` callback is invoked with each audio chunk as it arrives
    * from the upstream provider. The returned promise resolves with the
    * complete concatenated result once all chunks have been delivered.
+   *
+   * Providers that advertise `capabilities.alignment === true` also invoke
+   * the optional `onAlignment` callback with per-phoneme alignment events
+   * interleaved with the audio chunks. Providers that don't support
+   * alignment simply never call it; callers must tolerate a silent
+   * channel and fall back to amplitude-based heuristics.
    */
   synthesizeStream?(
     request: TtsSynthesisRequest,
     onChunk: (chunk: Uint8Array) => void,
+    onAlignment?: (event: TtsAlignmentEvent) => void,
   ): Promise<TtsSynthesisResult>;
 }

--- a/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
@@ -1,0 +1,663 @@
+/**
+ * Unit tests for the TTS lip-sync tap:
+ *   - `MeetTtsBridge`'s `onViseme` channel (provider-alignment path +
+ *     RMS-amplitude fallback).
+ *   - `startTtsLipsync()` forwarding events to `POST /avatar/viseme` and
+ *     tolerating HTTP errors.
+ *
+ * These tests exercise both halves of the PR 4 contract:
+ *   1. A provider that advertises `capabilities.alignment = true` drives
+ *      viseme events through the alignment callback — no RMS extractor
+ *      runs.
+ *   2. A provider that does not advertise alignment triggers the
+ *      amplitude-envelope fallback; events are emitted with
+ *      `phoneme === "amp"` at 50 ms cadence.
+ *   3. The forwarder POSTs events to the bot and swallows 404 /
+ *      network errors (bot hasn't deployed PR 5 yet, or is briefly
+ *      unreachable).
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  TtsAlignmentEvent,
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../../../../assistant/src/tts/types.js";
+import { MeetTtsBridge } from "../tts-bridge.js";
+import type { VisemeEvent } from "../tts-bridge.js";
+import {
+  DEFAULT_LIPSYNC_REQUEST_TIMEOUT_MS,
+  startTtsLipsync,
+} from "../tts-lipsync.js";
+
+// ---------------------------------------------------------------------------
+// Fake ffmpeg child — identical to `tts-bridge.test.ts` but inlined to keep
+// the two files independently runnable.
+// ---------------------------------------------------------------------------
+
+interface FakeFfmpegChild extends EventEmitter {
+  stdin: Writable;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeFakeFfmpegChild(): FakeFfmpegChild {
+  const emitter = new EventEmitter() as FakeFfmpegChild;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new Writable({
+    write(chunk, _encoding, cb) {
+      stdout.write(chunk, cb);
+    },
+    final(cb) {
+      stdout.end();
+      cb();
+    },
+  });
+  emitter.stdin = stdin;
+  emitter.stdout = stdout;
+  emitter.stderr = stderr;
+  emitter.killed = false;
+  emitter.kill = (_signal?: string) => {
+    emitter.killed = true;
+    try {
+      stdout.end();
+    } catch {
+      /* best-effort */
+    }
+    return true;
+  };
+  return emitter;
+}
+
+function makeFakeProbeChild(): FakeFfmpegChild {
+  const child = makeFakeFfmpegChild();
+  setImmediate(() => child.emit("exit", 0, null));
+  return child;
+}
+
+function makeSpawnMock(): {
+  spawn: typeof import("node:child_process").spawn;
+} {
+  const spawn = mock((..._args: unknown[]) => {
+    const maybeArgs = _args[1];
+    const isProbe =
+      Array.isArray(maybeArgs) &&
+      maybeArgs.length === 1 &&
+      maybeArgs[0] === "-version";
+    if (isProbe) {
+      return makeFakeProbeChild() as unknown as ReturnType<
+        typeof import("node:child_process").spawn
+      >;
+    }
+    return makeFakeFfmpegChild() as unknown as ReturnType<
+      typeof import("node:child_process").spawn
+    >;
+  }) as unknown as typeof import("node:child_process").spawn;
+  return { spawn };
+}
+
+// ---------------------------------------------------------------------------
+// Fake bot server — accepts POSTs to /play_audio and /avatar/viseme.
+// ---------------------------------------------------------------------------
+
+interface RecordedViseme {
+  authorization: string | null;
+  contentType: string | null;
+  body: VisemeEvent;
+}
+
+interface FakeBot {
+  url: string;
+  visemes: RecordedViseme[];
+  /**
+   * When set, every `/avatar/viseme` POST replies with this status. Used
+   * to verify 4xx/5xx tolerance.
+   */
+  visemeStatusOverride: number | null;
+  stop: () => Promise<void>;
+}
+
+function startFakeBot(): FakeBot {
+  const visemes: RecordedViseme[] = [];
+  const state: FakeBot = {
+    url: "",
+    visemes,
+    visemeStatusOverride: null,
+    stop: async () => {
+      /* set below */
+    },
+  };
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      if (req.method === "POST" && url.pathname === "/avatar/viseme") {
+        let parsed: VisemeEvent | null = null;
+        try {
+          parsed = (await req.json()) as VisemeEvent;
+        } catch {
+          return new Response("bad json", { status: 400 });
+        }
+        visemes.push({
+          authorization: req.headers.get("authorization"),
+          contentType: req.headers.get("content-type"),
+          body: parsed,
+        });
+        if (state.visemeStatusOverride !== null) {
+          return new Response("", { status: state.visemeStatusOverride });
+        }
+        return new Response("", { status: 200 });
+      }
+      // Drain any /play_audio POST body so the bridge finishes its POST
+      // without hanging — not under test here.
+      if (req.method === "POST" && url.pathname === "/play_audio") {
+        if (req.body) {
+          const reader = req.body.getReader();
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        }
+        return new Response("", { status: 200 });
+      }
+      return new Response("", { status: 405 });
+    },
+  });
+  const port = server.port;
+  if (port === undefined) throw new Error("fake bot failed to bind");
+  state.url = `http://127.0.0.1:${port}`;
+  state.stop = async () => {
+    await server.stop(true);
+  };
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Fake providers
+// ---------------------------------------------------------------------------
+
+/** Build a provider that does NOT emit alignment events. */
+function makePlainProvider(chunks: Uint8Array[]): TtsProvider {
+  return {
+    id: "fake-plain-provider",
+    capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+    async synthesize(_req: TtsSynthesisRequest): Promise<TtsSynthesisResult> {
+      const merged = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+    async synthesizeStream(
+      _req: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      for (const chunk of chunks) {
+        onChunk(chunk);
+      }
+      const merged = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+  };
+}
+
+/** Build a provider that DOES emit alignment events. */
+function makeAlignmentProvider(
+  chunks: Uint8Array[],
+  alignments: TtsAlignmentEvent[],
+): TtsProvider {
+  return {
+    id: "fake-alignment-provider",
+    capabilities: {
+      supportsStreaming: true,
+      supportedFormats: ["pcm"],
+      alignment: true,
+    },
+    async synthesize(_req: TtsSynthesisRequest): Promise<TtsSynthesisResult> {
+      const merged = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+    async synthesizeStream(
+      _req: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+      onAlignment?: (event: TtsAlignmentEvent) => void,
+    ): Promise<TtsSynthesisResult> {
+      for (const chunk of chunks) {
+        onChunk(chunk);
+      }
+      for (const event of alignments) {
+        onAlignment?.(event);
+      }
+      const merged = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      return { audio: merged, contentType: "audio/pcm" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Audio helpers — build a PCM buffer of a given duration at peak loudness.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an s16le / mono / 48 kHz buffer of the given duration with samples
+ * set to `amplitude` (useful for deterministic RMS windows).
+ */
+function makeConstantPcm(durationMs: number, amplitude: number): Uint8Array {
+  const sampleRate = 48_000;
+  const sampleCount = Math.floor((sampleRate * durationMs) / 1000);
+  const bytes = Buffer.alloc(sampleCount * 2);
+  for (let i = 0; i < sampleCount; i++) {
+    bytes.writeInt16LE(amplitude, i * 2);
+  }
+  return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const TOKEN = "lip-sync-token";
+const MEETING_ID = "m-tts-lipsync-test";
+
+let fakeBot: FakeBot;
+
+beforeEach(() => {
+  fakeBot = startFakeBot();
+});
+
+afterEach(async () => {
+  await fakeBot.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Bridge `onViseme` behavior
+// ---------------------------------------------------------------------------
+
+describe("MeetTtsBridge.onViseme — provider alignment path", () => {
+  test("forwards provider-emitted alignment events as VisemeEvents", async () => {
+    const payload = [makeConstantPcm(30, 8000)];
+    const alignments: TtsAlignmentEvent[] = [
+      { phoneme: "a", weight: 0.3, timestamp: 10 },
+      { phoneme: "e", weight: 0.7, timestamp: 25 },
+    ];
+    const provider = makeAlignmentProvider(payload, alignments);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-align",
+      },
+    );
+
+    const events: VisemeEvent[] = [];
+    bridge.onViseme((e) => events.push(e));
+
+    const { completion } = await bridge.speak({ text: "hi" });
+    await completion;
+
+    // Only the alignment events should have been forwarded; no "amp"
+    // fallback entries since the provider advertised alignment support.
+    expect(events).toEqual([
+      { phoneme: "a", weight: 0.3, timestamp: 10 },
+      { phoneme: "e", weight: 0.7, timestamp: 25 },
+    ]);
+    expect(events.every((e) => e.phoneme !== "amp")).toBe(true);
+  });
+
+  test("clamps out-of-range alignment weights into [0, 1]", async () => {
+    const payload = [makeConstantPcm(20, 4000)];
+    const provider = makeAlignmentProvider(payload, [
+      { phoneme: "x", weight: -0.2, timestamp: 0 },
+      { phoneme: "y", weight: 1.4, timestamp: 10 },
+      { phoneme: "z", weight: Number.NaN, timestamp: 20 },
+    ]);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      {
+        meetingId: MEETING_ID,
+        botBaseUrl: fakeBot.url,
+        botApiToken: TOKEN,
+      },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-clamp",
+      },
+    );
+
+    const events: VisemeEvent[] = [];
+    bridge.onViseme((e) => events.push(e));
+    const { completion } = await bridge.speak({ text: "clamp" });
+    await completion;
+
+    expect(events).toHaveLength(3);
+    expect(events[0]!.weight).toBe(0);
+    expect(events[1]!.weight).toBe(1);
+    expect(events[2]!.weight).toBe(0);
+  });
+
+  test("skips alignment plumbing when no subscribers are registered", async () => {
+    const payload = [makeConstantPcm(30, 8000)];
+    // If the bridge called `onAlignment` despite no subscribers, we'd see
+    // a test failure here because the provider's `onAlignment` would be
+    // defined — assert via a spy that it was not called.
+    let onAlignmentSpy: ((e: TtsAlignmentEvent) => void) | undefined;
+    const provider: TtsProvider = {
+      id: "fake-alignment-provider-spy",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["pcm"],
+        alignment: true,
+      },
+      async synthesize(_req) {
+        return {
+          audio: Buffer.from(payload[0]!),
+          contentType: "audio/pcm",
+        };
+      },
+      async synthesizeStream(_req, onChunk, onAlignment) {
+        onAlignmentSpy = onAlignment;
+        for (const chunk of payload) onChunk(chunk);
+        return {
+          audio: Buffer.from(payload[0]!),
+          contentType: "audio/pcm",
+        };
+      },
+    };
+    const { spawn } = makeSpawnMock();
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-no-sub",
+      },
+    );
+    const { completion } = await bridge.speak({ text: "skip" });
+    await completion;
+    // With no subscribers, the bridge should not have passed an
+    // `onAlignment` callback down to the provider.
+    expect(onAlignmentSpy).toBeUndefined();
+  });
+});
+
+describe("MeetTtsBridge.onViseme — amplitude fallback path", () => {
+  test("emits 'amp' viseme events at 50ms cadence when provider lacks alignment", async () => {
+    // 200 ms of steady audio at half-scale amplitude → 4 RMS windows.
+    const amplitude = 16_384;
+    const payload = [makeConstantPcm(200, amplitude)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-amp",
+      },
+    );
+
+    const events: VisemeEvent[] = [];
+    bridge.onViseme((e) => events.push(e));
+
+    const { completion } = await bridge.speak({ text: "amp" });
+    await completion;
+
+    expect(events.length).toBeGreaterThanOrEqual(4);
+    // Every event must be an amplitude fallback.
+    for (const e of events) {
+      expect(e.phoneme).toBe("amp");
+      expect(e.weight).toBeGreaterThanOrEqual(0);
+      expect(e.weight).toBeLessThanOrEqual(1);
+    }
+    // Timestamps must be strictly monotonically increasing with 50 ms spacing.
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i]!.timestamp - events[i - 1]!.timestamp).toBe(50);
+    }
+    // First window's timestamp is 0 (start of utterance).
+    expect(events[0]!.timestamp).toBe(0);
+    // RMS of a constant amplitude `a` is `a`. Weight = 16384 / 32768 = 0.5.
+    // Allow a small epsilon for float accumulation.
+    expect(events[0]!.weight).toBeGreaterThan(0.4);
+    expect(events[0]!.weight).toBeLessThan(0.6);
+  });
+
+  test("does not run the amplitude tap when no subscribers are registered", async () => {
+    // Use a plain provider that would otherwise trigger the fallback; if
+    // the bridge still installed the tap it would fire events we've
+    // subscribed to afterwards (we don't subscribe here, so silence is
+    // the signal of correctness — assert no events after subscribing
+    // post-speak).
+    const payload = [makeConstantPcm(100, 16_000)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-no-tap",
+      },
+    );
+
+    const { completion } = await bridge.speak({ text: "silent" });
+    await completion;
+
+    // Subscribing after the call completes must receive nothing — the tap
+    // was never installed for that call.
+    const events: VisemeEvent[] = [];
+    bridge.onViseme((e) => events.push(e));
+    // Give any hypothetical late emissions a chance to land.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(events).toEqual([]);
+  });
+
+  test("onViseme returns an unsubscribe that stops further delivery", async () => {
+    const amplitude = 16_384;
+    const payload = [makeConstantPcm(100, amplitude)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-unsub",
+      },
+    );
+
+    const beforeEvents: VisemeEvent[] = [];
+    const afterEvents: VisemeEvent[] = [];
+    const unsub = bridge.onViseme((e) => beforeEvents.push(e));
+    unsub();
+    bridge.onViseme((e) => afterEvents.push(e));
+
+    const { completion } = await bridge.speak({ text: "unsub" });
+    await completion;
+
+    expect(beforeEvents).toEqual([]);
+    expect(afterEvents.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `startTtsLipsync` forwarder
+// ---------------------------------------------------------------------------
+
+describe("startTtsLipsync", () => {
+  test("forwards viseme events to POST /avatar/viseme with auth header", async () => {
+    const amplitude = 16_384;
+    const payload = [makeConstantPcm(100, amplitude)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-forward",
+      },
+    );
+
+    const observed: VisemeEvent[] = [];
+    const handle = startTtsLipsync({
+      bridge,
+      botApiToken: TOKEN,
+      onEvent: (e) => observed.push(e),
+    });
+
+    const { completion } = await bridge.speak({ text: "forward" });
+    await completion;
+
+    // Wait briefly for outbound POSTs to settle (fire-and-forget).
+    await new Promise((r) => setTimeout(r, 50));
+    handle.stop();
+
+    // We observed at least one amplitude window — assert the bot saw a
+    // matching number of POSTs (minus at most a few still in flight; in
+    // practice all complete under 50 ms against a local Bun.serve).
+    expect(observed.length).toBeGreaterThan(0);
+    expect(fakeBot.visemes.length).toBeGreaterThan(0);
+
+    // Headers and body shape are validated on the very first recorded
+    // POST — they must all be identical.
+    const first = fakeBot.visemes[0]!;
+    expect(first.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(first.contentType).toBe("application/json");
+    expect(first.body.phoneme).toBe("amp");
+    expect(typeof first.body.weight).toBe("number");
+    expect(typeof first.body.timestamp).toBe("number");
+  });
+
+  test("tolerates 404 responses from a bot that hasn't deployed /avatar/viseme", async () => {
+    fakeBot.visemeStatusOverride = 404;
+
+    const payload = [makeConstantPcm(100, 16_384)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-404",
+      },
+    );
+
+    const observed: VisemeEvent[] = [];
+    const handle = startTtsLipsync({
+      bridge,
+      botApiToken: TOKEN,
+      onEvent: (e) => observed.push(e),
+    });
+
+    const { completion } = await bridge.speak({ text: "404-ok" });
+    // The speak pipeline must not surface a rejection from the
+    // 404-returning forwarder — it must complete cleanly.
+    await expect(completion).resolves.toBeUndefined();
+
+    await new Promise((r) => setTimeout(r, 50));
+    handle.stop();
+
+    expect(observed.length).toBeGreaterThan(0);
+    // The bot recorded the POSTs even though it replied 404 — forwarder
+    // did not give up or crash after the first 404.
+    expect(fakeBot.visemes.length).toBe(observed.length);
+  });
+
+  test("tolerates network errors on the forwarder's POST", async () => {
+    const payload = [makeConstantPcm(100, 16_384)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-net-err",
+      },
+    );
+
+    const observed: VisemeEvent[] = [];
+    const fetchErrors: string[] = [];
+    const failingFetch = mock(async (url: string | URL) => {
+      fetchErrors.push(String(url));
+      throw new Error("simulated-network-failure");
+    }) as unknown as (
+      input: string | URL,
+      init?: RequestInit,
+    ) => Promise<Response>;
+
+    const handle = startTtsLipsync({
+      bridge,
+      botApiToken: TOKEN,
+      fetch: failingFetch,
+      onEvent: (e) => observed.push(e),
+    });
+
+    const { completion } = await bridge.speak({ text: "net-err-ok" });
+    await expect(completion).resolves.toBeUndefined();
+
+    await new Promise((r) => setTimeout(r, 50));
+    handle.stop();
+
+    expect(observed.length).toBeGreaterThan(0);
+    expect(fetchErrors.length).toBe(observed.length);
+  });
+
+  test("stop() unsubscribes so subsequent events are not forwarded", async () => {
+    const payload = [makeConstantPcm(100, 16_384)];
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-stop",
+      },
+    );
+
+    const observed: VisemeEvent[] = [];
+    const handle = startTtsLipsync({
+      bridge,
+      botApiToken: TOKEN,
+      onEvent: (e) => observed.push(e),
+    });
+    handle.stop();
+    // Calling stop a second time is idempotent.
+    handle.stop();
+
+    const { completion } = await bridge.speak({ text: "post-stop" });
+    await completion;
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(observed).toEqual([]);
+    expect(fakeBot.visemes).toEqual([]);
+  });
+
+  test("default request timeout constant is exported for configuration", () => {
+    expect(DEFAULT_LIPSYNC_REQUEST_TIMEOUT_MS).toBe(2_000);
+  });
+});

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -32,10 +32,11 @@
 
 import { spawn as nodeSpawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 
 import { getLogger } from "../../../assistant/src/util/logger.js";
 import type {
+  TtsAlignmentEvent,
   TtsProvider,
   TtsSynthesisRequest,
 } from "../../../assistant/src/tts/types.js";
@@ -63,6 +64,75 @@ export const BOT_AUDIO_ENCODING = "pcm_s16le";
  * indefinitely.
  */
 export const CANCEL_DELETE_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Lip-sync tap — viseme channel and amplitude fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Window over which the amplitude-envelope fallback computes RMS. Chosen
+ * to match the ~50ms cadence the avatar consumer expects (PR 4 of the
+ * meet-phase-4 plan). 50ms at 48 kHz mono s16le = 2400 samples = 4800 bytes.
+ */
+export const AMPLITUDE_WINDOW_MS = 50;
+
+/** Sample rate used for the amplitude fallback — matches the bot wire format. */
+const AMPLITUDE_SAMPLE_RATE_HZ = BOT_AUDIO_SAMPLE_RATE_HZ;
+
+/** Bytes per sample for the ffmpeg output (s16le mono = 2 bytes per sample). */
+const AMPLITUDE_BYTES_PER_SAMPLE =
+  (BOT_AUDIO_SAMPLE_BITS / 8) * BOT_AUDIO_CHANNELS;
+
+/** Samples per amplitude window. */
+const AMPLITUDE_SAMPLES_PER_WINDOW = Math.floor(
+  (AMPLITUDE_SAMPLE_RATE_HZ * AMPLITUDE_WINDOW_MS) / 1000,
+);
+
+/** Bytes per amplitude window. */
+const AMPLITUDE_BYTES_PER_WINDOW =
+  AMPLITUDE_SAMPLES_PER_WINDOW * AMPLITUDE_BYTES_PER_SAMPLE;
+
+/**
+ * Maximum absolute sample value for 16-bit signed audio — used to normalize
+ * the RMS into a `[0, 1]` weight for downstream blendshape mapping.
+ */
+const AMPLITUDE_MAX_SAMPLE = 32768;
+
+/**
+ * Viseme event emitted from the bridge's `onViseme` channel.
+ *
+ * TODO: import from `skills/meet-join/bot/src/media/avatar/types.ts` once
+ * PR 1 of the meet-phase-4 plan lands on `main`. The shape is identical
+ * to the `VisemeEvent` declared there — duplicated here to unblock this
+ * PR shipping in Wave 1 alongside PR 1.
+ */
+export interface VisemeEvent {
+  /**
+   * Phoneme or viseme label. Provider-backed events pass through whatever
+   * label the provider emitted (e.g. IPA phoneme, ElevenLabs character).
+   * Amplitude-fallback events emit the literal string `"amp"`.
+   */
+  phoneme: string;
+  /** Normalized intensity in the range [0, 1]. */
+  weight: number;
+  /** Milliseconds from the start of the synthesized utterance. */
+  timestamp: number;
+}
+
+/**
+ * Subscriber callback shape for {@link MeetTtsBridge.onViseme}. Called
+ * synchronously from the bridge's event loop — subscribers must not
+ * block (enqueue work, do not await).
+ */
+export type VisemeListener = (event: VisemeEvent) => void;
+
+/** Clamp a numeric weight into `[0, 1]` — tolerates slightly-out-of-range providers. */
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
 
 /**
  * ffmpeg arguments that read whatever format the TTS provider emits on
@@ -221,6 +291,15 @@ export class MeetTtsBridge {
   private readonly deps: Required<MeetTtsBridgeDeps>;
   private readonly streams = new Map<string, ActiveStream>();
   /**
+   * Subscribers to the per-bridge viseme channel. Populated via
+   * {@link MeetTtsBridge.onViseme}. Events from both the provider
+   * alignment path and the RMS-amplitude fallback fan out to every
+   * subscriber. The set is shared across every `speak` call on this
+   * bridge — the lip-sync forwarder subscribes once at construction,
+   * not per utterance.
+   */
+  private readonly visemeListeners = new Set<VisemeListener>();
+  /**
    * Memoized `ffmpeg -version` probe. Cached after the first `speak` call so
    * subsequent speaks re-use the result without re-spawning ffmpeg. Resolves
    * with `{ available: true }` when ffmpeg is on PATH and exits (regardless
@@ -344,6 +423,22 @@ export class MeetTtsBridge {
       );
     });
 
+    // --- Decide which lip-sync tap to install ------------------------------
+    //
+    // Providers that advertise `capabilities.alignment === true` route their
+    // alignment events through an `onAlignment` callback; we emit those
+    // directly as viseme events. Providers without alignment fall back to
+    // an RMS-amplitude extractor running over the ffmpeg-normalized PCM
+    // stdout stream (guaranteed 48 kHz / mono / s16le, so a simple
+    // byte-windowed RMS is accurate regardless of the provider's native
+    // output format). The amplitude fallback only runs when there is at
+    // least one viseme subscriber — otherwise we skip the extra work.
+    const providerSupportsAlignment =
+      provider.capabilities.alignment === true;
+    const hasVisemeSubscribers = this.visemeListeners.size > 0;
+    const useAmplitudeFallback =
+      !providerSupportsAlignment && hasVisemeSubscribers;
+
     // --- Drive the provider's streaming synthesis into ffmpeg stdin --------
     //
     // We kick off synthesis concurrently with the HTTP POST so the bot
@@ -356,19 +451,33 @@ export class MeetTtsBridge {
       voiceId: input.voice,
       signal: abort.signal,
     };
-    const synthesisPromise = provider
-      .synthesizeStream(synthesisRequest, (chunk) => {
-        if (abort.signal.aborted) return;
-        try {
-          ffmpeg.stdin.write(Buffer.from(chunk));
-        } catch (err) {
-          log.warn(
-            { err, meetingId: this.meetingId, streamId },
-            "ffmpeg stdin write threw — aborting stream",
-          );
-          abort.abort(err);
+    const onAlignment = providerSupportsAlignment && hasVisemeSubscribers
+      ? (event: TtsAlignmentEvent) => {
+          if (abort.signal.aborted) return;
+          this.emitVisemeEvent({
+            phoneme: event.phoneme,
+            weight: clamp01(event.weight),
+            timestamp: event.timestamp,
+          });
         }
-      })
+      : undefined;
+    const synthesisPromise = provider
+      .synthesizeStream(
+        synthesisRequest,
+        (chunk) => {
+          if (abort.signal.aborted) return;
+          try {
+            ffmpeg.stdin.write(Buffer.from(chunk));
+          } catch (err) {
+            log.warn(
+              { err, meetingId: this.meetingId, streamId },
+              "ffmpeg stdin write threw — aborting stream",
+            );
+            abort.abort(err);
+          }
+        },
+        onAlignment,
+      )
       .catch((err) => {
         if (!abort.signal.aborted) {
           log.warn(
@@ -392,9 +501,20 @@ export class MeetTtsBridge {
     //
     // Node's undici-backed fetch accepts a `ReadableStream` body; convert
     // the node-stream `ffmpeg.stdout` into a web stream so we can hand it
-    // off to fetch with `duplex: "half"`.
+    // off to fetch with `duplex: "half"`. When the amplitude fallback is
+    // active we splice a PassThrough into the pipeline so we can observe
+    // every PCM byte without buffering the whole stream ourselves — the
+    // tap runs RMS over 50 ms windows and emits viseme events without
+    // delaying the outbound HTTP body.
+    let httpBodySource: NodeJS.ReadableStream = ffmpeg.stdout;
+    if (useAmplitudeFallback) {
+      const tap = new PassThrough();
+      ffmpeg.stdout.pipe(tap);
+      this.attachAmplitudeTap(tap, abort.signal);
+      httpBodySource = tap;
+    }
     const bodyStream = Readable.toWeb(
-      ffmpeg.stdout,
+      httpBodySource as Readable,
     ) as unknown as ReadableStream<Uint8Array>;
 
     const url = `${this.botBaseUrl}/play_audio?stream_id=${encodeURIComponent(streamId)}`;
@@ -481,9 +601,116 @@ export class MeetTtsBridge {
     await Promise.allSettled(ids.map((id) => this.cancel(id)));
   }
 
+  /**
+   * Subscribe to per-utterance viseme events. When the active TTS provider
+   * advertises `capabilities.alignment === true`, provider-sourced alignment
+   * events are forwarded unchanged. Otherwise, an RMS-amplitude extractor
+   * runs over the ffmpeg-normalized PCM stream and emits fallback events of
+   * the shape `{ phoneme: "amp", weight, timestamp }`.
+   *
+   * Returns an unsubscribe function. Subscribers added before a `speak`
+   * call starts receive events from that call; subscribers added after a
+   * call has started are ignored by that specific in-flight call's tap
+   * (the tap is installed once at the top of `speak`) but will pick up
+   * the next call.
+   *
+   * Subscriber callbacks are invoked synchronously on the bridge's event
+   * loop — they must not block or await.
+   */
+  onViseme(listener: VisemeListener): () => void {
+    this.visemeListeners.add(listener);
+    return () => {
+      this.visemeListeners.delete(listener);
+    };
+  }
+
   // -------------------------------------------------------------------------
   // Internals
   // -------------------------------------------------------------------------
+
+  /**
+   * Fan out a viseme event to every subscriber. Errors from individual
+   * subscribers are logged and swallowed — a misbehaving consumer must
+   * not tear down the TTS stream.
+   */
+  private emitVisemeEvent(event: VisemeEvent): void {
+    for (const listener of this.visemeListeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId, phoneme: event.phoneme },
+          "onViseme subscriber threw — dropping event",
+        );
+      }
+    }
+  }
+
+  /**
+   * Wire an amplitude-envelope extractor over a PCM stream. The stream is
+   * expected to be `s16le` mono at {@link BOT_AUDIO_SAMPLE_RATE_HZ}, matching
+   * the ffmpeg transcode pipeline's stdout. For every 50 ms window of bytes
+   * the tap computes a normalized RMS and emits a `{ phoneme: "amp", ... }`
+   * viseme event with the window's start timestamp (milliseconds from the
+   * beginning of this utterance).
+   *
+   * The tap tolerates any amount of trailing bytes that don't fill a full
+   * window — leftover audio under 50 ms just doesn't emit a final event,
+   * which keeps the calculation self-consistent and spares consumers a
+   * ragged-edge weight.
+   */
+  private attachAmplitudeTap(
+    stream: NodeJS.ReadableStream,
+    signal: AbortSignal,
+  ): void {
+    let totalBytesConsumed = 0;
+    let windowBuffer = Buffer.alloc(0);
+
+    const flushWindow = (): void => {
+      while (windowBuffer.length >= AMPLITUDE_BYTES_PER_WINDOW) {
+        const windowBytes = windowBuffer.subarray(
+          0,
+          AMPLITUDE_BYTES_PER_WINDOW,
+        );
+        const windowStartByte = totalBytesConsumed;
+        totalBytesConsumed += AMPLITUDE_BYTES_PER_WINDOW;
+        windowBuffer = windowBuffer.subarray(AMPLITUDE_BYTES_PER_WINDOW);
+
+        // Timestamp is the wall-of-bytes offset at the start of this window,
+        // converted to ms. 2 bytes/sample × 48 samples/ms = 96 bytes/ms.
+        const timestamp = Math.round(
+          windowStartByte /
+            (AMPLITUDE_BYTES_PER_SAMPLE * (AMPLITUDE_SAMPLE_RATE_HZ / 1000)),
+        );
+
+        let sumOfSquares = 0;
+        for (let i = 0; i < windowBytes.length; i += 2) {
+          const sample = windowBytes.readInt16LE(i);
+          sumOfSquares += sample * sample;
+        }
+        const rms = Math.sqrt(sumOfSquares / AMPLITUDE_SAMPLES_PER_WINDOW);
+        const weight = clamp01(rms / AMPLITUDE_MAX_SAMPLE);
+
+        this.emitVisemeEvent({ phoneme: "amp", weight, timestamp });
+      }
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (signal.aborted) return;
+      windowBuffer =
+        windowBuffer.length === 0
+          ? Buffer.from(chunk)
+          : Buffer.concat([windowBuffer, chunk]);
+      try {
+        flushWindow();
+      } catch (err) {
+        log.warn(
+          { err, meetingId: this.meetingId },
+          "amplitude tap window flush threw — suppressing",
+        );
+      }
+    });
+  }
 
   private async runPost(args: {
     url: string;

--- a/skills/meet-join/daemon/tts-lipsync.ts
+++ b/skills/meet-join/daemon/tts-lipsync.ts
@@ -1,0 +1,177 @@
+/**
+ * TTS lip-sync forwarder — subscribes to a {@link MeetTtsBridge}'s viseme
+ * channel and POSTs each event to the Meet-bot's `/avatar/viseme` endpoint
+ * so the in-bot avatar renderer can drive blendshape weights against the
+ * audio that the bot is simultaneously playing out.
+ *
+ * High-level flow:
+ *   1. Caller builds a bridge (Phase 3) and calls {@link startTtsLipsync}.
+ *   2. The forwarder subscribes to the bridge's `onViseme` channel.
+ *   3. Each event is forwarded to the bot via `POST /avatar/viseme` and
+ *      optionally fanned out to a local observer callback (tests, metrics).
+ *   4. HTTP errors (including 404 when the bot hasn't yet deployed PR 5's
+ *      endpoint, or 5xx during transient failures) are swallowed with a
+ *      `debug`-level log — dropped events simply cause a visibly less
+ *      synced avatar, not a crash or a dropped utterance.
+ *   5. Caller invokes the returned `stop()` to unsubscribe and prevent
+ *      further outbound HTTP traffic.
+ *
+ * The bot endpoint (`POST /avatar/viseme`) lands in PR 5 of the
+ * meet-phase-4 plan; this PR lands the daemon producer in parallel.
+ * Until PR 5 merges, bots respond 404 and the forwarder silently drops
+ * those events — graceful degradation.
+ */
+
+import { getLogger } from "../../../assistant/src/util/logger.js";
+
+import type { MeetTtsBridge, VisemeEvent } from "./tts-bridge.js";
+
+const log = getLogger("meet-tts-lipsync");
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fetch shape the forwarder needs — identical to the global
+ * `fetch` but kept as an explicit dependency for tests.
+ */
+export type LipsyncFetchFn = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface StartTtsLipsyncArgs {
+  /** Bridge whose `onViseme` channel drives the forwarder. */
+  bridge: MeetTtsBridge;
+  /** Per-meeting bearer token — matches the token used for `/play_audio`. */
+  botApiToken: string;
+  /**
+   * Optional fetch override (tests). Defaults to the global `fetch`.
+   */
+  fetch?: LipsyncFetchFn;
+  /**
+   * Optional observer invoked with every event _before_ the HTTP POST
+   * fires. Used by tests and local metrics to assert which events reached
+   * the forwarder irrespective of bot availability.
+   */
+  onEvent?: (event: VisemeEvent) => void;
+  /**
+   * Per-request timeout for the outbound POST. Kept short because a stuck
+   * viseme POST would block subsequent events behind a `fetch` queue — we'd
+   * rather drop a frame than fall minutes behind. Default 2 s.
+   */
+  requestTimeoutMs?: number;
+}
+
+/** Handle returned from {@link startTtsLipsync}. Call `stop()` on teardown. */
+export interface TtsLipsyncHandle {
+  /** Unsubscribe from the bridge's viseme channel. Idempotent. */
+  stop(): void;
+}
+
+/**
+ * Default HTTP timeout per `/avatar/viseme` POST. Individual events are
+ * cheap and frequent (up to ~20/s during the amplitude-fallback path) —
+ * we'd rather drop an event than let a pending POST linger.
+ */
+export const DEFAULT_LIPSYNC_REQUEST_TIMEOUT_MS = 2_000;
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Start a forwarder that subscribes to `bridge.onViseme` and POSTs each
+ * event to `${bridge.botBaseUrl}/avatar/viseme`. Returns a handle whose
+ * `stop()` method unsubscribes — stopping is idempotent and safe to call
+ * in teardown handlers that may also be triggered by a different code path.
+ *
+ * The forwarder is deliberately fire-and-forget at the HTTP layer:
+ * `fetch` errors are logged at `debug` level and swallowed, so a bot that
+ * hasn't deployed the `/avatar/viseme` route yet (404) or is briefly
+ * unreachable (network hiccup) doesn't disrupt the speak pipeline. This
+ * matches the plan's acceptance criterion: "Errors are tolerated —
+ * dropped events just cause a visibly less-synced avatar, not a crash."
+ */
+export function startTtsLipsync(args: StartTtsLipsyncArgs): TtsLipsyncHandle {
+  const {
+    bridge,
+    botApiToken,
+    fetch: fetchImpl,
+    onEvent,
+    requestTimeoutMs,
+  } = args;
+
+  const timeoutMs = requestTimeoutMs ?? DEFAULT_LIPSYNC_REQUEST_TIMEOUT_MS;
+  const doFetch: LipsyncFetchFn =
+    fetchImpl ?? ((url, init) => fetch(url, init));
+  const endpointUrl = `${bridge.botBaseUrl}/avatar/viseme`;
+
+  let stopped = false;
+  let unsubscribe: (() => void) | null = null;
+
+  const forward = (event: VisemeEvent): void => {
+    if (stopped) return;
+    try {
+      onEvent?.(event);
+    } catch (err) {
+      log.debug(
+        { err, meetingId: bridge.meetingId },
+        "onEvent observer threw — suppressing",
+      );
+    }
+
+    // Fire-and-forget POST. We do not await here because the listener is
+    // called on the bridge's synchronous emit path and must return
+    // immediately. The explicit `.catch` keeps unhandled rejections off
+    // the global handler.
+    const timeout = AbortSignal.timeout(timeoutMs);
+    doFetch(endpointUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${botApiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(event),
+      signal: timeout,
+    })
+      .then(async (response) => {
+        if (stopped) return;
+        if (!response.ok) {
+          log.debug(
+            {
+              meetingId: bridge.meetingId,
+              status: response.status,
+              phoneme: event.phoneme,
+            },
+            "POST /avatar/viseme returned non-2xx — dropping event",
+          );
+          // Drain so the connection can be reused.
+          await response.arrayBuffer().catch(() => {});
+          return;
+        }
+        await response.arrayBuffer().catch(() => {});
+      })
+      .catch((err) => {
+        log.debug(
+          { err, meetingId: bridge.meetingId, phoneme: event.phoneme },
+          "POST /avatar/viseme failed — dropping event",
+        );
+      });
+  };
+
+  unsubscribe = bridge.onViseme(forward);
+
+  return {
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      try {
+        unsubscribe?.();
+      } finally {
+        unsubscribe = null;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extends `MeetTtsBridge` to emit per-utterance viseme events (via provider alignment metadata when available, RMS-amplitude fallback otherwise).
- New `tts-lipsync.ts` subscribes to the viseme channel and POSTs events to the bot's `/avatar/viseme` endpoint (bot handler lands in PR 5).
- Additive only — existing Phase-3 `MeetTtsBridge` callers are unaffected.

Part of plan: meet-phase-4-avatar.md (PR 4 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
