### PR TITLE
feat: add IPC routes for watcher CRUD operations

### DIFF
--- a/assistant/src/ipc/__tests__/watcher-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/watcher-ipc.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests for the watcher IPC routes.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with the real SQLite watcher store backing
+ * the route handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../../memory/db.js";
+import { registerWatcherProvider } from "../../watcher/provider-registry.js";
+import type { WatcherProvider } from "../../watcher/provider-types.js";
+import type { Watcher, WatcherEvent } from "../../watcher/watcher-store.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// DB + provider setup
+// ---------------------------------------------------------------------------
+
+initializeDb();
+
+const mockProvider: WatcherProvider = {
+  id: "test-provider",
+  displayName: "Test Provider",
+  requiredCredentialService: "test-cred",
+  async fetchNew() {
+    return { items: [], watermark: "w1" };
+  },
+  async getInitialWatermark() {
+    return "initial";
+  },
+  cleanup() {},
+};
+
+registerWatcherProvider(mockProvider);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+
+/** IDs of watchers created during a test, cleaned up in afterEach. */
+const createdWatcherIds: string[] = [];
+
+beforeEach(async () => {
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(async () => {
+  // Clean up watchers created during the test.
+  for (const id of createdWatcherIds) {
+    await cliIpcCall("watcher/delete", { watcher_id: id });
+  }
+  createdWatcherIds.length = 0;
+
+  server?.stop();
+  server = null;
+});
+
+/** Helper to create a watcher and track it for cleanup. */
+async function createTestWatcher(
+  overrides?: Record<string, unknown>,
+): Promise<Watcher> {
+  const result = await cliIpcCall<Watcher>("watcher/create", {
+    name: "Test Watcher",
+    provider: "test-provider",
+    action_prompt: "Handle events",
+    ...overrides,
+  });
+  expect(result.ok).toBe(true);
+  expect(result.result).toBeDefined();
+  createdWatcherIds.push(result.result!.id);
+  return result.result!;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("watcher IPC routes", () => {
+  // -- CRUD round-trip --------------------------------------------------------
+
+  test("create -> list -> update -> delete round-trip", async () => {
+    // Create
+    const watcher = await createTestWatcher();
+    expect(watcher.name).toBe("Test Watcher");
+    expect(watcher.providerId).toBe("test-provider");
+    expect(watcher.actionPrompt).toBe("Handle events");
+    expect(watcher.enabled).toBe(true);
+    expect(watcher.status).toBe("idle");
+
+    // List all
+    const listResult = await cliIpcCall<Watcher[]>("watcher/list", {});
+    expect(listResult.ok).toBe(true);
+    expect(Array.isArray(listResult.result)).toBe(true);
+    const found = listResult.result!.find((w) => w.id === watcher.id);
+    expect(found).toBeDefined();
+
+    // List single
+    const detailResult = await cliIpcCall<{
+      watcher: Watcher;
+      events: WatcherEvent[];
+    }>("watcher/list", { watcher_id: watcher.id });
+    expect(detailResult.ok).toBe(true);
+    expect(detailResult.result!.watcher.id).toBe(watcher.id);
+    expect(Array.isArray(detailResult.result!.events)).toBe(true);
+
+    // Update
+    const updateResult = await cliIpcCall<Watcher>("watcher/update", {
+      watcher_id: watcher.id,
+      name: "Updated Watcher",
+    });
+    expect(updateResult.ok).toBe(true);
+    expect(updateResult.result!.name).toBe("Updated Watcher");
+
+    // Delete
+    const deleteResult = await cliIpcCall<{ deleted: boolean; name: string }>(
+      "watcher/delete",
+      { watcher_id: watcher.id },
+    );
+    expect(deleteResult.ok).toBe(true);
+    expect(deleteResult.result!.deleted).toBe(true);
+    expect(deleteResult.result!.name).toBe("Updated Watcher");
+
+    // Remove from cleanup tracking since we already deleted it.
+    const idx = createdWatcherIds.indexOf(watcher.id);
+    if (idx >= 0) createdWatcherIds.splice(idx, 1);
+
+    // Confirm gone
+    const afterDelete = await cliIpcCall<Watcher[]>("watcher/list", {});
+    expect(afterDelete.ok).toBe(true);
+    const gone = afterDelete.result!.find((w) => w.id === watcher.id);
+    expect(gone).toBeUndefined();
+  });
+
+  // -- Create: unknown provider -----------------------------------------------
+
+  test("watcher/create rejects unknown provider", async () => {
+    const result = await cliIpcCall("watcher/create", {
+      name: "Bad Watcher",
+      provider: "nonexistent",
+      action_prompt: "Do stuff",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Unknown provider "nonexistent"');
+    expect(result.error).toContain("test-provider");
+  });
+
+  // -- Create: poll interval too low ------------------------------------------
+
+  test("watcher/create rejects poll_interval_ms < 15000", async () => {
+    const result = await cliIpcCall("watcher/create", {
+      name: "Fast Watcher",
+      provider: "test-provider",
+      action_prompt: "Handle events",
+      poll_interval_ms: 5000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // -- List: empty state ------------------------------------------------------
+
+  test("watcher/list returns empty array when no watchers exist", async () => {
+    const result = await cliIpcCall<Watcher[]>("watcher/list", {});
+    expect(result.ok).toBe(true);
+    expect(Array.isArray(result.result)).toBe(true);
+    // There might be leftover watchers from other tests, but the important
+    // thing is that the call succeeds and returns an array.
+  });
+
+  // -- Update: no fields provided ---------------------------------------------
+
+  test("watcher/update rejects when no update fields provided", async () => {
+    const watcher = await createTestWatcher();
+    const result = await cliIpcCall("watcher/update", {
+      watcher_id: watcher.id,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("No updates provided");
+  });
+
+  // -- Delete: non-existent watcher -------------------------------------------
+
+  test("watcher/delete returns error for non-existent watcher", async () => {
+    const result = await cliIpcCall("watcher/delete", {
+      watcher_id: "does-not-exist",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Watcher not found");
+  });
+
+  // -- Digest: empty events ---------------------------------------------------
+
+  test("watcher/digest returns empty events when no events exist", async () => {
+    const result = await cliIpcCall<{
+      events: WatcherEvent[];
+      watcherNames: Record<string, string>;
+    }>("watcher/digest", {});
+    expect(result.ok).toBe(true);
+    expect(Array.isArray(result.result!.events)).toBe(true);
+    expect(typeof result.result!.watcherNames).toBe("object");
+  });
+
+  // -- Underscore aliases -----------------------------------------------------
+
+  test("watcher_create alias works identically to watcher/create", async () => {
+    const result = await cliIpcCall<Watcher>("watcher_create", {
+      name: "Alias Watcher",
+      provider: "test-provider",
+      action_prompt: "Handle events",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.result!.name).toBe("Alias Watcher");
+    createdWatcherIds.push(result.result!.id);
+  });
+
+  test("watcher_list alias works identically to watcher/list", async () => {
+    const watcher = await createTestWatcher();
+    const result = await cliIpcCall<Watcher[]>("watcher_list", {});
+    expect(result.ok).toBe(true);
+    expect(Array.isArray(result.result)).toBe(true);
+    const found = result.result!.find((w) => w.id === watcher.id);
+    expect(found).toBeDefined();
+  });
+
+  test("watcher_update alias works identically to watcher/update", async () => {
+    const watcher = await createTestWatcher();
+    const result = await cliIpcCall<Watcher>("watcher_update", {
+      watcher_id: watcher.id,
+      name: "Alias Updated",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.result!.name).toBe("Alias Updated");
+  });
+
+  test("watcher_delete alias works identically to watcher/delete", async () => {
+    const watcher = await createTestWatcher();
+    const result = await cliIpcCall<{ deleted: boolean; name: string }>(
+      "watcher_delete",
+      { watcher_id: watcher.id },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.result!.deleted).toBe(true);
+
+    // Remove from cleanup tracking.
+    const idx = createdWatcherIds.indexOf(watcher.id);
+    if (idx >= 0) createdWatcherIds.splice(idx, 1);
+  });
+
+  test("watcher_digest alias works identically to watcher/digest", async () => {
+    const result = await cliIpcCall<{
+      events: WatcherEvent[];
+      watcherNames: Record<string, string>;
+    }>("watcher_digest", {});
+    expect(result.ok).toBe(true);
+    expect(Array.isArray(result.result!.events)).toBe(true);
+  });
+
+  // -- Create: credential_service override ------------------------------------
+
+  test("watcher/create uses provider default credential_service when not overridden", async () => {
+    const watcher = await createTestWatcher();
+    expect(watcher.credentialService).toBe("test-cred");
+  });
+
+  test("watcher/create accepts credential_service override", async () => {
+    const watcher = await createTestWatcher({
+      credential_service: "custom-cred",
+    });
+    expect(watcher.credentialService).toBe("custom-cred");
+  });
+
+  // -- Create: config passthrough ---------------------------------------------
+
+  test("watcher/create passes config as configJson", async () => {
+    const watcher = await createTestWatcher({
+      config: { filter: "important" },
+    });
+    expect(watcher.configJson).toBe(JSON.stringify({ filter: "important" }));
+  });
+
+  // -- Create: custom poll interval -------------------------------------------
+
+  test("watcher/create accepts valid poll_interval_ms", async () => {
+    const watcher = await createTestWatcher({ poll_interval_ms: 30000 });
+    expect(watcher.pollIntervalMs).toBe(30000);
+  });
+});

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -3,6 +3,7 @@ import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
 import { uiRequestRoute } from "./ui-request.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
+import { watcherRoutes } from "./watcher.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
@@ -10,4 +11,5 @@ export const cliIpcRoutes: IpcRoute[] = [
   uiRequestRoute,
   wakeConversationRoute,
   ...cacheRoutes,
+  ...watcherRoutes,
 ];

--- a/assistant/src/ipc/routes/watcher.ts
+++ b/assistant/src/ipc/routes/watcher.ts
@@ -1,0 +1,203 @@
+/**
+ * IPC routes for watcher CRUD operations.
+ *
+ * Exposes create/list/update/delete/digest operations so CLI commands
+ * and external processes can manage watchers via the daemon IPC socket.
+ *
+ * Each operation is registered under both a slash-style method name
+ * (e.g. `watcher/create`) and an underscore alias (`watcher_create`).
+ */
+
+import { z } from "zod";
+
+import {
+  getWatcherProvider,
+  listWatcherProviders,
+} from "../../watcher/provider-registry.js";
+import {
+  createWatcher,
+  deleteWatcher,
+  getWatcher,
+  listWatcherEvents,
+  listWatchers,
+  updateWatcher,
+} from "../../watcher/watcher-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// -- Param schemas ------------------------------------------------------------
+
+const WatcherCreateParams = z.object({
+  name: z.string().min(1),
+  provider: z.string().min(1),
+  action_prompt: z.string().min(1),
+  poll_interval_ms: z.number().int().min(15000).optional(),
+  config: z.record(z.unknown()).optional(),
+  credential_service: z.string().optional(),
+});
+
+const WatcherListParams = z.object({
+  watcher_id: z.string().optional(),
+  enabled_only: z.boolean().optional().default(false),
+});
+
+const WatcherUpdateParams = z.object({
+  watcher_id: z.string().min(1),
+  name: z.string().optional(),
+  action_prompt: z.string().optional(),
+  poll_interval_ms: z.number().int().min(15000).optional(),
+  enabled: z.boolean().optional(),
+  config: z.record(z.unknown()).optional(),
+});
+
+const WatcherDeleteParams = z.object({
+  watcher_id: z.string().min(1),
+});
+
+const WatcherDigestParams = z.object({
+  watcher_id: z.string().optional(),
+  hours: z.number().positive().optional().default(24),
+  limit: z.number().int().positive().optional().default(50),
+});
+
+// -- Handlers -----------------------------------------------------------------
+
+function handleWatcherCreate(params?: Record<string, unknown>): unknown {
+  const {
+    name,
+    provider: providerId,
+    action_prompt: actionPrompt,
+    poll_interval_ms: pollIntervalMs,
+    config,
+    credential_service: credentialServiceOverride,
+  } = WatcherCreateParams.parse(params);
+
+  const provider = getWatcherProvider(providerId);
+  if (!provider) {
+    const available =
+      listWatcherProviders()
+        .map((p) => p.id)
+        .join(", ") || "none";
+    throw new Error(
+      `Unknown provider "${providerId}". Available: ${available}`,
+    );
+  }
+
+  const credentialService =
+    credentialServiceOverride ?? provider.requiredCredentialService;
+
+  const watcher = createWatcher({
+    name,
+    providerId,
+    actionPrompt,
+    credentialService,
+    pollIntervalMs,
+    configJson: config ? JSON.stringify(config) : null,
+  });
+
+  return watcher;
+}
+
+function handleWatcherList(params?: Record<string, unknown>): unknown {
+  const { watcher_id: watcherId, enabled_only: enabledOnly } =
+    WatcherListParams.parse(params);
+
+  if (watcherId) {
+    const watcher = getWatcher(watcherId);
+    if (!watcher) {
+      throw new Error(`Watcher not found: ${watcherId}`);
+    }
+    const events = listWatcherEvents({ watcherId, limit: 10 });
+    return { watcher, events };
+  }
+
+  return listWatchers({ enabledOnly });
+}
+
+function handleWatcherUpdate(params?: Record<string, unknown>): unknown {
+  const {
+    watcher_id: watcherId,
+    name,
+    action_prompt: actionPrompt,
+    poll_interval_ms: pollIntervalMs,
+    enabled,
+    config,
+  } = WatcherUpdateParams.parse(params);
+
+  const updates: {
+    name?: string;
+    actionPrompt?: string;
+    pollIntervalMs?: number;
+    enabled?: boolean;
+    configJson?: string | null;
+  } = {};
+
+  if (name !== undefined) updates.name = name;
+  if (actionPrompt !== undefined) updates.actionPrompt = actionPrompt;
+  if (pollIntervalMs !== undefined) updates.pollIntervalMs = pollIntervalMs;
+  if (enabled !== undefined) updates.enabled = enabled;
+  if (config !== undefined) updates.configJson = JSON.stringify(config);
+
+  if (Object.keys(updates).length === 0) {
+    throw new Error(
+      "No updates provided. Specify at least one field to update.",
+    );
+  }
+
+  const watcher = updateWatcher(watcherId, updates);
+  if (!watcher) {
+    throw new Error(`Watcher not found: ${watcherId}`);
+  }
+
+  return watcher;
+}
+
+function handleWatcherDelete(params?: Record<string, unknown>): unknown {
+  const { watcher_id: watcherId } = WatcherDeleteParams.parse(params);
+
+  const watcher = getWatcher(watcherId);
+  if (!watcher) {
+    throw new Error(`Watcher not found: ${watcherId}`);
+  }
+
+  deleteWatcher(watcherId);
+
+  // Evict any in-process provider state (e.g. Linear issue-state cache)
+  const provider = getWatcherProvider(watcher.providerId);
+  provider?.cleanup?.(watcherId);
+
+  return { deleted: true, name: watcher.name };
+}
+
+function handleWatcherDigest(params?: Record<string, unknown>): unknown {
+  const {
+    watcher_id: watcherId,
+    hours,
+    limit,
+  } = WatcherDigestParams.parse(params);
+
+  const since = Date.now() - hours * 3_600_000;
+  const events = listWatcherEvents({ watcherId, limit, since });
+
+  const allWatchers = listWatchers();
+  const watcherNames: Record<string, string> = {};
+  for (const w of allWatchers) {
+    watcherNames[w.id] = w.name;
+  }
+
+  return { events, watcherNames };
+}
+
+// -- Route definitions --------------------------------------------------------
+
+export const watcherRoutes: IpcRoute[] = [
+  { method: "watcher/create", handler: handleWatcherCreate },
+  { method: "watcher_create", handler: handleWatcherCreate },
+  { method: "watcher/list", handler: handleWatcherList },
+  { method: "watcher_list", handler: handleWatcherList },
+  { method: "watcher/update", handler: handleWatcherUpdate },
+  { method: "watcher_update", handler: handleWatcherUpdate },
+  { method: "watcher/delete", handler: handleWatcherDelete },
+  { method: "watcher_delete", handler: handleWatcherDelete },
+  { method: "watcher/digest", handler: handleWatcherDigest },
+  { method: "watcher_digest", handler: handleWatcherDigest },
+];

--- a/assistant/src/ipc/routes/watcher.ts
+++ b/assistant/src/ipc/routes/watcher.ts
@@ -31,7 +31,7 @@ const WatcherCreateParams = z.object({
   provider: z.string().min(1),
   action_prompt: z.string().min(1),
   poll_interval_ms: z.number().int().min(15000).optional(),
-  config: z.record(z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
   credential_service: z.string().optional(),
 });
 
@@ -46,7 +46,7 @@ const WatcherUpdateParams = z.object({
   action_prompt: z.string().optional(),
   poll_interval_ms: z.number().int().min(15000).optional(),
   enabled: z.boolean().optional(),
-  config: z.record(z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
 });
 
 const WatcherDeleteParams = z.object({

--- a/assistant/src/ipc/routes/watcher.ts
+++ b/assistant/src/ipc/routes/watcher.ts
@@ -99,7 +99,7 @@ function handleWatcherCreate(params?: Record<string, unknown>): unknown {
 
 function handleWatcherList(params?: Record<string, unknown>): unknown {
   const { watcher_id: watcherId, enabled_only: enabledOnly } =
-    WatcherListParams.parse(params);
+    WatcherListParams.parse(params ?? {});
 
   if (watcherId) {
     const watcher = getWatcher(watcherId);
@@ -173,7 +173,7 @@ function handleWatcherDigest(params?: Record<string, unknown>): unknown {
     watcher_id: watcherId,
     hours,
     limit,
-  } = WatcherDigestParams.parse(params);
+  } = WatcherDigestParams.parse(params ?? {});
 
   const since = Date.now() - hours * 3_600_000;
   const events = listWatcherEvents({ watcherId, limit, since });


### PR DESCRIPTION
## Summary
- Add 5 IPC routes (watcher/create, list, update, delete, digest) with underscore aliases
- Zod schema validation for all route params
- Integration tests exercising full IPC round-trip

Part of plan: watcher-skill-migrate.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
