### PR TITLE
chore(clients): add SwiftMath dependency for LaTeX rendering

### DIFF
--- a/clients/Package.resolved
+++ b/clients/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf792bd452094443684e39ed76c3397f5a7d6610ddb6afc933e7ef731178a7e7",
+  "originHash" : "19634286c8d7ba1f2082a67539d25b895b3951132537c46c5cf3d273ca249872",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -251,6 +251,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swiftmath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mgriebling/SwiftMath.git",
+      "state" : {
+        "revision" : "606f9be66db6afe0c41c3b064723a57061723db7",
+        "version" : "1.7.1"
       }
     },
     {

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.8.1"),
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", exact: "1.11.2"),
+        .package(url: "https://github.com/mgriebling/SwiftMath.git", exact: "1.7.1"),
     ],
     targets: [
         .target(
@@ -75,6 +76,7 @@ let package = Package(
                 "Sparkle",
                 .product(name: "Sentry", package: "sentry-cocoa"),
                 .product(name: "SwiftTerm", package: "SwiftTerm"),
+                .product(name: "SwiftMath", package: "SwiftMath"),
             ],
             path: "macos/vellum-assistant",
             exclude: ["Resources/Info.plist", "Resources/VellumDocument.icns"],


### PR DESCRIPTION
## Summary
- Add SwiftMath (MIT, pure-Swift Core Text LaTeX renderer) to clients/Package.swift, pinned to exact version 1.7.1.
- Link SwiftMath into the VellumAssistantLib target.
- No Swift source imports it yet — this PR only adds the package graph edge.

## License check
SwiftMath is MIT-licensed (verified at https://github.com/mgriebling/SwiftMath/blob/main/LICENSE — 'MIT License, Copyright (c) 2023 Computer Inspirations'), compatible with our MIT license per CLAUDE.md § Dependencies.

## Validation
- `swift package resolve` succeeded — SwiftMath 1.7.1 recorded in Package.resolved.
- `swift build -c debug` succeeded.

Part of plan: latex-chat-rendering.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
