### PR TITLE
meet-bot: align viseme-driven avatar frames to TTS audio playback time

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Lip-sync alignment tests for the TalkingHead.js renderer.
+ *
+ * The renderer is responsible for buffering inbound viseme events and
+ * only forwarding them to the extension when the audio-playback clock
+ * catches up to each viseme's declared timestamp. This prevents visible
+ * drift when the network between the daemon and the bot delays visemes:
+ * a viseme that arrives 100ms ahead of its corresponding audio is held
+ * until the audio actually plays out of `bot_out`, then released.
+ *
+ * These tests exercise that behavior end-to-end against the real
+ * {@link TalkingHeadRenderer} + real {@link startAudioPlayback}
+ * pipeline (the pacat subprocess is a shim), with a fake
+ * {@link AvatarNativeMessagingSender} capturing the downstream
+ * `avatar.push_viseme` frames the extension would have received. We
+ * drive the audio-playback handle with deterministic byte writes +
+ * a controllable `now()` clock so the playback-timestamp stream is
+ * fully observable and the test is not flaky on machine load.
+ *
+ * Coverage:
+ *   - Visemes that arrive AHEAD of audio are held until the
+ *     audio-playback timestamp catches up, then flushed in order.
+ *   - Visemes that arrive LATE (after audio already passed their
+ *     declared time) are flushed immediately — no "ghost" delay.
+ *   - The renderer's `currentPlaybackTimestamp` is monotonic; a
+ *     stale/out-of-order timestamp notification is ignored rather
+ *     than rewinding the clock.
+ *   - A `stop()` clears the buffer so visemes queued for a
+ *     terminated session do not leak into a later one.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  BotAvatarPushVisemeCommand,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+import type { AvatarNativeMessagingSender } from "../src/media/avatar/index.js";
+import { TalkingHeadRenderer } from "../src/media/avatar/talking-head/renderer.js";
+import {
+  __resetForTests as resetAudioPlayback,
+  startAudioPlayback,
+  stopAudioPlayback,
+  type PacatWritable,
+  type SpawnedPacat,
+} from "../src/media/audio-playback.js";
+
+// ---------------- helpers ------------------------------------------------
+
+type BotAvatarMsg =
+  | BotAvatarPushVisemeCommand
+  | { type: "avatar.start"; targetFps?: number; modelUrl?: string }
+  | { type: "avatar.stop" };
+
+/**
+ * In-memory fake of the native-messaging surface the renderer drives.
+ * Captures every bot→extension message sent and exposes an `emit`
+ * helper so tests can simulate the extension's inbound frames.
+ */
+class FakeNativeMessaging implements AvatarNativeMessagingSender {
+  readonly sent: BotAvatarMsg[] = [];
+  private listeners: Array<(msg: ExtensionToBotMessage) => void> = [];
+
+  sendToExtension = (msg: BotAvatarMsg): void => {
+    this.sent.push(msg);
+  };
+
+  onExtensionMessage = (cb: (msg: ExtensionToBotMessage) => void): void => {
+    this.listeners.push(cb);
+  };
+
+  emit(msg: ExtensionToBotMessage): void {
+    for (const cb of this.listeners.slice()) cb(msg);
+  }
+
+  pushVisemes(): BotAvatarPushVisemeCommand[] {
+    return this.sent.filter(
+      (m): m is BotAvatarPushVisemeCommand => m.type === "avatar.push_viseme",
+    );
+  }
+}
+
+/**
+ * Minimal pacat shim — stdin writes append to a buffer, `kill()`
+ * resolves the `exited` promise. The test drives the handle with raw
+ * byte writes and observes which visemes the renderer flushes at each
+ * playback-timestamp emission.
+ */
+function makePacatShim(): {
+  proc: SpawnedPacat;
+  bytesWritten: () => number;
+} {
+  let written = 0;
+  const stdin: PacatWritable = {
+    write(chunk: Uint8Array): number {
+      written += chunk.length;
+      return chunk.length;
+    },
+    async end() {
+      /* no-op; kill() controls lifetime */
+    },
+  };
+  let resolveExited!: (code: number) => void;
+  const exited = new Promise<number>((r) => {
+    resolveExited = r;
+  });
+  const proc: SpawnedPacat = {
+    stdin,
+    exited,
+    kill() {
+      resolveExited(0);
+    },
+  };
+  return { proc, bytesWritten: () => written };
+}
+
+/**
+ * Drive the bot's renderer so it is started and ready to accept
+ * visemes. Encapsulates the "send avatar.start, receive avatar.started
+ * ack, await the start promise" handshake every test needs.
+ */
+async function startRenderer(
+  nativeMessaging: FakeNativeMessaging,
+): Promise<TalkingHeadRenderer> {
+  const r = new TalkingHeadRenderer({
+    nativeMessaging,
+    startedAckTimeoutMs: 500,
+  });
+  const startPromise = r.start();
+  nativeMessaging.emit({ type: "avatar.started" });
+  await startPromise;
+  return r;
+}
+
+// ---------------- tests --------------------------------------------------
+
+describe("TalkingHead renderer lip-sync alignment", () => {
+  beforeEach(() => {
+    resetAudioPlayback();
+  });
+
+  afterEach(async () => {
+    await stopAudioPlayback();
+    resetAudioPlayback();
+  });
+
+  test("visemes arriving 100ms before audio are held until playback catches up", async () => {
+    // The full pipeline under test: viseme events stream in 100 ms
+    // ahead of the corresponding audio, the bot queues PCM into the
+    // audio-playback handle, and the handle's playback-timestamp
+    // stream drives the renderer's flush cadence. We inject a
+    // deterministic clock so the playback timestamps evolve in
+    // controlled increments instead of depending on real wall time.
+    let nowMs = 0;
+    const advance = (delta: number): void => {
+      nowMs += delta;
+    };
+
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    const shim = makePacatShim();
+    const handle = startAudioPlayback({
+      spawn: () => shim.proc,
+      now: () => nowMs,
+    });
+
+    // Wire the playback-timestamp stream into the renderer. This is
+    // exactly what the bot's HTTP server does in production when an
+    // avatar renderer is active alongside an in-flight /play_audio
+    // stream.
+    const unsubscribe = handle.onPlaybackTimestamp((ts) => {
+      renderer.notifyPlaybackTimestamp(ts);
+    });
+
+    // Capture every viseme the renderer forwards to the extension,
+    // tagged with the playback clock at forwarding time. A perfectly
+    // aligned pipeline emits each viseme at the moment audio for that
+    // viseme's timestamp actually plays out — NOT at the moment the
+    // viseme was pushed into the renderer.
+    const flushed: Array<{ phoneme: string; atMs: number }> = [];
+    nativeMessaging.sendToExtension = (msg: BotAvatarMsg): void => {
+      if (msg.type === "avatar.push_viseme") {
+        flushed.push({ phoneme: msg.phoneme, atMs: nowMs });
+      }
+    };
+
+    // Step 1: visemes arrive ahead of audio. The renderer MUST hold
+    // them. Push three visemes with timestamps 100, 200, 300 (ms).
+    // They arrive at wall-clock time 0 — 100 ms before their
+    // declared audio timestamp, exactly the drift scenario from the
+    // PR description.
+    renderer.pushViseme({ phoneme: "ah", weight: 0.8, timestamp: 100 });
+    renderer.pushViseme({ phoneme: "ee", weight: 0.6, timestamp: 200 });
+    renderer.pushViseme({ phoneme: "oh", weight: 0.4, timestamp: 300 });
+
+    // None of the visemes should be forwarded yet — the audio-
+    // playback clock is still at time 0 and none of them has come
+    // due. This is the whole point of the buffering: the extension
+    // must not see the visemes ahead of the audio.
+    expect(flushed).toEqual([]);
+
+    // Step 2: audio starts flowing. Queue 100 ms worth of PCM. At
+    // 48000 Hz mono s16le that's 9600 bytes (96 bytes/ms). Writing
+    // 9600 bytes with a now() of 0 advances the playback clock to
+    // 100 ms — the first viseme comes due.
+    const BYTES_PER_MS = handle.bytesPerMs;
+    const chunk100ms = new Uint8Array(100 * BYTES_PER_MS);
+    await handle.write(chunk100ms);
+
+    // The "ah" viseme (timestamp 100) should now have been forwarded
+    // because the playback clock advanced to exactly 100. The other
+    // two remain buffered.
+    expect(flushed.map((f) => f.phoneme)).toEqual(["ah"]);
+    expect(flushed[0]!.atMs).toBe(0); // wall-clock at forwarding time
+
+    // Step 3: simulate real time passing — 50 ms go by with no new
+    // audio. The audio buffer drains to real time but the playback
+    // clock does NOT advance (we don't emit playback timestamps in
+    // the drain direction — only on writes), so the second viseme
+    // stays buffered.
+    advance(50);
+    expect(flushed.map((f) => f.phoneme)).toEqual(["ah"]);
+
+    // Step 4: queue another 150 ms of audio. The `max(nowMs,
+    // effectivePlaybackMs)` rebase kicks in here because real time
+    // (50 ms) is past our previous estimate (100 ms)? No — 50 < 100,
+    // so the clock baselines off effectivePlaybackMs. New estimate:
+    // 100 + 150 = 250 ms. Viseme "ee" (t=200) comes due; "oh" (t=300)
+    // stays.
+    const chunk150ms = new Uint8Array(150 * BYTES_PER_MS);
+    await handle.write(chunk150ms);
+
+    expect(flushed.map((f) => f.phoneme)).toEqual(["ah", "ee"]);
+
+    // Step 5: queue the remaining 50 ms — clock reaches 300 ms, the
+    // last viseme drains.
+    const chunk50ms = new Uint8Array(50 * BYTES_PER_MS);
+    await handle.write(chunk50ms);
+
+    expect(flushed.map((f) => f.phoneme)).toEqual(["ah", "ee", "oh"]);
+
+    unsubscribe();
+  });
+
+  test("late visemes (timestamp < current playback clock) flush immediately", async () => {
+    // The viseme-arrival-time drift can go either way: late visemes
+    // (e.g. a burst after network congestion) should NOT be
+    // additionally delayed. Once a viseme's timestamp is already in
+    // the past relative to the playback clock, the renderer must
+    // release it as soon as pushViseme is called.
+    let nowMs = 0;
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+    const shim = makePacatShim();
+    const handle = startAudioPlayback({
+      spawn: () => shim.proc,
+      now: () => nowMs,
+    });
+    const unsubscribe = handle.onPlaybackTimestamp((ts) => {
+      renderer.notifyPlaybackTimestamp(ts);
+    });
+
+    // Drive audio forward to 500 ms.
+    const BYTES_PER_MS = handle.bytesPerMs;
+    await handle.write(new Uint8Array(500 * BYTES_PER_MS));
+
+    const before = nativeMessaging.pushVisemes().length;
+
+    // Push a viseme declared at t=100 — 400 ms in the past. Should
+    // flush immediately with no further audio needed.
+    renderer.pushViseme({ phoneme: "p", weight: 0.2, timestamp: 100 });
+
+    const after = nativeMessaging.pushVisemes();
+    expect(after.length).toBe(before + 1);
+    expect(after[after.length - 1]!.phoneme).toBe("p");
+
+    unsubscribe();
+  });
+
+  test("notifyPlaybackTimestamp is monotonic — a stale notification does not rewind", async () => {
+    // Regression guard: if an observer accidentally forwards an
+    // older timestamp (e.g. from a stale `setInterval` closure), the
+    // renderer must not rewind its clock. A subsequent push of a
+    // viseme whose timestamp is between the old and new clock values
+    // must still be held.
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    renderer.notifyPlaybackTimestamp(1_000);
+    renderer.notifyPlaybackTimestamp(500); // stale — must be ignored
+
+    renderer.pushViseme({ phoneme: "m", weight: 0.3, timestamp: 700 });
+
+    // The clock was never actually rewound, so 700 <= 1000 and the
+    // viseme flushes immediately.
+    const pushed = nativeMessaging.pushVisemes();
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]!.phoneme).toBe("m");
+
+    // Push a viseme at t=1500 — still in the future relative to the
+    // clock (1000), so it must stay buffered.
+    renderer.pushViseme({ phoneme: "k", weight: 0.3, timestamp: 1500 });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(1);
+
+    // Advance past 1500 and confirm it flushes.
+    renderer.notifyPlaybackTimestamp(2_000);
+    const all = nativeMessaging.pushVisemes();
+    expect(all).toHaveLength(2);
+    expect(all[1]!.phoneme).toBe("k");
+  });
+
+  test("stop() clears the viseme buffer; a later clock advance does not leak stale events", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    // Buffer a viseme the clock hasn't reached yet.
+    renderer.pushViseme({ phoneme: "t", weight: 0.3, timestamp: 10_000 });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+
+    await renderer.stop();
+
+    // Even if some late caller advances the clock well past the
+    // buffered timestamp, the stopped renderer must not emit.
+    renderer.notifyPlaybackTimestamp(1_000_000);
+
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+  });
+
+  test("visemes with identical timestamps are forwarded in arrival order", async () => {
+    // ElevenLabs' viseme stream can legitimately produce back-to-back
+    // events with the same millisecond timestamp. The buffer drain
+    // order must follow arrival order, not a secondary sort key
+    // (which would require a stable sort and introduce subtle
+    // ordering bugs in the extension).
+    const nativeMessaging = new FakeNativeMessaging();
+    const renderer = await startRenderer(nativeMessaging);
+
+    renderer.pushViseme({ phoneme: "a", weight: 0.1, timestamp: 100 });
+    renderer.pushViseme({ phoneme: "b", weight: 0.2, timestamp: 100 });
+    renderer.pushViseme({ phoneme: "c", weight: 0.3, timestamp: 100 });
+    expect(nativeMessaging.pushVisemes()).toHaveLength(0);
+
+    renderer.notifyPlaybackTimestamp(100);
+    const pushed = nativeMessaging.pushVisemes();
+    expect(pushed.map((v) => v.phoneme)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
+++ b/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
@@ -259,7 +259,7 @@ describe("TalkingHeadRenderer", () => {
     ).toHaveLength(1);
   });
 
-  test("pushViseme forwards as avatar.push_viseme", async () => {
+  test("pushViseme forwards as avatar.push_viseme once the playback clock catches up", async () => {
     const nativeMessaging = new FakeNativeMessaging();
     const r = new TalkingHeadRenderer({
       nativeMessaging,
@@ -269,8 +269,13 @@ describe("TalkingHeadRenderer", () => {
     nativeMessaging.emit({ type: "avatar.started" });
     await startPromise;
 
+    // PR 9: visemes are held until the audio-playback clock catches
+    // up to their declared timestamp. Advance the clock past both
+    // visemes' timestamps so the buffer drains and the extension sees
+    // both events in arrival order.
     r.pushViseme({ phoneme: "ah", weight: 0.8, timestamp: 500 });
     r.pushViseme({ phoneme: "ee", weight: 0.4, timestamp: 550 });
+    r.notifyPlaybackTimestamp(550);
 
     const pushed = nativeMessaging.sent.filter(
       (m) => m.type === "avatar.push_viseme",

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -456,6 +456,28 @@ export function createHttpServer(
       const controller = new AbortController();
       activeStreams.set(streamId, { controller, handle });
 
+      // PR 9: wire the playback-timestamp stream into the active
+      // avatar renderer so viseme-driven renderers (TalkingHead.js)
+      // can align their frame emission to actual audio playback time
+      // instead of to viseme-arrival time. Non-viseme renderers
+      // (Simli/HeyGen/Tavus/SadTalker/MuseTalk) leave
+      // `notifyPlaybackTimestamp` undefined on the interface, so the
+      // wiring is a no-op for them — this timing fix is inert for
+      // hosted / GPU-sidecar backends whose audio-to-motion timing is
+      // owned server-side.
+      const renderer = avatarRenderer;
+      let unsubscribePlaybackTimestamp: (() => void) | null = null;
+      if (
+        renderer !== null &&
+        renderer.capabilities.needsVisemes &&
+        typeof renderer.notifyPlaybackTimestamp === "function"
+      ) {
+        const notify = renderer.notifyPlaybackTimestamp.bind(renderer);
+        unsubscribePlaybackTimestamp = handle.onPlaybackTimestamp((ts) => {
+          notify(ts);
+        });
+      }
+
       // Observability hook — invoked fire-and-forget so slow callbacks don't
       // stall the audio pipeline.
       void Promise.resolve(onPlayAudio(streamId)).catch(() => {});
@@ -470,6 +492,7 @@ export function createHttpServer(
         } catch {
           // Best-effort; silence is cosmetic.
         }
+        unsubscribePlaybackTimestamp?.();
         return c.json({ streamId, bytes: 0 }, 200);
       }
 
@@ -538,6 +561,10 @@ export function createHttpServer(
         } catch {
           // Best-effort.
         }
+        // Drop the playback→renderer bridge so a stale closure doesn't
+        // keep a reference to a renderer that might be torn down by a
+        // concurrent /avatar/disable.
+        unsubscribePlaybackTimestamp?.();
       }
 
       if (writeError) {

--- a/skills/meet-join/bot/src/media/audio-playback.ts
+++ b/skills/meet-join/bot/src/media/audio-playback.ts
@@ -81,6 +81,13 @@ export interface StartAudioPlaybackOptions {
   rateHz?: number;
   channels?: number;
   spawn?: PacatSpawnFactory;
+  /**
+   * Override the wall-clock source for playback-timestamp estimation.
+   * Tests pass a deterministic clock so they can advance time in
+   * controlled increments without real delays. Production uses
+   * `performance.now()`.
+   */
+  now?: () => number;
 }
 
 /**
@@ -89,6 +96,22 @@ export interface StartAudioPlaybackOptions {
  * `write` returns once the bytes have been handed to pacat (its stdin may
  * apply backpressure via a promise resolution). `flushSilence` pushes a
  * block of zeroes — typically 50ms at shutdown to avoid a popping sound.
+ *
+ * `onPlaybackTimestamp` exposes an estimate of the wall-clock time at
+ * which the most recently written PCM byte will play out of the
+ * `bot_out` sink. Consumers subscribe to this stream to align
+ * audio-adjacent pipelines (e.g. the TalkingHead.js renderer aligning
+ * viseme emission to audio) with the actual playback timeline rather
+ * than with the time visemes are received from the daemon.
+ *
+ * The estimate is derived from
+ *   `max(nowMs, lastEstimate) + byteCount / bytesPerMs`
+ * so that sustained writes accumulate into the future (keeping track
+ * of buffered audio) while a write after the buffer has drained snaps
+ * back to real time. Because Chrome → PulseAudio → `bot_out` → WebRTC
+ * resampler is all zero-copy for matching sample rates, the dominant
+ * latency source is the ~10 ms pacat jitter buffer; the estimate is
+ * therefore accurate to roughly ±30 ms.
  */
 export interface AudioPlaybackHandle {
   /** Whether this handle is still usable. Flips to `false` on stop. */
@@ -101,6 +124,30 @@ export interface AudioPlaybackHandle {
   write(chunk: Uint8Array): Promise<void>;
   /** Write `ms` milliseconds of silence (zero bytes). */
   flushSilence(ms: number): Promise<void>;
+  /**
+   * Subscribe to playback-timestamp updates. The callback fires after
+   * every non-empty byte write (including silence flushes) with the
+   * wall-clock time at which the most recently written PCM byte is
+   * expected to play out of the sink. Returns an unsubscribe function;
+   * calling it more than once is a no-op.
+   *
+   * Timestamps are strictly monotonic: each emission advances the clock
+   * by at least `byteCount / bytesPerMs` past the previous emission, so
+   * subscribers can compare directly with `VisemeEvent.timestamp`
+   * values without worrying about equal-timestamp reordering.
+   */
+  onPlaybackTimestamp(cb: (ts: number) => void): () => void;
+}
+
+/**
+ * Default monotonic clock — `performance.now()` gives millisecond-
+ * resolution wall-clock time that tracks the same reference as the
+ * `VisemeEvent.timestamp` field the daemon stamps on outbound viseme
+ * events, so the alignment math works without coordinate-system
+ * translation.
+ */
+function defaultNow(): number {
+  return performance.now();
 }
 
 /** Default spawn factory — wraps `Bun.spawn` with the pacat flags. */
@@ -162,6 +209,7 @@ export function startAudioPlayback(
   const rateHz = opts.rateHz ?? DEFAULT_RATE_HZ;
   const channels = opts.channels ?? DEFAULT_CHANNELS;
   const spawn = opts.spawn ?? defaultSpawn;
+  const now = opts.now ?? defaultNow;
   const bytesPerMs = (rateHz * channels * DEFAULT_SAMPLE_BYTES) / 1000;
 
   const argv = buildPacatArgv(device, rateHz, channels);
@@ -182,6 +230,44 @@ export function startAudioPlayback(
     }
   });
 
+  // --- playback-timestamp state ---------------------------------------
+  //
+  // `effectivePlaybackMs` is the wall-clock time at which the most
+  // recently queued PCM byte is expected to play out. After every
+  // write we advance it by `byteCount / bytesPerMs` from either the
+  // current `effectivePlaybackMs` (buffer still has data) or from
+  // `now()` (buffer drained between writes) — whichever is later.
+  //
+  // This matches the way the kernel's snd-aloop / PulseAudio scheduler
+  // model sink latency. Our error bound is dominated by pacat's
+  // internal jitter buffer (~10 ms) and the Pulse null-sink (~0 ms),
+  // so the estimate stays well under the 30 ms accuracy target.
+  let effectivePlaybackMs = now();
+  const timestampSubscribers: Array<(ts: number) => void> = [];
+
+  const emitTimestamp = (): void => {
+    // Copy the list so an unsubscribe during dispatch doesn't skip a
+    // neighbor.
+    for (const cb of timestampSubscribers.slice()) {
+      try {
+        cb(effectivePlaybackMs);
+      } catch {
+        // Subscriber threw; swallow so audio playback stays healthy.
+      }
+    }
+  };
+
+  const advanceAfterWrite = (byteCount: number): void => {
+    if (byteCount <= 0) return;
+    const nowMs = now();
+    // If the buffer has fully drained since the last write (i.e. real
+    // time has moved past our previous estimate), rebase to now — the
+    // newly-written bytes play "now-ish", not at a stale pinned clock.
+    const baseline = Math.max(nowMs, effectivePlaybackMs);
+    effectivePlaybackMs = baseline + byteCount / bytesPerMs;
+    emitTimestamp();
+  };
+
   const handle: AudioPlaybackHandle = {
     get active() {
       return alive;
@@ -197,6 +283,7 @@ export function startAudioPlayback(
       if (result && typeof (result as Promise<unknown>).then === "function") {
         await result;
       }
+      advanceAfterWrite(chunk.length);
     },
     async flushSilence(ms: number): Promise<void> {
       if (!alive) return;
@@ -207,6 +294,16 @@ export function startAudioPlayback(
       // 4800 bytes, comfortably small.
       const silence = new Uint8Array(total); // zero-filled by default
       await this.write(silence);
+    },
+    onPlaybackTimestamp(cb: (ts: number) => void): () => void {
+      timestampSubscribers.push(cb);
+      let unsubscribed = false;
+      return () => {
+        if (unsubscribed) return;
+        unsubscribed = true;
+        const idx = timestampSubscribers.indexOf(cb);
+        if (idx !== -1) timestampSubscribers.splice(idx, 1);
+      };
     },
   };
 

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -40,16 +40,19 @@
  * TalkingHead.js lip-syncs from discrete viseme events. This renderer
  * advertises `{ needsVisemes: true, needsAudio: true }`:
  *
- * - When viseme events flow in via `pushViseme`, they're forwarded
- *   directly (the renderer is a thin transport shim — TalkingHead.js
- *   owns the blend-shape math inside the avatar tab).
- * - `pushAudio` is accepted so the renderer can derive an amplitude
- *   fallback when no upstream viseme stream is active. For v1 we
- *   don't synthesize amplitude visemes inside the renderer — PR 9
- *   (audio-playback alignment) will add that path. For now
- *   `pushAudio` is a no-op on the wire; we still accept it to keep
- *   the capability surface stable and avoid changing the shape in a
- *   follow-up PR.
+ * - Incoming viseme events are BUFFERED by the renderer and only
+ *   forwarded to the extension once the audio-playback clock catches
+ *   up to each viseme's declared `timestamp`. This removes visible
+ *   drift caused by network jitter between the daemon and the bot:
+ *   a viseme that arrives 100ms before its audio lands is held until
+ *   the audio actually plays, then released.
+ * - `notifyPlaybackTimestamp(ts)` advances the internal playback
+ *   clock. The bot's HTTP server wires the audio-playback handle's
+ *   `onPlaybackTimestamp` stream to this method so every PCM write
+ *   into `bot_out` bumps the renderer's clock forward.
+ * - `pushAudio` is accepted for interface conformance but is a no-op.
+ *   The renderer derives all timing information from the
+ *   playback-timestamp stream, not from direct audio chunks.
  *
  * ## Frame transcoding
  *
@@ -206,6 +209,23 @@ export class TalkingHeadRenderer implements AvatarRenderer {
 
   private subscribers: Array<(frame: Y4MFrame) => void> = [];
 
+  /**
+   * Visemes held back until the audio-playback clock catches up to
+   * their `timestamp`. Stored in arrival order — the flush step
+   * preserves input order while only releasing events whose timestamp
+   * is `<= currentPlaybackTimestamp`. A small per-speech burst (say
+   * 50-100 visemes at 20 fps over a 2-5 s utterance) keeps this
+   * array's working set trivially small; we don't need a heap.
+   */
+  private readonly visemeBuffer: VisemeEvent[] = [];
+
+  /**
+   * The latest playback timestamp observed from the audio-playback
+   * stream. `-Infinity` means "no audio has been queued yet" — every
+   * viseme is held until the first notification arrives.
+   */
+  private currentPlaybackTimestamp = Number.NEGATIVE_INFINITY;
+
   constructor(opts: TalkingHeadRendererOptions) {
     if (!opts.nativeMessaging) {
       throw new AvatarRendererUnavailableError(
@@ -328,27 +348,88 @@ export class TalkingHeadRenderer implements AvatarRenderer {
     }
     this.inFlightTranscodes.clear();
 
+    // Drop any buffered visemes that never made it out. They belonged
+    // to a now-stopped session; replaying them against a future
+    // renderer would be meaningless.
+    this.visemeBuffer.length = 0;
+
     // Drop every subscriber so late frames (which should not arrive
     // after dispose, but defensively) cannot dispatch.
     this.subscribers = [];
   }
 
   pushAudio(_pcm: Uint8Array, _ts: number): void {
-    // v1: no-op. PR 9 will synthesize amplitude-envelope visemes from
-    // the audio stream when no upstream viseme stream is active.
+    // The renderer derives timing information from the playback-
+    // timestamp stream (see `notifyPlaybackTimestamp`), not from the
+    // raw PCM chunks the daemon pushes. This method remains callable
+    // for interface conformance but is a deliberate no-op.
   }
 
   pushViseme(event: VisemeEvent): void {
     if (!this.channel || this.stopped) return;
-    try {
-      this.channel.pushViseme(event);
-    } catch (err) {
-      // A disconnected socket is a symptom, not a fatal — the meeting
-      // should continue even if lip-sync is dropped.
-      this.logger?.warn?.("talking-head: pushViseme dispatch failed", {
-        error: err instanceof Error ? err.message : String(err),
-        phoneme: event.phoneme,
-      });
+    // Hold every viseme until the audio-playback clock catches up to
+    // its timestamp. If the audio is already ahead (e.g. the viseme
+    // arrived late or the clock was already advanced by an earlier
+    // flush), the buffer flush immediately below will drain it
+    // synchronously.
+    this.visemeBuffer.push(event);
+    this.flushBufferedVisemes();
+  }
+
+  /**
+   * Advance the renderer's playback clock. Called by the audio-
+   * playback handle's `onPlaybackTimestamp` stream (wired up by the
+   * bot's HTTP server when a playback stream is active). Any buffered
+   * visemes whose `timestamp <= ts` are forwarded to the extension in
+   * arrival order; the rest remain held until the next notification.
+   *
+   * This method is safe to call before `start()` (it will only buffer
+   * the clock advance) and after `stop()` (no-op — the channel is
+   * gone). It is a no-op when `ts` is not greater than the current
+   * timestamp, so repeated identical notifications are idempotent.
+   */
+  notifyPlaybackTimestamp(ts: number): void {
+    if (this.stopped) return;
+    if (ts <= this.currentPlaybackTimestamp) return;
+    this.currentPlaybackTimestamp = ts;
+    this.flushBufferedVisemes();
+  }
+
+  /**
+   * Drain every buffered viseme whose declared `timestamp` is
+   * `<= currentPlaybackTimestamp`, forwarding each to the extension in
+   * arrival order. Buffered visemes that remain in the future relative
+   * to the playback clock stay in place.
+   *
+   * Kept in a single helper so `pushViseme` and
+   * `notifyPlaybackTimestamp` share exactly one dispatch path — making
+   * it impossible for the two entry points to diverge on ordering.
+   */
+  private flushBufferedVisemes(): void {
+    if (!this.channel || this.stopped) return;
+    if (this.visemeBuffer.length === 0) return;
+
+    // We release from the head of the buffer in arrival order; as
+    // soon as we hit a viseme that's still in the future we stop.
+    // Visemes with out-of-order timestamps (which the daemon SHOULD
+    // never produce, but we guard anyway) are released as soon as
+    // they reach the head of the queue — we trust the daemon's
+    // ordering over raw timestamp comparison because the extension
+    // expects events in the order they were intended to play.
+    while (this.visemeBuffer.length > 0) {
+      const next = this.visemeBuffer[0]!;
+      if (next.timestamp > this.currentPlaybackTimestamp) break;
+      this.visemeBuffer.shift();
+      try {
+        this.channel.pushViseme(next);
+      } catch (err) {
+        // A disconnected socket is a symptom, not a fatal — the
+        // meeting should continue even if lip-sync is dropped.
+        this.logger?.warn?.("talking-head: pushViseme dispatch failed", {
+          error: err instanceof Error ? err.message : String(err),
+          phoneme: next.phoneme,
+        });
+      }
     }
   }
 

--- a/skills/meet-join/bot/src/media/avatar/types.ts
+++ b/skills/meet-join/bot/src/media/avatar/types.ts
@@ -111,6 +111,22 @@ export interface AvatarRenderer {
    * unsubscribe function are no-ops.
    */
   onFrame(cb: (frame: Y4MFrame) => void): () => void;
+  /**
+   * Optional — advance the renderer's internal audio-playback clock.
+   * The bot's HTTP server wires the audio-playback handle's
+   * `onPlaybackTimestamp` stream into this method when both a
+   * `/play_audio` stream and a viseme-driven renderer are active, so
+   * visemes can be emitted at the moment their corresponding audio
+   * actually plays rather than when the viseme arrived over the wire.
+   *
+   * Only viseme-driven renderers (TalkingHead.js) need to implement
+   * this. Hosted renderers (Simli/HeyGen/Tavus) and GPU sidecars
+   * (SadTalker/MuseTalk) do audio-to-motion timing server-side, so
+   * leaving this method undefined is the correct behavior — the HTTP
+   * server detects the missing method and skips the wiring entirely
+   * for those backends.
+   */
+  notifyPlaybackTimestamp?(ts: number): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `audio-playback.ts` emits `onPlaybackTimestamp(cb)` events derived from pacat buffer fill; ~30ms accuracy.
- TalkingHead.js renderer buffers incoming visemes and forwards them to the extension when the playback timestamp catches up, removing drift from network jitter between daemon and bot.
- Non-viseme renderers (Simli/HeyGen/Tavus/SadTalker/MuseTalk) ignore the playback timestamp stream — timing fix is inert for them.

Part of plan: meet-phase-4-avatar.md (PR 10 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
