### PR TITLE
meet-controller-ext: toggle Meet camera on/off via the extension

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
@@ -464,4 +464,246 @@ describe("avatar HTTP routes", () => {
       expect(second.stopCount).toBe(0);
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Camera-toggle wiring
+  //
+  // `/avatar/enable` and `/avatar/disable` call into the optional `camera`
+  // field on `HttpServerAvatarOptions` AFTER starting the renderer (enable)
+  // and BEFORE tearing it down (disable) — so Meet's camera reflects the
+  // renderer's liveness without a black frame between the two transitions.
+  // ---------------------------------------------------------------------
+
+  describe("camera-toggle integration", () => {
+    test("/avatar/enable calls camera.enableCamera after the renderer starts", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const callOrder: string[] = [];
+
+      // Tag the renderer start + device open so the order against the
+      // camera enable is asserted directly.
+      const openDevice = async (): Promise<VideoDeviceHandle> => {
+        callOrder.push("open-device");
+        return device.handle;
+      };
+      const enableCamera = async (): Promise<{ changed: boolean }> => {
+        callOrder.push("camera-enable");
+        return { changed: true };
+      };
+      let disableCalls = 0;
+      const disableCamera = async (): Promise<{ changed: boolean }> => {
+        disableCalls += 1;
+        return { changed: false };
+      };
+
+      // Wrap the renderer's `start` so we can log the order too.
+      const origStart = fake.start.bind(fake);
+      fake.start = async () => {
+        callOrder.push("renderer-start");
+        await origStart();
+      };
+
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice,
+        camera: { enableCamera, disableCamera },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.active).toBe(true);
+      expect(body.cameraChanged).toBe(true);
+
+      // Order: renderer starts BEFORE the device opens BEFORE the camera
+      // is flipped on. The device must be attached before Meet reads
+      // frames (the camera-on flip is what prompts Meet to start reading),
+      // and the renderer must be running before the device is attached
+      // so the writer has something to pump. disableCamera must NOT be
+      // called on the enable path.
+      expect(callOrder).toEqual([
+        "renderer-start",
+        "open-device",
+        "camera-enable",
+      ]);
+      expect(disableCalls).toBe(0);
+    });
+
+    test("/avatar/enable surfaces camera errors in the response body without failing the renderer", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const enableCamera = async (): Promise<{ changed: boolean }> => {
+        throw new Error("aria-state did not transition to on within 5000ms");
+      };
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+        camera: {
+          enableCamera,
+          disableCamera: async () => ({ changed: false }),
+        },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      // Renderer stayed up — the response is still 200 — but the camera
+      // error is surfaced in the body so the daemon can log it.
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.active).toBe(true);
+      expect(body.cameraError).toMatch(/did not transition/);
+      expect(fake.startCount).toBe(1);
+      // No spurious teardown on camera failure.
+      expect(fake.stopCount).toBe(0);
+    });
+
+    test("/avatar/disable calls camera.disableCamera BEFORE tearing down the renderer", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const callOrder: string[] = [];
+      let closedBefore: string[] = [];
+
+      const enableCamera = async (): Promise<{ changed: boolean }> => {
+        callOrder.push("camera-enable");
+        return { changed: true };
+      };
+      const disableCamera = async (): Promise<{ changed: boolean }> => {
+        callOrder.push("camera-disable");
+        closedBefore = [...callOrder];
+        return { changed: true };
+      };
+
+      const origStop = fake.stop.bind(fake);
+      fake.stop = async () => {
+        callOrder.push("renderer-stop");
+        await origStop();
+      };
+      const origClose = device.handle.close.bind(device.handle);
+      device.handle.close = async () => {
+        callOrder.push("device-close");
+        await origClose();
+      };
+
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+        camera: { enableCamera, disableCamera },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      const res = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.disabled).toBe(true);
+      expect(body.wasActive).toBe(true);
+      expect(body.cameraChanged).toBe(true);
+
+      // camera-disable must come before renderer-stop and device-close.
+      // closedBefore snapshots the call order as of when the camera was
+      // disabled — it must only contain the enable-path entries, not the
+      // stop/close entries.
+      expect(closedBefore).not.toContain("renderer-stop");
+      expect(closedBefore).not.toContain("device-close");
+      // Final order sanity-check.
+      expect(callOrder).toEqual([
+        "camera-enable",
+        "camera-disable",
+        "device-close",
+        "renderer-stop",
+      ]);
+    });
+
+    test("/avatar/disable still tears down the renderer when camera.disableCamera throws", async () => {
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const enableCamera = async (): Promise<{ changed: boolean }> => ({
+        changed: true,
+      });
+      const disableCamera = async (): Promise<{ changed: boolean }> => {
+        throw new Error("extension disconnected");
+      };
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+        camera: { enableCamera, disableCamera },
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+
+      const res = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.disabled).toBe(true);
+      expect(body.wasActive).toBe(true);
+      expect(body.cameraError).toContain("extension disconnected");
+      // Renderer + device still torn down — camera failure must not leak
+      // resources.
+      expect(fake.stopCount).toBe(1);
+      expect(device.closed()).toBe(true);
+    });
+
+    test("when `camera` is absent, /avatar/enable + /avatar/disable still work without a toggle call", async () => {
+      // Boot-smoke-test shape: no extension is attached, so no camera
+      // channel is wired. The avatar routes must still run the renderer
+      // + device lifecycle without throwing.
+      const fake = new FakeAvatarRenderer({ id: "fake" });
+      const device = fakeDeviceHandle();
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+        openDevice: async () => device.handle,
+        // `camera` intentionally omitted.
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const enable = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(enable.status).toBe(200);
+      const enableBody = await enable.json();
+      // No cameraChanged / cameraError in the body when camera is absent.
+      expect(enableBody.cameraChanged).toBeUndefined();
+      expect(enableBody.cameraError).toBeUndefined();
+
+      const disable = await fetch(`${base}/avatar/disable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      expect(disable.status).toBe(200);
+      const disableBody = await disable.json();
+      expect(disableBody.cameraChanged).toBeUndefined();
+      expect(disableBody.cameraError).toBeUndefined();
+    });
+  });
 });

--- a/skills/meet-join/bot/__tests__/camera-channel.test.ts
+++ b/skills/meet-join/bot/__tests__/camera-channel.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for `src/native-messaging/camera-channel.ts`.
+ *
+ * Drives the channel with a fake socket-server plumbing so the request/
+ * response correlation, timeout, and shutdown paths can be exercised
+ * without standing up a real Unix socket.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+import {
+  createCameraChannel,
+  DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS,
+} from "../src/native-messaging/camera-channel.js";
+
+interface FakeSocket {
+  sent: BotToExtensionMessage[];
+  listeners: Array<(msg: ExtensionToBotMessage) => void>;
+  sendToExtension: (msg: BotToExtensionMessage) => void;
+  onExtensionMessage: (cb: (msg: ExtensionToBotMessage) => void) => void;
+  /** Simulate an inbound frame from the extension. */
+  emit: (msg: ExtensionToBotMessage) => void;
+}
+
+function makeFakeSocket(): FakeSocket {
+  const sent: BotToExtensionMessage[] = [];
+  const listeners: Array<(msg: ExtensionToBotMessage) => void> = [];
+  return {
+    sent,
+    listeners,
+    sendToExtension: (msg) => {
+      sent.push(msg);
+    },
+    onExtensionMessage: (cb) => {
+      listeners.push(cb);
+    },
+    emit: (msg) => {
+      for (const cb of listeners) cb(msg);
+    },
+  };
+}
+
+describe("createCameraChannel", () => {
+  test("enableCamera dispatches camera.enable with a requestId and awaits camera_result", async () => {
+    const socket = makeFakeSocket();
+    let counter = 0;
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => `req-${++counter}`,
+    });
+
+    const p = channel.enableCamera();
+
+    // One frame dispatched: camera.enable with req-1.
+    expect(socket.sent).toHaveLength(1);
+    const sent = socket.sent[0]!;
+    expect(sent.type).toBe("camera.enable");
+    if (sent.type === "camera.enable") {
+      expect(sent.requestId).toBe("req-1");
+    }
+
+    // Extension replies ok=true changed=true.
+    socket.emit({
+      type: "camera_result",
+      requestId: "req-1",
+      ok: true,
+      changed: true,
+    });
+
+    const result = await p;
+    expect(result).toEqual({ changed: true });
+  });
+
+  test("disableCamera dispatches camera.disable with a fresh requestId", async () => {
+    const socket = makeFakeSocket();
+    let counter = 0;
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => `req-${++counter}`,
+    });
+
+    const p = channel.disableCamera();
+    const sent = socket.sent[0]!;
+    expect(sent.type).toBe("camera.disable");
+    if (sent.type === "camera.disable") {
+      expect(sent.requestId).toBe("req-1");
+    }
+
+    socket.emit({
+      type: "camera_result",
+      requestId: "req-1",
+      ok: true,
+      changed: false,
+    });
+
+    const result = await p;
+    expect(result).toEqual({ changed: false });
+  });
+
+  test("rejects with the extension-provided error on ok=false", async () => {
+    const socket = makeFakeSocket();
+    let counter = 0;
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => `req-${++counter}`,
+    });
+
+    const p = channel.enableCamera();
+    socket.emit({
+      type: "camera_result",
+      requestId: "req-1",
+      ok: false,
+      error: "toggle button not found",
+    });
+
+    await expect(p).rejects.toThrow(/toggle button not found/);
+  });
+
+  test("rejects with a timeout error when the extension never replies", async () => {
+    const socket = makeFakeSocket();
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => "req-timeout",
+      timeoutMs: 50,
+    });
+
+    await expect(channel.enableCamera()).rejects.toThrow(/did not reply within/);
+  });
+
+  test("ignores a camera_result for an unknown requestId (late reply after timeout)", async () => {
+    const socket = makeFakeSocket();
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => "req-late",
+      timeoutMs: 30,
+    });
+
+    // First await the timeout, then fire a late reply — this must not
+    // throw, crash, or leak state.
+    await expect(channel.enableCamera()).rejects.toThrow();
+    expect(() => {
+      socket.emit({
+        type: "camera_result",
+        requestId: "req-late",
+        ok: true,
+        changed: true,
+      });
+    }).not.toThrow();
+  });
+
+  test("ignores non-camera_result frames (fan-out alongside other listeners)", async () => {
+    const socket = makeFakeSocket();
+    let counter = 0;
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => `req-${++counter}`,
+    });
+
+    const p = channel.enableCamera();
+
+    // Unrelated diagnostic must not complete the pending camera request.
+    socket.emit({ type: "diagnostic", level: "info", message: "hello" });
+
+    // Now the real reply — this should resolve the promise.
+    socket.emit({
+      type: "camera_result",
+      requestId: "req-1",
+      ok: true,
+      changed: true,
+    });
+
+    await expect(p).resolves.toEqual({ changed: true });
+  });
+
+  test("shutdown rejects in-flight requests with the provided reason", async () => {
+    const socket = makeFakeSocket();
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+      generateRequestId: () => "req-1",
+      timeoutMs: 10_000,
+    });
+
+    const p = channel.enableCamera();
+    channel.shutdown("bot stopping");
+
+    await expect(p).rejects.toThrow(/bot stopping/);
+  });
+
+  test("rejects synchronously when sendToExtension throws", async () => {
+    const throwingSocket: FakeSocket = {
+      ...makeFakeSocket(),
+      sendToExtension: () => {
+        throw new Error("socket not connected");
+      },
+    };
+    const channel = createCameraChannel({
+      sendToExtension: throwingSocket.sendToExtension,
+      onExtensionMessage: throwingSocket.onExtensionMessage,
+      generateRequestId: () => "req-1",
+    });
+
+    await expect(channel.enableCamera()).rejects.toThrow(/socket not connected/);
+  });
+
+  test("DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS is generous enough for the 5s extension poll", () => {
+    // Sanity: default timeout must exceed the extension's aria-state poll
+    // window so a slow-but-successful transition doesn't trip the bot-side
+    // timer before the extension has a chance to reply.
+    expect(DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+  });
+});
+
+describe("createCameraChannel (integration with the http-server shape)", () => {
+  // Smoke: camera channel exposes the exact interface the http-server's
+  // `HttpServerAvatarOptions.camera` callsite requires.
+  test("exposes enableCamera + disableCamera matching the http-server contract", () => {
+    const socket = makeFakeSocket();
+    const channel = createCameraChannel({
+      sendToExtension: socket.sendToExtension,
+      onExtensionMessage: socket.onExtensionMessage,
+    });
+    expect(typeof channel.enableCamera).toBe("function");
+    expect(typeof channel.disableCamera).toBe("function");
+    expect(typeof channel.shutdown).toBe("function");
+  });
+});
+
+afterEach(() => {
+  // No global state to clean up — each test creates its own fake socket.
+});

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -9,8 +9,8 @@
  *   - `POST /send_chat`               — post a chat message into the Meet chat panel.
  *   - `POST /play_audio`              — stream raw PCM into pacat (Phase 3).
  *   - `DELETE /play_audio/:streamId`  — cancel an in-flight playback (barge-in).
- *   - `POST /avatar/enable`           — start the configured avatar renderer + wire its frames to `/dev/video10`.
- *   - `POST /avatar/disable`          — tear down the renderer + detach the device writer.
+ *   - `POST /avatar/enable`           — start the configured avatar renderer, wire its frames to `/dev/video10`, then flip the Meet camera toggle ON via the camera channel.
+ *   - `POST /avatar/disable`          — flip the Meet camera toggle OFF (before renderer teardown to avoid a brief black frame), then tear down the renderer + detach the device writer.
  *   - `POST /avatar/viseme`           — forward a viseme event into the active renderer (no-op when disabled).
  *
  * Every mutating route validates its body against the corresponding Zod
@@ -157,6 +157,33 @@ export interface HttpServerAvatarOptions {
    * tests can validate FPS-gating behavior.
    */
   maxFps?: number;
+  /**
+   * Camera-channel handle the server uses to ask the extension to turn
+   * the Meet camera on / off. When absent, `/avatar/enable` starts the
+   * renderer and `/avatar/disable` stops it — without flipping the
+   * camera toggle. This is the boot-smoke-test behavior (no extension
+   * is attached) and also the fallback when the extension is temporarily
+   * disconnected.
+   *
+   * When present, `/avatar/enable` starts the renderer FIRST (so the
+   * v4l2loopback device has frames to emit the moment Meet reads from
+   * it) and then flips the camera toggle ON; `/avatar/disable` flips the
+   * toggle OFF FIRST (so Meet stops emitting to other participants
+   * before the renderer tears down the frames) and then stops the
+   * renderer. This ordering avoids a brief black frame between the two
+   * transitions that other participants would otherwise see.
+   *
+   * A failed camera toggle is non-fatal on the enable path: the server
+   * logs the failure via the response body and leaves the renderer
+   * running, since tearing it back down would be strictly worse than a
+   * stuck camera toggle. On the disable path, a failed toggle is also
+   * non-fatal — we still stop the renderer so the device doesn't leak
+   * frames into a Meet tab that may still have the camera on.
+   */
+  camera?: {
+    enableCamera: () => Promise<{ changed: boolean }>;
+    disableCamera: () => Promise<{ changed: boolean }>;
+  };
 }
 
 export interface HttpServerHandle {
@@ -715,15 +742,38 @@ export function createHttpServer(
       avatarDeviceHandle = deviceHandle;
       avatarDeviceWriter = writer;
 
-      return c.json(
-        {
-          enabled: true,
-          renderer: renderer.id,
-          active: true,
-          devicePath: deviceHandle.devicePath,
-        },
-        200,
-      );
+      // Flip the Meet camera toggle ON so other participants start
+      // receiving frames from `/dev/video10` (now fed by the renderer).
+      // Ordered AFTER renderer start + device attach so the moment the
+      // toggle flips the camera ON, Meet reads real frames instead of a
+      // black frame. Non-fatal on failure: a stuck camera toggle is a
+      // regression signal but tearing the renderer back down would be
+      // strictly worse — the device is attached, the renderer is
+      // running, and the next `/avatar/enable` retry or a manual user
+      // click can recover.
+      let cameraChange: { changed: boolean } | null = null;
+      let cameraError: string | null = null;
+      if (avatar.camera) {
+        try {
+          cameraChange = await avatar.camera.enableCamera();
+        } catch (err) {
+          cameraError = err instanceof Error ? err.message : String(err);
+        }
+      }
+
+      const body: Record<string, unknown> = {
+        enabled: true,
+        renderer: renderer.id,
+        active: true,
+        devicePath: deviceHandle.devicePath,
+      };
+      if (cameraChange !== null) {
+        body.cameraChanged = cameraChange.changed;
+      }
+      if (cameraError !== null) {
+        body.cameraError = cameraError;
+      }
+      return c.json(body, 200);
     } finally {
       release(undefined);
     }
@@ -763,6 +813,22 @@ export function createHttpServer(
       avatarDeviceHandle = null;
       avatarRenderer = null;
 
+      // Flip the camera OFF BEFORE tearing down the renderer so other
+      // participants stop seeing the video track before the frame source
+      // disappears — this avoids the brief black frame gap that would
+      // otherwise appear while the renderer/device teardown is in
+      // flight. Non-fatal on failure; we still complete teardown so the
+      // device doesn't hold open a handle.
+      let cameraChange: { changed: boolean } | null = null;
+      let cameraError: string | null = null;
+      if (avatar.camera) {
+        try {
+          cameraChange = await avatar.camera.disableCamera();
+        } catch (err) {
+          cameraError = err instanceof Error ? err.message : String(err);
+        }
+      }
+
       // Teardown order (reverse of setup): writer → device → renderer.
       if (writer) {
         try {
@@ -782,13 +848,17 @@ export function createHttpServer(
         });
       }
 
-      return c.json(
-        {
-          disabled: true,
-          wasActive: renderer !== null,
-        },
-        200,
-      );
+      const body: Record<string, unknown> = {
+        disabled: true,
+        wasActive: renderer !== null,
+      };
+      if (cameraChange !== null) {
+        body.cameraChanged = cameraChange.changed;
+      }
+      if (cameraError !== null) {
+        body.cameraError = cameraError;
+      }
+      return c.json(body, 200);
     } finally {
       release(undefined);
     }

--- a/skills/meet-join/bot/src/native-messaging/camera-channel.ts
+++ b/skills/meet-join/bot/src/native-messaging/camera-channel.ts
@@ -1,0 +1,169 @@
+/**
+ * Bot-side helpers for the camera.enable / camera.disable native-messaging
+ * round-trip. Dispatches a `camera.enable` / `camera.disable` command to
+ * the extension over the shared NMH socket and awaits the matching
+ * `camera_result` frame correlated by `requestId`.
+ *
+ * Mirrors the shape of the `/send_chat` path in `main.ts` — both use the
+ * same `pendingRequests` pattern and the same request-id correlation.
+ * Extracted into its own module (rather than inlined in `main.ts`) so the
+ * HTTP server's `/avatar/enable` and `/avatar/disable` routes can call
+ * into a small, testable surface that only knows how to toggle the
+ * camera, without taking a dependency on the broader bot wiring.
+ *
+ * Timeout: the extension's camera feature polls aria-state for up to 5s
+ * before giving up, so the bot's bound is set to 7s — the extension-side
+ * poll plus a small buffer for native-messaging round-trip latency. A
+ * timeout here means the extension never replied at all (crashed, or the
+ * socket disconnected mid-toggle), which is distinct from the extension
+ * replying `ok: false` (which surfaces as a rejected promise with the
+ * extension's own error message).
+ */
+
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+
+/**
+ * Default timeout for a camera-toggle round-trip. Sized to allow the
+ * extension's 5s aria-state confirmation window plus a small buffer for
+ * native-messaging latency. Override in tests via the `timeoutMs` option.
+ */
+export const DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS = 7_000;
+
+/** Options common to {@link enableCamera} and {@link disableCamera}. */
+export interface CameraChannelOptions {
+  /**
+   * Dispatch a command to the extension. Thin wrapper over
+   * `NmhSocketServer.sendToExtension` so the channel can be unit-tested
+   * without standing up a real socket.
+   */
+  sendToExtension: (msg: BotToExtensionMessage) => void;
+  /**
+   * Factory for a listener-registration hook. Returns the
+   * `socketServer.onExtensionMessage` shape; the channel registers its
+   * listener at construction time (via {@link createCameraChannel}).
+   */
+  onExtensionMessage: (cb: (msg: ExtensionToBotMessage) => void) => void;
+  /** Correlation-id factory. Defaults to `crypto.randomUUID()`. */
+  generateRequestId?: () => string;
+  /** Per-call timeout. Defaults to {@link DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/**
+ * Result of a camera-toggle round-trip. `changed` distinguishes a real
+ * state transition from a no-op short-circuit (toggle was already in the
+ * requested state).
+ */
+export interface CameraChannelResult {
+  changed: boolean;
+}
+
+/**
+ * Narrow surface the camera channel exposes to the rest of the bot. The
+ * HTTP server's `/avatar/enable` / `/avatar/disable` routes call these
+ * directly; each method returns the extension's confirmation that the
+ * toggle reached the requested state (or rejects with a descriptive error).
+ */
+export interface CameraChannel {
+  enableCamera(): Promise<CameraChannelResult>;
+  disableCamera(): Promise<CameraChannelResult>;
+  /**
+   * Reject every in-flight request so callers awaiting
+   * {@link enableCamera} / {@link disableCamera} unblock on shutdown
+   * rather than hanging until their own timer fires.
+   */
+  shutdown(reason: string): void;
+}
+
+/**
+ * Build a camera channel wired to the provided socket-server callbacks.
+ * Registers a single listener for `camera_result` frames; subsequent
+ * dispatches pipe through the same listener without re-registering.
+ */
+export function createCameraChannel(
+  opts: CameraChannelOptions,
+): CameraChannel {
+  const { sendToExtension, onExtensionMessage } = opts;
+  const generateRequestId =
+    opts.generateRequestId ?? (() => crypto.randomUUID());
+  const defaultTimeoutMs = opts.timeoutMs ?? DEFAULT_CAMERA_CHANNEL_TIMEOUT_MS;
+
+  interface Pending {
+    resolve: (result: CameraChannelResult) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+
+  const pending = new Map<string, Pending>();
+
+  // Register the listener exactly once at construction. The socket server
+  // supports multiple listeners (fan-out), so adding one here is safe even
+  // when other modules also subscribe for their own message types.
+  onExtensionMessage((msg) => {
+    if (msg.type !== "camera_result") return;
+    const req = pending.get(msg.requestId);
+    if (!req) {
+      // Late reply for a request we already gave up on (timeout) or a
+      // fabricated requestId. Drop silently — the bot's main logger
+      // layer surfaces unknown-request-id noise for send_chat but we
+      // keep this path quiet because the avatar enable/disable retry
+      // loop can produce bursts of late replies during reconnect.
+      return;
+    }
+    clearTimeout(req.timer);
+    pending.delete(msg.requestId);
+    if (msg.ok) {
+      req.resolve({ changed: msg.changed ?? true });
+      return;
+    }
+    req.reject(
+      new Error(
+        msg.error
+          ? `camera toggle failed: ${msg.error}`
+          : "camera toggle failed (extension did not provide a reason)",
+      ),
+    );
+  });
+
+  function roundTrip(
+    type: "camera.enable" | "camera.disable",
+  ): Promise<CameraChannelResult> {
+    const requestId = generateRequestId();
+    return new Promise<CameraChannelResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(requestId);
+        reject(
+          new Error(
+            `camera toggle (${type}): extension did not reply within ${defaultTimeoutMs}ms (requestId=${requestId})`,
+          ),
+        );
+      }, defaultTimeoutMs);
+      pending.set(requestId, { resolve, reject, timer });
+
+      try {
+        sendToExtension({ type, requestId });
+      } catch (err) {
+        clearTimeout(timer);
+        pending.delete(requestId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  return {
+    enableCamera: () => roundTrip("camera.enable"),
+    disableCamera: () => roundTrip("camera.disable"),
+    shutdown(reason: string): void {
+      for (const [requestId, req] of pending.entries()) {
+        clearTimeout(req.timer);
+        req.reject(
+          new Error(`camera toggle aborted: ${reason} (requestId=${requestId})`),
+        );
+      }
+      pending.clear();
+    },
+  };
+}

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -195,6 +195,43 @@ export type ExtensionSendChatResultMessage = z.infer<
 >;
 
 /**
+ * Result of a prior `camera.enable` / `camera.disable` command, correlated
+ * by `requestId`. Semantics mirror {@link ExtensionSendChatResultMessageSchema}:
+ *
+ * - `ok: true` indicates the extension confirmed the Meet camera toggle
+ *   reached the requested state (either because a click was dispatched and
+ *   the aria-state transition was observed, or because the toggle was
+ *   already in the requested state — see `changed`).
+ * - `ok: false` indicates the extension could not bring the toggle to the
+ *   requested state (toggle element missing, aria-state polling timed out).
+ *   `error` carries a human-readable reason the bot surfaces in logs.
+ * - `changed` distinguishes a no-op short-circuit (`false` — toggle was
+ *   already in the requested state) from a successful click that produced
+ *   a state transition (`true`). The bot uses this for observability — a
+ *   spammy `/avatar/enable` retry loop that keeps reporting `changed=false`
+ *   is informative signal that the renderer is flapping without the camera
+ *   drifting.
+ */
+export const ExtensionCameraResultMessageSchema = z.object({
+  type: z.literal("camera_result"),
+  /** Correlation id from the originating `camera.enable` / `camera.disable` command. */
+  requestId: z.string().min(1),
+  /** Whether the camera toggle reached the requested state. */
+  ok: z.boolean(),
+  /**
+   * True if a click was dispatched and the aria-state transition was
+   * observed; false if the toggle was already in the requested state (no
+   * click happened). Only meaningful when `ok === true`.
+   */
+  changed: z.boolean().optional(),
+  /** Human-readable failure reason when `ok === false`. */
+  error: z.string().optional(),
+});
+export type ExtensionCameraResultMessage = z.infer<
+  typeof ExtensionCameraResultMessageSchema
+>;
+
+/**
  * Every payload the extension may send to the bot over the native-messaging
  * pipe. Consumers should parse incoming frames with this schema to both
  * validate and narrow on `type`.
@@ -209,6 +246,7 @@ export const ExtensionToBotMessageSchema = z.discriminatedUnion("type", [
   ExtensionTrustedClickMessageSchema,
   ExtensionTrustedTypeMessageSchema,
   ExtensionSendChatResultMessageSchema,
+  ExtensionCameraResultMessageSchema,
 ]);
 export type ExtensionToBotMessage = z.infer<typeof ExtensionToBotMessageSchema>;
 
@@ -223,6 +261,7 @@ export const EXTENSION_TO_BOT_MESSAGE_TYPES = [
   "trusted_click",
   "trusted_type",
   "send_chat_result",
+  "camera_result",
 ] as const;
 
 export type ExtensionToBotMessageType =
@@ -271,6 +310,48 @@ export const BotSendChatCommandSchema = z.object({
 });
 export type BotSendChatCommand = z.infer<typeof BotSendChatCommandSchema>;
 
+// ---------------------------------------------------------------------------
+// camera.enable / camera.disable — toggle the Meet camera via the extension.
+//
+// The bot drives the Meet camera via the extension (not via any CDP path)
+// because Meet's bottom-toolbar buttons are inside the same DOM the extension
+// already manages. The extension reads the camera-toggle button's aria-label
+// to determine current state, short-circuits when the toggle is already in
+// the requested state, clicks the toggle otherwise, then polls the aria-state
+// for up to 5s to confirm the transition landed.
+//
+// Reply shape: {@link ExtensionCameraResultMessageSchema}, correlated by
+// `requestId`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Ask the extension to turn the Meet camera ON. If the camera is already on,
+ * the extension short-circuits without clicking. The extension replies with
+ * a `camera_result` carrying the same `requestId`.
+ */
+export const BotCameraEnableCommandSchema = z.object({
+  type: z.literal("camera.enable"),
+  /** Correlation id the extension must echo back in `camera_result`. */
+  requestId: z.string().min(1),
+});
+export type BotCameraEnableCommand = z.infer<
+  typeof BotCameraEnableCommandSchema
+>;
+
+/**
+ * Ask the extension to turn the Meet camera OFF. If the camera is already
+ * off, the extension short-circuits without clicking. The extension replies
+ * with a `camera_result` carrying the same `requestId`.
+ */
+export const BotCameraDisableCommandSchema = z.object({
+  type: z.literal("camera.disable"),
+  /** Correlation id the extension must echo back in `camera_result`. */
+  requestId: z.string().min(1),
+});
+export type BotCameraDisableCommand = z.infer<
+  typeof BotCameraDisableCommandSchema
+>;
+
 /**
  * Every command the bot may send to the extension over the native-messaging
  * pipe. Consumers should parse incoming frames with this schema to both
@@ -280,6 +361,8 @@ export const BotToExtensionMessageSchema = z.discriminatedUnion("type", [
   BotJoinCommandSchema,
   BotLeaveCommandSchema,
   BotSendChatCommandSchema,
+  BotCameraEnableCommandSchema,
+  BotCameraDisableCommandSchema,
 ]);
 export type BotToExtensionMessage = z.infer<typeof BotToExtensionMessageSchema>;
 
@@ -288,6 +371,8 @@ export const BOT_TO_EXTENSION_MESSAGE_TYPES = [
   "join",
   "leave",
   "send_chat",
+  "camera.enable",
+  "camera.disable",
 ] as const;
 
 export type BotToExtensionMessageType =

--- a/skills/meet-join/meet-controller-ext/src/__tests__/camera-feature.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/camera-feature.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for `src/features/camera.ts` — jsdom-only.
+ *
+ * Exercises the aria-state no-op short-circuit, the click + poll success
+ * path, the timeout failure path, and the `trusted_click` emit for the
+ * xdotool bridge.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { JSDOM } from "jsdom";
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+
+import { controlSelectors, isCameraOn } from "../dom/selectors.js";
+import { disableCamera, enableCamera } from "../features/camera.js";
+
+const FIXTURE_DIR = join(import.meta.dir, "..", "dom", "__tests__", "fixtures");
+const INGAME_FIXTURE = readFileSync(
+  join(FIXTURE_DIR, "meet-dom-ingame.html"),
+  "utf8",
+);
+
+interface InstalledDom {
+  dom: JSDOM;
+  doc: Document;
+  /** Number of times the camera toggle button was clicked. */
+  clicks: () => number;
+  /** Set the camera toggle's aria-label (mutates the button in place). */
+  setCameraState: (on: boolean) => void;
+  /** Remove the camera toggle from the DOM (for the "missing toggle" case). */
+  removeCameraToggle: () => void;
+  /**
+   * Arrange the toggle so that clicking it is a no-op (simulates Meet's
+   * isTrusted gate rejecting the synthetic `.click()`). The aria-label stays
+   * in its initial state and never flips.
+   */
+  makeClickNoOp: () => void;
+}
+
+/**
+ * Install a JSDOM document on `globalThis` so `camera.ts`'s bare `document`
+ * references resolve to the fixture. Wires up a click handler that flips
+ * the aria-label to mimic Meet's state transition on a real click.
+ */
+function installDom(): InstalledDom {
+  const dom = new JSDOM(INGAME_FIXTURE, { runScripts: "outside-only" });
+  const window = dom.window;
+  const document = window.document;
+
+  const camera = document.querySelector<HTMLButtonElement>(
+    controlSelectors.CAMERA_TOGGLE,
+  );
+  if (!camera) throw new Error("fixture missing the camera toggle");
+
+  let clickCount = 0;
+  let flipOnClick = true;
+  camera.addEventListener("click", () => {
+    clickCount += 1;
+    if (!flipOnClick) return;
+    const label = camera.getAttribute("aria-label");
+    if (label === "Turn off camera") {
+      camera.setAttribute("aria-label", "Turn on camera");
+    } else if (label === "Turn on camera") {
+      camera.setAttribute("aria-label", "Turn off camera");
+    }
+  });
+
+  const originals: Record<string, unknown> = {};
+  const wire = (key: string, value: unknown): void => {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    (globalThis as Record<string, unknown>)[key] = value;
+  };
+  wire("document", document);
+  wire("window", window);
+  wire("HTMLButtonElement", window.HTMLButtonElement);
+
+  (dom as unknown as { __restore: () => void }).__restore = () => {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) {
+        delete (globalThis as Record<string, unknown>)[k];
+      } else {
+        (globalThis as Record<string, unknown>)[k] = v;
+      }
+    }
+  };
+
+  return {
+    dom,
+    doc: document,
+    clicks: () => clickCount,
+    setCameraState: (on) => {
+      camera.setAttribute(
+        "aria-label",
+        on ? "Turn off camera" : "Turn on camera",
+      );
+    },
+    removeCameraToggle: () => camera.remove(),
+    makeClickNoOp: () => {
+      flipOnClick = false;
+    },
+  };
+}
+
+describe("isCameraOn", () => {
+  let installed: InstalledDom | null = null;
+  beforeEach(() => {
+    installed = installDom();
+  });
+  afterEach(() => {
+    if (installed) {
+      (installed.dom as unknown as { __restore: () => void }).__restore();
+      installed = null;
+    }
+  });
+
+  test("returns true when the aria-label indicates camera on", () => {
+    installed!.setCameraState(true);
+    expect(isCameraOn()).toBe(true);
+  });
+
+  test("returns false when the aria-label indicates camera off", () => {
+    installed!.setCameraState(false);
+    expect(isCameraOn()).toBe(false);
+  });
+
+  test("returns null when the toggle is missing", () => {
+    installed!.removeCameraToggle();
+    expect(isCameraOn()).toBe(null);
+  });
+});
+
+describe("enableCamera", () => {
+  let installed: InstalledDom | null = null;
+
+  beforeEach(() => {
+    installed = installDom();
+  });
+
+  afterEach(() => {
+    if (installed) {
+      (installed.dom as unknown as { __restore: () => void }).__restore();
+      installed = null;
+    }
+  });
+
+  test("is a no-op when the camera is already on", async () => {
+    installed!.setCameraState(true);
+    expect(installed!.clicks()).toBe(0);
+
+    const events: ExtensionToBotMessage[] = [];
+    const result = await enableCamera({ onEvent: (ev) => events.push(ev) });
+
+    expect(result).toEqual({ changed: false });
+    expect(installed!.clicks()).toBe(0);
+    // No trusted_click should be emitted on the no-op path.
+    expect(events.filter((e) => e.type === "trusted_click")).toHaveLength(0);
+  });
+
+  test("clicks the toggle when the camera is off and confirms the state", async () => {
+    installed!.setCameraState(false);
+
+    const result = await enableCamera({ timeoutMs: 1_000 });
+
+    expect(result).toEqual({ changed: true });
+    expect(installed!.clicks()).toBe(1);
+    expect(isCameraOn()).toBe(true);
+  });
+
+  test("emits a trusted_click with computed screen coords before clicking", async () => {
+    installed!.setCameraState(false);
+
+    // Stub the toggle's getBoundingClientRect so the coordinate math is
+    // deterministic. Math mirrors `features/chat.ts`'s send-button block:
+    //   x = screenX + rect.left + rect.width/2
+    //   y = screenY + (outerHeight - innerHeight) + rect.top + rect.height/2
+    const toggle = installed!.doc.querySelector<HTMLButtonElement>(
+      controlSelectors.CAMERA_TOGGLE,
+    )!;
+    toggle.getBoundingClientRect = () =>
+      ({
+        left: 800,
+        top: 680,
+        width: 60,
+        height: 40,
+        right: 860,
+        bottom: 720,
+        x: 800,
+        y: 680,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const events: ExtensionToBotMessage[] = [];
+    // Record the trusted_click emit against the JS click fallback so the
+    // ordering assertion has something to compare.
+    const callOrder: string[] = [];
+    toggle.addEventListener("click", () => callOrder.push("js-click"));
+
+    const result = await enableCamera({
+      onEvent: (ev) => {
+        events.push(ev);
+        if (ev.type === "trusted_click") callOrder.push("trusted-click");
+      },
+      // chrome = outerHeight - innerHeight = 100; screen origin = (0, 0).
+      // Expected: x = 800 + 30 = 830, y = 100 + 680 + 20 = 800.
+      window: {
+        screenX: 0,
+        screenY: 0,
+        outerHeight: 820,
+        innerHeight: 720,
+      },
+      timeoutMs: 1_000,
+    });
+
+    expect(result).toEqual({ changed: true });
+
+    const trustedClicks = events.filter(
+      (e) => e.type === "trusted_click",
+    ) as Array<Extract<ExtensionToBotMessage, { type: "trusted_click" }>>;
+    expect(trustedClicks).toHaveLength(1);
+    expect(trustedClicks[0]!.x).toBe(830);
+    expect(trustedClicks[0]!.y).toBe(800);
+
+    // trusted_click emits BEFORE the JS click fallback — so the bot will
+    // have dispatched the real xdotool click by the time the fallback
+    // runs, mirroring `features/chat.ts`.
+    expect(callOrder).toEqual(["trusted-click", "js-click"]);
+  });
+
+  test("throws a descriptive error when the toggle is missing", async () => {
+    installed!.removeCameraToggle();
+    await expect(enableCamera({ timeoutMs: 100 })).rejects.toThrow(
+      /toggle button not found/,
+    );
+  });
+
+  test("throws after the timeout when the click is swallowed (isTrusted gate simulation)", async () => {
+    installed!.setCameraState(false);
+    installed!.makeClickNoOp();
+
+    // A short timeout + short poll interval keeps the test quick.
+    const err = await enableCamera({
+      timeoutMs: 200,
+      pollIntervalMs: 20,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/did not transition to on/);
+    // The click was still dispatched — the gate just rejected it.
+    expect(installed!.clicks()).toBe(1);
+    // Camera stayed off.
+    expect(isCameraOn()).toBe(false);
+  });
+});
+
+describe("disableCamera", () => {
+  let installed: InstalledDom | null = null;
+
+  beforeEach(() => {
+    installed = installDom();
+  });
+
+  afterEach(() => {
+    if (installed) {
+      (installed.dom as unknown as { __restore: () => void }).__restore();
+      installed = null;
+    }
+  });
+
+  test("is a no-op when the camera is already off", async () => {
+    installed!.setCameraState(false);
+    expect(installed!.clicks()).toBe(0);
+
+    const result = await disableCamera({ timeoutMs: 1_000 });
+
+    expect(result).toEqual({ changed: false });
+    expect(installed!.clicks()).toBe(0);
+  });
+
+  test("clicks the toggle when the camera is on and confirms the state", async () => {
+    installed!.setCameraState(true);
+
+    const result = await disableCamera({ timeoutMs: 1_000 });
+
+    expect(result).toEqual({ changed: true });
+    expect(installed!.clicks()).toBe(1);
+    expect(isCameraOn()).toBe(false);
+  });
+
+  test("throws after the timeout when the click is swallowed", async () => {
+    installed!.setCameraState(true);
+    installed!.makeClickNoOp();
+
+    const err = await disableCamera({
+      timeoutMs: 200,
+      pollIntervalMs: 20,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/did not transition to off/);
+    expect(installed!.clicks()).toBe(1);
+    expect(isCameraOn()).toBe(true);
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the content-script `handleCameraToggle` handler.
+ *
+ * `handleCameraToggle` is the path the bot takes when it needs to flip
+ * the Meet camera on/off (e.g. in response to an HTTP `/avatar/enable`
+ * or `/avatar/disable` route). We need to confirm it threads an
+ * `onEvent` sink + `window` reference through to the camera feature
+ * module and emits a correlated `camera_result` reply back through
+ * `chrome.runtime.sendMessage`.
+ *
+ * Mirrors the harness pattern in `content-send-chat.test.ts` — `content.ts`
+ * runs side effects at import time, so we install a fake `chrome` + JSDOM
+ * before the dynamic import.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { JSDOM } from "jsdom";
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+
+import { controlSelectors } from "../dom/selectors.js";
+
+const FIXTURE_DIR = pathJoin(
+  import.meta.dir,
+  "..",
+  "dom",
+  "__tests__",
+  "fixtures",
+);
+const INGAME_FIXTURE = readFileSync(
+  pathJoin(FIXTURE_DIR, "meet-dom-ingame.html"),
+  "utf8",
+);
+
+interface FakeChrome {
+  runtime: {
+    sendMessage: (msg: unknown) => void;
+    onMessage: {
+      addListener: (
+        cb: (
+          raw: unknown,
+          sender: unknown,
+          sendResponse: (response?: unknown) => void,
+        ) => boolean,
+      ) => void;
+    };
+  };
+  sent: unknown[];
+}
+
+interface InstalledHarness {
+  dom: JSDOM;
+  chrome: FakeChrome;
+  /** Set the camera toggle's aria-label. */
+  setCameraState: (on: boolean) => void;
+  /** Make the toggle's `.click()` a no-op (simulate isTrusted rejection). */
+  makeClickNoOp: () => void;
+  restore: () => void;
+}
+
+function installHarness(): InstalledHarness {
+  const dom = new JSDOM(INGAME_FIXTURE, {
+    runScripts: "outside-only",
+    url: "https://meet.google.com/abc-defg-hij",
+  });
+  const window = dom.window;
+  const document = window.document;
+
+  const camera = document.querySelector<HTMLButtonElement>(
+    controlSelectors.CAMERA_TOGGLE,
+  );
+  if (!camera) throw new Error("fixture missing camera toggle");
+
+  let flipOnClick = true;
+  camera.addEventListener("click", () => {
+    if (!flipOnClick) return;
+    const label = camera.getAttribute("aria-label");
+    if (label === "Turn off camera") {
+      camera.setAttribute("aria-label", "Turn on camera");
+    } else if (label === "Turn on camera") {
+      camera.setAttribute("aria-label", "Turn off camera");
+    }
+  });
+
+  const sent: unknown[] = [];
+  const chrome: FakeChrome = {
+    sent,
+    runtime: {
+      sendMessage: (msg) => {
+        sent.push(msg);
+      },
+      onMessage: {
+        addListener: () => {},
+      },
+    },
+  };
+
+  const originals: Record<string, unknown> = {};
+  const wire = (key: string, value: unknown): void => {
+    originals[key] = (globalThis as Record<string, unknown>)[key];
+    (globalThis as Record<string, unknown>)[key] = value;
+  };
+  wire("document", document);
+  wire("window", window);
+  wire("location", window.location);
+  wire("HTMLButtonElement", window.HTMLButtonElement);
+  wire("chrome", chrome);
+  wire("screenX", 0);
+  wire("screenY", 0);
+  wire("outerHeight", 820);
+  wire("innerHeight", 720);
+
+  return {
+    dom,
+    chrome,
+    setCameraState: (on) => {
+      camera.setAttribute(
+        "aria-label",
+        on ? "Turn off camera" : "Turn on camera",
+      );
+    },
+    makeClickNoOp: () => {
+      flipOnClick = false;
+    },
+    restore: () => {
+      for (const [k, v] of Object.entries(originals)) {
+        if (v === undefined) {
+          delete (globalThis as Record<string, unknown>)[k];
+        } else {
+          (globalThis as Record<string, unknown>)[k] = v;
+        }
+      }
+    },
+  };
+}
+
+describe("handleCameraToggle", () => {
+  let harness: InstalledHarness | null = null;
+  let handleCameraToggle:
+    | ((cmd: {
+        type: "camera.enable" | "camera.disable";
+        requestId: string;
+      }) => Promise<void>)
+    | null = null;
+
+  beforeEach(async () => {
+    harness = installHarness();
+    const mod = (await import("../content.js")) as {
+      __handleCameraToggle: typeof handleCameraToggle;
+    };
+    handleCameraToggle = mod.__handleCameraToggle;
+  });
+
+  afterEach(() => {
+    if (harness) {
+      harness.restore();
+      harness = null;
+    }
+    handleCameraToggle = null;
+  });
+
+  test("camera.enable on an already-on camera emits camera_result(ok=true, changed=false) with no trusted_click", async () => {
+    harness!.setCameraState(true);
+
+    await handleCameraToggle!({ type: "camera.enable", requestId: "req-1" });
+
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    const results = sent.filter((e) => e.type === "camera_result");
+    expect(results).toHaveLength(1);
+    const result = results[0]!;
+    if (result.type === "camera_result") {
+      expect(result.requestId).toBe("req-1");
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(false);
+    }
+    // No trusted_click because the no-op short-circuit fires before the
+    // click + emit block.
+    expect(sent.filter((e) => e.type === "trusted_click")).toHaveLength(0);
+  });
+
+  test("camera.enable on an off camera clicks + emits trusted_click + camera_result(ok=true, changed=true)", async () => {
+    harness!.setCameraState(false);
+
+    await handleCameraToggle!({ type: "camera.enable", requestId: "req-2" });
+
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    const trustedClicks = sent.filter((e) => e.type === "trusted_click");
+    expect(trustedClicks).toHaveLength(1);
+
+    const results = sent.filter((e) => e.type === "camera_result");
+    expect(results).toHaveLength(1);
+    const result = results[0]!;
+    if (result.type === "camera_result") {
+      expect(result.requestId).toBe("req-2");
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(true);
+    }
+  });
+
+  test("camera.disable on an on camera clicks + emits trusted_click + camera_result(ok=true, changed=true)", async () => {
+    harness!.setCameraState(true);
+
+    await handleCameraToggle!({
+      type: "camera.disable",
+      requestId: "req-3",
+    });
+
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    const trustedClicks = sent.filter((e) => e.type === "trusted_click");
+    expect(trustedClicks).toHaveLength(1);
+
+    const results = sent.filter((e) => e.type === "camera_result");
+    expect(results).toHaveLength(1);
+    const result = results[0]!;
+    if (result.type === "camera_result") {
+      expect(result.requestId).toBe("req-3");
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(true);
+    }
+  });
+
+  test("camera.disable on an already-off camera emits camera_result(ok=true, changed=false)", async () => {
+    harness!.setCameraState(false);
+
+    await handleCameraToggle!({
+      type: "camera.disable",
+      requestId: "req-4",
+    });
+
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    const results = sent.filter((e) => e.type === "camera_result");
+    expect(results).toHaveLength(1);
+    const result = results[0]!;
+    if (result.type === "camera_result") {
+      expect(result.requestId).toBe("req-4");
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(false);
+    }
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -24,13 +24,20 @@
  * in that case because the scrapers require an admitted meeting.
  */
 import type {
+  BotCameraDisableCommand,
+  BotCameraEnableCommand,
   BotSendChatCommand,
   BotToExtensionMessage,
+  ExtensionCameraResultMessage,
   ExtensionSendChatResultMessage,
   ExtensionToBotMessage,
 } from "../../contracts/native-messaging.js";
 import { BotToExtensionMessageSchema } from "../../contracts/native-messaging.js";
 
+import {
+  disableCamera,
+  enableCamera,
+} from "./features/camera.js";
 import {
   type ChatReader,
   sendChat,
@@ -203,6 +210,11 @@ chrome.runtime.onMessage.addListener(
       return false;
     }
 
+    if (msg.type === "camera.enable" || msg.type === "camera.disable") {
+      void handleCameraToggle(msg);
+      return false;
+    }
+
     return false;
   },
 );
@@ -333,10 +345,68 @@ async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
   }
 }
 
-// Export the send-chat handler for unit testing. It is wired into
-// `chrome.runtime.onMessage` above when the script loads; the test
-// imports it directly to drive the `meet_send_chat` tool path end-to-end
-// without needing to fake the chrome.runtime.onMessage dispatcher. Not
-// part of the extension's public surface — the background SW never
-// imports content.ts.
+/**
+ * Execute a {@link BotCameraEnableCommand} / {@link BotCameraDisableCommand}
+ * and emit a matching {@link ExtensionCameraResultMessage} back to the
+ * background. Mirrors {@link handleSendChat}: forwards a trusted_click via
+ * `onEvent` so the bot drives the click through xdotool (Meet's isTrusted
+ * gate rejects synthetic clicks on bottom-toolbar controls in general, so
+ * we assume the camera toggle is gated too and route through xdotool by
+ * default). Errors are surfaced via `ok: false` with a descriptive reason.
+ */
+async function handleCameraToggle(
+  cmd: BotCameraEnableCommand | BotCameraDisableCommand,
+): Promise<void> {
+  const sendToBot = (event: ExtensionToBotMessage): void => {
+    try {
+      void chrome.runtime.sendMessage(event);
+    } catch (err) {
+      console.warn("[meet-ext] sendMessage failed:", err);
+    }
+  };
+
+  let reply: ExtensionCameraResultMessage;
+  try {
+    const run =
+      cmd.type === "camera.enable" ? enableCamera : disableCamera;
+    const result = await run({
+      onEvent: sendToBot,
+      // Pass the live `window` so the camera feature can compute screen-
+      // space coordinates for the toggle's `trusted_click`. Mirrors the
+      // fallback that `postConsentMessage` / `sendChat` rely on.
+      window: globalThis as unknown as {
+        screenX: number;
+        screenY: number;
+        outerHeight: number;
+        innerHeight: number;
+      },
+    });
+    reply = {
+      type: "camera_result",
+      requestId: cmd.requestId,
+      ok: true,
+      changed: result.changed,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    reply = {
+      type: "camera_result",
+      requestId: cmd.requestId,
+      ok: false,
+      error: message,
+    };
+  }
+  try {
+    chrome.runtime.sendMessage(reply);
+  } catch (err) {
+    console.warn("[meet-ext] failed to send camera_result:", err);
+  }
+}
+
+// Export the send-chat + camera-toggle handlers for unit testing. They are
+// wired into `chrome.runtime.onMessage` above when the script loads; the
+// tests import them directly to drive the tool paths end-to-end without
+// needing to fake the chrome.runtime.onMessage dispatcher. Not part of the
+// extension's public surface — the background SW never imports content.ts.
 export { handleSendChat as __handleSendChat };
+export { handleCameraToggle as __handleCameraToggle };

--- a/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
+++ b/skills/meet-join/meet-controller-ext/src/dom/selectors.ts
@@ -203,13 +203,16 @@ export const controlSelectors = {
   /**
    * Camera on/off toggle. Meet switches the aria-label between "Turn on
    * camera" and "Turn off camera" depending on state; we match either so the
-   * selector works in both states.
+   * selector works in both states. Use {@link isCameraOn} to read the
+   * current state from the aria-label (clicking the button is what the
+   * camera feature module does to toggle it).
    */
   CAMERA_TOGGLE:
     'button[aria-label="Turn off camera"], button[aria-label="Turn on camera"]',
 
   /**
    * Microphone on/off toggle. Same dual-aria-label pattern as the camera.
+   * Use {@link isMicOn} to read the current state.
    */
   MIC_TOGGLE:
     'button[aria-label="Turn off microphone"], button[aria-label="Turn on microphone"]',
@@ -292,3 +295,57 @@ export const selectors = {
 } as const;
 
 export type SelectorKey = keyof typeof selectors;
+
+// ---------------------------------------------------------------------------
+// ARIA-state accessors
+// ---------------------------------------------------------------------------
+//
+// Meet's camera/mic toggle buttons report their current state only through
+// the aria-label swap: "Turn off X" when X is currently ON (click to turn
+// off), "Turn on X" when X is currently OFF (click to turn on). There is no
+// `aria-pressed` attribute and no stable class distinguishing the two
+// states. These helpers centralize the label parsing so feature modules
+// don't have to repeat the string match.
+//
+// Each helper returns `null` when the toggle element isn't present in the
+// DOM (e.g. the bot is still in the waiting room, or the toolbar hasn't
+// mounted). Callers distinguish that from the boolean states so they can
+// report a descriptive "camera toggle not found" error instead of a silent
+// false.
+
+/**
+ * Read the Meet camera toggle's current on/off state from its aria-label.
+ * Returns `null` when the toggle button isn't in the DOM.
+ *
+ * The aria-label is the authoritative state bit: "Turn off camera" ⇒
+ * camera is currently ON; "Turn on camera" ⇒ camera is currently OFF. We
+ * match the exact label rather than a prefix because Meet currently does
+ * not decorate this label (unlike the prejoin admission button).
+ */
+export function isCameraOn(doc: Document = document): boolean | null {
+  const btn = doc.querySelector(controlSelectors.CAMERA_TOGGLE);
+  if (!btn) return null;
+  const label = btn.getAttribute("aria-label") ?? "";
+  if (label === "Turn off camera") return true;
+  if (label === "Turn on camera") return false;
+  // Unrecognized label (localized Meet variant, future drift) — treat as
+  // "unknown" so callers fall through to the click + poll path rather than
+  // short-circuiting on bogus state.
+  return null;
+}
+
+/**
+ * Read the Meet microphone toggle's current on/off state from its
+ * aria-label. Returns `null` when the toggle button isn't in the DOM.
+ *
+ * Mirrors {@link isCameraOn} — kept symmetric so a future mic feature
+ * module can consume the same accessor.
+ */
+export function isMicOn(doc: Document = document): boolean | null {
+  const btn = doc.querySelector(controlSelectors.MIC_TOGGLE);
+  if (!btn) return null;
+  const label = btn.getAttribute("aria-label") ?? "";
+  if (label === "Turn off microphone") return true;
+  if (label === "Turn on microphone") return false;
+  return null;
+}

--- a/skills/meet-join/meet-controller-ext/src/features/camera.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/camera.ts
@@ -1,0 +1,256 @@
+/**
+ * In-meeting camera-toggle feature for the content script.
+ *
+ * Drives the Google Meet camera on/off toggle in the bottom toolbar. The
+ * avatar subsystem calls into this module (via native-messaging
+ * `camera.enable` / `camera.disable` commands dispatched from the bot's
+ * HTTP `/avatar/enable` / `/avatar/disable` routes) so that enabling the
+ * avatar renderer also turns the camera ON (so Meet starts emitting the
+ * v4l2loopback-fed video stream to other participants), and disabling the
+ * renderer turns the camera OFF.
+ *
+ * ## State model
+ *
+ * Meet reports the camera's on/off state exclusively through the
+ * `aria-label` swap on the toolbar button: `"Turn off camera"` ⇒ camera
+ * is currently ON, `"Turn on camera"` ⇒ camera is currently OFF. There is
+ * no `aria-pressed` attribute. See {@link isCameraOn} in `../dom/selectors.ts`
+ * for the label parser.
+ *
+ * ## Click strategy
+ *
+ * Meet gates the prejoin admission button on `event.isTrusted` — a
+ * programmatic `.click()` from a content script is silently ignored. The
+ * in-meeting camera toggle was not empirically verified to be gated at the
+ * time of this feature landing, BUT two independent signals argue for
+ * using the trusted-click path anyway:
+ *
+ *   1. Every other post-admission surface we've instrumented (chat send,
+ *      chat panel toggle) turned out to be gated, so assuming the mic and
+ *      camera buttons also are is the safer default.
+ *   2. `features/chat.ts` already emits `trusted_click` for the chat send
+ *      button (see the `sendChat` implementation). Mirroring the pattern
+ *      keeps the feature modules symmetric.
+ *
+ * We therefore emit a `trusted_click` over native messaging with the
+ * button's computed screen coordinates, then also call the JS `.click()`
+ * fallback so the jsdom test harness exercises a real click path and any
+ * Meet build that ever relaxes the `isTrusted` gate continues to work.
+ *
+ * ## Polling confirmation
+ *
+ * After the click, the feature polls {@link isCameraOn} for up to 5s until
+ * the aria-label flips to the expected post-click state. If the state never
+ * transitions, the feature throws a descriptive error so the bot can
+ * surface it in logs — the `/avatar/enable` HTTP route treats a failed
+ * camera toggle as best-effort (the renderer is already running, so a
+ * stuck camera toggle is a regression signal but not a reason to tear the
+ * renderer back down).
+ *
+ * ## No-op short-circuit
+ *
+ * If the toggle is already in the requested state (enable called when the
+ * camera is already on, or vice versa), `enableCamera` / `disableCamera`
+ * return `{ changed: false }` without clicking. This keeps the daemon's
+ * retry path idempotent — repeated enable calls against an already-on
+ * camera don't rack up a spurious click per retry that would bounce the
+ * state off then back on.
+ */
+
+import type { ExtensionToBotMessage } from "../../../contracts/native-messaging.js";
+import { controlSelectors, isCameraOn } from "../dom/selectors.js";
+
+/**
+ * How long {@link enableCamera} / {@link disableCamera} wait for the
+ * aria-label to flip after clicking before giving up. Sized for production
+ * latency (the xdotool trusted_click is a fire-and-forget native-messaging
+ * emit that queues through the bot → xdotool → X-server → Chromium
+ * pipeline, which typically lands in 50–400ms under load) with generous
+ * slack for the tail.
+ */
+const TOGGLE_CONFIRM_TIMEOUT_MS = 5_000;
+
+/**
+ * How often to re-check the aria-label while polling for the post-click
+ * state transition. Short enough that a fast click lands well under the
+ * timeout, long enough to avoid busy-looping a React reconciliation cycle.
+ */
+const TOGGLE_CONFIRM_POLL_INTERVAL_MS = 50;
+
+/**
+ * Result of a {@link enableCamera} / {@link disableCamera} call.
+ *
+ * `changed: false` means the toggle was already in the requested state;
+ * `changed: true` means a click was dispatched and the aria-label
+ * transition was confirmed. Both count as success — the distinction is
+ * observability. Throwing is the signal that the toggle could not reach
+ * the requested state (element missing, polling timed out).
+ */
+export interface ToggleCameraResult {
+  changed: boolean;
+}
+
+/** Options for {@link enableCamera} / {@link disableCamera}. */
+export interface ToggleCameraOptions {
+  /**
+   * Sink for extension→bot events. When provided, emits a `trusted_click`
+   * with screen-space coordinates for the toggle button so the bot can
+   * dispatch a real X-server click via xdotool. Same pattern as
+   * `features/chat.ts` and `features/join.ts`.
+   */
+  onEvent?: (msg: ExtensionToBotMessage) => void;
+  /**
+   * Window used to compute screen-space coordinates. Defaults to the live
+   * `window` / `globalThis` when omitted; tests override with a JSDOM-backed
+   * shape so the coord math is deterministic.
+   */
+  window?: {
+    screenX: number;
+    screenY: number;
+    outerHeight: number;
+    innerHeight: number;
+  };
+  /**
+   * Document to operate against. Defaults to the live `document` so the
+   * production content script can call `enableCamera()` without passing
+   * it through; tests override with a JSDOM-backed document.
+   */
+  doc?: Document;
+  /**
+   * Override for the aria-state polling timeout. Defaults to
+   * {@link TOGGLE_CONFIRM_TIMEOUT_MS}; tests pass shorter values so the
+   * timeout path is exercised without waiting 5s.
+   */
+  timeoutMs?: number;
+  /**
+   * Override for the aria-state polling interval. Defaults to
+   * {@link TOGGLE_CONFIRM_POLL_INTERVAL_MS}; tests can shorten it to
+   * minimize test wall-clock.
+   */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Turn the Meet camera ON. Returns `{ changed: false }` if the camera was
+ * already on; `{ changed: true }` after a successful click + aria-state
+ * confirmation. Throws a descriptive error if the toggle is missing or if
+ * the aria-state never transitions within the timeout.
+ */
+export async function enableCamera(
+  opts: ToggleCameraOptions = {},
+): Promise<ToggleCameraResult> {
+  return toggleCameraTo(true, opts);
+}
+
+/**
+ * Turn the Meet camera OFF. Symmetric to {@link enableCamera}.
+ */
+export async function disableCamera(
+  opts: ToggleCameraOptions = {},
+): Promise<ToggleCameraResult> {
+  return toggleCameraTo(false, opts);
+}
+
+/**
+ * Shared implementation for enable/disable. Keeps the click + confirm
+ * logic in one place so the two public entry points can't drift.
+ */
+async function toggleCameraTo(
+  desired: boolean,
+  opts: ToggleCameraOptions,
+): Promise<ToggleCameraResult> {
+  const doc = opts.doc ?? document;
+  const timeoutMs = opts.timeoutMs ?? TOGGLE_CONFIRM_TIMEOUT_MS;
+  const pollIntervalMs = opts.pollIntervalMs ?? TOGGLE_CONFIRM_POLL_INTERVAL_MS;
+
+  const current = isCameraOn(doc);
+  if (current === null) {
+    throw new Error(
+      `camera: toggle button not found (selector: ${controlSelectors.CAMERA_TOGGLE})`,
+    );
+  }
+  if (current === desired) {
+    return { changed: false };
+  }
+
+  const toggle = doc.querySelector<HTMLButtonElement>(
+    controlSelectors.CAMERA_TOGGLE,
+  );
+  if (!toggle) {
+    // `isCameraOn` already confirmed a matching element exists, but a
+    // concurrent DOM mutation could have removed it between the two
+    // queries. Surface that as the same "not found" error for simplicity.
+    throw new Error(
+      `camera: toggle button not found (selector: ${controlSelectors.CAMERA_TOGGLE})`,
+    );
+  }
+
+  // Emit trusted_click with computed screen coords when the caller wired
+  // up an onEvent sink. Math mirrors `features/chat.ts` and
+  // `features/join.ts` — see the long comment in `features/join.ts` for
+  // the assumptions about screenX/Y, chrome offsets, and DPI. Production
+  // Xvfb pins the window to (0,0) with no bottom chrome, so the
+  // `outerHeight - innerHeight` delta is the top chrome offset.
+  if (opts.onEvent) {
+    try {
+      const rect = toggle.getBoundingClientRect();
+      const win = opts.window ?? (doc.defaultView ?? globalThis);
+      const chromeOffsetY = Math.max(
+        0,
+        (win as typeof globalThis).outerHeight -
+          (win as typeof globalThis).innerHeight,
+      );
+      const screenX = Math.round(
+        ((win as typeof globalThis).screenX ?? 0) + rect.left + rect.width / 2,
+      );
+      const screenY = Math.round(
+        ((win as typeof globalThis).screenY ?? 0) +
+          chromeOffsetY +
+          rect.top +
+          rect.height / 2,
+      );
+      opts.onEvent({ type: "trusted_click", x: screenX, y: screenY });
+    } catch {
+      // If the rect or window shape is bogus, fall through to the JS click
+      // fallback rather than swallowing the whole toggle attempt.
+    }
+  }
+
+  try {
+    toggle.click();
+  } catch {
+    // `.click()` can fail if the button is detached mid-flight; fall
+    // through to the poll — if the trusted_click also failed to produce a
+    // state transition, we'll time out below with a descriptive error.
+  }
+
+  // Poll the aria-state for the post-click transition. Shared between
+  // the jsdom test harness (which flips the label synchronously from the
+  // JS `.click()` fallback) and production (which waits for xdotool's
+  // X-server click to land tens of ms later via the `trusted_click` path).
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const now = isCameraOn(doc);
+    if (now === desired) {
+      return { changed: true };
+    }
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, pollIntervalMs),
+    );
+  }
+
+  // Final check at the deadline boundary so a transition that lands
+  // exactly on the last tick isn't lost to the loop exit condition.
+  const final = isCameraOn(doc);
+  if (final === desired) {
+    return { changed: true };
+  }
+
+  throw new Error(
+    `camera: aria-state did not transition to ${
+      desired ? "on" : "off"
+    } within ${timeoutMs}ms (last observed: ${
+      final === null ? "unknown" : final ? "on" : "off"
+    })`,
+  );
+}


### PR DESCRIPTION
## Summary
- New `features/camera.ts` in the Chrome extension mirrors the mic-toggle pattern: `enableCamera()`/`disableCamera()` with aria-state no-op short-circuit and 5s polled confirmation.
- Zod schemas for `camera.enable`/`camera.disable` land in `contracts/native-messaging.ts`.
- Bot-side `camera-channel.ts` helpers send the NM messages; `http-server.ts` wires `/avatar/enable` to toggle camera on after renderer start, `/avatar/disable` to toggle camera off before renderer stop (avoids a black-frame gap).

Part of plan: meet-phase-4-avatar.md (PR 9 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
