### PR TITLE
feat(openrouter): support provider.only routing preference

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -186,6 +186,7 @@ describe("AssistantConfigSchema", () => {
           nonInteractiveLatestTurnCompression: "truncate",
         },
       },
+      openrouter: { only: [] },
     });
     expect(result.llm.profiles).toEqual({});
     expect(result.llm.callSites).toEqual({});

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -27,6 +27,7 @@ const fullDefault = {
       nonInteractiveLatestTurnCompression: "truncate" as const,
     },
   },
+  openrouter: { only: [] as string[] },
 };
 
 describe("resolveCallSiteConfig", () => {

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -90,6 +90,7 @@ describe("LLMSchema", () => {
           nonInteractiveLatestTurnCompression: "truncate",
         },
       },
+      openrouter: { only: [] },
     });
     expect(parsed.profiles).toEqual({});
     expect(parsed.callSites).toEqual({});
@@ -173,6 +174,31 @@ describe("LLMSchema", () => {
         enabled: false,
       });
     }
+  });
+
+  test("openrouter.only accepts a list of provider names in default/profile/callSite", () => {
+    const parsed = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        openrouter: { only: ["Anthropic", "Google"] },
+      },
+      profiles: {
+        pinned: { openrouter: { only: ["Anthropic"] } },
+      },
+      callSites: {
+        mainAgent: { openrouter: { only: ["Google"] } },
+      },
+    });
+    expect(parsed.default.openrouter.only).toEqual(["Anthropic", "Google"]);
+    expect(parsed.profiles["pinned"]?.openrouter?.only).toEqual(["Anthropic"]);
+    expect(parsed.callSites.mainAgent?.openrouter?.only).toEqual(["Google"]);
+  });
+
+  test("openrouter.only rejects empty string entries", () => {
+    const result = LLMSchema.safeParse({
+      default: { ...fullDefault, openrouter: { only: [""] } },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("contextWindow deep-partial override accepted (nested overflowRecovery only)", () => {

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractOnlyList,
+  OpenRouterProvider,
+  withOpenRouterBodyExtras,
+} from "../providers/openrouter/client.js";
+import type { SendMessageOptions } from "../providers/types.js";
+
+/** Expose the protected `buildExtraCreateParams` hook for assertion. */
+class ProbeOpenRouterProvider extends OpenRouterProvider {
+  public probeExtras(
+    options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    return this.buildExtraCreateParams(options);
+  }
+}
+
+describe("OpenRouter provider.only plumbing", () => {
+  describe("extractOnlyList", () => {
+    test("returns the list when present and well-formed", () => {
+      expect(
+        extractOnlyList({ openrouter: { only: ["Anthropic", "Google"] } }),
+      ).toEqual(["Anthropic", "Google"]);
+    });
+
+    test("filters empty strings and non-strings", () => {
+      expect(
+        extractOnlyList({
+          openrouter: { only: ["Anthropic", "", 42, null, "Google"] },
+        }),
+      ).toEqual(["Anthropic", "Google"]);
+    });
+
+    test("returns [] when openrouter/only is absent or malformed", () => {
+      expect(extractOnlyList(undefined)).toEqual([]);
+      expect(extractOnlyList({})).toEqual([]);
+      expect(extractOnlyList({ openrouter: {} })).toEqual([]);
+      expect(extractOnlyList({ openrouter: { only: "Anthropic" } })).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("withOpenRouterBodyExtras", () => {
+    test("moves openrouter.only into top-level provider on config", () => {
+      const result = withOpenRouterBodyExtras({
+        config: {
+          model: "anthropic/claude-opus-4.7",
+          openrouter: { only: ["Anthropic"] },
+        },
+      });
+      expect(result?.config).toEqual({
+        model: "anthropic/claude-opus-4.7",
+        provider: { only: ["Anthropic"] },
+      });
+      expect((result?.config as Record<string, unknown>).openrouter).toBe(
+        undefined,
+      );
+    });
+
+    test("returns options unchanged when only list is empty", () => {
+      const options = {
+        config: { model: "anthropic/claude-opus-4.7", openrouter: { only: [] } },
+      };
+      expect(withOpenRouterBodyExtras(options)).toBe(options);
+    });
+
+    test("returns options unchanged when config is absent", () => {
+      expect(withOpenRouterBodyExtras(undefined)).toBe(undefined);
+      const options = {};
+      expect(withOpenRouterBodyExtras(options)).toBe(options);
+    });
+
+    test("preserves unrelated config fields", () => {
+      const result = withOpenRouterBodyExtras({
+        config: {
+          model: "anthropic/claude-opus-4.7",
+          max_tokens: 1024,
+          effort: "high",
+          openrouter: { only: ["Anthropic"] },
+        },
+      });
+      expect(result?.config).toEqual({
+        model: "anthropic/claude-opus-4.7",
+        max_tokens: 1024,
+        effort: "high",
+        provider: { only: ["Anthropic"] },
+      });
+    });
+  });
+
+  describe("buildExtraCreateParams (OpenAI-compat path)", () => {
+    test("emits provider.only in extras when config has openrouter.only", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({
+        config: { openrouter: { only: ["xAI"] } },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: false },
+        provider: { only: ["xAI"] },
+      });
+    });
+
+    test("omits provider when openrouter.only is absent", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({ config: {} });
+      expect(extras).toEqual({ reasoning: { enabled: false } });
+      expect(extras.provider).toBe(undefined);
+    });
+
+    test("still carries reasoning flag alongside provider.only", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { type: "adaptive" },
+          openrouter: { only: ["xAI"] },
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true },
+        provider: { only: ["xAI"] },
+      });
+    });
+  });
+});

--- a/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
+++ b/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Verifies that `RetryProvider.normalizeSendMessageOptions` plumbs
+ * `openrouter.only` only to the `openrouter` provider and strips it for every
+ * other provider — so strict-schema clients (Anthropic, OpenAI, …) never see
+ * the unknown field on the wire.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
+});
+
+function makePipeline(providerName: string): {
+  provider: Provider;
+  lastConfig: () => Record<string, unknown> | undefined;
+} {
+  let captured: Record<string, unknown> | undefined;
+  const inner: Provider = {
+    name: providerName,
+    async sendMessage(
+      _messages: Message[],
+      _tools?: ToolDefinition[],
+      _systemPrompt?: string,
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      captured = options?.config as Record<string, unknown> | undefined;
+      return {
+        content: [],
+        model: "test",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "stop",
+      };
+    },
+  };
+  return {
+    provider: new RetryProvider(inner),
+    lastConfig: () => captured,
+  };
+}
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+describe("retry normalization for openrouter.only", () => {
+  test("forwards openrouter.only on the outbound config for openrouter", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.7",
+        openrouter: { only: ["Anthropic"] },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.openrouter).toEqual({ only: ["Anthropic"] });
+  });
+
+  test("omits openrouter from config when resolved list is empty", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.7",
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.openrouter).toBe(undefined);
+  });
+
+  test("strips openrouter from config for non-openrouter providers", async () => {
+    const { provider, lastConfig } = makePipeline("anthropic");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { openrouter: { only: ["Anthropic"] } },
+    });
+    const out = lastConfig();
+    expect(out?.openrouter).toBe(undefined);
+  });
+
+  test("strips openrouter from config for openai provider", async () => {
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { openrouter: { only: ["Anthropic"] } },
+    });
+    expect(lastConfig()?.openrouter).toBe(undefined);
+  });
+
+  test("call-site override replaces default openrouter.only", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.7",
+        openrouter: { only: ["Anthropic"] },
+      },
+      callSites: {
+        mainAgent: { openrouter: { only: ["Google"] } },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.openrouter).toEqual({ only: ["Google"] });
+  });
+});

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -198,6 +198,28 @@ const ContextWindowDeepPartialSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// OpenRouter provider-routing preferences
+//
+// OpenRouter's `/v1/chat/completions` and `/v1/messages` endpoints both accept
+// a `provider: { only: [...] }` body field that restricts which upstream
+// providers (Anthropic, Google, etc.) may fulfill a request. Exposed here so
+// users can pin routing via config without touching the wire-format knobs
+// directly. Nested shape keeps room for sibling OpenRouter knobs (`order`,
+// `allow_fallbacks`, …) to be added later without another schema reshape.
+// ---------------------------------------------------------------------------
+
+const OpenRouterOnlyItemSchema = z.string().min(1);
+
+export const OpenRouterSchema = z.object({
+  only: z.array(OpenRouterOnlyItemSchema).default([]),
+});
+export type OpenRouter = z.infer<typeof OpenRouterSchema>;
+
+const OpenRouterDeepPartialSchema = z.object({
+  only: z.array(OpenRouterOnlyItemSchema).optional(),
+});
+
+// ---------------------------------------------------------------------------
 // Pricing overrides
 // ---------------------------------------------------------------------------
 
@@ -228,6 +250,7 @@ export const LLMConfigBase = z.object({
   temperature: TemperatureSchema.default(null),
   thinking: ThinkingSchema.default(ThinkingSchema.parse({})),
   contextWindow: ContextWindowSchema.default(ContextWindowSchema.parse({})),
+  openrouter: OpenRouterSchema.default(OpenRouterSchema.parse({})),
 });
 export type LLMConfigBase = z.infer<typeof LLMConfigBase>;
 
@@ -246,6 +269,7 @@ export const LLMConfigFragment = z.object({
   temperature: TemperatureSchema.optional(),
   thinking: ThinkingFragmentSchema.optional(),
   contextWindow: ContextWindowDeepPartialSchema.optional(),
+  openrouter: OpenRouterDeepPartialSchema.optional(),
 });
 export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
 

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -32,6 +32,43 @@ function toAnthropicMessagesBaseURL(openRouterBaseURL: string): string {
   return openRouterBaseURL.replace(/\/v1\/?$/, "");
 }
 
+/**
+ * Extract the normalized `openrouter.only` list from a per-call config. Returns
+ * an empty array when the field is absent, empty, or contains no usable string
+ * entries, so callers can branch on `length > 0` to decide whether to emit the
+ * wire-format `provider: { only: [...] }` field. Exported for tests.
+ */
+export function extractOnlyList(config: unknown): string[] {
+  const cfg = config as { openrouter?: { only?: unknown } } | undefined;
+  const only = cfg?.openrouter?.only;
+  if (!Array.isArray(only)) return [];
+  return only.filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
+}
+
+/**
+ * Rewrite `options.config` for the Anthropic-compat path so OpenRouter's
+ * `provider: { only: [...] }` body field travels through `AnthropicProvider`'s
+ * `...restConfig` spread into `Anthropic.MessageStreamParams`. The `openrouter`
+ * key itself is removed because Anthropic's JSON parser doesn't know about it
+ * — only the translated `provider` field should reach the wire. Safe to inject
+ * here because `getAnthropicInner()` hardcodes OpenRouter's baseURL; the inner
+ * `AnthropicProvider` never talks to Anthropic directly. Exported for tests.
+ */
+export function withOpenRouterBodyExtras(
+  options?: SendMessageOptions,
+): SendMessageOptions | undefined {
+  if (!options?.config) return options;
+  const only = extractOnlyList(options.config);
+  if (only.length === 0) return options;
+  const { openrouter: _openrouter, ...rest } = options.config as Record<
+    string,
+    unknown
+  >;
+  return { ...options, config: { ...rest, provider: { only } } };
+}
+
 export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   private readonly openRouterApiKey: string;
   private readonly defaultModel: string;
@@ -80,7 +117,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
         messages,
         tools,
         systemPrompt,
-        options,
+        withOpenRouterBodyExtras(options),
       );
     }
     return super.sendMessage(messages, tools, systemPrompt, options);
@@ -96,7 +133,14 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   ): Record<string, unknown> {
     const config = options?.config as Record<string, unknown> | undefined;
     const thinkingEnabled = config?.thinking !== undefined;
-    return { reasoning: { enabled: thinkingEnabled } };
+    const extras: Record<string, unknown> = {
+      reasoning: { enabled: thinkingEnabled },
+    };
+    const only = extractOnlyList(config);
+    if (only.length > 0) {
+      extras.provider = { only };
+    }
+    return extras;
   }
 
   private resolveEffectiveModel(options?: SendMessageOptions): string {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -149,6 +149,17 @@ function normalizeSendMessageOptions(
         nextConfig.thinking = { type: "adaptive" };
       }
     }
+    // Forward OpenRouter-only routing preferences so `OpenRouterProvider` can
+    // translate `openrouter.only` into the wire-format `provider: { only: [...] }`
+    // body field on both the OpenAI-compat and Anthropic-compat endpoints.
+    if (
+      providerName === "openrouter" &&
+      nextConfig.openrouter === undefined &&
+      Array.isArray(resolved.openrouter?.only) &&
+      resolved.openrouter.only.length > 0
+    ) {
+      nextConfig.openrouter = { only: resolved.openrouter.only };
+    }
     // `contextWindow` and `provider` are server-side concerns, not provider
     // request parameters: `contextWindow` is consumed by the agent loop's
     // overflow recovery and the conversation manager directly from
@@ -179,6 +190,12 @@ function normalizeSendMessageOptions(
   // speed (fast mode) is Anthropic-specific; strip for other providers
   if (providerName !== "anthropic" && nextConfig.speed !== undefined) {
     delete nextConfig.speed;
+  }
+
+  // `openrouter.only` is OpenRouter-specific routing; strip for other
+  // providers so strict-schema clients don't see an unknown field.
+  if (providerName !== "openrouter" && nextConfig.openrouter !== undefined) {
+    delete nextConfig.openrouter;
   }
 
   return {


### PR DESCRIPTION
## Summary
- New nested \`llm.openrouter.only: string[]\` config knob (schema-level default \`[]\`) lets callers pin OpenRouter upstream routing, e.g. \`{ only: [\"Anthropic\"] }\`.
- Wired through both OpenRouter paths: the OpenAI-compat endpoint gets \`provider: { only: [...] }\` via \`buildExtraCreateParams\`; the Anthropic-compat endpoint gets it injected into \`SendMessageOptions.config\` so the inner \`AnthropicProvider\`'s \`...restConfig\` spread carries it into \`Anthropic.MessageStreamParams\`.
- Retry normalizer forwards the field only when \`providerName === \"openrouter\"\` and strips it for every other provider, so Anthropic/OpenAI never see an unknown body field.

## Original prompt
Add support for the only parameter when using Anthropic models on OpenRouter: https://openrouter.ai/docs/api/api-reference/anthropic-messages/create-messages#request.body.provider.only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
