### PR TITLE
fix(anthropic): honor 30-min timeout via SDK, drop transport-abort retry

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -52,7 +52,6 @@ mock.module("../util/retry.js", () => {
   const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
     /socket.*closed unexpectedly/i,
     /socket hang up/i,
-    /request was aborted/i,
   ];
 
   function isRetryableNetworkError(error: unknown): boolean {
@@ -449,28 +448,13 @@ describe("RetryProvider — network error retries", () => {
     expect(inner.calls).toBe(1);
   });
 
-  test("retries on 'Request was aborted' (transport-level abort, no abortReason)", async () => {
-    // Exactly the wire-format the Anthropic SDK emits when its underlying
-    // fetch AbortSignal fires without a daemon-tagged reason (bun fetch
-    // deadline, edge LB, NAT idle).
-    const inner = makeFlaky(
-      1,
-      new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
-        "anthropic",
-      ),
-    );
-    const provider = new RetryProvider(inner);
-
-    const result = await provider.sendMessage(MESSAGES);
-    expect(inner.calls).toBe(2);
-    expect(result.stopReason).toBe("end_turn");
-  });
-
-  test("does NOT retry 'Request was aborted' when abortReason is set (caller/daemon cancel)", async () => {
+  test("does NOT retry a ProviderError tagged with abortReason", async () => {
+    // Defensive: if any future retryable pattern matches an error carrying
+    // a daemon/user-initiated abortReason, the abortReason guard in
+    // providers/retry.ts:isRetryableError must still short-circuit it.
     const inner = makeFailing(
       new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
+        "Anthropic request failed: socket closed unexpectedly",
         "anthropic",
         undefined,
         { abortReason: { kind: "user_cancel", source: "test" } },
@@ -479,9 +463,8 @@ describe("RetryProvider — network error retries", () => {
     const provider = new RetryProvider(inner);
 
     await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
-      "Request was aborted",
+      "socket closed",
     );
-    // Only the initial call — no retries.
     expect(inner.calls).toBe(1);
   });
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -627,16 +627,27 @@ export class AnthropicProvider implements Provider {
       authToken?: string;
     } = {},
   ) {
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
+    // Pass the same deadline to the SDK so its per-request timeout can't
+    // fire before `createStreamTimeout` does. The SDK's default is 10 min,
+    // which truncates any request we intend to run longer than that. We add
+    // a 60s buffer so `createStreamTimeout` always wins — its abort reason
+    // produces a clearer error message than the SDK's generic timeout.
+    const sdkTimeoutMs = this.streamTimeoutMs + 60_000;
     this.client = options.authToken
       ? new Anthropic({
           apiKey: null,
           authToken: options.authToken,
           baseURL: options.baseURL,
+          timeout: sdkTimeoutMs,
         })
-      : new Anthropic({ apiKey, baseURL: options.baseURL });
+      : new Anthropic({
+          apiKey,
+          baseURL: options.baseURL,
+          timeout: sdkTimeoutMs,
+        });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
   }
 
   async sendMessage(

--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -77,19 +77,10 @@ export function isRetryableStatus(status: number): boolean {
 /**
  * Message patterns that indicate a retryable network/transport error even
  * when no errno code is present (e.g. Bun's native fetch socket errors).
- *
- * `/request was aborted/i` catches Anthropic SDK's `APIUserAbortError`,
- * which the SDK throws whenever the underlying fetch's AbortSignal fires.
- * When the daemon initiated the abort, the ProviderError carries an
- * `abortReason` tag and the provider-retry layer short-circuits before
- * reaching this pattern; when the abort came from a transport-level cutoff
- * (bun fetch's internal deadline, an edge LB, a NAT idle timeout) the tag
- * is absent and we retry.
  */
 const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
   /socket.*closed unexpectedly/i,
   /socket hang up/i,
-  /request was aborted/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #26675. User feedback: the 5-min cutoff + retry meant a 10-min wait before an error surfaced; the desired behavior is for the request to actually run for up to 30 min (our `streamTimeoutMs` default).
- Pass the SDK an explicit `timeout` equal to `streamTimeoutMs + 60s` in both Anthropic client constructions (auth-token and default). Previously we relied on the SDK default (10 min), which truncated any long request.
- Drop the transport-abort retry path: remove `/request was aborted/i` from `RETRYABLE_NETWORK_MESSAGE_PATTERNS` and the corresponding retry test; keep the `abortReason` guard (defensive) and the inner-timeout non-retry test. Keep the enriched error logging and inner-timeout message rewrite from #26675 — both are independently useful.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
