### PR TITLE
feat(macos-chat): parse $$...$$ into .math segment with plain-text fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -20,6 +20,10 @@ enum MarkdownSegment: Hashable {
     case codeBlock(language: String?, code: String)
     case horizontalRule
     case list(items: [MarkdownListItem])
+    /// Block-level LaTeX math (delimited by `$$...$$`). `display: true` means
+    /// block/display math; the field is plumbed through now so a future
+    /// inline-math (`$...$`) pass can reuse the same case with `display: false`.
+    case math(latex: String, display: Bool)
 }
 
 /// Returns true if `line` is a markdown heading (1-6 `#` chars followed by a space).
@@ -119,6 +123,61 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
             codeBlockLanguage = lang.isEmpty ? nil : lang
             i += 1
             continue
+        }
+
+        // --- Block math detection (`$$...$$`) ---
+        //
+        // Handled BEFORE tables/headings/etc. but AFTER fenced-code handling so
+        // `$$` inside a fenced code block stays verbatim. Two forms:
+        //   1. Single-line: `$$<expr>$$` on one trimmed line (length > 4 and
+        //      at least one non-`$` between the delimiters — guards against
+        //      the degenerate `$$$$` input).
+        //   2. Multi-line: a line that is exactly `$$` opens a block; the
+        //      next line that is exactly `$$` closes it. Contents between
+        //      are taken verbatim. If EOF is reached without a closing `$$`,
+        //      we revert the collected lines back to plain text.
+        if trimmed.hasPrefix("$$") && trimmed.hasSuffix("$$")
+            && trimmed.count > 4
+            && trimmed.dropFirst(2).dropLast(2).contains(where: { $0 != "$" }) {
+            flushText()
+            let inner = String(trimmed.dropFirst(2).dropLast(2))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            segments.append(.math(latex: inner, display: true))
+            i += 1
+            continue
+        }
+        if trimmed == "$$" {
+            // Multi-line block — scan forward for the closing `$$`.
+            flushText()
+            var mathLines: [String] = []
+            var j = i + 1
+            var closed = false
+            while j < lines.count {
+                if lines[j].trimmingCharacters(in: .whitespaces) == "$$" {
+                    closed = true
+                    break
+                }
+                mathLines.append(lines[j])
+                j += 1
+            }
+            if closed {
+                let latex = mathLines.joined(separator: "\n")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                segments.append(.math(latex: latex, display: true))
+                i = j + 1
+                continue
+            } else {
+                // Unclosed — fall back to plain text. Restore the opening `$$`
+                // and any collected lines to `currentText` so they render
+                // verbatim (mirrors the unclosed-fence behavior of emitting
+                // what we have instead of dropping content).
+                currentText.append(lines[i])
+                for line in mathLines {
+                    currentText.append(line)
+                }
+                i = j
+                continue
+            }
         }
 
         // --- Table detection ---

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -121,6 +121,18 @@ struct MarkdownSegmentView: View, Equatable {
                         .frame(height: 1)
                         .optionalMaxWidth(maxContentWidth)
                         .padding(.vertical, VSpacing.xs)
+
+                case .math(let latex, _):
+                    // Fallback until SwiftMath integration lands in a follow-up PR.
+                    // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
+                    HStack(spacing: 0) {
+                        Text(latex)
+                            .font(.custom("DMMono-Regular", size: 13))
+                            .foregroundStyle(textColor)
+                            .textSelection(.enabled)
+                            .lineLimit(nil)
+                        Spacer(minLength: 0)
+                    }
                 }
             }
         }
@@ -131,7 +143,7 @@ struct MarkdownSegmentView: View, Equatable {
             switch groups[index] {
             case .selectableRun, .table:
                 return index
-            case .codeBlock, .image, .horizontalRule:
+            case .codeBlock, .image, .horizontalRule, .math:
                 continue
             }
         }
@@ -149,6 +161,7 @@ struct MarkdownSegmentView: View, Equatable {
         case table(headers: [String], rows: [[String]])
         case image(alt: String, url: String)
         case horizontalRule
+        case math(latex: String, display: Bool)
     }
 
     #if os(macOS)
@@ -244,6 +257,9 @@ struct MarkdownSegmentView: View, Equatable {
             case .horizontalRule:
                 flushRun()
                 groups.append(.horizontalRule)
+            case .math(let latex, let display):
+                flushRun()
+                groups.append(.math(latex: latex, display: display))
             }
         }
 
@@ -326,6 +342,7 @@ struct MarkdownSegmentView: View, Equatable {
             case .codeBlock(_, let c): return total + c.count
             case .list(let items): return total + items.reduce(0) { $0 + $1.text.count }
             case .table(let h, let r): return total + h.joined().count + r.flatMap { $0 }.joined().count
+            case .math(let latex, _): return total + latex.count
             case .image, .horizontalRule: return total
             }
         }

--- a/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
@@ -250,6 +250,12 @@ private func groupSegments(_ segments: [MarkdownSegment]) -> [SegmentGroup] {
         case .horizontalRule:
             flushRun()
             groups.append(.horizontalRule)
+        case .math:
+            // Math is rendered standalone (same as codeBlock/table/image) —
+            // not merged into a selectableRun. The perf test harness doesn't
+            // render math, so we just break the run and drop the segment on
+            // the floor (it's not represented in the local SegmentGroup enum).
+            flushRun()
         }
     }
     flushRun()

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -423,6 +423,83 @@ final class MarkdownSegmentViewTests: XCTestCase {
         )
     }
 
+    // MARK: - Block Math (`$$…$$`) Parsing
+
+    func testBlockMath_singleLine() {
+        let segments = parseMarkdownSegments("$$x^2$$")
+        XCTAssertEqual(segments, [.math(latex: "x^2", display: true)])
+    }
+
+    func testBlockMath_multiLine() {
+        let segments = parseMarkdownSegments("$$\n\\frac{a}{b}\n$$")
+        XCTAssertEqual(segments, [.math(latex: "\\frac{a}{b}", display: true)])
+    }
+
+    /// Regression test for the original report that motivated this feature —
+    /// LaTeX pasted into a single-line `$$…$$` wrapper must emit exactly one
+    /// `.math` segment whose payload is the raw inner expression.
+    func testBlockMath_screenshotRegression() {
+        let input = "$$m_\\text{ferrite} \\propto (\\text{ferrite thickness}) "
+            + "\\propto \\frac{F_\\text{required}}{F_\\text{available per m}} "
+            + "\\propto \\frac{1}{\\text{margin}}$$"
+        let expectedInner = "m_\\text{ferrite} \\propto (\\text{ferrite thickness}) "
+            + "\\propto \\frac{F_\\text{required}}{F_\\text{available per m}} "
+            + "\\propto \\frac{1}{\\text{margin}}"
+
+        let segments = parseMarkdownSegments(input)
+        XCTAssertEqual(segments.count, 1)
+        guard case .math(let latex, let display) = segments.first else {
+            return XCTFail("Expected .math segment, got \(segments)")
+        }
+        XCTAssertEqual(latex, expectedInner)
+        XCTAssertTrue(display)
+    }
+
+    func testBlockMath_insideCodeBlockIsPreserved() {
+        let segments = parseMarkdownSegments("```\n$$x^2$$\n```")
+        XCTAssertEqual(segments, [.codeBlock(language: nil, code: "$$x^2$$")])
+    }
+
+    func testBlockMath_unclosedFallsBackToText() {
+        let segments = parseMarkdownSegments("$$\nx^2")
+        XCTAssertEqual(segments.count, 1)
+        guard case .text(let content) = segments.first else {
+            return XCTFail("Expected .text segment for unclosed $$, got \(segments)")
+        }
+        // Unclosed block-math reverts to plain text — the `$$` opener and any
+        // collected lines must both survive (though outer whitespace is
+        // trimmed by flushText). No `.math` segment should be emitted.
+        XCTAssertTrue(content.contains("$$"), "Unclosed `$$` opener must appear verbatim in the text; got: \(content)")
+        XCTAssertTrue(content.contains("x^2"), "Content after the unclosed opener must survive; got: \(content)")
+        for segment in segments {
+            if case .math = segment {
+                XCTFail("Unclosed `$$` must not emit a .math segment")
+            }
+        }
+    }
+
+    func testBlockMath_emptyDelimitersAreText() {
+        let segments = parseMarkdownSegments("$$$$")
+        XCTAssertEqual(segments, [.text("$$$$")])
+    }
+
+    func testBlockMath_twoBackToBack() {
+        let segments = parseMarkdownSegments("$$a$$\n\n$$b$$")
+        XCTAssertEqual(segments, [
+            .math(latex: "a", display: true),
+            .math(latex: "b", display: true),
+        ])
+    }
+
+    func testBlockMath_mixedWithProse() {
+        let segments = parseMarkdownSegments("Here is math:\n\n$$x^2$$\n\nEnd.")
+        XCTAssertEqual(segments, [
+            .text("Here is math:"),
+            .math(latex: "x^2", display: true),
+            .text("End."),
+        ])
+    }
+
     private func makeRenderedMarkdown(_ markdown: String) -> (NSAttributedString, Bool) {
         let source = (try? makeAttributedString(from: markdown)) ?? AttributedString(markdown)
         return MarkdownSegmentView.convertToNSAttributedString(

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -212,6 +212,12 @@ private func groupSegments(_ segments: [MarkdownSegment]) -> [SegmentGroup] {
         case .horizontalRule:
             flushRun()
             groups.append(.horizontalRule)
+        case .math:
+            // Math is rendered standalone (same as codeBlock/table/image) —
+            // not merged into a selectableRun. The perf test harness doesn't
+            // render math, so we just break the run and drop the segment on
+            // the floor (it's not represented in the local SegmentGroup enum).
+            flushRun()
         }
     }
     flushRun()


### PR DESCRIPTION
## Summary
- Add `.math(latex:, display:)` case to `MarkdownSegment` and extend `parseMarkdownSegments` to detect block math `$$...$$` (single-line and multi-line forms). Code blocks still opt out so `$$` inside fences stays verbatim.
- Render `.math` as monospaced plain text for now — a deploy-safe placeholder; SwiftMath rendering lands in PR 3.
- Cover the parser with unit tests including a regression test for the exact LaTeX from the original feature request.

Part of plan: latex-chat-rendering.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
