### PR TITLE
fix(knip): add meet-controller-ext content.ts as entry point

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -13,6 +13,7 @@
     "../skills/meet-join/contracts/**/__tests__/**/*.ts",
     "../skills/meet-join/meet-controller-ext/scripts/build.ts",
     "../skills/meet-join/meet-controller-ext/src/background.ts",
+    "../skills/meet-join/meet-controller-ext/src/content.ts",
     "../skills/meet-join/meet-controller-ext/src/avatar/avatar.ts",
     "../skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts"
   ],


### PR DESCRIPTION
## Summary
- Added `content.ts` to the knip entry points for `meet-controller-ext` — it's a browser extension content script entry point referenced in `manifest.json` and `scripts/build.ts`, missed in #26694

## Original prompt
Add `../skills/meet-join/meet-controller-ext/src/content.ts` as a knip entry point in `assistant/knip.json` alongside the other meet-controller-ext entry points. It's a browser extension content script entry point referenced in manifest.json and build.ts. --yolo
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
