### PR TITLE
test(oauth2): deflake loopback transport test by awaiting openUrl callback

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -280,18 +280,23 @@ describe("OAuth2 gateway transport", () => {
     test("uses loopback transport when explicitly specified", async () => {
       mockPublicBaseUrl = "https://gw.example.com";
 
-      let capturedAuthUrl = "";
+      let resolveOpenUrl!: (url: string) => void;
+      const openUrlPromise = new Promise<string>((resolve) => {
+        resolveOpenUrl = resolve;
+      });
       const flowPromise = startOAuth2Flow(
         BASE_OAUTH_CONFIG,
         {
           openUrl: (url) => {
-            capturedAuthUrl = url;
+            resolveOpenUrl(url);
           },
         },
         { callbackTransport: "loopback" },
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      // Wait for the loopback server to bind and build the auth URL.
+      // Awaiting the openUrl callback instead of a fixed timer avoids CI-load flakes.
+      const capturedAuthUrl = await openUrlPromise;
 
       // Should use loopback redirect even though gateway URL is available
       expect(capturedAuthUrl).toMatch(/localhost|127\.0\.0\.1/);


### PR DESCRIPTION
## Summary
- The explicit-loopback test in \`oauth2-gateway-transport.test.ts\` relied on a fixed 50 ms \`setTimeout\` between kicking off \`startOAuth2Flow\` and asserting on \`capturedAuthUrl\`. On CI under load the loopback server did not finish binding within that window, leaving \`capturedAuthUrl\` empty and the \`toMatch(/localhost|127\\.0\\.0\\.1/)\` assertion failing.
- Switched the test to the same promise-based pattern used by the other loopback transport tests in this file (e.g. "falls back to loopback transport when ingress.publicBaseUrl is not configured"): resolve a \`Promise<string>\` from the \`openUrl\` callback and \`await\` it before inspecting the URL.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24624987481/job/72002292556
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
