### PR TITLE
feat(cli): add `assistant stt transcribe` command

### DIFF
--- a/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
+++ b/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the `assistant stt transcribe` CLI command.
+ *
+ * Validates:
+ *   - Help text renders correctly for `stt` and `stt transcribe`
+ *   - Error when --file points to a nonexistent file
+ *   - Error when no STT provider is configured
+ *   - Success case with mocked transcriber
+ *   - --json output format
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import type { BatchTranscriber } from "../../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockAccessResult: "ok" | Error = "ok";
+let mockTranscriber: BatchTranscriber | null = null;
+let mockSpawnResult = {
+  exitCode: 0,
+  stdout: "120.5",
+  stderr: "",
+};
+let mockFileSize = 1024;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before module-under-test import
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs/promises", () => ({
+  access: async () => {
+    if (mockAccessResult !== "ok") throw mockAccessResult;
+  },
+  readFile: async () => Buffer.from("fake-audio-data"),
+  unlink: async () => {},
+  mkdir: async () => {},
+  readdir: async () => [],
+  rm: async () => {},
+}));
+
+mock.module("../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => mockTranscriber,
+}));
+
+mock.module("../../../util/spawn.js", () => ({
+  FFMPEG_TRANSCODE_TIMEOUT_MS: 120_000,
+  FFPROBE_TIMEOUT_MS: 15_000,
+  spawnWithTimeout: async () => mockSpawnResult,
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ services: { stt: { provider: "openai-whisper" } } }),
+  getConfigReadOnly: () => ({
+    services: { stt: { provider: "openai-whisper" } },
+  }),
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  initFeatureFlagOverrides: async () => {},
+  _setOverridesForTesting: () => {},
+  isFeatureEnabled: () => true,
+}));
+
+// Mock Bun.file for file size checks
+const _originalBunFile = Bun.file;
+Bun.file = ((_path: string) => ({
+  size: mockFileSize,
+})) as typeof Bun.file;
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerSttCommand } = await import("../stt.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  // Mock process.exit to throw so we can capture it
+  const originalExit = process.exit;
+  process.exit = ((code?: number) => {
+    process.exitCode = code ?? 0;
+    throw new Error(`__EXIT_${code ?? 0}__`);
+  }) as typeof process.exit;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerSttCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    /* commander exit override or process.exit mock throws */
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockAccessResult = "ok";
+  mockTranscriber = null;
+  mockSpawnResult = { exitCode: 0, stdout: "120.5", stderr: "" };
+  mockFileSize = 1024;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("stt --help renders command group with examples", async () => {
+    const { stdout } = await runCommand(["stt", "--help"]);
+    expect(stdout).toContain("Speech-to-text operations");
+    expect(stdout).toContain("assistant config set services.stt.provider");
+    expect(stdout).toContain("assistant stt transcribe");
+  });
+
+  test("stt transcribe --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand(["stt", "transcribe", "--help"]);
+    expect(stdout).toContain("--file <path>");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("Supported audio formats");
+    expect(stdout).toContain("Supported video formats");
+    expect(stdout).toContain("ffmpeg");
+    expect(stdout).toContain("assistant stt transcribe --file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe("error cases", () => {
+  test("nonexistent file exits with code 1 and actionable error", async () => {
+    mockAccessResult = new Error("ENOENT");
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/nonexistent/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("File not found: /nonexistent/audio.wav");
+  });
+
+  test("no STT provider configured exits with code 1 and actionable error", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = null;
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No speech-to-text provider is configured");
+    expect(stderr).toContain("assistant config set services.stt.provider");
+  });
+
+  test("unsupported file type exits with code 1", async () => {
+    mockAccessResult = "ok";
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/document.pdf",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unsupported file type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+describe("success cases", () => {
+  const fakeTranscriber: BatchTranscriber = {
+    providerId: "openai-whisper",
+    boundaryId: "daemon-batch",
+    transcribe: async () => ({ text: "Hello, this is a test transcript." }),
+  };
+
+  test("transcribes audio file and prints transcript to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Hello, this is a test transcript.");
+  });
+
+  test("transcribes video file (auto-extracts audio)", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/video.mp4",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Hello, this is a test transcript.");
+  });
+
+  test("--json output contains expected fields", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.transcript).toBe("Hello, this is a test transcript.");
+    expect(parsed.provider).toBe("openai-whisper");
+    expect(typeof parsed.durationSeconds).toBe("number");
+  });
+
+  test("no speech detected prints appropriate message", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      ...fakeTranscriber,
+      transcribe: async () => ({ text: "" }),
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/silence.wav",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No speech detected");
+  });
+
+  test("no speech detected with --json returns empty transcript", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      ...fakeTranscriber,
+      transcribe: async () => ({ text: "" }),
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/silence.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.transcript).toBe("");
+    expect(parsed.provider).toBe("openai-whisper");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcription failure
+// ---------------------------------------------------------------------------
+
+describe("transcription failure", () => {
+  test("ffmpeg failure exits with code 1 and error message", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => ({ text: "ok" }),
+    };
+    mockSpawnResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ffmpeg error: codec not found",
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Transcription failed");
+  });
+});

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -1,0 +1,307 @@
+/**
+ * CLI command group: `assistant stt`
+ *
+ * Speech-to-text operations using the configured STT provider.
+ * Stateless, request-response commands — no daemon dependency.
+ */
+
+import { randomUUID } from "node:crypto";
+import { access, mkdir, readdir, readFile, rm, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
+
+import type { Command } from "commander";
+
+import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
+import type { BatchTranscriber } from "../../stt/types.js";
+import {
+  FFMPEG_TRANSCODE_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../util/spawn.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+  ".webm",
+  ".m4v",
+  ".mpeg",
+  ".mpg",
+]);
+const AUDIO_EXTENSIONS = new Set([
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".aac",
+  ".ogg",
+  ".flac",
+  ".aiff",
+  ".wma",
+]);
+
+/** Max file size for a single STT chunk request (25MB). */
+const STT_CHUNK_MAX_BYTES = 25 * 1024 * 1024;
+
+/** Duration per chunk when splitting for large files (10 minutes). */
+const CHUNK_DURATION_SECS = 600;
+
+/** Timeout for a single STT transcription request. */
+const STT_REQUEST_TIMEOUT_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAudioDuration(audioPath: string): Promise<number> {
+  const result = await spawnWithTimeout(
+    [
+      "ffprobe",
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "csv=p=0",
+      audioPath,
+    ],
+    FFPROBE_TIMEOUT_MS,
+  );
+  if (result.exitCode !== 0) return 0;
+  return parseFloat(result.stdout.trim()) || 0;
+}
+
+async function splitAudio(
+  audioPath: string,
+  chunkDir: string,
+  chunkDurationSecs: number,
+): Promise<string[]> {
+  const chunkPattern = join(chunkDir, "chunk-%03d.wav");
+  const result = await spawnWithTimeout(
+    [
+      "ffmpeg",
+      "-y",
+      "-i",
+      audioPath,
+      "-f",
+      "segment",
+      "-segment_time",
+      String(chunkDurationSecs),
+      "-acodec",
+      "pcm_s16le",
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      chunkPattern,
+    ],
+    FFMPEG_TRANSCODE_TIMEOUT_MS,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to split audio: ${result.stderr.slice(0, 300)}`);
+  }
+  const files = await readdir(chunkDir);
+  return files
+    .filter((f) => f.startsWith("chunk-") && f.endsWith(".wav"))
+    .sort()
+    .map((f) => join(chunkDir, f));
+}
+
+/** Convert source to 16kHz mono WAV for consistent processing. */
+async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
+  const wavPath = join(tmpdir(), `vellum-transcribe-${randomUUID()}.wav`);
+  const args = ["ffmpeg", "-y", "-i", inputPath];
+  if (isVideo) args.push("-vn");
+  args.push("-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", wavPath);
+  const result = await spawnWithTimeout(args, FFMPEG_TRANSCODE_TIMEOUT_MS);
+  if (result.exitCode !== 0) {
+    throw new Error(`ffmpeg failed: ${result.stderr.slice(0, 500)}`);
+  }
+  return wavPath;
+}
+
+async function transcribeWithProvider(
+  audioPath: string,
+  transcriber: BatchTranscriber,
+): Promise<string> {
+  const duration = await getAudioDuration(audioPath);
+  const fileSize = Bun.file(audioPath).size;
+
+  // If small enough, send directly
+  if (fileSize <= STT_CHUNK_MAX_BYTES) {
+    const audioBuffer = await readFile(audioPath);
+    const result = await transcriber.transcribe({
+      audio: audioBuffer,
+      mimeType: "audio/wav",
+      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+    });
+    return result.text;
+  }
+
+  // Split into chunks for large files
+  const chunkDir = join(tmpdir(), `vellum-transcribe-chunks-${randomUUID()}`);
+  await mkdir(chunkDir, { recursive: true });
+
+  try {
+    process.stderr.write(
+      `Large file (${Math.round(duration / 60)}min) - splitting into chunks...\n`,
+    );
+    const chunks = await splitAudio(audioPath, chunkDir, CHUNK_DURATION_SECS);
+    const parts: string[] = [];
+
+    for (let i = 0; i < chunks.length; i++) {
+      process.stderr.write(
+        `  Transcribing chunk ${i + 1}/${chunks.length}...\n`,
+      );
+      const audioBuffer = await readFile(chunks[i]);
+      const result = await transcriber.transcribe({
+        audio: audioBuffer,
+        mimeType: "audio/wav",
+        signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+      });
+      if (result.text) parts.push(result.text);
+    }
+
+    return parts.join(" ");
+  } finally {
+    await rm(chunkDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerSttCommand(program: Command): void {
+  const sttCmd = program
+    .command("stt")
+    .description("Speech-to-text operations");
+
+  sttCmd.addHelpText(
+    "after",
+    `
+Speech-to-text commands use your configured STT provider to transcribe
+audio and video files. The provider is set via:
+
+  $ assistant config set services.stt.provider <provider>
+
+Supported providers include openai-whisper, deepgram, and google-gemini.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/meeting.wav
+  $ assistant stt transcribe --file /path/to/video.mp4 --json`,
+  );
+
+  // ── transcribe ──────────────────────────────────────────────────────
+
+  sttCmd
+    .command("transcribe")
+    .description("Transcribe an audio or video file to text")
+    .requiredOption("--file <path>", "Absolute path to the audio/video file")
+    .option("--json", "Output structured JSON instead of plain transcript text")
+    .addHelpText(
+      "after",
+      `
+Transcribes an audio or video file using the configured speech-to-text
+provider. Video files automatically have their audio extracted via ffmpeg.
+Large files (>25MB as WAV) are automatically split into chunks and
+transcribed sequentially.
+
+Supported audio formats: .mp3, .wav, .m4a, .aac, .ogg, .flac, .aiff, .wma
+Supported video formats: .mp4, .mov, .avi, .mkv, .webm, .m4v, .mpeg, .mpg
+
+Requires ffmpeg and ffprobe to be installed and on PATH.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/recording.wav
+  $ assistant stt transcribe --file /path/to/meeting.mp4
+  $ assistant stt transcribe --file /path/to/podcast.mp3 --json`,
+    )
+    .action(async (opts: { file: string; json?: boolean }) => {
+      const filePath = opts.file;
+      const jsonOutput = opts.json ?? false;
+
+      // Validate file exists
+      try {
+        await access(filePath);
+      } catch {
+        process.stderr.write(`File not found: ${filePath}\n`);
+        process.exit(1);
+      }
+
+      // Validate file extension
+      const ext = extname(filePath).toLowerCase();
+      const isVideo = VIDEO_EXTENSIONS.has(ext);
+      const isAudio = AUDIO_EXTENSIONS.has(ext);
+      if (!isVideo && !isAudio) {
+        process.stderr.write(
+          `Unsupported file type: ${ext}. Only audio and video files can be transcribed.\n`,
+        );
+        process.exit(1);
+      }
+
+      // Resolve STT provider
+      const transcriber = await resolveBatchTranscriber();
+      if (!transcriber) {
+        process.stderr.write(
+          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.\n",
+        );
+        process.exit(1);
+      }
+
+      let wavPath: string | null = null;
+      try {
+        // Convert to WAV
+        wavPath = await toWav(filePath, isVideo);
+
+        const startTime = Date.now();
+        const text = await transcribeWithProvider(wavPath, transcriber);
+        const durationSeconds = (Date.now() - startTime) / 1000;
+
+        if (!text.trim()) {
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                transcript: "",
+                provider: transcriber.providerId,
+                durationSeconds,
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write("No speech detected in the audio.\n");
+          }
+          return;
+        }
+
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({
+              transcript: text,
+              provider: transcriber.providerId,
+              durationSeconds,
+            }) + "\n",
+          );
+        } else {
+          process.stdout.write(text + "\n");
+        }
+      } catch (err) {
+        process.stderr.write(
+          `Transcription failed: ${(err as Error).message}\n`,
+        );
+        process.exit(1);
+      } finally {
+        if (wavPath) {
+          try {
+            await unlink(wavPath);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -36,6 +36,7 @@ import { registerRoutesCommand } from "./commands/routes.js";
 import { registerSequenceCommand } from "./commands/sequence.js";
 import { registerShotgunCommand } from "./commands/shotgun.js";
 import { registerSkillsCommand } from "./commands/skills.js";
+import { registerSttCommand } from "./commands/stt.js";
 import { registerTrustCommand } from "./commands/trust.js";
 import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
@@ -100,6 +101,7 @@ Examples:
 
   registerShotgunCommand(program);
   registerSequenceCommand(program);
+  registerSttCommand(program);
 
   // Fail fast when no assistant workspace exists on disk. The workspace is
   // created by `vellum hatch` and must be present for any command to work.


### PR DESCRIPTION
## Summary
- Add `assistant stt` command group with `transcribe` subcommand
- Transcribes audio/video files via the configured STT provider
- Supports video auto-extraction, large-file chunking, and --json output

Part of plan: service-cli-commands.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
