### PR TITLE
fix(meet): type composer text via xdotool when native-setter pattern is ignored

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -94,6 +94,8 @@ interface MakeDepsOpts {
   chromeLaunchError?: Error;
   /** Force `xdotoolClick` to reject. */
   xdotoolClickError?: Error;
+  /** Force `xdotoolType` to reject. */
+  xdotoolTypeError?: Error;
   /** Force `startXvfb` to reject. */
   xvfbError?: Error;
   /** Short-circuit `waitForReady` to reject with this error. */
@@ -259,6 +261,15 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         display: clickOpts.display,
       });
       if (opts.xdotoolClickError) throw opts.xdotoolClickError;
+    },
+    xdotoolType: async (typeOpts) => {
+      calls.push({
+        kind: "xdotool.type",
+        text: typeOpts.text,
+        delayMs: typeOpts.delayMs,
+        display: typeOpts.display,
+      });
+      if (opts.xdotoolTypeError) throw opts.xdotoolTypeError;
     },
     startAudioCapture: async (audioOpts) => {
       calls.push({ kind: "audio.start", socketPath: audioOpts.socketPath });
@@ -598,6 +609,57 @@ describe("runBot — extension message routing", () => {
     expect(
       handles.errors.some((m) =>
         m.includes("trusted_click failed: xdotool exit code 1"),
+      ),
+    ).toBe(true);
+    // Bot stays alive — no shutdown triggered.
+    const counts = handles.stopCounts();
+    expect(counts.chrome).toBe(0);
+    expect(counts.xvfb).toBe(0);
+  });
+
+  test("trusted_type invokes xdotoolType with the payload + configured display", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    handles.fireExtensionMessage({
+      type: "trusted_type",
+      text: "hello world",
+      delayMs: 25,
+    });
+    // xdotoolType is fire-and-forget (same pattern as trusted_click), so
+    // give it a microtask to settle and the logInfo to land.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const typeCall = handles.calls.find((c) => c.kind === "xdotool.type");
+    expect(typeCall).toBeDefined();
+    expect(typeCall!.text).toBe("hello world");
+    expect(typeCall!.delayMs).toBe(25);
+    expect(typeCall!.display).toBe(":99");
+    // Success should surface via logInfo with the character count.
+    expect(
+      handles.infos.some((m) =>
+        m.includes("trusted_type dispatched (11 chars)"),
+      ),
+    ).toBe(true);
+  });
+
+  test("trusted_type xdotool failures surface via logError but don't shut down", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({
+      xdotoolTypeError: new Error("xdotool type exit code 1"),
+    });
+    await bootHappyPath(deps, handles);
+
+    handles.fireExtensionMessage({
+      type: "trusted_type",
+      text: "fail me",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(
+      handles.errors.some((m) =>
+        m.includes("trusted_type failed: xdotool type exit code 1"),
       ),
     ).toBe(true);
     // Bot stays alive — no shutdown triggered.

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -65,6 +65,7 @@ import {
   type LaunchChromeOptions,
 } from "./browser/chrome-launcher.js";
 import { xdotoolClick } from "./browser/xdotool-click.js";
+import { xdotoolType } from "./browser/xdotool-type.js";
 import { startXvfb, stopXvfb, type XvfbHandle } from "./browser/xvfb.js";
 import { DaemonClient } from "./control/daemon-client.js";
 import {
@@ -161,6 +162,18 @@ export interface BotDeps {
    * See `browser/xdotool-click.ts` for rationale.
    */
   xdotoolClick: (opts: { x: number; y: number; display: string }) => Promise<void>;
+  /**
+   * Type text via real X-server keystrokes into whatever is currently
+   * focused on the Xvfb display. Used as belt-and-suspenders for the
+   * chat composer when Meet gates input on `event.isTrusted === true`.
+   * The extension is responsible for focusing the right element before
+   * emitting `trusted_type`. See `browser/xdotool-type.ts` for rationale.
+   */
+  xdotoolType: (opts: {
+    text: string;
+    display: string;
+    delayMs?: number;
+  }) => Promise<void>;
   startAudioCapture: (opts: AudioCaptureOptions) => Promise<AudioCaptureHandle>;
   createDaemonClient: (opts: {
     daemonUrl: string;
@@ -233,6 +246,7 @@ export function defaultDeps(): BotDeps {
     createNmhSocketServer: (opts) => createNmhSocketServer(opts),
     launchChrome: (opts) => launchChrome(opts),
     xdotoolClick: (opts) => xdotoolClick(opts),
+    xdotoolType: (opts) => xdotoolType(opts),
     startAudioCapture,
     createDaemonClient: (opts) =>
       new DaemonClient({
@@ -811,6 +825,28 @@ export async function runBot(deps: BotDeps): Promise<void> {
           .catch((err: unknown) => {
             const detail = err instanceof Error ? err.message : String(err);
             deps.logError(`meet-bot: trusted_click failed: ${detail}`);
+          });
+        return;
+      }
+      case "trusted_type": {
+        // Mirror of trusted_click: fire-and-forget, log on success /
+        // failure, never cascade into a bot shutdown. The extension has
+        // already focused the target element; the bot just types into
+        // whatever is focused on the Xvfb display.
+        deps
+          .xdotoolType({
+            text: msg.text,
+            delayMs: msg.delayMs,
+            display: env.xvfbDisplay,
+          })
+          .then(() =>
+            deps.logInfo(
+              `meet-bot: trusted_type dispatched (${msg.text.length} chars)`,
+            ),
+          )
+          .catch((err: unknown) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            deps.logError(`meet-bot: trusted_type failed: ${detail}`);
           });
         return;
       }

--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -441,6 +441,75 @@ describe("sendChat", () => {
     expect(sendClicks).toBe(1);
   });
 
+  test("emits exactly one trusted_type event between the input event and send click when onEvent is provided", async () => {
+    const doc = installed!.dom.window.document;
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
+    const sendButton = doc.querySelector<HTMLButtonElement>(
+      chatSelectors.SEND_BUTTON,
+    );
+    expect(input).not.toBeNull();
+    expect(sendButton).not.toBeNull();
+
+    // Record the temporal order of:
+    //   1. the synthetic "input" event firing on the textarea (post `.value = text`)
+    //   2. each onEvent call (trusted_type or trusted_click for the send button)
+    //   3. the send-button click.
+    const timeline: Array<
+      | { kind: "input"; value: string }
+      | { kind: "event"; ev: ExtensionToBotMessage }
+      | { kind: "send-click"; inputValue: string }
+    > = [];
+
+    input!.addEventListener("input", () => {
+      timeline.push({ kind: "input", value: input!.value });
+    });
+    sendButton!.addEventListener("click", () => {
+      timeline.push({ kind: "send-click", inputValue: input!.value });
+    });
+
+    const onEvent = (ev: ExtensionToBotMessage): void => {
+      timeline.push({ kind: "event", ev });
+    };
+
+    await sendChat("hello", {
+      onEvent,
+      window: {
+        screenX: 0,
+        screenY: 0,
+        outerHeight: 820,
+        innerHeight: 720,
+      },
+    });
+
+    // Exactly one trusted_type event with the literal payload.
+    const trustedTypes = timeline.filter(
+      (entry): entry is { kind: "event"; ev: ExtensionToBotMessage } =>
+        entry.kind === "event" && entry.ev.type === "trusted_type",
+    );
+    expect(trustedTypes.length).toBe(1);
+    const trustedType = trustedTypes[0]!.ev;
+    if (trustedType.type === "trusted_type") {
+      expect(trustedType.text).toBe("hello");
+    }
+
+    // Ordering: input event first (carries the native-setter value), then
+    // trusted_type, then any send-button trusted_click, then the JS click.
+    const inputIdx = timeline.findIndex((e) => e.kind === "input");
+    const trustedTypeIdx = timeline.findIndex(
+      (e) => e.kind === "event" && e.ev.type === "trusted_type",
+    );
+    const sendClickIdx = timeline.findIndex((e) => e.kind === "send-click");
+    expect(inputIdx).toBeGreaterThanOrEqual(0);
+    expect(trustedTypeIdx).toBeGreaterThan(inputIdx);
+    expect(sendClickIdx).toBeGreaterThan(trustedTypeIdx);
+
+    // The textarea should still carry the native-setter value at send time.
+    const sendEntry = timeline[sendClickIdx];
+    if (sendEntry && sendEntry.kind === "send-click") {
+      expect(sendEntry.inputValue).toBe("hello");
+    }
+  });
+
   test("accepts exactly 2000 characters", async () => {
     const doc = installed!.dom.window.document;
     const sendButton = doc.querySelector<HTMLButtonElement>(

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -178,14 +178,27 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
  * Assumes the chat panel is open — callers that need to lazily open it
  * should use {@link postConsentMessage}.
  *
- * When `opts.onEvent` is provided, emits a `trusted_click` for the send
- * button's screen coordinates before calling `sendButton.click()`. This
- * mirrors the panel-toggle fix in {@link ensurePanelOpen} and the
- * admission-button fix in `features/join.ts` — by symmetry with the other
- * `isTrusted`-gated buttons in Meet's UI, we expect the send button is also
- * gated, so a bare JS `.click()` from a content script would be silently
- * ignored. The `.click()` call is kept as a fallback for the jsdom test
- * harness and any Meet build that does not enforce `isTrusted` on send.
+ * When `opts.onEvent` is provided, two extra extension→bot signals are
+ * emitted so the bot can drive the composer + send via real X-server
+ * events (required by any Meet build that enforces `event.isTrusted` on
+ * the corresponding controls):
+ *
+ * 1. After the native-setter `.value = text` + synthetic `input` event,
+ *    the composer is focused and a `trusted_type` event is emitted so the
+ *    bot can xdotool-type the text as real keystrokes. This is
+ *    belt-and-suspenders: if Meet accepts the synthetic path, the
+ *    xdotool-typed text lands in the same focused field and is harmless;
+ *    if not, xdotool fills the gap. We wait ~250ms after emitting so the
+ *    (async) keystrokes have time to land before clicking send.
+ *
+ * 2. Before the send-button `.click()`, a `trusted_click` is emitted for
+ *    the button's screen coordinates. This mirrors the panel-toggle fix
+ *    in {@link ensurePanelOpen} and the admission-button fix in
+ *    `features/join.ts` — by symmetry with other `isTrusted`-gated
+ *    buttons in Meet's UI, we expect the send button is also gated, so a
+ *    bare JS `.click()` from a content script would be silently ignored.
+ *    The `.click()` call is kept as a fallback for the jsdom test
+ *    harness and any Meet build that does not enforce `isTrusted` on send.
  */
 export async function sendChat(
   text: string,
@@ -211,6 +224,22 @@ export async function sendChat(
   // hood through Playwright's element-handle bindings.
   input.value = text;
   input.dispatchEvent(new Event("input", { bubbles: true }));
+
+  // If the caller wired up an `onEvent` sink, also drive the composer via
+  // xdotool-type. Focus the field first so xdotool's X-server keystrokes
+  // land on the right element, then emit the trusted_type event and give
+  // the bot a short window to type before we click send. No coord math
+  // here — the bot types into whatever is focused on the Xvfb display.
+  if (opts?.onEvent) {
+    try {
+      input.focus();
+    } catch {
+      // Some jsdom / degraded DOM builds throw on .focus(); fall through
+      // and let the synthetic-setter path carry the composer.
+    }
+    opts.onEvent({ type: "trusted_type", text });
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+  }
 
   const sendButton = document.querySelector<HTMLButtonElement>(
     chatSelectors.SEND_BUTTON,


### PR DESCRIPTION
## Summary
- `sendChat` now focuses the input, emits `trusted_type`, waits 250ms, then proceeds to the send-button path
- Bot-side `handleExtensionMessage` routes `trusted_type` → `deps.xdotoolType` (fire-and-forget, non-cascading on failure)
- Belt-and-suspenders for the consent-post path; if native-setter + send-button trusted_click (PR 5 + 6) is sufficient live, this is no-op safety. If not, this closes the gap.

Part of plan: meet-phase-1-12-prime-time.md (PR 9 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
