### PR TITLE
feat(browser): propagate conversation context through host shell and browser IPC

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -674,6 +674,18 @@ describe("host_bash — spawn error handling", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("<command_completed />");
   });
+
+  test("injects __CONVERSATION_ID for local host_bash execution", async () => {
+    const result = await hostShellTool.execute(
+      {
+        command: 'echo "$__CONVERSATION_ID"',
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe("test-conversation");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -681,6 +693,34 @@ describe("host_bash — spawn error handling", () => {
 // ---------------------------------------------------------------------------
 
 describe("host_bash — proxy delegation", () => {
+  const ROUTING_ENV_KEYS = [
+    "BASE_DATA_DIR",
+    "VELLUM_WORKSPACE_DIR",
+    "VELLUM_DATA_DIR",
+    "VELLUM_ENVIRONMENT",
+    "INTERNAL_GATEWAY_BASE_URL",
+  ] as const;
+
+  function captureEnv(
+    keys: readonly string[],
+  ): Record<string, string | undefined> {
+    const snapshot: Record<string, string | undefined> = {};
+    for (const key of keys) {
+      snapshot[key] = process.env[key];
+    }
+    return snapshot;
+  }
+
+  function restoreEnv(snapshot: Record<string, string | undefined>): void {
+    for (const [key, value] of Object.entries(snapshot)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
   function makeMockProxy(result: ToolExecutionResult) {
     const calls: Array<{
       input: {
@@ -843,6 +883,12 @@ describe("host_bash — proxy delegation", () => {
       "ces-shell-lockdown": true,
     });
 
+    const envSnapshot = captureEnv(ROUTING_ENV_KEYS);
+    // Keep this test focused on lockdown propagation behavior only.
+    for (const key of ROUTING_ENV_KEYS) {
+      delete process.env[key];
+    }
+
     try {
       const proxyResult: ToolExecutionResult = {
         content: "proxied",
@@ -863,32 +909,92 @@ describe("host_bash — proxy delegation", () => {
 
       expect(result).toBe(proxyResult);
       expect(calls.length).toBe(1);
-      expect(calls[0].input.env).toEqual({ VELLUM_UNTRUSTED_SHELL: "1" });
+      expect(calls[0].input.env).toEqual({
+        VELLUM_UNTRUSTED_SHELL: "1",
+        __CONVERSATION_ID: "test-conversation",
+      });
     } finally {
       _setOverridesForTesting({});
+      restoreEnv(envSnapshot);
     }
   });
 
   test("does not propagate env to proxy when CES lockdown is inactive", async () => {
-    const proxyResult: ToolExecutionResult = {
-      content: "proxied",
-      isError: false,
-    };
-    const { proxy, calls } = makeMockProxy(proxyResult);
+    const envSnapshot = captureEnv(ROUTING_ENV_KEYS);
+    for (const key of ROUTING_ENV_KEYS) {
+      delete process.env[key];
+    }
 
-    const ctx: ToolContext = {
-      ...makeContext(),
-      trustClass: "guardian", // trusted actor — no lockdown
-      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
-    };
+    try {
+      const proxyResult: ToolExecutionResult = {
+        content: "proxied",
+        isError: false,
+      };
+      const { proxy, calls } = makeMockProxy(proxyResult);
 
-    const result = await hostShellTool.execute(
-      { command: "echo no-lockdown" },
-      ctx,
-    );
+      const ctx: ToolContext = {
+        ...makeContext(),
+        trustClass: "guardian", // trusted actor — no lockdown
+        hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+      };
 
-    expect(result).toBe(proxyResult);
-    expect(calls.length).toBe(1);
-    expect(calls[0].input.env).toBeUndefined();
+      const result = await hostShellTool.execute(
+        { command: "echo no-lockdown" },
+        ctx,
+      );
+
+      expect(result).toBe(proxyResult);
+      expect(calls.length).toBe(1);
+      expect(calls[0].input.env).toEqual({
+        __CONVERSATION_ID: "test-conversation",
+      });
+    } finally {
+      restoreEnv(envSnapshot);
+    }
+  });
+
+  test("propagates daemon routing env vars to proxy for nested assistant CLI calls", async () => {
+    const envSnapshot = captureEnv([
+      ...ROUTING_ENV_KEYS,
+      "VELLUM_UNTRUSTED_SHELL",
+    ]);
+    process.env.BASE_DATA_DIR = "/tmp/vellum-instance";
+    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-instance/.vellum/workspace";
+    process.env.VELLUM_DATA_DIR = "/tmp/vellum-instance/.vellum/workspace/data";
+    process.env.VELLUM_ENVIRONMENT = "local";
+    process.env.INTERNAL_GATEWAY_BASE_URL = "http://127.0.0.1:7830";
+    delete process.env.VELLUM_UNTRUSTED_SHELL;
+
+    try {
+      const proxyResult: ToolExecutionResult = {
+        content: "proxied",
+        isError: false,
+      };
+      const { proxy, calls } = makeMockProxy(proxyResult);
+
+      const ctx: ToolContext = {
+        ...makeContext(),
+        trustClass: "guardian", // trusted actor — no lockdown
+        hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+      };
+
+      const result = await hostShellTool.execute(
+        { command: "assistant browser status --json" },
+        ctx,
+      );
+
+      expect(result).toBe(proxyResult);
+      expect(calls.length).toBe(1);
+      expect(calls[0].input.env).toEqual({
+        BASE_DATA_DIR: "/tmp/vellum-instance",
+        VELLUM_WORKSPACE_DIR: "/tmp/vellum-instance/.vellum/workspace",
+        VELLUM_DATA_DIR: "/tmp/vellum-instance/.vellum/workspace/data",
+        VELLUM_ENVIRONMENT: "local",
+        INTERNAL_GATEWAY_BASE_URL: "http://127.0.0.1:7830",
+        __CONVERSATION_ID: "test-conversation",
+      });
+    } finally {
+      restoreEnv(envSnapshot);
+    }
   });
 });

--- a/assistant/src/cli/commands/__tests__/browser.test.ts
+++ b/assistant/src/cli/commands/__tests__/browser.test.ts
@@ -117,6 +117,8 @@ beforeEach(() => {
     result: { content: "ok", isError: false },
   };
   process.exitCode = 0;
+  delete process.env.__CONVERSATION_ID;
+  delete process.env.__SKILL_CONTEXT_JSON;
 });
 
 // ---------------------------------------------------------------------------
@@ -359,6 +361,34 @@ describe("IPC payload mapping", () => {
   test("default session is 'default'", async () => {
     await runCommand(["browser", "snapshot"]);
     expect(lastIpcCall!.params!.sessionId).toBe("default");
+  });
+
+  test("uses __CONVERSATION_ID for browser_execute when available", async () => {
+    process.env.__CONVERSATION_ID = "conv-from-env";
+
+    await runCommand(["browser", "status"]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("conv-from-env");
+  });
+
+  test("prefers __SKILL_CONTEXT_JSON.conversationId over __CONVERSATION_ID", async () => {
+    process.env.__CONVERSATION_ID = "conv-fallback";
+    process.env.__SKILL_CONTEXT_JSON = JSON.stringify({
+      conversationId: "conv-from-skill",
+    });
+
+    await runCommand(["browser", "status"]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("conv-from-skill");
+  });
+
+  test("falls back to __CONVERSATION_ID when __SKILL_CONTEXT_JSON is invalid", async () => {
+    process.env.__CONVERSATION_ID = "conv-fallback";
+    process.env.__SKILL_CONTEXT_JSON = "{invalid-json";
+
+    await runCommand(["browser", "status"]);
+
+    expect(lastIpcCall!.params!.conversationId).toBe("conv-fallback");
   });
 
   test("--browser-mode injects browser_mode into input", async () => {

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -58,6 +58,39 @@ function camelToSnake(camel: string): string {
 }
 
 /**
+ * Resolve conversation ID from CLI execution context.
+ *
+ * Precedence:
+ *   1. `__SKILL_CONTEXT_JSON.conversationId`
+ *   2. `__CONVERSATION_ID`
+ *
+ * Returns undefined when neither source is available.
+ */
+function resolveContextConversationId(): string | undefined {
+  const contextJson = process.env.__SKILL_CONTEXT_JSON;
+  if (contextJson) {
+    try {
+      const parsed = JSON.parse(contextJson) as { conversationId?: unknown };
+      if (
+        typeof parsed.conversationId === "string" &&
+        parsed.conversationId.length > 0
+      ) {
+        return parsed.conversationId;
+      }
+    } catch {
+      // Ignore malformed skill context and fall through.
+    }
+  }
+
+  const envConversationId = process.env.__CONVERSATION_ID;
+  if (envConversationId && envConversationId.length > 0) {
+    return envConversationId;
+  }
+
+  return undefined;
+}
+
+/**
  * Parse a CLI option value according to its field type.
  */
 function parseFieldValue(
@@ -134,6 +167,7 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
     };
     const sessionId = parentOpts.session ?? "default";
     const jsonMode = parentOpts.json ?? false;
+    const conversationId = resolveContextConversationId();
 
     // Map Commander camelCase options back to snake_case input keys,
     // filtering out parent-level options (session, json, browserMode)
@@ -170,6 +204,7 @@ function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
         operation: meta.operation,
         input,
         sessionId,
+        ...(conversationId ? { conversationId } : {}),
       },
       { timeoutMs: 180_000 },
     );

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -27,6 +27,7 @@ import type { CesProcessManager } from "../credential-execution/process-manager.
 import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { CliIpcServer } from "../ipc/cli-server.js";
+import { registerBrowserIpcContextResolver } from "../ipc/routes/browser-context.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
@@ -868,6 +869,23 @@ export class DaemonServer {
       // the user submits, cancels, or the timeout elapses.
       const surfaceId = `ui-standalone-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       return showStandaloneSurface(conversation, request, surfaceId);
+    });
+
+    // Allow `browser_execute` IPC calls to reuse live conversation browser
+    // proxy wiring (when a caller passes a conversationId from
+    // __CONVERSATION_ID / __SKILL_CONTEXT_JSON). This keeps nested
+    // `assistant browser status` checks consistent with the parent turn's
+    // extension connectivity instead of always falling back to a synthetic
+    // browser-cli session that has no hostBrowserProxy.
+    registerBrowserIpcContextResolver((conversationId) => {
+      const conversation = this.conversations.get(conversationId);
+      if (!conversation) return null;
+      return {
+        conversationId,
+        trustClass: conversation.trustContext?.trustClass ?? "guardian",
+        hostBrowserProxy: conversation.hostBrowserProxy,
+        transportInterface: conversation.transportInterface,
+      };
     });
 
     // Start the CLI IPC server. Built-in methods (wake_conversation) are

--- a/assistant/src/ipc/__tests__/browser-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/browser-ipc.test.ts
@@ -21,20 +21,56 @@ let mockOperationCalls: Array<{
   operation: string;
   input: Record<string, unknown>;
   conversationId: string;
+  trustClass?: string;
+  hostBrowserProxy?: unknown;
+  transportInterface?: string;
+}> = [];
+let mockResolvedContext: {
+  conversationId: string;
+  trustClass: string;
+  hostBrowserProxy?: unknown;
+  transportInterface?: string;
+} | null = null;
+let mockResolverCalls: Array<{
+  requestedConversationId?: string;
+  fallbackConversationId: string;
 }> = [];
 
 mock.module("../../browser/operations.js", () => ({
   executeBrowserOperation: async (
     operation: string,
     input: Record<string, unknown>,
-    context: { conversationId: string },
+    context: {
+      conversationId: string;
+      trustClass?: string;
+      hostBrowserProxy?: unknown;
+      transportInterface?: string;
+    },
   ) => {
     mockOperationCalls.push({
       operation,
       input,
       conversationId: context.conversationId,
+      trustClass: context.trustClass,
+      hostBrowserProxy: context.hostBrowserProxy,
+      transportInterface: context.transportInterface,
     });
     return mockOperationResult;
+  },
+}));
+
+mock.module("../routes/browser-context.js", () => ({
+  resolveBrowserIpcContext: (params: {
+    requestedConversationId?: string;
+    fallbackConversationId: string;
+  }) => {
+    mockResolverCalls.push(params);
+    return (
+      mockResolvedContext ?? {
+        conversationId: params.fallbackConversationId,
+        trustClass: "guardian",
+      }
+    );
   },
 }));
 
@@ -49,6 +85,8 @@ const { browserExecuteRoute, browserCliConversationKey } =
 afterEach(() => {
   mockOperationResult = { content: "ok", isError: false };
   mockOperationCalls = [];
+  mockResolvedContext = null;
+  mockResolverCalls = [];
 });
 
 // ---------------------------------------------------------------------------
@@ -120,6 +158,46 @@ describe("browser_execute IPC route", () => {
 
     expect(mockOperationCalls).toHaveLength(1);
     expect(mockOperationCalls[0].conversationId).toBe("browser-cli:default");
+  });
+
+  test("passes requested conversationId to context resolver", async () => {
+    await browserExecuteRoute.handler({
+      operation: "status",
+      input: {},
+      sessionId: "s1",
+      conversationId: "conv-live-123",
+    });
+
+    expect(mockResolverCalls).toHaveLength(1);
+    expect(mockResolverCalls[0]).toEqual({
+      requestedConversationId: "conv-live-123",
+      fallbackConversationId: "browser-cli:s1",
+    });
+  });
+
+  test("uses resolved context fields when resolver returns live conversation context", async () => {
+    const fakeProxy = { isAvailable: () => true };
+    mockResolvedContext = {
+      conversationId: "conv-live-456",
+      trustClass: "trusted",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "chrome-extension",
+    };
+
+    await browserExecuteRoute.handler({
+      operation: "status",
+      input: {},
+      sessionId: "unused",
+      conversationId: "conv-live-456",
+    });
+
+    expect(mockOperationCalls).toHaveLength(1);
+    expect(mockOperationCalls[0]).toMatchObject({
+      conversationId: "conv-live-456",
+      trustClass: "trusted",
+      hostBrowserProxy: fakeProxy,
+      transportInterface: "chrome-extension",
+    });
   });
 
   test("same sessionId produces same conversation key", () => {

--- a/assistant/src/ipc/routes/browser-context.ts
+++ b/assistant/src/ipc/routes/browser-context.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared context resolver for `browser_execute` IPC calls.
+ *
+ * The browser CLI can optionally pass a live conversation ID (for example
+ * from `__CONVERSATION_ID` in a nested `bash` tool invocation). When that
+ * conversation is currently active in daemon memory, we can reuse its
+ * host-browser proxy wiring so browser operations (including `status`) see
+ * extension connectivity exactly as the parent turn does.
+ *
+ * If no resolver is registered, or the requested conversation isn't active,
+ * callers fall back to the deterministic `browser-cli:<sessionId>` context.
+ */
+
+import type { InterfaceId } from "../../channels/types.js";
+import type { HostBrowserProxy } from "../../daemon/host-browser-proxy.js";
+import type { TrustClass } from "../../runtime/actor-trust-resolver.js";
+
+export interface BrowserIpcContextResolution {
+  conversationId: string;
+  trustClass: TrustClass;
+  hostBrowserProxy?: HostBrowserProxy;
+  transportInterface?: InterfaceId;
+}
+
+export type BrowserIpcContextResolver = (
+  conversationId: string,
+) => BrowserIpcContextResolution | null;
+
+let resolver: BrowserIpcContextResolver | null = null;
+
+export function registerBrowserIpcContextResolver(
+  nextResolver: BrowserIpcContextResolver,
+): void {
+  resolver = nextResolver;
+}
+
+/**
+ * Test-only helper to clear the module-level resolver.
+ *
+ * @internal
+ */
+export function resetBrowserIpcContextResolverForTests(): void {
+  resolver = null;
+}
+
+export function resolveBrowserIpcContext(params: {
+  requestedConversationId?: string;
+  fallbackConversationId: string;
+}): BrowserIpcContextResolution {
+  const { requestedConversationId, fallbackConversationId } = params;
+
+  if (requestedConversationId && resolver) {
+    const resolved = resolver(requestedConversationId);
+    if (resolved) return resolved;
+  }
+
+  return {
+    conversationId: fallbackConversationId,
+    trustClass: "guardian",
+  };
+}

--- a/assistant/src/ipc/routes/browser.ts
+++ b/assistant/src/ipc/routes/browser.ts
@@ -18,6 +18,7 @@ import {
 } from "../../browser/types.js";
 import type { ContentBlock } from "../../providers/types.js";
 import type { IpcRoute } from "../cli-server.js";
+import { resolveBrowserIpcContext } from "./browser-context.js";
 
 // ── Param validation ─────────────────────────────────────────────────
 
@@ -25,6 +26,7 @@ const BrowserExecuteParams = z.object({
   operation: z.enum(BROWSER_OPERATIONS as unknown as [string, ...string[]]),
   input: z.record(z.string(), z.unknown()).default({}),
   sessionId: z.string().min(1).default("default"),
+  conversationId: z.string().min(1).optional(),
 });
 
 // ── Conversation key ─────────────────────────────────────────────────
@@ -64,17 +66,22 @@ function extractScreenshots(
 export const browserExecuteRoute: IpcRoute = {
   method: "browser_execute",
   handler: async (params) => {
-    const { operation, input, sessionId } = BrowserExecuteParams.parse(params);
-
-    const conversationId = browserCliConversationKey(sessionId);
+    const { operation, input, sessionId, conversationId } =
+      BrowserExecuteParams.parse(params);
+    const resolvedContext = resolveBrowserIpcContext({
+      requestedConversationId: conversationId,
+      fallbackConversationId: browserCliConversationKey(sessionId),
+    });
 
     const result = await executeBrowserOperation(
       operation as BrowserOperation,
       input,
       {
         workingDir: process.cwd(),
-        conversationId,
-        trustClass: "guardian",
+        conversationId: resolvedContext.conversationId,
+        trustClass: resolvedContext.trustClass,
+        hostBrowserProxy: resolvedContext.hostBrowserProxy,
+        transportInterface: resolvedContext.transportInterface,
       },
     );
 

--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ToolContext } from "../../types.js";
 import {
@@ -13,6 +13,11 @@ const probeOutcomes: Record<string, ProbeOutcome> = {
   [BROWSER_STATUS_MODE.EXTENSION]: "ok",
   [BROWSER_STATUS_MODE.CDP_INSPECT]: "ok",
   [BROWSER_STATUS_MODE.LOCAL]: "ok",
+};
+const probeErrors: Record<string, CdpError | null> = {
+  [BROWSER_STATUS_MODE.EXTENSION]: null,
+  [BROWSER_STATUS_MODE.CDP_INSPECT]: null,
+  [BROWSER_STATUS_MODE.LOCAL]: null,
 };
 
 const buildCandidateListMock = mock((_context: ToolContext) => [
@@ -30,7 +35,10 @@ const getCdpClientMock = mock(
       conversationId: "test-conversation",
       send: mock(async () => {
         if (outcome === "fail") {
-          throw new CdpError("transport_error", `${mode} probe failed`);
+          throw (
+            probeErrors[mode] ??
+            new CdpError("transport_error", `${mode} probe failed`)
+          );
         }
         return { result: { value: "complete" } };
       }),
@@ -86,6 +94,15 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 }
 
 describe("executeBrowserStatus", () => {
+  beforeEach(() => {
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "ok";
+    probeOutcomes[BROWSER_STATUS_MODE.CDP_INSPECT] = "ok";
+    probeOutcomes[BROWSER_STATUS_MODE.LOCAL] = "ok";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = null;
+    probeErrors[BROWSER_STATUS_MODE.CDP_INSPECT] = null;
+    probeErrors[BROWSER_STATUS_MODE.LOCAL] = null;
+  });
+
   test("reports extension preflight-unavailable when no host browser proxy is bound", async () => {
     const result = await executeBrowserStatus({}, makeContext());
     expect(result.isError).toBe(false);
@@ -119,5 +136,31 @@ describe("executeBrowserStatus", () => {
     expect(result.content).toContain(
       `${BROWSER_STATUS_INPUT_FIELD.CHECK_LOCAL_LAUNCH} must be a boolean`,
     );
+  });
+
+  test("reports extension as connected when probe fails on restricted chrome:// page", async () => {
+    probeOutcomes[BROWSER_STATUS_MODE.EXTENSION] = "fail";
+    probeErrors[BROWSER_STATUS_MODE.EXTENSION] = new CdpError(
+      "cdp_error",
+      "Cannot access a chrome:// URL",
+    );
+
+    const result = await executeBrowserStatus(
+      {},
+      makeContext({
+        hostBrowserProxy: {
+          isAvailable: () => true,
+        } as ToolContext["hostBrowserProxy"],
+      }),
+    );
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    const extension = payload.modes.find(
+      (m: { mode: string }) => m.mode === BROWSER_STATUS_MODE.EXTENSION,
+    );
+    expect(extension).toBeDefined();
+    expect(extension.available).toBe(true);
+    expect(extension.verified).toBe("active_probe");
+    expect(extension.details.restrictedActiveTab).toBe(true);
   });
 });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -327,6 +327,14 @@ function collectRemediationHints(
 }
 
 /**
+ * Detect the common extension CDP failure where the active tab is a
+ * restricted Chrome internal page (e.g. `chrome://newtab`).
+ */
+function isRestrictedChromePageProbeError(error: CdpError): boolean {
+  return error.message.toLowerCase().includes("chrome://");
+}
+
+/**
  * Parse browser_mode from input and acquire a CdpClient. Returns
  * either a `{ cdp, browserMode }` pair on success or a pre-formatted
  * `{ errorResult }` on failure (invalid mode or pinned-mode
@@ -2291,6 +2299,29 @@ async function checkExtensionModeStatus(
         proxyBound,
         proxyConnected,
         backendKind: probe.backendKind,
+      },
+    };
+  }
+
+  if (isRestrictedChromePageProbeError(probe.error)) {
+    return {
+      mode: BROWSER_STATUS_MODE.EXTENSION,
+      available: true,
+      verified: "active_probe",
+      autoCandidate,
+      summary:
+        "Extension mode transport is connected, but the active Chrome tab is a restricted chrome:// page. Switch to a regular website tab if browser actions fail.",
+      userActions: [
+        "Switch Chrome to a regular http(s) tab (not chrome://...) and retry.",
+      ],
+      tradeoffs: modeTradeoffs(BROWSER_STATUS_MODE.EXTENSION),
+      details: {
+        proxyBound,
+        proxyConnected,
+        restrictedActiveTab: true,
+        errorCode: probe.error.code,
+        diagnostic: probe.diagnostic,
+        attemptDiagnostics: probe.error.attemptDiagnostics ?? [],
       },
     };
   }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -31,6 +31,18 @@ import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("host-shell-tool");
 
+const HOST_BASH_PROXY_ENV_KEYS = [
+  // Preserve per-instance routing so nested `assistant` CLI commands invoked
+  // over host_bash proxy target the same daemon/socket as the origin turn.
+  "BASE_DATA_DIR",
+  "VELLUM_WORKSPACE_DIR",
+  // Keep legacy/diagnostic workspace + environment context aligned.
+  "VELLUM_DATA_DIR",
+  "VELLUM_ENVIRONMENT",
+  // Preserve local control-plane routing when nested commands call APIs.
+  "INTERNAL_GATEWAY_BASE_URL",
+] as const;
+
 function buildHostShellEnv(): Record<string, string> {
   const env = buildSanitizedEnv();
   // Ensure ~/.local/bin and ~/.bun/bin are in PATH so `vellum` and `bun` are
@@ -43,6 +55,29 @@ function buildHostShellEnv(): Record<string, string> {
   if (missing.length > 0) {
     env.PATH = [...missing, currentPath].filter(Boolean).join(":");
   }
+  return env;
+}
+
+function buildHostBashProxyEnv(
+  hostLockdownActive: boolean,
+  conversationId: string,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const key of HOST_BASH_PROXY_ENV_KEYS) {
+    const value = process.env[key];
+    if (value != null && value.length > 0) {
+      env[key] = value;
+    }
+  }
+
+  if (hostLockdownActive) {
+    env.VELLUM_UNTRUSTED_SHELL = "1";
+  }
+
+  // Keep nested `assistant` CLI calls in host_bash aligned with the
+  // originating conversation so browser IPC can resolve live proxy context.
+  env.__CONVERSATION_ID = conversationId;
   return env;
 }
 
@@ -150,11 +185,13 @@ class HostShellTool implements Tool {
         1,
         Math.min(rawSec, shellMaxTimeoutSec),
       );
-      // Propagate VELLUM_UNTRUSTED_SHELL to the proxied client so CLI
-      // commands self-deny raw-secret flows even when executed remotely.
-      const proxyEnv: Record<string, string> | undefined = hostLockdownActive
-        ? { VELLUM_UNTRUSTED_SHELL: "1" }
-        : undefined;
+      // Forward instance-routing env vars so nested `assistant` CLI commands
+      // executed on a proxied host machine can still resolve the correct
+      // daemon IPC socket and workspace, plus lockdown marker when required.
+      const proxyEnv = buildHostBashProxyEnv(
+        hostLockdownActive,
+        context.conversationId,
+      );
       return context.hostBashProxy.request(
         {
           command,
@@ -199,6 +236,9 @@ class HostShellTool implements Tool {
       if (hostLockdownActive) {
         hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
       }
+      // Match `bash` tool behavior so nested assistant CLI calls can bind to
+      // the active conversation when running through host_bash.
+      hostEnv.__CONVERSATION_ID = context.conversationId;
 
       const child = spawn("bash", ["-c", "--", command], {
         cwd: workingDir,


### PR DESCRIPTION
## Summary
- Propagate `__CONVERSATION_ID` and daemon routing env vars through host shell (local + proxied) so nested `assistant browser` CLI calls resolve the parent conversation's live browser proxy context via a new `browser-context.ts` IPC resolver
- Browser CLI now reads `__CONVERSATION_ID` / `__SKILL_CONTEXT_JSON` to pass conversation context to browser IPC calls
- Extension CDP probe failures on restricted `chrome://` pages are now reported as "connected but restricted" instead of "unavailable"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
