### PR TITLE
meet-bot: Chrome camera-device flag when avatar enabled

### DIFF
--- a/skills/meet-join/bot/__tests__/chrome-launcher-avatar-flag.test.ts
+++ b/skills/meet-join/bot/__tests__/chrome-launcher-avatar-flag.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for the Phase 4 PR 3 `avatarEnabled` option on the
+ * chrome-launcher primitive.
+ *
+ * These assertions are deliberately strict:
+ *
+ *   1. With `avatarEnabled` absent or explicitly `false`, the composed
+ *      argv must be byte-identical to the pre-PR-3 baseline. Any drift
+ *      would silently change the Phase 1 non-avatar launch path — exactly
+ *      what the plan's acceptance criteria forbid.
+ *   2. With `avatarEnabled: true`, both avatar flags
+ *      (`--use-fake-device-for-media-stream` and
+ *      `--use-file-for-fake-video-capture=<path>`) must appear in the
+ *      argv, in that order, AFTER `--use-fake-ui-for-media-stream` so the
+ *      camera-source toggles live adjacent to the permission-prompt
+ *      toggle.
+ *   3. The existing `--use-fake-ui-for-media-stream` permission-prompt
+ *      flag must survive in both modes — without it, Chrome pops a
+ *      runtime camera-permission dialog the bot can't click.
+ *   4. The avatar device-path default is `/dev/video10` (matching
+ *      `DEFAULT_VIDEO_DEVICE_PATH` in `src/media/video-device.ts` and the
+ *      CLI's `VELLUM_MEET_AVATAR_DEVICE` default), and an explicit
+ *      override threads through to the `--use-file-for-fake-video-capture`
+ *      argument.
+ *   5. CDP trip-wires (`--remote-debugging-*`, `--enable-automation`)
+ *      remain absent in avatar mode — Meet's BotGuard rejects any CDP
+ *      attachment regardless of the camera source.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import {
+  DEFAULT_AVATAR_DEVICE_PATH,
+  launchChrome,
+} from "../src/browser/chrome-launcher.js";
+
+interface SpawnCall {
+  command: string;
+  args: string[];
+  options: { env?: NodeJS.ProcessEnv; stdio?: unknown };
+}
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: (signal?: NodeJS.Signals) => boolean;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 54321;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = () => true;
+  return child;
+}
+
+function makeFakeSpawn(fakeChild: FakeChild): {
+  spawn: never;
+  calls: SpawnCall[];
+} {
+  const calls: SpawnCall[] = [];
+  const impl = (
+    command: string,
+    args: readonly string[],
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+  ) => {
+    calls.push({ command, args: [...args], options });
+    return fakeChild;
+  };
+  return { spawn: impl as unknown as never, calls };
+}
+
+const BASE_OPTS = {
+  meetingUrl: "https://meet.google.com/abc-defg-hij",
+  displayNumber: ":99",
+  extensionPath: "/app/ext",
+  userDataDir: "/tmp/profile",
+};
+
+/**
+ * The exact argv the launcher emits when `avatarEnabled` is absent or
+ * false. This snapshot is the acceptance criterion's "pre-PR baseline" —
+ * any change to the launch flags (adding, removing, reordering) breaks
+ * this test intentionally so the author reviews the impact on the Phase
+ * 1 no-avatar flow.
+ */
+const BASELINE_ARGV: readonly string[] = [
+  "--no-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-setuid-sandbox",
+  "--disable-background-networking",
+  "--disable-breakpad",
+  "--window-size=1280,720",
+  "--window-position=0,0",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-default-apps",
+  "--use-fake-ui-for-media-stream",
+  "--enable-logging=stderr",
+  "--v=0",
+  "--user-data-dir=/tmp/profile",
+  "--load-extension=/app/ext",
+  "https://meet.google.com/abc-defg-hij",
+];
+
+describe("launchChrome avatarEnabled flag", () => {
+  test("default (avatarEnabled undefined) matches pre-PR-3 baseline byte-for-byte", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({ ...BASE_OPTS, spawn: fake.spawn });
+
+    expect(fake.calls.length).toBe(1);
+    expect(fake.calls[0]!.args).toEqual([...BASELINE_ARGV]);
+  });
+
+  test("avatarEnabled: false is equivalent to undefined", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: false,
+      spawn: fake.spawn,
+    });
+
+    expect(fake.calls[0]!.args).toEqual([...BASELINE_ARGV]);
+  });
+
+  test("avatarEnabled: false ignores avatarDevicePath override", async () => {
+    // Sanity-check: an avatarDevicePath override without avatarEnabled
+    // must NOT leak into the argv. The flag gates the whole avatar-arg
+    // bundle; a stray path should be silently dropped.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: false,
+      avatarDevicePath: "/dev/video42",
+      spawn: fake.spawn,
+    });
+
+    expect(fake.calls[0]!.args).toEqual([...BASELINE_ARGV]);
+  });
+
+  test("avatarEnabled: true appends both avatar flags in deterministic order", async () => {
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: true,
+      spawn: fake.spawn,
+    });
+
+    const { args } = fake.calls[0]!;
+
+    // Both avatar flags are present.
+    expect(args).toContain("--use-fake-device-for-media-stream");
+    expect(args).toContain(
+      `--use-file-for-fake-video-capture=${DEFAULT_AVATAR_DEVICE_PATH}`,
+    );
+
+    // They land adjacent to each other, immediately after the always-on
+    // `--use-fake-ui-for-media-stream`. This gives the reviewer a
+    // deterministic string they can grep for across logs.
+    const fakeUiIdx = args.indexOf("--use-fake-ui-for-media-stream");
+    const fakeDeviceIdx = args.indexOf(
+      "--use-fake-device-for-media-stream",
+    );
+    const fakeFileIdx = args.indexOf(
+      `--use-file-for-fake-video-capture=${DEFAULT_AVATAR_DEVICE_PATH}`,
+    );
+    expect(fakeUiIdx).toBeGreaterThanOrEqual(0);
+    expect(fakeDeviceIdx).toBe(fakeUiIdx + 1);
+    expect(fakeFileIdx).toBe(fakeDeviceIdx + 1);
+
+    // And the argv's final element is still the meeting URL — the avatar
+    // flags must never reorder the URL to a non-terminal position (Chrome
+    // treats any bare positional as the initial URL).
+    expect(args[args.length - 1]).toBe(BASE_OPTS.meetingUrl);
+  });
+
+  test("avatarEnabled: true yields a full expected argv", async () => {
+    // Explicit equality against the expected ordered shape — this is the
+    // deterministic-order acceptance criterion from the plan.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: true,
+      spawn: fake.spawn,
+    });
+
+    expect(fake.calls[0]!.args).toEqual([
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-setuid-sandbox",
+      "--disable-background-networking",
+      "--disable-breakpad",
+      "--window-size=1280,720",
+      "--window-position=0,0",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-default-apps",
+      "--use-fake-ui-for-media-stream",
+      "--use-fake-device-for-media-stream",
+      `--use-file-for-fake-video-capture=${DEFAULT_AVATAR_DEVICE_PATH}`,
+      "--enable-logging=stderr",
+      "--v=0",
+      "--user-data-dir=/tmp/profile",
+      "--load-extension=/app/ext",
+      "https://meet.google.com/abc-defg-hij",
+    ]);
+  });
+
+  test("avatarDevicePath override threads into --use-file-for-fake-video-capture", async () => {
+    // Operators running v4l2loopback with a custom `video_nr` point the
+    // device path to something other than `/dev/video10` via the CLI's
+    // `VELLUM_MEET_AVATAR_DEVICE` env; that value flows through the
+    // session manager as `avatarDevicePath`.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: true,
+      avatarDevicePath: "/dev/video11",
+      spawn: fake.spawn,
+    });
+
+    const { args } = fake.calls[0]!;
+    expect(args).toContain(
+      "--use-file-for-fake-video-capture=/dev/video11",
+    );
+    // Default path must NOT appear when an override is provided.
+    expect(args).not.toContain(
+      `--use-file-for-fake-video-capture=${DEFAULT_AVATAR_DEVICE_PATH}`,
+    );
+  });
+
+  test("--use-fake-ui-for-media-stream survives in both modes", async () => {
+    // The permission-prompt auto-accept is load-bearing for either launch
+    // path: disabling it would make Chrome pop a camera-perm dialog the
+    // bot can't click.
+    for (const avatarEnabled of [true, false]) {
+      const child = makeFakeChild();
+      const fake = makeFakeSpawn(child);
+
+      await launchChrome({
+        ...BASE_OPTS,
+        avatarEnabled,
+        spawn: fake.spawn,
+      });
+
+      expect(fake.calls[0]!.args).toContain("--use-fake-ui-for-media-stream");
+    }
+  });
+
+  test("avatar mode does NOT reintroduce any CDP trip-wire flag", async () => {
+    // Same trip-wires the base launcher test (`chrome-launcher.test.ts`)
+    // asserts against — re-checked here to pin the invariant under the
+    // new avatar branch. BotGuard's CDP detection is orthogonal to the
+    // camera source, so adding `--remote-debugging-*` in the avatar
+    // branch would be just as fatal as adding it to the base argv.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    await launchChrome({
+      ...BASE_OPTS,
+      avatarEnabled: true,
+      spawn: fake.spawn,
+    });
+
+    for (const arg of fake.calls[0]!.args) {
+      expect(arg.startsWith("--remote-debugging-port")).toBe(false);
+      expect(arg.startsWith("--remote-debugging-pipe")).toBe(false);
+      expect(arg.startsWith("--enable-automation")).toBe(false);
+    }
+  });
+
+  test("DEFAULT_AVATAR_DEVICE_PATH is /dev/video10 (mirrors PR 2)", async () => {
+    // Lock the default string so a future edit can't silently drift from
+    // `DEFAULT_VIDEO_DEVICE_PATH` in `src/media/video-device.ts` or from
+    // `DEFAULT_MEET_AVATAR_DEVICE_PATH` in `cli/src/lib/docker.ts`. All
+    // three must agree.
+    expect(DEFAULT_AVATAR_DEVICE_PATH).toBe("/dev/video10");
+  });
+});

--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -159,6 +159,7 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     nmhSocketPath: "/run/nmh.sock",
     xvfbDisplay: ":99",
     chromeUserDataRoot: "/tmp/chrome-profile",
+    avatarEnabled: false,
   };
 
   const daemonClient: DaemonClientLike = {

--- a/skills/meet-join/bot/src/browser/chrome-launcher.ts
+++ b/skills/meet-join/bot/src/browser/chrome-launcher.ts
@@ -62,6 +62,29 @@ export interface LaunchChromeOptions {
    * to 5000 (the value production uses). Tests override to avoid 5s waits.
    */
   sigkillGraceMs?: number;
+  /**
+   * When `true`, append the Phase 4 avatar flags so Chrome uses the
+   * v4l2loopback virtual camera as its getUserMedia video source:
+   *
+   *   --use-fake-device-for-media-stream
+   *   --use-file-for-fake-video-capture=<avatarDevicePath>
+   *
+   * Chromium on Linux accepts a v4l2 character-device path in place of a
+   * file when the loopback driver is loaded with `exclusive_caps=1` — see
+   * PR 2's host-setup docs in `skills/meet-join/bot/README.md`.
+   *
+   * Defaults to `false`, which preserves the pre-PR-3 argv byte-for-byte.
+   */
+  avatarEnabled?: boolean;
+  /**
+   * Absolute path to the v4l2loopback character-device node consumed when
+   * `avatarEnabled` is true. Defaults to {@link DEFAULT_AVATAR_DEVICE_PATH}
+   * (`/dev/video10`), matching PR 2's `DEFAULT_VIDEO_DEVICE_PATH` in
+   * `src/media/video-device.ts` and the CLI's `VELLUM_MEET_AVATAR_DEVICE`
+   * default (see `cli/src/lib/docker.ts:resolveMeetAvatarDevicePath`).
+   * Only consulted when `avatarEnabled` is true.
+   */
+  avatarDevicePath?: string;
 }
 
 export interface ChromeProcessHandle {
@@ -80,6 +103,17 @@ export interface ChromeProcessHandle {
 /** Default grace period between SIGTERM and SIGKILL during `stop()`. */
 const DEFAULT_SIGKILL_GRACE_MS = 5_000;
 
+/**
+ * Default v4l2loopback device path consumed when `avatarEnabled` is true.
+ *
+ * Kept as a local constant rather than imported from
+ * `src/media/video-device.ts` so the launcher stays independent of the
+ * video-device module's `node:fs` / `v4l2-ctl` surface. The two modules
+ * must agree on the string; see {@link LaunchChromeOptions.avatarDevicePath}
+ * and `DEFAULT_VIDEO_DEVICE_PATH` in `video-device.ts` for the mirror.
+ */
+export const DEFAULT_AVATAR_DEVICE_PATH = "/dev/video10";
+
 /** No-op logger used when caller doesn't supply one. */
 const NOOP_LOGGER: ChromeLauncherLogger = {
   info: () => {},
@@ -93,12 +127,28 @@ const NOOP_LOGGER: ChromeLauncherLogger = {
  * Phase 1.11 debugging pass. Do NOT add any CDP-related flag here
  * (`--remote-debugging-port`, `--remote-debugging-pipe`, `--enable-automation`)
  * — their absence is the whole point of this launcher.
+ *
+ * Avatar mode (Phase 4 PR 3): when `avatarEnabled` is true, two extra
+ * flags are inserted immediately after the always-on
+ * `--use-fake-ui-for-media-stream` so the camera-source toggles live
+ * adjacent to the permission-prompt toggle. The insertion is at a fixed
+ * position rather than the tail so the argv shape stays deterministic
+ * regardless of the meeting URL. When `avatarEnabled` is false, the argv
+ * is byte-identical to the pre-PR-3 baseline.
  */
 function buildChromeArgs(opts: {
   meetingUrl: string;
   extensionPath: string;
   userDataDir: string;
+  avatarEnabled: boolean;
+  avatarDevicePath: string;
 }): string[] {
+  const avatarArgs = opts.avatarEnabled
+    ? [
+        "--use-fake-device-for-media-stream",
+        `--use-file-for-fake-video-capture=${opts.avatarDevicePath}`,
+      ]
+    : [];
   return [
     "--no-sandbox",
     "--disable-dev-shm-usage",
@@ -111,6 +161,7 @@ function buildChromeArgs(opts: {
     "--no-default-browser-check",
     "--disable-default-apps",
     "--use-fake-ui-for-media-stream",
+    ...avatarArgs,
     "--enable-logging=stderr",
     "--v=0",
     `--user-data-dir=${opts.userDataDir}`,
@@ -137,6 +188,8 @@ export async function launchChrome(
     meetingUrl: opts.meetingUrl,
     extensionPath: opts.extensionPath,
     userDataDir: opts.userDataDir,
+    avatarEnabled: opts.avatarEnabled === true,
+    avatarDevicePath: opts.avatarDevicePath ?? DEFAULT_AVATAR_DEVICE_PATH,
   });
 
   const env: NodeJS.ProcessEnv = {

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -115,6 +115,34 @@ interface BotEnv {
   xvfbDisplay: string;
   /** User-data directory root for Chrome — suffixed with meetingId per launch. */
   chromeUserDataRoot: string;
+  /**
+   * Phase 4 avatar opt-in. `AVATAR_ENABLED=1` (or a common truthy
+   * synonym — `true`, `yes`, `on`) threads the v4l2loopback camera flags
+   * through to {@link launchChrome}. Absent or any non-truthy value falls
+   * back to the Phase 1 launcher argv byte-for-byte. The session manager
+   * in the daemon sets this env on the bot container when the assistant
+   * has the Meet avatar feature enabled.
+   */
+  avatarEnabled: boolean;
+}
+
+/**
+ * Parse a truthy env value. Accepts `"1"`, `"true"`, `"yes"`, `"on"`
+ * (case-insensitive, trimmed). Anything else — including `undefined`,
+ * `"0"`, `"false"`, `"no"`, `"off"`, and empty strings — is false.
+ * Kept deliberately narrow so an accidental leading/trailing space or an
+ * operator typing `AVATAR_ENABLED=true` both flip the same switch as
+ * `AVATAR_ENABLED=1`.
+ */
+function parseBooleanEnv(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
 }
 
 function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
@@ -132,6 +160,7 @@ function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
     nmhSocketPath: env.NMH_SOCKET_PATH ?? "/run/nmh.sock",
     xvfbDisplay: env.XVFB_DISPLAY ?? ":99",
     chromeUserDataRoot: env.CHROME_USER_DATA_ROOT ?? "/tmp/chrome-profile",
+    avatarEnabled: parseBooleanEnv(env.AVATAR_ENABLED),
   };
 }
 
@@ -621,6 +650,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
       displayNumber: env.xvfbDisplay,
       extensionPath: env.extensionPath,
       userDataDir,
+      avatarEnabled: env.avatarEnabled,
       logger: {
         info: (m) => deps.logInfo(m),
         error: (m) => deps.logError(m),


### PR DESCRIPTION
## Summary
- `chrome-launcher.ts` accepts `avatarEnabled` option; when true, appends `--use-fake-device-for-media-stream` and `--use-file-for-fake-video-capture=/dev/video10` alongside the existing `--use-fake-ui-for-media-stream`.
- `main.ts` reads `AVATAR_ENABLED` env and passes it through; pre-PR baseline args are preserved when the env is unset.
- Snapshot/equality test locks the default behavior against regression.

Part of plan: meet-phase-4-avatar.md (PR 6 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
