### PR TITLE
fix(macos): MeetStatusPanel renders on SSE reconnect mid-meeting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
@@ -19,14 +19,19 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MeetS
 ///
 /// The state transitions are driven purely by events:
 /// - `meet.joining` → `.joining(meetingId, url)`
-/// - `meet.joined`  → `.joined(meetingId, title, joinedAt = now)` ONLY if we
-///   previously saw a `meet.joining` for the same meeting. Out-of-order
-///   `meet.joined` (no preceding `meet.joining`) is ignored so the panel
-///   stays idle.
+/// - `meet.joined`  → `.joined(meetingId, title, joinedAt = now)`. When a
+///   preceding `meet.joining` is present for the same meeting, the joining
+///   URL is carried forward as the title. When `meet.joined` arrives without
+///   a prior `meet.joining` (e.g. the client reconnected its SSE stream
+///   mid-meeting), we still transition to `.joined` but use the meetingId as
+///   the title fallback — the daemon does not republish `meet.joining` on
+///   reconnect, so gating on it would leave the panel blank while the bot is
+///   demonstrably live.
 /// - `meet.error`   → `.error(reason)`
 /// - `meet.left`    → `.idle` (any in-flight state collapses to idle)
 ///
-/// Out-of-order `meet.left` with no in-flight state is a no-op.
+/// Out-of-order `meet.left` with no in-flight state is a no-op — if `.left`
+/// fires while idle, the meeting is over and there is nothing to render.
 @MainActor
 @Observable
 public final class MeetStatusViewModel {
@@ -74,19 +79,24 @@ public final class MeetStatusViewModel {
             state = .joining(meetingId: m.meetingId, url: m.url)
 
         case .meetJoined(let m):
-            // Only promote to `.joined` if we were already in a `.joining`
-            // state for this meeting. An out-of-order `meet.joined` with no
-            // preceding `meet.joining` is treated as stale and ignored —
-            // this is the acceptance-criteria "out-of-order events" guard.
-            guard case let .joining(existingId, url) = state,
-                  existingId == m.meetingId
-            else {
-                log.debug("Ignoring meet.joined without preceding meet.joining: \(m.meetingId, privacy: .public)")
-                return
+            // Carry the joining URL forward as the title when we saw a
+            // matching `meet.joining` for this meeting. Otherwise this is
+            // either a reconnect (the SSE stream dropped and resubscribed
+            // mid-meeting, so the daemon has already published `meet.joining`
+            // and will not republish it) or an event we observed before the
+            // view model was constructed. In both cases the bot is live, so
+            // we must transition into `.joined` anyway — using the meetingId
+            // as a title fallback until a later event populates real data.
+            let title: String
+            if case let .joining(existingId, url) = state, existingId == m.meetingId {
+                title = url
+            } else {
+                log.debug("meet.joined without preceding meet.joining — using meetingId as title fallback: \(m.meetingId, privacy: .public)")
+                title = m.meetingId
             }
             state = .joined(
                 meetingId: m.meetingId,
-                title: url,
+                title: title,
                 joinedAt: clock()
             )
 

--- a/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
@@ -155,9 +155,10 @@ final class MeetStatusPanelTests: XCTestCase {
 
     // MARK: - Out-of-order
 
-    /// A `meet.left` arriving while the panel is already idle (e.g. because
-    /// the client reconnected mid-meeting and missed `meet.joining`/
-    /// `meet.joined`) must not throw — and must leave the panel idle.
+    /// A `meet.left` arriving while the panel is already idle must not
+    /// throw — and must leave the panel idle. `meet.left` unambiguously means
+    /// the meeting is over, so there is nothing for the panel to render even
+    /// if we missed the preceding lifecycle events.
     func testLeftBeforeJoinedKeepsPanelIdle() async throws {
         let (vm, continuation) = makeViewModel()
         XCTAssertEqual(vm.state, .idle)
@@ -175,20 +176,33 @@ final class MeetStatusPanelTests: XCTestCase {
         XCTAssertEqual(vm.state, .idle)
     }
 
-    /// A `meet.joined` with no preceding `meet.joining` is stale (likely a
-    /// late event from a previous meeting that the client missed the join
-    /// event for). The state machine should ignore it rather than flip into
-    /// a bogus `.joined` state with a fabricated URL.
-    func testJoinedWithoutJoiningIsIgnored() async throws {
-        let (vm, continuation) = makeViewModel()
+    /// SSE reconnect mid-meeting — the daemon has already published
+    /// `meet.joining` before the client subscribed, so the next `meet.joined`
+    /// arrives with no matching prior state. The panel must still show the
+    /// live meeting (the bot is demonstrably in it), using the meetingId as
+    /// the title fallback until later events populate real data.
+    func testJoinedWithoutJoiningOnReconnectShowsPanel() async throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_700_777_777)
+        let (vm, continuation) = makeViewModel(fixedNow: fixedNow)
         XCTAssertEqual(vm.state, .idle)
 
         continuation.yield(.meetJoined(
-            MeetJoinedMessage(type: "meet.joined", meetingId: "phantom")
+            MeetJoinedMessage(type: "meet.joined", meetingId: "reconnect-meeting")
         ))
 
-        try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertEqual(vm.state, .idle)
+        try await waitUntil(timeout: 2.0) {
+            if case .joined = vm.state { return true }
+            return false
+        }
+
+        guard case let .joined(meetingId, title, joinedAt) = vm.state else {
+            return XCTFail("expected .joined state")
+        }
+        XCTAssertEqual(meetingId, "reconnect-meeting")
+        // With no prior `.joining` we fall back to the meetingId as a
+        // placeholder title until a richer event arrives.
+        XCTAssertEqual(title, "reconnect-meeting")
+        XCTAssertEqual(joinedAt, fixedNow)
     }
 
     // MARK: - Error


### PR DESCRIPTION
## Summary
Plan review gap fix. `MeetStatusViewModel` required a prior `meet.joining` before promoting `meet.joined` — so if the macOS client reconnected SSE mid-meeting it would stay idle forever despite the bot being live. Now `meet.joined` without prior `.joining` transitions directly to `.joined` with the meetingId as title fallback. `meet.left` without prior `.joined` still keeps the panel idle (the meeting is over; nothing to show).

**Gap:** MeetStatusViewModel stays idle forever on SSE reconnect during a live meeting
**Plan:** meet-phase-1-12-prime-time.md (review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
