### PR TITLE
fix: break circular dependency between tool-manifest.ts and skills/load.ts

### DIFF
--- a/assistant/src/daemon/external-skills-bootstrap.ts
+++ b/assistant/src/daemon/external-skills-bootstrap.ts
@@ -4,7 +4,7 @@
  * Loads first-party skills that expose **in-process tools** to the daemon.
  * Importing this module triggers each skill's `register.ts` to run, which
  * in turn calls `registerExternalTools()` on the assistant-side tool
- * manifest. The daemon's `initializeTools()` then picks the registered
+ * registry. The daemon's `initializeTools()` then picks the registered
  * tools up and makes them available to the LLM.
  *
  * ## Why the cross-directory import exists

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -16,6 +16,29 @@ const log = getLogger("tool-registry");
 
 const tools = new Map<string, Tool>();
 
+// ── External tool registry ───────────────────────────────────────────
+// Skills register their tools here at initialization time so the tool
+// manifest can include them without importing from `../skills/`.
+const externalTools: Tool[] = [];
+
+/**
+ * Register tools provided by an external skill. Called during skill
+ * initialization (e.g. meet-join bootstrap).
+ *
+ * Lives in registry.ts (not tool-manifest.ts) to avoid a circular
+ * dependency: skills/load.ts → … → meet-join/register.ts → tool-manifest.ts
+ * → skills/load.ts. Keeping it here lets external skill bootstraps import
+ * from registry.ts, which is already a leaf in the dependency graph.
+ */
+export function registerExternalTools(tools: Tool[]): void {
+  externalTools.push(...tools);
+}
+
+/** Return all externally registered tools. */
+export function getExternalTools(): Tool[] {
+  return [...externalTools];
+}
+
 // Snapshot of core tools captured after initializeTools() completes.
 // Used by __resetRegistryForTesting() to restore eager tools that cannot
 // be re-registered because ESM import caching prevents side effects
@@ -230,7 +253,6 @@ export async function initializeTools(): Promise<void> {
     explicitTools,
     getCesToolsIfEnabled,
     cesTools,
-    getExternalTools,
   } = await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
@@ -250,8 +272,8 @@ export async function initializeTools(): Promise<void> {
   // `registerExternalTools()`. Called at init time (not spread into
   // `explicitTools`) so registrations that happen between module-load
   // and `initializeTools()` are picked up.
-  const externalTools = getExternalTools();
-  for (const tool of externalTools) {
+  const extTools = getExternalTools();
+  for (const tool of extTools) {
     registerTool(tool);
   }
 
@@ -289,7 +311,7 @@ export async function initializeTools(): Promise<void> {
     const manifestToolNames = new Set<string>([
       ...eagerModuleToolNames,
       ...explicitTools.map((t: Tool) => t.name),
-      ...externalTools.map((t: Tool) => t.name),
+      ...extTools.map((t: Tool) => t.name),
       ...hostTools.map((t: Tool) => t.name),
       ...cesTools.map((t: Tool) => t.name),
       ...allComputerUseTools.map((t: Tool) => t.name),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -29,24 +29,6 @@ import { requestSystemPermissionTool } from "./system/request-permission.js";
 import { shellTool } from "./terminal/shell.js";
 import type { Tool } from "./types.js";
 
-// ── External tool registry ───────────────────────────────────────────
-// Skills register their tools here at initialization time so the tool
-// manifest can include them without importing from `../skills/`.
-const externalTools: Tool[] = [];
-
-/**
- * Register tools provided by an external skill. Called during skill
- * initialization.
- */
-export function registerExternalTools(tools: Tool[]): void {
-  externalTools.push(...tools);
-}
-
-/** Return all externally registered tools. */
-export function getExternalTools(): Tool[] {
-  return [...externalTools];
-}
-
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects on
 // first evaluation. The named imports above serve double duty: they give us
@@ -109,14 +91,12 @@ export const explicitTools: Tool[] = [
   recallTool,
   credentialStoreTool,
   notifyParentTool,
-  // NOTE: external skill tools (registered via registerExternalTools) are
-  // intentionally NOT spread into this array. `explicitTools` is a module-
-  // level const whose value is fixed at the first evaluation of this file,
-  // so spreading `getExternalTools()` here would bake in whatever was
-  // registered at that moment (usually an empty list, because skill
-  // bootstrap modules haven't loaded yet). `initializeTools()` in
-  // `registry.ts` calls `getExternalTools()` separately at runtime so
-  // skills registered between module-load and tool-init are picked up.
+  // NOTE: external skill tools (registered via registerExternalTools in
+  // registry.ts) are intentionally NOT included here. `explicitTools` is a
+  // module-level const whose value is fixed at first evaluation, so
+  // external tools registered after this file loads would be missed.
+  // `initializeTools()` in `registry.ts` calls `getExternalTools()`
+  // separately at runtime so late registrations are picked up.
 ];
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────

--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -13,7 +13,7 @@ relative paths. The Docker build copies `assistant/` and `packages/` but not
 
 Skills wire into the assistant through registries:
 
-- **Tools**: `registerExternalTools()` in `assistant/src/tools/tool-manifest.ts`
+- **Tools**: `registerExternalTools()` in `assistant/src/tools/registry.ts`
 - **Routes**: `registerSkillRoute()` in `assistant/src/runtime/skill-route-registry.ts`
 - **Shutdown**: `registerShutdownHook()` in `assistant/src/daemon/shutdown-registry.ts`
 

--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -13,7 +13,7 @@
  * exactly what the bootstrap call registers without pulling in the
  * whole assistant tool-registry module graph (which would force us
  * to stand up SQLite, credential storage, etc. just to assert a tool
- * list). The real integration from register.ts → tool-manifest.ts is
+ * list). The real integration from register.ts → registry.ts is
  * thin enough that a pure-call assertion here is sufficient.
  */
 
@@ -23,7 +23,7 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 let flagEnabled = true;
 let captured: Array<{ name: string }> | null = null;
 
-mock.module("../../../assistant/src/tools/tool-manifest.js", () => ({
+mock.module("../../../assistant/src/tools/registry.js", () => ({
   registerExternalTools: (tools: Array<{ name: string }>) => {
     captured = tools.map((t) => ({ name: t.name }));
   },

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -2,10 +2,10 @@
  * meet-join skill — tool registration entry point.
  *
  * Imports every meet_* tool exported by this skill and hands them to the
- * assistant's external-tool registry when the `meet` feature flag is on.
+ * assistant's tool registry when the `meet` feature flag is on.
  * `initializeTools()` in `assistant/src/tools/registry.ts` reads the
- * registry at daemon startup so the tools become visible to the LLM for
- * the lifetime of the process.
+ * external tool list at daemon startup so the tools become visible to the
+ * LLM for the lifetime of the process.
  *
  * This module is intentionally a pure side-effect module: `import`ing it
  * is all the bootstrap needs to do. It has no default export and its
@@ -14,7 +14,7 @@
  * ## Feature-flag semantics
  *
  * Registration is gated by the `meet` feature flag at module-load time,
- * mirroring the CES-tools pattern in `tool-manifest.ts` — tools only
+ * mirroring the CES-tools pattern in `registry.ts` — tools only
  * enter the registry (and therefore only occupy LLM tool-list tokens)
  * when the flag is on. Toggling the flag requires a daemon restart to
  * take effect, which is acceptable because the same is true for every
@@ -27,7 +27,7 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../assistant/src/config/assistant-feature-flags.js";
 import { getConfig } from "../../assistant/src/config/loader.js";
-import { registerExternalTools } from "../../assistant/src/tools/tool-manifest.js";
+import { registerExternalTools } from "../../assistant/src/tools/registry.js";
 import {
   meetDisableAvatarTool,
   meetEnableAvatarTool,


### PR DESCRIPTION
## Summary
- Moved `registerExternalTools` and `getExternalTools` from `tool-manifest.ts` to `registry.ts` to break a circular module dependency introduced by the meet-join external skill bootstrap
- Updated `meet-join/register.ts` to import from `registry.ts` instead of `tool-manifest.ts`
- Updated the meet-join register test mock to target `registry.js`

## Original prompt
help me fix this CI failure https://github.com/vellum-ai/vellum-assistant/actions/runs/24630004111/job/72015586147
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
