### PR TITLE
meet-bot: pluggable avatar renderer registry + noop default

### DIFF
--- a/skills/meet-join/__tests__/config-schema.test.ts
+++ b/skills/meet-join/__tests__/config-schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  DEFAULT_AVATAR_DEVICE_PATH,
   DEFAULT_MEET_OBJECTION_KEYWORDS,
   DEFAULT_MEET_PROACTIVE_CHAT_KEYWORDS,
   MeetServiceSchema,
@@ -12,6 +13,12 @@ const DEFAULT_PROACTIVE_CHAT = {
   tier2DebounceMs: 5_000,
   escalationCooldownSec: 30,
   tier2MaxTranscriptSec: 30,
+};
+
+const DEFAULT_AVATAR = {
+  enabled: false,
+  renderer: "noop",
+  devicePath: DEFAULT_AVATAR_DEVICE_PATH,
 };
 
 describe("MeetServiceSchema", () => {
@@ -28,6 +35,7 @@ describe("MeetServiceSchema", () => {
       dockerNetwork: "bridge",
       maxMeetingMinutes: 240,
       proactiveChat: DEFAULT_PROACTIVE_CHAT,
+      avatar: DEFAULT_AVATAR,
     });
   });
 
@@ -56,7 +64,11 @@ describe("MeetServiceSchema", () => {
       maxMeetingMinutes: 60,
     };
     const parsed = MeetServiceSchema.parse(input);
-    expect(parsed).toEqual({ ...input, proactiveChat: DEFAULT_PROACTIVE_CHAT });
+    expect(parsed).toEqual({
+      ...input,
+      proactiveChat: DEFAULT_PROACTIVE_CHAT,
+      avatar: DEFAULT_AVATAR,
+    });
   });
 
   test("rejects negative maxMeetingMinutes", () => {
@@ -199,5 +211,68 @@ describe("MeetServiceSchema", () => {
     expect(parsed.joinName).toBe(null);
     expect(parsed.autoLeaveOnObjection).toBe(true);
     expect(parsed.maxMeetingMinutes).toBe(240);
+  });
+});
+
+describe("MeetServiceSchema.avatar", () => {
+  test("avatar defaults to disabled with the noop renderer", () => {
+    const parsed = MeetServiceSchema.parse({});
+    expect(parsed.avatar.enabled).toBe(false);
+    expect(parsed.avatar.renderer).toBe("noop");
+    expect(parsed.avatar.devicePath).toBe(DEFAULT_AVATAR_DEVICE_PATH);
+  });
+
+  test("accepts each renderer id in the documented enum", () => {
+    const ids = [
+      "noop",
+      "talking-head",
+      "simli",
+      "heygen",
+      "tavus",
+      "sadtalker",
+      "musetalk",
+    ];
+    for (const id of ids) {
+      const parsed = MeetServiceSchema.parse({
+        avatar: { enabled: true, renderer: id },
+      });
+      expect(parsed.avatar.renderer).toBe(id);
+    }
+  });
+
+  test("rejects an unknown renderer id", () => {
+    const result = MeetServiceSchema.safeParse({
+      avatar: { renderer: "not-a-renderer" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("per-renderer option blocks are all optional at the schema level", () => {
+    // Each renderer PR fills in its own required shape inside its
+    // `start()` implementation — the schema stays permissive so a
+    // partially-configured avatar block still round-trips through the
+    // config loader.
+    const parsed = MeetServiceSchema.parse({
+      avatar: {
+        enabled: true,
+        renderer: "simli",
+        simli: { apiKeyCredentialId: "credential-simli-prod" },
+      },
+    });
+    expect(parsed.avatar.renderer).toBe("simli");
+    expect(parsed.avatar.simli).toEqual({
+      apiKeyCredentialId: "credential-simli-prod",
+    });
+  });
+
+  test("devicePath can be overridden for non-default v4l2loopback nodes", () => {
+    const parsed = MeetServiceSchema.parse({
+      avatar: {
+        enabled: true,
+        renderer: "noop",
+        devicePath: "/dev/video11",
+      },
+    });
+    expect(parsed.avatar.devicePath).toBe("/dev/video11");
   });
 });

--- a/skills/meet-join/bot/__tests__/avatar-device-writer.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-device-writer.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for `attachDeviceWriter` — the glue that forwards an
+ * `AvatarRenderer`'s Y4M frames into an open v4l2 device sink.
+ *
+ * Coverage:
+ *   - Frames delivered to the renderer's `onFrame` channel are
+ *     forwarded to the sink when the FPS cap permits.
+ *   - Frames arriving inside the min-interval window are dropped
+ *     (`droppedCount` increments, `dispatchedCount` does not).
+ *   - `stop()` detaches the subscription — a frame emitted after
+ *     stop does not reach the sink.
+ *   - `stop()` is idempotent: repeat calls settle without throwing,
+ *     and the renderer's subscriber count is 0 after the first call.
+ *   - Sink write failures are counted as drops rather than bubbling
+ *     up (so the bot doesn't crash if the kernel buffer momentarily
+ *     back-pressures).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  __resetAvatarRegistryForTests,
+  attachDeviceWriter,
+  DEFAULT_MAX_FPS,
+  type Y4MFrame,
+} from "../src/media/avatar/index.js";
+
+import { FakeAvatarRenderer } from "./avatar-interface.test.js";
+
+function makeFrame(overrides: Partial<Y4MFrame> = {}): Y4MFrame {
+  return {
+    bytes: overrides.bytes ?? new Uint8Array([1, 2, 3, 4]),
+    timestamp: overrides.timestamp ?? 0,
+    width: overrides.width ?? 1280,
+    height: overrides.height ?? 720,
+  };
+}
+
+interface RecordingSink {
+  writes: Uint8Array[];
+  write(chunk: Uint8Array): boolean;
+}
+
+function makeSink(): RecordingSink {
+  const writes: Uint8Array[] = [];
+  return {
+    writes,
+    write(chunk: Uint8Array): boolean {
+      writes.push(chunk);
+      return true;
+    },
+  };
+}
+
+describe("attachDeviceWriter", () => {
+  beforeEach(() => {
+    __resetAvatarRegistryForTests();
+  });
+
+  test("forwards frames from renderer.onFrame to sink.write", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+
+    // Synthetic clock so we fully control the FPS gate.
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      maxFps: 30,
+      now: () => now,
+    });
+
+    const frameA = makeFrame({ timestamp: 1 });
+    renderer.emitFrame(frameA);
+    // Next allowed dispatch is now + 33ms (floor(1000/30))
+    now = 100;
+    const frameB = makeFrame({ timestamp: 2 });
+    renderer.emitFrame(frameB);
+
+    expect(sink.writes).toHaveLength(2);
+    expect(sink.writes[0]).toBe(frameA.bytes);
+    expect(sink.writes[1]).toBe(frameB.bytes);
+    expect(handle.dispatchedCount()).toBe(2);
+    expect(handle.droppedCount()).toBe(0);
+
+    handle.stop();
+  });
+
+  test("drops frames that arrive inside the FPS cap interval", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      maxFps: 30,
+      now: () => now,
+    });
+
+    // Frame 1 at t=0 → dispatched (first frame always clears).
+    renderer.emitFrame(makeFrame({ timestamp: 1 }));
+    // Frame 2 at t=10ms (< 33ms interval for 30 FPS) → dropped.
+    now = 10;
+    renderer.emitFrame(makeFrame({ timestamp: 2 }));
+    // Frame 3 at t=20ms (< 33ms) → dropped.
+    now = 20;
+    renderer.emitFrame(makeFrame({ timestamp: 3 }));
+    // Frame 4 at t=34ms (≥ 33ms) → dispatched.
+    now = 34;
+    renderer.emitFrame(makeFrame({ timestamp: 4 }));
+
+    expect(sink.writes).toHaveLength(2);
+    expect(handle.dispatchedCount()).toBe(2);
+    expect(handle.droppedCount()).toBe(2);
+
+    handle.stop();
+  });
+
+  test("uses the default FPS cap when unspecified", () => {
+    // Sanity: confirm DEFAULT_MAX_FPS is applied. The floor of 1000/30
+    // is 33ms, so two frames at t=0 and t=20 should collapse to 1.
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+    let now = 0;
+
+    expect(DEFAULT_MAX_FPS).toBe(30);
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      now: () => now,
+    });
+    renderer.emitFrame(makeFrame());
+    now = 20;
+    renderer.emitFrame(makeFrame());
+    expect(handle.dispatchedCount()).toBe(1);
+    expect(handle.droppedCount()).toBe(1);
+    handle.stop();
+  });
+
+  test("maxFps=Infinity disables the cap (every frame dispatched)", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      maxFps: Infinity,
+      now: () => now,
+    });
+    for (let i = 0; i < 10; i++) {
+      renderer.emitFrame(makeFrame({ timestamp: i }));
+      // Advance clock by 1ms per frame — far inside any sane FPS cap.
+      now += 1;
+    }
+    expect(handle.dispatchedCount()).toBe(10);
+    expect(handle.droppedCount()).toBe(0);
+    handle.stop();
+  });
+
+  test("stop() detaches the subscription — late frames do not reach sink", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      now: () => now,
+    });
+
+    renderer.emitFrame(makeFrame());
+    expect(sink.writes).toHaveLength(1);
+    // Renderer has one subscriber attached.
+    expect(renderer.subscriberCount()).toBe(1);
+
+    handle.stop();
+    // Subscriber list cleared after stop.
+    expect(renderer.subscriberCount()).toBe(0);
+
+    now = 500;
+    renderer.emitFrame(makeFrame());
+    // No additional writes despite the frame being emitted.
+    expect(sink.writes).toHaveLength(1);
+  });
+
+  test("stop() is idempotent — repeat calls settle without throwing", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      now: () => 0,
+    });
+    handle.stop();
+    handle.stop();
+    handle.stop();
+    // No subscriber leaks.
+    expect(renderer.subscriberCount()).toBe(0);
+  });
+
+  test("sink.write throwing counts as a drop (no crash)", () => {
+    const renderer = new FakeAvatarRenderer();
+    const angrySink = {
+      write(): boolean {
+        throw new Error("kernel buffer full");
+      },
+    };
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink: angrySink,
+      maxFps: 30,
+      now: () => now,
+    });
+
+    // Should not throw.
+    renderer.emitFrame(makeFrame());
+    expect(handle.dispatchedCount()).toBe(0);
+    expect(handle.droppedCount()).toBe(1);
+
+    handle.stop();
+  });
+
+  test("onFrameProcessed observer fires for every frame with dispatch decision", () => {
+    const renderer = new FakeAvatarRenderer();
+    const sink = makeSink();
+    const observed: Array<{ timestamp: number; dispatched: boolean }> = [];
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink,
+      maxFps: 30,
+      now: () => now,
+      onFrameProcessed: (frame, dispatched) => {
+        observed.push({ timestamp: frame.timestamp, dispatched });
+      },
+    });
+
+    renderer.emitFrame(makeFrame({ timestamp: 1 }));
+    now = 5;
+    renderer.emitFrame(makeFrame({ timestamp: 2 }));
+    now = 50;
+    renderer.emitFrame(makeFrame({ timestamp: 3 }));
+
+    expect(observed).toEqual([
+      { timestamp: 1, dispatched: true },
+      { timestamp: 2, dispatched: false },
+      { timestamp: 3, dispatched: true },
+    ]);
+
+    handle.stop();
+  });
+});

--- a/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
@@ -1,0 +1,467 @@
+/**
+ * HTTP-layer tests for the avatar routes: `/avatar/viseme`,
+ * `/avatar/enable`, `/avatar/disable`.
+ *
+ * Uses a stubbed device opener + the `FakeAvatarRenderer` fixture from
+ * `avatar-interface.test.ts` so the routes can be exercised on macOS
+ * developer machines with no real `/dev/video10`. The `resolveRenderer`
+ * override lets each test swap in whatever factory semantics it needs
+ * (successful renderer, renderer-throws-unavailable, renderer-returns-null)
+ * without going through the global registry.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  AvatarRendererUnavailableError,
+  type AvatarRenderer,
+  type VisemeEvent,
+} from "../src/media/avatar/index.js";
+import {
+  createHttpServer,
+  type HttpServerAvatarOptions,
+  type HttpServerHandle,
+} from "../src/control/http-server.js";
+import { BotState } from "../src/control/state.js";
+import type { VideoDeviceHandle } from "../src/media/video-device.js";
+
+import { FakeAvatarRenderer } from "./avatar-interface.test.js";
+
+const API_TOKEN = "test-token-xyz";
+
+function fakeDeviceHandle(): {
+  writes: Uint8Array[];
+  close: () => Promise<void>;
+  closed: () => boolean;
+  handle: VideoDeviceHandle;
+} {
+  const writes: Uint8Array[] = [];
+  let closed = false;
+  const handle: VideoDeviceHandle = {
+    devicePath: "/dev/video10",
+    width: 1280,
+    height: 720,
+    pixelFormat: "YU12",
+    sink: {
+      write(chunk: Uint8Array): boolean {
+        writes.push(chunk);
+        return true;
+      },
+      end(cb?: () => void): void {
+        cb?.();
+      },
+      destroy(): void {
+        /* noop */
+      },
+    },
+    async close(): Promise<void> {
+      closed = true;
+    },
+  };
+  return {
+    writes,
+    close: () => handle.close(),
+    closed: () => closed,
+    handle,
+  };
+}
+
+function makeServer(avatar: HttpServerAvatarOptions | undefined): {
+  server: HttpServerHandle;
+} {
+  const server = createHttpServer({
+    apiToken: API_TOKEN,
+    onLeave: () => {},
+    onSendChat: () => {},
+    onPlayAudio: () => {},
+    avatar,
+  });
+  return { server };
+}
+
+async function startOnRandomPort(server: HttpServerHandle): Promise<string> {
+  const { port } = await server.start(0);
+  return `http://127.0.0.1:${port}`;
+}
+
+describe("avatar HTTP routes", () => {
+  let server: HttpServerHandle | null = null;
+
+  beforeEach(() => {
+    BotState.__resetForTests();
+  });
+
+  afterEach(async () => {
+    if (server !== null) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // POST /avatar/viseme
+  // ---------------------------------------------------------------------
+
+  describe("POST /avatar/viseme", () => {
+    test("without an active renderer, returns 200 + dispatched=false", async () => {
+      const { server: s } = makeServer({
+        config: { enabled: false, renderer: "noop" },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/viseme`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ phoneme: "ah", weight: 0.5, timestamp: 10 }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ dispatched: false });
+    });
+
+    test("rejects a malformed viseme body with 400", async () => {
+      const { server: s } = makeServer({
+        config: { enabled: false, renderer: "noop" },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/viseme`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ phoneme: 42, weight: "zero" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("with an active viseme-consuming renderer, forwards to pushViseme", async () => {
+      const fake = new FakeAvatarRenderer({
+        id: "fake",
+        capabilities: { needsVisemes: true, needsAudio: false },
+      });
+      const device = fakeDeviceHandle();
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      // Flip the renderer on first.
+      const enable = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(enable.status).toBe(200);
+
+      const viseme: VisemeEvent = {
+        phoneme: "ah",
+        weight: 0.9,
+        timestamp: 123,
+      };
+      const res = await fetch(`${base}/avatar/viseme`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(viseme),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ dispatched: true });
+      expect(fake.visemes).toHaveLength(1);
+      expect(fake.visemes[0]).toEqual(viseme);
+    });
+
+    test("with a renderer that advertises needsVisemes=false, drops the event", async () => {
+      const fake = new FakeAvatarRenderer({
+        id: "fake",
+        capabilities: { needsVisemes: false, needsAudio: true },
+      });
+      const device = fakeDeviceHandle();
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+
+      const res = await fetch(`${base}/avatar/viseme`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ phoneme: "ah", weight: 0.5, timestamp: 0 }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ dispatched: false });
+      expect(fake.visemes).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // POST /avatar/enable
+  // ---------------------------------------------------------------------
+
+  describe("POST /avatar/enable", () => {
+    test("returns 503 when the avatar subsystem is not wired up", async () => {
+      const { server: s } = makeServer(undefined);
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(503);
+    });
+
+    test("returns 200 active=false when resolver returns null (noop / disabled)", async () => {
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "noop" },
+        resolveRenderer: () => null,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.enabled).toBe(true);
+      expect(body.active).toBe(false);
+      expect(body.renderer).toBe("noop");
+    });
+
+    test("returns 503 with rendererId + reason when resolver throws AvatarRendererUnavailableError", async () => {
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "simli" },
+        resolveRenderer: () => {
+          throw new AvatarRendererUnavailableError(
+            "simli",
+            "missing SIMLI_API_KEY credential",
+          );
+        },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.enabled).toBe(false);
+      expect(body.renderer).toBe("simli");
+      expect(body.error).toBe("missing SIMLI_API_KEY credential");
+    });
+
+    test("starts the renderer, opens the device, returns 200 active=true", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      let openCalls = 0;
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async (path) => {
+          openCalls += 1;
+          expect(path).toBe("/dev/video10");
+          return device.handle;
+        },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.enabled).toBe(true);
+      expect(body.active).toBe(true);
+      expect(body.renderer).toBe("fake");
+      expect(body.devicePath).toBe("/dev/video10");
+      expect(fake.startCount).toBe(1);
+      expect(openCalls).toBe(1);
+    });
+
+    test("a second /avatar/enable call is idempotent (alreadyRunning=true)", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      let openCalls = 0;
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => {
+          openCalls += 1;
+          return device.handle;
+        },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      const second = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(second.status).toBe(200);
+      const body = await second.json();
+      expect(body.alreadyRunning).toBe(true);
+      expect(fake.startCount).toBe(1);
+      expect(openCalls).toBe(1);
+    });
+
+    test("when the renderer starts but the device open fails, returns 503 and tears the renderer down", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => {
+          throw new Error("ENOENT /dev/video10 not present");
+        },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.enabled).toBe(false);
+      expect(body.renderer).toBe("fake");
+      expect(body.error).toContain("failed to open avatar device");
+      // Renderer was started, then stopped on the failure path.
+      expect(fake.startCount).toBe(1);
+      expect(fake.stopCount).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // POST /avatar/disable
+  // ---------------------------------------------------------------------
+
+  describe("POST /avatar/disable", () => {
+    test("returns 200 when avatar subsystem is not configured", async () => {
+      const { server: s } = makeServer(undefined);
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.disabled).toBe(true);
+    });
+
+    test("returns 200 wasActive=false when nothing is running", async () => {
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "noop" },
+        resolveRenderer: () => null,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.disabled).toBe(true);
+      expect(body.wasActive).toBe(false);
+    });
+
+    test("tears down the active renderer and device", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(fake.startCount).toBe(1);
+
+      const res = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.disabled).toBe(true);
+      expect(body.wasActive).toBe(true);
+      expect(fake.stopCount).toBe(1);
+      expect(device.closed()).toBe(true);
+    });
+
+    test("disable then re-enable produces a fresh renderer instance", async () => {
+      const first = new FakeAvatarRenderer({ id: "fake" });
+      const second = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const rendererQueue: AvatarRenderer[] = [first, second];
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => {
+          const next = rendererQueue.shift();
+          if (!next) throw new Error("rendererQueue exhausted");
+          return next;
+        },
+        openDevice: async () => device.handle,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(first.startCount).toBe(1);
+      expect(first.stopCount).toBe(1);
+      expect(second.startCount).toBe(1);
+      expect(second.stopCount).toBe(0);
+    });
+  });
+});

--- a/skills/meet-join/bot/__tests__/avatar-registry.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-registry.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the avatar renderer registry.
+ *
+ * Coverage:
+ *   - `registerAvatarRenderer` + `resolveAvatarRenderer` happy path.
+ *   - Short-circuit when `config.enabled === false` → `null`.
+ *   - Short-circuit when `config.renderer === "noop"` → `null`
+ *     (even though the noop renderer is registered — the registry
+ *     treats the explicit noop id as an off-switch at the resolver
+ *     level so callers can avoid starting a no-op lifecycle).
+ *   - `AvatarRendererUnavailableError` surfaces for unknown ids.
+ *   - Factory-thrown `AvatarRendererUnavailableError` propagates
+ *     through `resolveAvatarRenderer` unchanged.
+ *   - Registry isolation helper resets state between tests.
+ *
+ * We use {@link FakeAvatarRenderer} from `avatar-interface.test.ts` as
+ * the per-test renderer fixture so the factory shape under test is the
+ * same shape future renderer PRs will implement.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  AvatarRendererUnavailableError,
+  __resetAvatarRegistryForTests,
+  isAvatarRendererRegistered,
+  listRegisteredAvatarRenderers,
+  registerAvatarRenderer,
+  resolveAvatarRenderer,
+  type AvatarConfig,
+  type AvatarRendererDeps,
+} from "../src/media/avatar/index.js";
+
+import { FakeAvatarRenderer } from "./avatar-interface.test.js";
+
+function makeConfig(overrides: Partial<AvatarConfig> = {}): AvatarConfig {
+  return {
+    enabled: true,
+    renderer: "fake",
+    ...overrides,
+  };
+}
+
+const noDeps: AvatarRendererDeps = {};
+
+describe("resolveAvatarRenderer", () => {
+  afterEach(() => {
+    __resetAvatarRegistryForTests();
+  });
+
+  test("returns null when `config.enabled` is false", () => {
+    // Register a fake so we can prove the short-circuit fires BEFORE
+    // the factory lookup — the factory must not be invoked.
+    let invocations = 0;
+    registerAvatarRenderer("fake", () => {
+      invocations += 1;
+      return new FakeAvatarRenderer();
+    });
+
+    const renderer = resolveAvatarRenderer(
+      makeConfig({ enabled: false }),
+      noDeps,
+    );
+    expect(renderer).toBeNull();
+    expect(invocations).toBe(0);
+  });
+
+  test("returns null when `config.renderer` is noop (regardless of registration)", () => {
+    // Register noop so the factory exists; we still expect `null`
+    // because the resolver treats noop as an off-switch at the
+    // resolver level.
+    let invocations = 0;
+    registerAvatarRenderer("noop", () => {
+      invocations += 1;
+      return new FakeAvatarRenderer({ id: "noop" });
+    });
+
+    const renderer = resolveAvatarRenderer(
+      makeConfig({ renderer: "noop" }),
+      noDeps,
+    );
+    expect(renderer).toBeNull();
+    expect(invocations).toBe(0);
+  });
+
+  test("resolves a registered factory by id", () => {
+    const constructed: FakeAvatarRenderer[] = [];
+    registerAvatarRenderer("fake", () => {
+      const r = new FakeAvatarRenderer();
+      constructed.push(r);
+      return r;
+    });
+
+    const renderer = resolveAvatarRenderer(makeConfig(), noDeps);
+    expect(renderer).not.toBeNull();
+    expect(renderer).toBeInstanceOf(FakeAvatarRenderer);
+    expect(constructed).toHaveLength(1);
+    expect(renderer).toBe(constructed[0]);
+  });
+
+  test("forwards the caller's config + deps into the factory", () => {
+    const captured: Array<{
+      config: AvatarConfig;
+      deps: AvatarRendererDeps;
+    }> = [];
+    registerAvatarRenderer("fake", (config, deps) => {
+      captured.push({ config, deps });
+      return new FakeAvatarRenderer();
+    });
+
+    const deps: AvatarRendererDeps = {
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    };
+    const config: AvatarConfig = makeConfig({
+      apiKey: "X",
+      extraField: 42,
+    });
+    resolveAvatarRenderer(config, deps);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.config).toEqual(config);
+    expect(captured[0]!.deps).toBe(deps);
+  });
+
+  test("each resolve call produces a fresh instance", () => {
+    registerAvatarRenderer("fake", () => new FakeAvatarRenderer());
+    const a = resolveAvatarRenderer(makeConfig(), noDeps);
+    const b = resolveAvatarRenderer(makeConfig(), noDeps);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a).not.toBe(b);
+  });
+
+  test("throws AvatarRendererUnavailableError for an unknown id", () => {
+    // Nothing registered → any id is unknown.
+    let err: unknown;
+    try {
+      resolveAvatarRenderer(makeConfig({ renderer: "nope" }), noDeps);
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const avatarErr = err as AvatarRendererUnavailableError;
+    expect(avatarErr.rendererId).toBe("nope");
+    expect(avatarErr.reason).toContain("no factory registered");
+    expect(avatarErr.reason).toContain("nope");
+  });
+
+  test("unknown-id error lists available ids for diagnostics", () => {
+    registerAvatarRenderer("fake", () => new FakeAvatarRenderer());
+    registerAvatarRenderer("other", () => new FakeAvatarRenderer({ id: "other" }));
+
+    let err: unknown;
+    try {
+      resolveAvatarRenderer(makeConfig({ renderer: "missing" }), noDeps);
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const message = (err as AvatarRendererUnavailableError).reason;
+    expect(message).toContain("fake");
+    expect(message).toContain("other");
+  });
+
+  test("propagates AvatarRendererUnavailableError thrown by the factory", () => {
+    registerAvatarRenderer("simli", () => {
+      throw new AvatarRendererUnavailableError(
+        "simli",
+        "missing SIMLI_API_KEY credential",
+      );
+    });
+
+    let err: unknown;
+    try {
+      resolveAvatarRenderer(makeConfig({ renderer: "simli" }), noDeps);
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const avatarErr = err as AvatarRendererUnavailableError;
+    expect(avatarErr.rendererId).toBe("simli");
+    expect(avatarErr.reason).toBe("missing SIMLI_API_KEY credential");
+  });
+
+  test("non-AvatarRendererUnavailableError thrown by factory propagates as-is", () => {
+    registerAvatarRenderer("broken", () => {
+      throw new TypeError("unexpected factory bug");
+    });
+
+    expect(() => {
+      resolveAvatarRenderer(makeConfig({ renderer: "broken" }), noDeps);
+    }).toThrow(TypeError);
+  });
+});
+
+describe("registerAvatarRenderer", () => {
+  afterEach(() => {
+    __resetAvatarRegistryForTests();
+  });
+
+  test("later registration replaces an earlier one for the same id", () => {
+    const firstRenderer = new FakeAvatarRenderer({ id: "fake" });
+    const secondRenderer = new FakeAvatarRenderer({ id: "fake" });
+
+    registerAvatarRenderer("fake", () => firstRenderer);
+    registerAvatarRenderer("fake", () => secondRenderer);
+
+    const resolved = resolveAvatarRenderer(
+      { enabled: true, renderer: "fake" },
+      noDeps,
+    );
+    expect(resolved).toBe(secondRenderer);
+  });
+
+  test("isAvatarRendererRegistered reflects registration state", () => {
+    expect(isAvatarRendererRegistered("fake")).toBe(false);
+    registerAvatarRenderer("fake", () => new FakeAvatarRenderer());
+    expect(isAvatarRendererRegistered("fake")).toBe(true);
+    __resetAvatarRegistryForTests();
+    expect(isAvatarRendererRegistered("fake")).toBe(false);
+  });
+
+  test("listRegisteredAvatarRenderers returns sorted ids", () => {
+    registerAvatarRenderer("simli", () => new FakeAvatarRenderer({ id: "simli" }));
+    registerAvatarRenderer("noop", () => new FakeAvatarRenderer({ id: "noop" }));
+    registerAvatarRenderer("alpha", () => new FakeAvatarRenderer({ id: "alpha" }));
+    expect(listRegisteredAvatarRenderers()).toEqual(["alpha", "noop", "simli"]);
+  });
+});
+
+describe("noop renderer self-registration", () => {
+  test("the resolver short-circuits renderer === 'noop' even after a reset", () => {
+    // The noop file's import-time `registerAvatarRenderer("noop", ...)`
+    // call ran once when the barrel was first loaded. Because the
+    // registry's internal Map is a module-local singleton and ES module
+    // imports are cached, re-importing the file doesn't re-run the
+    // side effect — so `__resetAvatarRegistryForTests()` alone would
+    // leave the registry empty here.
+    //
+    // What matters for the noop path is that `resolveAvatarRenderer`
+    // short-circuits on `renderer === "noop"` AT THE RESOLVER LEVEL
+    // without needing a factory to exist. That's the invariant
+    // callers rely on — they never have to register anything to use
+    // the "off" state.
+    __resetAvatarRegistryForTests();
+    expect(isAvatarRendererRegistered("noop")).toBe(false);
+    const renderer = resolveAvatarRenderer(
+      { enabled: true, renderer: "noop" },
+      noDeps,
+    );
+    expect(renderer).toBeNull();
+  });
+});

--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -162,6 +162,9 @@ function makeDeps(opts: MakeDepsOpts = {}): {
     xvfbDisplay: ":99",
     chromeUserDataRoot: "/tmp/chrome-profile",
     avatarEnabled: false,
+    avatarRenderer: "noop",
+    avatarConfigJson: undefined,
+    avatarDevicePath: undefined,
   };
 
   const daemonClient: DaemonClientLike = {

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -9,6 +9,9 @@
  *   - `POST /send_chat`               — post a chat message into the Meet chat panel.
  *   - `POST /play_audio`              — stream raw PCM into pacat (Phase 3).
  *   - `DELETE /play_audio/:streamId`  — cancel an in-flight playback (barge-in).
+ *   - `POST /avatar/enable`           — start the configured avatar renderer + wire its frames to `/dev/video10`.
+ *   - `POST /avatar/disable`          — tear down the renderer + detach the device writer.
+ *   - `POST /avatar/viseme`           — forward a viseme event into the active renderer (no-op when disabled).
  *
  * Every mutating route validates its body against the corresponding Zod
  * schema from the contracts barrel so command shapes stay in sync with
@@ -27,6 +30,17 @@ import {
 import { Hono, type Context } from "hono";
 import { randomUUID } from "node:crypto";
 
+import {
+  attachDeviceWriter,
+  AvatarRendererUnavailableError,
+  resolveAvatarRenderer,
+  type AvatarConfig,
+  type AvatarRenderer,
+  type DeviceWriterHandle,
+  type VisemeEvent,
+} from "../media/avatar/index.js";
+import type { VideoDeviceHandle } from "../media/video-device.js";
+import { openVideoDevice as defaultOpenVideoDevice } from "../media/video-device.js";
 import {
   startAudioPlayback,
   type AudioPlaybackHandle,
@@ -88,6 +102,61 @@ export interface CreateHttpServerOptions extends HttpServerCallbacks {
    * child process.
    */
   playbackSpawnOptions?: StartAudioPlaybackOptions;
+  /**
+   * Avatar-subsystem options. When absent, the `/avatar/*` routes still
+   * mount (the surface is always present for a consistent API) but every
+   * route returns 503 with an "avatar disabled" body, so callers that
+   * POST to `/avatar/enable` get a clear error rather than silent
+   * success. Populated by `main.ts` at boot when the avatar feature is
+   * opted into via `AVATAR_ENABLED=1`.
+   */
+  avatar?: HttpServerAvatarOptions;
+}
+
+/**
+ * Configuration handed to `createHttpServer` when the avatar subsystem
+ * is available. Mirrors the dependency-injection pattern the rest of
+ * the bot uses so tests can stub out the registry, the device opener,
+ * and the config without touching real v4l2 devices.
+ */
+export interface HttpServerAvatarOptions {
+  /**
+   * Fully-resolved `services.meet.avatar.*` config block the daemon
+   * passed down via env vars. Contains at least `renderer` + `enabled`;
+   * renderer-specific sub-objects are accessed by name inside each
+   * factory. Credentials are already resolved to raw values (the bot
+   * has no vault access) so any credential field in this object is
+   * safe to read directly.
+   */
+  config: AvatarConfig;
+  /**
+   * Renderer-resolver override. Defaults to
+   * {@link resolveAvatarRenderer}; tests swap in a lambda that returns
+   * a `FakeAvatarRenderer` so the HTTP flow can be exercised without
+   * registering a real backend.
+   */
+  resolveRenderer?: (
+    config: AvatarConfig,
+  ) => AvatarRenderer | null;
+  /**
+   * Device opener override. Defaults to
+   * {@link defaultOpenVideoDevice}; tests provide a shim that returns
+   * an in-memory sink so `/avatar/enable` can run without a real
+   * `/dev/video10` on the test host. When absent, the default is used.
+   */
+  openDevice?: (devicePath: string) => Promise<VideoDeviceHandle>;
+  /**
+   * Explicit device path override. When absent, the runtime falls
+   * back to whatever default the device opener uses (today
+   * `/dev/video10`).
+   */
+  devicePath?: string;
+  /**
+   * Maximum FPS cap applied to renderer output before it reaches the
+   * device sink. Defaults to the module default; kept configurable so
+   * tests can validate FPS-gating behavior.
+   */
+  maxFps?: number;
 }
 
 export interface HttpServerHandle {
@@ -130,8 +199,18 @@ export function createHttpServer(
     onPlayAudio,
     startPlayback,
     playbackSpawnOptions,
+    avatar,
   } = options;
   const playbackFactory = startPlayback ?? startAudioPlayback;
+
+  // Avatar state — nulls when the subsystem isn't active. Guarded by a
+  // serialization lock (`avatarMutationChain`) so concurrent `/avatar/enable`
+  // + `/avatar/disable` requests can't interleave a half-torn-down renderer
+  // with a fresh one.
+  let avatarRenderer: AvatarRenderer | null = null;
+  let avatarDeviceHandle: VideoDeviceHandle | null = null;
+  let avatarDeviceWriter: DeviceWriterHandle | null = null;
+  let avatarMutationChain: Promise<unknown> = Promise.resolve();
 
   const activeStreams = new Map<string, ActiveStream>();
 
@@ -472,6 +551,250 @@ export function createHttpServer(
   });
 
   // -------------------------------------------------------------------------
+  // POST /avatar/viseme — forward a viseme event to the active renderer.
+  //
+  // Body shape must match `VisemeEvent` from
+  // `../media/avatar/types.ts` — the same shape the daemon's
+  // `tts-lipsync.ts` forwarder POSTs. When no renderer is active (the
+  // feature is off, or `/avatar/enable` has not yet been called), the
+  // event is dropped with a 200 so the forwarder doesn't buffer /
+  // retry. When the active renderer advertises `needsVisemes: false`,
+  // the event is similarly dropped without calling the renderer — the
+  // drop is cheap enough that the branch is just a belt-and-suspenders
+  // gate in case a renderer forgets to self-check.
+  // -------------------------------------------------------------------------
+
+  app.post("/avatar/viseme", async (c) => {
+    const body = await readJson(c);
+    const parsed = parseVisemeEvent(body);
+    if (!parsed) {
+      return c.json({ error: "invalid viseme event body" }, 400);
+    }
+    // Drop silently when the renderer isn't active. Keeping a 200 here
+    // means the daemon's fire-and-forget forwarder doesn't flood retry
+    // traffic against a bot that simply hasn't flipped the renderer on.
+    if (!avatarRenderer) {
+      return c.json({ dispatched: false }, 200);
+    }
+    if (!avatarRenderer.capabilities.needsVisemes) {
+      return c.json({ dispatched: false }, 200);
+    }
+    try {
+      avatarRenderer.pushViseme(parsed);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json(
+        { dispatched: false, error: `pushViseme threw: ${message}` },
+        500,
+      );
+    }
+    return c.json({ dispatched: true }, 200);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /avatar/enable — start the configured renderer + attach the
+  // device writer. Concurrency-safe via `avatarMutationChain` so racing
+  // enables don't produce two live renderers on one device.
+  // -------------------------------------------------------------------------
+
+  app.post("/avatar/enable", async (c) => {
+    if (!avatar) {
+      return c.json(
+        {
+          enabled: false,
+          error: "avatar subsystem disabled (AVATAR_ENABLED not set)",
+        },
+        503,
+      );
+    }
+    const previous = avatarMutationChain;
+    let release!: (v: unknown) => void;
+    avatarMutationChain = new Promise((resolve) => {
+      release = resolve;
+    });
+    try {
+      await previous;
+    } catch {
+      // A prior mutation failed; we still hold the lock and can proceed.
+    }
+    try {
+      // Idempotent: if a renderer is already running, just return
+      // success so the daemon's retry path doesn't thrash the device.
+      if (avatarRenderer) {
+        return c.json(
+          {
+            enabled: true,
+            renderer: avatarRenderer.id,
+            alreadyRunning: true,
+          },
+          200,
+        );
+      }
+
+      let renderer: AvatarRenderer | null;
+      try {
+        const resolveFn =
+          avatar.resolveRenderer ?? ((config) => resolveAvatarRenderer(config, {}));
+        renderer = resolveFn(avatar.config);
+      } catch (err) {
+        if (err instanceof AvatarRendererUnavailableError) {
+          return c.json(
+            {
+              enabled: false,
+              renderer: err.rendererId,
+              error: err.reason,
+            },
+            503,
+          );
+        }
+        throw err;
+      }
+
+      // `null` means "noop / disabled at config level" — return 200
+      // because the feature is behaving as configured. No device
+      // attachment happens, and the bot's camera track stays absent
+      // (identical to phase 3 behavior).
+      if (!renderer) {
+        return c.json(
+          {
+            enabled: true,
+            renderer: "noop",
+            active: false,
+          },
+          200,
+        );
+      }
+
+      // Start the renderer BEFORE opening the device so a
+      // construction-time `AvatarRendererUnavailableError` thrown
+      // from `start()` doesn't leak a held file descriptor.
+      try {
+        await renderer.start();
+      } catch (err) {
+        if (err instanceof AvatarRendererUnavailableError) {
+          return c.json(
+            {
+              enabled: false,
+              renderer: err.rendererId,
+              error: err.reason,
+            },
+            503,
+          );
+        }
+        throw err;
+      }
+
+      const openDeviceFn = avatar.openDevice ?? defaultOpenVideoDevice;
+      let deviceHandle: VideoDeviceHandle;
+      try {
+        deviceHandle = avatar.devicePath
+          ? await openDeviceFn(avatar.devicePath)
+          : await openDeviceFn("/dev/video10");
+      } catch (err) {
+        // If the device couldn't be opened, tear the renderer down so
+        // we don't leak a live GPU session or tab.
+        await renderer.stop().catch(() => {});
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json(
+          {
+            enabled: false,
+            renderer: renderer.id,
+            error: `failed to open avatar device: ${message}`,
+          },
+          503,
+        );
+      }
+
+      const writer = attachDeviceWriter({
+        renderer,
+        sink: deviceHandle.sink,
+        maxFps: avatar.maxFps,
+      });
+
+      avatarRenderer = renderer;
+      avatarDeviceHandle = deviceHandle;
+      avatarDeviceWriter = writer;
+
+      return c.json(
+        {
+          enabled: true,
+          renderer: renderer.id,
+          active: true,
+          devicePath: deviceHandle.devicePath,
+        },
+        200,
+      );
+    } finally {
+      release(undefined);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /avatar/disable — detach the writer, stop the renderer, close
+  // the device. Idempotent: returns 200 even when nothing is running.
+  // -------------------------------------------------------------------------
+
+  app.post("/avatar/disable", async (c) => {
+    if (!avatar) {
+      return c.json(
+        {
+          disabled: true,
+          reason: "avatar subsystem disabled (AVATAR_ENABLED not set)",
+        },
+        200,
+      );
+    }
+    const previous = avatarMutationChain;
+    let release!: (v: unknown) => void;
+    avatarMutationChain = new Promise((resolve) => {
+      release = resolve;
+    });
+    try {
+      await previous;
+    } catch {
+      /* previous mutation error; proceed with teardown */
+    }
+    try {
+      const writer = avatarDeviceWriter;
+      const device = avatarDeviceHandle;
+      const renderer = avatarRenderer;
+
+      avatarDeviceWriter = null;
+      avatarDeviceHandle = null;
+      avatarRenderer = null;
+
+      // Teardown order (reverse of setup): writer → device → renderer.
+      if (writer) {
+        try {
+          writer.stop();
+        } catch {
+          /* best-effort */
+        }
+      }
+      if (device) {
+        await device.close().catch(() => {
+          /* best-effort */
+        });
+      }
+      if (renderer) {
+        await renderer.stop().catch(() => {
+          /* best-effort */
+        });
+      }
+
+      return c.json(
+        {
+          disabled: true,
+          wasActive: renderer !== null,
+        },
+        200,
+      );
+    } finally {
+      release(undefined);
+    }
+  });
+
+  // -------------------------------------------------------------------------
   // Lifecycle — Bun's native server as the listener.
   // -------------------------------------------------------------------------
 
@@ -513,4 +836,34 @@ async function readJson(c: Context): Promise<unknown> {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Validate `/avatar/viseme` request bodies against the `VisemeEvent`
+ * shape declared in `../media/avatar/types.ts` without bringing zod
+ * into the bot's runtime surface. The avatar module is deliberately
+ * schema-free (it's shared with hosted renderer factories that may
+ * run in sandboxed environments), so we hand-roll the predicate here.
+ *
+ * Accepts `phoneme: string`, `weight: number`, `timestamp: number`.
+ * Returns `null` for any shape mismatch so the route can reply with a
+ * generic 400 — the daemon's `tts-lipsync.ts` forwarder already tolerates
+ * 4xx/5xx from this route, so surfacing specific issues isn't worth the
+ * extra surface.
+ */
+function parseVisemeEvent(body: unknown): VisemeEvent | null {
+  if (!body || typeof body !== "object") return null;
+  const raw = body as Record<string, unknown>;
+  if (typeof raw.phoneme !== "string") return null;
+  if (typeof raw.weight !== "number" || !Number.isFinite(raw.weight)) {
+    return null;
+  }
+  if (typeof raw.timestamp !== "number" || !Number.isFinite(raw.timestamp)) {
+    return null;
+  }
+  return {
+    phoneme: raw.phoneme,
+    weight: raw.weight,
+    timestamp: raw.timestamp,
+  };
 }

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -70,10 +70,19 @@ import { startXvfb, stopXvfb, type XvfbHandle } from "./browser/xvfb.js";
 import { DaemonClient } from "./control/daemon-client.js";
 import {
   createHttpServer,
+  type HttpServerAvatarOptions,
   type HttpServerCallbacks,
   type HttpServerHandle,
 } from "./control/http-server.js";
 import { BotState } from "./control/state.js";
+// Importing the avatar barrel has the side effect of registering the noop
+// factory. Individual renderer-backend PRs extend this list with their own
+// side-effect imports.
+import {
+  AvatarRendererUnavailableError,
+  resolveAvatarRenderer,
+  type AvatarConfig,
+} from "./media/avatar/index.js";
 import {
   startAudioCapture,
   type AudioCaptureHandle,
@@ -125,6 +134,28 @@ interface BotEnv {
    * has the Meet avatar feature enabled.
    */
   avatarEnabled: boolean;
+  /**
+   * Phase 4 renderer selector. Defaults to `"noop"` (safe fallback)
+   * when unset. Drives which factory the registry resolves when the
+   * daemon calls `/avatar/enable`. The session-manager sets this env
+   * from `services.meet.avatar.renderer` on the bot container.
+   */
+  avatarRenderer: string;
+  /**
+   * Optional JSON-encoded avatar-config bundle. The session-manager
+   * serializes the fully-resolved `services.meet.avatar.*` block (with
+   * vault-resolved credentials substituted in) and passes it as a
+   * single env var so the bot can hand the whole thing to each
+   * renderer factory without having to juggle a dozen env vars.
+   */
+  avatarConfigJson: string | undefined;
+  /**
+   * Explicit device-path override. Mirrors
+   * `services.meet.avatar.devicePath` from the daemon config. When
+   * unset, the bot falls back to `/dev/video10` (the default
+   * {@link launchChrome} also uses).
+   */
+  avatarDevicePath: string | undefined;
 }
 
 /**
@@ -162,6 +193,9 @@ function readEnv(env: NodeJS.ProcessEnv = process.env): BotEnv {
     xvfbDisplay: env.XVFB_DISPLAY ?? ":99",
     chromeUserDataRoot: env.CHROME_USER_DATA_ROOT ?? "/tmp/chrome-profile",
     avatarEnabled: parseBooleanEnv(env.AVATAR_ENABLED),
+    avatarRenderer: env.AVATAR_RENDERER ?? "noop",
+    avatarConfigJson: env.AVATAR_CONFIG_JSON,
+    avatarDevicePath: env.AVATAR_DEVICE_PATH,
   };
 }
 
@@ -211,7 +245,10 @@ export interface BotDeps {
     onError: (err: Error) => void;
   }) => DaemonClientLike;
   createHttpServer: (
-    opts: HttpServerCallbacks & { apiToken: string },
+    opts: HttpServerCallbacks & {
+      apiToken: string;
+      avatar?: HttpServerAvatarOptions;
+    },
   ) => HttpServerHandle;
   /**
    * Ensure a directory exists (recursive). Exposed as a dep so tests can
@@ -754,7 +791,19 @@ export async function runBot(deps: BotDeps): Promise<void> {
 
     // ---------------------------------------------------------------------
     // Step 8 — HTTP control surface.
+    //
+    // When `AVATAR_ENABLED=1` is set, construct the avatar options bag
+    // the server needs to wire the `/avatar/*` routes. We ALSO eagerly
+    // attempt to resolve the configured renderer here so a misconfig
+    // (missing credential, bad id, unreachable sidecar) surfaces in
+    // the bot boot log rather than the first time the agent tries to
+    // turn the avatar on. Note that we intentionally only CONSTRUCT —
+    // we do not call `start()` — so an eager construction failure
+    // just logs; the renderer is actually started on the daemon's
+    // `/avatar/enable` HTTP call.
     // ---------------------------------------------------------------------
+    const avatarHttpOptions = buildAvatarHttpOptions(env, deps);
+
     subsystems.httpServer = deps.createHttpServer({
       apiToken: botApiToken,
       onLeave: (reason) => {
@@ -768,6 +817,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
       onPlayAudio: () => {
         // Phase 3 will replace the 501 stub with a real implementation.
       },
+      avatar: avatarHttpOptions,
     });
     await subsystems.httpServer.start(env.httpPort);
 
@@ -952,6 +1002,66 @@ export async function runBot(deps: BotDeps): Promise<void> {
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Assemble the avatar options bag passed to `createHttpServer` when the
+ * avatar feature is enabled. Returns `undefined` when
+ * `AVATAR_ENABLED=0` (or unset) so the HTTP server short-circuits
+ * `/avatar/*` routes with 503. Also performs an eager construction
+ * probe: if the configured renderer can't be resolved the failure is
+ * logged — but we do NOT bail the bot boot, since the renderer is not
+ * strictly required for the meeting to proceed.
+ */
+function buildAvatarHttpOptions(
+  env: BotEnv,
+  deps: BotDeps,
+): HttpServerAvatarOptions | undefined {
+  if (!env.avatarEnabled) return undefined;
+
+  // Parse the JSON-encoded config blob the daemon passed down. Fall
+  // back to a minimal config derived from `AVATAR_RENDERER` + the
+  // device-path env so tests and operators can exercise the path
+  // without populating the full blob.
+  let parsed: Record<string, unknown> | null = null;
+  if (env.avatarConfigJson) {
+    try {
+      const raw = JSON.parse(env.avatarConfigJson);
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        parsed = raw as Record<string, unknown>;
+      }
+    } catch (err) {
+      deps.logError(
+        `meet-bot: AVATAR_CONFIG_JSON is not valid JSON: ${errMsg(err)} — falling back to env defaults`,
+      );
+    }
+  }
+
+  const config: AvatarConfig = {
+    ...(parsed ?? {}),
+    enabled: true,
+    renderer: env.avatarRenderer,
+  };
+
+  // Eager construction probe — non-fatal on failure.
+  try {
+    resolveAvatarRenderer(config, {});
+  } catch (err) {
+    if (err instanceof AvatarRendererUnavailableError) {
+      deps.logError(
+        `meet-bot: avatar renderer "${err.rendererId}" unavailable at boot: ${err.reason} (will respond 503 on /avatar/enable)`,
+      );
+    } else {
+      deps.logError(
+        `meet-bot: avatar renderer eager-probe threw: ${errMsg(err)} (will surface on /avatar/enable)`,
+      );
+    }
+  }
+
+  return {
+    config,
+    ...(env.avatarDevicePath ? { devicePath: env.avatarDevicePath } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/meet-join/bot/src/media/avatar/device-writer.ts
+++ b/skills/meet-join/bot/src/media/avatar/device-writer.ts
@@ -1,0 +1,155 @@
+/**
+ * Device writer — pipes an {@link AvatarRenderer}'s Y4M frames into an
+ * open {@link VideoDeviceHandle}.
+ *
+ * Subscribes to the renderer's `onFrame` channel on `start()`. Each
+ * arriving frame is rate-limited against a configurable max-FPS cap
+ * (default 30 FPS) and then forwarded to the device handle's `sink`.
+ * The cap exists because hosted backends (Simli, HeyGen, Tavus) can
+ * burst frames faster than the v4l2 ring can consume them — flooding
+ * the device risks dropped frames and, in some kernel versions,
+ * full-speed buffer overrun errors on the consumer side.
+ *
+ * Stopping is idempotent: repeated `stop()` calls settle without
+ * throwing. `stop()` unsubscribes the renderer listener before
+ * returning so a late frame delivered after shutdown cannot reach the
+ * sink.
+ *
+ * This module owns no actual v4l2 configuration — the device handle
+ * (`openVideoDevice` from `../video-device.ts`) already negotiated the
+ * pixel format. The writer is just the glue between the renderer's
+ * frame channel and the kernel-side sink.
+ */
+
+import type { AvatarRenderer, Y4MFrame } from "./types.js";
+
+/** Default max FPS cap applied to renderer output. */
+export const DEFAULT_MAX_FPS = 30;
+
+/** Minimal slice of {@link VideoDeviceHandle} the writer actually consumes. */
+export interface DeviceWriterSink {
+  /** Write a chunk of frame bytes. */
+  write(chunk: Uint8Array): boolean;
+}
+
+export interface AttachDeviceWriterOptions {
+  /** Renderer whose frames are forwarded to the sink. */
+  renderer: AvatarRenderer;
+  /** The open v4l2 device handle's write target. */
+  sink: DeviceWriterSink;
+  /**
+   * Maximum frames-per-second forwarded to the sink. Frames arriving
+   * inside the cap's interval are dropped. Defaults to
+   * {@link DEFAULT_MAX_FPS}. Pass `Infinity` to disable rate limiting.
+   */
+  maxFps?: number;
+  /**
+   * Monotonic clock source. Defaults to `Date.now`. Tests inject a
+   * synthetic clock so FPS-cap behaviour can be asserted without
+   * wall-clock sleeps.
+   */
+  now?: () => number;
+  /**
+   * Optional observer fired for every frame received from the renderer
+   * — _before_ the FPS gate. Used by tests to count inputs. Receives
+   * the dispatch decision so tests can assert on drop counts.
+   */
+  onFrameProcessed?: (frame: Y4MFrame, dispatched: boolean) => void;
+}
+
+/** Handle returned from {@link attachDeviceWriter}. Call `stop()` to detach. */
+export interface DeviceWriterHandle {
+  /** Unsubscribe from the renderer and stop forwarding frames. Idempotent. */
+  stop(): void;
+  /** How many frames have been forwarded to the sink. Diagnostic. */
+  dispatchedCount(): number;
+  /** How many frames were dropped by the FPS cap. Diagnostic. */
+  droppedCount(): number;
+}
+
+/**
+ * Compute the minimum milliseconds that must elapse between two
+ * dispatches at the given FPS cap. `Infinity` disables the cap entirely
+ * (every frame goes through).
+ */
+function minIntervalMs(maxFps: number): number {
+  if (!Number.isFinite(maxFps) || maxFps <= 0) return 0;
+  return Math.floor(1000 / maxFps);
+}
+
+/**
+ * Attach a device writer that forwards the renderer's frames to the
+ * sink, applying an FPS cap. Returns a handle whose `stop()` unhooks
+ * the subscription — the handle's `dispatchedCount` /
+ * `droppedCount` accessors are diagnostic (useful in tests and in
+ * future `/avatar/status` endpoints).
+ */
+export function attachDeviceWriter(
+  options: AttachDeviceWriterOptions,
+): DeviceWriterHandle {
+  const {
+    renderer,
+    sink,
+    maxFps = DEFAULT_MAX_FPS,
+    now = Date.now,
+    onFrameProcessed,
+  } = options;
+
+  const interval = minIntervalMs(maxFps);
+  let lastDispatchedAt = Number.NEGATIVE_INFINITY;
+  let dispatched = 0;
+  let dropped = 0;
+  let stopped = false;
+
+  const unsubscribe = renderer.onFrame((frame) => {
+    if (stopped) return;
+
+    // FPS cap: drop if the previous dispatch is too recent.
+    const ts = now();
+    let allowDispatch: boolean;
+    if (interval <= 0) {
+      allowDispatch = true;
+    } else {
+      allowDispatch = ts - lastDispatchedAt >= interval;
+    }
+
+    if (!allowDispatch) {
+      dropped += 1;
+      onFrameProcessed?.(frame, false);
+      return;
+    }
+
+    lastDispatchedAt = ts;
+    try {
+      sink.write(frame.bytes);
+      dispatched += 1;
+      onFrameProcessed?.(frame, true);
+    } catch {
+      // Sink errors are best-effort — a failed write usually means the
+      // kernel buffer hit back-pressure or the device handle was torn
+      // down out from under us. Count it as a drop so the diagnostic
+      // counters stay consistent.
+      dropped += 1;
+      onFrameProcessed?.(frame, false);
+    }
+  });
+
+  return {
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      try {
+        unsubscribe();
+      } catch {
+        // Best-effort — the renderer's unsubscribe should be idempotent
+        // but we don't want a buggy backend to crash the teardown path.
+      }
+    },
+    dispatchedCount(): number {
+      return dispatched;
+    },
+    droppedCount(): number {
+      return dropped;
+    },
+  };
+}

--- a/skills/meet-join/bot/src/media/avatar/index.ts
+++ b/skills/meet-join/bot/src/media/avatar/index.ts
@@ -1,9 +1,14 @@
 /**
  * Public entry point for the meet-bot's avatar subsystem.
  *
- * Only the shared types/interface are re-exported today. Concrete
- * renderers (TalkingHead.js, hosted WebRTC, GPU sidecars) and the
- * renderer factory land in PR 5 and the PR 5a/b/c/d follow-ups.
+ * Re-exports the shared interface types, the renderer registry, the
+ * device writer, and the noop renderer. Importing the barrel pulls in
+ * the noop renderer's import-time self-registration so
+ * `resolveAvatarRenderer({ renderer: "noop" })` just works. Concrete
+ * backend renderers (TalkingHead.js, hosted WebRTC, GPU sidecars) land
+ * in the PR 5a/b/c/d follow-ups — those PRs import their own file
+ * (e.g. `./backends/simli-renderer.js`) for the same side-effect
+ * registration pattern.
  */
 export {
   AvatarRendererUnavailableError,
@@ -12,3 +17,29 @@ export {
   type VisemeEvent,
   type Y4MFrame,
 } from "./types.js";
+
+export {
+  attachDeviceWriter,
+  DEFAULT_MAX_FPS,
+  type AttachDeviceWriterOptions,
+  type DeviceWriterHandle,
+  type DeviceWriterSink,
+} from "./device-writer.js";
+
+export { NoopAvatarRenderer } from "./noop-renderer.js";
+
+export {
+  __resetAvatarRegistryForTests,
+  isAvatarRendererRegistered,
+  listRegisteredAvatarRenderers,
+  registerAvatarRenderer,
+  resolveAvatarRenderer,
+  type AvatarConfig,
+  type AvatarRendererDeps,
+  type AvatarRendererFactory,
+} from "./registry.js";
+
+// Side-effect import: registers the noop factory under `"noop"` so
+// `resolveAvatarRenderer` can find it when something explicitly asks
+// for the id rather than relying on the null short-circuit path.
+import "./noop-renderer.js";

--- a/skills/meet-join/bot/src/media/avatar/noop-renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/noop-renderer.ts
@@ -1,0 +1,95 @@
+/**
+ * Noop avatar renderer — the safe default / fallback backend.
+ *
+ * Used in two situations:
+ *
+ * 1. `services.meet.avatar.enabled = false` or
+ *    `services.meet.avatar.renderer = "noop"`: the feature is explicitly
+ *    off, so the registry short-circuits before even consulting this
+ *    renderer. The bot never attaches a device writer and Meet sees no
+ *    video track.
+ *
+ * 2. A concrete renderer fails to construct
+ *    ({@link AvatarRendererUnavailableError}). The session-manager falls
+ *    back to the noop renderer so `/avatar/enable` can still return 200
+ *    and the meeting proceeds — the bot simply emits no frames instead
+ *    of a broken video stream.
+ *
+ * The renderer advertises `{ needsVisemes: false, needsAudio: false }`
+ * so the daemon can skip the TTS lip-sync forwarder and the PCM fan-out
+ * when this backend is active. `pushAudio` / `pushViseme` remain
+ * callable for interface conformance but drop every input; `onFrame`
+ * never fires.
+ *
+ * Importing this module has the side effect of registering the factory
+ * under the `"noop"` id so `resolveAvatarRenderer` can find it by name
+ * if some caller explicitly asks for it. The bot's entry point imports
+ * this file at boot so the registration lands before any HTTP traffic
+ * can arrive.
+ */
+
+import { registerAvatarRenderer } from "./registry.js";
+import type {
+  AvatarCapabilities,
+  AvatarRenderer,
+  VisemeEvent,
+  Y4MFrame,
+} from "./types.js";
+
+const NOOP_ID = "noop";
+const NOOP_CAPS: AvatarCapabilities = {
+  needsVisemes: false,
+  needsAudio: false,
+};
+
+/**
+ * The noop renderer itself. Everything is a no-op except bookkeeping:
+ * `startCount` / `stopCount` are exposed for tests but not part of the
+ * public {@link AvatarRenderer} surface — external callers must not
+ * depend on these fields.
+ */
+export class NoopAvatarRenderer implements AvatarRenderer {
+  readonly id = NOOP_ID;
+  readonly capabilities = NOOP_CAPS;
+
+  /** Incremented on each `start()` call. Tests only. */
+  startCount = 0;
+  /** Incremented on each `stop()` call. Tests only. */
+  stopCount = 0;
+
+  async start(): Promise<void> {
+    this.startCount += 1;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCount += 1;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- interface contract
+  pushAudio(_pcm: Uint8Array, _ts: number): void {
+    // Intentionally empty — the renderer advertises `needsAudio: false`,
+    // but the interface contract says this method is always callable.
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- interface contract
+  pushViseme(_event: VisemeEvent): void {
+    // Intentionally empty — see `pushAudio`.
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- interface contract
+  onFrame(_cb: (frame: Y4MFrame) => void): () => void {
+    // No frames will ever fire, but the contract requires a real
+    // unsubscribe function. Return a no-op disposer so callers that
+    // invoke it (idempotently) don't throw.
+    return () => {
+      /* noop */
+    };
+  }
+}
+
+// Register at import time so a later `resolveAvatarRenderer({ renderer: "noop" })`
+// finds the factory. The registry's short-circuit for `"noop"` means this
+// factory is rarely actually invoked — it exists so tests and explicit
+// callers that bypass the short-circuit (e.g. a fallback path that
+// synthesizes an AvatarConfig) still have something to resolve.
+registerAvatarRenderer(NOOP_ID, () => new NoopAvatarRenderer());

--- a/skills/meet-join/bot/src/media/avatar/registry.ts
+++ b/skills/meet-join/bot/src/media/avatar/registry.ts
@@ -1,0 +1,180 @@
+/**
+ * Pluggable avatar-renderer factory registry.
+ *
+ * Each concrete renderer backend (TalkingHead.js, Simli, HeyGen, Tavus,
+ * SadTalker, MuseTalk, …) registers a factory keyed by its stable id at
+ * module import time:
+ *
+ * ```ts
+ * registerAvatarRenderer("simli", (config, deps) => new SimliRenderer(...));
+ * ```
+ *
+ * The session-manager (daemon) resolves the configured renderer at
+ * `/avatar/enable` time via {@link resolveAvatarRenderer}, which walks
+ * the registered factories and either returns a fresh instance or
+ * throws {@link AvatarRendererUnavailableError} with a human-readable
+ * reason the HTTP server can relay back to the caller.
+ *
+ * This module does not import any concrete renderer. Registration is
+ * side-effectful: the entry point that wants a given backend available
+ * imports that backend's module for its import-time side effect
+ * (`import "./backends/simli-renderer.js"`). The noop renderer (in
+ * `./noop-renderer.ts`) is the only renderer this module ships with out
+ * of the box, and it self-registers when that file is imported.
+ *
+ * The registry is process-local and deliberately simple — no LRU, no
+ * multi-tenancy, no lifecycle-aware caching. Each `resolveAvatarRenderer`
+ * call constructs a fresh renderer; the session-manager owns the
+ * instance and tears it down on `/avatar/disable` or meeting end. The
+ * factory's only job is to turn a validated config object + deps into a
+ * working renderer instance (or fail fast with
+ * {@link AvatarRendererUnavailableError}).
+ */
+
+import {
+  AvatarRendererUnavailableError,
+  type AvatarRenderer,
+} from "./types.js";
+
+/**
+ * Dependencies the daemon hands to every renderer factory. Currently a
+ * logger — concrete renderers typically also take their own construction
+ * arguments (endpoint URLs, credentials) via the `config` object rather
+ * than through this deps bag. Kept as a shape so later PRs can grow it
+ * without breaking existing factories.
+ */
+export interface AvatarRendererDeps {
+  /** Minimal structured-logger surface. No-ops when omitted. */
+  logger?: {
+    info(msg: string, extra?: Record<string, unknown>): void;
+    warn(msg: string, extra?: Record<string, unknown>): void;
+    error(msg: string, extra?: Record<string, unknown>): void;
+  };
+}
+
+/**
+ * Shape of the per-renderer configuration object handed to a factory.
+ *
+ * Factories receive the full `services.meet.avatar.*` config block the
+ * daemon resolved from its config file. Renderer-specific sub-objects
+ * (e.g. `simli`, `talkingHead`) are addressed by key inside the factory
+ * — each factory knows which sub-object it depends on and fails fast
+ * (via {@link AvatarRendererUnavailableError}) when its sub-object is
+ * missing or malformed. Credentials are resolved through the vault in
+ * the daemon before `config` reaches the bot, so any string field in
+ * this object is already safe to read directly.
+ *
+ * The shape is permissive (`Record<string, unknown>`) so the bot side
+ * of the package doesn't have to import zod or the full MeetService
+ * schema — keeps the bot's build slim and keeps renderer factories
+ * independent of any one schema revision.
+ */
+export type AvatarConfig = Record<string, unknown> & {
+  /** Renderer id the daemon resolved. Always present. */
+  renderer: string;
+  /** Whether the feature is enabled. Always present. */
+  enabled: boolean;
+};
+
+/**
+ * Signature every avatar-renderer factory implements. Factories may be
+ * synchronous; use `async` only inside the renderer's `start()` method
+ * so the registry can remain a plain map.
+ *
+ * Construction errors — missing credentials, bad endpoints, unreachable
+ * GPU sidecar — must throw {@link AvatarRendererUnavailableError}. The
+ * session-manager catches that specific error and degrades to the noop
+ * renderer; any other thrown error is treated as an unexpected bug and
+ * surfaces as a 500 at the HTTP layer.
+ */
+export type AvatarRendererFactory = (
+  config: AvatarConfig,
+  deps: AvatarRendererDeps,
+) => AvatarRenderer;
+
+/**
+ * Module-local factory map. Keyed by the stable renderer id
+ * (e.g. `"noop"`, `"talking-head"`). Later registrations for the same
+ * id replace earlier ones — this matters for tests that swap a real
+ * factory for a fake via the same id, and for renderer PRs that
+ * intentionally shadow a placeholder.
+ */
+const factories = new Map<string, AvatarRendererFactory>();
+
+/**
+ * Register a factory for a given renderer id. Called at import time by
+ * the renderer's module. Safe to call multiple times for the same id —
+ * the most recent registration wins, which lets tests override a
+ * production factory with a fake.
+ */
+export function registerAvatarRenderer(
+  id: string,
+  factory: AvatarRendererFactory,
+): void {
+  factories.set(id, factory);
+}
+
+/**
+ * Look up whether a renderer id is currently registered. Exposed so
+ * the HTTP layer can decide between "not registered → 503" vs
+ * "construction failed → 503 with a reason" before calling the factory.
+ */
+export function isAvatarRendererRegistered(id: string): boolean {
+  return factories.has(id);
+}
+
+/**
+ * List every registered renderer id. Used by `/avatar/status`-style
+ * diagnostics and by unit tests that want to assert "this entry point
+ * registered exactly the factories I expected".
+ */
+export function listRegisteredAvatarRenderers(): string[] {
+  return Array.from(factories.keys()).sort();
+}
+
+/**
+ * Resolve the configured renderer to an {@link AvatarRenderer}
+ * instance.
+ *
+ * Behavior:
+ * - Returns `null` when the feature is explicitly off
+ *   (`config.enabled === false`) or the configured id is `"noop"`.
+ *   Callers use the null return to short-circuit device-writer
+ *   attachment — there's nothing to wire up.
+ * - Throws {@link AvatarRendererUnavailableError} when the requested id
+ *   isn't registered (typo, missing import, wrong build). The error's
+ *   `reason` is a human-readable pointer at the registration step.
+ * - Forwards any {@link AvatarRendererUnavailableError} the factory
+ *   itself throws (missing credential, missing asset, unreachable
+ *   sidecar). Other thrown errors propagate unchanged so a genuine
+ *   factory bug doesn't get silently squashed into a 503.
+ */
+export function resolveAvatarRenderer(
+  config: AvatarConfig,
+  deps: AvatarRendererDeps,
+): AvatarRenderer | null {
+  if (!config.enabled) return null;
+  if (config.renderer === "noop") return null;
+
+  const factory = factories.get(config.renderer);
+  if (!factory) {
+    throw new AvatarRendererUnavailableError(
+      config.renderer,
+      `no factory registered for id "${config.renderer}" (available: ${
+        listRegisteredAvatarRenderers().join(", ") || "<none>"
+      })`,
+    );
+  }
+
+  return factory(config, deps);
+}
+
+/**
+ * Drop every registration. For tests only — production code has no
+ * reason to call this. Exposed as a clearly-named export so test files
+ * can reset the registry between suites without reaching into module
+ * internals.
+ */
+export function __resetAvatarRegistryForTests(): void {
+  factories.clear();
+}

--- a/skills/meet-join/config-schema.ts
+++ b/skills/meet-join/config-schema.ts
@@ -63,6 +63,220 @@ function normalizeJoinName(value: string | null): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+/**
+ * Open enum of avatar renderer identifiers. Concrete renderer PRs (PR 5a–d)
+ * register themselves against one of these ids and assert their required
+ * option shape at `start()` time. The set is kept small and explicit here so
+ * configuration mistakes (typos, wrong ids) surface at schema-validation time
+ * rather than at meeting-join time; adding a new renderer is a single schema
+ * change + a new factory registration.
+ */
+export const AVATAR_RENDERER_IDS = [
+  "noop",
+  "talking-head",
+  "simli",
+  "heygen",
+  "tavus",
+  "sadtalker",
+  "musetalk",
+] as const;
+
+/**
+ * Default v4l2loopback device node the renderer pushes frames into. Matches
+ * {@link DEFAULT_AVATAR_DEVICE_PATH} in `bot/src/browser/chrome-launcher.ts`
+ * and {@link DEFAULT_MEET_AVATAR_DEVICE_PATH} in `cli/src/lib/docker.ts` —
+ * all three must agree so the Chrome camera-flag wiring, the
+ * device-passthrough wiring, and the renderer's writer all target the same
+ * node.
+ */
+export const DEFAULT_AVATAR_DEVICE_PATH = "/dev/video10";
+
+/**
+ * Per-renderer option block for TalkingHead.js (WebGL) renderer. All fields
+ * optional at the schema level — the renderer's `start()` asserts the shape
+ * it actually needs. Landed as a placeholder here so the config path exists
+ * before the concrete renderer merges.
+ */
+const TalkingHeadAvatarOptionsSchema = z
+  .object({
+    /** Absolute path (or bot-container path) to the GLB avatar model. */
+    modelPath: z
+      .string({
+        error: "services.meet.avatar.talkingHead.modelPath must be a string",
+      })
+      .optional()
+      .describe("Path to the GLB avatar model used by the WebGL renderer."),
+  })
+  .optional()
+  .describe("TalkingHead.js WebGL renderer options.");
+
+/**
+ * Per-renderer option block for the Simli hosted WebRTC renderer.
+ * Credentials resolve through the vault via `apiKeyCredentialId` — the
+ * schema never stores raw API keys.
+ */
+const SimliAvatarOptionsSchema = z
+  .object({
+    apiKeyCredentialId: z
+      .string({
+        error:
+          "services.meet.avatar.simli.apiKeyCredentialId must be a string",
+      })
+      .optional()
+      .describe(
+        "Vault credential id that resolves to the Simli API key. Raw keys are never stored in config — always reference them through the credential vault.",
+      ),
+    avatarId: z
+      .string({
+        error: "services.meet.avatar.simli.avatarId must be a string",
+      })
+      .optional()
+      .describe("Simli avatar identifier used for frame generation."),
+  })
+  .optional()
+  .describe("Simli hosted WebRTC renderer options.");
+
+/** HeyGen hosted renderer options — credentials via the vault. */
+const HeygenAvatarOptionsSchema = z
+  .object({
+    apiKeyCredentialId: z
+      .string({
+        error:
+          "services.meet.avatar.heygen.apiKeyCredentialId must be a string",
+      })
+      .optional(),
+    avatarId: z
+      .string({
+        error: "services.meet.avatar.heygen.avatarId must be a string",
+      })
+      .optional(),
+  })
+  .optional()
+  .describe("HeyGen hosted renderer options.");
+
+/** Tavus hosted renderer options — credentials via the vault. */
+const TavusAvatarOptionsSchema = z
+  .object({
+    apiKeyCredentialId: z
+      .string({
+        error:
+          "services.meet.avatar.tavus.apiKeyCredentialId must be a string",
+      })
+      .optional(),
+    replicaId: z
+      .string({
+        error: "services.meet.avatar.tavus.replicaId must be a string",
+      })
+      .optional(),
+  })
+  .optional()
+  .describe("Tavus hosted renderer options.");
+
+/** SadTalker GPU-sidecar options. */
+const SadtalkerAvatarOptionsSchema = z
+  .object({
+    endpoint: z
+      .string({
+        error: "services.meet.avatar.sadtalker.endpoint must be a string",
+      })
+      .optional()
+      .describe("HTTP endpoint for the SadTalker sidecar."),
+    referenceImagePath: z
+      .string({
+        error:
+          "services.meet.avatar.sadtalker.referenceImagePath must be a string",
+      })
+      .optional(),
+  })
+  .optional()
+  .describe("SadTalker GPU-sidecar renderer options.");
+
+/** MuseTalk GPU-sidecar options. */
+const MusetalkAvatarOptionsSchema = z
+  .object({
+    endpoint: z
+      .string({
+        error: "services.meet.avatar.musetalk.endpoint must be a string",
+      })
+      .optional()
+      .describe("HTTP endpoint for the MuseTalk sidecar."),
+    referenceImagePath: z
+      .string({
+        error:
+          "services.meet.avatar.musetalk.referenceImagePath must be a string",
+      })
+      .optional(),
+  })
+  .optional()
+  .describe("MuseTalk GPU-sidecar renderer options.");
+
+/**
+ * Avatar subsystem schema for the Meet bot.
+ *
+ * The avatar pipeline is intentionally pluggable: the daemon resolves one of
+ * several renderer backends (WebGL, hosted WebRTC, GPU sidecar) via the
+ * renderer registry and pipes Y4M frames into the bot's v4l2loopback device.
+ * When `enabled` is `false` or `renderer` is `"noop"`, the bot behaves like
+ * Phase 3 — no video track is published. The per-renderer option blocks are
+ * all optional at the schema level; each concrete renderer asserts its own
+ * required shape inside its factory at `start()` time, so a misconfigured
+ * renderer fails fast (and gracefully — callers catch
+ * `AvatarRendererUnavailableError` and degrade to the noop renderer).
+ *
+ * Credentials are referenced via `credentialId` fields rather than raw keys
+ * — the daemon resolves them through the vault before handing env vars to
+ * the bot container (the bot has no vault access).
+ */
+const MeetAvatarSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "services.meet.avatar.enabled must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "Whether the Meet bot publishes a virtual-camera video track with a synthesized avatar. Even when true, the top-level `meet` feature flag must also be on and the bot must be able to open the configured `devicePath` inside its container.",
+      ),
+    renderer: z
+      .enum(AVATAR_RENDERER_IDS, {
+        error:
+          "services.meet.avatar.renderer must be one of: " +
+          AVATAR_RENDERER_IDS.join(", "),
+      })
+      .default("noop")
+      .describe(
+        "Which avatar renderer backend to use. `noop` renders nothing and is the safe default; concrete backends (talking-head, simli, heygen, tavus, sadtalker, musetalk) register themselves with the renderer registry and assert their own configuration shape at start time.",
+      ),
+    devicePath: z
+      .string({
+        error: "services.meet.avatar.devicePath must be a string",
+      })
+      .default(DEFAULT_AVATAR_DEVICE_PATH)
+      .describe(
+        "Absolute v4l2loopback device node the renderer writes Y4M frames into. Must match the device passed through to the bot container via Docker `--device` and the Chrome `--use-file-for-fake-video-capture` flag.",
+      ),
+    talkingHead: TalkingHeadAvatarOptionsSchema,
+    simli: SimliAvatarOptionsSchema,
+    heygen: HeygenAvatarOptionsSchema,
+    tavus: TavusAvatarOptionsSchema,
+    sadtalker: SadtalkerAvatarOptionsSchema,
+    musetalk: MusetalkAvatarOptionsSchema,
+  })
+  .default({
+    enabled: false,
+    renderer: "noop",
+    devicePath: DEFAULT_AVATAR_DEVICE_PATH,
+  })
+  .describe(
+    "Pluggable avatar renderer configuration. When enabled, the Meet bot publishes a synthesized video track to Meet via a v4l2loopback device.",
+  );
+
+/** Convenience export so the daemon can narrow on the fully-parsed shape. */
+export type MeetAvatarConfig = z.infer<typeof MeetAvatarSchema>;
+
+/** Narrow union of supported avatar renderer ids. */
+export type AvatarRendererId = (typeof AVATAR_RENDERER_IDS)[number];
+
 export const MeetServiceSchema = z
   .object({
     enabled: z
@@ -200,6 +414,7 @@ export const MeetServiceSchema = z
       .describe(
         "Proactive-chat opportunity detector tuning. The detector uses a Tier 1 regex fast filter plus a Tier 2 LLM confirmation before the assistant posts in meeting chat.",
       ),
+    avatar: MeetAvatarSchema,
   })
   .describe(
     "Google Meet bot configuration — controls the containerized Meet joining bot, consent messaging, and objection handling",

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -874,6 +874,33 @@ class MeetSessionManagerImpl {
       SKIP_PULSE: "0",
     };
 
+    // Avatar config → bot env.
+    //
+    // When the avatar feature is enabled we thread the config down to the
+    // bot via a trio of env vars:
+    //
+    //   - `AVATAR_ENABLED` — flips the bot's Chrome flags into
+    //     v4l2loopback mode (added in PR 3) and mounts the `/avatar/*`
+    //     HTTP surface.
+    //   - `AVATAR_RENDERER` — which factory the bot's registry resolves.
+    //   - `AVATAR_CONFIG_JSON` — the full config block, serialized as a
+    //     single JSON string so renderer-specific sub-objects flow through
+    //     without having to explode each one into its own env var.
+    //   - `AVATAR_DEVICE_PATH` — explicit device-node override the bot
+    //     passes through to its Chrome launcher and `/avatar/enable`
+    //     handler.
+    //
+    // Credential fields inside the config are resolved to raw values in
+    // the daemon (via the vault) before being handed off — the bot has
+    // no vault access. Concrete renderer PRs extend this serialization
+    // step to substitute in their own vault-resolved credentials.
+    if (meet.avatar.enabled) {
+      env.AVATAR_ENABLED = "1";
+      env.AVATAR_RENDERER = meet.avatar.renderer;
+      env.AVATAR_CONFIG_JSON = JSON.stringify(meet.avatar);
+      env.AVATAR_DEVICE_PATH = meet.avatar.devicePath;
+    }
+
     const runner = this.deps.dockerRunnerFactory();
 
     let runResult: DockerRunResult;
@@ -909,6 +936,16 @@ class MeetSessionManagerImpl {
           [MEET_BOT_LABEL]: "true",
           [MEET_BOT_MEETING_ID_LABEL]: meetingId,
         },
+        // When avatar is enabled, pass through the v4l2loopback device so
+        // the bot container can open `/dev/video10` (or whatever override
+        // the user configured) as a character device and push frames into
+        // it. The CLI (`cli/src/lib/docker.ts`) is responsible for
+        // bind-mounting the host device into the assistant container in
+        // Docker mode; this daemon-side wiring threads it one more hop to
+        // the bot container.
+        ...(meet.avatar.enabled
+          ? { avatarDevicePath: meet.avatar.devicePath }
+          : {}),
       });
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary
- New `registry.ts` + `noop-renderer.ts` + `device-writer.ts` under `skills/meet-join/bot/src/media/avatar/` — backends call `registerAvatarRenderer(id, factory)` at import time, `resolveAvatarRenderer(config, deps)` returns the configured renderer or throws `AvatarRendererUnavailableError`.
- `config-schema.ts` adds `services.meet.avatar` with `enabled`, `renderer` enum, and per-renderer option blocks (optional at the schema level).
- Bot HTTP server grows `/avatar/viseme`, `/avatar/enable`, `/avatar/disable`. Daemon session-manager threads avatar config + device path through to the bot container.
- With `enabled=false` the bot behaves identically to Phase 3; with `renderer="noop"` `/avatar/enable` returns 200 to prove the infra path end-to-end.

Part of plan: meet-phase-4-avatar.md (PR 7 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
