### PR TITLE
fix(meet): register meet tools via registerExternalTools so LLM can invoke them

### DIFF
--- a/assistant/src/daemon/external-skills-bootstrap.ts
+++ b/assistant/src/daemon/external-skills-bootstrap.ts
@@ -1,0 +1,39 @@
+/**
+ * External skill bootstrap.
+ *
+ * Loads first-party skills that expose **in-process tools** to the daemon.
+ * Importing this module triggers each skill's `register.ts` to run, which
+ * in turn calls `registerExternalTools()` on the assistant-side tool
+ * manifest. The daemon's `initializeTools()` then picks the registered
+ * tools up and makes them available to the LLM.
+ *
+ * ## Why the cross-directory import exists
+ *
+ * `CLAUDE.md` and `skills/meet-join/AGENTS.md` establish a general rule
+ * that `assistant/` must not import from `skills/` via relative paths so
+ * that skills stay portable and extractable. For in-process tools this
+ * creates a chicken-and-egg problem: skills need their `register.ts` to
+ * execute before `initializeTools()` runs, but in a `bun --compile`
+ * binary only statically analyzed imports end up in the bundle, and
+ * dynamic imports with variable paths fail inside `/$bunfs/`.
+ *
+ * We resolve the tension by:
+ *
+ *   1. Keeping this file as the **one** place in `assistant/` that
+ *      reaches into `skills/`. Every other import direction (skill ->
+ *      assistant) remains legal and intentional.
+ *   2. Limiting entries to **first-party bundled skills** whose source
+ *      is copied into the Docker build and statically compiled into the
+ *      Bun binary. The assistant Dockerfile already copies
+ *      `skills/meet-join/` for exactly this reason.
+ *   3. Keeping the imports as **side-effect only** so the skill owns
+ *      both the tool list and the feature-flag semantics — this file
+ *      just wires module evaluation into the startup path.
+ *
+ * When a new bundled first-party skill wants to expose in-process tools
+ * to the LLM, add another side-effect import here and update the
+ * assistant `Dockerfile` to copy the skill's source. Non-bundled skills
+ * (workspace-installed, third-party) never belong in this file.
+ */
+
+import "../../../skills/meet-join/register.js";

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -27,6 +27,12 @@ import { googleCalendarProvider } from "../watcher/providers/google-calendar.js"
 import { linearProvider } from "../watcher/providers/linear.js";
 import { outlookProvider } from "../watcher/providers/outlook.js";
 import { outlookCalendarProvider } from "../watcher/providers/outlook-calendar.js";
+
+// Side-effect import: runs each bundled first-party skill's tool
+// registration before `initializeTools()` so external tools are visible
+// to the LLM. See `external-skills-bootstrap.ts` for the rationale.
+import "./external-skills-bootstrap.js";
+
 const log = getLogger("lifecycle");
 
 export async function initializeProvidersAndTools(

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -230,6 +230,7 @@ export async function initializeTools(): Promise<void> {
     explicitTools,
     getCesToolsIfEnabled,
     cesTools,
+    getExternalTools,
   } = await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
@@ -242,6 +243,15 @@ export async function initializeTools(): Promise<void> {
 
   // Explicit tool instances - no side-effect import required.
   for (const tool of explicitTools) {
+    registerTool(tool);
+  }
+
+  // External skill tools — registered by skill bootstrap modules via
+  // `registerExternalTools()`. Called at init time (not spread into
+  // `explicitTools`) so registrations that happen between module-load
+  // and `initializeTools()` are picked up.
+  const externalTools = getExternalTools();
+  for (const tool of externalTools) {
     registerTool(tool);
   }
 
@@ -272,13 +282,14 @@ export async function initializeTools(): Promise<void> {
   // arbitrary test tools that were registered before init.
   //
   // A pre-existing tool is included only if it is a known manifest tool
-  // (declared in eagerModuleToolNames, explicitTools, or hostTools).
-  // This handles ESM cache hits where eager-module tools are already in
-  // the registry before init ran.
+  // (declared in eagerModuleToolNames, explicitTools, hostTools, or any
+  // registered external skill tool).  This handles ESM cache hits where
+  // eager-module tools are already in the registry before init ran.
   if (!coreToolsSnapshot) {
     const manifestToolNames = new Set<string>([
       ...eagerModuleToolNames,
       ...explicitTools.map((t: Tool) => t.name),
+      ...externalTools.map((t: Tool) => t.name),
       ...hostTools.map((t: Tool) => t.name),
       ...cesTools.map((t: Tool) => t.name),
       ...allComputerUseTools.map((t: Tool) => t.name),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -109,9 +109,14 @@ export const explicitTools: Tool[] = [
   recallTool,
   credentialStoreTool,
   notifyParentTool,
-  // Meet tools are registered via registerExternalTools() during skill
-  // initialization — the assistant never imports directly from skills/.
-  ...getExternalTools(),
+  // NOTE: external skill tools (registered via registerExternalTools) are
+  // intentionally NOT spread into this array. `explicitTools` is a module-
+  // level const whose value is fixed at the first evaluation of this file,
+  // so spreading `getExternalTools()` here would bake in whatever was
+  // registered at that moment (usually an empty list, because skill
+  // bootstrap modules haven't loaded yet). `initializeTools()` in
+  // `registry.ts` calls `getExternalTools()` separately at runtime so
+  // skills registered between module-load and tool-init are picked up.
 ];
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────

--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for `skills/meet-join/register.ts`.
+ *
+ * The register module is a pure side-effect: importing it pushes every
+ * meet_* tool onto the assistant's external-tool registry when the
+ * `meet` feature flag is on. Without this bootstrap, the daemon's
+ * `initializeTools()` never sees the meet tools and they remain
+ * invisible to the LLM. These assertions guard that invariant — if
+ * a meet tool is added/renamed/removed, this test catches the drift
+ * before the tool silently disappears from production.
+ *
+ * Test strategy: we mock `registerExternalTools` so we can capture
+ * exactly what the bootstrap call registers without pulling in the
+ * whole assistant tool-registry module graph (which would force us
+ * to stand up SQLite, credential storage, etc. just to assert a tool
+ * list). The real integration from register.ts → tool-manifest.ts is
+ * thin enough that a pure-call assertion here is sufficient.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+// Module-scope state so each test can tweak inputs without re-installing mocks.
+let flagEnabled = true;
+let captured: Array<{ name: string }> | null = null;
+
+mock.module("../../../assistant/src/tools/tool-manifest.js", () => ({
+  registerExternalTools: (tools: Array<{ name: string }>) => {
+    captured = tools.map((t) => ({ name: t.name }));
+  },
+}));
+
+mock.module(
+  "../../../assistant/src/config/assistant-feature-flags.js",
+  () => ({
+    isAssistantFeatureFlagEnabled: (key: string) => {
+      if (key === "meet") return flagEnabled;
+      return true;
+    },
+  }),
+);
+
+mock.module("../../../assistant/src/config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// Stub the session manager — register.ts does not invoke it, but the
+// meet tool modules import it at evaluation time, so the mock keeps
+// module loading cheap and side-effect-free.
+mock.module("../daemon/session-manager.js", () => ({
+  MeetSessionManager: {
+    activeSessions: () => [],
+    getSession: () => null,
+    join: async () => {
+      throw new Error("join not used in register tests");
+    },
+    leave: async () => {},
+    sendChat: async () => {},
+    speak: async () => ({ streamId: "unused" }),
+    cancelSpeak: async () => {},
+    enableAvatar: async () => ({ enabled: true }),
+    disableAvatar: async () => ({ disabled: true }),
+  },
+  MeetSessionNotFoundError: class extends Error {
+    readonly name = "MeetSessionNotFoundError";
+  },
+  MeetSessionUnreachableError: class extends Error {
+    readonly name = "MeetSessionUnreachableError";
+  },
+  MeetBotAvatarError: class extends Error {
+    readonly name = "MeetBotAvatarError";
+  },
+  MeetBotChatError: class extends Error {
+    readonly name = "MeetBotChatError";
+  },
+}));
+
+mock.module("../meet-config.js", () => ({
+  getMeetConfig: () => ({
+    consentMessage: "test-consent",
+  }),
+}));
+
+mock.module("../../../assistant/src/daemon/identity-helpers.js", () => ({
+  getAssistantName: () => "TestAssistant",
+}));
+
+mock.module("../../../assistant/src/util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const EXPECTED_TOOL_NAMES = [
+  "meet_cancel_speak",
+  "meet_disable_avatar",
+  "meet_enable_avatar",
+  "meet_join",
+  "meet_leave",
+  "meet_send_chat",
+  "meet_speak",
+];
+
+// Flag must be true BEFORE the initial import — register.ts runs its
+// side effect at module-load time, and the ESM cache means we only get
+// one shot at observing the call.
+flagEnabled = true;
+
+// Evaluate register.ts once at top level so the assertions below see
+// the exact call made at production module-load time. Subsequent
+// imports hit the ESM cache and do not re-run the side effect.
+await import("../register.js");
+
+// Snapshot the captured tools so later mutations to the `captured`
+// module-scope variable (via beforeEach in other describe blocks or
+// stray test cleanup) cannot invalidate these assertions.
+const registeredAtImport: Array<{ name: string }> | null = captured
+  ? [...captured]
+  : null;
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("meet-join register", () => {
+  test("registers every meet_* tool when the meet flag is on", () => {
+    expect(registeredAtImport).not.toBeNull();
+    const registeredNames = (registeredAtImport ?? [])
+      .map((t) => t.name)
+      .sort();
+
+    for (const expected of EXPECTED_TOOL_NAMES) {
+      expect(registeredNames).toContain(expected);
+    }
+
+    // Exactly 7 distinct meet_* tools are expected. A count mismatch is
+    // a signal to update the plan and related tests, not to silently
+    // accept the drift.
+    const meetTools = registeredNames.filter((n) => n.startsWith("meet_"));
+    expect(new Set(meetTools).size).toBe(EXPECTED_TOOL_NAMES.length);
+  });
+});

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -1,0 +1,64 @@
+/**
+ * meet-join skill — tool registration entry point.
+ *
+ * Imports every meet_* tool exported by this skill and hands them to the
+ * assistant's external-tool registry when the `meet` feature flag is on.
+ * `initializeTools()` in `assistant/src/tools/registry.ts` reads the
+ * registry at daemon startup so the tools become visible to the LLM for
+ * the lifetime of the process.
+ *
+ * This module is intentionally a pure side-effect module: `import`ing it
+ * is all the bootstrap needs to do. It has no default export and its
+ * name is never referenced by downstream code.
+ *
+ * ## Feature-flag semantics
+ *
+ * Registration is gated by the `meet` feature flag at module-load time,
+ * mirroring the CES-tools pattern in `tool-manifest.ts` — tools only
+ * enter the registry (and therefore only occupy LLM tool-list tokens)
+ * when the flag is on. Toggling the flag requires a daemon restart to
+ * take effect, which is acceptable because the same is true for every
+ * other feature-flag-gated capability on the daemon.
+ *
+ * Each tool also performs a defensive in-`execute()` flag check so
+ * stale tool definitions cached by a long-running agent turn can't
+ * silently fall through to the session manager.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../../assistant/src/config/assistant-feature-flags.js";
+import { getConfig } from "../../assistant/src/config/loader.js";
+import { registerExternalTools } from "../../assistant/src/tools/tool-manifest.js";
+import {
+  meetDisableAvatarTool,
+  meetEnableAvatarTool,
+} from "./tools/meet-avatar-tool.js";
+import { MEET_FLAG_KEY, meetJoinTool } from "./tools/meet-join-tool.js";
+import { meetLeaveTool } from "./tools/meet-leave-tool.js";
+import { meetSendChatTool } from "./tools/meet-send-chat-tool.js";
+import { meetCancelSpeakTool, meetSpeakTool } from "./tools/meet-speak-tool.js";
+
+function tryRegisterMeetTools(): void {
+  try {
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
+      return;
+    }
+  } catch {
+    // Config not yet loaded (e.g. during certain test setups) — treat as
+    // flag off so tool definitions don't leak into test scopes that
+    // haven't opted in.
+    return;
+  }
+
+  registerExternalTools([
+    meetJoinTool,
+    meetLeaveTool,
+    meetSendChatTool,
+    meetSpeakTool,
+    meetCancelSpeakTool,
+    meetEnableAvatarTool,
+    meetDisableAvatarTool,
+  ]);
+}
+
+tryRegisterMeetTools();


### PR DESCRIPTION
## Summary
Fixes a pre-existing registration gap surfaced during Phase-4 plan review.

- `registerExternalTools` was defined in `tool-manifest.ts` but never called, so all meet_* tools (meet_join, meet_leave, meet_send_chat, meet_speak, meet_cancel_speak, and the new meet_enable_avatar / meet_disable_avatar) were defined-but-never-surfaced to the LLM.
- New `skills/meet-join/register.ts` calls `registerExternalTools([...])` for all 7 meet tools at module-load time, feature-flag-gated on the `meet` flag (mirrors the CES-tools registration pattern).
- Wired into the daemon's tool-init path via a dedicated `assistant/src/daemon/external-skills-bootstrap.ts` side-effect module, so it executes once per daemon boot before `initializeTools()`.
- Fixed a secondary timing bug: `explicitTools` was spreading `getExternalTools()` at module-load time (when the list was empty), so the registration never reached the registry. `initializeTools()` now iterates `getExternalTools()` separately at runtime.

## Architectural decision: the assistant/ → skills/ import
CLAUDE.md's general isolation rule forbids relative imports from `assistant/` into `skills/`. For in-process skills, some bridging is unavoidable because `bun --compile` bundles require static imports (dynamic relative imports fail inside `/$bunfs/`). The chosen middle ground:

1. `external-skills-bootstrap.ts` is the **one** file in `assistant/` that reaches into `skills/` — clearly documented as such.
2. Only **first-party bundled skills** (whose source the Dockerfile already copies) are eligible.
3. The import is **side-effect only** — the skill owns tool list and flag semantics.

Worth a flag for follow-up: this crosses the CLAUDE.md boundary. If we grow a second bundled first-party skill with in-process tools, the same pattern applies; if the portfolio stays at one (meet-join), a refactor could collapse the bootstrap file.

## Follow-ups (not fixed here)
- `always-loaded-tools-guard.test.ts` reads `~/.vellum/protected/feature-flags.json` directly (the `protected/` dir is **not** redirected by the test-preload's `VELLUM_WORKSPACE_DIR` override, per the "Feature flag overrides" gotcha). On a machine with `"meet": true` in the local overrides file the test will see meet tools and fail — CI has no override file, so CI passes. This is a pre-existing isolation gap my change surfaces; left as a separate triage item.

Part of remediation: meet-phase-4-avatar.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
