### PR TITLE
feat(cli): add `assistant inference send` command with `assistant llm` alias

### DIFF
--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Tests for the `assistant inference send` and `assistant llm send` CLI
+ * commands.
+ *
+ * Validates:
+ *   - Help text renders for both `inference send` and `llm send`
+ *   - Error when no LLM provider is configured
+ *   - Error when no message is provided (no args, no stdin)
+ *   - Success with mocked provider (response text on stdout)
+ *   - `--system-prompt` is passed through to the provider call
+ *   - `--json` output format
+ *   - `--model` override is passed through
+ *   - `llm send` produces the same result as `inference send`
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../../../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** Whether `getConfiguredProvider` returns a mock provider or null. */
+let mockProviderAvailable = true;
+
+/** The response the mock provider will return. */
+let mockProviderResponse: ProviderResponse = {
+  content: [{ type: "text", text: "42" }],
+  model: "claude-test-1",
+  usage: { inputTokens: 10, outputTokens: 5 },
+  stopReason: "end_turn",
+};
+
+/** Captures the last `sendMessage` call for assertions. */
+let lastSendMessageCall: {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  systemPrompt?: string;
+  options?: SendMessageOptions;
+} | null = null;
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockProvider: Provider = {
+  name: "mock-provider",
+  sendMessage: async (
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ) => {
+    lastSendMessageCall = { messages, tools, systemPrompt, options };
+    return mockProviderResponse;
+  },
+};
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () =>
+    mockProviderAvailable ? mockProvider : null,
+  extractAllText: (response: ProviderResponse) => {
+    return response.content
+      .filter(
+        (
+          b,
+        ): b is Extract<(typeof response.content)[number], { type: "text" }> =>
+          b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" ");
+  },
+  userMessage: (text: string): Message => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerInferenceCommand } = await import("../inference.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerInferenceCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockProviderAvailable = true;
+  mockProviderResponse = {
+    content: [{ type: "text", text: "42" }],
+    model: "claude-test-1",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+  lastSendMessageCall = null;
+  mockStdinContent = null;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("inference send --help renders argument docs", async () => {
+    const { stdout } = await runCommand(["inference", "send", "--help"]);
+    expect(stdout).toContain("send");
+    expect(stdout).toContain("--system-prompt");
+    expect(stdout).toContain("--model");
+    expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("[message...]");
+  });
+
+  test("llm send --help renders argument docs", async () => {
+    const { stdout } = await runCommand(["llm", "send", "--help"]);
+    expect(stdout).toContain("send");
+    expect(stdout).toContain("--system-prompt");
+    expect(stdout).toContain("--model");
+    expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("[message...]");
+  });
+
+  test("inference --help renders with examples", async () => {
+    const { stdout } = await runCommand(["inference", "--help"]);
+    expect(stdout).toContain("inference");
+    expect(stdout).toContain("Examples:");
+  });
+
+  test("llm --help renders with examples", async () => {
+    const { stdout } = await runCommand(["llm", "--help"]);
+    expect(stdout).toContain("llm");
+    expect(stdout).toContain("Examples:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error: no provider configured
+// ---------------------------------------------------------------------------
+
+describe("no provider configured", () => {
+  test("exits with code 1 and actionable error when no provider", async () => {
+    mockProviderAvailable = false;
+
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "Hello",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No LLM provider is configured");
+    expect(parsed.error).toContain("assistant config set");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error: no message provided
+// ---------------------------------------------------------------------------
+
+describe("no message provided", () => {
+  test("exits with code 1 when no args and no stdin", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No message provided");
+  });
+
+  test("exits with code 1 when empty stdin", async () => {
+    mockStdinContent = "   ";
+
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No message provided");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success: positional args
+// ---------------------------------------------------------------------------
+
+describe("success with positional args", () => {
+  test("sends message and prints response text", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "What",
+      "is",
+      "2+2?",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("42");
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.messages[0].content[0]).toEqual({
+      type: "text",
+      text: "What is 2+2?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success: stdin
+// ---------------------------------------------------------------------------
+
+describe("success with stdin", () => {
+  test("reads message from stdin when no positional args", async () => {
+    mockStdinContent = "What is 2+2?";
+
+    const { exitCode, stdout } = await runCommand(["inference", "send"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("42");
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.messages[0].content[0]).toEqual({
+      type: "text",
+      text: "What is 2+2?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --system-prompt
+// ---------------------------------------------------------------------------
+
+describe("--system-prompt", () => {
+  test("passes system prompt through to provider", async () => {
+    await runCommand([
+      "inference",
+      "send",
+      "--system-prompt",
+      "You are a poet",
+      "Write a haiku",
+    ]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.systemPrompt).toBe("You are a poet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --json output
+// ---------------------------------------------------------------------------
+
+describe("--json output", () => {
+  test("produces structured JSON with response, model, and usage", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.response).toBe("42");
+    expect(parsed.model).toBe("claude-test-1");
+    expect(parsed.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --model override
+// ---------------------------------------------------------------------------
+
+describe("--model override", () => {
+  test("passes model override through to provider config", async () => {
+    await runCommand([
+      "inference",
+      "send",
+      "--model",
+      "claude-sonnet-4-20250514",
+      "Hello",
+    ]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.options?.config?.model).toBe(
+      "claude-sonnet-4-20250514",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --max-tokens
+// ---------------------------------------------------------------------------
+
+describe("--max-tokens", () => {
+  test("passes max tokens through to provider config", async () => {
+    await runCommand(["inference", "send", "--max-tokens", "1024", "Hello"]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.options?.config?.max_tokens).toBe(1024);
+  });
+
+  test("errors on invalid max-tokens value", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--max-tokens",
+      "abc",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("Invalid --max-tokens");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// llm alias equivalence
+// ---------------------------------------------------------------------------
+
+describe("llm alias", () => {
+  test("llm send produces the same result as inference send", async () => {
+    const inferenceResult = await runCommand([
+      "inference",
+      "send",
+      "--json",
+      "Hello",
+    ]);
+
+    // Reset for the second call
+    lastSendMessageCall = null;
+
+    const llmResult = await runCommand(["llm", "send", "--json", "Hello"]);
+
+    expect(inferenceResult.exitCode).toBe(0);
+    expect(llmResult.exitCode).toBe(0);
+    expect(inferenceResult.stdout).toBe(llmResult.stdout);
+  });
+});

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import {
+  extractAllText,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { log } from "../logger.js";
+
+/**
+ * Attach the `send` subcommand to the given command group (`inference` or
+ * `llm`). Both groups share the same implementation.
+ */
+function attachSendSubcommand(group: Command): void {
+  group
+    .command("send")
+    .description("Send a message to the configured LLM and print the response")
+    .option("--system-prompt <text>", "System prompt for the model")
+    .option("--model <model-id>", "Model override")
+    .option("--max-tokens <n>", "Max response tokens", undefined)
+    .option("--json", "Output structured JSON")
+    .argument("[message...]", "User message (joined with spaces)")
+    .addHelpText(
+      "after",
+      `
+Behavioral notes:
+  - If no message argument is provided, reads from stdin.
+  - If --model is omitted, uses the configured default model.
+  - Requires a configured LLM provider (see 'assistant config set').
+
+Examples:
+  $ assistant inference send "What is 2+2?"
+  $ echo "Summarize this" | assistant inference send
+  $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"`,
+    )
+    .action(
+      async (
+        messageParts: string[],
+        opts: {
+          systemPrompt?: string;
+          model?: string;
+          maxTokens?: string;
+          json?: boolean;
+        },
+      ) => {
+        const { systemPrompt, model, json: jsonOutput } = opts;
+        const maxTokens = opts.maxTokens
+          ? parseInt(opts.maxTokens, 10)
+          : undefined;
+
+        if (
+          opts.maxTokens !== undefined &&
+          (!Number.isFinite(maxTokens) || maxTokens! < 1)
+        ) {
+          const msg = "Invalid --max-tokens value. Must be a positive integer.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Determine user message: positional args or stdin.
+        let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
+
+        if (!messageText) {
+          try {
+            messageText = readFileSync("/dev/stdin", "utf-8").trim();
+          } catch {
+            // stdin not available or empty
+          }
+        }
+
+        if (!messageText) {
+          const msg =
+            "No message provided. Pass a message as an argument or pipe via stdin.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Resolve provider.
+        const provider = await getConfiguredProvider("inference");
+        if (!provider) {
+          const msg =
+            "No LLM provider is configured. Run 'assistant config set llm.default.provider <provider>' to set one up.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        try {
+          const response = await provider.sendMessage(
+            [userMessage(messageText)],
+            undefined,
+            systemPrompt,
+            {
+              config: {
+                callSite: "inference",
+                max_tokens: maxTokens,
+                model,
+              },
+            },
+          );
+
+          const text = extractAllText(response);
+
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                response: text,
+                model: response.model,
+                usage: {
+                  inputTokens: response.usage.inputTokens,
+                  outputTokens: response.usage.outputTokens,
+                },
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write(text + "\n");
+          }
+        } catch (err) {
+          const msg =
+            err instanceof Error ? err.message : "Unknown error occurred";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
+}
+
+/**
+ * Register `inference` and `llm` command groups on the top-level program.
+ * Both expose the same subcommands — `llm` is an alias for `inference`.
+ */
+export function registerInferenceCommand(program: Command): void {
+  const inference = program
+    .command("inference")
+    .description("LLM inference operations");
+
+  inference.addHelpText(
+    "after",
+    `
+The inference command group sends requests to your configured LLM provider.
+The provider is resolved from your assistant config (llm.default.provider).
+
+Examples:
+  $ assistant inference send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant inference send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"`,
+  );
+
+  attachSendSubcommand(inference);
+
+  const llm = program
+    .command("llm")
+    .description("LLM inference operations (alias for 'inference')");
+
+  llm.addHelpText(
+    "after",
+    `
+The llm command group is an alias for 'inference'. It sends requests to your
+configured LLM provider, resolved from your assistant config (llm.default.provider).
+
+Examples:
+  $ assistant llm send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant llm send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant llm send --model claude-sonnet-4-20250514 --json "Hello"`,
+  );
+
+  attachSendSubcommand(llm);
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -26,6 +26,7 @@ import { registerCredentialsCommand } from "./commands/credentials.js";
 import { registerDefaultAction } from "./commands/default-action.js";
 import { registerDomainCommand } from "./commands/domain.js";
 import { registerEmailCommand } from "./commands/email.js";
+import { registerInferenceCommand } from "./commands/inference.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
 import { registerMemoryCommand } from "./commands/memory.js";
@@ -100,6 +101,8 @@ Examples:
 
   registerShotgunCommand(program);
   registerSequenceCommand(program);
+
+  registerInferenceCommand(program);
 
   // Fail fast when no assistant workspace exists on disk. The workspace is
   // created by `vellum hatch` and must be present for any command to work.

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -65,6 +65,7 @@ export const LLMCallSiteEnum = z.enum([
   "skillCategoryInference",
   "meetConsentMonitor",
   "meetChatOpportunity",
+  "inference",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 
@@ -297,9 +298,7 @@ export const LLMSchema = z
     // every call site). Latency-optimized defaults for background call sites
     // are seeded into the user's on-disk config by migration 040, not at
     // schema level, so `LLMSchema.parse({})` yields an empty map.
-    callSites: z
-      .partialRecord(LLMCallSiteEnum, LLMCallSiteConfig)
-      .default({}),
+    callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {


### PR DESCRIPTION
## Summary
- Add `assistant inference` and `assistant llm` command groups with `send` subcommand
- Sends messages to the configured LLM provider with system prompt, model, and token options
- Supports stdin piping and --json structured output

Part of plan: service-cli-commands.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
