### PR TITLE
fix(meet-bot): wire camera-channel + thread avatarDevicePath to Chrome launch

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -241,6 +241,8 @@ function makeDeps(opts: MakeDepsOpts = {}): {
         extensionPath: chromeOpts.extensionPath,
         displayNumber: chromeOpts.displayNumber,
         userDataDir: chromeOpts.userDataDir,
+        avatarEnabled: chromeOpts.avatarEnabled,
+        avatarDevicePath: chromeOpts.avatarDevicePath,
       });
       if (opts.chromeLaunchError) throw opts.chromeLaunchError;
       return {
@@ -1272,5 +1274,59 @@ describe("runBot — Gap C: error detail forwarding", () => {
     // Detail must contain BOTH the generic context AND the specific cause.
     expect(errState?.detail).toContain("extension never signaled ready");
     expect(errState?.detail).toContain(specific);
+  });
+});
+
+/** -----------------------------------------------------------------------
+ * avatarDevicePath threading to launchChrome
+ * -----------------------------------------------------------------------
+ * When `services.meet.avatar.devicePath` is set (threaded down as
+ * `AVATAR_DEVICE_PATH` on the bot env), the bot must pass the same
+ * device path to `launchChrome` so Chrome's
+ * `--use-file-for-fake-video-capture=<path>` flag targets the device
+ * the renderer writes to. Without this, the renderer writes frames to
+ * one node (e.g. `/dev/video11`) and Chrome reads from another
+ * (`/dev/video10` default) and participants see a black frame.
+ */
+describe("runBot — avatarDevicePath threads to launchChrome", () => {
+  test("env.avatarDevicePath flows through to launchChrome when set", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    const realEnv = deps.env;
+    deps.env = () => ({
+      ...realEnv(),
+      avatarEnabled: true,
+      avatarDevicePath: "/dev/video11",
+    });
+
+    await bootHappyPath(deps, handles);
+
+    const launchCall = handles.calls.find((c) => c.kind === "chrome.launch");
+    expect(launchCall).toBeDefined();
+    expect(launchCall!.avatarEnabled).toBe(true);
+    expect(launchCall!.avatarDevicePath).toBe("/dev/video11");
+  });
+
+  test("omits avatarDevicePath from launchChrome when env is unset", async () => {
+    // When no operator override exists, the key is absent from the
+    // options object so the launcher falls back to its module-local
+    // DEFAULT_AVATAR_DEVICE_PATH. This is important: a spurious
+    // `avatarDevicePath: undefined` would also work, but absence is
+    // the cleanest signal "use the default".
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    const realEnv = deps.env;
+    deps.env = () => ({
+      ...realEnv(),
+      avatarEnabled: true,
+      avatarDevicePath: undefined,
+    });
+
+    await bootHappyPath(deps, handles);
+
+    const launchCall = handles.calls.find((c) => c.kind === "chrome.launch");
+    expect(launchCall).toBeDefined();
+    expect(launchCall!.avatarEnabled).toBe(true);
+    expect(launchCall!.avatarDevicePath).toBeUndefined();
   });
 });

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -91,6 +91,10 @@ import {
 } from "./media/audio-capture.js";
 import { setupPulseAudio } from "./media/pulse.js";
 import {
+  createCameraChannel,
+  type CameraChannel,
+} from "./native-messaging/camera-channel.js";
+import {
   createNmhSocketServer,
   type NmhSocketServer,
   type NmhSocketServerOptions,
@@ -438,6 +442,15 @@ export async function runBot(deps: BotDeps): Promise<void> {
     daemonClient: DaemonClientLike | null;
     audioCapture: AudioCaptureHandle | null;
     httpServer: HttpServerHandle | null;
+    /**
+     * Camera-toggle channel. Constructed alongside the avatar HTTP
+     * options (when avatar is enabled AND the NMH socket server is up)
+     * so the HTTP server's `/avatar/enable`/`/avatar/disable` routes can
+     * flip the Meet camera on/off via the extension. `shutdown()` is
+     * called during bot teardown so in-flight round-trips reject
+     * deterministically rather than waiting for their 7s timeout.
+     */
+    cameraChannel: CameraChannel | null;
   };
   const subsystems: Subsystems = {
     xvfb: null,
@@ -446,6 +459,7 @@ export async function runBot(deps: BotDeps): Promise<void> {
     daemonClient: null,
     audioCapture: null,
     httpServer: null,
+    cameraChannel: null,
   };
 
   // Pending `send_chat` requests, correlated by requestId so the extension's
@@ -535,6 +549,24 @@ export async function runBot(deps: BotDeps): Promise<void> {
           ? () => subsystems.httpServer!.stop()
           : null,
       );
+      // Abort any in-flight camera round-trips so HTTP handlers awaiting
+      // enableCamera / disableCamera don't hang for the full 7s channel
+      // timeout. Runs after HTTP stop (no new requests can enter) and
+      // before chrome/socket teardown (so the extension is still notionally
+      // around to respond, but we no longer care about the result). Safe
+      // when the channel was never created (avatar disabled, or booted
+      // without a socket server).
+      if (subsystems.cameraChannel) {
+        try {
+          subsystems.cameraChannel.shutdown(
+            detail ?? (finalState === "error" ? "error" : "shutdown"),
+          );
+        } catch (err) {
+          deps.logError(
+            `meet-bot: camera-channel shutdown failed: ${errMsg(err)}`,
+          );
+        }
+      }
       // Send `leave` best-effort; swallow errors because the extension
       // may already be gone. Give it a short grace period to animate out.
       if (subsystems.socketServer) {
@@ -703,6 +735,15 @@ export async function runBot(deps: BotDeps): Promise<void> {
       extensionPath: env.extensionPath,
       userDataDir,
       avatarEnabled: env.avatarEnabled,
+      // When an operator overrides `services.meet.avatar.devicePath`
+      // (threaded here as `AVATAR_DEVICE_PATH`), the renderer will write
+      // frames to that path — Chrome's `--use-file-for-fake-video-capture`
+      // flag must target the same device or Meet reads from the wrong
+      // node and participants see a black frame. Omitting the key when
+      // unset preserves the launcher's module-local default (/dev/video10).
+      ...(env.avatarDevicePath
+        ? { avatarDevicePath: env.avatarDevicePath }
+        : {}),
       logger: {
         info: (m) => deps.logInfo(m),
         error: (m) => deps.logError(m),
@@ -803,11 +844,9 @@ export async function runBot(deps: BotDeps): Promise<void> {
     // just logs; the renderer is actually started on the daemon's
     // `/avatar/enable` HTTP call.
     // ---------------------------------------------------------------------
-    const avatarHttpOptions = buildAvatarHttpOptions(
-      env,
-      deps,
-      subsystems.socketServer,
-    );
+    const { options: avatarHttpOptions, cameraChannel } =
+      buildAvatarHttpOptions(env, deps, subsystems.socketServer);
+    subsystems.cameraChannel = cameraChannel;
 
     subsystems.httpServer = deps.createHttpServer({
       apiToken: botApiToken,
@@ -1011,7 +1050,7 @@ function errMsg(err: unknown): string {
 
 /**
  * Assemble the avatar options bag passed to `createHttpServer` when the
- * avatar feature is enabled. Returns `undefined` when
+ * avatar feature is enabled. Returns `undefined` options when
  * `AVATAR_ENABLED=0` (or unset) so the HTTP server short-circuits
  * `/avatar/*` routes with 503. Also performs an eager construction
  * probe: if the configured renderer can't be resolved the failure is
@@ -1021,13 +1060,23 @@ function errMsg(err: unknown): string {
  * When `socketServer` is non-null the caller forwards a narrowed
  * `AvatarNativeMessagingSender` so the TalkingHead.js renderer (and
  * any future extension-mediated renderer) can drive the avatar tab.
+ * In that same case we also construct a {@link CameraChannel} bound
+ * to the full `sendToExtension` surface (so `camera.enable` /
+ * `camera.disable` frames round-trip through the extension) and thread
+ * its `enableCamera`/`disableCamera` into `HttpServerAvatarOptions.camera`
+ * so `/avatar/enable` and `/avatar/disable` actually flip the Meet
+ * camera toggle. The channel handle is returned separately so the
+ * caller can invoke `shutdown()` during bot teardown.
  */
 function buildAvatarHttpOptions(
   env: BotEnv,
   deps: BotDeps,
   socketServer: NmhSocketServer | null,
-): HttpServerAvatarOptions | undefined {
-  if (!env.avatarEnabled) return undefined;
+): {
+  options: HttpServerAvatarOptions | undefined;
+  cameraChannel: CameraChannel | null;
+} {
+  if (!env.avatarEnabled) return { options: undefined, cameraChannel: null };
 
   // Parse the JSON-encoded config blob the daemon passed down. Fall
   // back to a minimal config derived from `AVATAR_RENDERER` + the
@@ -1080,11 +1129,37 @@ function buildAvatarHttpOptions(
     }
   }
 
-  return {
+  // Stand up the camera-toggle channel when the NMH socket server is
+  // wired up. Uses the full `sendToExtension` / `onExtensionMessage`
+  // surface (NOT the narrowed avatar-only `AvatarNativeMessagingSender`)
+  // because `camera.enable` / `camera.disable` live outside the narrow
+  // avatar.* command set. Absent a socket server (boot smoke builds,
+  // tests without a socket-server mock), the channel stays null and the
+  // HTTP server falls back to its "renderer-only, no camera toggle"
+  // path — which is the correct behavior because there's no extension
+  // to receive the toggle command anyway.
+  const cameraChannel: CameraChannel | null = socketServer
+    ? createCameraChannel({
+        sendToExtension: (msg) => socketServer.sendToExtension(msg),
+        onExtensionMessage: (cb) => socketServer.onExtensionMessage(cb),
+      })
+    : null;
+
+  const options: HttpServerAvatarOptions = {
     config,
     ...(nativeMessaging ? { nativeMessaging } : {}),
     ...(env.avatarDevicePath ? { devicePath: env.avatarDevicePath } : {}),
+    ...(cameraChannel
+      ? {
+          camera: {
+            enableCamera: () => cameraChannel.enableCamera(),
+            disableCamera: () => cameraChannel.disableCamera(),
+          },
+        }
+      : {}),
   };
+
+  return { options, cameraChannel };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes two production-wiring gaps identified during Phase-4 plan review.

- **Camera-toggle not wired**: `buildAvatarHttpOptions` now constructs `createCameraChannel` when the native-messaging socket server is available and passes it as `avatar.camera` so `/avatar/enable`/`/avatar/disable` actually flip the Meet camera. Without this, participants saw no video track despite frames flowing to /dev/video10.
- **Chrome flag / renderer device-path desync**: `launchChrome` now receives `avatarDevicePath` from env so a non-default `services.meet.avatar.devicePath` routes Chrome to the same device the renderer writes to.

Part of remediation: meet-phase-4-avatar.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
