### PR TITLE
fix(meet): wire startTtsLipsync into MeetSessionManager

### DIFF
--- a/skills/meet-join/daemon/__tests__/session-manager.test.ts
+++ b/skills/meet-join/daemon/__tests__/session-manager.test.ts
@@ -40,7 +40,9 @@ import {
   type MeetAudioIngestLike,
   type MeetConversationBridgeLike,
   type MeetStorageWriterLike,
+  type MeetTtsLipsyncFactoryArgs,
 } from "../session-manager.js";
+import type { TtsLipsyncHandle } from "../tts-lipsync.js";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -1696,5 +1698,209 @@ describe("MeetSessionManager proactive chat-opportunity detector wiring", () => 
     expect(typeof _typeGuard).toBe("function");
 
     await manager.leave("m-llm-shape", "cleanup");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TTS lip-sync forwarder wiring
+// ---------------------------------------------------------------------------
+
+describe("MeetSessionManager TTS lip-sync forwarder wiring", () => {
+  /**
+   * Fake lipsync factory — records every factory invocation and the
+   * returned handle's `stop()` calls so tests can assert the forwarder
+   * was constructed with the session's bridge + token and that its
+   * handle was stopped on leave.
+   */
+  interface FakeLipsyncHandle extends TtsLipsyncHandle {
+    stop: ReturnType<typeof mock>;
+  }
+  interface FakeLipsyncFactoryResult {
+    factory: (args: MeetTtsLipsyncFactoryArgs) => FakeLipsyncHandle;
+    lastArgs: () => MeetTtsLipsyncFactoryArgs | null;
+    lastHandle: () => FakeLipsyncHandle | null;
+    constructCount: () => number;
+  }
+
+  function makeFakeLipsyncFactory(): FakeLipsyncFactoryResult {
+    let lastArgs: MeetTtsLipsyncFactoryArgs | null = null;
+    let lastHandle: FakeLipsyncHandle | null = null;
+    let constructCount = 0;
+    return {
+      factory: (args) => {
+        lastArgs = args;
+        constructCount += 1;
+        const handle: FakeLipsyncHandle = {
+          stop: mock(() => {}),
+        };
+        lastHandle = handle;
+        return handle;
+      },
+      lastArgs: () => lastArgs,
+      lastHandle: () => lastHandle,
+      constructCount: () => constructCount,
+    };
+  }
+
+  test("join() constructs lipsync forwarder with session bridge and bot token", async () => {
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const lipsyncFactory = makeFakeLipsyncFactory();
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: audioIngestFactory.factory,
+      ttsLipsyncFactory: lipsyncFactory.factory,
+    });
+
+    const session = await manager.join({
+      url: "u",
+      meetingId: "m-lipsync-wire",
+      conversationId: "c",
+    });
+
+    // Factory must have been invoked exactly once with the session's
+    // bridge, per-meeting bot token, and meeting id — these are the
+    // inputs the forwarder needs to POST events to the right bot.
+    expect(lipsyncFactory.constructCount()).toBe(1);
+    const args = lipsyncFactory.lastArgs();
+    expect(args).not.toBeNull();
+    expect(args!.meetingId).toBe("m-lipsync-wire");
+    expect(args!.botApiToken).toBe(session.botApiToken);
+    // The bridge is the live object the session manager will use for
+    // `speak` / `cancelSpeak` — not a separate construction — so object
+    // identity must match what `getSession` would see on the happy path.
+    expect(args!.bridge).toBeDefined();
+
+    // Handle is alive (stop not yet called) until leave.
+    const handle = lipsyncFactory.lastHandle()!;
+    expect(handle.stop).toHaveBeenCalledTimes(0);
+
+    await manager.leave("m-lipsync-wire", "cleanup");
+  });
+
+  test("leave() stops the lipsync forwarder handle", async () => {
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+    const lipsyncFactory = makeFakeLipsyncFactory();
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: audioIngestFactory.factory,
+      ttsLipsyncFactory: lipsyncFactory.factory,
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "m-lipsync-leave",
+      conversationId: "c",
+    });
+    await manager.leave("m-lipsync-leave", "cleanup");
+
+    const handle = lipsyncFactory.lastHandle()!;
+    expect(handle.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("leave() stops the forwarder BEFORE tearing the ttsBridge down", async () => {
+    // Teardown order matters: if `ttsBridge.cancelAll` ran before the
+    // forwarder unsubscribed, any late viseme event emitted during a
+    // cancelled stream's flush could fire a POST against a shutting-down
+    // bridge. This test pins the ordering by capturing call timestamps on
+    // both the lipsync stop and the bridge's `cancelAll`, then asserting
+    // lipsync stop happened strictly earlier.
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+
+    const callOrder: string[] = [];
+
+    const lipsyncFactory: (
+      args: MeetTtsLipsyncFactoryArgs,
+    ) => TtsLipsyncHandle = (_args) => ({
+      stop: () => {
+        callOrder.push("lipsync.stop");
+      },
+    });
+
+    // Wrap the default bridge factory with a stub that only records the
+    // cancelAll call. `speak`/`cancel`/`activeStreamCount` are not
+    // exercised by this test — the session manager only calls cancelAll
+    // during leave.
+    const ttsBridgeFactory = () => ({
+      speak: async () => ({
+        streamId: "unused",
+        completion: Promise.resolve(),
+      }),
+      cancel: async () => {},
+      cancelAll: async () => {
+        callOrder.push("ttsBridge.cancelAll");
+      },
+      activeStreamCount: () => 0,
+    });
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: audioIngestFactory.factory,
+      ttsBridgeFactory,
+      ttsLipsyncFactory: lipsyncFactory,
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "m-lipsync-order",
+      conversationId: "c",
+    });
+    await manager.leave("m-lipsync-order", "cleanup");
+
+    const lipsyncIdx = callOrder.indexOf("lipsync.stop");
+    const cancelAllIdx = callOrder.indexOf("ttsBridge.cancelAll");
+    expect(lipsyncIdx).toBeGreaterThanOrEqual(0);
+    expect(cancelAllIdx).toBeGreaterThanOrEqual(0);
+    expect(lipsyncIdx).toBeLessThan(cancelAllIdx);
+  });
+
+  test("leave continues cleanly when the lipsync handle's stop throws", async () => {
+    // A misbehaving forwarder must not block meeting teardown — the bot
+    // container still needs to be stopped/removed regardless.
+    const runner = makeMockRunner();
+    const audioIngestFactory = makeFakeAudioIngestFactory();
+
+    const lipsyncFactory: (
+      args: MeetTtsLipsyncFactoryArgs,
+    ) => TtsLipsyncHandle = () => ({
+      stop: () => {
+        throw new Error("simulated lipsync stop failure");
+      },
+    });
+
+    const manager = _createMeetSessionManagerForTests({
+      dockerRunnerFactory: () => runner,
+      getProviderKey: async () => "k",
+      getWorkspaceDir: () => workspaceDir,
+      botLeaveFetch: async () => {},
+      audioIngestFactory: audioIngestFactory.factory,
+      ttsLipsyncFactory: lipsyncFactory,
+    });
+
+    await manager.join({
+      url: "u",
+      meetingId: "m-lipsync-throw",
+      conversationId: "c",
+    });
+
+    await expect(
+      manager.leave("m-lipsync-throw", "cleanup"),
+    ).resolves.toBeUndefined();
+
+    // Container was still removed — teardown made it all the way through.
+    expect(runner.remove).toHaveBeenCalledTimes(1);
   });
 });

--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -121,6 +121,11 @@ import {
   MeetTtsCancelledError,
   type SpeakInput,
 } from "./tts-bridge.js";
+import {
+  startTtsLipsync,
+  type StartTtsLipsyncArgs,
+  type TtsLipsyncHandle,
+} from "./tts-lipsync.js";
 
 const log = getLogger("meet-session-manager");
 
@@ -332,6 +337,17 @@ interface ActiveSession extends MeetSession {
    */
   ttsBridge: MeetTtsBridgeLike;
   /**
+   * Forwarder that subscribes to {@link MeetTtsBridge.onViseme} and POSTs
+   * each event to the bot's `/avatar/viseme` endpoint so the in-bot avatar
+   * renderer drives blendshape weights against the audio the bot is
+   * simultaneously playing out. Started in `join()` right after the TTS
+   * bridge is constructed and stopped in `leave()` BEFORE
+   * `ttsBridge.cancelAll()` so no late POSTs fire against a shutting-down
+   * bridge. See {@link startTtsLipsync} for the forwarder's fire-and-forget
+   * HTTP semantics.
+   */
+  ttsLipsyncHandle: TtsLipsyncHandle;
+  /**
    * Barge-in watcher for this meeting — auto-cancels in-flight TTS when
    * a non-bot speaker takes the floor while the bot is mid-utterance.
    * Started in `join()` immediately after the session record is in place
@@ -447,6 +463,13 @@ export interface MeetTtsBridgeFactoryArgs {
   meetingId: string;
   botBaseUrl: string;
   botApiToken: string;
+}
+
+/** Arguments passed to {@link MeetSessionManagerDeps.ttsLipsyncFactory}. */
+export interface MeetTtsLipsyncFactoryArgs {
+  bridge: MeetTtsBridgeLike;
+  botApiToken: string;
+  meetingId: string;
 }
 
 /** Arguments passed to {@link MeetSessionManagerDeps.bargeInWatcherFactory}. */
@@ -575,6 +598,14 @@ export interface MeetSessionManagerDeps {
    */
   ttsBridgeFactory?: (args: MeetTtsBridgeFactoryArgs) => MeetTtsBridgeLike;
   /**
+   * Override the TTS lip-sync forwarder factory. Default invokes
+   * {@link startTtsLipsync} to subscribe the bridge's `onViseme` channel
+   * and POST each event to the bot's `/avatar/viseme` endpoint. Tests can
+   * inject a fake that returns a handle whose `stop()` is observed without
+   * needing the bridge or bot to exist.
+   */
+  ttsLipsyncFactory?: (args: MeetTtsLipsyncFactoryArgs) => TtsLipsyncHandle;
+  /**
    * Override the barge-in watcher factory. Default constructs a
    * {@link MeetBargeInWatcher} that subscribes to the meeting's
    * dispatcher and the {@link assistantEventHub} for `meet.speaking_*`
@@ -662,6 +693,8 @@ class MeetSessionManagerImpl {
         deps.chatOpportunityDetectorFactory ??
         defaultChatOpportunityDetectorFactory,
       ttsBridgeFactory: deps.ttsBridgeFactory ?? defaultTtsBridgeFactory,
+      ttsLipsyncFactory:
+        deps.ttsLipsyncFactory ?? defaultTtsLipsyncFactory,
       bargeInWatcherFactory:
         deps.bargeInWatcherFactory ?? defaultBargeInWatcherFactory,
       wakeAgent: deps.wakeAgent ?? defaultWakeAgent,
@@ -726,6 +759,11 @@ class MeetSessionManagerImpl {
       }
       try {
         session.chatOpportunityDetector?.dispose();
+      } catch {
+        /* best-effort */
+      }
+      try {
+        session.ttsLipsyncHandle.stop();
       } catch {
         /* best-effort */
       }
@@ -1135,6 +1173,22 @@ class MeetSessionManagerImpl {
       botApiToken,
     });
 
+    // TTS lip-sync forwarder — subscribes to the bridge's viseme channel
+    // and POSTs each event to the bot's `/avatar/viseme` endpoint so the
+    // in-bot avatar renderer drives mouth blendshapes against the audio
+    // the bot is simultaneously playing out. Must be constructed AFTER
+    // the bridge (it subscribes synchronously in `startTtsLipsync`) and
+    // BEFORE any speak() call can land — since all speaks are gated on
+    // the session record hitting `this.sessions`, wiring it here (before
+    // the session is inserted) guarantees the tap is in place when the
+    // first speak fires. Its handle lives on the ActiveSession so
+    // `leave()` can stop the forwarder BEFORE the bridge is torn down.
+    const ttsLipsyncHandle = this.deps.ttsLipsyncFactory({
+      bridge: ttsBridge,
+      botApiToken,
+      meetingId,
+    });
+
     // Barge-in watcher — auto-cancels in-flight TTS when a non-bot speaker
     // takes the floor mid-utterance. Subscribes to the dispatcher and the
     // assistant-event-hub for `meet.speaking_*` lifecycle. Constructed
@@ -1163,6 +1217,7 @@ class MeetSessionManagerImpl {
       storageWriter,
       chatOpportunityDetector,
       ttsBridge,
+      ttsLipsyncHandle,
       bargeInWatcher,
     };
     this.sessions.set(meetingId, session);
@@ -1219,6 +1274,13 @@ class MeetSessionManagerImpl {
         try {
           unsubscribe();
         } catch {}
+      }
+      // Unsubscribe the lip-sync forwarder before we move on so no viseme
+      // event fires against the soon-to-be-removed bridge / container.
+      try {
+        ttsLipsyncHandle.stop();
+      } catch {
+        /* best-effort */
       }
       unregisterMeetingDispatcher(meetingId);
       await audioIngest.stop().catch(() => {});
@@ -1341,6 +1403,20 @@ class MeetSessionManagerImpl {
       log.warn(
         { err, meetingId },
         "MeetBargeInWatcher.stop threw during leave — continuing teardown",
+      );
+    }
+
+    // Stop the TTS lip-sync forwarder BEFORE we cancel in-flight TTS so no
+    // late viseme POST fires against a shutting-down bridge. The forwarder's
+    // `stop()` only unsubscribes from the bridge's `onViseme` channel — it
+    // does not wait for any in-flight `/avatar/viseme` POSTs to settle, since
+    // those are fire-and-forget and tolerate being dropped.
+    try {
+      session.ttsLipsyncHandle.stop();
+    } catch (err) {
+      log.warn(
+        { err, meetingId },
+        "TtsLipsyncHandle.stop threw during leave — continuing teardown",
       );
     }
 
@@ -1816,6 +1892,11 @@ class MeetSessionManagerImpl {
             /* best-effort */
           }
           try {
+            lingering.ttsLipsyncHandle.stop();
+          } catch {
+            /* best-effort */
+          }
+          try {
             await lingering.ttsBridge.cancelAll();
           } catch {
             /* best-effort */
@@ -2044,6 +2125,30 @@ function defaultTtsBridgeFactory(
     },
   };
   return new MeetTtsBridge(bridgeArgs, bridgeDeps);
+}
+
+/**
+ * Default {@link startTtsLipsync} factory — subscribes to the bridge's
+ * viseme channel and forwards every event to the bot's `/avatar/viseme`
+ * endpoint. The forwarder tolerates bot-side HTTP errors (404 before
+ * PR 5's route is deployed, 5xx during transient failures) internally, so
+ * the session manager never observes a rejection from this path. Tests
+ * can inject a fake via {@link MeetSessionManagerDeps.ttsLipsyncFactory}
+ * to observe start/stop without touching the bridge's emit path or the
+ * bot HTTP surface. The default cast is only safe because
+ * {@link MeetTtsBridgeLike} is a strict subset of the {@link MeetTtsBridge}
+ * shape {@link startTtsLipsync} reads — `onViseme`, `botBaseUrl`, and
+ * `meetingId` are only accessed through the real bridge instance, not
+ * through the narrow session-manager interface.
+ */
+function defaultTtsLipsyncFactory(
+  args: MeetTtsLipsyncFactoryArgs,
+): TtsLipsyncHandle {
+  const lipsyncArgs: StartTtsLipsyncArgs = {
+    bridge: args.bridge as unknown as MeetTtsBridge,
+    botApiToken: args.botApiToken,
+  };
+  return startTtsLipsync(lipsyncArgs);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes a production-wiring gap identified during Phase-4 plan review.

- `startTtsLipsync` was defined in PR 4 and the bot's `/avatar/viseme` endpoint was added in PR 5, but `MeetSessionManager.join()` never called `startTtsLipsync`, so visemes never flowed from the TTS bridge to the bot. Avatar mouths stayed still during TTS.
- Session-manager now starts the forwarder on join and stops it (before the TTS bridge) on leave. Handle tracked in `ActiveSession`.

Part of remediation: meet-phase-4-avatar.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
