### PR TITLE
feat: add tasks skill to skills/ with CLI-based SKILL.md

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -463,6 +463,25 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "tasks",
+      "name": "tasks",
+      "description": "Two-layer task system with reusable templates and a prioritized work queue",
+      "metadata": {
+        "emoji": "✅",
+        "vellum": {
+          "display-name": "Tasks",
+          "activation-hints": [
+            "User wants to add, check, or manage items on their to-do list or task queue",
+            "For one-off action items, not recurring automations (use schedule for those)"
+          ],
+          "avoid-when": [
+            "User wants recurring/scheduled automation — use the schedule skill instead"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "telegram-setup",
       "name": "telegram-setup",
       "description": "Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage",

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: tasks
+description: Two-layer task system with reusable templates and a prioritized work queue
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "✅"
+  vellum:
+    display-name: "Tasks"
+    activation-hints:
+      - "User wants to add, check, or manage items on their to-do list or task queue"
+      - "For one-off action items, not recurring automations (use schedule for those)"
+    avoid-when:
+      - "User wants recurring/scheduled automation — use the schedule skill instead"
+---
+
+Two-layer task system: **task templates** (reusable definitions with input placeholders) and **work items** (instances in the Task Queue with priority tiers and status tracking).
+
+## Task Templates
+
+Templates are reusable definitions saved from conversations. They capture the conversation pattern with placeholders that can be run later with different inputs. Manage templates with the `assistant task` CLI:
+
+```bash
+# Save the current conversation as a reusable task template
+assistant task save --conversation-id <id> --title "Weekly report"
+
+# List all saved task templates
+assistant task list
+
+# Run a saved template with specific inputs
+assistant task run --name "Weekly report" --inputs '{"team": "engineering"}'
+
+# Delete a task template by ID
+assistant task delete <id>
+```
+
+## Work Items (Task Queue)
+
+Work items are the user-facing "Tasks" managed through conversation. They track status and priority:
+
+- **Priority tiers**: 0 = high, 1 = medium (default), 2 = low
+- **Status flow**: queued -> running -> awaiting_review -> done
+- **Resolution precedence**: work_item_id > task_id > task_name > title
+
+Manage the queue with `assistant task queue`:
+
+```bash
+# View the current task queue
+assistant task queue show
+
+# Add an item to the queue (ad-hoc or from a template)
+assistant task queue add --title "Review Q2 metrics" --required-tools host_bash web_search
+
+# Update a work item's status
+assistant task queue update --work-item-id <id> --status done
+
+# Remove a work item from the queue
+assistant task queue remove --work-item-id <id>
+
+# Run a specific work item from the queue
+assistant task queue run --work-item-id <id>
+```
+
+## Tips
+
+- When the user says "add to my tasks" or "add to my queue", use `assistant task queue add` (NOT schedule).
+- Use `assistant task save` only when the user wants to capture a conversation pattern as a reusable template.
+- `assistant task list` shows saved templates; `assistant task queue show` shows the active work queue.
+- **Always specify `--required-tools`** when running `assistant task queue add`. Think about what tools the task will need at execution time and list them explicitly (e.g. `host_bash` for shell commands, `host_file_read host_file_write` for file operations, `web_search web_fetch` for web lookups). The user must approve these tools before the task can run -- omitting them forces a fallback to all tools, which is noisy and may miss non-standard tools the task actually needs.

--- a/skills/tasks/assets/icon.svg
+++ b/skills/tasks/assets/icon.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect width="16" height="16" fill="#f0f0f0"/>
+  
+  <!-- Left task list (template layer) -->
+  <rect x="1" y="2" width="6" height="12" fill="#e8f4f8" stroke="#4a90e2" stroke-width="0.5"/>
+  <rect x="2" y="3" width="4" height="1" fill="#4a90e2"/>
+  <rect x="2" y="5" width="1" height="1" fill="#2ecc71"/>
+  <rect x="4" y="5" width="2" height="1" fill="#95a5a6"/>
+  <rect x="2" y="7" width="1" height="1" fill="#2ecc71"/>
+  <rect x="4" y="7" width="2" height="1" fill="#95a5a6"/>
+  <rect x="2" y="9" width="1" height="1" fill="#2ecc71"/>
+  <rect x="4" y="9" width="2" height="1" fill="#95a5a6"/>
+  <rect x="2" y="11" width="1" height="1" fill="#2ecc71"/>
+  <rect x="4" y="11" width="2" height="1" fill="#95a5a6"/>
+  
+  <!-- Right task queue (prioritized work) -->
+  <rect x="9" y="2" width="6" height="12" fill="#fff4e6" stroke="#f39c12" stroke-width="0.5"/>
+  <rect x="10" y="3" width="4" height="1" fill="#f39c12"/>
+  
+  <!-- Priority indicators (arrows) -->
+  <rect x="10" y="5" width="1" height="1" fill="#e74c3c"/>
+  <rect x="12" y="5" width="2" height="1" fill="#95a5a6"/>
+  
+  <rect x="10" y="7" width="1" height="1" fill="#f39c12"/>
+  <rect x="12" y="7" width="2" height="1" fill="#95a5a6"/>
+  
+  <rect x="10" y="9" width="1" height="1" fill="#2ecc71"/>
+  <rect x="12" y="9" width="2" height="1" fill="#95a5a6"/>
+  
+  <!-- Connection arrow between lists -->
+  <rect x="7" y="7" width="2" height="1" fill="#4a90e2" opacity="0.6"/>
+  <rect x="8" y="6" width="1" height="1" fill="#4a90e2" opacity="0.6"/>
+  <rect x="8" y="8" width="1" height="1" fill="#4a90e2" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add tasks skill to skills/ following AGENTS.md guidelines
- Rewrite SKILL.md to reference CLI commands instead of custom tools
- Move icon.svg to assets/

Part of plan: migrate-tasks-to-skills.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
