### PR TITLE
meet-bot: v4l2loopback tooling in Dockerfile + host setup docs

### DIFF
--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -1,7 +1,11 @@
-import { describe, test, expect } from "bun:test";
+import { afterEach, beforeEach, describe, test, expect } from "bun:test";
 import {
   ASSISTANT_INTERNAL_PORT,
+  DEFAULT_MEET_AVATAR_DEVICE_PATH,
   dockerResourceNames,
+  MEET_AVATAR_DEVICE_ENV_VAR,
+  MEET_AVATAR_ENV_VAR,
+  resolveMeetAvatarDevicePath,
   serviceDockerRunArgs,
   type ServiceName,
 } from "../docker.js";
@@ -74,5 +78,91 @@ describe("serviceDockerRunArgs — assistant", () => {
     const portIndex = args.indexOf(portSpec);
     expect(portIndex).toBeGreaterThan(0);
     expect(args[portIndex - 1]).toBe("-p");
+  });
+});
+
+describe("Meet avatar device passthrough (VELLUM_MEET_AVATAR opt-in)", () => {
+  // Snapshot + restore the process env so tests can flip the env-var
+  // without leaking state to later suites or other CLI tests.
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of [MEET_AVATAR_ENV_VAR, MEET_AVATAR_DEVICE_ENV_VAR]) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  test("resolveMeetAvatarDevicePath returns null when the env var is unset", () => {
+    expect(resolveMeetAvatarDevicePath({})).toBeNull();
+  });
+
+  test("resolveMeetAvatarDevicePath treats 0/false/no as disabled", () => {
+    for (const value of ["", "0", "false", "FALSE", "no", " NO "]) {
+      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
+        null,
+      );
+    }
+  });
+
+  test("resolveMeetAvatarDevicePath returns the default device path when enabled with a truthy value", () => {
+    for (const value of ["1", "true", "YES"]) {
+      expect(resolveMeetAvatarDevicePath({ [MEET_AVATAR_ENV_VAR]: value })).toBe(
+        DEFAULT_MEET_AVATAR_DEVICE_PATH,
+      );
+    }
+  });
+
+  test("resolveMeetAvatarDevicePath honors the VELLUM_MEET_AVATAR_DEVICE override", () => {
+    expect(
+      resolveMeetAvatarDevicePath({
+        [MEET_AVATAR_ENV_VAR]: "1",
+        [MEET_AVATAR_DEVICE_ENV_VAR]: "/dev/video11",
+      }),
+    ).toBe("/dev/video11");
+  });
+
+  test("assistant args omit --device and the avatar env vars when VELLUM_MEET_AVATAR is unset", () => {
+    const args = buildAssistantArgs();
+    expect(args).not.toContain("--device");
+    expect(
+      args.some((a) => a.startsWith(`${MEET_AVATAR_ENV_VAR}=`)),
+    ).toBe(false);
+    expect(
+      args.some((a) => a.startsWith(`${MEET_AVATAR_DEVICE_ENV_VAR}=`)),
+    ).toBe(false);
+  });
+
+  test("assistant args include --device=/dev/video10:/dev/video10 when VELLUM_MEET_AVATAR=1", () => {
+    process.env[MEET_AVATAR_ENV_VAR] = "1";
+    const args = buildAssistantArgs();
+    const deviceIdx = args.indexOf("--device");
+    expect(deviceIdx).toBeGreaterThan(0);
+    expect(args[deviceIdx + 1]).toBe(
+      `${DEFAULT_MEET_AVATAR_DEVICE_PATH}:${DEFAULT_MEET_AVATAR_DEVICE_PATH}`,
+    );
+    // The env var must also be propagated into the container so the daemon
+    // knows to turn on avatar passthrough when spawning the bot.
+    expect(args).toContain(`${MEET_AVATAR_ENV_VAR}=1`);
+    expect(args).toContain(
+      `${MEET_AVATAR_DEVICE_ENV_VAR}=${DEFAULT_MEET_AVATAR_DEVICE_PATH}`,
+    );
+  });
+
+  test("assistant args honor a custom device path from VELLUM_MEET_AVATAR_DEVICE", () => {
+    process.env[MEET_AVATAR_ENV_VAR] = "1";
+    process.env[MEET_AVATAR_DEVICE_ENV_VAR] = "/dev/video11";
+    const args = buildAssistantArgs();
+    const deviceIdx = args.indexOf("--device");
+    expect(deviceIdx).toBeGreaterThan(0);
+    expect(args[deviceIdx + 1]).toBe("/dev/video11:/dev/video11");
+    expect(args).toContain(`${MEET_AVATAR_DEVICE_ENV_VAR}=/dev/video11`);
   });
 });

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -46,6 +46,60 @@ export const GATEWAY_INTERNAL_PORT = 7830;
 /** Max time to wait for the assistant container to emit the readiness sentinel. */
 export const DOCKER_READY_TIMEOUT_MS = 3 * 60 * 1000;
 
+/**
+ * Default virtual-camera device path when the Meet avatar feature is
+ * enabled. Matches the `video_nr=10` value in the README's host-setup
+ * section (`skills/meet-join/bot/README.md`). Operators can override the
+ * path by setting `VELLUM_MEET_AVATAR_DEVICE` to something other than the
+ * default (e.g. `/dev/video11` if a different `video_nr` was used).
+ */
+export const DEFAULT_MEET_AVATAR_DEVICE_PATH = "/dev/video10";
+
+/**
+ * Env-var opt-in for bind-mounting the v4l2loopback virtual-camera device
+ * into the assistant container. Set to a truthy value (`1`, `true`, `yes`)
+ * to enable; unset or falsy disables the passthrough entirely.
+ *
+ * Kept as an env-var rather than a config-schema field because the Meet
+ * avatar config schema lands in a later PR (PR 5 of the phase-4 plan) —
+ * threading the config through the CLI's boot flow now would force a
+ * forward dependency. Once the schema lands, the CLI can either keep this
+ * env-var as a pre-config override or move the opt-in into the workspace
+ * config.
+ */
+export const MEET_AVATAR_ENV_VAR = "VELLUM_MEET_AVATAR";
+
+/**
+ * Override for the virtual-camera device path. Defaults to
+ * {@link DEFAULT_MEET_AVATAR_DEVICE_PATH}.
+ */
+export const MEET_AVATAR_DEVICE_ENV_VAR = "VELLUM_MEET_AVATAR_DEVICE";
+
+/**
+ * Resolve the Meet avatar device path to pass through to the assistant
+ * container, or `null` if the feature is not opted into. Exported so tests
+ * can assert against the env-var parsing without reaching into the shell.
+ */
+export function resolveMeetAvatarDevicePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const flag = env[MEET_AVATAR_ENV_VAR];
+  if (!flag) return null;
+  const normalized = flag.trim().toLowerCase();
+  if (
+    normalized === "" ||
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "no"
+  ) {
+    return null;
+  }
+  const override = env[MEET_AVATAR_DEVICE_ENV_VAR];
+  return override && override.length > 0
+    ? override
+    : DEFAULT_MEET_AVATAR_DEVICE_PATH;
+}
+
 /** Default memory (GiB) allocated to the Colima VM. */
 const COLIMA_DEFAULT_MEMORY_GIB = 8;
 
@@ -660,6 +714,24 @@ export function serviceDockerRunArgs(opts: {
         for (const [key, value] of Object.entries(extraAssistantEnv)) {
           args.push("-e", `${key}=${value}`);
         }
+      }
+      // Optional Meet avatar (v4l2loopback) passthrough. When
+      // `VELLUM_MEET_AVATAR=1` is set in the caller's environment, bind the
+      // virtual-camera device node (default `/dev/video10`) into the
+      // assistant container so the nested `dockerd` can in turn pass it
+      // through to the Meet-bot container. The daemon-side equivalent of
+      // this opt-in lives on `DockerRunner.run()`'s `avatarDevicePath`
+      // option (see `skills/meet-join/daemon/docker-runner.ts`).
+      const avatarDevice = resolveMeetAvatarDevicePath();
+      if (avatarDevice) {
+        args.push(
+          "--device",
+          `${avatarDevice}:${avatarDevice}`,
+          "-e",
+          `${MEET_AVATAR_ENV_VAR}=1`,
+          "-e",
+          `${MEET_AVATAR_DEVICE_ENV_VAR}=${avatarDevice}`,
+        );
       }
       args.push(imageTags.assistant);
       return args;

--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -42,8 +42,17 @@ FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4
 #                      at runtime.
 #   dbus-x11:          required at runtime by Chromium.
 #   ffmpeg:            audio/video encoding for transcript + recording paths.
+#                      Also used to convert the avatar renderer's output frames
+#                      into Y4M / YU12 for the v4l2loopback virtual camera.
 #   fonts-liberation/libvulkan1/xdg-utils: chromium runtime deps.
 #   libnss3/libgbm1/libasound2: Chromium shared-library dependencies.
+#   v4l2loopback-utils: ships `v4l2-ctl`, used by `src/media/video-device.ts`
+#                      to configure the virtual camera's pixel format when the
+#                      avatar feature is enabled. The kernel module itself is
+#                      loaded on the HOST (see README "Avatar (v4l2loopback)
+#                      host setup") — the container only needs the userspace
+#                      tooling so it can talk to the bind-mounted
+#                      `/dev/video10` node.
 #   xdotool:           posts trusted X-server mouse events for buttons that
 #                      Meet gates on `event.isTrusted` (the prejoin admission
 #                      button is the main one — JS `.click()` from the
@@ -59,6 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvulkan1 \
     pulseaudio \
     pulseaudio-utils \
+    v4l2loopback-utils \
     xdg-utils \
     xdotool \
     xvfb \

--- a/skills/meet-join/bot/README.md
+++ b/skills/meet-join/bot/README.md
@@ -76,6 +76,86 @@ against a live Meet session. The refresh procedure:
    the combined fixture-plus-selector refresh in a single PR so the diff is
    reviewable as one unit.
 
+## Avatar (v4l2loopback) host setup
+
+The optional avatar pipeline (Phase 4) pushes rendered video frames into a
+virtual V4L2 camera that Chrome exposes as a `videoinput` device inside the
+bot container. The virtual camera is implemented by the `v4l2loopback`
+Linux kernel module, which runs on the **host**, not inside the container.
+The container only needs the userspace tooling (`v4l2-ctl`, ffmpeg codecs)
+already baked into the image via `v4l2loopback-utils`.
+
+### One-time host setup (Linux host)
+
+Linux hosts (including the Docker-Desktop-on-Linux configuration) need to
+load the module once per boot. Most distributions ship the DKMS package,
+which rebuilds the module automatically against the running kernel:
+
+```bash
+sudo apt-get install v4l2loopback-dkms
+sudo modprobe v4l2loopback video_nr=10 card_label="VellumAvatar" exclusive_caps=1
+```
+
+The three module arguments matter:
+
+- `video_nr=10` pins the device to `/dev/video10`. The bot defaults to this
+  path; callers that need a different number must override the `devicePath`
+  argument to `openVideoDevice()` and the `--device` passthrough on both
+  the daemon and bot containers.
+- `card_label="VellumAvatar"` sets the `friendlyName` Chrome surfaces in the
+  camera-picker UI. Any string works; `VellumAvatar` is just a stable label
+  for operator debugging.
+- `exclusive_caps=1` is required for Chrome to treat the node as a normal
+  capture device. Without it, Chrome enumerates the loopback node in a way
+  that Meet ignores.
+
+To persist the load across reboots, drop the module name into
+`/etc/modules-load.d/vellum-avatar.conf` and the arguments into
+`/etc/modprobe.d/vellum-avatar.conf`:
+
+```
+# /etc/modules-load.d/vellum-avatar.conf
+v4l2loopback
+
+# /etc/modprobe.d/vellum-avatar.conf
+options v4l2loopback video_nr=10 card_label="VellumAvatar" exclusive_caps=1
+```
+
+### macOS / Docker Desktop note
+
+v4l2loopback is a Linux-kernel module and cannot be loaded on a macOS host
+directly. Docker Desktop for macOS runs containers inside a Linux VM, so it
+is possible in principle to load the module inside the VM kernel — the
+procedure involves attaching to the VM shell (`lima shell`, `docker
+desktop debug`, or the equivalent) and running `modprobe v4l2loopback` from
+inside. This path is brittle across Docker Desktop upgrades and is not
+officially supported. **The avatar feature is only tested on Linux hosts
+today.** Running the Meet bot on macOS without avatar works normally; the
+bot simply does not enable its virtual camera code path.
+
+### Device passthrough to the bot container
+
+Loading the module makes `/dev/video10` visible on the host. The bot
+container receives it as a bind-mount:
+
+- **Bare-metal mode** — the daemon passes
+  `--device=/dev/video10:/dev/video10` to the bot container's `docker run`
+  when the avatar feature is enabled. The assistant's `DockerRunner`
+  accepts an opt-in `avatarDevicePath` option for this.
+- **Docker mode (DinD)** — the CLI must also pass
+  `--device=/dev/video10:/dev/video10` to the assistant container so the
+  device node exists inside the DinD environment. Set
+  `VELLUM_MEET_AVATAR=1` in the environment before `vellum` spawns the
+  assistant container to opt in. The `DockerRunner` then forwards the same
+  flag to the inner `dockerd` when spawning bot containers.
+
+If `/dev/video10` is missing inside the bot container at runtime, the
+`openVideoDevice()` helper throws a clear error pointing operators back to
+this section. The most common causes are (1) the host `modprobe` step was
+skipped, (2) a different `video_nr` was used, or (3) the `--device`
+passthrough was not wired through both the daemon and bot `docker run`
+invocations in Docker mode.
+
 ## Manual end-to-end verification against a real Meet call
 
 The automated test suite stubs Docker, the configured STT provider, and the

--- a/skills/meet-join/bot/__tests__/video-device.test.ts
+++ b/skills/meet-join/bot/__tests__/video-device.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for the v4l2loopback virtual-camera wrapper.
+ *
+ * The tests never touch a real `/dev/video*` node — every external effect
+ * (fs.stat, fs.open, `v4l2-ctl` spawn, write-stream creation) is injected
+ * as a shim so the suite is fully hermetic and runs on macOS CI where
+ * v4l2loopback is unloadable.
+ *
+ * Coverage:
+ *   - Missing device surfaces the actionable host-setup message.
+ *   - Existing-but-wrong-file-type surfaces a distinct error.
+ *   - `v4l2-ctl` is invoked with the expected argv (default + overrides).
+ *   - `v4l2-ctl` non-zero exit propagates its stderr into the thrown error.
+ *   - Successful open returns a handle with the configured geometry.
+ *   - `close()` tears down the sink and the file handle (idempotent).
+ *   - The exported missing-device message references the README section.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { FileHandle } from "node:fs/promises";
+
+import {
+  buildV4l2CtlArgv,
+  DEFAULT_FRAME_HEIGHT,
+  DEFAULT_FRAME_WIDTH,
+  DEFAULT_PIXEL_FORMAT,
+  DEFAULT_VIDEO_DEVICE_PATH,
+  missingDeviceMessage,
+  openVideoDevice,
+  type SpawnedV4l2Ctl,
+  type VideoFrameSink,
+} from "../src/media/video-device.js";
+
+interface SinkState {
+  writes: Uint8Array[];
+  endCalls: number;
+  destroyCalls: number;
+  endedCallbacks: Array<() => void>;
+}
+
+function recordingSink(): { sink: VideoFrameSink; state: SinkState } {
+  const state: SinkState = {
+    writes: [],
+    endCalls: 0,
+    destroyCalls: 0,
+    endedCallbacks: [],
+  };
+  const sink: VideoFrameSink = {
+    write(chunk: Uint8Array): boolean {
+      // Copy so callers mutating the source buffer can't retroactively
+      // change what we've "received".
+      state.writes.push(new Uint8Array(chunk));
+      return true;
+    },
+    end(callback?: () => void) {
+      state.endCalls += 1;
+      if (callback) {
+        state.endedCallbacks.push(callback);
+        // Fire synchronously — this matches how Node's WriteStream.end
+        // surfaces in tests without a real event loop waiting on the fs.
+        callback();
+      }
+    },
+    destroy() {
+      state.destroyCalls += 1;
+    },
+  };
+  return { sink, state };
+}
+
+interface FakeHandleState {
+  closeCalls: number;
+}
+
+function fakeFileHandle(): { handle: FileHandle; state: FakeHandleState } {
+  const state: FakeHandleState = { closeCalls: 0 };
+  // Only the bits of `FileHandle` that `openVideoDevice` reaches for at
+  // runtime — `close()` and (via the injected `createWriteStream` shim) the
+  // absence of `createWriteStream` from the default path. The `as`-cast
+  // keeps this tight without forcing a mirror of the full FileHandle type.
+  const handle = {
+    close: async () => {
+      state.closeCalls += 1;
+    },
+  } as unknown as FileHandle;
+  return { handle, state };
+}
+
+function fakeStat(options: {
+  isCharacterDevice?: boolean;
+  notFound?: boolean;
+}): (devicePath: string) => Promise<{ isCharacterDevice(): boolean }> {
+  return async () => {
+    if (options.notFound) {
+      const err: NodeJS.ErrnoException = new Error(
+        "ENOENT: no such file or directory",
+      );
+      err.code = "ENOENT";
+      throw err;
+    }
+    const isChar = options.isCharacterDevice ?? true;
+    return { isCharacterDevice: () => isChar };
+  };
+}
+
+function fakeSpawn(options: {
+  argv?: string[][];
+  exitCode?: number;
+  stderr?: string;
+}): (argv: readonly string[]) => SpawnedV4l2Ctl {
+  return (argv: readonly string[]) => {
+    options.argv?.push([...argv]);
+    const stderrText = options.stderr ?? "";
+    const stderrStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (stderrText.length > 0) {
+          controller.enqueue(new TextEncoder().encode(stderrText));
+        }
+        controller.close();
+      },
+    });
+    return {
+      stderr: stderrStream,
+      exited: Promise.resolve(options.exitCode ?? 0),
+    };
+  };
+}
+
+describe("buildV4l2CtlArgv", () => {
+  test("emits the v4l2-ctl --set-fmt-video command with interpolated values", () => {
+    const argv = buildV4l2CtlArgv("/dev/video10", 1280, 720, "YU12");
+    expect(argv).toEqual([
+      "v4l2-ctl",
+      "--device=/dev/video10",
+      "--set-fmt-video=width=1280,height=720,pixelformat=YU12",
+    ]);
+  });
+});
+
+describe("missingDeviceMessage", () => {
+  test("references the README section so operators can find the modprobe instructions", () => {
+    const msg = missingDeviceMessage("/dev/video10");
+    expect(msg).toContain("/dev/video10");
+    expect(msg).toContain("v4l2loopback");
+    expect(msg).toContain("README.md");
+    // The exact README anchor matters so operators don't hunt for the
+    // section — keep this guarded.
+    expect(msg).toContain("Avatar (v4l2loopback) host setup");
+    // Must mention both mitigations — host-side modprobe and the bot
+    // --device passthrough.
+    expect(msg).toContain("modprobe");
+    expect(msg).toContain("--device");
+  });
+});
+
+describe("openVideoDevice", () => {
+  test("throws the host-setup message when the device node is missing", async () => {
+    await expect(
+      openVideoDevice("/dev/video10", {
+        stat: fakeStat({ notFound: true }),
+        spawn: fakeSpawn({}),
+        open: async () => fakeFileHandle().handle,
+        createWriteStream: () => recordingSink().sink,
+      }),
+    ).rejects.toThrow(missingDeviceMessage("/dev/video10"));
+  });
+
+  test("throws a distinct error when the path exists but is not a character device", async () => {
+    let thrown: unknown;
+    try {
+      await openVideoDevice("/dev/video10", {
+        stat: fakeStat({ isCharacterDevice: false }),
+        spawn: fakeSpawn({}),
+        open: async () => fakeFileHandle().handle,
+        createWriteStream: () => recordingSink().sink,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const msg = (thrown as Error).message;
+    expect(msg).toContain("not a character device");
+    // Must NOT be the "missing device" message — that would misdirect
+    // operators to run modprobe when the real issue is a stray file.
+    expect(msg).not.toContain("must be loaded on the HOST");
+  });
+
+  test("invokes v4l2-ctl with the configured geometry and returns the write stream", async () => {
+    const argv: string[][] = [];
+    const { handle } = fakeFileHandle();
+    const { sink } = recordingSink();
+
+    const result = await openVideoDevice("/dev/video10", {
+      stat: fakeStat({}),
+      spawn: fakeSpawn({ argv, exitCode: 0 }),
+      open: async () => handle,
+      createWriteStream: () => sink,
+    });
+
+    expect(argv).toHaveLength(1);
+    expect(argv[0]).toEqual([
+      "v4l2-ctl",
+      "--device=/dev/video10",
+      `--set-fmt-video=width=${DEFAULT_FRAME_WIDTH},height=${DEFAULT_FRAME_HEIGHT},pixelformat=${DEFAULT_PIXEL_FORMAT}`,
+    ]);
+    expect(result.devicePath).toBe("/dev/video10");
+    expect(result.width).toBe(DEFAULT_FRAME_WIDTH);
+    expect(result.height).toBe(DEFAULT_FRAME_HEIGHT);
+    expect(result.pixelFormat).toBe(DEFAULT_PIXEL_FORMAT);
+    expect(result.sink).toBe(sink);
+  });
+
+  test("honors width/height/pixelFormat overrides in the v4l2-ctl argv", async () => {
+    const argv: string[][] = [];
+    const { handle } = fakeFileHandle();
+    const { sink } = recordingSink();
+
+    const result = await openVideoDevice("/dev/video10", {
+      width: 640,
+      height: 480,
+      pixelFormat: "YUYV",
+      stat: fakeStat({}),
+      spawn: fakeSpawn({ argv, exitCode: 0 }),
+      open: async () => handle,
+      createWriteStream: () => sink,
+    });
+
+    expect(argv[0]).toEqual([
+      "v4l2-ctl",
+      "--device=/dev/video10",
+      "--set-fmt-video=width=640,height=480,pixelformat=YUYV",
+    ]);
+    expect(result.width).toBe(640);
+    expect(result.height).toBe(480);
+    expect(result.pixelFormat).toBe("YUYV");
+  });
+
+  test("surfaces v4l2-ctl stderr on non-zero exit", async () => {
+    await expect(
+      openVideoDevice("/dev/video10", {
+        stat: fakeStat({}),
+        spawn: fakeSpawn({
+          exitCode: 1,
+          stderr: "VIDIOC_S_FMT: failed: Invalid argument\n",
+        }),
+        open: async () => fakeFileHandle().handle,
+        createWriteStream: () => recordingSink().sink,
+      }),
+    ).rejects.toThrow(/v4l2-ctl failed to configure \/dev\/video10 \(exit 1\)/);
+  });
+
+  test("rejects on non-positive geometry before touching the filesystem", async () => {
+    const argv: string[][] = [];
+    const opened: string[] = [];
+    await expect(
+      openVideoDevice("/dev/video10", {
+        width: 0,
+        height: 720,
+        stat: fakeStat({}),
+        spawn: fakeSpawn({ argv, exitCode: 0 }),
+        open: async (p) => {
+          opened.push(p);
+          return fakeFileHandle().handle;
+        },
+        createWriteStream: () => recordingSink().sink,
+      }),
+    ).rejects.toThrow(/width\/height must be > 0/);
+    // Guard invariant: we bail before any external side effects fire.
+    expect(argv).toHaveLength(0);
+    expect(opened).toHaveLength(0);
+  });
+
+  test("uses /dev/video10 as the default device path when none is supplied", async () => {
+    const argv: string[][] = [];
+    const { handle } = fakeFileHandle();
+    const { sink } = recordingSink();
+
+    await openVideoDevice(undefined, {
+      stat: fakeStat({}),
+      spawn: fakeSpawn({ argv, exitCode: 0 }),
+      open: async () => handle,
+      createWriteStream: () => sink,
+    });
+
+    expect(argv[0]).toEqual([
+      "v4l2-ctl",
+      `--device=${DEFAULT_VIDEO_DEVICE_PATH}`,
+      `--set-fmt-video=width=${DEFAULT_FRAME_WIDTH},height=${DEFAULT_FRAME_HEIGHT},pixelformat=${DEFAULT_PIXEL_FORMAT}`,
+    ]);
+  });
+
+  test("close() ends the sink and releases the underlying handle (idempotent)", async () => {
+    const { handle, state: handleState } = fakeFileHandle();
+    const { sink, state: sinkState } = recordingSink();
+
+    const result = await openVideoDevice("/dev/video10", {
+      stat: fakeStat({}),
+      spawn: fakeSpawn({ exitCode: 0 }),
+      open: async () => handle,
+      createWriteStream: () => sink,
+    });
+
+    await result.close();
+    // Second call — must not throw and must not double-close.
+    await result.close();
+
+    expect(sinkState.endCalls).toBe(1);
+    expect(sinkState.destroyCalls).toBe(1);
+    expect(handleState.closeCalls).toBe(1);
+  });
+
+  test("close() swallows a double fd-close (EBADF) from the write-stream teardown", async () => {
+    const { sink, state: sinkState } = recordingSink();
+    let closeCalls = 0;
+    const handle = {
+      close: async () => {
+        closeCalls += 1;
+        const err: NodeJS.ErrnoException = new Error("EBADF");
+        err.code = "EBADF";
+        throw err;
+      },
+    } as unknown as FileHandle;
+
+    const result = await openVideoDevice("/dev/video10", {
+      stat: fakeStat({}),
+      spawn: fakeSpawn({ exitCode: 0 }),
+      open: async () => handle,
+      createWriteStream: () => sink,
+    });
+
+    // Must not reject — the second close is expected to happen when the
+    // stream has already released the fd. Test validates that we swallow
+    // the error rather than leaking it to the caller.
+    await result.close();
+    expect(closeCalls).toBe(1);
+    expect(sinkState.endCalls).toBe(1);
+  });
+});

--- a/skills/meet-join/bot/src/media/video-device.ts
+++ b/skills/meet-join/bot/src/media/video-device.ts
@@ -1,0 +1,329 @@
+/**
+ * Virtual-camera (v4l2loopback) handle for the meet-bot.
+ *
+ * The avatar renderer streams raw video frames into a v4l2loopback device
+ * node (`/dev/video10` by default). Chrome, launched with
+ * `--use-fake-device-for-media-stream=false --use-file-for-fake-video-capture=
+ * /dev/video10` or simply selecting the loopback device as the default
+ * `videoinput`, then sees those frames as the bot's webcam inside the Meet
+ * tab.
+ *
+ * Responsibilities of this module:
+ *
+ *   1. Verify the device node exists inside the container. If it doesn't,
+ *      the host has not loaded v4l2loopback — surface a clear error pointing
+ *      operators at the README's host-setup section.
+ *   2. Configure the device's pixel format via `v4l2-ctl`. Defaults match the
+ *      renderer's output: 1280x720 YU12 (planar YUV 4:2:0 — byte-compatible
+ *      with the Y4M format ffmpeg produces).
+ *   3. Return a writable handle that downstream code can push raw frame
+ *      bytes into. The handle owns the underlying file descriptor and tears
+ *      it down on `close()`.
+ *
+ * Device I/O goes through `node:fs`'s async `open` + a file-handle backed
+ * `createWriteStream`. The caller is responsible for writing frames at the
+ * correct rate — this module does not paces or buffers; it just hands back a
+ * stream that writes land on the kernel's v4l2 ring directly.
+ *
+ * Like the audio-capture / audio-playback modules, every external effect
+ * (filesystem probes, `v4l2-ctl` invocation, stream creation) is injectable
+ * via options so the unit tests can verify the wiring without requiring a
+ * real v4l2loopback device on the test runner.
+ */
+
+import { constants as fsConstants } from "node:fs";
+import { stat, open as fsOpen, type FileHandle } from "node:fs/promises";
+import type { WriteStream } from "node:fs";
+import type { Subprocess } from "bun";
+
+/** Default device path for the virtual camera — loaded by host modprobe. */
+export const DEFAULT_VIDEO_DEVICE_PATH = "/dev/video10";
+
+/**
+ * Default frame geometry. 720p matches what the renderer produces today and
+ * what Meet's pipeline is happiest ingesting; callers can override if a
+ * specific renderer demands a different output size.
+ */
+export const DEFAULT_FRAME_WIDTH = 1280;
+export const DEFAULT_FRAME_HEIGHT = 720;
+
+/**
+ * Default pixel format — YU12 is planar YUV 4:2:0, byte-compatible with the
+ * Y4M frames ffmpeg emits and widely supported by Chrome's camera ingest.
+ */
+export const DEFAULT_PIXEL_FORMAT = "YU12";
+
+/** Path to `v4l2-ctl`. Provided by the `v4l2loopback-utils` apt package. */
+const V4L2_CTL_BIN = "v4l2-ctl";
+
+/**
+ * Minimal slice of `Bun.spawn`'s return type that `openVideoDevice`
+ * actually reads from. Tests provide a shim rather than a full Subprocess.
+ */
+export interface SpawnedV4l2Ctl {
+  /** stderr stream — drained on failure for diagnostic context. */
+  stderr: ReadableStream<Uint8Array> | null;
+  /** Resolves with the child's exit code. */
+  exited: Promise<number>;
+}
+
+export type V4l2CtlSpawnFactory = (
+  argv: readonly string[],
+) => SpawnedV4l2Ctl;
+
+/**
+ * Injectable opener for the underlying device node. Defaults to
+ * `fs.promises.open(..., "w")` which yields a `FileHandle`; the handle is
+ * then used to construct the writable stream returned to the caller.
+ */
+export type VideoFileOpener = (devicePath: string) => Promise<FileHandle>;
+
+/**
+ * Minimal slice of the writable stream we return to callers. Matches
+ * Node's {@link WriteStream} at runtime; declared as a narrow interface so
+ * tests can inject a shim without implementing the full fs.WriteStream
+ * surface.
+ */
+export interface VideoFrameSink {
+  write(chunk: Uint8Array): boolean;
+  end(callback?: () => void): void;
+  destroy(err?: Error): void;
+}
+
+/**
+ * Injectable factory that turns a `FileHandle` into a writable stream.
+ * Default delegates to `FileHandle.createWriteStream`.
+ */
+export type VideoWriteStreamFactory = (handle: FileHandle) => VideoFrameSink;
+
+/**
+ * Optional `fs.stat` shim — used to verify the device node exists before
+ * we attempt to open it. Default is `fs.promises.stat`.
+ */
+export type VideoFileStat = (devicePath: string) => Promise<{
+  isCharacterDevice(): boolean;
+}>;
+
+export interface OpenVideoDeviceOptions {
+  width?: number;
+  height?: number;
+  pixelFormat?: string;
+  /** Test hook — Bun.spawn-shaped factory for `v4l2-ctl`. */
+  spawn?: V4l2CtlSpawnFactory;
+  /** Test hook — replaces `fs.promises.open`. */
+  open?: VideoFileOpener;
+  /** Test hook — replaces `fs.promises.stat`. */
+  stat?: VideoFileStat;
+  /** Test hook — replaces `FileHandle.createWriteStream`. */
+  createWriteStream?: VideoWriteStreamFactory;
+}
+
+/**
+ * Writable handle for the virtual camera. `sink` is the write target for
+ * raw frame bytes; `close()` tears down the underlying file descriptor
+ * and resolves once the kernel has flushed any outstanding writes.
+ */
+export interface VideoDeviceHandle {
+  /** Absolute device path this handle is bound to. */
+  readonly devicePath: string;
+  /** Frame geometry the device was configured with. */
+  readonly width: number;
+  readonly height: number;
+  readonly pixelFormat: string;
+  /** Writable sink for raw frame bytes. */
+  readonly sink: VideoFrameSink;
+  /** Tear down the device handle. Idempotent. */
+  close(): Promise<void>;
+}
+
+/**
+ * Default `Bun.spawn` wrapper — captures stderr so we can surface the tool's
+ * own error message when the configure call fails.
+ */
+function defaultSpawn(argv: readonly string[]): SpawnedV4l2Ctl {
+  const proc: Subprocess = Bun.spawn(argv as string[], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    stderr: proc.stderr as ReadableStream<Uint8Array> | null,
+    exited: proc.exited,
+  };
+}
+
+/**
+ * Default file opener — writes only. We don't need read access because the
+ * kernel-side v4l2loopback driver handles the consumer side for Chrome.
+ */
+async function defaultOpen(devicePath: string): Promise<FileHandle> {
+  return fsOpen(devicePath, fsConstants.O_WRONLY);
+}
+
+/**
+ * Default stat shim. Raises the same `ENOENT` Error Node does natively; the
+ * caller wraps that into the user-facing "host modprobe missing" message.
+ */
+async function defaultStat(
+  devicePath: string,
+): Promise<{ isCharacterDevice(): boolean }> {
+  return stat(devicePath);
+}
+
+function defaultCreateWriteStream(handle: FileHandle): VideoFrameSink {
+  // `FileHandle.createWriteStream` returns a full Node WriteStream.
+  const stream: WriteStream = handle.createWriteStream();
+  return stream;
+}
+
+/**
+ * Build the argv for `v4l2-ctl --device=<path> --set-fmt-video=width=<w>,
+ * height=<h>,pixelformat=<fmt>`. Exported so tests can assert on the shape
+ * without replicating the string interpolation in-line.
+ */
+export function buildV4l2CtlArgv(
+  devicePath: string,
+  width: number,
+  height: number,
+  pixelFormat: string,
+): readonly string[] {
+  return [
+    V4L2_CTL_BIN,
+    `--device=${devicePath}`,
+    `--set-fmt-video=width=${width},height=${height},pixelformat=${pixelFormat}`,
+  ];
+}
+
+/**
+ * Human-facing error surfaced when `/dev/video10` doesn't exist in the
+ * container. Exported so tests can assert against the exact wording and so
+ * callers surfacing this to UX can rely on a stable prefix.
+ */
+export function missingDeviceMessage(devicePath: string): string {
+  return (
+    `v4l2 device ${devicePath} not found inside the container. ` +
+    `The v4l2loopback kernel module must be loaded on the HOST and the ` +
+    `device node bind-mounted into the bot container with ` +
+    `\`--device=${devicePath}:${devicePath}\`. ` +
+    `See skills/meet-join/bot/README.md ("Avatar (v4l2loopback) host setup") ` +
+    `for the one-time \`modprobe v4l2loopback\` instructions.`
+  );
+}
+
+/**
+ * Open + configure a v4l2loopback device node, returning a writable handle
+ * callers push raw frame bytes into. Throws with a clear message if the
+ * device doesn't exist, and with `v4l2-ctl`'s own stderr if the format-set
+ * step fails.
+ *
+ * The handle's `sink` is the target for frame writes. Call `close()` to
+ * tear down the file descriptor.
+ */
+export async function openVideoDevice(
+  devicePath: string = DEFAULT_VIDEO_DEVICE_PATH,
+  opts: OpenVideoDeviceOptions = {},
+): Promise<VideoDeviceHandle> {
+  const width = opts.width ?? DEFAULT_FRAME_WIDTH;
+  const height = opts.height ?? DEFAULT_FRAME_HEIGHT;
+  const pixelFormat = opts.pixelFormat ?? DEFAULT_PIXEL_FORMAT;
+  const spawn = opts.spawn ?? defaultSpawn;
+  const open = opts.open ?? defaultOpen;
+  const statDev = opts.stat ?? defaultStat;
+  const createWriteStream = opts.createWriteStream ?? defaultCreateWriteStream;
+
+  if (width <= 0 || height <= 0) {
+    throw new Error(
+      `openVideoDevice: width/height must be > 0 (got ${width}x${height})`,
+    );
+  }
+
+  // 1. Confirm the device node exists. A missing node = missing host-side
+  //    modprobe or a missing `--device` passthrough at `docker run` time.
+  //    Surface both possibilities in a single actionable error.
+  try {
+    const info = await statDev(devicePath);
+    if (!info.isCharacterDevice()) {
+      throw new Error(
+        `${devicePath} exists but is not a character device — is something ` +
+          `else (e.g. a stray regular file) occupying the path?`,
+      );
+    }
+  } catch (err) {
+    const code =
+      err && typeof err === "object" && "code" in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+    if (code === "ENOENT") {
+      throw new Error(missingDeviceMessage(devicePath));
+    }
+    throw err;
+  }
+
+  // 2. Configure the device's pixel format. Must succeed before we open the
+  //    file descriptor for writes — otherwise Chrome may negotiate an
+  //    incompatible format and silently drop frames.
+  const argv = buildV4l2CtlArgv(devicePath, width, height, pixelFormat);
+  const proc = spawn(argv);
+  const stderrText = proc.stderr
+    ? await new Response(proc.stderr).text()
+    : "";
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const trimmed = stderrText.trim();
+    const detail = trimmed.length > 0 ? `: ${trimmed}` : "";
+    throw new Error(
+      `v4l2-ctl failed to configure ${devicePath} (exit ${exitCode})${detail}`,
+    );
+  }
+
+  // 3. Open the device for writing and wrap in a write stream.
+  const handle = await open(devicePath);
+  let sink: VideoFrameSink;
+  try {
+    sink = createWriteStream(handle);
+  } catch (err) {
+    // If stream creation throws, the FileHandle owns the fd — close it so
+    // we don't leak.
+    await handle.close().catch(() => {
+      /* best-effort */
+    });
+    throw err;
+  }
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    // End the stream first so any queued writes drain, then release the
+    // underlying fd. Both are best-effort on shutdown.
+    await new Promise<void>((resolve) => {
+      try {
+        sink.end(() => resolve());
+      } catch {
+        resolve();
+      }
+    });
+    try {
+      sink.destroy();
+    } catch {
+      // Destroy is best-effort if the stream already ended.
+    }
+    // A `WriteStream` built from a `FileHandle` closes the handle itself
+    // when it ends. Closing twice surfaces `EBADF`; swallow that — the fd
+    // is already gone.
+    try {
+      await handle.close();
+    } catch {
+      /* already closed by the write-stream teardown */
+    }
+  };
+
+  return {
+    devicePath,
+    width,
+    height,
+    pixelFormat,
+    sink,
+    close,
+  };
+}

--- a/skills/meet-join/daemon/__tests__/docker-runner.test.ts
+++ b/skills/meet-join/daemon/__tests__/docker-runner.test.ts
@@ -406,6 +406,44 @@ describe("buildCreateBody", () => {
     // workspace-mount vocabulary.
     expect(hc.Mounts).toBeUndefined();
   });
+
+  test("omits HostConfig.Devices when avatarDevicePath is not set", () => {
+    const body = buildCreateBody({ image: "x:y" });
+    const hc = body.HostConfig as Record<string, unknown>;
+    expect(hc.Devices).toBeUndefined();
+  });
+
+  test("emits HostConfig.Devices when avatarDevicePath is set (same in bare-metal + DinD)", () => {
+    const body = buildCreateBody({
+      image: "x:y",
+      avatarDevicePath: "/dev/video10",
+    });
+    const hc = body.HostConfig as Record<string, unknown>;
+    // Docker Engine API's Devices field corresponds to `docker run --device`.
+    // The cgroup perms must be `rwm` (read/write/mknod) to match CLI defaults.
+    expect(hc.Devices).toEqual([
+      {
+        PathOnHost: "/dev/video10",
+        PathInContainer: "/dev/video10",
+        CgroupPermissions: "rwm",
+      },
+    ]);
+  });
+
+  test("supports custom device paths (e.g. /dev/video11 when video_nr=11 was used)", () => {
+    const body = buildCreateBody({
+      image: "x:y",
+      avatarDevicePath: "/dev/video11",
+    });
+    const hc = body.HostConfig as Record<string, unknown>;
+    expect(hc.Devices).toEqual([
+      {
+        PathOnHost: "/dev/video11",
+        PathInContainer: "/dev/video11",
+        CgroupPermissions: "rwm",
+      },
+    ]);
+  });
 });
 
 describe("resolveWorkspaceSubpath", () => {

--- a/skills/meet-join/daemon/docker-runner.ts
+++ b/skills/meet-join/daemon/docker-runner.ts
@@ -133,6 +133,27 @@ export interface DockerRunOptions {
   ports?: PortMapping[];
   name?: string;
   network?: string;
+  /**
+   * Optional virtual-camera (`v4l2loopback`) device path to pass through to
+   * the bot container. When set (e.g. `/dev/video10`), the runner adds a
+   * device entry to `HostConfig.Devices` so the bot can open the node as a
+   * character device and push avatar frames into it. Leave unset to skip
+   * avatar passthrough entirely — callers that don't enable the avatar
+   * feature don't need to touch this.
+   *
+   * Behavior is identical in bare-metal and Docker (DinD) modes: the Docker
+   * Engine API's `Devices` field has the same semantics whether the target
+   * is the host's engine or an inner nested `dockerd`. In Docker mode the
+   * device must also be bind-mounted into the assistant container
+   * (`cli/src/lib/docker.ts` handles that when `VELLUM_MEET_AVATAR=1` is
+   * set in the environment) so inner `dockerd` can see the node.
+   *
+   * Intentionally a run-time argument rather than a config-schema field:
+   * the avatar config schema lands in a later PR, and threading it through
+   * here now would force a forward dependency. The session-manager wires
+   * this up once the config is available.
+   */
+  avatarDevicePath?: string;
 }
 
 /** Minimal shape of the Docker `containers/<id>/json` response we rely on. */
@@ -682,6 +703,21 @@ export function buildCreateBody(
     ];
   }
 
+  // Avatar device passthrough. The Docker Engine `Devices` field maps to
+  // `--device=<host>:<container>:<cgroup-perms>`; we use `rwm` (read/write/
+  // mknod) to match the CLI default. Only emitted when the caller opts in
+  // via `avatarDevicePath` — callers without the avatar feature enabled
+  // don't need to touch this.
+  const devices = opts.avatarDevicePath
+    ? [
+        {
+          PathOnHost: opts.avatarDevicePath,
+          PathInContainer: opts.avatarDevicePath,
+          CgroupPermissions: "rwm",
+        },
+      ]
+    : [];
+
   const hostConfig: Record<string, unknown> = {
     Binds: binds,
     PortBindings: portBindings,
@@ -698,6 +734,7 @@ export function buildCreateBody(
     // (`--disable-dev-shm-usage` in the Chrome launch args routes shared
     // memory to `/tmp` as a separate belt-and-suspenders hedge.)
     ShmSize: 2 * 1024 * 1024 * 1024,
+    ...(devices.length > 0 ? { Devices: devices } : {}),
     ...(opts.network ? { NetworkMode: opts.network } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Adds v4l2loopback-utils to the bot Dockerfile so the container can configure and write to /dev/video10.
- New `openVideoDevice()` helper in `bot/src/media/video-device.ts` for writing Y4M frames to the virtual camera.
- Device-passthrough wiring in `docker-runner.ts` + `cli/src/lib/docker.ts` (bare-metal and DinD); both opt-in, config schema lands in PR 5.
- README documents the one-time host `modprobe v4l2loopback` setup.

Part of plan: meet-phase-4-avatar.md (PR 3 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
