### PR TITLE
feat(now-md): note 10-line cap in context injection tag

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -754,7 +754,7 @@ describe("injectNowScratchpad", () => {
     expect(injected.type).toBe("text");
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toBe(
-      "<NOW.md Always keep this up to date>\nCurrent focus: shipping PR 3\n</NOW.md>",
+      "<NOW.md Always keep this up to date; keep under 10 lines>\nCurrent focus: shipping PR 3\n</NOW.md>",
     );
     // Original content comes last
     expect((result.content[1] as { type: "text"; text: string }).text).toBe(

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -577,7 +577,7 @@ export function injectNowScratchpad(
 ): Message {
   const scratchpadBlock = {
     type: "text" as const,
-    text: `<NOW.md Always keep this up to date>\n${content}\n</NOW.md>`,
+    text: `<NOW.md Always keep this up to date; keep under 10 lines>\n${content}\n</NOW.md>`,
   };
 
   // Find insertion point: skip any leading injected-context text blocks
@@ -606,7 +606,9 @@ export function injectNowScratchpad(
 /** Strip `<NOW.md>` blocks injected by `injectNowScratchpad`. */
 export function stripNowScratchpad(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, [
-    "<NOW.md Always keep this up to date>",
+    // Shared prefix catches both the current tag and any pre-line-limit
+    // variant that may linger in in-flight histories during a rolling deploy.
+    "<NOW.md Always keep this up to date",
     "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   ]);
 }
@@ -1513,7 +1515,9 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<active_workspace>",
   "<active_dynamic_page>",
   "<non_interactive_context>",
-  "<NOW.md Always keep this up to date>",
+  // Shared prefix catches both the current NOW.md tag and any pre-line-limit
+  // variant that may linger in in-flight histories during a rolling deploy.
+  "<NOW.md Always keep this up to date",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<pkb>",
   "<system_reminder>",
@@ -1542,16 +1546,23 @@ export function stripInjectionsForCompaction(messages: Message[]): Message[] {
  * Returns null if no NOW.md injection is found.
  */
 export function findLastInjectedNowContent(messages: Message[]): string | null {
-  const prefix = "<NOW.md Always keep this up to date>\n";
+  // Matches every NOW.md opening tag we emit (the tag text may evolve over
+  // time, e.g. adding a line-limit hint), so in-flight histories with older
+  // tag variants remain discoverable during a rolling deploy.
+  const openTagPrefix = "<NOW.md Always keep this up to date";
   const suffix = "\n</NOW.md>";
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "user") continue;
     for (const block of msg.content) {
-      if (block.type === "text" && block.text.startsWith(prefix)) {
-        const end = block.text.lastIndexOf(suffix);
-        if (end > prefix.length) return block.text.slice(prefix.length, end);
+      if (block.type !== "text" || !block.text.startsWith(openTagPrefix)) {
+        continue;
       }
+      const tagEnd = block.text.indexOf(">\n");
+      if (tagEnd < 0) continue;
+      const contentStart = tagEnd + ">\n".length;
+      const end = block.text.lastIndexOf(suffix);
+      if (end > contentStart) return block.text.slice(contentStart, end);
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- Extends the NOW.md injection open-tag from `<NOW.md Always keep this up to date>` to `<NOW.md Always keep this up to date; keep under 10 lines>` so the model sees the length cap every turn.
- Switches the strip prefix and `findLastInjectedNowContent` matcher to the tag-agnostic prefix `<NOW.md Always keep this up to date`, so in-flight histories with the old tag are still stripped and extracted correctly during rollout.

## Original prompt
Add a note to the NOW.md context injection to keep that file under 10 lines
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
