### PR TITLE
feat(trust): preserve user overrides of default trust rules across upgrades

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -329,6 +329,32 @@ describe("Trust Store", () => {
       expect(found).toBeDefined();
       expect(found!.userModifiedAt).toBeGreaterThan(0);
     });
+
+    test("does not set userModifiedAt on no-op default rule update", () => {
+      // Updating a default rule with values identical to the template
+      // should NOT set userModifiedAt — the rule hasn't actually diverged.
+      const updated = updateRule("default:ask-host_bash-global", {
+        decision: "ask",
+      });
+      expect(updated.userModifiedAt).toBeUndefined();
+    });
+
+    test("clears userModifiedAt when default rule is reset to template values", () => {
+      // First, modify the rule to diverge from the template
+      updateRule("default:ask-host_bash-global", { decision: "allow" });
+      let found = getAllRules().find(
+        (r) => r.id === "default:ask-host_bash-global",
+      )!;
+      expect(found.userModifiedAt).toBeGreaterThan(0);
+
+      // Now reset it back to the template value
+      updateRule("default:ask-host_bash-global", { decision: "ask" });
+      found = getAllRules().find(
+        (r) => r.id === "default:ask-host_bash-global",
+      )!;
+      // userModifiedAt should be cleared since rule matches template again
+      expect(found.userModifiedAt).toBeUndefined();
+    });
   });
 
   // ── findMatchingRule ────────────────────────────────────────────

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -305,6 +305,30 @@ describe("Trust Store", () => {
       expect(updated.priority).toBe(100);
       expect(updated.createdAt).toBe(rule.createdAt);
     });
+
+    test("does not set userModifiedAt on non-default rules", () => {
+      const rule = addRule("bash", "git *", "/tmp");
+      const updated = updateRule(rule.id, { decision: "deny" });
+      expect(updated.userModifiedAt).toBeUndefined();
+    });
+
+    test("sets userModifiedAt when updating a default rule", () => {
+      const before = Date.now();
+      const updated = updateRule("default:ask-host_bash-global", {
+        decision: "allow",
+      });
+      expect(updated.userModifiedAt).toBeGreaterThanOrEqual(before);
+      expect(updated.userModifiedAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    test("persists userModifiedAt to disk for default rules", () => {
+      updateRule("default:ask-host_bash-global", { decision: "allow" });
+      clearCache();
+      const rules = getAllRules();
+      const found = rules.find((r) => r.id === "default:ask-host_bash-global");
+      expect(found).toBeDefined();
+      expect(found!.userModifiedAt).toBeGreaterThan(0);
+    });
   });
 
   // ── findMatchingRule ────────────────────────────────────────────
@@ -1097,6 +1121,71 @@ describe("Trust Store", () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:ask-file_edit-managed-skills");
       expect(match!.decision).toBe("ask");
+    });
+
+    // ── userModifiedAt and backfill migration ──────────────────────
+
+    test("default rules without userModifiedAt are migrated when template changes", () => {
+      // First load backfills defaults
+      getAllRules();
+      // Manually alter a default rule on disk to simulate a template change
+      // (the rule on disk has old values, template has new ones)
+      const raw = JSON.parse(readFileSync(trustPath, "utf-8"));
+      const idx = raw.rules.findIndex(
+        (r: { id: string }) => r.id === "default:ask-host_bash-global",
+      );
+      expect(idx).toBeGreaterThanOrEqual(0);
+      // Manually set an old priority to simulate the rule diverging from template
+      raw.rules[idx].priority = 9999;
+      writeFileSync(trustPath, JSON.stringify(raw, null, 2));
+      clearCache();
+      const rules = getAllRules();
+      const found = rules.find((r) => r.id === "default:ask-host_bash-global");
+      expect(found).toBeDefined();
+      // Should be migrated back to the template priority (50)
+      expect(found!.priority).toBe(50);
+    });
+
+    test("default rules with userModifiedAt are preserved during backfill migration", () => {
+      // First load backfills defaults
+      getAllRules();
+      // Modify the rule via updateRule to set userModifiedAt
+      updateRule("default:ask-host_bash-global", { decision: "allow" });
+      // Verify userModifiedAt is set
+      let rules = getAllRules();
+      let found = rules.find((r) => r.id === "default:ask-host_bash-global");
+      expect(found).toBeDefined();
+      expect(found!.userModifiedAt).toBeGreaterThan(0);
+      expect(found!.decision).toBe("allow");
+
+      // Now simulate a template change by altering what the template expects:
+      // on disk the rule has decision=allow + userModifiedAt, but the template
+      // would try to migrate it back to decision=ask. Since userModifiedAt is
+      // set, backfillDefaults should skip it.
+      clearCache();
+      rules = getAllRules();
+      found = rules.find((r) => r.id === "default:ask-host_bash-global");
+      expect(found).toBeDefined();
+      // The user's override should be preserved
+      expect(found!.decision).toBe("allow");
+      expect(found!.userModifiedAt).toBeGreaterThan(0);
+    });
+
+    test("userModifiedAt survives round-trip through disk", () => {
+      getAllRules(); // backfill
+      updateRule("default:ask-host_bash-global", { priority: 999 });
+      const before = getAllRules().find(
+        (r) => r.id === "default:ask-host_bash-global",
+      )!;
+      expect(before.userModifiedAt).toBeGreaterThan(0);
+
+      // Round-trip through disk
+      clearCache();
+      const after = getAllRules().find(
+        (r) => r.id === "default:ask-host_bash-global",
+      )!;
+      expect(after.userModifiedAt).toBe(before.userModifiedAt);
+      expect(after.priority).toBe(999);
     });
   });
 

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -202,6 +202,9 @@ function backfillDefaults(rules: TrustRule[]): boolean {
   // or allowHighRisk has changed in the template (e.g. host_bash pattern
   // changed from '*' to '**', host tool priorities changed from 1000 to 50,
   // workspace scope changed from getRootDir()+workspace to getWorkspaceDir()).
+  //
+  // Rules with `userModifiedAt` set are skipped — the user explicitly
+  // customized them and their override should be preserved across upgrades.
   for (const template of getDefaultRuleTemplates()) {
     if (existingIds.has(template.id)) {
       const rule = rules.find((r) => r.id === template.id);
@@ -213,6 +216,13 @@ function backfillDefaults(rules: TrustRule[]): boolean {
           rule.decision !== template.decision ||
           rule.allowHighRisk !== template.allowHighRisk)
       ) {
+        if (rule.userModifiedAt != null) {
+          log.info(
+            { ruleId: rule.id, userModifiedAt: rule.userModifiedAt },
+            "Skipping migration of user-modified default rule",
+          );
+          continue;
+        }
         log.info(
           {
             ruleId: rule.id,
@@ -469,9 +479,6 @@ function fileUpdateRule(
     priority?: number;
   },
 ): TrustRule {
-  const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
-  if (defaultIds.has(id))
-    throw new Error(`Cannot modify default trust rule: ${id}`);
   if (updates.tool?.startsWith("__internal:"))
     throw new Error(
       `Cannot update tool to internal pseudo-rule: ${updates.tool}`,
@@ -488,6 +495,13 @@ function fileUpdateRule(
   if (updates.scope != null) merged.scope = updates.scope;
   if (updates.decision != null) merged.decision = updates.decision;
   if (updates.priority != null) merged.priority = updates.priority;
+
+  // Mark default rules with userModifiedAt so backfillDefaults() preserves
+  // the user's customization across upgrades instead of overwriting it.
+  const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
+  if (defaultIds.has(id)) {
+    merged.userModifiedAt = Date.now();
+  }
 
   // Canonicalize through parseTrustRule so that fields invalid for the
   // (potentially changed) tool family are stripped. For example, if a rule's

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -498,9 +498,26 @@ function fileUpdateRule(
 
   // Mark default rules with userModifiedAt so backfillDefaults() preserves
   // the user's customization across upgrades instead of overwriting it.
-  const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
-  if (defaultIds.has(id)) {
-    merged.userModifiedAt = Date.now();
+  // Only set the timestamp when the merged result actually diverges from the
+  // template — a no-op PATCH (same values) should not permanently opt a rule
+  // out of future template migrations.
+  const templates = getDefaultRuleTemplates();
+  const template = templates.find((t) => t.id === id);
+  if (template) {
+    const diverges =
+      merged.tool !== template.tool ||
+      merged.pattern !== template.pattern ||
+      merged.scope !== template.scope ||
+      merged.decision !== template.decision ||
+      merged.priority !== template.priority ||
+      merged.allowHighRisk !== template.allowHighRisk;
+    if (diverges) {
+      merged.userModifiedAt = Date.now();
+    } else {
+      // Rule matches the template again — clear the override marker so
+      // future template changes are applied normally.
+      delete merged.userModifiedAt;
+    }
   }
 
   // Canonicalize through parseTrustRule so that fields invalid for the

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -87,6 +87,13 @@ export interface TrustRuleBase {
   decision: TrustDecision;
   priority: number;
   createdAt: number;
+  /**
+   * Set when a user explicitly modifies a default trust rule.
+   * When present, `backfillDefaults()` will not overwrite the rule
+   * with updated template values on upgrade — preserving the user's
+   * customization.
+   */
+  userModifiedAt?: number;
 }
 
 /**
@@ -236,6 +243,8 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     typeof raw.createdAt === "number"
       ? raw.createdAt
       : ((normalized = true), 0);
+  const userModifiedAt =
+    typeof raw.userModifiedAt === "number" ? raw.userModifiedAt : undefined;
 
   // Build the base rule
   const base: TrustRuleBase = {
@@ -246,6 +255,7 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     decision,
     priority,
     createdAt,
+    ...(userModifiedAt != null ? { userModifiedAt } : {}),
   };
 
   // Determine the family and strip invalid fields


### PR DESCRIPTION
## Summary
- Add `userModifiedAt?: number` to `TrustRuleBase` in `ces-contracts`, preserved through `parseTrustRule()` and round-tripped to disk
- Remove the hard block on modifying default rules in `fileUpdateRule()` — instead, set `userModifiedAt: Date.now()` when a user updates a default rule
- In `backfillDefaults()`, skip the template migration for rules where `userModifiedAt` is set, so user customizations are preserved across version upgrades
- Add tests covering: userModifiedAt set on default rule update, not set on non-default rules, disk round-trip, backfill skip behavior

## Original prompt
Add a `userModifiedAt` timestamp field to `TrustRule` so we can track whether a user explicitly overrode a default trust rule. Then update the migration logic in `backfillDefaults()` to skip rules where `userModifiedAt` is set — preserving user customizations when we ship new defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
