### PR TITLE
meet: meet_enable_avatar / meet_disable_avatar tools

### DIFF
--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -137,6 +137,15 @@ export const BOT_LEAVE_HTTP_TIMEOUT_MS = 10_000;
 export const BOT_SEND_CHAT_HTTP_TIMEOUT_MS = 10_000;
 
 /**
+ * Timeout for the bot `/avatar/enable` and `/avatar/disable` HTTP calls.
+ * Enable can take several seconds when a heavy renderer (e.g. SadTalker)
+ * is first spinning up, so we budget more generously than chat. Disable
+ * is nearly instant in practice but shares the same ceiling so the two
+ * lifecycle verbs are symmetric.
+ */
+export const BOT_AVATAR_HTTP_TIMEOUT_MS = 30_000;
+
+/**
  * Shared deadline for tearing down every active Meet session during daemon
  * shutdown. Past this budget any remaining containers are force-stopped
  * directly and the session records are dropped so the next daemon start
@@ -168,9 +177,10 @@ export const MEET_JOIN_NAME_FALLBACK = "Vellum";
 // ---------------------------------------------------------------------------
 
 /**
- * Thrown by {@link MeetSessionManager.sendChat} when no active session exists
- * for the given meeting id. Callers (e.g. the `meet_send_chat` tool) match
- * on this class to surface a targeted error rather than a generic failure.
+ * Thrown by session-manager methods (`sendChat`, `speak`, `enableAvatar`, etc.)
+ * when no active session exists for the given meeting id. Callers (e.g. the
+ * `meet_*` tools) match on this class to surface a targeted error rather
+ * than a generic failure.
  */
 export class MeetSessionNotFoundError extends Error {
   readonly name = "MeetSessionNotFoundError";
@@ -181,10 +191,10 @@ export class MeetSessionNotFoundError extends Error {
 }
 
 /**
- * Thrown by {@link MeetSessionManager.sendChat} when the bot's control API
- * could not be reached (network error, timeout, container gone). Distinct
- * from {@link MeetBotChatError} which represents a well-formed bot response
- * whose body indicates failure.
+ * Thrown by session-manager methods that hit the bot's control API when the
+ * bot could not be reached (network error, timeout, container gone). Distinct
+ * from {@link MeetBotChatError} / {@link MeetBotAvatarError} which represent
+ * well-formed bot responses whose status indicates failure.
  */
 export class MeetSessionUnreachableError extends Error {
   readonly name = "MeetSessionUnreachableError";
@@ -206,6 +216,25 @@ export class MeetBotChatError extends Error {
   constructor(meetingId: string, status: number, detail: string) {
     super(
       `Meet bot /send_chat returned ${status} for meetingId=${meetingId}: ${detail}`,
+    );
+    this.status = status;
+  }
+}
+
+/**
+ * Thrown by {@link MeetSessionManager.enableAvatar} /
+ * {@link MeetSessionManager.disableAvatar} when the bot responded with a
+ * non-2xx status code — e.g. a 503 when the avatar subsystem is disabled
+ * or the configured renderer is unavailable. Preserves the status code and
+ * the raw body so tool-layer callers can relay a helpful message.
+ */
+export class MeetBotAvatarError extends Error {
+  readonly name = "MeetBotAvatarError";
+  readonly status: number;
+
+  constructor(meetingId: string, endpoint: string, status: number, detail: string) {
+    super(
+      `Meet bot ${endpoint} returned ${status} for meetingId=${meetingId}: ${detail}`,
     );
     this.status = status;
   }
@@ -467,6 +496,19 @@ export interface MeetSessionManagerDeps {
     text: string,
     meetingId: string,
   ) => Promise<void>;
+  /**
+   * Override the function that hits the bot's `/avatar/enable` and
+   * `/avatar/disable` endpoints. Resolves with the parsed JSON body on 2xx,
+   * throws {@link MeetBotAvatarError} on non-2xx (e.g. 503 when the avatar
+   * subsystem is disabled or the renderer is unavailable), and throws
+   * {@link MeetSessionUnreachableError} when the fetch itself fails.
+   */
+  botAvatarFetch?: (
+    url: string,
+    token: string,
+    endpoint: string,
+    meetingId: string,
+  ) => Promise<Record<string, unknown>>;
   /** Override the daemon-URL resolver (used for `DAEMON_URL` env var). */
   resolveDaemonUrl?: () => string;
   /** Override workspace directory resolution (tests). */
@@ -595,6 +637,7 @@ class MeetSessionManagerImpl {
       getProviderKey: deps.getProviderKey ?? getProviderKeyAsync,
       botLeaveFetch: deps.botLeaveFetch ?? defaultBotLeaveFetch,
       botSendChatFetch: deps.botSendChatFetch ?? defaultBotSendChatFetch,
+      botAvatarFetch: deps.botAvatarFetch ?? defaultBotAvatarFetch,
       resolveDaemonUrl: deps.resolveDaemonUrl ?? defaultResolveDaemonUrl,
       getWorkspaceDir: deps.getWorkspaceDir ?? getWorkspaceDir,
       audioIngestFactory:
@@ -1598,6 +1641,74 @@ class MeetSessionManagerImpl {
   }
 
   /**
+   * Turn on the bot's video avatar via the bot's `/avatar/enable` endpoint.
+   * The bot starts its configured renderer, attaches it to the v4l2loopback
+   * device that backs the Meet camera, and flips the Meet camera toggle ON
+   * so other participants start receiving frames. Idempotent on the bot
+   * side: calling again while the avatar is already running returns
+   * `{alreadyRunning: true}` without re-initializing the renderer.
+   *
+   * Returns the parsed JSON body from the bot so tool-layer callers can
+   * relay useful fields (`renderer`, `alreadyRunning`, `cameraChanged`,
+   * etc.) back to the model.
+   *
+   * Throws:
+   *   - {@link MeetSessionNotFoundError} when no active session exists.
+   *   - {@link MeetSessionUnreachableError} on network-level failure.
+   *   - {@link MeetBotAvatarError} when the bot responded with a non-2xx
+   *     status (e.g. 503 when the avatar subsystem is disabled or the
+   *     renderer is unavailable on this host).
+   */
+  async enableAvatar(meetingId: string): Promise<Record<string, unknown>> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      throw new MeetSessionNotFoundError(meetingId);
+    }
+
+    const body = await this.deps.botAvatarFetch(
+      `${session.botBaseUrl}/avatar/enable`,
+      session.botApiToken,
+      "/avatar/enable",
+      meetingId,
+    );
+
+    log.info({ meetingId, body }, "Meet avatar enabled");
+    return body;
+  }
+
+  /**
+   * Turn off the bot's video avatar via the bot's `/avatar/disable`
+   * endpoint. The bot flips the Meet camera toggle OFF and tears down the
+   * renderer + device writer. Idempotent on the bot side: calling while
+   * already off returns `{wasActive: false}` without error.
+   *
+   * Returns the parsed JSON body so tool-layer callers can relay
+   * `wasActive`, `cameraChanged`, etc. back to the model.
+   *
+   * Throws:
+   *   - {@link MeetSessionNotFoundError} when no active session exists.
+   *   - {@link MeetSessionUnreachableError} on network-level failure.
+   *   - {@link MeetBotAvatarError} when the bot responded with a non-2xx
+   *     status.
+   */
+  async disableAvatar(meetingId: string): Promise<Record<string, unknown>> {
+    const session = this.sessions.get(meetingId);
+    if (!session) {
+      throw new MeetSessionNotFoundError(meetingId);
+    }
+
+    const body = await this.deps.botAvatarFetch(
+      `${session.botBaseUrl}/avatar/disable`,
+      session.botApiToken,
+      "/avatar/disable",
+      meetingId,
+    );
+
+    log.info({ meetingId, body }, "Meet avatar disabled");
+    return body;
+  }
+
+  /**
    * Tear down every active meeting in parallel with a shared overall deadline.
    *
    * Invoked from the daemon's shutdown sequence so live meetings don't leak
@@ -2087,6 +2198,48 @@ async function defaultBotSendChatFetch(
     const body = await response.text().catch(() => "");
     throw new MeetBotChatError(meetingId, response.status, body);
   }
+}
+
+/**
+ * Default bot `/avatar/{enable,disable}` hitter. Honors
+ * {@link BOT_AVATAR_HTTP_TIMEOUT_MS}. On network-level failure throws
+ * {@link MeetSessionUnreachableError}; on non-2xx throws
+ * {@link MeetBotAvatarError} so the tool layer can surface the upstream
+ * status (e.g. 503 when the renderer is unavailable on this host).
+ *
+ * Parses the 2xx body as JSON and returns it verbatim so callers can
+ * relay useful fields (e.g. `alreadyRunning`, `renderer`, `cameraChanged`)
+ * back to the model. A body that fails to parse as JSON is coerced to an
+ * empty object rather than throwing — the endpoint is defined to return
+ * JSON on success, but an empty-body / non-JSON 2xx is still a success
+ * from the caller's perspective.
+ */
+async function defaultBotAvatarFetch(
+  url: string,
+  token: string,
+  endpoint: string,
+  meetingId: string,
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(BOT_AVATAR_HTTP_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new MeetSessionUnreachableError(meetingId, detail);
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new MeetBotAvatarError(meetingId, endpoint, response.status, body);
+  }
+  const parsed = (await response.json().catch(() => ({}))) as unknown;
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
 }
 
 /**

--- a/skills/meet-join/tools/__tests__/meet-avatar-tool.test.ts
+++ b/skills/meet-join/tools/__tests__/meet-avatar-tool.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for the `meet_enable_avatar` and `meet_disable_avatar` tools.
+ *
+ * Exercises feature-flag gating, input validation (optional meetingId),
+ * disambiguation when the caller omits `meetingId` (0 / 1 / many active
+ * sessions), explicit-id pass-through, and error propagation from the
+ * session manager. Mirrors the mocking style used in the sibling
+ * `meet-send-chat-tool.test.ts` / `meet-speak-tool.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let flagEnabled = true;
+let activeSessionsValue: Array<{
+  meetingId: string;
+  conversationId: string;
+  containerId: string;
+  botBaseUrl: string;
+  botApiToken: string;
+  startedAt: number;
+  joinTimeoutMs: number;
+}> = [];
+
+const enableAvatarMock = mock(
+  async (_meetingId: string): Promise<Record<string, unknown>> => ({
+    enabled: true,
+    renderer: "noop",
+    active: false,
+  }),
+);
+const disableAvatarMock = mock(
+  async (_meetingId: string): Promise<Record<string, unknown>> => ({
+    disabled: true,
+    wasActive: false,
+  }),
+);
+
+class FakeMeetSessionNotFoundError extends Error {
+  readonly name = "MeetSessionNotFoundError";
+}
+class FakeMeetSessionUnreachableError extends Error {
+  readonly name = "MeetSessionUnreachableError";
+}
+class FakeMeetBotAvatarError extends Error {
+  readonly name = "MeetBotAvatarError";
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+class FakeMeetBotChatError extends Error {
+  readonly name = "MeetBotChatError";
+  readonly status: number = 0;
+}
+
+// All error classes exported from the real session-manager module are
+// reproduced here so sibling test files (e.g. meet-send-chat-tool.test.ts)
+// don't hit a "Export named 'MeetBotChatError' not found" error when bun's
+// module cache reuses this mock across files in the same run.
+mock.module("../../daemon/session-manager.js", () => ({
+  MeetSessionManager: {
+    join: async () => {
+      throw new Error("join should not be invoked in avatar tests");
+    },
+    leave: async () => {},
+    activeSessions: () => activeSessionsValue,
+    getSession: (meetingId: string) =>
+      activeSessionsValue.find((s) => s.meetingId === meetingId) ?? null,
+    sendChat: async () => {},
+    speak: async () => ({ streamId: "unused" }),
+    cancelSpeak: async () => {},
+    enableAvatar: enableAvatarMock,
+    disableAvatar: disableAvatarMock,
+  },
+  MeetSessionNotFoundError: FakeMeetSessionNotFoundError,
+  MeetSessionUnreachableError: FakeMeetSessionUnreachableError,
+  MeetBotAvatarError: FakeMeetBotAvatarError,
+  MeetBotChatError: FakeMeetBotChatError,
+}));
+
+mock.module(
+  "../../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
+
+mock.module("../../../../assistant/src/config/loader.js", () => ({
+  getConfig: () => ({
+    services: { meet: { consentMessage: "unused-in-avatar-tests" } },
+  }),
+}));
+
+mock.module("../../../../assistant/src/util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const { meetEnableAvatarTool, meetDisableAvatarTool } = await import(
+  "../meet-avatar-tool.js"
+);
+
+import type { ToolContext } from "../../../../assistant/src/tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-test",
+    trustClass: "guardian",
+    ...overrides,
+  } as ToolContext;
+}
+
+function fakeSession(meetingId: string) {
+  return {
+    meetingId,
+    conversationId: "conv-test",
+    containerId: `c-${meetingId}`,
+    botBaseUrl: "http://127.0.0.1:49000",
+    botApiToken: "token",
+    startedAt: Date.now(),
+    joinTimeoutMs: 60_000,
+  };
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  activeSessionsValue = [];
+  enableAvatarMock.mockClear();
+  enableAvatarMock.mockImplementation(async () => ({
+    enabled: true,
+    renderer: "noop",
+    active: false,
+  }));
+  disableAvatarMock.mockClear();
+  disableAvatarMock.mockImplementation(async () => ({
+    disabled: true,
+    wasActive: false,
+  }));
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// meet_enable_avatar — feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_enable_avatar feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(enableAvatarMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_enable_avatar — input validation
+// ---------------------------------------------------------------------------
+
+describe("meet_enable_avatar input validation", () => {
+  test("rejects non-string meetingId", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetEnableAvatarTool.execute(
+      { meetingId: 123 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(enableAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty-string meetingId", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    const result = await meetEnableAvatarTool.execute(
+      { meetingId: "  " },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(enableAvatarMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_enable_avatar — disambiguation
+// ---------------------------------------------------------------------------
+
+describe("meet_enable_avatar disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(enableAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    enableAvatarMock.mockImplementationOnce(async () => ({
+      enabled: true,
+      renderer: "talking-head",
+      active: true,
+      devicePath: "/dev/video10",
+    }));
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(false);
+    expect(enableAvatarMock).toHaveBeenCalledTimes(1);
+    expect(enableAvatarMock.mock.calls[0][0]).toBe("solo");
+    const body = JSON.parse(result.content) as {
+      meetingId: string;
+      enabled: boolean;
+      renderer: string;
+      active: boolean;
+      devicePath: string;
+    };
+    expect(body).toEqual({
+      meetingId: "solo",
+      enabled: true,
+      renderer: "talking-head",
+      active: true,
+      devicePath: "/dev/video10",
+    });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(result.content).toContain("m1");
+    expect(result.content).toContain("m2");
+    expect(enableAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetEnableAvatarTool.execute(
+      { meetingId: "m2" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(enableAvatarMock).toHaveBeenCalledTimes(1);
+    expect(enableAvatarMock.mock.calls[0][0]).toBe("m2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_enable_avatar — error propagation
+// ---------------------------------------------------------------------------
+
+describe("meet_enable_avatar error propagation", () => {
+  test("surfaces MeetSessionNotFoundError as a targeted tool error", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    enableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionNotFoundError("no session");
+    });
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no active Meet session");
+    expect(result.content).toContain("solo");
+  });
+
+  test("surfaces MeetSessionUnreachableError with a bot-unreachable message", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    enableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionUnreachableError("connect ECONNREFUSED");
+    });
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet bot unreachable");
+    expect(result.content).toContain("ECONNREFUSED");
+  });
+
+  test("surfaces MeetBotAvatarError with the upstream status code", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    enableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetBotAvatarError("renderer unavailable", 503);
+    });
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("status 503");
+    expect(result.content).toContain("renderer unavailable");
+  });
+
+  test("surfaces unknown errors verbatim", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    enableAvatarMock.mockImplementationOnce(async () => {
+      throw new Error("something exploded");
+    });
+    const result = await meetEnableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed to enable Meet avatar");
+    expect(result.content).toContain("something exploded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_disable_avatar — feature-flag gating
+// ---------------------------------------------------------------------------
+
+describe("meet_disable_avatar feature-flag gating", () => {
+  test("returns an error when the meet flag is off", async () => {
+    flagEnabled = false;
+    activeSessionsValue = [fakeSession("m1")];
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet feature is disabled");
+    expect(disableAvatarMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_disable_avatar — disambiguation
+// ---------------------------------------------------------------------------
+
+describe("meet_disable_avatar disambiguation", () => {
+  test("errors when no active sessions exist", async () => {
+    activeSessionsValue = [];
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("no active meet session");
+    expect(disableAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the single active session when meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    disableAvatarMock.mockImplementationOnce(async () => ({
+      disabled: true,
+      wasActive: true,
+      cameraChanged: true,
+    }));
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(false);
+    expect(disableAvatarMock).toHaveBeenCalledTimes(1);
+    expect(disableAvatarMock.mock.calls[0][0]).toBe("solo");
+    const body = JSON.parse(result.content) as {
+      meetingId: string;
+      disabled: boolean;
+      wasActive: boolean;
+      cameraChanged: boolean;
+    };
+    expect(body).toEqual({
+      meetingId: "solo",
+      disabled: true,
+      wasActive: true,
+      cameraChanged: true,
+    });
+  });
+
+  test("errors when multiple active sessions and meetingId is omitted", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("multiple active");
+    expect(disableAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts an explicit meetingId even when multiple sessions are active", async () => {
+    activeSessionsValue = [fakeSession("m1"), fakeSession("m2")];
+    const result = await meetDisableAvatarTool.execute(
+      { meetingId: "m1" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(disableAvatarMock).toHaveBeenCalledTimes(1);
+    expect(disableAvatarMock.mock.calls[0][0]).toBe("m1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// meet_disable_avatar — error propagation
+// ---------------------------------------------------------------------------
+
+describe("meet_disable_avatar error propagation", () => {
+  test("surfaces MeetSessionNotFoundError as a targeted tool error", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    disableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionNotFoundError("no session");
+    });
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no active Meet session");
+    expect(result.content).toContain("solo");
+  });
+
+  test("surfaces MeetSessionUnreachableError with a bot-unreachable message", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    disableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetSessionUnreachableError("connect ECONNREFUSED");
+    });
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("meet bot unreachable");
+    expect(result.content).toContain("ECONNREFUSED");
+  });
+
+  test("surfaces MeetBotAvatarError with the upstream status code", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    disableAvatarMock.mockImplementationOnce(async () => {
+      throw new FakeMeetBotAvatarError("teardown failed", 500);
+    });
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("status 500");
+    expect(result.content).toContain("teardown failed");
+  });
+
+  test("surfaces unknown errors verbatim", async () => {
+    activeSessionsValue = [fakeSession("solo")];
+    disableAvatarMock.mockImplementationOnce(async () => {
+      throw new Error("kernel panic");
+    });
+    const result = await meetDisableAvatarTool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed to disable Meet avatar");
+    expect(result.content).toContain("kernel panic");
+  });
+});

--- a/skills/meet-join/tools/meet-avatar-tool.ts
+++ b/skills/meet-join/tools/meet-avatar-tool.ts
@@ -1,0 +1,274 @@
+/**
+ * meet_enable_avatar / meet_disable_avatar tools — toggle the bot's video
+ * avatar inside an active Meet call.
+ *
+ * Paired with {@link ./meet-join-tool.ts meet_join} and the other
+ * in-meeting verbs ({@link ./meet-send-chat-tool.ts meet_send_chat},
+ * {@link ./meet-speak-tool.ts meet_speak}): all are first-party tools
+ * because they command the in-process `MeetSessionManager` (per-meeting
+ * bearer tokens, container lifecycle). See the rationale comment at the
+ * top of `meet-join-tool.ts` — keeping the avatar control surface
+ * in-process avoids a new HTTP API that mirrors the same session-manager
+ * state.
+ *
+ * The SKILL.md "Video avatar" section (`skills/meet-join/SKILL.md`)
+ * carries the canonical guidance on *when* to enable/disable — the tool
+ * descriptions below are intentionally terse and defer to that section
+ * rather than duplicating it, so the model's routing logic stays in one
+ * place.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../../assistant/src/config/loader.js";
+import { RiskLevel } from "../../../assistant/src/permissions/types.js";
+import type { ToolDefinition } from "../../../assistant/src/providers/types.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../assistant/src/tools/types.js";
+import { getLogger } from "../../../assistant/src/util/logger.js";
+import {
+  MeetBotAvatarError,
+  MeetSessionManager,
+  MeetSessionNotFoundError,
+  MeetSessionUnreachableError,
+} from "../daemon/session-manager.js";
+import { MEET_FLAG_KEY } from "./meet-join-tool.js";
+
+const log = getLogger("meet-avatar-tool");
+
+const MeetAvatarInputSchema = z.object({
+  meetingId: z.string().trim().min(1).optional(),
+});
+
+export type MeetAvatarInput = z.infer<typeof MeetAvatarInputSchema>;
+
+/**
+ * Resolve the target meetingId from caller input + active sessions. Returns
+ * `{ ok: true, meetingId }` when a single target is determined, or
+ * `{ ok: false, content }` carrying the error string the tool should
+ * surface verbatim. Mirrors the disambiguation logic in `meet_leave`,
+ * `meet_send_chat`, and `meet_speak` so every meet_* tool behaves
+ * consistently when called without an explicit meetingId.
+ */
+function resolveTargetMeetingId(
+  explicitId: string | undefined,
+): { ok: true; meetingId: string } | { ok: false; content: string } {
+  if (explicitId) {
+    return { ok: true, meetingId: explicitId };
+  }
+  const active = MeetSessionManager.activeSessions();
+  if (active.length === 0) {
+    return { ok: false, content: "Error: no active Meet session." };
+  }
+  if (active.length > 1) {
+    const ids = active.map((s) => s.meetingId).join(", ");
+    return {
+      ok: false,
+      content: `Error: multiple active Meet sessions (${ids}). Pass meetingId explicitly.`,
+    };
+  }
+  return { ok: true, meetingId: active[0].meetingId };
+}
+
+class MeetEnableAvatarTool implements Tool {
+  name = "meet_enable_avatar";
+  description =
+    "Turn on the assistant's video avatar in an active Google Meet call. The avatar lip-syncs to meet_speak output; it is off by default on join and must be explicitly enabled. See the Video avatar section of the meet-join SKILL.md for when to use this. When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  // Low: consent for on-camera participation is established meeting-wide
+  // by `meet_join` (High) and the join-consent message; flipping the
+  // avatar within that bounded session is within the user's expressed
+  // consent envelope. Idempotent on the bot side (calling enable when
+  // already on returns `alreadyRunning: true`), so a stray retry is
+  // harmless. Aligns with the other in-meeting verbs (also Low).
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting to enable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate — symmetric with the other meet_* tools.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation. All fields are optional so a bare `{}` is valid;
+    //    Zod still catches wrong-type submissions.
+    const parsed = MeetAvatarInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_enable_avatar input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId } = parsed.data;
+
+    // 3. Disambiguate target session.
+    const target = resolveTargetMeetingId(explicitId);
+    if (!target.ok) {
+      return { content: target.content, isError: true };
+    }
+    const targetMeetingId = target.meetingId;
+
+    // 4. Delegate.
+    try {
+      const body = await MeetSessionManager.enableAvatar(targetMeetingId);
+      return {
+        content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
+        isError: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId },
+        "meet_enable_avatar tool failed",
+      );
+      if (err instanceof MeetSessionNotFoundError) {
+        return {
+          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetSessionUnreachableError) {
+        return {
+          content: `Error: meet bot unreachable — ${message}`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetBotAvatarError) {
+        return {
+          content: `Error: meet bot rejected avatar enable (status ${err.status}) — ${message}`,
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: failed to enable Meet avatar — ${message}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+class MeetDisableAvatarTool implements Tool {
+  name = "meet_disable_avatar";
+  description =
+    "Turn off the assistant's video avatar in an active Google Meet call. See the Video avatar section of the meet-join SKILL.md for when to use this (notably: disable during long stretches of silence so participants don't read the avatar as watching). When exactly one Meet session is active, meetingId may be omitted and the active session is targeted automatically; otherwise pass the specific meetingId returned by meet_join.";
+  category = "meet";
+  // Low: turning the assistant's own camera off is strictly less invasive
+  // than turning it on, and idempotent on the bot side.
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          meetingId: {
+            type: "string",
+            description:
+              "The id of the meeting to disable the avatar in, as returned by meet_join. Optional when exactly one session is active.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    // 1. Feature-flag gate.
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return {
+        content:
+          "Error: the meet feature is disabled. Enable the `meet` feature flag to manage Google Meet calls.",
+        isError: true,
+      };
+    }
+
+    // 2. Input validation.
+    const parsed = MeetAvatarInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const message =
+        parsed.error.issues[0]?.message ?? "invalid meet_disable_avatar input";
+      return { content: `Error: ${message}`, isError: true };
+    }
+    const { meetingId: explicitId } = parsed.data;
+
+    // 3. Disambiguate target session.
+    const target = resolveTargetMeetingId(explicitId);
+    if (!target.ok) {
+      return { content: target.content, isError: true };
+    }
+    const targetMeetingId = target.meetingId;
+
+    // 4. Delegate. `disableAvatar` is idempotent on the bot side.
+    try {
+      const body = await MeetSessionManager.disableAvatar(targetMeetingId);
+      return {
+        content: JSON.stringify({ meetingId: targetMeetingId, ...body }),
+        isError: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, meetingId: targetMeetingId },
+        "meet_disable_avatar tool failed",
+      );
+      if (err instanceof MeetSessionNotFoundError) {
+        return {
+          content: `Error: no active Meet session for meetingId=${targetMeetingId}.`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetSessionUnreachableError) {
+        return {
+          content: `Error: meet bot unreachable — ${message}`,
+          isError: true,
+        };
+      }
+      if (err instanceof MeetBotAvatarError) {
+        return {
+          content: `Error: meet bot rejected avatar disable (status ${err.status}) — ${message}`,
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: failed to disable Meet avatar — ${message}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+/** Exported singletons so the tool registry can re-register after test resets. */
+export const meetEnableAvatarTool = new MeetEnableAvatarTool();
+export const meetDisableAvatarTool = new MeetDisableAvatarTool();


### PR DESCRIPTION
## Summary
- `MeetSessionManager` gains `enableAvatar(meetingId)` / `disableAvatar(meetingId)` which POST to the bot's `/avatar/enable` / `/avatar/disable` endpoints (landed in PR 6).
- New `meet-avatar-tool.ts` registers `meet_enable_avatar` and `meet_disable_avatar` tools, gated on the `meet` feature flag, and mirrors the existing meet-*-tool.ts patterns for optional meetingId resolution.
- Registered in `assistant/src/tools/index.ts` alongside the other Meet tools.

Part of plan: meet-phase-4-avatar.md (PR 11 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
