### PR TITLE
fix(macos-chat): tighten MathBlockView cache lifecycle, cost, and defensive fallbacks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -335,6 +335,9 @@ struct MarkdownSegmentView: View, Equatable {
         prefixWidthCache.removeAll()
         groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
+        #if canImport(SwiftMath)
+        clearMathImageCache()
+        #endif
         #if os(macOS)
         measuredTextCache.removeAllObjects()
         typographyRetryScheduled = false
@@ -897,11 +900,23 @@ private let mathImageCache: NSCache<NSString, MathImageCacheEntry> = {
     return cache
 }()
 
+/// Drops every entry in `mathImageCache`. Invoked from
+/// `MarkdownSegmentView.clearAttributedStringCache()` so the math render cache
+/// participates in the same lifecycle reset as the other render caches.
+func clearMathImageCache() {
+    mathImageCache.removeAllObjects()
+}
+
 /// Converts an `NSColor` to a stable hex cache-key component. Uses the
 /// sRGB-calibrated components so color-space shifts don't cause cache misses
-/// on logically identical colors.
+/// on logically identical colors. Returns a sentinel when the color cannot be
+/// bridged into sRGB (e.g. an asset-catalog pattern or named color whose
+/// component accessors would throw) so the caller falls back to a stable but
+/// non-RGB-derived key instead of crashing.
 private func mathCacheColorKey(_ color: NSColor) -> String {
-    let rgb = color.usingColorSpace(.sRGB) ?? color
+    guard let rgb = color.usingColorSpace(.sRGB) else {
+        return "unresolved"
+    }
     let r = Int((rgb.redComponent * 255).rounded())
     let g = Int((rgb.greenComponent * 255).rounded())
     let b = Int((rgb.blueComponent * 255).rounded())
@@ -912,20 +927,12 @@ private func mathCacheColorKey(_ color: NSColor) -> String {
 /// Renders a LaTeX block via `SwiftMath.MathImage`. Results are cached per
 /// (latex, display, color, fontSize) so re-renders during SwiftUI body
 /// evaluation don't retrigger the typesetter.
-private struct MathBlockView: View, Equatable {
+private struct MathBlockView: View {
     let latex: String
     let display: Bool
     let textColor: Color
     let codeBackgroundColor: Color
     let maxContentWidth: CGFloat?
-
-    static func == (lhs: MathBlockView, rhs: MathBlockView) -> Bool {
-        lhs.latex == rhs.latex
-            && lhs.display == rhs.display
-            && lhs.textColor == rhs.textColor
-            && lhs.codeBackgroundColor == rhs.codeBackgroundColor
-            && lhs.maxContentWidth == rhs.maxContentWidth
-    }
 
     private enum RenderResult {
         case image(NSImage, CGSize)
@@ -959,7 +966,18 @@ private struct MathBlockView: View, Equatable {
             return .failure("unknown error")
         }
         let intrinsic = image.size
-        let cost = Int(intrinsic.width * intrinsic.height * 4)
+        // Prefer the actual bitmap pixel dimensions for the NSCache cost so
+        // the `totalCostLimit` reflects real memory pressure. Falling back to
+        // `image.size * 4` under-counts by ~4x on 2x Retina (points vs pixels),
+        // which would let the cache hold ~4x more bytes than intended.
+        let cost: Int = {
+            if let bitmapRep = image.representations.lazy
+                .compactMap({ $0 as? NSBitmapImageRep }).first {
+                return bitmapRep.pixelsWide * bitmapRep.pixelsHigh * 4
+            }
+            let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+            return Int(intrinsic.width * scale * intrinsic.height * scale * 4)
+        }()
         mathImageCache.setObject(
             MathImageCacheEntry(image: image, intrinsicSize: intrinsic),
             forKey: cacheKey,

--- a/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
@@ -252,9 +252,10 @@ private func groupSegments(_ segments: [MarkdownSegment]) -> [SegmentGroup] {
             groups.append(.horizontalRule)
         case .math:
             // Math is rendered standalone (same as codeBlock/table/image) —
-            // not merged into a selectableRun. The perf test harness doesn't
-            // render math, so we just break the run and drop the segment on
-            // the floor (it's not represented in the local SegmentGroup enum).
+            // not merged into a selectableRun. The perf harness does not
+            // model math today; if a future seed adds math, fail loudly so
+            // the harness is extended rather than silently undercounting.
+            XCTFail("Perf test harness does not currently model .math segments. If you added math to the seed corpus, extend SegmentGroup accordingly.")
             flushRun()
         }
     }

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -504,6 +504,37 @@ final class MarkdownSegmentViewTests: XCTestCase {
         ])
     }
 
+    /// Pins the current parser behavior for prose that contains `$` signs —
+    /// no `.math` segment should be emitted. This protects against silent
+    /// regressions when inline-math (`$…$`) support lands in the future; any
+    /// new inline-math parser must still leave price-like prose alone.
+    func testProse_withDollarSigns_isNotMisparsedAsMath() {
+        let inputs = [
+            "Prices: $10 and $20",
+            "$price: $10 vs $15$",
+            "Spent $5 on coffee.",
+            "Net of $3.50 after fees.",
+            "One $ left.",
+        ]
+        for input in inputs {
+            let segments = parseMarkdownSegments(input)
+            for segment in segments {
+                if case .math = segment {
+                    XCTFail("Prose with `$` must not emit a .math segment. Input=\(input), got=\(segments)")
+                }
+            }
+            // Every prose input above should collapse into a single .text
+            // segment — pin that too so future refactors don't silently
+            // split prose across multiple segments.
+            XCTAssertEqual(segments.count, 1, "Expected a single .text segment for input=\(input), got \(segments)")
+            if case .text(let text)? = segments.first {
+                XCTAssertEqual(text, input, "Prose must round-trip verbatim")
+            } else {
+                XCTFail("Expected first segment to be .text for input=\(input), got \(segments)")
+            }
+        }
+    }
+
     private func makeRenderedMarkdown(_ markdown: String) -> (NSAttributedString, Bool) {
         let source = (try? makeAttributedString(from: markdown)) ?? AttributedString(markdown)
         return MarkdownSegmentView.convertToNSAttributedString(

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -214,9 +214,10 @@ private func groupSegments(_ segments: [MarkdownSegment]) -> [SegmentGroup] {
             groups.append(.horizontalRule)
         case .math:
             // Math is rendered standalone (same as codeBlock/table/image) —
-            // not merged into a selectableRun. The perf test harness doesn't
-            // render math, so we just break the run and drop the segment on
-            // the floor (it's not represented in the local SegmentGroup enum).
+            // not merged into a selectableRun. The perf harness does not
+            // model math today; if a future seed adds math, fail loudly so
+            // the harness is extended rather than silently undercounting.
+            XCTFail("Perf test harness does not currently model .math segments. If you added math to the seed corpus, extend SegmentGroup accordingly.")
             flushRun()
         }
     }


### PR DESCRIPTION
## Summary
Self-review follow-up for the LaTeX block-math PR series (#26677, #26678, #26679). Addresses six gaps from the integration review:

- Clear `mathImageCache` from the same `clearAttributedStringCache` entry point that clears the other render caches (under a `#if canImport(SwiftMath)` guard).
- Harden `mathCacheColorKey` against future non-sRGB `NSColor` values (fail-safe sentinel instead of crashing component reads).
- Compute NSCache cost from bitmap rep pixel dimensions so the 20 MB budget reflects actual memory, not ~4x-under-counted Retina points.
- Drop the unused `Equatable` conformance on `MathBlockView` — it was never wired via `.equatable()` and diverged from neighboring views.
- Replace the silent drop of `.math` in the two perf harnesses with an `XCTFail` that forces future seeders to extend the harness.
- Pin prose-with-`$` as `.text` with a regression test to protect the eventual inline-math follow-up.

No behavior change for normal users — correctness and consistency only.