### PR TITLE
Group chrome extension build artifact in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,8 @@ vellum-assistant-safe-do-permissions
 clients/macos/assistant-bin/vellum-assistant
 vellum-assistant-do-fix-retriever-null-check
 
+# Chrome browser extension build
+clients/chrome-extension/vellum-browser-relay.zip
+
 # Drizzle migration files — schema is applied via drizzle-kit push at runtime
 gateway/src/db/migrations/


### PR DESCRIPTION
## Summary
- Move `clients/chrome-extension/vellum-browser-relay.zip` gitignore entry under a descriptive "Chrome browser extension build" comment header for better organization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
