### PR TITLE
fix(providers): retry transport-level Anthropic stream aborts

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -52,6 +52,7 @@ mock.module("../util/retry.js", () => {
   const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
     /socket.*closed unexpectedly/i,
     /socket hang up/i,
+    /request was aborted/i,
   ];
 
   function isRetryableNetworkError(error: unknown): boolean {
@@ -444,6 +445,57 @@ describe("RetryProvider — network error retries", () => {
 
     await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
       "model not found",
+    );
+    expect(inner.calls).toBe(1);
+  });
+
+  test("retries on 'Request was aborted' (transport-level abort, no abortReason)", async () => {
+    // Exactly the wire-format the Anthropic SDK emits when its underlying
+    // fetch AbortSignal fires without a daemon-tagged reason (bun fetch
+    // deadline, edge LB, NAT idle).
+    const inner = makeFlaky(
+      1,
+      new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(inner.calls).toBe(2);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("does NOT retry 'Request was aborted' when abortReason is set (caller/daemon cancel)", async () => {
+    const inner = makeFailing(
+      new ProviderError(
+        "Anthropic API error (undefined): Request was aborted.",
+        "anthropic",
+        undefined,
+        { abortReason: { kind: "user_cancel", source: "test" } },
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
+      "Request was aborted",
+    );
+    // Only the initial call — no retries.
+    expect(inner.calls).toBe(1);
+  });
+
+  test("does NOT retry 'Anthropic stream timed out' (inner streamTimeoutMs fired)", async () => {
+    const inner = makeFailing(
+      new ProviderError(
+        "Anthropic API error (undefined): Anthropic stream timed out after 1800s (inner streamTimeoutMs)",
+        "anthropic",
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
+      "stream timed out",
     );
     expect(inner.calls).toBe(1);
   });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -651,6 +651,11 @@ export class AnthropicProvider implements Provider {
         | "5m"
         | "1h") ?? "1h";
     let sentMessages: Anthropic.MessageParam[] | undefined;
+    const startedAt = Date.now();
+    // Hoisted so the catch block can distinguish our inner stream timeout
+    // (30 min default) from an external transport abort (bun fetch deadline,
+    // edge LB, NAT idle) — only the latter should be retried.
+    let innerTimeoutSignal: AbortSignal | undefined;
     try {
       const formatted = messages
         .map((m) => {
@@ -971,6 +976,7 @@ export class AnthropicProvider implements Provider {
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);
+      innerTimeoutSignal = timeoutSignal;
 
       /** Minimal stream interface shared by MessageStream and BetaMessageStream. */
       interface UnifiedStream {
@@ -1200,10 +1206,18 @@ export class AnthropicProvider implements Provider {
     } catch (error) {
       // Propagate a tagged AbortReason (set by the daemon at controller.abort())
       // so wrapped errors can be classified as user cancellation downstream.
+      const callerAborted = signal?.aborted === true;
       const abortReason =
-        signal?.aborted && isAbortReason(signal.reason)
-          ? signal.reason
+        callerAborted && isAbortReason(signal!.reason)
+          ? signal!.reason
           : undefined;
+      const elapsedMs = Date.now() - startedAt;
+      // Inner-timeout means OUR 30-min stream deadline fired, not the caller
+      // and not an external transport cutoff. We rewrite the message so the
+      // retry layer can distinguish it from a transport abort (which should
+      // retry) — a timed-out stream would almost certainly time out again.
+      const innerTimeoutFired =
+        innerTimeoutSignal?.aborted === true && !callerAborted;
       if (error instanceof Anthropic.APIError) {
         // Log detailed message structure for tool_use/tool_result ordering errors
         if (
@@ -1219,15 +1233,32 @@ export class AnthropicProvider implements Provider {
             "Anthropic 400: tool_use/tool_result pairing error — dumping message structure",
           );
         }
+        const isAbortMessage =
+          error.status === undefined &&
+          /request was aborted/i.test(error.message);
         if (abortReason) {
           log.info(
-            { abortReason, message: error.message },
+            { abortReason, elapsedMs, message: error.message },
             "Anthropic request aborted by daemon",
+          );
+        } else if (isAbortMessage) {
+          log.error(
+            {
+              elapsedMs,
+              cause: error.cause,
+              callerSignalAborted: callerAborted,
+              innerTimeoutFired,
+              message: error.message,
+            },
+            innerTimeoutFired
+              ? "Anthropic stream timed out (inner streamTimeoutMs fired)"
+              : "Anthropic stream aborted by transport — no daemon or inner-timeout abort; likely bun fetch deadline, edge LB, or network idle cutoff",
           );
         } else {
           log.error(
             {
               status: error.status,
+              elapsedMs,
               message: error.message,
               headers: Object.fromEntries(error.headers?.entries() ?? []),
             },
@@ -1238,11 +1269,23 @@ export class AnthropicProvider implements Provider {
         const errorOptions: {
           retryAfterMs?: number;
           abortReason?: unknown;
+          cause?: unknown;
         } = {};
         if (retryAfterMs !== undefined) errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
+        // Only preserve the original error as `cause` for transport aborts
+        // without a daemon-tagged reason — it's the diagnostic signal the
+        // retry layer and log reader rely on. Don't leak it through the
+        // caller-aborted path, which already carries `abortReason`.
+        if (!abortReason && isAbortMessage) errorOptions.cause = error;
+        // Rewrite the message only for inner-timeout, so the retry layer
+        // won't retry a request that already hit its 30-min deadline.
+        const rewrittenMessage =
+          isAbortMessage && innerTimeoutFired
+            ? `Anthropic stream timed out after ${Math.round(elapsedMs / 1000)}s (inner streamTimeoutMs)`
+            : error.message;
         throw new ProviderError(
-          `Anthropic API error (${error.status}): ${error.message}`,
+          `Anthropic API error (${error.status}): ${rewrittenMessage}`,
           "anthropic",
           error.status,
           Object.keys(errorOptions).length > 0 ? errorOptions : undefined,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -62,6 +62,14 @@ function isRetryableProviderMessage(error: unknown): boolean {
 }
 
 function isRetryableError(error: unknown): boolean {
+  // Daemon/user-initiated aborts are never retryable. The catch-site tags
+  // these with `abortReason` exactly when `signal.aborted` was true at the
+  // time of failure, so this short-circuits before any message-based pattern
+  // matches — which matters because transport-level aborts (retryable) and
+  // caller-cancels both surface as "Request was aborted" from the SDK.
+  if (error instanceof ProviderError && error.abortReason !== undefined) {
+    return false;
+  }
   if (error instanceof ProviderError && error.statusCode !== undefined) {
     if (error.statusCode === 429 || error.statusCode >= 500) return true;
   }

--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -77,10 +77,19 @@ export function isRetryableStatus(status: number): boolean {
 /**
  * Message patterns that indicate a retryable network/transport error even
  * when no errno code is present (e.g. Bun's native fetch socket errors).
+ *
+ * `/request was aborted/i` catches Anthropic SDK's `APIUserAbortError`,
+ * which the SDK throws whenever the underlying fetch's AbortSignal fires.
+ * When the daemon initiated the abort, the ProviderError carries an
+ * `abortReason` tag and the provider-retry layer short-circuits before
+ * reaching this pattern; when the abort came from a transport-level cutoff
+ * (bun fetch's internal deadline, an edge LB, a NAT idle timeout) the tag
+ * is absent and we retry.
  */
 const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
   /socket.*closed unexpectedly/i,
   /socket hang up/i,
+  /request was aborted/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Daemon was failing Anthropic streaming turns at exactly 5 min with `Request was aborted.` — no daemon abort, no inner-timeout (30 min default) — most likely bun fetch's runtime deadline on quiet streams.
- Retry these in the existing `RetryProvider`: add the SDK's abort-message pattern to retryable transport errors, guard against retrying daemon/user-initiated aborts (they carry an `abortReason` tag), and rewrite the message when our inner 30-min `streamTimeoutMs` fires so those don't get retried into another 30-min wait.
- Log `elapsedMs`, `cause`, `callerSignalAborted`, `innerTimeoutFired` on the `anthropic-client` error path so future occurrences are easier to diagnose.

## Original prompt
it