### PR TITLE
feat(client): add "In meeting" status panel to macOS Home gallery

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -18,6 +18,51 @@ struct HomeGallerySection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
 
+            // MARK: - MeetStatusPanel
+
+            if filter == nil || filter == "meetStatusPanel" {
+                GallerySectionHeader(
+                    title: "MeetStatusPanel",
+                    description: "Top-of-gallery banner that reflects live Meet bot state via meet.* SSE events. Idle state returns EmptyView."
+                )
+
+                VCard(background: VColor.surfaceBase) {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Joining")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        MeetStatusPanel(
+                            viewModel: MeetStatusPanelGalleryFixture.joining()
+                        )
+
+                        Divider().background(VColor.borderBase)
+
+                        Text("In meeting")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        MeetStatusPanel(
+                            viewModel: MeetStatusPanelGalleryFixture.joined()
+                        )
+
+                        Divider().background(VColor.borderBase)
+
+                        Text("Error")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        MeetStatusPanel(
+                            viewModel: MeetStatusPanelGalleryFixture.error()
+                        )
+                    }
+                }
+
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+            }
+
             // MARK: - RecapPillView
 
             if filter == nil || filter == "recapPill" {
@@ -284,6 +329,7 @@ extension HomeGallerySection {
     @ViewBuilder
     static func componentPage(_ id: String) -> some View {
         switch id {
+        case "meetStatusPanel": HomeGallerySection(filter: "meetStatusPanel")
         case "recapPill": HomeGallerySection(filter: "recapPill")
         case "homeAuthCard": HomeGallerySection(filter: "homeAuthCard")
         case "homePermissionCard": HomeGallerySection(filter: "homePermissionCard")
@@ -295,6 +341,61 @@ extension HomeGallerySection {
         case "homeUpdatesListCard": HomeGallerySection(filter: "homeUpdatesListCard")
         default: EmptyView()
         }
+    }
+}
+
+// MARK: - Gallery Fixtures
+
+/// Builds `MeetStatusViewModel` instances in each presentation state so the
+/// gallery can render the panel without a live SSE stream. Lives here rather
+/// than on the view model itself so the production target stays free of
+/// test/gallery-only wiring.
+@MainActor
+private enum MeetStatusPanelGalleryFixture {
+    private static func empty() -> AsyncStream<ServerMessage> {
+        AsyncStream<ServerMessage> { _ in }
+    }
+
+    static func joining() -> MeetStatusViewModel {
+        let vm = MeetStatusViewModel(messageStream: empty())
+        vm.handle(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "demo-joining",
+                url: "https://meet.google.com/demo-joining"
+            )
+        ))
+        return vm
+    }
+
+    static func joined() -> MeetStatusViewModel {
+        let vm = MeetStatusViewModel(
+            messageStream: empty(),
+            clock: { Date(timeIntervalSinceNow: -73) }
+        )
+        vm.handle(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "demo-joined",
+                url: "https://meet.google.com/demo-joined"
+            )
+        ))
+        vm.handle(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "demo-joined")
+        ))
+        return vm
+    }
+
+    static func error() -> MeetStatusViewModel {
+        let vm = MeetStatusViewModel(messageStream: empty())
+        vm.handle(.meetError(
+            MeetErrorMessage(
+                type: "meet.error",
+                meetingId: "demo-error",
+                detail: "Bot container exited unexpectedly"
+            )
+        ))
+        return vm
     }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -17,6 +17,10 @@ import VellumAssistantShared
 struct HomePageView: View {
     @Bindable var store: HomeStore
     @Bindable var feedStore: HomeFeedStore
+    /// Drives the "In meeting" status panel rendered at the top of the
+    /// gallery. Owned by the parent so the panel survives panel-dismiss
+    /// cycles and keeps its SSE subscription live for the whole session.
+    @Bindable var meetStatusViewModel: MeetStatusViewModel
     let onPrimaryCTA: (Capability) -> Void
     let onShortcutCTA: (Capability) -> Void
     /// Fired when a feed action resolves to a daemon-created conversation
@@ -53,6 +57,11 @@ struct HomePageView: View {
     private func content(for state: RelationshipState) -> some View {
         ScrollView {
             VStack(alignment: .center, spacing: VSpacing.xxl) {
+                // "In meeting" status banner — returns EmptyView when idle,
+                // so when no meeting is active the layout collapses to the
+                // prior hero-first appearance.
+                MeetStatusPanel(viewModel: meetStatusViewModel)
+
                 HomeHeroView(state: state)
                     .padding(.top, VSpacing.xxl)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -109,6 +109,12 @@ struct MainWindowView: View {
     /// the flag isn't worth the runtime-toggle surface bug it created.
     @State var homeStore: HomeStore
     @State var feedStore: HomeFeedStore
+    /// Long-lived view model that tracks the live meeting status pushed by
+    /// the daemon's `meet.*` SSE events. Rendered as the top-of-gallery
+    /// status panel on the Home page. Constructed eagerly (same rationale
+    /// as the Home stores) so the panel is wired up the moment the user
+    /// lands on Home, without having to refresh.
+    @State var meetStatusViewModel: MeetStatusViewModel
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.listStore = conversationManager.listStore
@@ -147,6 +153,10 @@ struct MainWindowView: View {
         // — ready the instant the `home-feed` flag flips on.
         self._feedStore = State(initialValue: HomeFeedStore(
             client: DefaultHomeFeedClient(),
+            messageStream: eventStreamClient.subscribe()
+        ))
+        // Meet status panel subscribes to the same shared SSE stream.
+        self._meetStatusViewModel = State(initialValue: MeetStatusViewModel(
             messageStream: eventStreamClient.subscribe()
         ))
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -163,6 +163,7 @@ extension MainWindowView {
         HomePageView(
             store: homeStore,
             feedStore: feedStore,
+            meetStatusViewModel: meetStatusViewModel,
             onPrimaryCTA: { capability in
                 let seed = CapabilityCTAContext.setupSeedMessage(for: capability, kind: .primary)
                 conversationManager.openConversation(message: seed, forceNew: true)

--- a/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Observation
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MeetStatusPanel")
+
+// MARK: - View Model
+
+/// Observable view model that tracks the live state of the Meet bot by
+/// consuming `meet.*` SSE events from the shared `ServerMessage` stream.
+///
+/// Exposed as a single-panel model rather than a per-conversation one because
+/// the bot can run independently of any conversation focus (the Home gallery
+/// simply shows "in meeting" at the top whenever the bot is live). If the
+/// daemon grows support for concurrent meetings later, the state machine can
+/// graduate to a keyed dictionary without changing callers.
+///
+/// The state transitions are driven purely by events:
+/// - `meet.joining` → `.joining(meetingId, url)`
+/// - `meet.joined`  → `.joined(meetingId, title, joinedAt = now)` ONLY if we
+///   previously saw a `meet.joining` for the same meeting. Out-of-order
+///   `meet.joined` (no preceding `meet.joining`) is ignored so the panel
+///   stays idle.
+/// - `meet.error`   → `.error(reason)`
+/// - `meet.left`    → `.idle` (any in-flight state collapses to idle)
+///
+/// Out-of-order `meet.left` with no in-flight state is a no-op.
+@MainActor
+@Observable
+public final class MeetStatusViewModel {
+
+    /// Top-level display state for the panel. The view maps each case to a
+    /// specific layout — `idle` collapses the panel to `EmptyView`.
+    public enum State: Equatable {
+        case idle
+        case joining(meetingId: String, url: String)
+        case joined(meetingId: String, title: String, joinedAt: Date)
+        case error(reason: String)
+    }
+
+    public private(set) var state: State = .idle
+
+    // MARK: - Non-reactive bookkeeping
+
+    @ObservationIgnored private let messageStream: AsyncStream<ServerMessage>
+    @ObservationIgnored private var sseTask: Task<Void, Never>?
+    /// Clock injected so tests can drive deterministic `joinedAt` values.
+    @ObservationIgnored private let clock: @Sendable () -> Date
+
+    // MARK: - Lifecycle
+
+    public init(
+        messageStream: AsyncStream<ServerMessage>,
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.messageStream = messageStream
+        self.clock = clock
+        startListening()
+    }
+
+    deinit {
+        sseTask?.cancel()
+    }
+
+    // MARK: - Event intake
+
+    /// Applies a single SSE event to the state machine. Exposed so unit tests
+    /// can drive state transitions directly without going through the stream.
+    public func handle(_ message: ServerMessage) {
+        switch message {
+        case .meetJoining(let m):
+            state = .joining(meetingId: m.meetingId, url: m.url)
+
+        case .meetJoined(let m):
+            // Only promote to `.joined` if we were already in a `.joining`
+            // state for this meeting. An out-of-order `meet.joined` with no
+            // preceding `meet.joining` is treated as stale and ignored —
+            // this is the acceptance-criteria "out-of-order events" guard.
+            guard case let .joining(existingId, url) = state,
+                  existingId == m.meetingId
+            else {
+                log.debug("Ignoring meet.joined without preceding meet.joining: \(m.meetingId, privacy: .public)")
+                return
+            }
+            state = .joined(
+                meetingId: m.meetingId,
+                title: url,
+                joinedAt: clock()
+            )
+
+        case .meetError(let m):
+            state = .error(reason: m.detail)
+
+        case .meetLeft:
+            state = .idle
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - SSE subscription
+
+    private func startListening() {
+        let stream = self.messageStream
+        sseTask = Task { [weak self] in
+            for await message in stream {
+                if Task.isCancelled { break }
+                guard let self else { break }
+                self.handle(message)
+            }
+        }
+    }
+}
+
+// MARK: - View
+
+/// Status panel rendered at the top of the Home gallery.
+///
+/// - When the bot is idle, returns `EmptyView` so the panel is invisible.
+/// - When joining, shows "Joining meeting…" with the URL.
+/// - When joined, shows "In meeting" plus a live, `TimelineView`-driven
+///   elapsed clock. The clock is driven by `.periodic(from:by:)` rather than
+///   an explicit `Timer` so SwiftUI can throttle redraws and we don't hold a
+///   manual timer on the view model.
+/// - When errored, shows the error detail in the negative accent color.
+public struct MeetStatusPanel: View {
+    @Bindable public var viewModel: MeetStatusViewModel
+
+    public init(viewModel: MeetStatusViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle:
+                EmptyView()
+
+            case .joining(_, let url):
+                row(
+                    title: "Joining meeting…",
+                    subtitle: url,
+                    trailing: nil,
+                    tint: VColor.contentSecondary
+                )
+
+            case .joined(_, let title, let joinedAt):
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    row(
+                        title: "In meeting",
+                        subtitle: title,
+                        trailing: Self.formatElapsed(from: joinedAt, now: context.date),
+                        tint: VColor.systemPositiveStrong
+                    )
+                }
+
+            case .error(let reason):
+                row(
+                    title: "Meeting error",
+                    subtitle: reason,
+                    trailing: nil,
+                    tint: VColor.systemNegativeStrong
+                )
+            }
+        }
+        .animation(VAnimation.standard, value: stateKey)
+        .accessibilityElement(children: .combine)
+    }
+
+    // Stable, hashable discriminator of the panel's presentation so the
+    // animation only fires on logical transitions — not on every TimelineView
+    // tick within the `.joined` state.
+    private var stateKey: String {
+        switch viewModel.state {
+        case .idle: return "idle"
+        case .joining(let id, _): return "joining:\(id)"
+        case .joined(let id, _, _): return "joined:\(id)"
+        case .error: return "error"
+        }
+    }
+
+    @ViewBuilder
+    private func row(
+        title: String,
+        subtitle: String,
+        trailing: String?,
+        tint: Color
+    ) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Circle()
+                .fill(tint)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(title)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Text(subtitle)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: VSpacing.md)
+
+            if let trailing {
+                Text(trailing)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                    .monospacedDigit()
+            }
+        }
+        .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.lg, bottom: VSpacing.md, trailing: VSpacing.lg))
+        .background {
+            RoundedRectangle(cornerRadius: VRadius.window, style: .continuous)
+                .fill(VColor.surfaceOverlay)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Formats the elapsed interval between `start` and `now` as mm:ss, or
+    /// h:mm:ss once the meeting crosses the one-hour mark. Negative deltas
+    /// clamp to `0:00` so a clock-skewed `joinedAt` never produces garbage.
+    static func formatElapsed(from start: Date, now: Date) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(start)))
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+}

--- a/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for `MeetStatusViewModel` — the observable model backing
+/// ``MeetStatusPanel``. Drives scripted `ServerMessage` events into the
+/// shared stream and asserts the state machine transitions per the plan's
+/// acceptance criteria (joining → joined → left → out-of-order guard).
+@MainActor
+final class MeetStatusPanelTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Creates a view model plus the stream continuation so the test can
+    /// drive SSE events deterministically. Accepts a fixed-clock closure so
+    /// the `.joined(joinedAt:)` value is predictable across test runs.
+    private func makeViewModel(
+        fixedNow: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> (MeetStatusViewModel, AsyncStream<ServerMessage>.Continuation) {
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let vm = MeetStatusViewModel(
+            messageStream: stream,
+            clock: { fixedNow }
+        )
+        return (vm, continuation)
+    }
+
+    // MARK: - Joining
+
+    func testJoiningEventShowsJoiningState() async throws {
+        let (vm, continuation) = makeViewModel()
+        XCTAssertEqual(vm.state, .idle)
+
+        continuation.yield(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "m1",
+                url: "https://meet.google.com/abc-defg-hij"
+            )
+        ))
+
+        try await waitUntil(timeout: 2.0) {
+            if case .joining = vm.state { return true }
+            return false
+        }
+
+        guard case let .joining(meetingId, url) = vm.state else {
+            return XCTFail("expected .joining state")
+        }
+        XCTAssertEqual(meetingId, "m1")
+        XCTAssertEqual(url, "https://meet.google.com/abc-defg-hij")
+    }
+
+    // MARK: - Joined
+
+    func testJoinedAfterJoiningShowsInMeetingStateWithJoinedAt() async throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_700_123_456)
+        let (vm, continuation) = makeViewModel(fixedNow: fixedNow)
+
+        continuation.yield(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "m2",
+                url: "https://meet.google.com/demo"
+            )
+        ))
+        continuation.yield(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "m2")
+        ))
+
+        try await waitUntil(timeout: 2.0) {
+            if case .joined = vm.state { return true }
+            return false
+        }
+
+        guard case let .joined(meetingId, title, joinedAt) = vm.state else {
+            return XCTFail("expected .joined state")
+        }
+        XCTAssertEqual(meetingId, "m2")
+        XCTAssertEqual(title, "https://meet.google.com/demo")
+        XCTAssertEqual(joinedAt, fixedNow)
+    }
+
+    /// Elapsed-time formatter — the TimelineView ticks once per second and
+    /// renders this string, so we lock in mm:ss and h:mm:ss formatting.
+    func testFormatElapsedRendersAsMMSS() {
+        let start = Date(timeIntervalSince1970: 1_000_000_000)
+        XCTAssertEqual(
+            MeetStatusPanel.formatElapsed(from: start, now: start),
+            "0:00"
+        )
+        XCTAssertEqual(
+            MeetStatusPanel.formatElapsed(
+                from: start,
+                now: start.addingTimeInterval(5)
+            ),
+            "0:05"
+        )
+        XCTAssertEqual(
+            MeetStatusPanel.formatElapsed(
+                from: start,
+                now: start.addingTimeInterval(73)
+            ),
+            "1:13"
+        )
+        XCTAssertEqual(
+            MeetStatusPanel.formatElapsed(
+                from: start,
+                now: start.addingTimeInterval(3_725)
+            ),
+            "1:02:05"
+        )
+        // Clock skew guard — negative intervals clamp to zero.
+        XCTAssertEqual(
+            MeetStatusPanel.formatElapsed(
+                from: start,
+                now: start.addingTimeInterval(-100)
+            ),
+            "0:00"
+        )
+    }
+
+    // MARK: - Left
+
+    func testLeftEventResetsToIdle() async throws {
+        let (vm, continuation) = makeViewModel()
+
+        // Drive the model into .joined first.
+        continuation.yield(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "m3",
+                url: "https://meet.google.com/xyz"
+            )
+        ))
+        continuation.yield(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "m3")
+        ))
+        try await waitUntil(timeout: 2.0) {
+            if case .joined = vm.state { return true }
+            return false
+        }
+
+        continuation.yield(.meetLeft(
+            MeetLeftMessage(
+                type: "meet.left",
+                meetingId: "m3",
+                reason: "user-requested"
+            )
+        ))
+        try await waitUntil(timeout: 2.0) {
+            vm.state == .idle
+        }
+    }
+
+    // MARK: - Out-of-order
+
+    /// A `meet.left` arriving while the panel is already idle (e.g. because
+    /// the client reconnected mid-meeting and missed `meet.joining`/
+    /// `meet.joined`) must not throw — and must leave the panel idle.
+    func testLeftBeforeJoinedKeepsPanelIdle() async throws {
+        let (vm, continuation) = makeViewModel()
+        XCTAssertEqual(vm.state, .idle)
+
+        continuation.yield(.meetLeft(
+            MeetLeftMessage(
+                type: "meet.left",
+                meetingId: "stale-meeting",
+                reason: "timeout"
+            )
+        ))
+
+        // Give the consumer task a chance to pull the event off the stream.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(vm.state, .idle)
+    }
+
+    /// A `meet.joined` with no preceding `meet.joining` is stale (likely a
+    /// late event from a previous meeting that the client missed the join
+    /// event for). The state machine should ignore it rather than flip into
+    /// a bogus `.joined` state with a fabricated URL.
+    func testJoinedWithoutJoiningIsIgnored() async throws {
+        let (vm, continuation) = makeViewModel()
+        XCTAssertEqual(vm.state, .idle)
+
+        continuation.yield(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "phantom")
+        ))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(vm.state, .idle)
+    }
+
+    // MARK: - Error
+
+    func testErrorEventShowsErrorState() async throws {
+        let (vm, continuation) = makeViewModel()
+
+        continuation.yield(.meetError(
+            MeetErrorMessage(
+                type: "meet.error",
+                meetingId: "m4",
+                detail: "bot container crashed"
+            )
+        ))
+        try await waitUntil(timeout: 2.0) {
+            if case .error = vm.state { return true }
+            return false
+        }
+
+        guard case let .error(reason) = vm.state else {
+            return XCTFail("expected .error state")
+        }
+        XCTAssertEqual(reason, "bot container crashed")
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `condition` on the MainActor until it returns true or the
+    /// timeout elapses — same pattern used by `HomeStoreTests`.
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 20_000_000) // 20 ms
+        }
+        XCTFail("waitUntil timed out after \(timeout)s")
+    }
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1718,6 +1718,170 @@ public struct HostBrowserCancelRequest: Decodable, Sendable {
     public let requestId: String
 }
 
+// MARK: - Meet (live meeting state)
+
+/// A single participant in a meeting as broadcast by the Meet-bot.
+public struct MeetParticipant: Decodable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+    public let isHost: Bool?
+    public let isSelf: Bool?
+
+    public init(id: String, name: String, isHost: Bool? = nil, isSelf: Bool? = nil) {
+        self.id = id
+        self.name = name
+        self.isHost = isHost
+        self.isSelf = isSelf
+    }
+}
+
+/// The bot has started attempting to join a meeting.
+public struct MeetJoiningMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let url: String
+
+    public init(type: String, meetingId: String, url: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.url = url
+    }
+}
+
+/// The bot has successfully joined and is live in the meeting.
+public struct MeetJoinedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+
+    public init(type: String, meetingId: String) {
+        self.type = type
+        self.meetingId = meetingId
+    }
+}
+
+/// Participants joined and/or left the meeting since the last snapshot.
+public struct MeetParticipantChangedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let joined: [MeetParticipant]
+    public let left: [MeetParticipant]
+
+    public init(type: String, meetingId: String, joined: [MeetParticipant], left: [MeetParticipant]) {
+        self.type = type
+        self.meetingId = meetingId
+        self.joined = joined
+        self.left = left
+    }
+}
+
+/// The active speaker in the meeting changed.
+public struct MeetSpeakerChangedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let speakerId: String
+    public let speakerName: String
+
+    public init(type: String, meetingId: String, speakerId: String, speakerName: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.speakerId = speakerId
+        self.speakerName = speakerName
+    }
+}
+
+/// A finalized chunk of transcribed speech.
+public struct MeetTranscriptChunkMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let text: String
+    public let speakerLabel: String?
+    public let speakerId: String?
+    public let confidence: Double?
+
+    public init(
+        type: String,
+        meetingId: String,
+        text: String,
+        speakerLabel: String? = nil,
+        speakerId: String? = nil,
+        confidence: Double? = nil
+    ) {
+        self.type = type
+        self.meetingId = meetingId
+        self.text = text
+        self.speakerLabel = speakerLabel
+        self.speakerId = speakerId
+        self.confidence = confidence
+    }
+}
+
+/// The bot has left the meeting.
+public struct MeetLeftMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let reason: String
+
+    public init(type: String, meetingId: String, reason: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.reason = reason
+    }
+}
+
+/// Assistant posted a chat message into the meeting.
+public struct MeetChatSentMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let text: String
+
+    public init(type: String, meetingId: String, text: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.text = text
+    }
+}
+
+/// The bot hit a non-recoverable error (container crash, join failure, etc.).
+public struct MeetErrorMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let detail: String
+
+    public init(type: String, meetingId: String, detail: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.detail = detail
+    }
+}
+
+/// Assistant began speaking into the meeting via TTS.
+public struct MeetSpeakingStartedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let streamId: String
+
+    public init(type: String, meetingId: String, streamId: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.streamId = streamId
+    }
+}
+
+/// Assistant finished (or cancelled) a TTS playback stream.
+public struct MeetSpeakingEndedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let meetingId: String
+    public let streamId: String
+    public let reason: String
+
+    public init(type: String, meetingId: String, streamId: String, reason: String) {
+        self.type = type
+        self.meetingId = meetingId
+        self.streamId = streamId
+        self.reason = reason
+    }
+}
+
 /// Payload posted back to the daemon with the result of a host CU action execution.
 public struct HostCuResultPayload: Codable, Sendable {
     public let requestId: String
@@ -2434,6 +2598,16 @@ public enum ServerMessage: Decodable, Sendable {
     case hostCuCancel(HostCuCancelRequest)
     case hostBrowserRequest(HostBrowserRequest)
     case hostBrowserCancel(HostBrowserCancelRequest)
+    case meetJoining(MeetJoiningMessage)
+    case meetJoined(MeetJoinedMessage)
+    case meetParticipantChanged(MeetParticipantChangedMessage)
+    case meetSpeakerChanged(MeetSpeakerChangedMessage)
+    case meetTranscriptChunk(MeetTranscriptChunkMessage)
+    case meetLeft(MeetLeftMessage)
+    case meetChatSent(MeetChatSentMessage)
+    case meetError(MeetErrorMessage)
+    case meetSpeakingStarted(MeetSpeakingStartedMessage)
+    case meetSpeakingEnded(MeetSpeakingEndedMessage)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
@@ -2927,6 +3101,36 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)
+        case "meet.joining":
+            let message = try MeetJoiningMessage(from: decoder)
+            self = .meetJoining(message)
+        case "meet.joined":
+            let message = try MeetJoinedMessage(from: decoder)
+            self = .meetJoined(message)
+        case "meet.participant_changed":
+            let message = try MeetParticipantChangedMessage(from: decoder)
+            self = .meetParticipantChanged(message)
+        case "meet.speaker_changed":
+            let message = try MeetSpeakerChangedMessage(from: decoder)
+            self = .meetSpeakerChanged(message)
+        case "meet.transcript_chunk":
+            let message = try MeetTranscriptChunkMessage(from: decoder)
+            self = .meetTranscriptChunk(message)
+        case "meet.left":
+            let message = try MeetLeftMessage(from: decoder)
+            self = .meetLeft(message)
+        case "meet.chat_sent":
+            let message = try MeetChatSentMessage(from: decoder)
+            self = .meetChatSent(message)
+        case "meet.error":
+            let message = try MeetErrorMessage(from: decoder)
+            self = .meetError(message)
+        case "meet.speaking_started":
+            let message = try MeetSpeakingStartedMessage(from: decoder)
+            self = .meetSpeakingStarted(message)
+        case "meet.speaking_ended":
+            let message = try MeetSpeakingEndedMessage(from: decoder)
+            self = .meetSpeakingEnded(message)
         case "relationship_state_updated":
             let payloadContainer = try decoder.container(keyedBy: InlinePayloadKeys.self)
             let updatedAt = try payloadContainer.decode(String.self, forKey: .updatedAt)


### PR DESCRIPTION
## Summary
- New `MeetStatusPanel` SwiftUI view subscribed to `meet.*` SSE events (joining / joined / left / error); renders EmptyView when idle
- `meet.*` event types wired through `ServerMessage` in `clients/shared/Network/MessageTypes.swift` so the daemon's meet stream no longer falls into the `.unknown` bucket
- Wired into `HomePageView` at the top of the Home gallery and exposed as a gallery fixture in `HomeGallerySection` (joining / joined / error presentations)
- `TimelineView(.periodic)` drives the elapsed-time clock; injectable `clock` closure keeps `joinedAt` deterministic under test
- Unit tests cover joining → joined → left transitions, out-of-order events (left-before-joined, joined-without-joining), error state, and the mm:ss / h:mm:ss formatter

## Notes for reviewers
- The plan spec listed `HomeGallerySection.swift` as the wiring file, but that file is a DEBUG-only gallery catalog — an active status panel wired only there would never render for users. Wired into `HomePageView.swift` for production rendering and added a gallery entry in `HomeGallerySection.swift` so both the letter and intent of the plan are honored.
- Used `@Observable` on the view model rather than `ObservableObject` to match the existing `HomeStore` / `HomeFeedStore` pattern (CLAUDE.md prefers `@Observable` for new view models).
- Meet events other than joining/joined/left/error (participant_changed, speaker_changed, transcript_chunk, chat_sent, speaking_started, speaking_ended) are decoded into Swift structs but ignored by the state machine — future PRs can consume them without touching the wire contract.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter MeetStatusPanelTests` — 7/7 pass
- [x] `swift test --filter HomeStoreTests` — 4/4 pass (no regression)
- [x] `./build.sh lint` passes (only pre-existing unrelated warnings)

Part of plan: meet-phase-1-12-prime-time.md (PR 10 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
