### PR TITLE
feat(slack): thread full ContentBlock[] through RenderableSlackMessage

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3441,6 +3441,54 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).toEqual([]);
   });
 
+  test("row content with interleaved text + tool_use still renders as tag-only text (PR 2 plumbing; tool_use elided by renderer)", () => {
+    // PR 2 plumbs `contentBlocks` through `rowToRenderable` so downstream
+    // consumers (PR 3) can access the original structured blocks. The
+    // renderer itself is unchanged — it still flattens to the text-only
+    // tag line via `extractPlainText`. This test pins down that a row
+    // persisted with `[text, tool_use]` produces output identical to a
+    // row persisted with just `[text]`; the tool_use is elided from the
+    // rendered transcript (preservation lands in PR 3).
+    const userMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_25,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    const assistantRowContent = JSON.stringify([
+      { type: "text", text: "looking it up" },
+      {
+        type: "tool_use",
+        id: "tu_1",
+        name: "search",
+        input: { q: "weather" },
+      },
+    ]);
+    const rows: SlackTranscriptInputRow[] = [
+      row("user", "what's the weather?", MS_14_25, metadataEnvelope(userMeta)),
+      {
+        role: "assistant",
+        content: assistantRowContent,
+        createdAt: MS_14_26,
+        metadata: metadataEnvelope(null),
+      },
+    ];
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "[14:25 @alice]: what's the weather?" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[14:26 @assistant]: looking it up" }],
+      },
+    ]);
+  });
+
   test("post-reconciliation: assistant rows with channelTs participate in thread tagging", () => {
     // Once `deliverReplyViaCallback` reconciles `channelTs` from the
     // gateway's response, assistant rows carry a fully-formed slackMeta

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1264,12 +1264,23 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
       ? "@assistant"
       : (slackMeta?.displayName ?? "@user");
 
+  let contentBlocks: ContentBlock[] = [];
+  try {
+    const parsed = JSON.parse(row.content);
+    if (Array.isArray(parsed)) {
+      contentBlocks = parsed as ContentBlock[];
+    }
+  } catch {
+    // Plain string row (legacy) — no structured blocks to preserve.
+  }
+
   return {
     role: row.role,
     content: extractPlainText(row.content),
     metadata: slackMeta,
     senderLabel,
     createdAt: row.createdAt,
+    contentBlocks,
   };
 }
 

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -683,3 +683,34 @@ describe("extractTagLineTexts", () => {
     expect(extractTagLineTexts([])).toEqual([]);
   });
 });
+
+// ── contentBlocks passthrough (PR 2 plumbing) ────────────────────────────────
+
+describe("renderSlackTranscript — contentBlocks field is ignored by renderer", () => {
+  // PR 2 adds an optional `contentBlocks` field on RenderableSlackMessage so
+  // downstream consumers (tool-block preservation in PR 3) can read the
+  // original structured blocks without re-parsing the row. The renderer
+  // itself is unchanged: output must be byte-identical whether or not
+  // `contentBlocks` is populated. This guards against accidental coupling
+  // — PR 3 will introduce the behavioural change in a follow-up.
+  test("renderer output is identical with and without contentBlocks populated", () => {
+    const base = userMsg(TS_14_25, "@alice", "hi there");
+    const withBlocks: RenderableSlackMessage = {
+      ...base,
+      contentBlocks: [
+        { type: "text", text: "hi there" },
+        { type: "tool_use", id: "tu_1", name: "search", input: { q: "x" } },
+      ],
+    };
+    const outWithout = renderSlackTranscript([base]);
+    const outWith = renderSlackTranscript([withBlocks]);
+    expect(outWith).toEqual(outWithout);
+    // Sanity: the tool_use block from contentBlocks must not leak into output.
+    const texts = outWith.flatMap((m) =>
+      m.content.map((b) => (b.type === "text" ? b.text : "")),
+    );
+    for (const t of texts) {
+      expect(t).not.toMatch(/tool_use/);
+    }
+  });
+});

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -16,7 +16,7 @@
 
 import { createHash } from "node:crypto";
 
-import type { Message } from "../../../providers/types.js";
+import type { ContentBlock, Message } from "../../../providers/types.js";
 import type { SlackMessageMetadata } from "./message-metadata.js";
 
 export interface RenderableSlackMessage {
@@ -28,6 +28,15 @@ export interface RenderableSlackMessage {
   senderLabel: string;
   /** Fallback sort key for legacy rows; ignored when metadata.channelTs is set. */
   createdAt: number;
+  /**
+   * Full structured content blocks parsed from the persisted row, when
+   * available. Optional so existing fixtures and callers that only need the
+   * flattened `content` string continue to compile. The current
+   * `renderSlackTranscript` implementation ignores this field — it exists so
+   * downstream consumers (tool-block preservation) can access the original
+   * `tool_use` / `tool_result` blocks without re-parsing the row.
+   */
+  readonly contentBlocks?: readonly ContentBlock[];
 }
 
 export interface RenderOptions {


### PR DESCRIPTION
## Summary
- Add optional contentBlocks field on RenderableSlackMessage
- Populate it from rowToRenderable by parsing the row's JSON content
- Renderer ignores the field; preservation lands in PR 3

Part of plan: slack-tool-block-preservation.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
