### PR TITLE
fix(macos): point .local env at dev servers and improve chrome auth tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ clients/chrome-extension/vellum-browser-relay.zip
 
 # Drizzle migration files — schema is applied via drizzle-kit push at runtime
 gateway/src/db/migrations/
+clients/chrome-extension/vellum-browser-relay.zip

--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -136,6 +136,16 @@ describe('signInCloud', () => {
     await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow('incomplete payload');
   });
 
+  test('oauth-style error fragment rejects with error detail', async () => {
+    launchWebAuthFlowImpl = async () =>
+      'https://fakeextid.chromiumapp.org/cloud-auth#error=assistant_forbidden&error_description=owner_mismatch&trace_id=trace-123';
+
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow(
+      'cloud sign-in failed: assistant_forbidden (owner_mismatch) [trace=trace-123]',
+    );
+    expect(fakeStorage.data[cloudTokenStorageKey(ASSISTANT_A)]).toBeUndefined();
+  });
+
   test('cancelled flow rejects with "cancelled"', async () => {
     launchWebAuthFlowImpl = async () => undefined;
 
@@ -154,21 +164,19 @@ describe('signInCloud', () => {
     expect(seenUrl).not.toContain('www.vellum.ai//accounts');
   });
 
-  test('retries without assistant_id when Chrome reports auth page load failure', async () => {
+  test('does not retry when no alternate auth base URL exists', async () => {
     const seenUrls: string[] = [];
     launchWebAuthFlowImpl = async (details) => {
       seenUrls.push(details.url);
-      if (seenUrls.length === 1) {
-        throw new Error('Authorization page could not be loaded.');
-      }
-      return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
+      throw new Error('Authorization page could not be loaded.');
     };
 
-    await signInCloud(ASSISTANT_A, config);
+    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow(
+      'Authorization page could not be loaded.',
+    );
 
-    expect(seenUrls.length).toBe(2);
+    expect(seenUrls.length).toBe(1);
     expect(seenUrls[0]).toContain(`assistant_id=${ASSISTANT_A}`);
-    expect(seenUrls[1]).not.toContain('assistant_id=');
   });
 
   test('does not retry against platform runtime host for auth fallback', async () => {
@@ -185,18 +193,17 @@ describe('signInCloud', () => {
       }),
     ).rejects.toThrow('Authorization page could not be loaded.');
 
-    // platform.vellum.ai remaps to www.vellum.ai, so both runtime
-    // fallback attempts are deduped against the primary base URL.
-    expect(seenUrls.length).toBe(2);
+    // platform.vellum.ai remaps to www.vellum.ai and dedupes to a
+    // single candidate URL.
+    expect(seenUrls.length).toBe(1);
     expect(seenUrls[0]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
-    expect(seenUrls[1]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
   });
 
   test('retries against assistant-web host derived from runtimeBaseUrl', async () => {
     const seenUrls: string[] = [];
     launchWebAuthFlowImpl = async (details) => {
       seenUrls.push(details.url);
-      if (seenUrls.length < 3) {
+      if (seenUrls.length < 2) {
         throw new Error('Authorization page could not be loaded.');
       }
       return 'https://fakeextid.chromiumapp.org/cloud-auth#token=abc&expires_in=60&guardian_id=g1';
@@ -207,10 +214,9 @@ describe('signInCloud', () => {
       runtimeBaseUrl: 'https://dev-platform.vellum.ai',
     });
 
-    expect(seenUrls.length).toBe(3);
+    expect(seenUrls.length).toBe(2);
     expect(seenUrls[0]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
-    expect(seenUrls[1]).toContain('https://www.vellum.ai/accounts/chrome-extension/start');
-    expect(seenUrls[2]).toContain('https://dev-assistant.vellum.ai/accounts/chrome-extension/start');
+    expect(seenUrls[1]).toContain('https://dev-assistant.vellum.ai/accounts/chrome-extension/start');
   });
 });
 

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -219,6 +219,14 @@ async function persistToken(assistantId: string, token: StoredCloudToken): Promi
 function parseAuthResponseUrl(responseUrl: string): StoredCloudToken {
   const hash = new URL(responseUrl).hash.replace(/^#/, '');
   const params = new URLSearchParams(hash);
+  const error = params.get('error');
+  if (error) {
+    const description = params.get('error_description');
+    const traceId = params.get('trace_id');
+    const detail = description ? `${error} (${description})` : error;
+    const traceSuffix = traceId ? ` [trace=${traceId}]` : '';
+    throw new Error(`cloud sign-in failed: ${detail}${traceSuffix}`);
+  }
   const token = params.get('token');
   const expiresIn = parseInt(params.get('expires_in') ?? '0', 10);
   const guardianId = params.get('guardian_id') ?? '';
@@ -271,18 +279,22 @@ function buildAuthUrl(
   assistantId: string,
   options: {
     baseUrl?: string;
-    includeAssistantId?: boolean;
+    traceId?: string;
+    candidateIndex?: number;
   } = {},
 ): string {
   const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
-  const includeAssistantId = options.includeAssistantId ?? true;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? config.webBaseUrl);
   let url =
     `${baseUrl}/accounts/chrome-extension/start` +
     `?client_id=${encodeURIComponent(config.clientId)}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}`;
-  if (includeAssistantId) {
-    url += `&assistant_id=${encodeURIComponent(assistantId)}`;
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&assistant_id=${encodeURIComponent(assistantId)}`;
+  if (typeof options.traceId === 'string' && options.traceId.length > 0) {
+    url += `&trace_id=${encodeURIComponent(options.traceId)}`;
+    if (typeof options.candidateIndex === 'number') {
+      url += `&trace_candidate=${options.candidateIndex}`;
+    }
   }
   return url;
 }
@@ -290,10 +302,23 @@ function buildAuthUrl(
 interface AuthUrlCandidate {
   url: string;
   baseUrl: string;
-  includeAssistantId: boolean;
+  candidateIndex: number;
 }
 
-function buildAuthUrlCandidates(config: CloudAuthConfig, assistantId: string): AuthUrlCandidate[] {
+function createAuthTraceId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `trace-${Date.now()}-${Math.floor(Math.random() * 1_000_000)
+    .toString(16)
+    .padStart(5, '0')}`;
+}
+
+function buildAuthUrlCandidates(
+  config: CloudAuthConfig,
+  assistantId: string,
+  traceId: string,
+): AuthUrlCandidate[] {
   const runtimeFallbackBaseUrl =
     typeof config.runtimeBaseUrl === 'string' && config.runtimeBaseUrl.trim().length > 0
       ? normalizeRuntimeFallbackBaseUrl(config.runtimeBaseUrl)
@@ -307,20 +332,27 @@ function buildAuthUrlCandidates(config: CloudAuthConfig, assistantId: string): A
   const seenUrls = new Set<string>();
   const candidates: AuthUrlCandidate[] = [];
   for (const baseUrl of baseUrls) {
-    for (const includeAssistantId of [true, false]) {
-      const url = buildAuthUrl(config, assistantId, { baseUrl, includeAssistantId });
-      if (seenUrls.has(url)) continue;
-      seenUrls.add(url);
-      candidates.push({ url, baseUrl, includeAssistantId });
-    }
+    const candidateIndex = candidates.length;
+    const url = buildAuthUrl(config, assistantId, {
+      baseUrl,
+      traceId,
+      candidateIndex,
+    });
+    if (seenUrls.has(url)) continue;
+    seenUrls.add(url);
+    candidates.push({ url, baseUrl, candidateIndex });
   }
 
   if (candidates.length === 0) {
     const baseUrl = normalizeBaseUrl(config.webBaseUrl);
     candidates.push({
-      url: buildAuthUrl(config, assistantId, { baseUrl, includeAssistantId: true }),
+      url: buildAuthUrl(config, assistantId, {
+        baseUrl,
+        traceId,
+        candidateIndex: 0,
+      }),
       baseUrl,
-      includeAssistantId: true,
+      candidateIndex: 0,
     });
   }
 
@@ -332,30 +364,60 @@ function isAuthorizationPageLoadError(err: unknown): boolean {
   return message.toLowerCase().includes('authorization page could not be loaded');
 }
 
+function sanitizeResponseUrlForLog(responseUrl: string): string {
+  try {
+    const url = new URL(responseUrl);
+    return `${url.origin}${url.pathname}${url.search}`;
+  } catch {
+    return '<unparseable-response-url>';
+  }
+}
+
 async function launchWebAuthFlowWithFallback(
   assistantId: string,
   config: CloudAuthConfig,
   interactive: boolean,
 ): Promise<string | undefined> {
-  const candidates = buildAuthUrlCandidates(config, assistantId);
+  const traceId = createAuthTraceId();
+  const candidates = buildAuthUrlCandidates(config, assistantId, traceId);
   let lastError: unknown = null;
+  console.info(
+    `[vellum-cloud-auth] launching web auth flow trace=${traceId} interactive=${interactive} candidates=${candidates.length}`,
+  );
 
   for (let i = 0; i < candidates.length; i++) {
     const candidate = candidates[i]!;
+    console.info(
+      `[vellum-cloud-auth] launching candidate trace=${traceId} idx=${candidate.candidateIndex} base=${candidate.baseUrl}`,
+    );
     try {
-      return await chrome.identity.launchWebAuthFlow({
+      const responseUrl = await chrome.identity.launchWebAuthFlow({
         url: candidate.url,
         interactive,
       });
+      if (responseUrl) {
+        console.info(
+          `[vellum-cloud-auth] candidate succeeded trace=${traceId} idx=${candidate.candidateIndex} response=${sanitizeResponseUrlForLog(responseUrl)}`,
+        );
+      } else {
+        console.warn(
+          `[vellum-cloud-auth] candidate returned no URL trace=${traceId} idx=${candidate.candidateIndex}`,
+        );
+      }
+      return responseUrl;
     } catch (err) {
       lastError = err;
       const hasNext = i < candidates.length - 1;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[vellum-cloud-auth] candidate failed trace=${traceId} idx=${candidate.candidateIndex} base=${candidate.baseUrl} error=${message}`,
+      );
       if (hasNext && isAuthorizationPageLoadError(err)) {
         const next = candidates[i + 1]!;
         console.warn(
           `[vellum-cloud-auth] authorization page failed to load for ` +
-            `base=${candidate.baseUrl} includeAssistantId=${candidate.includeAssistantId}; ` +
-            `retrying with base=${next.baseUrl} includeAssistantId=${next.includeAssistantId}`,
+            `trace=${traceId} idx=${candidate.candidateIndex} base=${candidate.baseUrl}; ` +
+            `retrying idx=${next.candidateIndex} base=${next.baseUrl}`,
         );
         continue;
       }

--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -83,6 +83,7 @@ public enum NativeMessagingInstaller {
         try installChromeManifest(
             helperBinaryPath: helperBinaryPath,
             extensionIds: extensionIds,
+            vellumEnvironment: ProcessInfo.processInfo.environment["VELLUM_ENVIRONMENT"],
             homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
             fileManager: FileManager.default,
             gatekeeperAssessment: Self.runGatekeeperAssessment(at:)
@@ -106,6 +107,7 @@ public enum NativeMessagingInstaller {
     internal static func installChromeManifest(
         helperBinaryPath: URL,
         extensionIds: [String],
+        vellumEnvironment: String? = nil,
         homeDirectory: URL,
         fileManager: FileManager,
         gatekeeperAssessment: (String) -> Bool = { _ in true }
@@ -136,6 +138,16 @@ public enum NativeMessagingInstaller {
         )
 
         let manifestUrl = targetDir.appendingPathComponent("\(hostName).json")
+        let launcherUrl = launcherScriptPath(under: homeDirectory)
+        let launcherContents = buildLauncherScriptContents(
+            helperBinaryPath: helperBinaryPath.path,
+            vellumEnvironment: vellumEnvironment
+        )
+        try launcherContents.write(to: launcherUrl, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: launcherUrl.path
+        )
 
         // JSONSerialization is used (rather than a Codable struct) so the
         // field order matches the Chrome-expected shape and so the
@@ -148,7 +160,7 @@ public enum NativeMessagingInstaller {
         let manifest: [String: Any] = [
             "name": hostName,
             "description": hostDescription,
-            "path": helperBinaryPath.path,
+            "path": launcherUrl.path,
             "type": "stdio",
             "allowed_origins": extensionIds.map { "chrome-extension://\($0)/" },
         ]
@@ -177,9 +189,14 @@ public enum NativeMessagingInstaller {
     ) throws {
         let manifestUrl = manifestDirectory(under: homeDirectory)
             .appendingPathComponent("\(hostName).json")
+        let launcherUrl = launcherScriptPath(under: homeDirectory)
         if fileManager.fileExists(atPath: manifestUrl.path) {
             try fileManager.removeItem(at: manifestUrl)
             log.info("Removed Chrome native messaging manifest at \(manifestUrl.path, privacy: .public)")
+        }
+        if fileManager.fileExists(atPath: launcherUrl.path) {
+            try fileManager.removeItem(at: launcherUrl)
+            log.info("Removed Chrome native messaging launcher at \(launcherUrl.path, privacy: .public)")
         }
     }
 
@@ -194,6 +211,42 @@ public enum NativeMessagingInstaller {
             .appendingPathComponent("Google", isDirectory: true)
             .appendingPathComponent("Chrome", isDirectory: true)
             .appendingPathComponent("NativeMessagingHosts", isDirectory: true)
+    }
+
+    /// Path to the launcher script referenced by the native messaging manifest.
+    ///
+    /// The script exports `VELLUM_ENVIRONMENT` before exec'ing the real helper
+    /// binary so Chrome-launched processes resolve the correct env-scoped
+    /// lockfile paths even when Chrome provides a minimal process environment.
+    internal static func launcherScriptPath(under homeDirectory: URL) -> URL {
+        manifestDirectory(under: homeDirectory)
+            .appendingPathComponent("\(hostName)-launcher.sh")
+    }
+
+    internal static func buildLauncherScriptContents(
+        helperBinaryPath: String,
+        vellumEnvironment: String?
+    ) -> String {
+        let escapedBinaryPath = shellSingleQuote(helperBinaryPath)
+        let envLine: String
+        if let rawEnv = vellumEnvironment?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawEnv.isEmpty {
+            let escapedEnv = shellSingleQuote(rawEnv)
+            envLine = "if [ -z \"${VELLUM_ENVIRONMENT:-}\" ]; then export VELLUM_ENVIRONMENT=\(escapedEnv); fi"
+        } else {
+            envLine = ":"
+        }
+
+        return """
+#!/bin/sh
+set -e
+\(envLine)
+exec \(escapedBinaryPath) "$@"
+"""
+    }
+
+    private static func shellSingleQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
     }
 
     /// Runs `spctl -a -vv <path>` and returns `true` when Gatekeeper

--- a/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
+++ b/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
@@ -82,10 +82,33 @@ final class NativeMessagingInstallerTests: XCTestCase {
         XCTAssertEqual(parsed["name"] as? String, "com.vellum.daemon")
         XCTAssertEqual(parsed["description"] as? String, "Vellum assistant native messaging host")
         XCTAssertEqual(parsed["type"] as? String, "stdio")
-        XCTAssertEqual(parsed["path"] as? String, helperBinaryUrl.path)
+        XCTAssertEqual(
+            parsed["path"] as? String,
+            NativeMessagingInstaller.launcherScriptPath(under: mockHome).path
+        )
 
         let origins = try XCTUnwrap(parsed["allowed_origins"] as? [String])
         XCTAssertEqual(origins, [placeholderAllowedOrigin])
+    }
+
+    func testInstallWritesLauncherScriptThatExecsHelper() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            vellumEnvironment: "local",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: launcherUrl.path),
+            "launcher script should be written alongside the manifest"
+        )
+
+        let contents = try String(contentsOf: launcherUrl, encoding: .utf8)
+        XCTAssertTrue(contents.contains("export VELLUM_ENVIRONMENT='local'"))
+        XCTAssertTrue(contents.contains("exec '\(helperBinaryUrl.path)' \"$@\""))
     }
 
     func testInstallSetsManifestPermissionsTo0o644() throws {
@@ -103,6 +126,20 @@ final class NativeMessagingInstallerTests: XCTestCase {
         let attrs = try FileManager.default.attributesOfItem(atPath: manifestUrl.path)
         let perms = try XCTUnwrap(attrs[.posixPermissions] as? NSNumber)
         XCTAssertEqual(perms.intValue, 0o644)
+    }
+
+    func testInstallSetsLauncherPermissionsTo0o755() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        let attrs = try FileManager.default.attributesOfItem(atPath: launcherUrl.path)
+        let perms = try XCTUnwrap(attrs[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(perms.intValue, 0o755)
     }
 
     func testInstallCreatesIntermediateNativeMessagingHostsDirectory() throws {
@@ -161,7 +198,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
 
         XCTAssertEqual(
             parsed["path"] as? String,
-            helperBinaryUrl.path,
+            NativeMessagingInstaller.launcherScriptPath(under: mockHome).path,
             "second install should overwrite the stale path"
         )
         XCTAssertEqual(
@@ -274,7 +311,9 @@ final class NativeMessagingInstallerTests: XCTestCase {
         let manifestUrl = NativeMessagingInstaller
             .manifestDirectory(under: mockHome)
             .appendingPathComponent("com.vellum.daemon.json")
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
         XCTAssertTrue(FileManager.default.fileExists(atPath: manifestUrl.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: launcherUrl.path))
 
         try NativeMessagingInstaller.uninstallChromeManifest(
             homeDirectory: mockHome,
@@ -284,6 +323,10 @@ final class NativeMessagingInstallerTests: XCTestCase {
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: manifestUrl.path),
             "manifest should be removed after uninstall"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: launcherUrl.path),
+            "launcher should be removed after uninstall"
         )
     }
 

--- a/clients/shared/App/VellumEnvironment.swift
+++ b/clients/shared/App/VellumEnvironment.swift
@@ -89,7 +89,7 @@ public enum VellumEnvironment: String {
     public var platformURL: String {
         switch self {
         case .local:
-            return "http://localhost:8000"
+            return "https://dev-platform.vellum.ai"
         case .dev:
             return "https://dev-platform.vellum.ai"
         case .test:
@@ -121,7 +121,7 @@ public enum VellumEnvironment: String {
     public var webURL: String {
         switch self {
         case .local:
-            return "http://localhost:3000"
+            return "https://dev-assistant.vellum.ai"
         case .dev:
             return "https://dev-assistant.vellum.ai"
         case .test:


### PR DESCRIPTION
## Summary
- Fix macOS local builds redirecting to localhost for login/session validation by pointing `.local` environment at dev-platform and dev-assistant (still overridable via env vars)
- Chrome extension auth: always send assistant_id, add trace_id for debugging failed auth flows, parse OAuth error fragments
- NativeMessagingInstaller: generate a launcher script that exports VELLUM_ENVIRONMENT so Chrome-spawned helper processes use the correct lockfile paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
