### PR TITLE
meet-bot: TalkingHead.js renderer (default, no paid deps)

### DIFF
--- a/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
+++ b/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Tests for the TalkingHead.js-backed avatar renderer.
+ *
+ * The renderer delegates every interesting operation to the Chrome
+ * extension over the native-messaging bridge, so tests mock the
+ * {@link AvatarNativeMessagingSender} surface entirely — no real
+ * socket server or Chrome process is needed.
+ *
+ * Coverage:
+ *   - `start()` sends `avatar.start` over native messaging and waits
+ *     for the extension's `avatar.started` ack.
+ *   - `start()` throws `AvatarRendererUnavailableError` when the ack
+ *     doesn't arrive within the bounded timeout.
+ *   - `pushViseme` forwards the event as `avatar.push_viseme`.
+ *   - Inbound `avatar.frame` (JPEG) re-emits via `onFrame` after a
+ *     (mocked) ffmpeg transcode.
+ *   - Inbound `avatar.frame` (Y4M) re-emits via `onFrame` directly.
+ *   - `stop()` sends `avatar.stop`, is idempotent, and cancels the
+ *     pending ack waiter if invoked mid-start.
+ *   - Factory registration throws `AvatarRendererUnavailableError`
+ *     when `deps.nativeMessaging` is absent.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  BotAvatarPushVisemeCommand,
+  BotAvatarStartCommand,
+  BotAvatarStopCommand,
+  ExtensionAvatarFrameMessage,
+  ExtensionAvatarStartedMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+import {
+  AvatarRendererUnavailableError,
+  __resetAvatarRegistryForTests,
+  isAvatarRendererRegistered,
+  registerAvatarRenderer,
+  resolveAvatarRenderer,
+  type AvatarConfig,
+  type AvatarNativeMessagingSender,
+  type AvatarRendererDeps,
+  type Y4MFrame,
+} from "../src/media/avatar/index.js";
+// Importing the talking-head module has the side effect of registering
+// the factory with the registry.
+import "../src/media/avatar/talking-head/index.js";
+import {
+  TALKING_HEAD_RENDERER_ID,
+  TalkingHeadRenderer,
+  type JpegToY4mSpawnFactory,
+} from "../src/media/avatar/talking-head/renderer.js";
+
+/**
+ * Rebuild the talking-head factory registration after a sibling test
+ * suite (e.g. `avatar-registry.test.ts`) called
+ * `__resetAvatarRegistryForTests`. The factory module only self-
+ * registers on first import; ES modules cache and don't re-run on a
+ * subsequent import. We re-import the module dynamically isn't an
+ * option for the same reason, so we just register the factory
+ * ourselves using the same public surface the module uses.
+ */
+function ensureTalkingHeadRegistered(): void {
+  if (isAvatarRendererRegistered(TALKING_HEAD_RENDERER_ID)) return;
+  registerAvatarRenderer(
+    TALKING_HEAD_RENDERER_ID,
+    (config: AvatarConfig, deps: AvatarRendererDeps) => {
+      if (!deps.nativeMessaging) {
+        throw new AvatarRendererUnavailableError(
+          TALKING_HEAD_RENDERER_ID,
+          "native-messaging surface not wired (bot was booted without an NMH socket server)",
+        );
+      }
+      const rawSub = (config as Record<string, unknown>).talkingHead;
+      const sub =
+        rawSub && typeof rawSub === "object"
+          ? (rawSub as Record<string, unknown>)
+          : {};
+      const opts: ConstructorParameters<typeof TalkingHeadRenderer>[0] = {
+        nativeMessaging: deps.nativeMessaging,
+      };
+      if (typeof sub.modelUrl === "string") opts.modelUrl = sub.modelUrl;
+      else if (typeof sub.modelPath === "string")
+        opts.modelUrl = sub.modelPath;
+      if (typeof sub.targetFps === "number") opts.targetFps = sub.targetFps;
+      if (typeof sub.startedAckTimeoutMs === "number")
+        opts.startedAckTimeoutMs = sub.startedAckTimeoutMs;
+      return new TalkingHeadRenderer(opts);
+    },
+  );
+}
+
+type BotAvatarMsg =
+  | BotAvatarStartCommand
+  | BotAvatarStopCommand
+  | BotAvatarPushVisemeCommand;
+
+/**
+ * In-memory fake of the `AvatarNativeMessagingSender` surface the
+ * renderer depends on. Records every outbound message and exposes an
+ * `emit(...)` helper that drives the registered inbound listeners
+ * deterministically.
+ */
+class FakeNativeMessaging implements AvatarNativeMessagingSender {
+  readonly sent: BotAvatarMsg[] = [];
+  private listeners: Array<(msg: ExtensionToBotMessage) => void> = [];
+
+  sendToExtension = (msg: BotAvatarMsg): void => {
+    this.sent.push(msg);
+  };
+
+  onExtensionMessage = (cb: (msg: ExtensionToBotMessage) => void): void => {
+    this.listeners.push(cb);
+  };
+
+  /** Dispatch a message to every registered listener. */
+  emit(msg: ExtensionToBotMessage): void {
+    for (const cb of this.listeners.slice()) cb(msg);
+  }
+}
+
+function makeFrameMsg(
+  overrides: Partial<ExtensionAvatarFrameMessage> = {},
+): ExtensionAvatarFrameMessage {
+  return {
+    type: "avatar.frame",
+    bytes: overrides.bytes ?? "AAECAwQ=",
+    width: overrides.width ?? 1280,
+    height: overrides.height ?? 720,
+    format: overrides.format ?? "y4m",
+    ts: overrides.ts ?? 100,
+  };
+}
+
+/** Minimal JPEG→Y4M spawn fake — returns a fixed payload. */
+function makeTranscodeFactory(
+  output: Uint8Array,
+  opts: { failWith?: Error; delayMs?: number } = {},
+): JpegToY4mSpawnFactory {
+  return () => {
+    let killed = false;
+    return {
+      readY4m: async () => {
+        if (opts.delayMs) {
+          await new Promise((r) => setTimeout(r, opts.delayMs));
+        }
+        if (killed) {
+          throw new Error("killed");
+        }
+        if (opts.failWith) throw opts.failWith;
+        return output;
+      },
+      exited: Promise.resolve(0),
+      kill: () => {
+        killed = true;
+      },
+    };
+  };
+}
+
+describe("TalkingHeadRenderer", () => {
+  afterEach(() => {
+    // Registered once at module load; re-register after reset so
+    // other tests that rely on resolveAvatarRenderer see the factory.
+    // The import statement at the top of this file is idempotent — ES
+    // modules cache imports — so we rely on that for the
+    // `importRegistration` test below.
+  });
+
+  test("advertises id + capabilities", () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({ nativeMessaging });
+    expect(r.id).toBe(TALKING_HEAD_RENDERER_ID);
+    expect(r.capabilities).toEqual({ needsVisemes: true, needsAudio: true });
+  });
+
+  test("constructor throws AvatarRendererUnavailableError when nativeMessaging is missing", () => {
+    let err: unknown;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _r = new TalkingHeadRenderer({});
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const avatarErr = err as AvatarRendererUnavailableError;
+    expect(avatarErr.rendererId).toBe(TALKING_HEAD_RENDERER_ID);
+    expect(avatarErr.reason).toContain("native-messaging");
+  });
+
+  test("start() dispatches avatar.start and resolves on avatar.started ack", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 1_000,
+      targetFps: 24,
+    });
+    const startPromise = r.start();
+
+    // Exactly one avatar.start command must have been dispatched.
+    expect(nativeMessaging.sent).toHaveLength(1);
+    expect(nativeMessaging.sent[0]!.type).toBe("avatar.start");
+    const startCmd = nativeMessaging.sent[0] as BotAvatarStartCommand;
+    expect(startCmd.targetFps).toBe(24);
+
+    // Simulate the extension's ack.
+    const ack: ExtensionAvatarStartedMessage = { type: "avatar.started" };
+    nativeMessaging.emit(ack);
+    await startPromise;
+  });
+
+  test("start() forwards modelUrl when supplied", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 1_000,
+      modelUrl: "chrome-extension://abcdef/avatar/custom.glb",
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+    const startCmd = nativeMessaging.sent[0] as BotAvatarStartCommand;
+    expect(startCmd.modelUrl).toBe(
+      "chrome-extension://abcdef/avatar/custom.glb",
+    );
+  });
+
+  test("start() throws AvatarRendererUnavailableError when the ack does not arrive in time", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 20,
+    });
+    let err: unknown;
+    try {
+      await r.start();
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const avatarErr = err as AvatarRendererUnavailableError;
+    expect(avatarErr.rendererId).toBe(TALKING_HEAD_RENDERER_ID);
+    expect(avatarErr.reason).toContain("did not ack");
+  });
+
+  test("start() is a no-op on a second invocation against the same instance", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+    // Second call is a no-op — no additional avatar.start frame.
+    await r.start();
+    expect(
+      nativeMessaging.sent.filter((m) => m.type === "avatar.start"),
+    ).toHaveLength(1);
+  });
+
+  test("pushViseme forwards as avatar.push_viseme", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    r.pushViseme({ phoneme: "ah", weight: 0.8, timestamp: 500 });
+    r.pushViseme({ phoneme: "ee", weight: 0.4, timestamp: 550 });
+
+    const pushed = nativeMessaging.sent.filter(
+      (m) => m.type === "avatar.push_viseme",
+    ) as BotAvatarPushVisemeCommand[];
+    expect(pushed).toHaveLength(2);
+    expect(pushed[0]).toEqual({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.8,
+      timestamp: 500,
+    });
+    expect(pushed[1]).toEqual({
+      type: "avatar.push_viseme",
+      phoneme: "ee",
+      weight: 0.4,
+      timestamp: 550,
+    });
+  });
+
+  test("pushViseme is a no-op before start() and after stop()", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    // Before start: no channel, no dispatch.
+    r.pushViseme({ phoneme: "ah", weight: 0.5, timestamp: 10 });
+    expect(nativeMessaging.sent).toHaveLength(0);
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+    await r.stop();
+
+    // After stop: channel disposed, no dispatch.
+    const before = nativeMessaging.sent.length;
+    r.pushViseme({ phoneme: "ee", weight: 0.5, timestamp: 20 });
+    expect(nativeMessaging.sent.length).toBe(before);
+  });
+
+  test("inbound avatar.frame (y4m) re-emits via onFrame", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const received: Y4MFrame[] = [];
+    r.onFrame((f) => received.push(f));
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    // `AAECAwQ=` decodes to [0,1,2,3,4].
+    nativeMessaging.emit(
+      makeFrameMsg({
+        bytes: "AAECAwQ=",
+        format: "y4m",
+        width: 640,
+        height: 480,
+        ts: 1234,
+      }),
+    );
+
+    // Bot needs a turn to process the async handler chain.
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.width).toBe(640);
+    expect(received[0]!.height).toBe(480);
+    expect(received[0]!.timestamp).toBe(1234);
+    expect(Array.from(received[0]!.bytes)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("inbound avatar.frame (jpeg) transcodes via the injected ffmpeg factory and re-emits via onFrame", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const y4mPayload = new Uint8Array([0xaa, 0xbb, 0xcc]);
+    const spawnJpegToY4m = makeTranscodeFactory(y4mPayload);
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+      spawnJpegToY4m,
+    });
+    const received: Y4MFrame[] = [];
+    r.onFrame((f) => received.push(f));
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    nativeMessaging.emit(
+      makeFrameMsg({
+        bytes: "aGVsbG8=",
+        format: "jpeg",
+        width: 320,
+        height: 240,
+        ts: 42,
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(received).toHaveLength(1);
+    expect(Array.from(received[0]!.bytes)).toEqual([0xaa, 0xbb, 0xcc]);
+    expect(received[0]!.width).toBe(320);
+    expect(received[0]!.height).toBe(240);
+  });
+
+  test("onFrame returns a working unsubscribe", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const received: Y4MFrame[] = [];
+    const unsubscribe = r.onFrame((f) => received.push(f));
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    nativeMessaging.emit(makeFrameMsg({ bytes: "AA==", format: "y4m" }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(received).toHaveLength(1);
+
+    unsubscribe();
+
+    nativeMessaging.emit(makeFrameMsg({ bytes: "Ag==", format: "y4m" }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(received).toHaveLength(1);
+  });
+
+  test("failed jpeg transcode drops the frame without throwing", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const spawnJpegToY4m = makeTranscodeFactory(new Uint8Array(), {
+      failWith: new Error("ffmpeg barfed"),
+    });
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+      spawnJpegToY4m,
+    });
+    const received: Y4MFrame[] = [];
+    r.onFrame((f) => received.push(f));
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    nativeMessaging.emit(makeFrameMsg({ bytes: "AA==", format: "jpeg" }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(received).toHaveLength(0);
+  });
+
+  test("stop() dispatches avatar.stop and disposes the channel", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    await r.stop();
+    const stopMsgs = nativeMessaging.sent.filter(
+      (m) => m.type === "avatar.stop",
+    );
+    expect(stopMsgs).toHaveLength(1);
+  });
+
+  test("stop() is idempotent", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+
+    await r.stop();
+    await r.stop();
+    await r.stop();
+    const stopMsgs = nativeMessaging.sent.filter(
+      (m) => m.type === "avatar.stop",
+    );
+    // Second + third stop() are no-ops.
+    expect(stopMsgs).toHaveLength(1);
+  });
+
+  test("stop() rejects a pending start() waiter", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 5_000,
+    });
+    const startPromise = r.start();
+    // Do not emit the ack; instead, call stop() to race the waiter.
+    void r.stop();
+
+    let err: unknown;
+    try {
+      await startPromise;
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    expect((err as AvatarRendererUnavailableError).reason).toContain(
+      "stopped before",
+    );
+  });
+
+  test("frames arriving after stop() are dropped at the channel layer", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 500,
+    });
+    const received: Y4MFrame[] = [];
+    r.onFrame((f) => received.push(f));
+
+    const startPromise = r.start();
+    nativeMessaging.emit({ type: "avatar.started" });
+    await startPromise;
+    await r.stop();
+
+    nativeMessaging.emit(makeFrameMsg({ bytes: "AA==", format: "y4m" }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe("TalkingHead factory registration", () => {
+  beforeEach(() => {
+    // Sibling test suites (e.g. avatar-registry.test.ts) may have
+    // called __resetAvatarRegistryForTests() before we arrive. Re-
+    // register the factory so our assertions against the registry
+    // work no matter which order tests run in.
+    ensureTalkingHeadRegistered();
+  });
+
+  test("the talking-head factory is registered with the registry", () => {
+    expect(isAvatarRendererRegistered(TALKING_HEAD_RENDERER_ID)).toBe(true);
+  });
+
+  test("factory throws AvatarRendererUnavailableError when deps.nativeMessaging is missing", () => {
+    let err: unknown;
+    try {
+      resolveAvatarRenderer(
+        { enabled: true, renderer: TALKING_HEAD_RENDERER_ID },
+        {},
+      );
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    expect((err as AvatarRendererUnavailableError).rendererId).toBe(
+      TALKING_HEAD_RENDERER_ID,
+    );
+  });
+
+  test("factory returns a working renderer when deps.nativeMessaging is wired", () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = resolveAvatarRenderer(
+      { enabled: true, renderer: TALKING_HEAD_RENDERER_ID },
+      { nativeMessaging },
+    );
+    expect(renderer).not.toBeNull();
+    expect(renderer!.id).toBe(TALKING_HEAD_RENDERER_ID);
+    expect(renderer!.capabilities).toEqual({
+      needsVisemes: true,
+      needsAudio: true,
+    });
+  });
+
+  test("factory reads optional talkingHead sub-config", () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = resolveAvatarRenderer(
+      {
+        enabled: true,
+        renderer: TALKING_HEAD_RENDERER_ID,
+        talkingHead: {
+          modelUrl: "chrome-extension://abc/avatar/custom.glb",
+          targetFps: 30,
+          startedAckTimeoutMs: 2000,
+        },
+      },
+      { nativeMessaging },
+    );
+    expect(renderer).not.toBeNull();
+    expect(renderer!.id).toBe(TALKING_HEAD_RENDERER_ID);
+  });
+
+  test("a registry reset clears the talking-head factory", () => {
+    // Sanity check: the reset helper works as documented. Sibling
+    // tests (avatar-registry.test.ts) rely on this invariant to
+    // scope their own factory registrations to the test scope.
+    __resetAvatarRegistryForTests();
+    expect(isAvatarRendererRegistered(TALKING_HEAD_RENDERER_ID)).toBe(false);
+  });
+});

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -35,6 +35,7 @@ import {
   AvatarRendererUnavailableError,
   resolveAvatarRenderer,
   type AvatarConfig,
+  type AvatarNativeMessagingSender,
   type AvatarRenderer,
   type DeviceWriterHandle,
   type VisemeEvent,
@@ -138,6 +139,16 @@ export interface HttpServerAvatarOptions {
   resolveRenderer?: (
     config: AvatarConfig,
   ) => AvatarRenderer | null;
+  /**
+   * Native-messaging surface forwarded to the renderer factory's
+   * `deps.nativeMessaging`. Renderers that drive an extension-hosted
+   * avatar (TalkingHead.js) require this; renderers that render
+   * server-side or delegate to a hosted WebRTC backend ignore it.
+   * When absent, `/avatar/enable` falls back to a deps bag without a
+   * native-messaging surface — the TalkingHead factory then throws
+   * {@link AvatarRendererUnavailableError} and the route returns 503.
+   */
+  nativeMessaging?: AvatarNativeMessagingSender;
   /**
    * Device opener override. Defaults to
    * {@link defaultOpenVideoDevice}; tests provide a shim that returns
@@ -634,7 +645,13 @@ export function createHttpServer(
       let renderer: AvatarRenderer | null;
       try {
         const resolveFn =
-          avatar.resolveRenderer ?? ((config) => resolveAvatarRenderer(config, {}));
+          avatar.resolveRenderer ??
+          ((config) =>
+            resolveAvatarRenderer(config, {
+              ...(avatar.nativeMessaging
+                ? { nativeMessaging: avatar.nativeMessaging }
+                : {}),
+            }));
         renderer = resolveFn(avatar.config);
       } catch (err) {
         if (err instanceof AvatarRendererUnavailableError) {

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -76,12 +76,13 @@ import {
 } from "./control/http-server.js";
 import { BotState } from "./control/state.js";
 // Importing the avatar barrel has the side effect of registering the noop
-// factory. Individual renderer-backend PRs extend this list with their own
-// side-effect imports.
+// factory and the TalkingHead.js factory. Individual renderer-backend PRs
+// extend this list with their own side-effect imports.
 import {
   AvatarRendererUnavailableError,
   resolveAvatarRenderer,
   type AvatarConfig,
+  type AvatarNativeMessagingSender,
 } from "./media/avatar/index.js";
 import {
   startAudioCapture,
@@ -802,7 +803,11 @@ export async function runBot(deps: BotDeps): Promise<void> {
     // just logs; the renderer is actually started on the daemon's
     // `/avatar/enable` HTTP call.
     // ---------------------------------------------------------------------
-    const avatarHttpOptions = buildAvatarHttpOptions(env, deps);
+    const avatarHttpOptions = buildAvatarHttpOptions(
+      env,
+      deps,
+      subsystems.socketServer,
+    );
 
     subsystems.httpServer = deps.createHttpServer({
       apiToken: botApiToken,
@@ -1012,10 +1017,15 @@ function errMsg(err: unknown): string {
  * probe: if the configured renderer can't be resolved the failure is
  * logged — but we do NOT bail the bot boot, since the renderer is not
  * strictly required for the meeting to proceed.
+ *
+ * When `socketServer` is non-null the caller forwards a narrowed
+ * `AvatarNativeMessagingSender` so the TalkingHead.js renderer (and
+ * any future extension-mediated renderer) can drive the avatar tab.
  */
 function buildAvatarHttpOptions(
   env: BotEnv,
   deps: BotDeps,
+  socketServer: NmhSocketServer | null,
 ): HttpServerAvatarOptions | undefined {
   if (!env.avatarEnabled) return undefined;
 
@@ -1043,9 +1053,21 @@ function buildAvatarHttpOptions(
     renderer: env.avatarRenderer,
   };
 
+  // Narrow the NMH socket server to the three avatar.* outbound
+  // commands + the inbound listener hook. The renderer gets a
+  // hard-typed surface it can't use to smuggle `join`/`leave`/etc.
+  const nativeMessaging: AvatarNativeMessagingSender | undefined = socketServer
+    ? {
+        sendToExtension: (msg) => socketServer.sendToExtension(msg),
+        onExtensionMessage: (cb) => socketServer.onExtensionMessage(cb),
+      }
+    : undefined;
+
   // Eager construction probe — non-fatal on failure.
   try {
-    resolveAvatarRenderer(config, {});
+    resolveAvatarRenderer(config, {
+      ...(nativeMessaging ? { nativeMessaging } : {}),
+    });
   } catch (err) {
     if (err instanceof AvatarRendererUnavailableError) {
       deps.logError(
@@ -1060,6 +1082,7 @@ function buildAvatarHttpOptions(
 
   return {
     config,
+    ...(nativeMessaging ? { nativeMessaging } : {}),
     ...(env.avatarDevicePath ? { devicePath: env.avatarDevicePath } : {}),
   };
 }

--- a/skills/meet-join/bot/src/media/avatar/index.ts
+++ b/skills/meet-join/bot/src/media/avatar/index.ts
@@ -35,6 +35,7 @@ export {
   registerAvatarRenderer,
   resolveAvatarRenderer,
   type AvatarConfig,
+  type AvatarNativeMessagingSender,
   type AvatarRendererDeps,
   type AvatarRendererFactory,
 } from "./registry.js";
@@ -43,3 +44,10 @@ export {
 // `resolveAvatarRenderer` can find it when something explicitly asks
 // for the id rather than relying on the null short-circuit path.
 import "./noop-renderer.js";
+
+// Side-effect import: registers the TalkingHead.js factory under
+// `"talking-head"`. The factory throws AvatarRendererUnavailableError
+// when `deps.nativeMessaging` isn't wired (e.g. in tests without a
+// socket server) so the HTTP layer turns that into a 503 with a
+// clear reason rather than crashing.
+import "./talking-head/index.js";

--- a/skills/meet-join/bot/src/media/avatar/registry.ts
+++ b/skills/meet-join/bot/src/media/avatar/registry.ts
@@ -31,16 +31,49 @@
  * {@link AvatarRendererUnavailableError}).
  */
 
+import type {
+  BotAvatarPushVisemeCommand,
+  BotAvatarStartCommand,
+  BotAvatarStopCommand,
+  ExtensionToBotMessage,
+} from "../../../../contracts/native-messaging.js";
+
 import {
   AvatarRendererUnavailableError,
   type AvatarRenderer,
 } from "./types.js";
 
 /**
- * Dependencies the daemon hands to every renderer factory. Currently a
- * logger — concrete renderers typically also take their own construction
- * arguments (endpoint URLs, credentials) via the `config` object rather
- * than through this deps bag. Kept as a shape so later PRs can grow it
+ * Narrow slice of the NMH socket server the TalkingHead renderer (and
+ * any future extension-mediated renderer) uses to talk to the Chrome
+ * extension. Scoped to avatar-only message types so a buggy renderer
+ * cannot smuggle a `join`/`leave`/`send_chat` through this surface.
+ *
+ * The bot's `main.ts` wires a wrapper around {@link NmhSocketServer}
+ * that narrows to exactly the three avatar commands. Tests pass an
+ * in-memory fake that captures sent frames.
+ */
+export interface AvatarNativeMessagingSender {
+  /** Send one of the avatar.* commands. Throws if no extension is connected. */
+  sendToExtension: (
+    msg:
+      | BotAvatarStartCommand
+      | BotAvatarStopCommand
+      | BotAvatarPushVisemeCommand,
+  ) => void;
+  /**
+   * Register a handler for every inbound extension→bot message. The
+   * TalkingHead renderer filters for `avatar.started` / `avatar.frame`
+   * and ignores every other type (which is handled by the bot's main
+   * message router).
+   */
+  onExtensionMessage: (cb: (msg: ExtensionToBotMessage) => void) => void;
+}
+
+/**
+ * Dependencies the daemon hands to every renderer factory. Renderers
+ * use whichever fields they need and ignore the rest — the optional
+ * fields let the shape grow additively as new renderer backends arrive
  * without breaking existing factories.
  */
 export interface AvatarRendererDeps {
@@ -50,6 +83,14 @@ export interface AvatarRendererDeps {
     warn(msg: string, extra?: Record<string, unknown>): void;
     error(msg: string, extra?: Record<string, unknown>): void;
   };
+  /**
+   * Native-messaging surface the TalkingHead.js renderer uses to
+   * drive the extension-hosted avatar tab. Absent when the bot is
+   * booted without a live socket server (tests, smoke builds) — the
+   * renderer must throw {@link AvatarRendererUnavailableError} when
+   * it's not wired and a caller asks for TalkingHead specifically.
+   */
+  nativeMessaging?: AvatarNativeMessagingSender;
 }
 
 /**

--- a/skills/meet-join/bot/src/media/avatar/talking-head/index.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/index.ts
@@ -1,0 +1,118 @@
+/**
+ * TalkingHead.js renderer barrel + import-time self-registration.
+ *
+ * Importing this module registers the `"talking-head"` factory with
+ * the avatar registry. The bot's `main.ts` pulls this file in at
+ * boot so `resolveAvatarRenderer({ renderer: "talking-head" })` can
+ * find the factory by id.
+ *
+ * The factory reads the native-messaging sender from the
+ * {@link AvatarRendererDeps} bag. If the sender is absent (because the
+ * bot was booted without a live NMH socket server, e.g. a smoke test)
+ * the renderer constructor throws
+ * {@link AvatarRendererUnavailableError} — the registry lets that
+ * propagate so the HTTP layer turns it into a 503 with a clear
+ * reason.
+ *
+ * Per-renderer configuration lives under
+ * `services.meet.avatar.talkingHead` on the daemon side. The factory
+ * extracts:
+ *
+ * - `modelPath` / `modelUrl` — optional override for the bundled GLB.
+ * - `targetFps` — optional advisory hint forwarded to the extension.
+ * - `startedAckTimeoutMs` — optional override for the bounded wait
+ *   on the `avatar.started` ack.
+ *
+ * None of these are required; all have sensible defaults.
+ */
+
+import {
+  registerAvatarRenderer,
+  type AvatarConfig,
+  type AvatarRendererDeps,
+} from "../registry.js";
+import { AvatarRendererUnavailableError } from "../types.js";
+
+import {
+  TalkingHeadRenderer,
+  TALKING_HEAD_RENDERER_ID,
+  type TalkingHeadRendererOptions,
+} from "./renderer.js";
+
+export {
+  TalkingHeadRenderer,
+  TALKING_HEAD_RENDERER_ID,
+  DEFAULT_STARTED_ACK_TIMEOUT_MS,
+  DEFAULT_TARGET_FPS,
+  TALKING_HEAD_CAPABILITIES,
+  type JpegToY4mSpawnFactory,
+  type TalkingHeadRendererOptions,
+} from "./renderer.js";
+
+/**
+ * Narrow cast for the `services.meet.avatar.talkingHead` sub-object.
+ * Permissive shape so the bot package doesn't have to import the
+ * daemon's config schema — we validate each field we read.
+ */
+function readTalkingHeadSubConfig(
+  config: AvatarConfig,
+): Partial<{ modelUrl: string; targetFps: number; startedAckTimeoutMs: number }> {
+  const raw = (config as Record<string, unknown>).talkingHead;
+  if (!raw || typeof raw !== "object") return {};
+  const sub = raw as Record<string, unknown>;
+  const out: Partial<{
+    modelUrl: string;
+    targetFps: number;
+    startedAckTimeoutMs: number;
+  }> = {};
+  // Accept either `modelUrl` (preferred, explicit extension-URL) or
+  // `modelPath` (operator-facing: an absolute filesystem path the bot
+  // can turn into a file URL at a later stage).
+  const modelUrl = typeof sub.modelUrl === "string" ? sub.modelUrl : undefined;
+  const modelPath =
+    typeof sub.modelPath === "string" && sub.modelPath.length > 0
+      ? sub.modelPath
+      : undefined;
+  if (modelUrl) out.modelUrl = modelUrl;
+  else if (modelPath) out.modelUrl = modelPath;
+  if (typeof sub.targetFps === "number" && Number.isInteger(sub.targetFps)) {
+    out.targetFps = sub.targetFps;
+  }
+  if (
+    typeof sub.startedAckTimeoutMs === "number" &&
+    sub.startedAckTimeoutMs > 0
+  ) {
+    out.startedAckTimeoutMs = sub.startedAckTimeoutMs;
+  }
+  return out;
+}
+
+/**
+ * Factory the registry invokes on `/avatar/enable`. Throws
+ * {@link AvatarRendererUnavailableError} when the native-messaging
+ * surface isn't wired — the session-manager catches that specifically
+ * and falls back to the noop renderer.
+ */
+registerAvatarRenderer(TALKING_HEAD_RENDERER_ID, (config, deps) => {
+  if (!deps.nativeMessaging) {
+    throw new AvatarRendererUnavailableError(
+      TALKING_HEAD_RENDERER_ID,
+      "native-messaging surface not wired (bot was booted without an NMH socket server)",
+    );
+  }
+  const sub = readTalkingHeadSubConfig(config);
+  const opts: TalkingHeadRendererOptions = {
+    nativeMessaging: deps.nativeMessaging,
+    ...(sub.modelUrl !== undefined ? { modelUrl: sub.modelUrl } : {}),
+    ...(sub.targetFps !== undefined ? { targetFps: sub.targetFps } : {}),
+    ...(sub.startedAckTimeoutMs !== undefined
+      ? { startedAckTimeoutMs: sub.startedAckTimeoutMs }
+      : {}),
+    ...(deps.logger ? { logger: deps.logger } : {}),
+  };
+  return new TalkingHeadRenderer(opts);
+});
+
+// Re-export nothing else; this module's sole side effect is the
+// registration call above.
+export {};

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -1,0 +1,545 @@
+/**
+ * TalkingHead.js-backed avatar renderer for the meet-bot.
+ *
+ * TalkingHead.js (`@met4citizen/talkinghead` on npm) renders a Ready
+ * Player Me GLB avatar in a WebGL/three.js canvas and drives lip-sync
+ * from viseme events. Because TalkingHead.js requires a real browser
+ * runtime (three.js needs a `<canvas>`, a WebGL context, and an
+ * `AnimationFrame` loop), the renderer itself lives **inside a second
+ * Chrome tab** inside the meet-bot's Chrome process, not in the
+ * bot's Node runtime.
+ *
+ * Responsibilities of this bot-side renderer:
+ *
+ * 1. On `start()`: send `avatar.start` over the native-messaging bridge
+ *    to the meet-controller extension. The extension opens the avatar
+ *    tab (see `meet-controller-ext/src/features/avatar.ts`) and replies
+ *    with `avatar.started` once the tab has mounted.
+ *
+ *    We bound the wait for that ack with a configurable timeout
+ *    (default 5 s). On timeout we throw
+ *    {@link AvatarRendererUnavailableError} so the session-manager can
+ *    fall back to the noop renderer without crashing the meeting.
+ *
+ * 2. On `pushViseme(event)`: forward the event to the extension as
+ *    `avatar.push_viseme`. The extension relays the event into the
+ *    avatar tab via `chrome.tabs.sendMessage`.
+ *
+ * 3. On inbound `avatar.frame` from the extension: base64-decode the
+ *    payload. If the frame is JPEG, transcode it to Y4M via a
+ *    short-lived ffmpeg child; if it's already Y4M, emit the bytes
+ *    directly. Downstream: {@link attachDeviceWriter} forwards the
+ *    Y4M bytes to `/dev/video10`.
+ *
+ * 4. On `stop()`: send `avatar.stop`, tear down the ffmpeg child, and
+ *    dispose the native-messaging channel so late frames after
+ *    shutdown are dropped at the channel layer. Idempotent.
+ *
+ * ## Audio / viseme handling
+ *
+ * TalkingHead.js lip-syncs from discrete viseme events. This renderer
+ * advertises `{ needsVisemes: true, needsAudio: true }`:
+ *
+ * - When viseme events flow in via `pushViseme`, they're forwarded
+ *   directly (the renderer is a thin transport shim — TalkingHead.js
+ *   owns the blend-shape math inside the avatar tab).
+ * - `pushAudio` is accepted so the renderer can derive an amplitude
+ *   fallback when no upstream viseme stream is active. For v1 we
+ *   don't synthesize amplitude visemes inside the renderer — PR 9
+ *   (audio-playback alignment) will add that path. For now
+ *   `pushAudio` is a no-op on the wire; we still accept it to keep
+ *   the capability surface stable and avoid changing the shape in a
+ *   follow-up PR.
+ *
+ * ## Frame transcoding
+ *
+ * JPEG → Y4M conversion runs through a short-lived ffmpeg child per
+ * frame. This is the simplest correct implementation — the frame is
+ * written to ffmpeg's stdin, Y4M is read off its stdout, and the child
+ * exits. It's also the slowest: a sustained stream at 24 fps spawns
+ * 24 subprocesses per second which is inefficient. A future
+ * optimization is to keep a long-lived ffmpeg child with a persistent
+ * Y4M input stream; we defer that complexity to a later PR because:
+ *
+ * - v1 ships at 20–24 fps, which is still well under the 30 fps
+ *   device-writer cap and well within what per-frame spawning can
+ *   sustain on a modest bot VM.
+ * - The alignment math PR 9 introduces may change the frame-ingress
+ *   contract entirely; premature optimization would be wasted work.
+ *
+ * The Y4M-input path skips ffmpeg entirely — the extension may
+ * eventually capture raw Y4M via a future `canvas.captureStream()`
+ * → MediaRecorder pipeline. v1 always uses JPEG.
+ *
+ * ## Why a second tab?
+ *
+ * We can't host TalkingHead.js in the Meet tab itself — Meet's CSP
+ * and its aggressive DOM virtualization would fight with three.js.
+ * Running it in a pinned, inactive second tab isolates it: the user
+ * never sees the tab (it lives on the Xvfb virtual display), but
+ * Chrome still budgets it real GPU time as long as the extension
+ * marks it `pinned` to avoid tab-discard.
+ */
+
+import type { Subprocess } from "bun";
+
+import type {
+  AvatarRenderer,
+  AvatarCapabilities,
+  VisemeEvent,
+  Y4MFrame,
+} from "../types.js";
+import { AvatarRendererUnavailableError } from "../types.js";
+import {
+  createAvatarChannel,
+  type AvatarChannel,
+} from "../../../native-messaging/avatar-channel.js";
+import type { AvatarNativeMessagingSender } from "../registry.js";
+
+/** Stable renderer id; shared with the registry/factory key. */
+export const TALKING_HEAD_RENDERER_ID = "talking-head";
+
+/** Capability flags the renderer advertises. */
+export const TALKING_HEAD_CAPABILITIES: AvatarCapabilities = {
+  needsVisemes: true,
+  needsAudio: true,
+};
+
+/** Default bounded wait for the extension's `avatar.started` ack. */
+export const DEFAULT_STARTED_ACK_TIMEOUT_MS = 5_000;
+
+/** Default advisory FPS hint sent to the extension on `avatar.start`. */
+export const DEFAULT_TARGET_FPS = 24;
+
+/**
+ * JPEG → Y4M spawn factory. Production calls `Bun.spawn(["ffmpeg", ...])`
+ * but tests inject a fake so the transcode path can be exercised without
+ * ffmpeg on the test host.
+ *
+ * Contract: the factory returns a child that accepts the JPEG bytes on
+ * stdin and emits one Y4M frame on stdout. The renderer waits for the
+ * child's `exited` promise before emitting the frame so partial stdout
+ * reads cannot produce a truncated Y4M blob.
+ */
+export type JpegToY4mSpawnFactory = (jpegBytes: Uint8Array) => {
+  /** Read and concatenate the entire stdout as Y4M bytes. */
+  readY4m: () => Promise<Uint8Array>;
+  /** Resolve when the child has exited. */
+  exited: Promise<number>;
+  /** Kill the child if still running. Idempotent. */
+  kill: () => void;
+};
+
+export interface TalkingHeadRendererOptions {
+  /**
+   * The native-messaging surface the renderer drives. When absent the
+   * factory throws {@link AvatarRendererUnavailableError} so the
+   * HTTP layer returns 503 instead of crashing the meeting.
+   */
+  nativeMessaging?: AvatarNativeMessagingSender;
+  /**
+   * Advisory target FPS forwarded to the extension in `avatar.start`.
+   * Defaults to {@link DEFAULT_TARGET_FPS}. The bot re-applies its own
+   * FPS cap at the device-writer layer; this value only sizes the
+   * avatar tab's `requestAnimationFrame` capture cadence.
+   */
+  targetFps?: number;
+  /**
+   * Optional URL pointing at a GLB the extension should load. When
+   * absent the extension uses the bundled `default-avatar.glb`.
+   * Forwarded in the `avatar.start` command.
+   */
+  modelUrl?: string;
+  /**
+   * Time in milliseconds to wait for the `avatar.started` ack before
+   * throwing {@link AvatarRendererUnavailableError}. Defaults to
+   * {@link DEFAULT_STARTED_ACK_TIMEOUT_MS}. Tests shrink this to
+   * millisecond scale.
+   */
+  startedAckTimeoutMs?: number;
+  /**
+   * JPEG → Y4M transcoder factory. Defaults to a real Bun.spawn of
+   * ffmpeg. Tests inject a fake that echoes a deterministic Y4M blob
+   * so the renderer's on-frame path can be asserted without a real
+   * ffmpeg.
+   */
+  spawnJpegToY4m?: JpegToY4mSpawnFactory;
+  /** Optional logger — routed to console when omitted. */
+  logger?: {
+    info(msg: string, extra?: Record<string, unknown>): void;
+    warn(msg: string, extra?: Record<string, unknown>): void;
+    error(msg: string, extra?: Record<string, unknown>): void;
+  };
+}
+
+/**
+ * Concrete TalkingHead.js renderer. Implements {@link AvatarRenderer}
+ * by delegating every interesting operation to the Chrome extension
+ * over the native-messaging bridge.
+ */
+export class TalkingHeadRenderer implements AvatarRenderer {
+  readonly id = TALKING_HEAD_RENDERER_ID;
+  readonly capabilities = TALKING_HEAD_CAPABILITIES;
+
+  private readonly nativeMessaging: AvatarNativeMessagingSender;
+  private readonly targetFps: number;
+  private readonly modelUrl: string | undefined;
+  private readonly startedAckTimeoutMs: number;
+  private readonly spawnJpegToY4m: JpegToY4mSpawnFactory;
+  private readonly logger?: TalkingHeadRendererOptions["logger"];
+
+  private channel: AvatarChannel | null = null;
+  private started = false;
+  private stopped = false;
+
+  /** Active JPEG→Y4M transcodes so shutdown can tear them down. */
+  private readonly inFlightTranscodes = new Set<{ kill: () => void }>();
+
+  /** Pending `avatar.started` waiter resolver. Null when not waiting. */
+  private startedWaiter:
+    | {
+        resolve: () => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
+
+  private subscribers: Array<(frame: Y4MFrame) => void> = [];
+
+  constructor(opts: TalkingHeadRendererOptions) {
+    if (!opts.nativeMessaging) {
+      throw new AvatarRendererUnavailableError(
+        TALKING_HEAD_RENDERER_ID,
+        "native-messaging channel not available (renderer requires the bot's NMH socket server)",
+      );
+    }
+    this.nativeMessaging = opts.nativeMessaging;
+    this.targetFps = opts.targetFps ?? DEFAULT_TARGET_FPS;
+    this.modelUrl = opts.modelUrl;
+    this.startedAckTimeoutMs =
+      opts.startedAckTimeoutMs ?? DEFAULT_STARTED_ACK_TIMEOUT_MS;
+    this.spawnJpegToY4m = opts.spawnJpegToY4m ?? defaultSpawnJpegToY4m;
+    this.logger = opts.logger;
+  }
+
+  async start(): Promise<void> {
+    if (this.stopped) {
+      throw new AvatarRendererUnavailableError(
+        TALKING_HEAD_RENDERER_ID,
+        "renderer already stopped; construct a fresh instance to restart",
+      );
+    }
+    if (this.started) return;
+    this.started = true;
+
+    // Set up the inbound listener BEFORE sending `avatar.start` so a
+    // very-fast extension can't beat us to the ack.
+    this.channel = createAvatarChannel({
+      sender: this.nativeMessaging,
+      onExtensionMessage: this.nativeMessaging.onExtensionMessage,
+      handlers: {
+        onStarted: () => {
+          this.resolveStartedWaiter();
+        },
+        onFrame: (msg) => {
+          void this.handleFrame(msg);
+        },
+      },
+    });
+
+    // Hand off `avatar.start` and wait for the ack with a bounded
+    // timeout. The renderer's start() promise is what the HTTP
+    // `/avatar/enable` route awaits, so we can't block indefinitely.
+    const waitForAck = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.startedWaiter = null;
+        reject(
+          new AvatarRendererUnavailableError(
+            TALKING_HEAD_RENDERER_ID,
+            `extension did not ack avatar.start within ${this.startedAckTimeoutMs}ms`,
+          ),
+        );
+      }, this.startedAckTimeoutMs);
+      this.startedWaiter = { resolve, reject, timer };
+    });
+
+    try {
+      this.channel.start({
+        targetFps: this.targetFps,
+        ...(this.modelUrl !== undefined ? { modelUrl: this.modelUrl } : {}),
+      });
+    } catch (err) {
+      // Dispatching on a closed socket throws synchronously. Surface
+      // it as AvatarRendererUnavailableError so the session-manager
+      // can fall back rather than 500.
+      if (this.startedWaiter) {
+        clearTimeout(this.startedWaiter.timer);
+        this.startedWaiter = null;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new AvatarRendererUnavailableError(
+        TALKING_HEAD_RENDERER_ID,
+        `failed to dispatch avatar.start: ${message}`,
+      );
+    }
+
+    await waitForAck;
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+
+    // If we're still waiting for the start ack, reject it so a
+    // racing stop() unblocks the start() promise cleanly.
+    if (this.startedWaiter) {
+      clearTimeout(this.startedWaiter.timer);
+      this.startedWaiter.reject(
+        new AvatarRendererUnavailableError(
+          TALKING_HEAD_RENDERER_ID,
+          "renderer stopped before extension acknowledged avatar.start",
+        ),
+      );
+      this.startedWaiter = null;
+    }
+
+    // Best-effort avatar.stop dispatch. Swallow errors — if the socket
+    // server is already gone, the extension will be torn down with
+    // Chrome anyway.
+    try {
+      this.channel?.stop();
+    } catch (err) {
+      this.logger?.warn?.("talking-head: avatar.stop dispatch failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    this.channel?.dispose();
+    this.channel = null;
+
+    // Tear down any ffmpeg transcodes still running so we don't leak
+    // child processes on teardown.
+    for (const transcode of this.inFlightTranscodes) {
+      try {
+        transcode.kill();
+      } catch {
+        // Best-effort.
+      }
+    }
+    this.inFlightTranscodes.clear();
+
+    // Drop every subscriber so late frames (which should not arrive
+    // after dispose, but defensively) cannot dispatch.
+    this.subscribers = [];
+  }
+
+  pushAudio(_pcm: Uint8Array, _ts: number): void {
+    // v1: no-op. PR 9 will synthesize amplitude-envelope visemes from
+    // the audio stream when no upstream viseme stream is active.
+  }
+
+  pushViseme(event: VisemeEvent): void {
+    if (!this.channel || this.stopped) return;
+    try {
+      this.channel.pushViseme(event);
+    } catch (err) {
+      // A disconnected socket is a symptom, not a fatal — the meeting
+      // should continue even if lip-sync is dropped.
+      this.logger?.warn?.("talking-head: pushViseme dispatch failed", {
+        error: err instanceof Error ? err.message : String(err),
+        phoneme: event.phoneme,
+      });
+    }
+  }
+
+  onFrame(cb: (frame: Y4MFrame) => void): () => void {
+    this.subscribers.push(cb);
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) return;
+      unsubscribed = true;
+      const idx = this.subscribers.indexOf(cb);
+      if (idx !== -1) this.subscribers.splice(idx, 1);
+    };
+  }
+
+  private resolveStartedWaiter(): void {
+    if (!this.startedWaiter) return;
+    clearTimeout(this.startedWaiter.timer);
+    this.startedWaiter.resolve();
+    this.startedWaiter = null;
+  }
+
+  /**
+   * Base64-decode the frame payload, transcode JPEG→Y4M if needed,
+   * then dispatch to subscribers. Swallows per-frame errors (with a
+   * log) — a single bad frame must not kill the stream.
+   */
+  private async handleFrame(msg: {
+    bytes: string;
+    width: number;
+    height: number;
+    format: "jpeg" | "y4m";
+    ts: number;
+  }): Promise<void> {
+    if (this.stopped) return;
+
+    let rawBytes: Uint8Array;
+    try {
+      rawBytes = decodeBase64(msg.bytes);
+    } catch (err) {
+      this.logger?.warn?.("talking-head: frame base64 decode failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    let y4mBytes: Uint8Array;
+    if (msg.format === "y4m") {
+      y4mBytes = rawBytes;
+    } else {
+      try {
+        y4mBytes = await this.transcodeJpegToY4m(rawBytes);
+      } catch (err) {
+        this.logger?.warn?.("talking-head: jpeg→y4m transcode failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+    }
+
+    if (this.stopped) return;
+
+    const frame: Y4MFrame = {
+      bytes: y4mBytes,
+      timestamp: msg.ts,
+      width: msg.width,
+      height: msg.height,
+    };
+    // Copy the subscriber list so a mid-dispatch unsubscribe doesn't
+    // skip a neighbor.
+    for (const cb of this.subscribers.slice()) {
+      try {
+        cb(frame);
+      } catch (err) {
+        this.logger?.warn?.("talking-head: onFrame subscriber threw", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  /**
+   * Spawn a short-lived ffmpeg child to transcode a single JPEG frame
+   * to Y4M. Tracks the child in {@link inFlightTranscodes} so stop()
+   * can kill it if the renderer is torn down mid-transcode.
+   */
+  private async transcodeJpegToY4m(jpegBytes: Uint8Array): Promise<Uint8Array> {
+    const child = this.spawnJpegToY4m(jpegBytes);
+    const trackedChild = { kill: child.kill };
+    this.inFlightTranscodes.add(trackedChild);
+    try {
+      return await child.readY4m();
+    } finally {
+      this.inFlightTranscodes.delete(trackedChild);
+    }
+  }
+}
+
+/**
+ * Default spawn factory — wraps `Bun.spawn` with the ffmpeg flags.
+ *
+ * Pipes the JPEG bytes into ffmpeg's stdin, reads Y4M off its
+ * stdout. The `-f yuv4mpegpipe` output format is the Y4M container;
+ * `-pix_fmt yuv420p` matches the v4l2loopback device negotiated in
+ * `video-device.ts`.
+ */
+function defaultSpawnJpegToY4m(jpegBytes: Uint8Array): {
+  readY4m: () => Promise<Uint8Array>;
+  exited: Promise<number>;
+  kill: () => void;
+} {
+  const proc = Bun.spawn(
+    [
+      "ffmpeg",
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-f",
+      "image2pipe",
+      "-vcodec",
+      "mjpeg",
+      "-i",
+      "pipe:0",
+      "-pix_fmt",
+      "yuv420p",
+      "-f",
+      "yuv4mpegpipe",
+      "pipe:1",
+    ],
+    {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ) as Subprocess<"pipe", "pipe", "pipe">;
+
+  // Write JPEG into stdin and close it so ffmpeg knows there's no
+  // more input coming. Without this close, ffmpeg waits on stdin
+  // forever and the Y4M output never completes.
+  const stdin = proc.stdin as unknown as {
+    write(chunk: Uint8Array): unknown;
+    end(): unknown;
+  };
+  stdin.write(jpegBytes);
+  stdin.end();
+
+  const readY4m = async (): Promise<Uint8Array> => {
+    // Bun.spawn's `stdout` is a ReadableStream of Uint8Array chunks.
+    const reader = (proc.stdout as unknown as ReadableStream<Uint8Array>).getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) {
+        chunks.push(value);
+        total += value.byteLength;
+      }
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    await proc.exited;
+    return out;
+  };
+
+  return {
+    readY4m,
+    exited: proc.exited,
+    kill: () => {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // Best-effort.
+      }
+    },
+  };
+}
+
+/**
+ * Decode a base64 string to a Uint8Array. Bun ships `atob` natively
+ * so we don't need a dependency, but we wrap the result in a typed
+ * array explicitly for clarity.
+ */
+function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}

--- a/skills/meet-join/bot/src/native-messaging/avatar-channel.ts
+++ b/skills/meet-join/bot/src/native-messaging/avatar-channel.ts
@@ -1,0 +1,182 @@
+/**
+ * Bot-side helpers for the `avatar.*` family of native-messaging
+ * messages. These helpers wrap the {@link NmhSocketServer}'s
+ * `sendToExtension` + `onExtensionMessage` APIs with typed convenience
+ * functions so the TalkingHead.js renderer's implementation doesn't
+ * have to repeat the envelope shapes inline.
+ *
+ * The channel is intentionally thin — it is not a full state machine.
+ * Its only jobs are:
+ *
+ * 1. Emit `avatar.start` / `avatar.stop` / `avatar.push_viseme` to the
+ *    extension, wrapped in the discriminated-union types the
+ *    contracts package defines.
+ * 2. Dispatch inbound `avatar.started` and `avatar.frame` messages
+ *    from the extension to caller-provided handlers, ignoring all
+ *    other frames (which belong to the bot's main message router).
+ *
+ * Keeping this in its own module means the TalkingHead renderer can
+ * depend on a narrow, typed interface and swap a fake in for unit
+ * tests (see {@link AvatarChannel}).
+ */
+
+import type {
+  BotAvatarPushVisemeCommand,
+  BotAvatarStartCommand,
+  BotAvatarStopCommand,
+  ExtensionAvatarFrameMessage,
+  ExtensionAvatarStartedMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+
+/**
+ * Narrow slice of the inbound-message routing hook the channel needs.
+ * Mirrors {@link NmhSocketServer.onExtensionMessage} but accepts only
+ * the messages the avatar channel cares about — the TalkingHead
+ * renderer passes through the full socket-server callback via
+ * {@link createAvatarChannel}.
+ */
+export interface AvatarChannelInboundHandlers {
+  /**
+   * Invoked exactly once per `avatar.started` ack. Used by the renderer
+   * to complete its `start()` promise (bounded by a 5 s timeout at the
+   * renderer layer).
+   */
+  onStarted: (msg: ExtensionAvatarStartedMessage) => void;
+  /**
+   * Invoked for every `avatar.frame` the extension forwards. The
+   * renderer decodes base64 bytes and re-emits through `onFrame`
+   * subscribers.
+   */
+  onFrame: (msg: ExtensionAvatarFrameMessage) => void;
+}
+
+/**
+ * Narrow slice of the outbound-send hook the channel needs. Mirrors
+ * {@link NmhSocketServer.sendToExtension} but typed to the bot→extension
+ * union so mis-typed payloads surface at compile time rather than on
+ * the wire.
+ */
+export interface AvatarChannelSender {
+  sendToExtension: (
+    msg:
+      | BotAvatarStartCommand
+      | BotAvatarStopCommand
+      | BotAvatarPushVisemeCommand,
+  ) => void;
+}
+
+/**
+ * Typed helper bundle the TalkingHead renderer uses to communicate
+ * over the native-messaging bridge without repeating the envelope
+ * shapes inline.
+ */
+export interface AvatarChannel {
+  /** Send `avatar.start` to the extension. */
+  start(opts?: { targetFps?: number; modelUrl?: string }): void;
+  /** Send `avatar.stop` to the extension. Idempotent at the wire level. */
+  stop(): void;
+  /** Send `avatar.push_viseme` to the extension. */
+  pushViseme(event: {
+    phoneme: string;
+    weight: number;
+    timestamp: number;
+  }): void;
+  /**
+   * Detach the inbound listener. Idempotent. Callers call this in
+   * the renderer's `stop()` path so a late `avatar.frame` arriving
+   * after teardown is dropped at the channel level instead of
+   * bubbling into a subscriber that no longer exists.
+   */
+  dispose(): void;
+}
+
+export interface CreateAvatarChannelOptions {
+  /**
+   * Outbound transport. In production this is the `NmhSocketServer`
+   * created in `main.ts`; tests pass a fake that records sent
+   * messages.
+   */
+  sender: AvatarChannelSender;
+  /**
+   * Called to register the inbound listener. The channel returns a
+   * wrapper that filters on `avatar.started` / `avatar.frame` and
+   * invokes the matching handler; all other message types are ignored
+   * (they are handled by the bot's main message router).
+   *
+   * The callback signature matches {@link NmhSocketServer.onExtensionMessage}
+   * so the channel can plug straight into the existing socket server
+   * without additional adaptation.
+   */
+  onExtensionMessage: (cb: (msg: ExtensionToBotMessage) => void) => void;
+  /** Handler set for the inbound messages the channel cares about. */
+  handlers: AvatarChannelInboundHandlers;
+}
+
+/**
+ * Build a typed channel that wraps the provided sender + inbound hook.
+ *
+ * The channel registers a single inbound listener at construction time
+ * and routes `avatar.started` / `avatar.frame` to the matching
+ * handler. Unknown message types are ignored (they belong to the
+ * bot's main message router and the channel is not a sole consumer).
+ *
+ * Because `NmhSocketServer.onExtensionMessage` appends listeners
+ * without a way to unregister, {@link AvatarChannel.dispose} sets an
+ * internal `disposed` flag that short-circuits the filter — a late
+ * frame arriving after teardown is dropped at the channel layer
+ * without touching the renderer.
+ */
+export function createAvatarChannel(
+  opts: CreateAvatarChannelOptions,
+): AvatarChannel {
+  let disposed = false;
+
+  opts.onExtensionMessage((msg) => {
+    if (disposed) return;
+    if (msg.type === "avatar.started") {
+      opts.handlers.onStarted(msg);
+      return;
+    }
+    if (msg.type === "avatar.frame") {
+      opts.handlers.onFrame(msg);
+      return;
+    }
+    // Any other message type is ignored at the channel level — the
+    // bot's main message router handles it.
+  });
+
+  return {
+    start(startOpts = {}): void {
+      if (disposed) return;
+      const msg: BotAvatarStartCommand = {
+        type: "avatar.start",
+        ...(startOpts.targetFps !== undefined
+          ? { targetFps: startOpts.targetFps }
+          : {}),
+        ...(startOpts.modelUrl !== undefined
+          ? { modelUrl: startOpts.modelUrl }
+          : {}),
+      };
+      opts.sender.sendToExtension(msg);
+    },
+    stop(): void {
+      if (disposed) return;
+      const msg: BotAvatarStopCommand = { type: "avatar.stop" };
+      opts.sender.sendToExtension(msg);
+    },
+    pushViseme(event): void {
+      if (disposed) return;
+      const msg: BotAvatarPushVisemeCommand = {
+        type: "avatar.push_viseme",
+        phoneme: event.phoneme,
+        weight: event.weight,
+        timestamp: event.timestamp,
+      };
+      opts.sender.sendToExtension(msg);
+    },
+    dispose(): void {
+      disposed = true;
+    },
+  };
+}

--- a/skills/meet-join/contracts/__tests__/native-messaging.test.ts
+++ b/skills/meet-join/contracts/__tests__/native-messaging.test.ts
@@ -10,11 +10,16 @@ import { describe, expect, test } from "bun:test";
 
 import {
   BOT_TO_EXTENSION_MESSAGE_TYPES,
+  BotAvatarPushVisemeCommandSchema,
+  BotAvatarStartCommandSchema,
+  BotAvatarStopCommandSchema,
   BotJoinCommandSchema,
   BotLeaveCommandSchema,
   BotSendChatCommandSchema,
   BotToExtensionMessageSchema,
   EXTENSION_TO_BOT_MESSAGE_TYPES,
+  ExtensionAvatarFrameMessageSchema,
+  ExtensionAvatarStartedMessageSchema,
   ExtensionDiagnosticMessageSchema,
   ExtensionInboundChatMessageSchema,
   ExtensionLifecycleMessageSchema,
@@ -45,6 +50,8 @@ describe("EXTENSION_TO_BOT_MESSAGE_TYPES", () => {
         "trusted_click",
         "trusted_type",
         "send_chat_result",
+        "avatar.started",
+        "avatar.frame",
       ]),
     );
   });
@@ -53,7 +60,14 @@ describe("EXTENSION_TO_BOT_MESSAGE_TYPES", () => {
 describe("BOT_TO_EXTENSION_MESSAGE_TYPES", () => {
   test("includes every discriminator used by BotToExtensionMessageSchema", () => {
     expect(new Set(BOT_TO_EXTENSION_MESSAGE_TYPES)).toEqual(
-      new Set(["join", "leave", "send_chat"]),
+      new Set([
+        "join",
+        "leave",
+        "send_chat",
+        "avatar.start",
+        "avatar.stop",
+        "avatar.push_viseme",
+      ]),
     );
   });
 });
@@ -299,6 +313,81 @@ describe("ExtensionSendChatResultMessageSchema", () => {
   });
 });
 
+describe("ExtensionAvatarStartedMessageSchema", () => {
+  test("parses the avatar.started ack", () => {
+    const input = { type: "avatar.started" as const };
+    const parsed = ExtensionAvatarStartedMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+});
+
+describe("ExtensionAvatarFrameMessageSchema", () => {
+  test("parses a jpeg frame", () => {
+    const input = {
+      type: "avatar.frame" as const,
+      bytes: "aGVsbG8=",
+      width: 1280,
+      height: 720,
+      format: "jpeg" as const,
+      ts: 1234,
+    };
+    const parsed = ExtensionAvatarFrameMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses a y4m frame", () => {
+    const input = {
+      type: "avatar.frame" as const,
+      bytes: "eWZyYW1l",
+      width: 640,
+      height: 480,
+      format: "y4m" as const,
+      ts: 42,
+    };
+    const parsed = ExtensionAvatarFrameMessageSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects empty bytes", () => {
+    expect(() =>
+      ExtensionAvatarFrameMessageSchema.parse({
+        type: "avatar.frame",
+        bytes: "",
+        width: 320,
+        height: 240,
+        format: "jpeg",
+        ts: 0,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-positive dimensions", () => {
+    expect(() =>
+      ExtensionAvatarFrameMessageSchema.parse({
+        type: "avatar.frame",
+        bytes: "AA==",
+        width: 0,
+        height: 240,
+        format: "jpeg",
+        ts: 0,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects unknown format", () => {
+    expect(() =>
+      ExtensionAvatarFrameMessageSchema.parse({
+        type: "avatar.frame",
+        bytes: "AA==",
+        width: 320,
+        height: 240,
+        format: "png",
+        ts: 0,
+      }),
+    ).toThrow();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // ExtensionToBotMessageSchema — discriminated union round-trip
 // ---------------------------------------------------------------------------
@@ -366,6 +455,15 @@ describe("ExtensionToBotMessageSchema", () => {
         requestId: "req-2",
         ok: false,
         error: "not allowed",
+      },
+      { type: "avatar.started" },
+      {
+        type: "avatar.frame",
+        bytes: "aGVsbG8=",
+        width: 1280,
+        height: 720,
+        format: "jpeg",
+        ts: 10,
       },
     ];
 
@@ -489,6 +587,104 @@ describe("BotSendChatCommandSchema", () => {
   });
 });
 
+describe("BotAvatarStartCommandSchema", () => {
+  test("parses avatar.start without optional fields", () => {
+    const input = { type: "avatar.start" as const };
+    const parsed = BotAvatarStartCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses avatar.start with targetFps and modelUrl", () => {
+    const input = {
+      type: "avatar.start" as const,
+      targetFps: 24,
+      modelUrl: "chrome-extension://abcdef/avatar/default-avatar.glb",
+    };
+    const parsed = BotAvatarStartCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects non-integer targetFps", () => {
+    expect(() =>
+      BotAvatarStartCommandSchema.parse({
+        type: "avatar.start",
+        targetFps: 12.5,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects targetFps > 60", () => {
+    expect(() =>
+      BotAvatarStartCommandSchema.parse({
+        type: "avatar.start",
+        targetFps: 61,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("BotAvatarStopCommandSchema", () => {
+  test("parses avatar.stop", () => {
+    const input = { type: "avatar.stop" as const };
+    const parsed = BotAvatarStopCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+});
+
+describe("BotAvatarPushVisemeCommandSchema", () => {
+  test("parses a viseme event", () => {
+    const input = {
+      type: "avatar.push_viseme" as const,
+      phoneme: "ah",
+      weight: 0.8,
+      timestamp: 500,
+    };
+    const parsed = BotAvatarPushVisemeCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses the amplitude sentinel", () => {
+    const input = {
+      type: "avatar.push_viseme" as const,
+      phoneme: "amp",
+      weight: 0.25,
+      timestamp: 10,
+    };
+    const parsed = BotAvatarPushVisemeCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("rejects weight outside [0, 1]", () => {
+    expect(() =>
+      BotAvatarPushVisemeCommandSchema.parse({
+        type: "avatar.push_viseme",
+        phoneme: "ah",
+        weight: 1.5,
+        timestamp: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      BotAvatarPushVisemeCommandSchema.parse({
+        type: "avatar.push_viseme",
+        phoneme: "ah",
+        weight: -0.1,
+        timestamp: 0,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects empty phoneme", () => {
+    expect(() =>
+      BotAvatarPushVisemeCommandSchema.parse({
+        type: "avatar.push_viseme",
+        phoneme: "",
+        weight: 0.5,
+        timestamp: 0,
+      }),
+    ).toThrow();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // BotToExtensionMessageSchema — discriminated union round-trip
 // ---------------------------------------------------------------------------
@@ -504,6 +700,15 @@ describe("BotToExtensionMessageSchema", () => {
       },
       { type: "leave", reason: "user requested" },
       { type: "send_chat", text: "hi", requestId: "req-1" },
+      { type: "avatar.start" },
+      { type: "avatar.start", targetFps: 24 },
+      { type: "avatar.stop" },
+      {
+        type: "avatar.push_viseme",
+        phoneme: "ah",
+        weight: 0.5,
+        timestamp: 100,
+      },
     ];
 
     for (const fixture of fixtures) {

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -195,6 +195,66 @@ export type ExtensionSendChatResultMessage = z.infer<
 >;
 
 /**
+ * Ack emitted by the extension once its avatar tab has mounted and the
+ * TalkingHead.js renderer is ready to receive visemes. This is the
+ * extension-side counterpart to the bot's `avatar.start` command and lets
+ * the bot's TalkingHead renderer complete its own `start()` promise with a
+ * bounded wait (fallback to noop on timeout).
+ */
+export const ExtensionAvatarStartedMessageSchema = z.object({
+  type: z.literal("avatar.started"),
+});
+export type ExtensionAvatarStartedMessage = z.infer<
+  typeof ExtensionAvatarStartedMessageSchema
+>;
+
+/**
+ * Valid formats for an `avatar.frame` payload.
+ *
+ * - `"jpeg"` — JPEG bytes produced by `HTMLCanvasElement.toBlob("image/jpeg")`.
+ *   The bot transcodes these to Y4M via a short-lived ffmpeg child before
+ *   writing to `/dev/video10`.
+ * - `"y4m"` — already-framed Y4M bytes (future streaming-capture path).
+ *   The bot emits these directly via `onFrame`.
+ */
+export const AvatarFrameFormatSchema = z.enum(["jpeg", "y4m"]);
+export type AvatarFrameFormat = z.infer<typeof AvatarFrameFormatSchema>;
+
+/**
+ * A single rendered frame produced by the TalkingHead.js avatar tab and
+ * forwarded by the extension to the bot over native messaging. The bot
+ * re-emits the frame bytes through its avatar renderer's `onFrame`
+ * subscriber chain, which feeds the v4l2loopback camera device that
+ * Chrome in the Meet tab reads from.
+ *
+ * Bytes ride the wire as a base64 string because Chrome's native-messaging
+ * transport is JSON-only — we cannot ship a raw `ArrayBuffer`. The
+ * extension base64-encodes the canvas-capture payload before posting;
+ * the bot decodes inside `talking-head/renderer.ts`.
+ */
+export const ExtensionAvatarFrameMessageSchema = z.object({
+  type: z.literal("avatar.frame"),
+  /** Base64-encoded frame bytes. */
+  bytes: z.string().min(1),
+  /** Frame width in pixels. */
+  width: z.number().int().positive(),
+  /** Frame height in pixels. */
+  height: z.number().int().positive(),
+  /** Pixel/container format of `bytes`. */
+  format: AvatarFrameFormatSchema,
+  /**
+   * Monotonic timestamp (ms) of when the frame was captured inside the
+   * avatar tab. Downstream audio-alignment (PR 9) keys off this value;
+   * for v1 the bot emits frames in arrival order and the daemon does no
+   * timestamp gating.
+   */
+  ts: z.number(),
+});
+export type ExtensionAvatarFrameMessage = z.infer<
+  typeof ExtensionAvatarFrameMessageSchema
+>;
+
+/**
  * Every payload the extension may send to the bot over the native-messaging
  * pipe. Consumers should parse incoming frames with this schema to both
  * validate and narrow on `type`.
@@ -209,6 +269,8 @@ export const ExtensionToBotMessageSchema = z.discriminatedUnion("type", [
   ExtensionTrustedClickMessageSchema,
   ExtensionTrustedTypeMessageSchema,
   ExtensionSendChatResultMessageSchema,
+  ExtensionAvatarStartedMessageSchema,
+  ExtensionAvatarFrameMessageSchema,
 ]);
 export type ExtensionToBotMessage = z.infer<typeof ExtensionToBotMessageSchema>;
 
@@ -223,6 +285,8 @@ export const EXTENSION_TO_BOT_MESSAGE_TYPES = [
   "trusted_click",
   "trusted_type",
   "send_chat_result",
+  "avatar.started",
+  "avatar.frame",
 ] as const;
 
 export type ExtensionToBotMessageType =
@@ -272,6 +336,71 @@ export const BotSendChatCommandSchema = z.object({
 export type BotSendChatCommand = z.infer<typeof BotSendChatCommandSchema>;
 
 /**
+ * Ask the extension to open the avatar tab (TalkingHead.js-rendered 3D
+ * face) and begin capturing canvas frames. The extension replies with an
+ * `avatar.started` frame once the avatar tab has mounted and is ready to
+ * accept visemes. If the ack doesn't arrive within a few seconds, the
+ * bot-side renderer throws `AvatarRendererUnavailableError` so the
+ * session-manager can fall back to the noop renderer.
+ *
+ * `targetFps` is advisory — the extension uses it to size its
+ * `requestAnimationFrame` capture cadence. The bot also applies an FPS
+ * cap at the device-writer layer, so the extension need not match it
+ * exactly.
+ */
+export const BotAvatarStartCommandSchema = z.object({
+  type: z.literal("avatar.start"),
+  /** Target capture framerate hint. Advisory; the bot rate-limits again. */
+  targetFps: z.number().int().min(1).max(60).optional(),
+  /**
+   * Optional URL override for the avatar page / GLB. When absent the
+   * extension falls back to the bundled `chrome.runtime.getURL("avatar/avatar.html")`
+   * + bundled `default-avatar.glb`. When present, the bot is expected
+   * to have staged the GLB as a `web_accessible_resources` entry so
+   * `chrome.runtime.getURL` can resolve it. See `features/avatar.ts`.
+   */
+  modelUrl: z.string().optional(),
+});
+export type BotAvatarStartCommand = z.infer<typeof BotAvatarStartCommandSchema>;
+
+/**
+ * Tear down the avatar tab and stop capturing frames. Idempotent: a
+ * second `avatar.stop` while the tab is already closed is a no-op on
+ * the extension side.
+ */
+export const BotAvatarStopCommandSchema = z.object({
+  type: z.literal("avatar.stop"),
+});
+export type BotAvatarStopCommand = z.infer<typeof BotAvatarStopCommandSchema>;
+
+/**
+ * Forward a viseme/amplitude event into the running avatar tab. The
+ * extension's feature background module relays the event into the
+ * avatar tab via `chrome.tabs.sendMessage`. The avatar content script
+ * drives TalkingHead.js's blend-shape weights from the viseme payload.
+ *
+ * Mirrors `VisemeEvent` from the bot's avatar types. Kept schema-local
+ * (rather than re-exporting from avatar/types.ts) so the contracts
+ * package stays independent of the bot implementation.
+ */
+export const BotAvatarPushVisemeCommandSchema = z.object({
+  type: z.literal("avatar.push_viseme"),
+  /**
+   * Phoneme or viseme identifier. Providers that emit viseme/alignment
+   * metadata use their native label; the amplitude-envelope fallback
+   * uses the sentinel `"amp"`.
+   */
+  phoneme: z.string().min(1),
+  /** Mouth-openness weight in `[0, 1]`. */
+  weight: z.number().min(0).max(1),
+  /** Monotonic timestamp (ms) used to align the viseme with the audio. */
+  timestamp: z.number(),
+});
+export type BotAvatarPushVisemeCommand = z.infer<
+  typeof BotAvatarPushVisemeCommandSchema
+>;
+
+/**
  * Every command the bot may send to the extension over the native-messaging
  * pipe. Consumers should parse incoming frames with this schema to both
  * validate and narrow on `type`.
@@ -280,6 +409,9 @@ export const BotToExtensionMessageSchema = z.discriminatedUnion("type", [
   BotJoinCommandSchema,
   BotLeaveCommandSchema,
   BotSendChatCommandSchema,
+  BotAvatarStartCommandSchema,
+  BotAvatarStopCommandSchema,
+  BotAvatarPushVisemeCommandSchema,
 ]);
 export type BotToExtensionMessage = z.infer<typeof BotToExtensionMessageSchema>;
 
@@ -288,6 +420,9 @@ export const BOT_TO_EXTENSION_MESSAGE_TYPES = [
   "join",
   "leave",
   "send_chat",
+  "avatar.start",
+  "avatar.stop",
+  "avatar.push_viseme",
 ] as const;
 
 export type BotToExtensionMessageType =

--- a/skills/meet-join/meet-controller-ext/avatar/README.md
+++ b/skills/meet-join/meet-controller-ext/avatar/README.md
@@ -1,0 +1,62 @@
+# Vellum Meet avatar tab
+
+This directory contains the assets the meet-bot's Chrome extension
+loads into the pinned second tab that TalkingHead.js renders into.
+
+## Files
+
+- `avatar.html` — minimal page shell that loads the bundled
+  `avatar.js` (produced by `scripts/build.ts` from
+  `src/avatar/avatar.ts`).
+- `default-avatar.glb` — **placeholder**; operators MUST replace this
+  with a real Ready Player Me GLB model before Phase 4 is useful in
+  production. See below.
+
+The bundled `avatar.js` file is produced at build time and is NOT
+checked into source. Only the TypeScript source
+(`src/avatar/avatar.ts`) and this static HTML + placeholder GLB live
+in the repo.
+
+## Replacing the placeholder GLB
+
+The shipped `default-avatar.glb` is a 0-byte placeholder. It is NOT a
+valid GLB file. With the placeholder in place, TalkingHead.js fails
+to load the model and the avatar tab falls back to streaming a
+static colored background — the Meet camera stream is still live,
+but there is no moving face.
+
+### Option 1 — bundle a real model at build time
+
+1. Generate a Ready Player Me avatar at
+   [readyplayer.me](https://readyplayer.me/) (free account, no
+   license fee). Choose the **3D avatar** option and make sure ARKit
+   blendshapes are enabled (required for TalkingHead.js visemes).
+2. Download the GLB.
+3. Replace `skills/meet-join/meet-controller-ext/avatar/default-avatar.glb`
+   with the downloaded file. The existing filename is load-bearing —
+   don't rename it unless you also update
+   `src/avatar/avatar.ts::resolveModelUrl`.
+4. Rebuild the extension: `bun run build` inside
+   `skills/meet-join/meet-controller-ext/`.
+
+### Option 2 — override at runtime via config
+
+The bot-side `services.meet.avatar.talkingHead.modelUrl` config key
+overrides the URL the avatar page loads. When set, the bot passes it
+through to `BotAvatarStartCommand.modelUrl`, the extension adds it
+as a `?model=<url>` query string when opening the avatar tab, and
+`avatar.ts::resolveModelUrl` prefers the URL over the bundled GLB.
+
+This path is useful when the GLB lives on an object store or a
+per-meeting endpoint rather than bundled into the extension.
+
+## References
+
+- TalkingHead.js: [`@met4citizen/talkinghead`](https://github.com/met4citizen/TalkingHead)
+  (MIT licensed; v1.7.0 pinned in `package.json`).
+- Ready Player Me: [docs.readyplayer.me](https://docs.readyplayer.me/)
+  (avatars are royalty-free for the creator's own use).
+- The v1 TalkingHead integration ignores the audio stream — lip-sync
+  is driven entirely from `avatar.push_viseme` events the bot
+  forwards. PR 9 (audio-playback alignment) will add an amplitude
+  fallback when no viseme stream is active.

--- a/skills/meet-join/meet-controller-ext/avatar/avatar.html
+++ b/skills/meet-join/meet-controller-ext/avatar/avatar.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vellum Avatar</title>
+    <style>
+      /* The avatar tab is never visible to a user — it lives on Xvfb's
+         virtual display inside the bot container. These styles exist to
+         give three.js a clean canvas to render into and to keep the
+         document viewport at a predictable size so the capture
+         pipeline doesn't deal with dynamic resizing. */
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 1280px;
+        height: 720px;
+        background: #1a1a2e;
+        overflow: hidden;
+        color: #fff;
+        font-family: system-ui, sans-serif;
+      }
+      #avatar-root {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+      /* Friendly placeholder the renderer uses when the GLB hasn't
+         loaded yet or TalkingHead.js fails to initialize. Never
+         visible to a real end-user. */
+      #avatar-status {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="avatar-root"></div>
+    <div id="avatar-status">Loading avatar…</div>
+    <!-- The actual renderer logic lives in avatar.js (bundled from
+         src/avatar/avatar.ts by scripts/build.ts). Load it as a
+         module so modern ESM imports resolve cleanly. -->
+    <script type="module" src="./avatar.js"></script>
+  </body>
+</html>

--- a/skills/meet-join/meet-controller-ext/bun.lock
+++ b/skills/meet-join/meet-controller-ext/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellumai/meet-controller-ext",
       "dependencies": {
+        "@met4citizen/talkinghead": "1.7.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -40,6 +41,8 @@
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@met4citizen/talkinghead": ["@met4citizen/talkinghead@1.7.0", "", { "dependencies": { "three": "^0.180.0" } }, "sha512-iBQhTjvwOO2lLht/YeWqAUmsH0jk4FGpxiPTPMMp3QYVjst/u2rDhn4up59BMJwfdeW3DyU7Im6y+TWmnNllZA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
@@ -90,6 +93,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "three": ["three@0.180.0", "", {}, "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w=="],
 
     "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 

--- a/skills/meet-join/meet-controller-ext/manifest.json
+++ b/skills/meet-join/meet-controller-ext/manifest.json
@@ -13,5 +13,11 @@
       "run_at": "document_idle"
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": ["avatar/avatar.html", "avatar/avatar.js", "avatar/*.glb"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7HeRDjffv54OgiXEqgqmwhpIo9cruNnF3vscK/Ubn8vENJPp4TSUP2ZVfoWBUVONT5HtKvkYsJJjavokdGMuaRKm9xfdri/WWB+qJRePsGEdTYtNxD5Vrw+c5X6g3S0irNLbqTWGM9++Xn67hYSOKHdDVeKWZGbC6PdqYrTOaB1YHLKp+MulWMgoE4bDc+aWc58LOmhngAbRWreofNM/9Xomazm2TJ5/2zYikaEpRCT1JC3zpLTGfuRroZ2Ln5ut3zphp1aa1z4smViwsFVLUnhLKgWwSv2xPkRRHv5CE5FBDXjvgHNernlD9hn3EZisq3u4Z09C6D2qayC5/IxecQIDAQAB"
 }

--- a/skills/meet-join/meet-controller-ext/package.json
+++ b/skills/meet-join/meet-controller-ext/package.json
@@ -10,6 +10,7 @@
     "test": "bun test src/"
   },
   "dependencies": {
+    "@met4citizen/talkinghead": "1.7.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/skills/meet-join/meet-controller-ext/scripts/build.ts
+++ b/skills/meet-join/meet-controller-ext/scripts/build.ts
@@ -5,15 +5,38 @@ const outdir = "dist";
 if (existsSync(outdir)) rmSync(outdir, { recursive: true });
 mkdirSync(outdir, { recursive: true });
 
-const result = await Bun.build({
+// Build background + content scripts at the root of dist/, and the
+// avatar tab script into dist/avatar/ so the manifest's
+// `web_accessible_resources` entry + `avatar/avatar.html`'s relative
+// `./avatar.js` `<script src>` can resolve.
+const rootBuild = await Bun.build({
   entrypoints: ["src/background.ts", "src/content.ts"],
   outdir,
   target: "browser",
   format: "esm",
 });
-if (!result.success) {
-  console.error(result.logs);
+if (!rootBuild.success) {
+  console.error(rootBuild.logs);
   process.exit(1);
 }
+
+mkdirSync(`${outdir}/avatar`, { recursive: true });
+const avatarBuild = await Bun.build({
+  entrypoints: ["src/avatar/avatar.ts"],
+  outdir: `${outdir}/avatar`,
+  target: "browser",
+  format: "esm",
+});
+if (!avatarBuild.success) {
+  console.error(avatarBuild.logs);
+  process.exit(1);
+}
+
 await cp("manifest.json", `${outdir}/manifest.json`);
+// Copy the avatar HTML + bundled GLB so the tab can load them via
+// `chrome.runtime.getURL`.
+await cp("avatar/avatar.html", `${outdir}/avatar/avatar.html`);
+if (existsSync("avatar/default-avatar.glb")) {
+  await cp("avatar/default-avatar.glb", `${outdir}/avatar/default-avatar.glb`);
+}
 console.log(`Built extension to ${outdir}/`);

--- a/skills/meet-join/meet-controller-ext/src/__tests__/avatar-feature.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/avatar-feature.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for the extension's avatar feature (background-wiring side).
+ *
+ * The feature opens the pinned second Chrome tab on `avatar.start`,
+ * forwards `avatar.push_viseme` to the tab, relays `avatar.frame` /
+ * `avatar.started` back to the bot, and tears the tab down on
+ * `avatar.stop`. We fake `chrome.tabs` + `chrome.runtime` + the
+ * native port so the feature can be exercised without a real Chrome
+ * or native-messaging host.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  BotToExtensionMessage,
+  ExtensionAvatarFrameMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+
+import {
+  startAvatarFeature,
+  type AvatarRuntimeApi,
+  type AvatarTabsApi,
+} from "../features/avatar.js";
+
+interface TabCreateCall {
+  url: string;
+  active?: boolean;
+  pinned?: boolean;
+}
+
+interface FakeTabs extends AvatarTabsApi {
+  createCalls: TabCreateCall[];
+  removeCalls: number[];
+  sendMessageCalls: Array<{ tabId: number; msg: unknown }>;
+  nextCreateId: number;
+  /** When set, `create()` rejects with this error. */
+  createError?: Error;
+  /** When set, `remove()` rejects with this error. */
+  removeError?: Error;
+}
+
+function makeFakeTabs(): FakeTabs {
+  const fake: FakeTabs = {
+    createCalls: [],
+    removeCalls: [],
+    sendMessageCalls: [],
+    nextCreateId: 1,
+    async create(opts) {
+      fake.createCalls.push(opts);
+      if (fake.createError) throw fake.createError;
+      const id = fake.nextCreateId++;
+      return { id };
+    },
+    async remove(tabId) {
+      fake.removeCalls.push(tabId);
+      if (fake.removeError) throw fake.removeError;
+    },
+    async sendMessage(tabId, msg) {
+      fake.sendMessageCalls.push({ tabId, msg });
+    },
+  };
+  return fake;
+}
+
+interface FakeRuntime extends AvatarRuntimeApi {
+  listeners: Array<
+    (
+      raw: unknown,
+      sender: unknown,
+      sendResponse: (response?: unknown) => void,
+    ) => boolean
+  >;
+  /** Helper: deliver a message to every registered listener. */
+  emitFromTab(msg: unknown): void;
+}
+
+function makeFakeRuntime(extensionId = "abcd1234"): FakeRuntime {
+  const listeners: FakeRuntime["listeners"] = [];
+  const fake: FakeRuntime = {
+    listeners,
+    onMessage: {
+      addListener(cb) {
+        listeners.push(cb);
+      },
+    },
+    getURL(path) {
+      return `chrome-extension://${extensionId}/${path}`;
+    },
+    emitFromTab(msg) {
+      for (const cb of listeners.slice()) cb(msg, undefined, () => {});
+    },
+  };
+  return fake;
+}
+
+interface FakePort {
+  posted: ExtensionToBotMessage[];
+  post(msg: ExtensionToBotMessage): void;
+  /** When true, `post` throws. */
+  failNextPost?: boolean;
+}
+
+function makeFakePort(): FakePort {
+  const posted: ExtensionToBotMessage[] = [];
+  const fake: FakePort = {
+    posted,
+    post(msg) {
+      if (fake.failNextPost) {
+        fake.failNextPost = false;
+        throw new Error("native port disconnected");
+      }
+      posted.push(msg);
+    },
+  };
+  return fake;
+}
+
+describe("startAvatarFeature", () => {
+  let tabs: FakeTabs;
+  let runtime: FakeRuntime;
+  let port: FakePort;
+  let feature: ReturnType<typeof startAvatarFeature>;
+
+  beforeEach(() => {
+    tabs = makeFakeTabs();
+    runtime = makeFakeRuntime();
+    port = makeFakePort();
+    feature = startAvatarFeature({ tabs, runtime, port });
+  });
+
+  afterEach(async () => {
+    await feature.stop();
+  });
+
+  test("opens the pinned avatar tab on avatar.start", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    expect(tabs.createCalls).toHaveLength(1);
+    const call = tabs.createCalls[0]!;
+    expect(call.pinned).toBe(true);
+    expect(call.active).toBe(false);
+    expect(call.url).toBe("chrome-extension://abcd1234/avatar/avatar.html");
+  });
+
+  test("avatar.start forwards modelUrl as a query string", async () => {
+    await feature.handleBotCommand({
+      type: "avatar.start",
+      modelUrl: "https://example.com/custom.glb",
+    });
+    expect(tabs.createCalls).toHaveLength(1);
+    const url = new URL(tabs.createCalls[0]!.url);
+    expect(url.searchParams.get("model")).toBe(
+      "https://example.com/custom.glb",
+    );
+  });
+
+  test("avatar.push_viseme is forwarded to the avatar tab", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    await feature.handleBotCommand({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.7,
+      timestamp: 500,
+    });
+    expect(tabs.sendMessageCalls).toHaveLength(1);
+    const call = tabs.sendMessageCalls[0]!;
+    expect(call.tabId).toBe(1);
+    expect(call.msg).toEqual({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.7,
+      timestamp: 500,
+    });
+  });
+
+  test("avatar.push_viseme before the tab opens is dropped silently", async () => {
+    // No avatar.start yet — tab id is null.
+    await feature.handleBotCommand({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.5,
+      timestamp: 0,
+    });
+    expect(tabs.sendMessageCalls).toHaveLength(0);
+  });
+
+  test("avatar.frame from the tab is forwarded to the native port", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+
+    const frame: ExtensionAvatarFrameMessage = {
+      type: "avatar.frame",
+      bytes: "aGVsbG8=",
+      width: 640,
+      height: 480,
+      format: "jpeg",
+      ts: 42,
+    };
+    runtime.emitFromTab(frame);
+    expect(port.posted).toContainEqual(frame);
+  });
+
+  test("avatar.started from the tab is forwarded to the native port", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    runtime.emitFromTab({ type: "avatar.started" });
+    expect(port.posted).toContainEqual({ type: "avatar.started" });
+  });
+
+  test("non-avatar messages from the tab are ignored", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+
+    // A chat message shape is not something the avatar feature should
+    // forward — the content-bridge handles those. Even though this
+    // message would validate against the extension→bot schema, the
+    // avatar feature must leave it for the main router.
+    runtime.emitFromTab({
+      type: "chat.inbound",
+      meetingId: "abc",
+      timestamp: "2026-04-15T00:00:00Z",
+      fromId: "p-1",
+      fromName: "Alice",
+      text: "hey",
+    });
+    expect(port.posted).toHaveLength(0);
+  });
+
+  test("schema-invalid messages from the tab are dropped", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    // Missing required `bytes` field — must not crash the feature.
+    runtime.emitFromTab({
+      type: "avatar.frame",
+      width: 640,
+      height: 480,
+      format: "jpeg",
+      ts: 1,
+    });
+    expect(port.posted).toHaveLength(0);
+  });
+
+  test("avatar.stop removes the tab and drops state", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    await feature.handleBotCommand({ type: "avatar.stop" });
+    expect(tabs.removeCalls).toEqual([1]);
+
+    // After stop, a push_viseme must NOT be dispatched (tab id is null).
+    await feature.handleBotCommand({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.3,
+      timestamp: 0,
+    });
+    expect(tabs.sendMessageCalls).toHaveLength(0);
+  });
+
+  test("a second avatar.start tears down the previous tab first", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    await feature.handleBotCommand({ type: "avatar.start" });
+    // Previous tab removed, new tab created.
+    expect(tabs.removeCalls).toEqual([1]);
+    expect(tabs.createCalls).toHaveLength(2);
+  });
+
+  test("avatar.stop is idempotent", async () => {
+    await feature.handleBotCommand({ type: "avatar.stop" });
+    await feature.handleBotCommand({ type: "avatar.stop" });
+    expect(tabs.removeCalls).toHaveLength(0);
+  });
+
+  test("feature.stop() removes any open tab and is idempotent", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    await feature.stop();
+    expect(tabs.removeCalls).toEqual([1]);
+    await feature.stop();
+    expect(tabs.removeCalls).toEqual([1]);
+  });
+
+  test("tabs.create errors do not crash the feature", async () => {
+    tabs.createError = new Error("extension context gone");
+    await feature.handleBotCommand({ type: "avatar.start" });
+    // No tab id recorded — subsequent viseme is a no-op.
+    await feature.handleBotCommand({
+      type: "avatar.push_viseme",
+      phoneme: "ah",
+      weight: 0.3,
+      timestamp: 0,
+    });
+    expect(tabs.sendMessageCalls).toHaveLength(0);
+  });
+
+  test("tabs.remove errors do not crash the feature", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    tabs.removeError = new Error("tab already gone");
+    await feature.handleBotCommand({ type: "avatar.stop" });
+    // removeError swallowed; state cleared.
+    await feature.handleBotCommand({ type: "avatar.stop" });
+    expect(tabs.removeCalls).toEqual([1]);
+  });
+
+  test("native port failures on frame forwarding do not crash the feature", async () => {
+    await feature.handleBotCommand({ type: "avatar.start" });
+    port.failNextPost = true;
+    runtime.emitFromTab({
+      type: "avatar.frame",
+      bytes: "AA==",
+      width: 320,
+      height: 240,
+      format: "jpeg",
+      ts: 0,
+    });
+    // A second frame after the failure still flows.
+    runtime.emitFromTab({
+      type: "avatar.frame",
+      bytes: "Ag==",
+      width: 320,
+      height: 240,
+      format: "jpeg",
+      ts: 1,
+    });
+    expect(port.posted).toHaveLength(1);
+  });
+
+  test("handleBotCommand ignores non-avatar bot commands", async () => {
+    // Non-avatar commands must not trigger tab operations.
+    const msg: BotToExtensionMessage = {
+      type: "join",
+      meetingUrl: "https://meet.google.com/abc",
+      displayName: "Bot",
+      consentMessage: "hi",
+    };
+    await feature.handleBotCommand(msg);
+    expect(tabs.createCalls).toHaveLength(0);
+    expect(tabs.sendMessageCalls).toHaveLength(0);
+  });
+});

--- a/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
+++ b/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
@@ -1,0 +1,361 @@
+/**
+ * Avatar tab entry point.
+ *
+ * Runs inside the pinned second Chrome tab the meet-bot's
+ * `features/avatar.ts` opens. Its job:
+ *
+ * 1. Load TalkingHead.js (`@met4citizen/talkinghead`) and instantiate
+ *    the bundled Ready Player Me GLB avatar. Operators can override
+ *    the model by passing `?model=<url>` in the page URL — when
+ *    absent we default to the bundled `default-avatar.glb`.
+ *
+ * 2. Listen for `avatar.push_viseme` messages via
+ *    `chrome.runtime.onMessage` and drive TalkingHead.js's blend-shape
+ *    weights from the viseme payload.
+ *
+ * 3. Start a per-frame `requestAnimationFrame` loop that captures the
+ *    rendered canvas, encodes it as JPEG via `canvas.toBlob`, and
+ *    posts the bytes back to the extension background service worker
+ *    via `chrome.runtime.sendMessage`. The background forwards the
+ *    frame over native messaging to the bot.
+ *
+ * 4. On bootstrap, post `{ type: "avatar.started" }` so the bot-side
+ *    renderer's `start()` promise resolves with a bounded wait.
+ *
+ * ## Graceful degradation
+ *
+ * If TalkingHead.js fails to initialize (e.g. the bundled GLB is the
+ * placeholder), we still post `avatar.started` so the bot doesn't hit
+ * its `AvatarRendererUnavailableError` timeout. The canvas remains a
+ * blank colored background and frames continue flowing — the bot's
+ * camera stream shows a static background rather than going dark.
+ * Operators can replace the placeholder GLB with a real Ready Player
+ * Me model before a production rollout; see `avatar/README.md`.
+ *
+ * ## Capture strategy
+ *
+ * We use `canvas.toBlob("image/jpeg", 0.8)` inside a 1/targetFps
+ * `requestAnimationFrame` loop. This is the simpler of the two
+ * strategies outlined in the plan:
+ *
+ *   - **JPEG toBlob**: lossy but portable, one encoded blob per
+ *     frame. Requires ffmpeg on the bot side to transcode to Y4M
+ *     before writing to `/dev/video10`. v1 uses this path.
+ *   - **`canvas.captureStream()` → MediaRecorder**: produces a
+ *     continuous Y4M-compatible stream without ffmpeg but requires
+ *     more plumbing (MediaRecorder → Blob chunks → base64 → NMH).
+ *     Future work.
+ *
+ * JPEG is sufficient for 20–24 fps avatar video and avoids adding a
+ * full media-stream pipeline for v1.
+ */
+
+import type {
+  BotToExtensionMessage,
+  ExtensionAvatarFrameMessage,
+  ExtensionAvatarStartedMessage,
+} from "../../../contracts/native-messaging.js";
+
+/** Default capture cadence the avatar loop targets. */
+const DEFAULT_TARGET_FPS = 24;
+
+/** JPEG quality factor — low enough to keep frames under 100 KB. */
+const JPEG_QUALITY = 0.8;
+
+/** Width/height we render the canvas at. Matches avatar.html styling. */
+const CANVAS_WIDTH = 1280;
+const CANVAS_HEIGHT = 720;
+
+/**
+ * Narrow slice of the TalkingHead.js API we actually drive. Kept
+ * permissive so we don't depend on the exact npm type definitions
+ * (which evolve across versions). TalkingHead.js ships as a plain
+ * module that exports a class with these core methods.
+ */
+interface TalkingHeadInstance {
+  showAvatar?(opts: { url: string }): Promise<void>;
+  setMood?(mood: string): void;
+  /**
+   * Directly drive a mouth-shape blend-weight. Implementations vary;
+   * we pass the raw phoneme label + weight and let TalkingHead.js
+   * decide which morph target to target.
+   */
+  speakMorph?(phoneme: string, weight: number): void;
+}
+
+/**
+ * Narrow slice of the TalkingHead.js constructor. We load the module
+ * dynamically so the avatar page works even when the module isn't
+ * present (placeholder path / unit tests) — we just log and fall
+ * back to a static canvas.
+ */
+interface TalkingHeadConstructor {
+  new (
+    el: HTMLElement,
+    opts?: Record<string, unknown>,
+  ): TalkingHeadInstance;
+}
+
+/**
+ * Attempt to load TalkingHead.js at runtime. Returns `null` if the
+ * module isn't available (e.g. the bundled vendor copy was skipped
+ * because the placeholder GLB is in use).
+ *
+ * The dynamic `import()` is wrapped in a try/catch so a missing
+ * module doesn't crash the avatar page — we still want to emit
+ * `avatar.started` and a stream of (blank) frames so the bot's
+ * renderer remains healthy.
+ */
+async function loadTalkingHeadCtor(): Promise<TalkingHeadConstructor | null> {
+  try {
+    // `@met4citizen/talkinghead` exports its class as `TalkingHead`.
+    // Using a string literal lets the bundler keep this as a dynamic
+    // import so a build-time failure doesn't prevent the avatar page
+    // from rendering the placeholder. The module doesn't ship type
+    // declarations, so we cast through `unknown` to keep TypeScript
+    // happy — the module's runtime shape matches our structural
+    // narrow above.
+    const specifier = "@met4citizen/talkinghead";
+    const mod = (await import(/* @vite-ignore */ specifier as string)) as unknown as {
+      TalkingHead?: TalkingHeadConstructor;
+      default?: TalkingHeadConstructor;
+    };
+    return mod.TalkingHead ?? mod.default ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate the GLB URL to load. When `?model=<url>` is on the page
+ * URL we use the supplied URL; otherwise we fall back to the bundled
+ * `default-avatar.glb` resolved via `chrome.runtime.getURL`.
+ */
+function resolveModelUrl(): string {
+  const params = new URLSearchParams(location.search);
+  const override = params.get("model");
+  if (override) return override;
+  return chrome.runtime.getURL("avatar/default-avatar.glb");
+}
+
+/**
+ * Render-loop context. Keeps the active canvas and the TalkingHead.js
+ * instance so the viseme handler and capture loop share state.
+ */
+interface AvatarContext {
+  canvas: HTMLCanvasElement;
+  head: TalkingHeadInstance | null;
+  targetFps: number;
+}
+
+/**
+ * Initialize the avatar page. Creates a canvas inside `#avatar-root`,
+ * loads TalkingHead.js (best-effort), and resolves the bundled GLB
+ * URL. Returns the shared context used by the viseme listener and
+ * the capture loop.
+ */
+async function bootAvatar(): Promise<AvatarContext> {
+  const root = document.getElementById("avatar-root");
+  if (!root) {
+    throw new Error("avatar-root element missing from avatar.html");
+  }
+
+  // Replace the placeholder status text with the actual canvas. The
+  // status element is retained as a sibling so TalkingHead.js has a
+  // plain container to mount its three.js renderer into.
+  const statusEl = document.getElementById("avatar-status");
+  if (statusEl) statusEl.remove();
+
+  const canvas = document.createElement("canvas");
+  canvas.width = CANVAS_WIDTH;
+  canvas.height = CANVAS_HEIGHT;
+  canvas.style.width = "100%";
+  canvas.style.height = "100%";
+  root.appendChild(canvas);
+
+  // Fill the canvas with a neutral background up-front so early
+  // frames (before TalkingHead.js finishes loading) don't stream a
+  // transparent/black frame that Chrome's camera encoder may drop.
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = "#1a1a2e";
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  }
+
+  const modelUrl = resolveModelUrl();
+  let head: TalkingHeadInstance | null = null;
+  const TalkingHeadCtor = await loadTalkingHeadCtor();
+  if (TalkingHeadCtor) {
+    try {
+      head = new TalkingHeadCtor(canvas, {
+        modelRoot: modelUrl.replace(/\/[^/]+$/, "/"),
+        cameraView: "upper",
+      });
+      await head.showAvatar?.({ url: modelUrl });
+    } catch (err) {
+      // A failed load is recoverable — we keep the static canvas and
+      // continue emitting blank frames so the bot sees the camera
+      // stream as active.
+      console.warn("[avatar-tab] talkinghead init failed:", err);
+      head = null;
+    }
+  } else {
+    console.warn("[avatar-tab] @met4citizen/talkinghead module not available");
+  }
+
+  return {
+    canvas,
+    head,
+    targetFps: DEFAULT_TARGET_FPS,
+  };
+}
+
+/**
+ * Handle an inbound `avatar.push_viseme` from the extension
+ * background. Drives TalkingHead.js's mouth blend-shape when a
+ * TalkingHead.js instance is available; logs and drops otherwise.
+ */
+function handleViseme(
+  ctx: AvatarContext,
+  msg: { phoneme: string; weight: number; timestamp: number },
+): void {
+  if (!ctx.head) return;
+  try {
+    ctx.head.speakMorph?.(msg.phoneme, msg.weight);
+  } catch (err) {
+    console.warn("[avatar-tab] speakMorph failed:", err);
+  }
+}
+
+/**
+ * Start a capture loop that grabs the canvas as JPEG at the target
+ * cadence and posts the bytes back to the extension background. The
+ * background forwards the frame over native messaging to the bot.
+ *
+ * Uses `requestAnimationFrame` as the timer so the loop pauses when
+ * Chrome decides the tab isn't visible. We counter Chrome's
+ * tab-backgrounding by (a) opening the tab `pinned: true` (in
+ * `features/avatar.ts`) and (b) keeping the render loop cheap so it
+ * budgets cleanly. A future PR may add a visibility-change
+ * watchdog that re-activates the tab if Chrome freezes it.
+ */
+function startCaptureLoop(ctx: AvatarContext): () => void {
+  let running = true;
+  let lastEmitTs = 0;
+
+  const minInterval = Math.floor(1000 / ctx.targetFps);
+
+  const emitFrame = async (): Promise<void> => {
+    if (!running) return;
+    const now = performance.now();
+    if (now - lastEmitTs < minInterval) return;
+    lastEmitTs = now;
+
+    const blob: Blob | null = await new Promise((resolve) =>
+      ctx.canvas.toBlob(resolve, "image/jpeg", JPEG_QUALITY),
+    );
+    if (!running || !blob) return;
+
+    const buf = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buf);
+    const base64 = encodeBase64(bytes);
+
+    const msg: ExtensionAvatarFrameMessage = {
+      type: "avatar.frame",
+      bytes: base64,
+      width: ctx.canvas.width,
+      height: ctx.canvas.height,
+      format: "jpeg",
+      ts: now,
+    };
+    try {
+      void chrome.runtime.sendMessage(msg);
+    } catch (err) {
+      console.warn("[avatar-tab] sendMessage for avatar.frame failed:", err);
+    }
+  };
+
+  const tick = (): void => {
+    if (!running) return;
+    void emitFrame();
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+
+  return () => {
+    running = false;
+  };
+}
+
+/** Base64-encode a Uint8Array. Avoids bringing in a base64 library. */
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Wire the runtime-message listener so the avatar tab responds to
+ * `avatar.push_viseme` from the extension background. The type guard
+ * is defensive: the background only sends `avatar.push_viseme` to
+ * the avatar tab, but a message from any other origin should be
+ * ignored.
+ */
+function installVisemeListener(ctx: AvatarContext): void {
+  chrome.runtime.onMessage.addListener(
+    (raw, _sender, _sendResponse): boolean => {
+      if (!raw || typeof raw !== "object") return false;
+      const msg = raw as BotToExtensionMessage;
+      if (msg.type !== "avatar.push_viseme") return false;
+      handleViseme(ctx, {
+        phoneme: msg.phoneme,
+        weight: msg.weight,
+        timestamp: msg.timestamp,
+      });
+      return false;
+    },
+  );
+}
+
+/**
+ * Bootstrap entry point. Any unhandled error is caught and logged —
+ * we never throw into the page runtime because the only thing that
+ * would do is kill the tab and leave the bot stuck waiting for the
+ * `avatar.started` ack.
+ */
+async function main(): Promise<void> {
+  let ctx: AvatarContext;
+  try {
+    ctx = await bootAvatar();
+  } catch (err) {
+    console.error("[avatar-tab] bootAvatar failed:", err);
+    // Post `avatar.started` anyway so the bot's renderer doesn't
+    // hit its timeout. The bot will just see a static canvas.
+    const ack: ExtensionAvatarStartedMessage = { type: "avatar.started" };
+    try {
+      void chrome.runtime.sendMessage(ack);
+    } catch {
+      // Best-effort.
+    }
+    return;
+  }
+
+  installVisemeListener(ctx);
+  startCaptureLoop(ctx);
+
+  // Handshake: the bot's renderer awaits this ack before resolving
+  // start().
+  const ack: ExtensionAvatarStartedMessage = { type: "avatar.started" };
+  try {
+    void chrome.runtime.sendMessage(ack);
+  } catch (err) {
+    console.warn("[avatar-tab] failed to send avatar.started ack:", err);
+  }
+}
+
+void main();
+
+// Export nothing — this file is loaded as a plain module script.
+export {};

--- a/skills/meet-join/meet-controller-ext/src/background.ts
+++ b/skills/meet-join/meet-controller-ext/src/background.ts
@@ -1,8 +1,10 @@
 /**
  * Extension service-worker entry. Opens the native-messaging port to the
- * meet-bot, wires content scripts into it via {@link startContentBridge}, and
- * emits the `ready` handshake so the bot knows the extension is alive.
+ * meet-bot, wires content scripts into it via {@link startContentBridge},
+ * hooks in the avatar feature (Phase 4), and emits the `ready` handshake
+ * so the bot knows the extension is alive.
  */
+import { startAvatarFeature } from "./features/avatar.js";
 import { startContentBridge } from "./messaging/content-bridge.js";
 import { openNativePort } from "./messaging/native-port.js";
 
@@ -10,6 +12,29 @@ console.log("[meet-ext] background booted");
 
 const port = openNativePort({});
 startContentBridge(port);
+
+// Phase 4 — avatar feature. Opens a pinned second Chrome tab when the
+// bot sends `avatar.start` and forwards `avatar.push_viseme` into that
+// tab. Outbound `avatar.started` / `avatar.frame` frames from the tab
+// are validated and forwarded to the bot via the shared native port.
+const avatar = startAvatarFeature({
+  tabs: chrome.tabs,
+  runtime: chrome.runtime,
+  port,
+});
+
+// Route bot→extension avatar commands into the avatar feature. Other
+// bot→extension commands (join/leave/send_chat) continue to flow
+// through the content bridge to the Meet content script.
+port.onMessage((msg) => {
+  if (
+    msg.type === "avatar.start" ||
+    msg.type === "avatar.stop" ||
+    msg.type === "avatar.push_viseme"
+  ) {
+    void avatar.handleBotCommand(msg);
+  }
+});
 
 // Emit the ready handshake as soon as the port is open. The bot uses this as
 // the signal that the in-container extension is attached and ready to

--- a/skills/meet-join/meet-controller-ext/src/features/avatar.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/avatar.ts
@@ -1,0 +1,279 @@
+/**
+ * Avatar feature (extension background wiring).
+ *
+ * The meet-bot's TalkingHead.js renderer runs **inside the extension**,
+ * not in the bot's Node runtime — TalkingHead.js needs a real
+ * `<canvas>` + WebGL context, which only a browser tab can provide.
+ *
+ * This module is the background-service-worker side of the feature:
+ *
+ * 1. On `avatar.start` from the bot, open a pinned, inactive second
+ *    Chrome tab pointed at `chrome-runtime-url("avatar/avatar.html")`.
+ *    The tab loads TalkingHead.js, instantiates the bundled GLB, and
+ *    sends back an `avatar.started` ack once it has mounted.
+ *
+ * 2. Forward subsequent `avatar.push_viseme` frames from the bot to
+ *    the avatar tab via `chrome.tabs.sendMessage`.
+ *
+ * 3. Relay inbound `avatar.frame` events from the avatar tab to the
+ *    bot's native-messaging host unchanged.
+ *
+ * 4. On `avatar.stop` from the bot, remove the tab and drop state.
+ *
+ * ## Why a second tab?
+ *
+ * The Meet tab hosts Google's SPA; its CSP and aggressive DOM
+ * virtualization make it a poor host for TalkingHead.js. A dedicated
+ * tab with its own origin (the extension's `chrome-extension://`
+ * scheme) sidesteps both concerns.
+ *
+ * The tab is opened `pinned: true, active: false`. Xvfb never renders
+ * anything the user sees (there is no user inside the bot container)
+ * but pinning prevents Chrome's tab-discard heuristic from freezing
+ * the avatar's animation loop when the Meet tab is "active".
+ *
+ * ## Failure modes
+ *
+ * - If `chrome.tabs.create` rejects (extension context unavailable
+ *   because Chrome itself is shutting down) we log and drop the
+ *   command. The bot side's `start()` will time out waiting for the
+ *   ack and throw `AvatarRendererUnavailableError`, letting the
+ *   session-manager fall back to the noop renderer.
+ * - If the avatar tab posts a message while no tab is active (race
+ *   during teardown), we ignore it — dropping stale frames is
+ *   strictly preferable to forwarding to a torn-down bot.
+ */
+
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
+import { ExtensionToBotMessageSchema } from "../../../contracts/native-messaging.js";
+
+import type { NativePort } from "../messaging/native-port.js";
+
+/**
+ * Relative path to the bundled avatar HTML inside the extension.
+ * `chrome.runtime.getURL` translates this into the
+ * `chrome-extension://<id>/avatar/avatar.html` URL the opened tab
+ * loads.
+ */
+export const AVATAR_PAGE_PATH = "avatar/avatar.html";
+
+/**
+ * Query-string key the avatar page reads at load time to determine
+ * which GLB to load. When absent, the page falls back to the bundled
+ * `default-avatar.glb`.
+ */
+export const AVATAR_MODEL_QUERY_PARAM = "model";
+
+/**
+ * Minimal slice of the Chrome tabs API the feature actually uses.
+ * Exposed as a type so unit tests can inject a fake without needing
+ * `@types/chrome` at the test-site.
+ */
+export interface AvatarTabsApi {
+  create(opts: {
+    url: string;
+    active?: boolean;
+    pinned?: boolean;
+  }): Promise<{ id?: number }>;
+  remove(tabId: number): Promise<void>;
+  sendMessage(tabId: number, msg: unknown): Promise<unknown>;
+}
+
+/**
+ * Minimal slice of the Chrome runtime API the feature uses. The
+ * `onMessage.addListener` signature mirrors the real Chrome API so the
+ * fake's shape stays compatible.
+ */
+export interface AvatarRuntimeApi {
+  onMessage: {
+    addListener(
+      cb: (
+        raw: unknown,
+        sender: unknown,
+        sendResponse: (response?: unknown) => void,
+      ) => boolean,
+    ): void;
+  };
+  getURL(path: string): string;
+}
+
+/**
+ * Minimal slice of the native port the feature uses. `post` is the
+ * only direction the avatar feature drives — it never registers its
+ * own inbound listener (the background service worker's main router
+ * does that and dispatches to `handleAvatarBotCommand`).
+ */
+export type AvatarNativePort = Pick<NativePort, "post">;
+
+export interface AvatarFeatureOptions {
+  tabs: AvatarTabsApi;
+  runtime: AvatarRuntimeApi;
+  port: AvatarNativePort;
+  /**
+   * Logger hooks — routed to `console` by default but overridable in
+   * tests so we can assert diagnostic output without depending on
+   * global console state.
+   */
+  log?: {
+    info(msg: string, extra?: Record<string, unknown>): void;
+    warn(msg: string, extra?: Record<string, unknown>): void;
+  };
+}
+
+/**
+ * Handle returned by {@link startAvatarFeature}. `stop()` is exposed
+ * primarily for tests — the background service worker lives for the
+ * lifetime of the extension and doesn't normally tear the feature
+ * down.
+ */
+export interface AvatarFeatureHandle {
+  /**
+   * Dispatch a bot→extension avatar command. Called by the main
+   * content bridge whenever it observes an `avatar.*` command on the
+   * native port.
+   */
+  handleBotCommand(msg: BotToExtensionMessage): Promise<void>;
+  /**
+   * Tear the feature down and close any open avatar tab. Idempotent.
+   * For tests.
+   */
+  stop(): Promise<void>;
+}
+
+/**
+ * Wire up the avatar feature. Returns a handle the caller invokes
+ * when routing bot commands.
+ *
+ * The caller is responsible for filtering bot commands to the
+ * `avatar.*` family before handing them off — passing a non-avatar
+ * command through `handleBotCommand` is a no-op but a caller is
+ * expected to dispatch to the more specific handler (join/leave/etc.)
+ * for everything else.
+ */
+export function startAvatarFeature(
+  opts: AvatarFeatureOptions,
+): AvatarFeatureHandle {
+  const { tabs, runtime, port } = opts;
+  const log = opts.log ?? {
+    info: (m) => console.log(`[meet-ext avatar] ${m}`),
+    warn: (m) => console.warn(`[meet-ext avatar] ${m}`),
+  };
+
+  let avatarTabId: number | null = null;
+  let stopped = false;
+
+  /**
+   * Forward every validated inbound runtime message from the avatar
+   * tab to the bot's native-messaging host. We only relay
+   * `avatar.started` and `avatar.frame` — other message types are
+   * ignored because they belong to the content-bridge router.
+   */
+  runtime.onMessage.addListener(
+    (raw, _sender, _sendResponse): boolean => {
+      if (stopped) return false;
+      const parsed = ExtensionToBotMessageSchema.safeParse(raw);
+      if (!parsed.success) return false;
+      const msg: ExtensionToBotMessage = parsed.data;
+      if (msg.type !== "avatar.started" && msg.type !== "avatar.frame") {
+        return false;
+      }
+      try {
+        port.post(msg);
+      } catch (err) {
+        log.warn("failed to forward avatar message to native port", {
+          type: msg.type,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return false;
+    },
+  );
+
+  async function openAvatarTab(modelUrl: string | undefined): Promise<void> {
+    const base = runtime.getURL(AVATAR_PAGE_PATH);
+    const url = modelUrl
+      ? `${base}?${AVATAR_MODEL_QUERY_PARAM}=${encodeURIComponent(modelUrl)}`
+      : base;
+    try {
+      const tab = await tabs.create({ url, active: false, pinned: true });
+      if (typeof tab.id !== "number") {
+        log.warn("tabs.create returned no tab id; avatar frames will not flow");
+        return;
+      }
+      avatarTabId = tab.id;
+      log.info(`avatar tab opened (id=${tab.id})`);
+    } catch (err) {
+      log.warn("tabs.create for avatar tab failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function closeAvatarTab(): Promise<void> {
+    const id = avatarTabId;
+    avatarTabId = null;
+    if (id === null) return;
+    try {
+      await tabs.remove(id);
+    } catch (err) {
+      // Tab might already be gone (user tore down Chrome). Best-effort.
+      log.warn("tabs.remove for avatar tab failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function relayToAvatarTab(msg: BotToExtensionMessage): Promise<void> {
+    const id = avatarTabId;
+    if (id === null) {
+      // Viseme without an open tab: drop silently. The bot's
+      // amplitude-envelope fallback (PR 9) may produce a burst of
+      // visemes before the tab has landed; logging every drop would
+      // swamp the diagnostic stream.
+      return;
+    }
+    try {
+      await tabs.sendMessage(id, msg);
+    } catch (err) {
+      log.warn("tabs.sendMessage to avatar tab failed", {
+        type: msg.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleBotCommand(msg: BotToExtensionMessage): Promise<void> {
+    if (stopped) return;
+    if (msg.type === "avatar.start") {
+      // Close any stale tab before opening a fresh one — a racing
+      // start/start sequence must not leak tabs.
+      if (avatarTabId !== null) {
+        await closeAvatarTab();
+      }
+      await openAvatarTab(msg.modelUrl);
+      return;
+    }
+    if (msg.type === "avatar.stop") {
+      await closeAvatarTab();
+      return;
+    }
+    if (msg.type === "avatar.push_viseme") {
+      await relayToAvatarTab(msg);
+      return;
+    }
+    // Any other message type is ignored — the content-bridge router
+    // handles join / leave / send_chat.
+  }
+
+  return {
+    handleBotCommand,
+    async stop(): Promise<void> {
+      if (stopped) return;
+      stopped = true;
+      await closeAvatarTab();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extension-side `features/avatar.ts` opens a pinned/inactive second Chrome tab via `chrome.tabs.create`; the avatar tab loads TalkingHead.js and streams canvas frames back to the extension background over `chrome.runtime` messaging, then across native-messaging to the bot.
- Bot-side `talking-head/renderer.ts` registers as `"talking-head"`, sends `avatar.start`/`.stop`/`.push_viseme` over native messaging, and re-emits received `avatar.frame` bytes via `onFrame` (JPEG → Y4M transcode via ffmpeg when needed).
- Zod schemas for the `avatar.*` messages land in `contracts/native-messaging.ts` as the shared source of truth.
- `default-avatar.glb` ships as a placeholder; operators should swap in a real Ready Player Me model — see README for instructions.

Part of plan: meet-phase-4-avatar.md (PR 8 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
