### PR TITLE
ui(macos): widen scroll debug overlay for readability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -220,10 +220,10 @@ struct ScrollDebugOverlayView: View {
         HStack(spacing: 6) {
             Text(label)
                 .foregroundStyle(VColor.contentSecondary)
-                .frame(width: 84, alignment: .trailing)
+                .frame(width: 100, alignment: .trailing)
             Text(value)
                 .foregroundStyle(valueColor ?? VColor.contentDefault)
-                .frame(minWidth: 60, alignment: .leading)
+                .frame(minWidth: 80, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Summary
- Bump label column from 84pt → 100pt and value column minWidth from 60pt → 80pt in `ScrollDebugOverlayView.row(...)` so the developer HUD has more breathing room.

## Original prompt
[Image #1] Make this debug overlay slightly wider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
