### PR TITLE
feat(macos,chrome): local env defaults, Gatekeeper fallback, and chrome auth debug details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,13 @@ The `VELLUM_ENVIRONMENT` environment variable identifies the runtime environment
 | `staging` | QA against staging platform before production rollout. Default for release branch builds. |
 | `production` | Full production behavior, no developer shortcuts. Set explicitly for final production releases. |
 
-**Defaults**: `build.sh` sets the value automatically based on the build command. CI and developers can override it by exporting `VELLUM_ENVIRONMENT` before invoking the build script — the explicit value takes precedence.
+**Defaults**: `build.sh` sets the value automatically when `VELLUM_ENVIRONMENT` is unset:
+- `test` command => `test`
+- `release` / `release-application` => `staging` for `*-staging*` display versions, otherwise `production`
+- all other local build commands (`run`, plain build, etc.) => `dev`
+- if `VELLUM_PLATFORM_URL` or `VELLUM_WEB_URL` points at a loopback `http://...` host (for example `vel up`), default to `local` regardless of command
+
+CI and developers can always override by exporting `VELLUM_ENVIRONMENT` before invoking the build script — the explicit value takes precedence.
 
 **Reading the value at runtime** (Swift):
 ```swift

--- a/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/cloud-auth.test.ts
@@ -171,9 +171,14 @@ describe('signInCloud', () => {
       throw new Error('Authorization page could not be loaded.');
     };
 
-    await expect(signInCloud(ASSISTANT_A, config)).rejects.toThrow(
-      'Authorization page could not be loaded.',
-    );
+    let capturedMessage = '';
+    try {
+      await signInCloud(ASSISTANT_A, config);
+    } catch (err) {
+      capturedMessage = err instanceof Error ? err.message : String(err);
+    }
+    expect(capturedMessage).toContain('Authorization page could not be loaded.');
+    expect(capturedMessage).toContain('[trace=');
 
     expect(seenUrls.length).toBe(1);
     expect(seenUrls[0]).toContain(`assistant_id=${ASSISTANT_A}`);
@@ -191,7 +196,7 @@ describe('signInCloud', () => {
         ...config,
         runtimeBaseUrl: 'https://platform.vellum.ai',
       }),
-    ).rejects.toThrow('Authorization page could not be loaded.');
+    ).rejects.toThrow(/Authorization page could not be loaded\./);
 
     // platform.vellum.ai remaps to www.vellum.ai and dedupes to a
     // single candidate URL.

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -48,6 +48,24 @@ export interface StoredCloudToken {
   guardianId: string;
 }
 
+export interface CloudAuthCandidateFailure {
+  candidateIndex: number;
+  baseUrl: string;
+  error: string;
+}
+
+export class CloudAuthFlowError extends Error {
+  readonly traceId: string;
+  readonly debugDetails: string;
+
+  constructor(message: string, traceId: string, debugDetails: string) {
+    super(message);
+    this.name = 'CloudAuthFlowError';
+    this.traceId = traceId;
+    this.debugDetails = debugDetails;
+  }
+}
+
 /**
  * Window (ms) before `expiresAt` inside which we treat the stored token as
  * "stale" and proactively refresh it. 60 seconds gives us enough headroom
@@ -373,6 +391,37 @@ function sanitizeResponseUrlForLog(responseUrl: string): string {
   }
 }
 
+function formatCloudAuthDebugDetails(
+  traceId: string,
+  interactive: boolean,
+  failures: CloudAuthCandidateFailure[],
+): string {
+  const header = [
+    `trace_id=${traceId}`,
+    `interactive=${interactive}`,
+    `failure_count=${failures.length}`,
+  ].join(" ");
+
+  const body = failures.map(
+    (failure) =>
+      `candidate[${failure.candidateIndex}] base=${failure.baseUrl} error=${failure.error}`,
+  );
+
+  return [header, ...body].join("\n");
+}
+
+function toCloudAuthFlowError(
+  err: unknown,
+  traceId: string,
+  interactive: boolean,
+  failures: CloudAuthCandidateFailure[],
+): CloudAuthFlowError {
+  const baseMessage = err instanceof Error ? err.message : String(err);
+  const messageWithTrace = `${baseMessage} [trace=${traceId}]`;
+  const debugDetails = formatCloudAuthDebugDetails(traceId, interactive, failures);
+  return new CloudAuthFlowError(messageWithTrace, traceId, debugDetails);
+}
+
 async function launchWebAuthFlowWithFallback(
   assistantId: string,
   config: CloudAuthConfig,
@@ -381,6 +430,7 @@ async function launchWebAuthFlowWithFallback(
   const traceId = createAuthTraceId();
   const candidates = buildAuthUrlCandidates(config, assistantId, traceId);
   let lastError: unknown = null;
+  const failures: CloudAuthCandidateFailure[] = [];
   console.info(
     `[vellum-cloud-auth] launching web auth flow trace=${traceId} interactive=${interactive} candidates=${candidates.length}`,
   );
@@ -409,6 +459,11 @@ async function launchWebAuthFlowWithFallback(
       lastError = err;
       const hasNext = i < candidates.length - 1;
       const message = err instanceof Error ? err.message : String(err);
+      failures.push({
+        candidateIndex: candidate.candidateIndex,
+        baseUrl: candidate.baseUrl,
+        error: message,
+      });
       console.warn(
         `[vellum-cloud-auth] candidate failed trace=${traceId} idx=${candidate.candidateIndex} base=${candidate.baseUrl} error=${message}`,
       );
@@ -421,11 +476,13 @@ async function launchWebAuthFlowWithFallback(
         );
         continue;
       }
-      throw err;
+      throw toCloudAuthFlowError(err, traceId, interactive, failures);
     }
   }
 
-  if (lastError) throw lastError;
+  if (lastError) {
+    throw toCloudAuthFlowError(lastError, traceId, interactive, failures);
+  }
   return undefined;
 }
 

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -41,6 +41,7 @@ import {
   validateCloudToken,
   isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
+  CloudAuthFlowError,
   LEGACY_CLOUD_STORAGE_KEY,
   type CloudAuthConfig,
   type StoredCloudToken,
@@ -150,6 +151,7 @@ interface RelayAuthError {
   message: string;
   mode: 'cloud' | 'self-hosted';
   at: number;
+  debugDetails?: string;
 }
 
 async function setRelayAuthError(error: RelayAuthError): Promise<void> {
@@ -166,6 +168,21 @@ async function clearRelayAuthError(): Promise<void> {
   } catch (err) {
     console.warn('[vellum-relay] Failed to clear relay auth error', err);
   }
+}
+
+function serializeWorkerError(err: unknown): {
+  error: string;
+  debugDetails?: string;
+} {
+  if (err instanceof CloudAuthFlowError) {
+    return {
+      error: err.message,
+      debugDetails: err.debugDetails,
+    };
+  }
+  return {
+    error: err instanceof Error ? err.message : String(err),
+  };
 }
 
 /**
@@ -1185,7 +1202,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         // must not leave the flag set, otherwise the next bootstrap
         // would retry a doomed connect.
         await setAutoConnect(false);
-        const errorMessage = err instanceof Error ? err.message : String(err);
+        const serializedError = serializeWorkerError(err);
+        const errorMessage = serializedError.error;
         // Classify the failure: auth-related errors (MissingTokenError)
         // surface as `auth_required`; everything else is a generic `error`.
         if (err instanceof MissingTokenError) {
@@ -1197,7 +1215,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
             lastErrorMessage: errorMessage,
           });
         }
-        sendResponseFn({ ok: false, error: errorMessage });
+        sendResponseFn({ ok: false, ...serializedError });
       });
     return true; // async
   }
@@ -1255,7 +1273,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         return signInCloud(resolvedId, config);
       })
       .then((stored: StoredCloudToken) => sendResponseFn({ ok: true, token: stored }))
-      .catch((err) => sendResponseFn({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+      .catch((err) => sendResponseFn({ ok: false, ...serializeWorkerError(err) }));
     return true; // async
   }
   if (message.type === 'self-hosted-pair') {

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -282,6 +282,49 @@
       line-height: 1.45;
     }
 
+    .debug-details {
+      font-size: 11px;
+      color: var(--text-2);
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px 10px;
+      margin-bottom: 10px;
+    }
+
+    .debug-details-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 6px;
+    }
+
+    .debug-details-title {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-3);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .debug-copy-btn {
+      width: auto;
+      padding: 4px 8px;
+      font-size: 10px;
+      border-radius: 6px;
+    }
+
+    .debug-details-text {
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0;
+      font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+      font-size: 11px;
+      line-height: 1.4;
+      color: var(--text-2);
+    }
+
     .setup-message {
       font-size: 12px;
       color: var(--amber);
@@ -526,6 +569,13 @@
   </div>
 
   <p class="error-text" id="error-text" style="display:none"></p>
+  <div class="debug-details" id="debug-details" style="display:none">
+    <div class="debug-details-header">
+      <span class="debug-details-title">Debug details</span>
+      <button class="debug-copy-btn" id="copy-debug-details" type="button">Copy</button>
+    </div>
+    <p class="debug-details-text" id="debug-details-text"></p>
+  </div>
 
   <p id="setup-message" class="setup-message" style="display:none"></p>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -64,6 +64,13 @@ const statusDot = document.getElementById('status-dot') as HTMLDivElement;
 const statusText = document.getElementById('status-text') as HTMLParagraphElement;
 const statusBadge = document.getElementById('status-badge') as HTMLSpanElement;
 const errorText = document.getElementById('error-text') as HTMLParagraphElement;
+const debugDetails = document.getElementById('debug-details') as HTMLDivElement;
+const debugDetailsText = document.getElementById(
+  'debug-details-text',
+) as HTMLParagraphElement;
+const copyDebugDetailsButton = document.getElementById(
+  'copy-debug-details',
+) as HTMLButtonElement;
 const setupMessage = document.getElementById('setup-message') as HTMLParagraphElement;
 const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButtonElement;
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
@@ -101,6 +108,7 @@ let currentAuthProfile: AssistantAuthProfile | null = null;
 // section can react to state changes.
 
 let currentHealthState: ConnectionHealthState = 'paused';
+let currentDebugDetails: string | null = null;
 
 // ── Connection phase management ─────────────────────────────────────
 
@@ -185,6 +193,7 @@ function applyHealthState(
 
   if (health === 'connected') {
     errorText.style.display = 'none';
+    hideDebugDetails();
   }
 
   // Update troubleshooting section visibility and expansion.
@@ -234,9 +243,55 @@ function showErrorText(msg: string): void {
   errorText.style.display = 'block';
 }
 
-function showError(msg: string): void {
-  showErrorText(msg);
+function hideDebugDetails(): void {
+  currentDebugDetails = null;
+  debugDetailsText.textContent = '';
+  debugDetails.style.display = 'none';
 }
+
+function maybeShowDebugDetails(message: string, details?: string): void {
+  const traceMatch = message.match(/\[trace=([^\]]+)\]/);
+  const traceLine = traceMatch ? `trace_id=${traceMatch[1]}` : null;
+  const rendered =
+    details && details.trim().length > 0
+      ? details.trim()
+      : traceLine;
+
+  if (!rendered) {
+    hideDebugDetails();
+    return;
+  }
+
+  currentDebugDetails = rendered;
+  debugDetailsText.textContent = rendered;
+  debugDetails.style.display = 'block';
+}
+
+function showErrorTextWithDebug(msg: string, debugText?: string): void {
+  errorText.textContent = msg;
+  errorText.style.display = 'block';
+  maybeShowDebugDetails(msg, debugText);
+}
+
+function showError(msg: string, debugText?: string): void {
+  showErrorTextWithDebug(msg, debugText);
+}
+
+copyDebugDetailsButton.addEventListener('click', async () => {
+  if (!currentDebugDetails) return;
+  try {
+    await navigator.clipboard.writeText(currentDebugDetails);
+    const originalLabel = copyDebugDetailsButton.textContent;
+    copyDebugDetailsButton.textContent = 'Copied';
+    setTimeout(() => {
+      copyDebugDetailsButton.textContent = originalLabel;
+    }, 1000);
+  } catch (err) {
+    showError(
+      `Failed to copy debug details: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+});
 
 // ── Advanced section ─────────────────────────────────────────────────
 
@@ -397,6 +452,7 @@ assistantSelect.addEventListener('change', () => {
   if (!assistantId) return;
 
   errorText.style.display = 'none';
+  hideDebugDetails();
 
   chrome.runtime.sendMessage(
     { type: 'assistant-select', assistantId },
@@ -460,6 +516,7 @@ async function requestConnect(): Promise<void> {
   const port = getPort();
 
   errorText.style.display = 'none';
+  hideDebugDetails();
   setPhase('connecting');
 
   try {
@@ -475,9 +532,12 @@ async function requestConnect(): Promise<void> {
   }
 
   await new Promise<void>((resolve) => {
-    chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string }) => {
+    chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string; debugDetails?: string }) => {
       if (chrome.runtime.lastError || !response?.ok) {
-        showError(response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error');
+        showError(
+          response?.error ?? chrome.runtime.lastError?.message ?? 'Unknown error',
+          response?.debugDetails,
+        );
         applyHealthState('error');
         resolve();
         return;
@@ -659,6 +719,12 @@ async function refreshCloudStatus(): Promise<void> {
       typeof (authErr as { message?: unknown }).message === 'string'
     ) {
       showErrorText((authErr as { message: string }).message);
+      if (typeof (authErr as { debugDetails?: unknown }).debugDetails === 'string') {
+        maybeShowDebugDetails(
+          (authErr as { message: string }).message,
+          (authErr as { debugDetails: string }).debugDetails,
+        );
+      }
     }
   } catch (err) {
     setCloudStatus(`Error: ${err instanceof Error ? err.message : String(err)}`, false);
@@ -669,6 +735,7 @@ interface CloudSignInResponse {
   ok: boolean;
   token?: StoredCloudToken;
   error?: string;
+  debugDetails?: string;
 }
 
 function requestCloudSignIn(): Promise<CloudSignInResponse> {
@@ -687,6 +754,7 @@ btnCloudSignIn.addEventListener('click', async () => {
   btnCloudSignIn.disabled = true;
   setCloudStatus('Signing in\u2026', false);
   errorText.style.display = 'none';
+  hideDebugDetails();
   // Clear any stale auth-error the worker persisted during a failed
   // reconnect -- the user is explicitly retrying sign-in now.
   await chrome.storage.local.remove('vellum.relayAuthError');
@@ -694,8 +762,11 @@ btnCloudSignIn.addEventListener('click', async () => {
   const response = await requestCloudSignIn();
   if (response.ok && response.token) {
     setCloudStatus(`Signed in as guardian:${response.token.guardianId}`, true);
+    hideDebugDetails();
   } else {
-    setCloudStatus(`Sign-in failed: ${response.error ?? 'Unknown error'}`, false);
+    const message = `Sign-in failed: ${response.error ?? 'Unknown error'}`;
+    setCloudStatus(message, false);
+    showErrorTextWithDebug(message, response.debugDetails);
   }
   btnCloudSignIn.disabled = false;
 });

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -92,6 +92,15 @@ The fastest way to build and launch the app locally:
 
 The managed sign-in platform host is resolved from `VELLUM_ENVIRONMENT` (`local`, `dev`, `test`, `staging`, `production`) — set the environment to target a different platform host. See `VellumEnvironment.platformURL` in `clients/shared/App/VellumEnvironment.swift`.
 
+Defaulting behavior for local development:
+
+- `./build.sh` and `./build.sh run` default to `dev` (so local source builds point at the dev cloud stack).
+- If either `VELLUM_PLATFORM_URL` or `VELLUM_WEB_URL` is set to a loopback `http://...` URL (for example when running via `vel up`), the build defaults to `local`.
+- `./build.sh test` defaults to `test`.
+- `./build.sh release` / `./build.sh release-application` derive `staging` vs `production` from the release version (`*-staging*` => `staging`, otherwise `production`).
+
+`VELLUM_ENVIRONMENT` always takes precedence when explicitly exported.
+
 To point in-app docs links at a staging or local docs server for a local run:
 
 ```bash

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -471,20 +471,28 @@ bundle_kata_kernel() {
 # This must run before the early-exit commands (test, lint, clean, binaries)
 # so that swift test inherits the correct value.
 if [ -z "${VELLUM_ENVIRONMENT:-}" ]; then
-    case "$CMD" in
-        test)                          VELLUM_ENVIRONMENT="test" ;;
-        run)                           VELLUM_ENVIRONMENT="local" ;;
-        release|release-application)
-            # Staging releases have a prerelease suffix in DISPLAY_VERSION
-            # (e.g. "0.6.0-staging.3"); clean semver means production.
-            if [[ "${DISPLAY_VERSION:-}" == *-staging* ]]; then
-                VELLUM_ENVIRONMENT="staging"
-            else
-                VELLUM_ENVIRONMENT="production"
-            fi
-            ;;
-        *)                             VELLUM_ENVIRONMENT="local" ;;
-    esac
+    # Local web/platform overrides imply local full-stack development
+    # (`vel up`), even when VELLUM_ENVIRONMENT itself is not set.
+    _platform_override="${VELLUM_PLATFORM_URL:-}"
+    _web_override="${VELLUM_WEB_URL:-}"
+    if [[ "$_platform_override" =~ ^http://(localhost|127\.0\.0\.1|[^/]+\.localhost)(:[0-9]+)?$ ]] || \
+       [[ "$_web_override" =~ ^http://(localhost|127\.0\.0\.1|[^/]+\.localhost)(:[0-9]+)?$ ]]; then
+        VELLUM_ENVIRONMENT="local"
+    else
+        case "$CMD" in
+            test)                          VELLUM_ENVIRONMENT="test" ;;
+            release|release-application)
+                # Staging releases have a prerelease suffix in DISPLAY_VERSION
+                # (e.g. "0.6.0-staging.3"); clean semver means production.
+                if [[ "${DISPLAY_VERSION:-}" == *-staging* ]]; then
+                    VELLUM_ENVIRONMENT="staging"
+                else
+                    VELLUM_ENVIRONMENT="production"
+                fi
+                ;;
+            *)                             VELLUM_ENVIRONMENT="dev" ;;
+        esac
+    fi
 fi
 export VELLUM_ENVIRONMENT
 echo "VELLUM_ENVIRONMENT=$VELLUM_ENVIRONMENT"
@@ -1088,6 +1096,26 @@ if [ -n "${VELLUM_DOCS_BASE_URL:-}" ]; then
     _LSE_ENTRIES+="
         <key>VELLUM_DOCS_BASE_URL</key>
         <string>$DOCS_BASE_URL_OVERRIDE</string>"
+fi
+if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
+    PLATFORM_URL_OVERRIDE="${VELLUM_PLATFORM_URL%/}"
+    PLATFORM_URL_OVERRIDE="${PLATFORM_URL_OVERRIDE//&/&amp;}"
+    PLATFORM_URL_OVERRIDE="${PLATFORM_URL_OVERRIDE//</&lt;}"
+    PLATFORM_URL_OVERRIDE="${PLATFORM_URL_OVERRIDE//>/&gt;}"
+    echo "Embedding VELLUM_PLATFORM_URL override: $PLATFORM_URL_OVERRIDE"
+    _LSE_ENTRIES+="
+        <key>VELLUM_PLATFORM_URL</key>
+        <string>$PLATFORM_URL_OVERRIDE</string>"
+fi
+if [ -n "${VELLUM_WEB_URL:-}" ]; then
+    WEB_URL_OVERRIDE="${VELLUM_WEB_URL%/}"
+    WEB_URL_OVERRIDE="${WEB_URL_OVERRIDE//&/&amp;}"
+    WEB_URL_OVERRIDE="${WEB_URL_OVERRIDE//</&lt;}"
+    WEB_URL_OVERRIDE="${WEB_URL_OVERRIDE//>/&gt;}"
+    echo "Embedding VELLUM_WEB_URL override: $WEB_URL_OVERRIDE"
+    _LSE_ENTRIES+="
+        <key>VELLUM_WEB_URL</key>
+        <string>$WEB_URL_OVERRIDE</string>"
 fi
 if [ "$CONFIG" = "debug" ]; then
     echo "Embedding VELLUM_FLAG_PLATFORM_HOSTED_ENABLED for debug build"

--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -84,6 +84,7 @@ public enum NativeMessagingInstaller {
             helperBinaryPath: helperBinaryPath,
             extensionIds: extensionIds,
             vellumEnvironment: ProcessInfo.processInfo.environment["VELLUM_ENVIRONMENT"],
+            processEnvironment: ProcessInfo.processInfo.environment,
             homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
             fileManager: FileManager.default,
             gatekeeperAssessment: Self.runGatekeeperAssessment(at:)
@@ -108,26 +109,13 @@ public enum NativeMessagingInstaller {
         helperBinaryPath: URL,
         extensionIds: [String],
         vellumEnvironment: String? = nil,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: URL,
         fileManager: FileManager,
         gatekeeperAssessment: (String) -> Bool = { _ in true }
     ) throws {
         guard fileManager.fileExists(atPath: helperBinaryPath.path) else {
             throw InstallError.helperBinaryMissing(helperBinaryPath)
-        }
-
-        // Chrome refuses to launch a native messaging host that
-        // Gatekeeper rejects, so installing a manifest that points at a
-        // rejected helper leaves the extension permanently unable to
-        // connect — and worse, clobbers any working manually-installed
-        // manifest on every app launch. Skip the install in that case
-        // and let the developer fall back to the manual setup documented
-        // in clients/chrome-extension/README.md.
-        guard gatekeeperAssessment(helperBinaryPath.path) else {
-            log.warning(
-                "Skipping Chrome native messaging manifest install: bundled helper at \(helperBinaryPath.path, privacy: .public) is not accepted by Gatekeeper (expected for local dev builds with a self-signed helper). Follow the manual setup in clients/chrome-extension/README.md to install the extension bridge."
-            )
-            return
         }
 
         let targetDir = manifestDirectory(under: homeDirectory)
@@ -139,9 +127,34 @@ public enum NativeMessagingInstaller {
 
         let manifestUrl = targetDir.appendingPathComponent("\(hostName).json")
         let launcherUrl = launcherScriptPath(under: homeDirectory)
+        let helperPathForLauncher = resolveHelperPathForLauncher(
+            bundledHelperPath: helperBinaryPath.path,
+            manifestUrl: manifestUrl,
+            launcherUrl: launcherUrl,
+            fileManager: fileManager,
+            gatekeeperAssessment: gatekeeperAssessment
+        )
+        guard let helperPathForLauncher else {
+            // Chrome refuses to launch a native messaging host that
+            // Gatekeeper rejects, so installing a manifest that points at a
+            // rejected helper leaves the extension permanently unable to
+            // connect — and worse, clobbers any working manually-installed
+            // manifest on every app launch. Skip the install in that case
+            // and let the developer fall back to the manual setup documented
+            // in clients/chrome-extension/README.md.
+            log.warning(
+                "Skipping Chrome native messaging manifest install: bundled helper at \(helperBinaryPath.path, privacy: .public) is not accepted by Gatekeeper (expected for local dev builds with a self-signed helper), and no existing trusted helper path could be reused. Follow the manual setup in clients/chrome-extension/README.md to install the extension bridge."
+            )
+            return
+        }
+
+        let resolvedEnvironment = resolvedLauncherEnvironment(
+            vellumEnvironment: vellumEnvironment,
+            processEnvironment: processEnvironment
+        )
         let launcherContents = buildLauncherScriptContents(
-            helperBinaryPath: helperBinaryPath.path,
-            vellumEnvironment: vellumEnvironment
+            helperBinaryPath: helperPathForLauncher,
+            vellumEnvironment: resolvedEnvironment
         )
         try launcherContents.write(to: launcherUrl, atomically: true, encoding: .utf8)
         try fileManager.setAttributes(
@@ -163,6 +176,9 @@ public enum NativeMessagingInstaller {
             "path": launcherUrl.path,
             "type": "stdio",
             "allowed_origins": extensionIds.map { "chrome-extension://\($0)/" },
+            // Metadata for Vellum's installer fallback logic. Chrome ignores
+            // unknown keys in native host manifests.
+            "vellum_helper_path": helperPathForLauncher,
         ]
 
         let data = try JSONSerialization.data(
@@ -223,26 +239,123 @@ public enum NativeMessagingInstaller {
             .appendingPathComponent("\(hostName)-launcher.sh")
     }
 
+    internal static func resolvedLauncherEnvironment(
+        vellumEnvironment: String?,
+        processEnvironment: [String: String]
+    ) -> String {
+        if let resolved = normalizeEnvironmentName(vellumEnvironment) {
+            return resolved
+        }
+        if shouldDefaultToLocalEnvironment(processEnvironment: processEnvironment) {
+            return "local"
+        }
+        // Local source builds default to dev so developers hit the dev cloud
+        // stack unless they explicitly opt into local full-stack behavior.
+        return "dev"
+    }
+
     internal static func buildLauncherScriptContents(
         helperBinaryPath: String,
-        vellumEnvironment: String?
+        vellumEnvironment: String
     ) -> String {
         let escapedBinaryPath = shellSingleQuote(helperBinaryPath)
-        let envLine: String
-        if let rawEnv = vellumEnvironment?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !rawEnv.isEmpty {
-            let escapedEnv = shellSingleQuote(rawEnv)
-            envLine = "if [ -z \"${VELLUM_ENVIRONMENT:-}\" ]; then export VELLUM_ENVIRONMENT=\(escapedEnv); fi"
-        } else {
-            envLine = ":"
-        }
+        let escapedEnv = shellSingleQuote(vellumEnvironment)
 
         return """
 #!/bin/sh
 set -e
-\(envLine)
+if [ -z "${VELLUM_ENVIRONMENT:-}" ]; then export VELLUM_ENVIRONMENT=\(escapedEnv); fi
 exec \(escapedBinaryPath) "$@"
 """
+    }
+
+    private static func normalizeEnvironmentName(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        switch trimmed {
+        case "local", "dev", "test", "staging", "production":
+            return trimmed
+        default:
+            return nil
+        }
+    }
+
+    private static func shouldDefaultToLocalEnvironment(
+        processEnvironment: [String: String]
+    ) -> Bool {
+        isLoopbackHttpURL(processEnvironment["VELLUM_PLATFORM_URL"]) ||
+        isLoopbackHttpURL(processEnvironment["VELLUM_WEB_URL"])
+    }
+
+    private static func isLoopbackHttpURL(_ raw: String?) -> Bool {
+        guard let raw,
+              let url = URL(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http",
+              let host = url.host?.lowercased() else {
+            return false
+        }
+        return host == "localhost" || host == "127.0.0.1" || host.hasSuffix(".localhost")
+    }
+
+    private static func resolveHelperPathForLauncher(
+        bundledHelperPath: String,
+        manifestUrl: URL,
+        launcherUrl: URL,
+        fileManager: FileManager,
+        gatekeeperAssessment: (String) -> Bool
+    ) -> String? {
+        if gatekeeperAssessment(bundledHelperPath) {
+            return bundledHelperPath
+        }
+
+        // Local dev helper binaries are often unsigned/self-signed and fail
+        // Gatekeeper checks. In that case, fall back to an already-installed
+        // trusted helper path when available so we can still update launcher
+        // env wiring (for example, flipping from production -> local lockfile
+        // scope) without breaking native-host launchability.
+        if let fallbackPath = readExistingHelperPath(
+            manifestUrl: manifestUrl,
+            launcherUrl: launcherUrl,
+            fileManager: fileManager
+        ) {
+            log.warning(
+                "Bundled native helper at \(bundledHelperPath, privacy: .public) is not accepted by Gatekeeper; reusing existing helper path \(fallbackPath, privacy: .public)"
+            )
+            return fallbackPath
+        }
+        return nil
+    }
+
+    private static func readExistingHelperPath(
+        manifestUrl: URL,
+        launcherUrl: URL,
+        fileManager: FileManager
+    ) -> String? {
+        guard let data = try? Data(contentsOf: manifestUrl),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        if let explicitHelperPath = parsed["vellum_helper_path"] as? String {
+            let trimmed = explicitHelperPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty && fileManager.fileExists(atPath: trimmed) {
+                return trimmed
+            }
+        }
+
+        if let manifestPath = parsed["path"] as? String {
+            let trimmed = manifestPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty,
+               trimmed != launcherUrl.path,
+               fileManager.fileExists(atPath: trimmed) {
+                return trimmed
+            }
+        }
+
+        return nil
     }
 
     private static func shellSingleQuote(_ value: String) -> String {

--- a/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
+++ b/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
@@ -111,6 +111,57 @@ final class NativeMessagingInstallerTests: XCTestCase {
         XCTAssertTrue(contents.contains("exec '\(helperBinaryUrl.path)' \"$@\""))
     }
 
+    func testInstallDefaultsLauncherEnvironmentToDevWhenUnset() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            vellumEnvironment: nil,
+            processEnvironment: [:],
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        let contents = try String(contentsOf: launcherUrl, encoding: .utf8)
+        XCTAssertTrue(contents.contains("export VELLUM_ENVIRONMENT='dev'"))
+    }
+
+    func testInstallDefaultsLauncherEnvironmentToLocalWhenUsingLoopbackOverrides() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            vellumEnvironment: nil,
+            processEnvironment: [
+                "VELLUM_PLATFORM_URL": "http://localhost:8000",
+                "VELLUM_WEB_URL": "http://localhost:3000",
+            ],
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        let contents = try String(contentsOf: launcherUrl, encoding: .utf8)
+        XCTAssertTrue(contents.contains("export VELLUM_ENVIRONMENT='local'"))
+    }
+
+    func testInstallExplicitEnvironmentOverridesLoopbackHeuristic() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionIds: [placeholderExtensionId],
+            vellumEnvironment: "staging",
+            processEnvironment: [
+                "VELLUM_PLATFORM_URL": "http://localhost:8000",
+                "VELLUM_WEB_URL": "http://localhost:3000",
+            ],
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        let contents = try String(contentsOf: launcherUrl, encoding: .utf8)
+        XCTAssertTrue(contents.contains("export VELLUM_ENVIRONMENT='staging'"))
+    }
+
     func testInstallSetsManifestPermissionsTo0o644() throws {
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
@@ -243,6 +294,7 @@ final class NativeMessagingInstallerTests: XCTestCase {
         try NativeMessagingInstaller.installChromeManifest(
             helperBinaryPath: helperBinaryUrl,
             extensionIds: [placeholderExtensionId],
+            processEnvironment: [:],
             homeDirectory: mockHome,
             fileManager: .default,
             gatekeeperAssessment: { _ in false }
@@ -257,45 +309,65 @@ final class NativeMessagingInstallerTests: XCTestCase {
         )
     }
 
-    func testInstallPreservesExistingManifestWhenGatekeeperRejectsHelper() throws {
-        // First install a working manifest (e.g. from a prior manual
-        // setup pointing at a sh-wrapper that Gatekeeper trusts).
-        try NativeMessagingInstaller.installChromeManifest(
-            helperBinaryPath: helperBinaryUrl,
-            extensionIds: [placeholderExtensionId],
-            homeDirectory: mockHome,
-            fileManager: .default,
-            gatekeeperAssessment: { _ in true }
-        )
-
-        let manifestUrl = NativeMessagingInstaller
-            .manifestDirectory(under: mockHome)
-            .appendingPathComponent("com.vellum.daemon.json")
-        let originalData = try Data(contentsOf: manifestUrl)
-
-        // A later install whose bundled helper is Gatekeeper-rejected
-        // (e.g. a local dev build of the macOS app on top of a manual
-        // install) must not clobber the working manifest.
-        let rejectedBinary = tempDir.appendingPathComponent("rejected-binary")
+    func testInstallReusesExistingHelperPathWhenGatekeeperRejectsNewHelper() throws {
+        let trustedHelper = tempDir.appendingPathComponent("trusted-host")
         FileManager.default.createFile(
-            atPath: rejectedBinary.path,
+            atPath: trustedHelper.path,
             contents: Data("#!/bin/sh\nexit 0\n".utf8),
             attributes: [.posixPermissions: NSNumber(value: 0o755)]
         )
+
+        let manifestDir = NativeMessagingInstaller.manifestDirectory(under: mockHome)
+        try FileManager.default.createDirectory(
+            at: manifestDir,
+            withIntermediateDirectories: true
+        )
+        let manifestUrl = manifestDir.appendingPathComponent("com.vellum.daemon.json")
+        let preexisting: [String: Any] = [
+            "name": "com.vellum.daemon",
+            "description": "Vellum assistant native messaging host",
+            "path": trustedHelper.path,
+            "type": "stdio",
+            "allowed_origins": [placeholderAllowedOrigin],
+        ]
+        let preexistingData = try JSONSerialization.data(
+            withJSONObject: preexisting,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try preexistingData.write(to: manifestUrl, options: .atomic)
+
         try NativeMessagingInstaller.installChromeManifest(
-            helperBinaryPath: rejectedBinary,
+            helperBinaryPath: helperBinaryUrl,
             extensionIds: ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+            vellumEnvironment: nil,
+            processEnvironment: [:],
             homeDirectory: mockHome,
             fileManager: .default,
             gatekeeperAssessment: { _ in false }
         )
 
-        let afterData = try Data(contentsOf: manifestUrl)
-        XCTAssertEqual(
-            originalData,
-            afterData,
-            "existing manifest must be left untouched when Gatekeeper rejects the new helper"
+        let data = try Data(contentsOf: manifestUrl)
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
+        XCTAssertEqual(
+            parsed["path"] as? String,
+            NativeMessagingInstaller.launcherScriptPath(under: mockHome).path
+        )
+        XCTAssertEqual(
+            parsed["vellum_helper_path"] as? String,
+            trustedHelper.path,
+            "installer should carry forward the existing trusted helper path"
+        )
+        XCTAssertEqual(
+            parsed["allowed_origins"] as? [String],
+            ["chrome-extension://bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/"],
+            "manifest metadata should still refresh while reusing helper path"
+        )
+
+        let launcherUrl = NativeMessagingInstaller.launcherScriptPath(under: mockHome)
+        let contents = try String(contentsOf: launcherUrl, encoding: .utf8)
+        XCTAssertTrue(contents.contains("exec '\(trustedHelper.path)' \"$@\""))
     }
 
     // MARK: - uninstall

--- a/clients/shared/App/VellumEnvironment.swift
+++ b/clients/shared/App/VellumEnvironment.swift
@@ -89,7 +89,7 @@ public enum VellumEnvironment: String {
     public var platformURL: String {
         switch self {
         case .local:
-            return "https://dev-platform.vellum.ai"
+            return "http://localhost:8000"
         case .dev:
             return "https://dev-platform.vellum.ai"
         case .test:
@@ -121,7 +121,7 @@ public enum VellumEnvironment: String {
     public var webURL: String {
         switch self {
         case .local:
-            return "https://dev-assistant.vellum.ai"
+            return "http://localhost:3000"
         case .dev:
             return "https://dev-assistant.vellum.ai"
         case .test:


### PR DESCRIPTION
## Summary
- **Local environment overhaul**: `local` env now points at real localhost (port 8000/3000), `dev` is the new default for source builds, and loopback URL detection auto-selects `local` when `VELLUM_PLATFORM_URL`/`VELLUM_WEB_URL` point at localhost
- **Gatekeeper fallback**: When the bundled native helper fails Gatekeeper (local dev builds), the installer now reuses the existing trusted helper path from the manifest instead of skipping the install entirely — preserving env wiring updates
- **Chrome auth debug details**: Auth failures now surface a `CloudAuthFlowError` with trace IDs and per-candidate failure info, shown in a collapsible debug panel in the extension popup with copy-to-clipboard support
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
