### PR TITLE
fix(macos-client): don't leave permanent nil state on transient bootstrap failures

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -274,6 +274,35 @@ extension AppDelegate {
         let deviceId = PairingQRCodeSheet.computeHostId()
         let retryDelay: UInt64 = 500_000_000
 
+        // Self-heal path: if a refresh token survives in the keychain (e.g.
+        // from a slightly-stale CLI file import or a prior run), try to
+        // rotate it into a fresh access/refresh pair before hitting the
+        // bootstrap-lockfile-guarded init endpoint. The lockfile permanently
+        // 403s /v1/guardian/init after first use, so init alone has no path
+        // to recover — whereas refresh succeeds whenever the server still
+        // recognizes the refresh token, covering the common
+        // "access-expired-but-refresh-still-valid" case.
+        if ActorTokenManager.getRefreshToken() != nil {
+            if !connectionManager.isConnected {
+                await awaitConnectionEstablished()
+                guard !Task.isCancelled else { return }
+            }
+            let refreshResult = await ActorCredentialRefresher.refresh(
+                platform: "macos",
+                deviceId: deviceId
+            )
+            switch refreshResult {
+            case .success:
+                log.info("Initial actor token bootstrap recovered via refresh")
+                return
+            case .terminalError(let reason):
+                log.warning("Refresh terminal error (\(reason, privacy: .public)) — clearing credentials and falling back to /v1/guardian/init")
+                ActorTokenManager.deleteAllCredentials()
+            case .transientError:
+                log.info("Refresh transient error — falling back to /v1/guardian/init")
+            }
+        }
+
         while !Task.isCancelled {
             if !connectionManager.isConnected {
                 await awaitConnectionEstablished()

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -149,7 +149,25 @@ final class AvatarAppearanceManager {
 
     // MARK: - Avatar Fetch via Gateway
 
-    /// Fetches the avatar image via HTTP through the gateway.
+    /// Delay before retrying an avatar fetch that failed with a transient error.
+    /// Long enough for in-flight token refresh to complete, short enough that the
+    /// user sees the right avatar before the UI settles.
+    private static let transientRetryDelayNs: UInt64 = 2_000_000_000 // 2s
+
+    /// Whether a non-success response represents an authoritative "no avatar
+    /// exists" signal (404) as opposed to a transient failure (401, 5xx,
+    /// transport/network error). Authoritative absence clears cached state;
+    /// transient failures preserve it so a brief auth-race during bootstrap
+    /// does not replace a previously-good avatar with the bundled fallback.
+    static func isAuthoritativeAbsence(statusCode: Int) -> Bool {
+        return statusCode == 404
+    }
+
+    /// Fetches the avatar image via HTTP through the gateway. On transient
+    /// failure (401, 5xx, transport error) the existing cached image is
+    /// preserved and one retry is scheduled; only an authoritative 404 clears
+    /// it. Guarded by `avatarRetryInFlight` so repeated transient failures
+    /// don't stack retries.
     private func fetchAvatarViaHTTP() async {
         do {
             let response = try await GatewayHTTPClient.get(
@@ -157,24 +175,30 @@ final class AvatarAppearanceManager {
                 params: ["path": "data/avatar/avatar-image.png"],
                 timeout: 10
             )
-            guard response.isSuccess, !response.data.isEmpty else {
+            if response.isSuccess, !response.data.isEmpty {
+                cachedChatAvatar = nil
+                customAvatarImage = NSImage(data: response.data)
+                updateDockIcon()
+                return
+            }
+            if Self.isAuthoritativeAbsence(statusCode: response.statusCode) {
                 if customAvatarImage != nil { customAvatarImage = nil }
                 cachedChatAvatar = nil
                 updateDockIcon()
                 return
             }
-            cachedChatAvatar = nil
-            customAvatarImage = NSImage(data: response.data)
-            updateDockIcon()
+            log.warning("Transient avatar fetch failure (HTTP \(response.statusCode)) — preserving cached image and scheduling retry")
+            scheduleAvatarRetry()
         } catch {
-            log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
-            if customAvatarImage != nil { customAvatarImage = nil }
-            cachedChatAvatar = nil
-            updateDockIcon()
+            log.warning("Transport failure fetching avatar — preserving cached image and scheduling retry: \(error.localizedDescription)")
+            scheduleAvatarRetry()
         }
     }
 
-    /// Fetches character-traits.json via HTTP through the gateway.
+    /// Fetches character-traits.json via HTTP through the gateway. Same
+    /// transient-vs-authoritative policy as the avatar image: 404 clears the
+    /// cached traits, 401/5xx/transport errors preserve them and schedule one
+    /// retry.
     private func fetchTraitsViaHTTP() async {
         do {
             let response = try await GatewayHTTPClient.get(
@@ -182,38 +206,64 @@ final class AvatarAppearanceManager {
                 params: ["path": "data/avatar/character-traits.json"],
                 timeout: 10
             )
-            guard response.isSuccess, !response.data.isEmpty else {
+            if response.isSuccess, !response.data.isEmpty {
+                guard let components = try? JSONDecoder().decode(AvatarComponents.self, from: response.data) else {
+                    return
+                }
+                characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
+                characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
+                characterColor = AvatarColor(rawValue: components.color)
+                // Character traits loaded — the PNG is just a daemon rendering
+                // of the character, not a user upload. Clear it so the animated
+                // path is used.
+                customAvatarImage = nil
+                cachedChatAvatar = nil
+                cachedFallbackAvatar = nil
+                cachedFullFallbackAvatar = nil
+                updateDockIcon()
+                return
+            }
+            if Self.isAuthoritativeAbsence(statusCode: response.statusCode) {
                 if characterBodyShape != nil { characterBodyShape = nil }
                 if characterEyeStyle != nil { characterEyeStyle = nil }
                 if characterColor != nil { characterColor = nil }
                 cachedFallbackAvatar = nil
                 cachedFullFallbackAvatar = nil
-
                 updateDockIcon()
                 return
             }
-            guard let components = try? JSONDecoder().decode(AvatarComponents.self, from: response.data) else {
-                return
-            }
-            characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
-            characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
-            characterColor = AvatarColor(rawValue: components.color)
-            // Character traits loaded — the PNG is just a daemon rendering
-            // of the character, not a user upload. Clear it so the animated
-            // path is used.
-            customAvatarImage = nil
-            cachedChatAvatar = nil
-            cachedFallbackAvatar = nil
-            cachedFullFallbackAvatar = nil
-            updateDockIcon()
+            log.warning("Transient traits fetch failure (HTTP \(response.statusCode)) — preserving cached traits and scheduling retry")
+            scheduleTraitsRetry()
         } catch {
-            log.warning("Failed to fetch character traits via HTTP: \(error.localizedDescription)")
-            if characterBodyShape != nil { characterBodyShape = nil }
-            if characterEyeStyle != nil { characterEyeStyle = nil }
-            if characterColor != nil { characterColor = nil }
-            cachedFallbackAvatar = nil
-            cachedFullFallbackAvatar = nil
-            updateDockIcon()
+            log.warning("Transport failure fetching character traits — preserving cached traits and scheduling retry: \(error.localizedDescription)")
+            scheduleTraitsRetry()
+        }
+    }
+
+    /// Guards against stacking overlapping retries when repeated transient
+    /// failures arrive before the first retry has completed.
+    @ObservationIgnored private var avatarRetryInFlight = false
+    @ObservationIgnored private var traitsRetryInFlight = false
+
+    private func scheduleAvatarRetry() {
+        guard !avatarRetryInFlight else { return }
+        avatarRetryInFlight = true
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
+            guard let self else { return }
+            await self.fetchAvatarViaHTTP()
+            self.avatarRetryInFlight = false
+        }
+    }
+
+    private func scheduleTraitsRetry() {
+        guard !traitsRetryInFlight else { return }
+        traitsRetryInFlight = true
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
+            guard let self else { return }
+            await self.fetchTraitsViaHTTP()
+            self.traitsRetryInFlight = false
         }
     }
 

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerTransientFailureTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerTransientFailureTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Tests for the bootstrap-window amplifier fix in avatar fetches: transient
+/// failures (401 during auth race, 5xx backend hiccup, transport/network
+/// error) must not clear cached state. Only an authoritative 404 from the
+/// daemon counts as "no avatar exists" and clears cached state.
+@MainActor
+final class AvatarAppearanceManagerTransientFailureTests: XCTestCase {
+
+    // MARK: - isAuthoritativeAbsence
+
+    func test404CountsAsAuthoritativeAbsence() {
+        XCTAssertTrue(AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: 404))
+    }
+
+    func test401DoesNotCountAsAuthoritativeAbsence() {
+        // 401 during the bootstrap auth race is the exact scenario the fix
+        // addresses — an expired/missing token triggers the retry interceptor,
+        // and we must not wipe the cached avatar while that's happening.
+        XCTAssertFalse(AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: 401))
+    }
+
+    func test403DoesNotCountAsAuthoritativeAbsence() {
+        // 403 can mean the gateway is still locking out new tokens after a
+        // re-bootstrap; same preserve-and-retry policy as 401.
+        XCTAssertFalse(AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: 403))
+    }
+
+    func test5xxDoesNotCountAsAuthoritativeAbsence() {
+        for status in [500, 502, 503, 504] {
+            XCTAssertFalse(
+                AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: status),
+                "HTTP \(status) is a backend hiccup, not an authoritative absence"
+            )
+        }
+    }
+
+    func test2xxNotTreatedAsAbsence() {
+        // 2xx means the caller should not reach the absence check at all,
+        // but defensively verify.
+        XCTAssertFalse(AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: 200))
+        XCTAssertFalse(AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: 204))
+    }
+
+    func testOnlyExactly404CountsAsAbsence() {
+        // No accidental broader match — e.g. 4xx as a class is NOT absence,
+        // only the specific 404 "file not found" signal.
+        for status in [400, 402, 405, 410, 429] {
+            XCTAssertFalse(
+                AvatarAppearanceManager.isAuthoritativeAbsence(statusCode: status),
+                "Only 404 should be treated as authoritative absence; HTTP \(status) is not"
+            )
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/GuardianTokenFileReaderTests.swift
+++ b/clients/macos/vellum-assistantTests/GuardianTokenFileReaderTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Tests for the bootstrap-window amplifier fix: an expired access token must
+/// not cause the whole credential file to be thrown away when the refresh
+/// token is still valid. Exercises the pure `decideImport` function so no
+/// keychain side effects leak into the tests.
+final class GuardianTokenFileReaderTests: XCTestCase {
+
+    private var tmpDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guardian-token-reader-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tmpDir)
+        tmpDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - Fixture helpers
+
+    /// Writes a guardian-token.json fixture to `tmpDir` and returns its path.
+    /// `accessExpiresMs` and `refreshExpiresMs` are absolute epoch-ms so tests
+    /// can construct the exact expiry relationship they want to verify.
+    private func writeFixture(
+        accessExpiresMs: Int,
+        refreshExpiresMs: Int,
+        refreshAfterMs: Int? = nil
+    ) -> String {
+        let path = tmpDir.appendingPathComponent("guardian-token.json").path
+        let body: [String: Any] = [
+            "guardianPrincipalId": "vellum-principal-test",
+            "accessToken": "header.payload.signature",
+            "accessTokenExpiresAt": accessExpiresMs,
+            "refreshToken": "refresh-test-token",
+            "refreshTokenExpiresAt": refreshExpiresMs,
+            "refreshAfter": refreshAfterMs ?? (accessExpiresMs - 60_000),
+            "isNew": false,
+            "deviceId": "test-device-id",
+            "leasedAt": "2026-04-19T00:00:00Z"
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: body, options: [])
+        try! data.write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    // MARK: - decideImport
+
+    func testImportsWhenBothTokensValid() {
+        let nowMs = 1_000_000_000
+        let path = writeFixture(
+            accessExpiresMs: nowMs + 30 * 60_000, // +30 min
+            refreshExpiresMs: nowMs + 90 * 24 * 60 * 60_000 // +90 days
+        )
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: nowMs)
+        if case .importValid(let creds) = decision {
+            XCTAssertEqual(creds.accessToken, "header.payload.signature")
+            XCTAssertEqual(creds.refreshToken, "refresh-test-token")
+        } else {
+            XCTFail("Expected .importValid, got \(decision)")
+        }
+    }
+
+    /// The core amplifier fix: an expired access token with a still-valid
+    /// refresh token must import the credentials, not throw them away. The 401
+    /// retry interceptor will rotate the refresh token on the next request.
+    func testImportsWhenAccessExpiredButRefreshStillValid() {
+        let nowMs = 1_000_000_000
+        let path = writeFixture(
+            accessExpiresMs: nowMs - 10 * 60_000, // expired 10 min ago
+            refreshExpiresMs: nowMs + 60 * 24 * 60 * 60_000 // +60 days (still valid)
+        )
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: nowMs)
+        if case .importAccessExpired(let creds) = decision {
+            XCTAssertEqual(creds.refreshToken, "refresh-test-token",
+                           "Refresh token must be preserved for the 401 interceptor to rotate")
+            XCTAssertLessThan(creds.accessExpiresEpoch, nowMs,
+                              "Access expiry should be in the past as set up")
+            XCTAssertGreaterThan(creds.refreshExpiresEpoch, nowMs,
+                                 "Refresh expiry should be in the future as set up")
+        } else {
+            XCTFail("Expected .importAccessExpired (so the refresh token survives), got \(decision)")
+        }
+    }
+
+    func testSkipsWhenRefreshTokenExpired() {
+        let nowMs = 1_000_000_000
+        let path = writeFixture(
+            accessExpiresMs: nowMs - 10 * 60_000,
+            refreshExpiresMs: nowMs - 1 // expired
+        )
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: nowMs)
+        XCTAssertEqual(decision, .skipRefreshExpired)
+    }
+
+    func testBoundaryNowEqualToAccessExpiryTreatedAsExpired() {
+        // The guard is `nowMs >= accessExpiresEpoch`, so equality = expired.
+        let nowMs = 1_000_000_000
+        let path = writeFixture(
+            accessExpiresMs: nowMs,
+            refreshExpiresMs: nowMs + 60_000
+        )
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: nowMs)
+        if case .importAccessExpired = decision {
+            // Expected — equality counts as expired, refresh still valid.
+        } else {
+            XCTFail("Equality-at-expiry should route through .importAccessExpired, got \(decision)")
+        }
+    }
+
+    func testBoundaryNowEqualToRefreshExpirySkipsImport() {
+        // Equality on the refresh expiry also counts as expired → skip.
+        let nowMs = 1_000_000_000
+        let path = writeFixture(
+            accessExpiresMs: nowMs - 60_000,
+            refreshExpiresMs: nowMs
+        )
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: nowMs)
+        XCTAssertEqual(decision, .skipRefreshExpired)
+    }
+
+    func testSkipsWhenFileMissing() {
+        let path = tmpDir.appendingPathComponent("does-not-exist.json").path
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: 1_000_000_000)
+        XCTAssertEqual(decision, .skipMissingFile)
+    }
+
+    func testSkipsWhenJsonUnparseable() {
+        let path = tmpDir.appendingPathComponent("guardian-token.json").path
+        try! "not-json".data(using: .utf8)!.write(to: URL(fileURLWithPath: path))
+        let decision = GuardianTokenFileReader.decideImport(fromPath: path, nowMs: 1_000_000_000)
+        XCTAssertEqual(decision, .skipUnparseableJson)
+    }
+}

--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -54,33 +54,105 @@ public enum GuardianTokenFileReader {
 
     // MARK: - Public API
 
+    /// Outcome of inspecting a guardian-token file on disk. Separates the
+    /// decision (expose to tests) from the keychain side effect (exercised
+    /// only through the public entry point). `importValid` corresponds to
+    /// both tokens still valid; `importAccessExpired` corresponds to an
+    /// access token past its expiry but a refresh token still inside its
+    /// window — the 401 retry interceptor will rotate it on the next
+    /// request, so we import it anyway instead of throwing it away.
+    enum ImportDecision: Equatable {
+        case skipMissingFile
+        case skipUnreadableFile
+        case skipUnparseableJson
+        case skipUnparseableTimestamps
+        case skipRefreshExpired
+        case importValid(ParsedCredentials)
+        case importAccessExpired(ParsedCredentials)
+
+        var isImport: Bool {
+            switch self {
+            case .importValid, .importAccessExpired: return true
+            default: return false
+            }
+        }
+    }
+
+    struct ParsedCredentials: Equatable {
+        let guardianPrincipalId: String
+        let accessToken: String
+        let accessExpiresEpoch: Int
+        let refreshToken: String
+        let refreshExpiresEpoch: Int
+        let refreshAfterEpoch: Int
+    }
+
     /// Attempts to load a CLI-persisted guardian token for the given assistant
     /// and populate `ActorTokenManager` with its credentials.
     ///
     /// Returns `true` if credentials were successfully imported, `false` if the
-    /// file does not exist, is unreadable, or contains expired data.
+    /// file does not exist, is unreadable, or the refresh token is already
+    /// expired.
     public static func importIfAvailable(assistantId: String) -> Bool {
         let path = guardianTokenPath(for: assistantId)
+        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
 
-        guard FileManager.default.fileExists(atPath: path) else {
+        let decision = decideImport(fromPath: path, nowMs: nowMs)
+
+        switch decision {
+        case .skipMissingFile:
             log.info("No guardian token file at \(path, privacy: .public)")
-            return false
+        case .skipUnreadableFile:
+            log.warning("Guardian token file exists but is unreadable: \(path, privacy: .public)")
+        case .skipUnparseableJson:
+            log.error("Failed to decode guardian token file at \(path, privacy: .public)")
+        case .skipUnparseableTimestamps:
+            log.warning("Guardian token file at \(path, privacy: .public) has unparseable timestamps — skipping import")
+        case .skipRefreshExpired:
+            log.info("Guardian token file has expired refresh token — skipping import")
+        case .importValid(let creds):
+            ActorTokenManager.storeCredentials(
+                actorToken: creds.accessToken,
+                actorTokenExpiresAt: creds.accessExpiresEpoch,
+                refreshToken: creds.refreshToken,
+                refreshTokenExpiresAt: creds.refreshExpiresEpoch,
+                refreshAfter: creds.refreshAfterEpoch,
+                guardianPrincipalId: creds.guardianPrincipalId
+            )
+            log.info("Imported guardian token from CLI file for assistant \(assistantId, privacy: .public)")
+        case .importAccessExpired(let creds):
+            ActorTokenManager.storeCredentials(
+                actorToken: creds.accessToken,
+                actorTokenExpiresAt: creds.accessExpiresEpoch,
+                refreshToken: creds.refreshToken,
+                refreshTokenExpiresAt: creds.refreshExpiresEpoch,
+                refreshAfter: creds.refreshAfterEpoch,
+                guardianPrincipalId: creds.guardianPrincipalId
+            )
+            log.info("Imported guardian token from CLI file for assistant \(assistantId, privacy: .public) (access expired; refresh still valid — will rotate on first 401)")
+        }
+
+        return decision.isImport
+    }
+
+    /// Pure decision function used by the public entry point and by tests.
+    /// Reads the token file at `path`, parses it, and returns whether the
+    /// client should import the credentials (and in which mode). Does not
+    /// mutate `ActorTokenManager` or any other process state.
+    static func decideImport(fromPath path: String, nowMs: Int) -> ImportDecision {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return .skipMissingFile
         }
 
         guard let data = FileManager.default.contents(atPath: path) else {
-            log.warning("Guardian token file exists but is unreadable: \(path, privacy: .public)")
-            return false
+            return .skipUnreadableFile
         }
 
         let token: GuardianTokenFile
         do {
             token = try JSONDecoder().decode(GuardianTokenFile.self, from: data)
-        } catch let decodingError as DecodingError {
-            log.error("Failed to decode guardian token file at \(path, privacy: .public): \(Self.describeDecodingError(decodingError), privacy: .public)")
-            return false
         } catch {
-            log.error("Failed to read guardian token file at \(path, privacy: .public): \(String(describing: error), privacy: .public)")
-            return false
+            return .skipUnparseableJson
         }
 
         // Convert timestamps to epoch milliseconds for ActorTokenManager.
@@ -88,33 +160,31 @@ public enum GuardianTokenFileReader {
         guard let accessExpiresEpoch = epochMillis(from: token.accessTokenExpiresAt),
               let refreshExpiresEpoch = epochMillis(from: token.refreshTokenExpiresAt),
               let refreshAfterEpoch = epochMillis(from: token.refreshAfter) else {
-            log.warning("""
-                Guardian token file at \(path, privacy: .public) has unparseable timestamps — skipping import. \
-                accessTokenExpiresAt=\(token.accessTokenExpiresAt.stringValue, privacy: .public), \
-                refreshTokenExpiresAt=\(token.refreshTokenExpiresAt.stringValue, privacy: .public), \
-                refreshAfter=\(token.refreshAfter.stringValue, privacy: .public)
-                """)
-            return false
+            return .skipUnparseableTimestamps
         }
 
-        // Skip if the access token is already expired.
-        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
-        if nowMs >= accessExpiresEpoch {
-            log.info("Guardian token file contains expired access token — skipping import")
-            return false
+        // Import as long as the refresh token is still valid. An expired
+        // access token is fine — the 401 retry interceptor will exchange
+        // the refresh token for a fresh access token on the next request.
+        // Skipping the import when only the access token is expired throws
+        // away a still-valid refresh token, leaving the client with no
+        // credentials and no path to recover without a manual re-pair.
+        if nowMs >= refreshExpiresEpoch {
+            return .skipRefreshExpired
         }
 
-        ActorTokenManager.storeCredentials(
-            actorToken: token.accessToken,
-            actorTokenExpiresAt: accessExpiresEpoch,
+        let creds = ParsedCredentials(
+            guardianPrincipalId: token.guardianPrincipalId,
+            accessToken: token.accessToken,
+            accessExpiresEpoch: accessExpiresEpoch,
             refreshToken: token.refreshToken,
-            refreshTokenExpiresAt: refreshExpiresEpoch,
-            refreshAfter: refreshAfterEpoch,
-            guardianPrincipalId: token.guardianPrincipalId
+            refreshExpiresEpoch: refreshExpiresEpoch,
+            refreshAfterEpoch: refreshAfterEpoch
         )
 
-        log.info("Imported guardian token from CLI file for assistant \(assistantId, privacy: .public)")
-        return true
+        return nowMs >= accessExpiresEpoch
+            ? .importAccessExpired(creds)
+            : .importValid(creds)
     }
 
     // MARK: - Path Resolution
@@ -127,33 +197,6 @@ public enum GuardianTokenFileReader {
             .appendingPathComponent(assistantId)
             .appendingPathComponent("guardian-token.json")
             .path
-    }
-
-    // MARK: - Error Descriptions
-
-    /// Produces a human-readable summary of a `DecodingError`, including the
-    /// JSON key path and expected type so schema mismatches are easy to diagnose.
-    private static func describeDecodingError(_ error: DecodingError) -> String {
-        switch error {
-        case .keyNotFound(let key, let context):
-            let path = Self.codingPath(context.codingPath)
-            return "missing key '\(key.stringValue)' at \(path.isEmpty ? "root" : path)"
-        case .typeMismatch(let type, let context):
-            let path = Self.codingPath(context.codingPath)
-            return "type mismatch for \(type) at \(path.isEmpty ? "root" : path): \(context.debugDescription)"
-        case .valueNotFound(let type, let context):
-            let path = Self.codingPath(context.codingPath)
-            return "null value for \(type) at \(path.isEmpty ? "root" : path)"
-        case .dataCorrupted(let context):
-            return "corrupted data: \(context.debugDescription)"
-        @unknown default:
-            return String(describing: error)
-        }
-    }
-
-    /// Joins a coding-key path into a dot-separated string like `"refreshToken.expiresAt"`.
-    private static func codingPath(_ keys: [CodingKey]) -> String {
-        keys.map(\.stringValue).joined(separator: ".")
     }
 
     // MARK: - Timestamp Parsing


### PR DESCRIPTION
## Summary

- Import guardian-token.json credentials when access is expired but refresh is still valid, instead of throwing them away. The retry interceptor rotates on the next request.
- Try `ActorCredentialRefresher.refresh` before the lockfile-guarded `/v1/guardian/init` fallback if a refresh token survives in the keychain — init 403s permanently after first use, so this is the only self-heal path for a stale-refresh-token scenario.
- Preserve cached avatar/traits on 401/5xx/transport errors and schedule one retry. Only 404 authoritatively clears cached state.

## Testing

Unit tests added for site 1 (`GuardianTokenFileReaderTests.swift`) covering the expired-access-but-refresh-valid case, boundary conditions on both expiry timestamps, and skip paths. Unit tests added for site 3 (`AvatarAppearanceManagerTransientFailureTests.swift`) covering the 404-vs-transient distinction across relevant status codes. Site 2 (`performInitialBootstrap` refresh-first fallback) is only meaningfully exercisable with a fixture gateway so no unit test is added there — the new code is a thin glue wrapper over `ActorCredentialRefresher.refresh` which is itself network-mediated.

## Original prompt

Fix transient bootstrap failures in the macOS client so they don't leave permanent nil state. Three sites, one shape:

1. **`clients/shared/App/Auth/GuardianTokenFileReader.swift`** (lines ~100-105): `importIfAvailable(assistantId:)` currently bails and returns `false` when the access token is already expired, which also throws away the still-valid refresh token. Instead, when the access token is expired but the refresh token is still valid (`nowMs < refreshExpiresEpoch`), import the credentials anyway — the 401 interceptor will refresh on the next request. Only skip when *both* tokens are expired.

2. **`clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift`** (`performInitialBootstrap`, lines ~244-296): when the HTTP `/v1/guardian/init` fallback returns 403 "Bootstrap already completed", the current code just retries the same init forever. Instead, if `ActorTokenManager.getRefreshToken()` is present, attempt `ActorCredentialRefresher.refresh(platform:deviceId:)` first — if it succeeds we're done, if it returns `.terminalError` fall through to the init retry loop (user will need manual re-pair). This gives a self-heal path for the common case where a stale refresh token lands alongside a locked-bootstrap gateway.

3. **`clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift`** (`fetchAvatarViaHTTP`, lines ~153-175): on HTTP failure or empty response, don't unconditionally clear `customAvatarImage`. If the failure is 401/transport error (transient, likely auth-race during bootstrap), keep the existing image and schedule one retry ~2s later. Only clear on 404 (the actual "no avatar exists" signal). Same shape for `fetchTraitsViaHTTP` — 404 is authoritative, 401/transport is transient.

Context: diagnosed when Velissa stopped loading after the access token expired. Root cause was a stale refresh token on disk (rotated server-side on Apr 16 without updating `~/.config/vellum-local/assistants/<id>/guardian-token.json`), but the client-side amplifier is that every transient failure during the bootstrap window becomes a permanent nil until file-watch events or manual intervention kick it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
