### PR TITLE
feat(macos-chat): typeset block math via SwiftMath

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -3,6 +3,10 @@ import os
 import SwiftUI
 import VellumAssistantShared
 
+#if canImport(SwiftMath)
+import SwiftMath
+#endif
+
 private final class AttributedStringCacheEntry: NSObject {
     let attributedString: AttributedString
     init(_ attributedString: AttributedString) { self.attributedString = attributedString }
@@ -122,8 +126,17 @@ struct MarkdownSegmentView: View, Equatable {
                         .optionalMaxWidth(maxContentWidth)
                         .padding(.vertical, VSpacing.xs)
 
-                case .math(let latex, _):
-                    // Fallback until SwiftMath integration lands in a follow-up PR.
+                case .math(let latex, let display):
+                    #if canImport(SwiftMath)
+                    MathBlockView(
+                        latex: latex,
+                        display: display,
+                        textColor: textColor,
+                        codeBackgroundColor: codeBackgroundColor,
+                        maxContentWidth: maxContentWidth
+                    )
+                    #else
+                    // SwiftMath not available — raw LaTeX fallback.
                     // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
                     HStack(spacing: 0) {
                         Text(latex)
@@ -133,6 +146,7 @@ struct MarkdownSegmentView: View, Equatable {
                             .lineLimit(nil)
                         Spacer(minLength: 0)
                     }
+                    #endif
                 }
             }
         }
@@ -858,6 +872,160 @@ struct MarkdownSegmentView: View, Equatable {
     }
     #endif
 }
+
+// MARK: - Math Block View
+
+#if canImport(SwiftMath)
+
+/// Cache entry for a rendered math image. Stored in `mathImageCache`.
+private final class MathImageCacheEntry: NSObject {
+    let image: NSImage
+    let intrinsicSize: CGSize
+    init(image: NSImage, intrinsicSize: CGSize) {
+        self.image = image
+        self.intrinsicSize = intrinsicSize
+    }
+}
+
+/// File-private cache of rasterized math images keyed by
+/// `"latex|display|hexColor|fontSize"`. Sized to match `measuredTextCache`'s
+/// ~20 MB budget so a busy conversation doesn't blow past the text cache.
+private let mathImageCache: NSCache<NSString, MathImageCacheEntry> = {
+    let cache = NSCache<NSString, MathImageCacheEntry>()
+    cache.countLimit = 256
+    cache.totalCostLimit = 20_000_000
+    return cache
+}()
+
+/// Converts an `NSColor` to a stable hex cache-key component. Uses the
+/// sRGB-calibrated components so color-space shifts don't cause cache misses
+/// on logically identical colors.
+private func mathCacheColorKey(_ color: NSColor) -> String {
+    let rgb = color.usingColorSpace(.sRGB) ?? color
+    let r = Int((rgb.redComponent * 255).rounded())
+    let g = Int((rgb.greenComponent * 255).rounded())
+    let b = Int((rgb.blueComponent * 255).rounded())
+    let a = Int((rgb.alphaComponent * 255).rounded())
+    return String(format: "%02X%02X%02X%02X", r, g, b, a)
+}
+
+/// Renders a LaTeX block via `SwiftMath.MathImage`. Results are cached per
+/// (latex, display, color, fontSize) so re-renders during SwiftUI body
+/// evaluation don't retrigger the typesetter.
+private struct MathBlockView: View, Equatable {
+    let latex: String
+    let display: Bool
+    let textColor: Color
+    let codeBackgroundColor: Color
+    let maxContentWidth: CGFloat?
+
+    static func == (lhs: MathBlockView, rhs: MathBlockView) -> Bool {
+        lhs.latex == rhs.latex
+            && lhs.display == rhs.display
+            && lhs.textColor == rhs.textColor
+            && lhs.codeBackgroundColor == rhs.codeBackgroundColor
+            && lhs.maxContentWidth == rhs.maxContentWidth
+    }
+
+    private enum RenderResult {
+        case image(NSImage, CGSize)
+        case failure(String)
+    }
+
+    private func resolveRender() -> RenderResult {
+        // Font size matches the resolved chat markdown font so inline math
+        // visually aligns with surrounding body text. `.regular.pointSize`
+        // resolves against the current DM Sans font set (16pt at rest).
+        let fontSize = VFont.resolvedChatMarkdownFontSet().regular.pointSize
+        let nsTextColor = NSColor(textColor)
+        let labelMode: MTMathUILabelMode = display ? .display : .text
+        let cacheKey = "\(latex)|\(display)|\(mathCacheColorKey(nsTextColor))|\(fontSize)" as NSString
+
+        if let cached = mathImageCache.object(forKey: cacheKey) {
+            return .image(cached.image, cached.intrinsicSize)
+        }
+
+        var mathImage = MathImage(
+            latex: latex,
+            fontSize: fontSize,
+            textColor: nsTextColor,
+            labelMode: labelMode
+        )
+        let (error, image) = mathImage.asImage()
+        if let error = error {
+            return .failure(error.localizedDescription)
+        }
+        guard let image = image else {
+            return .failure("unknown error")
+        }
+        let intrinsic = image.size
+        let cost = Int(intrinsic.width * intrinsic.height * 4)
+        mathImageCache.setObject(
+            MathImageCacheEntry(image: image, intrinsicSize: intrinsic),
+            forKey: cacheKey,
+            cost: max(cost, 1)
+        )
+        return .image(image, intrinsic)
+    }
+
+    var body: some View {
+        switch resolveRender() {
+        case .image(let image, let intrinsicSize):
+            rendered(image: image, intrinsicSize: intrinsicSize)
+        case .failure(let message):
+            errorFallback(message: message)
+        }
+    }
+
+    @ViewBuilder
+    private func rendered(image: NSImage, intrinsicSize: CGSize) -> some View {
+        let limit = maxContentWidth ?? intrinsicSize.width
+        let needsScroll = intrinsicSize.width > limit && intrinsicSize.width > 0
+        let renderedWidth: CGFloat = needsScroll
+            ? intrinsicSize.width
+            : min(intrinsicSize.width, limit)
+        let renderedHeight: CGFloat = intrinsicSize.width > 0
+            ? intrinsicSize.height * (renderedWidth / intrinsicSize.width)
+            : intrinsicSize.height
+
+        if needsScroll {
+            // Mirror CodeBlockView's horizontal-scroll pattern so long
+            // equations scroll rather than clip or force the lazy cell wider.
+            ScrollView(.horizontal, showsIndicators: false) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: intrinsicSize.width, height: intrinsicSize.height)
+            }
+            .frame(height: intrinsicSize.height)
+        } else {
+            // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: renderedWidth, height: renderedHeight)
+        }
+    }
+
+    @ViewBuilder
+    private func errorFallback(message: String) -> some View {
+        // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
+        HStack(spacing: 0) {
+            Text("⚠️ \(latex)")
+                .font(.custom("DMMono-Regular", size: 13))
+                .foregroundStyle(textColor)
+                .textSelection(.enabled)
+                .lineLimit(nil)
+                .padding(VSpacing.sm)
+                .background(codeBackgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .accessibilityLabel("LaTeX rendering failed: \(message)")
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+#endif
 
 // MARK: - Code Block View
 

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -4,6 +4,10 @@ import XCTest
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
+#if canImport(SwiftMath)
+import SwiftMath
+#endif
+
 @MainActor
 final class MarkdownSegmentViewTests: XCTestCase {
     private static let markdownOptions = AttributedString.MarkdownParsingOptions(
@@ -609,4 +613,18 @@ final class MarkdownSegmentViewTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - SwiftMath
+
+    #if canImport(SwiftMath)
+    func testMathImage_rendersScreenshotLatex() {
+        let latex = #"m_\text{ferrite} \propto (\text{ferrite thickness}) \propto \frac{F_\text{required}}{F_\text{available per m}} \propto \frac{1}{\text{margin}}"#
+        var math = MathImage(latex: latex, fontSize: 13, textColor: NSColor.black, labelMode: .display)
+        let (error, image) = math.asImage()
+        XCTAssertNil(error, "SwiftMath rejected the screenshot LaTeX: \(error.map { String(describing: $0) } ?? "unknown")")
+        XCTAssertNotNil(image)
+        XCTAssertGreaterThan(image?.size.width ?? 0, 0)
+        XCTAssertGreaterThan(image?.size.height ?? 0, 0)
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
- Replace the plain-text `.math` placeholder in `MarkdownSegmentView` with real typeset math rendering via `SwiftMath.MathImage`. Rendered images are cached in a file-private NSCache keyed on (latex, display, color, fontSize).
- Long equations horizontally scroll instead of clipping; invalid LaTeX falls back to a monospaced error chrome with a ⚠️ prefix.
- Adds a smoke test covering the screenshot's LaTeX through SwiftMath's `MathImage.asImage()`.

## SwiftMath API used
- `MathImage(latex: String, fontSize: CGFloat, textColor: MTColor, labelMode: MTMathUILabelMode = .display, textAlignment: MTTextAlignment = .center)` — verified from `clients/.build/checkouts/SwiftMath/Sources/SwiftMath/MathBundle/MathImage.swift`.
- `mutating func asImage() -> (NSError?, MTImage?)` — unlabeled 2-tuple; on macOS `MTColor = NSColor`, `MTImage = NSImage` (from `MTConfig.swift`).
- Because `asImage()` is mutating, the struct is held in a local `var` at the call site.

## Font size rationale
- Pulled from `VFont.resolvedChatMarkdownFontSet().regular.pointSize` (16pt at rest, matching `VFont.chat`). This keeps math visually aligned with surrounding body text and auto-tracks typography regeneration rather than hardcoding 13pt.
- The cache key includes `fontSize`, so a future typography change invalidates the cached raster.

Part of plan: latex-chat-rendering.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
