### PR TITLE
fix(workspace): bump stale providerStreamTimeoutSec: 300 to 1800

### DIFF
--- a/assistant/src/workspace/migrations/044-bump-stale-provider-stream-timeout.ts
+++ b/assistant/src/workspace/migrations/044-bump-stale-provider-stream-timeout.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Bump stale `timeouts.providerStreamTimeoutSec: 300` to 1800.
+ *
+ * The schema default was raised from 300s (5 min) to 1800s (30 min) in
+ * PR #22702, but users whose workspace config was written before that change
+ * still carry an explicit 300 that overrides the new default, causing streams
+ * to abort after 5 minutes with "Anthropic stream timed out after 300s".
+ */
+export const bumpStaleProviderStreamTimeoutMigration: WorkspaceMigration = {
+  id: "044-bump-stale-provider-stream-timeout",
+  description:
+    "Bump legacy timeouts.providerStreamTimeoutSec: 300 to 1800 to match the current schema default",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const timeouts = config.timeouts;
+    if (!timeouts || typeof timeouts !== "object" || Array.isArray(timeouts))
+      return;
+    const timeoutsObj = timeouts as Record<string, unknown>;
+
+    if (timeoutsObj.providerStreamTimeoutSec !== 300) return;
+
+    timeoutsObj.providerStreamTimeoutSec = 1800;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const timeouts = config.timeouts;
+    if (!timeouts || typeof timeouts !== "object" || Array.isArray(timeouts))
+      return;
+    const timeoutsObj = timeouts as Record<string, unknown>;
+
+    if (timeoutsObj.providerStreamTimeoutSec !== 1800) return;
+
+    timeoutsObj.providerStreamTimeoutSec = 300;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -41,6 +41,7 @@ import { seedLatencyCallSiteDefaultsMigration } from "./040-seed-latency-callsit
 import { backfillGoogleGmailSettingsScopeMigration } from "./041-backfill-google-gmail-settings-scope.js";
 import { fixBackfillGoogleGmailSettingsScopeMigration } from "./042-fix-backfill-google-gmail-settings-scope.js";
 import { releaseNotesLatexRenderingMigration } from "./043-release-notes-latex-rendering.js";
+import { bumpStaleProviderStreamTimeoutMigration } from "./044-bump-stale-provider-stream-timeout.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -93,4 +94,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillGoogleGmailSettingsScopeMigration,
   fixBackfillGoogleGmailSettingsScopeMigration,
   releaseNotesLatexRenderingMigration,
+  bumpStaleProviderStreamTimeoutMigration,
 ];


### PR DESCRIPTION
## Summary
- Workspace config written before PR #22702 still has `timeouts.providerStreamTimeoutSec: 300`, overriding the current 1800s schema default and aborting long LLM streams after 5 minutes.
- Add migration 044 that rewrites the exact legacy value (300) to 1800; leaves any other value alone.
- Idempotent: short-circuits once the value is 1800.

## Original prompt
[Image #1] Can you increase this timeout to 30 minutes?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
