### PR TITLE
feat(cli): add `assistant image-generation generate` command

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Tests for the `assistant image-generation` CLI command.
+ *
+ * Validates:
+ *   - Help text for `image-generation` and `image-generation generate`
+ *   - Required --prompt enforcement
+ *   - Managed vs your-own credential resolution
+ *   - Error when no credentials are available
+ *   - Generate mode success (file written, path on stdout)
+ *   - --json output format
+ *   - Edit mode with --source (source images passed through)
+ *   - --variants passed through
+ *   - --model override
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** Config returned by getConfig() */
+let mockConfig = {
+  services: {
+    "image-generation": {
+      mode: "your-own" as "managed" | "your-own",
+      provider: "gemini" as const,
+      model: "gemini-3.1-flash-image-preview",
+    },
+  },
+};
+
+/** Result returned by buildManagedBaseUrl() */
+let mockManagedBaseUrl: string | undefined = undefined;
+
+/** Context returned by resolveManagedProxyContext() */
+let mockManagedProxyContext = {
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+};
+
+/** Key returned by getProviderKeyAsync() */
+let mockProviderKey: string | undefined = undefined;
+
+/** Result returned by generateImage() */
+let mockGenerateResult: {
+  images: Array<{ mimeType: string; dataBase64: string; title?: string }>;
+  text?: string;
+  resolvedModel: string;
+} = {
+  images: [
+    {
+      mimeType: "image/png",
+      dataBase64: Buffer.from("fake-png-data").toString("base64"),
+    },
+  ],
+  resolvedModel: "gemini-3.1-flash-image-preview",
+};
+
+/** Error to throw from generateImage() (if set) */
+let mockGenerateError: Error | undefined = undefined;
+
+/** Captured generateImage call args */
+let lastGenerateCall: {
+  credentials: unknown;
+  request: unknown;
+} | null = null;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  getConfigReadOnly: () => mockConfig,
+}));
+
+mock.module("../../../providers/managed-proxy/context.js", () => ({
+  buildManagedBaseUrl: async () => mockManagedBaseUrl,
+  resolveManagedProxyContext: async () => mockManagedProxyContext,
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async () => mockProviderKey,
+}));
+
+mock.module("../../../media/gemini-image-service.js", () => ({
+  generateImage: async (credentials: unknown, request: unknown) => {
+    lastGenerateCall = { credentials, request };
+    if (mockGenerateError) throw mockGenerateError;
+    return mockGenerateResult;
+  },
+  mapGeminiError: (error: unknown) => {
+    if (error instanceof Error) return `Mapped error: ${error.message}`;
+    return "An unexpected error occurred during image generation.";
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerImageGenerationCommand } =
+  await import("../image-generation.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerImageGenerationCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockConfig = {
+    services: {
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+    },
+  };
+  mockManagedBaseUrl = undefined;
+  mockManagedProxyContext = {
+    enabled: false,
+    platformBaseUrl: "",
+    assistantApiKey: "",
+  };
+  mockProviderKey = undefined;
+  mockGenerateResult = {
+    images: [
+      {
+        mimeType: "image/png",
+        dataBase64: Buffer.from("fake-png-data").toString("base64"),
+      },
+    ],
+    resolvedModel: "gemini-3.1-flash-image-preview",
+  };
+  mockGenerateError = undefined;
+  lastGenerateCall = null;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("image-generation --help renders mode explanation and examples", async () => {
+    const { stdout } = await runCommand(["image-generation", "--help"]);
+    expect(stdout).toContain("AI image generation and editing");
+    expect(stdout).toContain("managed");
+    expect(stdout).toContain("your-own");
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("generate");
+  });
+
+  test("image-generation generate --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--help",
+    ]);
+    expect(stdout).toContain("--prompt");
+    expect(stdout).toContain("--mode");
+    expect(stdout).toContain("--source");
+    expect(stdout).toContain("--variants");
+    expect(stdout).toContain("--output-dir");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("Examples:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Required --prompt enforcement
+// ---------------------------------------------------------------------------
+
+describe("required arguments", () => {
+  test("generate requires --prompt", async () => {
+    mockProviderKey = "test-key";
+    const { exitCode } = await runCommand(["image-generation", "generate"]);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No credentials error
+// ---------------------------------------------------------------------------
+
+describe("credential errors", () => {
+  test("exits with code 1 when no credentials in your-own mode", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = undefined;
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with code 1 when no credentials in managed mode", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = undefined;
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error when no credentials in your-own mode", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Gemini API key");
+  });
+
+  test("--json outputs error when no credentials in managed mode", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Managed proxy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential resolution paths
+// ---------------------------------------------------------------------------
+
+describe("credential resolution", () => {
+  test("your-own mode uses getProviderKeyAsync for direct credentials", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = "test-gemini-key";
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      os.tmpdir(),
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      apiKey: string;
+    };
+    expect(creds.type).toBe("direct");
+    expect(creds.apiKey).toBe("test-gemini-key");
+  });
+
+  test("managed mode uses buildManagedBaseUrl + resolveManagedProxyContext", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = "https://platform.example.com/proxy/gemini";
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-api-key",
+    };
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      os.tmpdir(),
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      assistantApiKey: string;
+      baseUrl: string;
+    };
+    expect(creds.type).toBe("managed-proxy");
+    expect(creds.assistantApiKey).toBe("managed-api-key");
+    expect(creds.baseUrl).toBe("https://platform.example.com/proxy/gemini");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generate mode success
+// ---------------------------------------------------------------------------
+
+describe("generate mode", () => {
+  test("generates image and prints file path to stdout", async () => {
+    mockProviderKey = "test-key";
+    const outDir = join(os.tmpdir(), `img-gen-test-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset over the ocean",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    const outputPath = stdout.trim();
+    expect(outputPath).toContain("image-1.png");
+    expect(existsSync(outputPath)).toBe(true);
+
+    // Verify file content matches decoded base64
+    const written = readFileSync(outputPath);
+    const expected = Buffer.from(
+      mockGenerateResult.images[0].dataBase64,
+      "base64",
+    );
+    expect(written).toEqual(expected);
+  });
+
+  test("--json produces structured output with paths, MIME types, and sizes", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("test-data").toString("base64"),
+        },
+      ],
+      text: "A beautiful sunset",
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+    const outDir = join(os.tmpdir(), `img-gen-json-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      outDir,
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.model).toBe("gemini-3.1-flash-image-preview");
+    expect(parsed.text).toBe("A beautiful sunset");
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.images[0].path).toContain("image-1.png");
+    expect(parsed.images[0].mimeType).toBe("image/png");
+    expect(typeof parsed.images[0].sizeBytes).toBe("number");
+    expect(parsed.images[0].sizeBytes).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode with --source
+// ---------------------------------------------------------------------------
+
+describe("edit mode", () => {
+  test("passes source images to generateImage in edit mode", async () => {
+    mockProviderKey = "test-key";
+
+    // Use a real temp file for the source image
+    const sourceDir = join(os.tmpdir(), `img-src-test-${Date.now()}`);
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(sourceDir, { recursive: true });
+    const sourcePath = join(sourceDir, "input.png");
+    writeFileSync(sourcePath, Buffer.from("fake-source-png"));
+
+    const outDir = join(os.tmpdir(), `img-edit-test-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Remove background",
+      "--mode",
+      "edit",
+      "--source",
+      sourcePath,
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as {
+      mode: string;
+      sourceImages: Array<{ mimeType: string; dataBase64: string }>;
+    };
+    expect(req.mode).toBe("edit");
+    expect(req.sourceImages).toBeDefined();
+    expect(req.sourceImages).toHaveLength(1);
+    expect(req.sourceImages[0].dataBase64).toBe(
+      Buffer.from("fake-source-png").toString("base64"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --variants
+// ---------------------------------------------------------------------------
+
+describe("variants", () => {
+  test("--variants is passed through to generateImage", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img1").toString("base64"),
+        },
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img2").toString("base64"),
+        },
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img3").toString("base64"),
+        },
+      ],
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+    const outDir = join(os.tmpdir(), `img-variants-test-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Logo design",
+      "--variants",
+      "3",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { variants: number };
+    expect(req.variants).toBe(3);
+
+    // Should output 3 file paths
+    const lines = stdout.trim().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("image-1.png");
+    expect(lines[1]).toContain("image-2.png");
+    expect(lines[2]).toContain("image-3.png");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --model override
+// ---------------------------------------------------------------------------
+
+describe("model override", () => {
+  test("--model overrides config model", async () => {
+    mockProviderKey = "test-key";
+    const outDir = join(os.tmpdir(), `img-model-test-${Date.now()}`);
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--model",
+      "gemini-3-pro-image-preview",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gemini-3-pro-image-preview");
+  });
+
+  test("falls back to config model when --model is not provided", async () => {
+    mockProviderKey = "test-key";
+    mockConfig.services["image-generation"].model =
+      "gemini-3.1-flash-image-preview";
+    const outDir = join(os.tmpdir(), `img-model-fallback-${Date.now()}`);
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gemini-3.1-flash-image-preview");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("error handling", () => {
+  test("maps generateImage error and exits with code 1", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateError = new Error("API rate limit exceeded");
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs mapped error on generateImage failure", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateError = new Error("Connection timeout");
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Connection timeout");
+  });
+});

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -1,0 +1,280 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+import { Command } from "commander";
+
+import { getConfig } from "../../config/loader.js";
+import {
+  generateImage,
+  type ImageGenCredentials,
+  mapGeminiError,
+} from "../../media/gemini-image-service.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../../providers/managed-proxy/context.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { log } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// MIME type → file extension mapping
+// ---------------------------------------------------------------------------
+
+function extensionForMime(mimeType: string): string {
+  switch (mimeType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MIME type from file extension (for source images)
+// ---------------------------------------------------------------------------
+
+function mimeForExtension(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerImageGenerationCommand(program: Command): void {
+  const imageGen = program
+    .command("image-generation")
+    .description("AI image generation and editing");
+
+  imageGen.addHelpText(
+    "after",
+    `
+Modes:
+  managed    — Uses platform-managed credentials (requires login to Vellum).
+  your-own   — Uses your own Gemini API key configured in settings.
+
+Supported models:
+  gemini-3.1-flash-image-preview (default)
+  gemini-3-pro-image-preview
+
+Examples:
+  $ assistant image-generation generate --prompt "A sunset over the ocean"
+  $ assistant image-generation generate --prompt "Remove background" --mode edit --source photo.png
+  $ assistant image-generation generate --prompt "Logo design" --variants 3 --output-dir ./output
+  $ assistant image-generation generate --prompt "A cat" --json`,
+  );
+
+  const generate = imageGen
+    .command("generate")
+    .description("Generate or edit images using AI")
+    .requiredOption(
+      "--prompt <text>",
+      "Description of the image to generate or edits to apply",
+    )
+    .option("--mode <mode>", "generate (default) or edit", "generate")
+    .option(
+      "--source <path...>",
+      "Source image file path for edit mode (repeatable)",
+    )
+    .option("--model <model-id>", "Model override")
+    .option(
+      "--variants <n>",
+      "Number of variants (1-4, default 1)",
+      (v: string) => parseInt(v, 10),
+      1,
+    )
+    .option("--output-dir <dir>", "Directory to save images")
+    .option("--json", "Output structured JSON");
+
+  generate.addHelpText(
+    "after",
+    `
+Notes:
+  Edit mode (--mode edit) requires at least one --source image file.
+  Output files are named image-1.png, image-2.png, etc. (extension matches MIME type).
+  Default output directory is the system temp directory.
+
+Examples:
+  $ assistant image-generation generate --prompt "A mountain landscape at dawn"
+  $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
+  $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
+  $ assistant image-generation generate --prompt "A robot" --model gemini-3-pro-image-preview --json`,
+  );
+
+  generate.action(async (opts) => {
+    const jsonOutput = opts.json === true;
+    const prompt: string = opts.prompt;
+    const mode: "generate" | "edit" =
+      opts.mode === "edit" ? "edit" : "generate";
+    const sourcePaths: string[] | undefined = opts.source;
+    const modelOverride: string | undefined = opts.model;
+    const variants: number = Math.max(1, Math.min(opts.variants ?? 1, 4));
+    const outputDir: string = opts.outputDir ?? os.tmpdir();
+
+    // --- Resolve credentials ---
+    const config = getConfig();
+    const imageGenMode = config.services["image-generation"].mode;
+
+    let credentials: ImageGenCredentials | undefined;
+
+    if (imageGenMode === "managed") {
+      const managedBaseUrl = await buildManagedBaseUrl("gemini");
+      if (managedBaseUrl) {
+        const ctx = await resolveManagedProxyContext();
+        credentials = {
+          type: "managed-proxy",
+          assistantApiKey: ctx.assistantApiKey,
+          baseUrl: managedBaseUrl,
+        };
+      }
+    } else {
+      const apiKey = await getProviderKeyAsync("gemini");
+      if (apiKey) {
+        credentials = { type: "direct", apiKey };
+      }
+    }
+
+    if (!credentials) {
+      const hint =
+        imageGenMode === "managed"
+          ? "Managed proxy is not available. Please log in to Vellum or switch to your-own mode:\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config."
+          : "No Gemini API key configured. Add your Gemini API key:\n  Run 'assistant keys set gemini' or configure it in Settings > Models & Services.";
+
+      if (jsonOutput) {
+        process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
+      } else {
+        log.error(hint);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    // --- Read source images for edit mode ---
+    let sourceImages:
+      | Array<{ mimeType: string; dataBase64: string }>
+      | undefined;
+
+    if (mode === "edit" && sourcePaths && sourcePaths.length > 0) {
+      const errors: string[] = [];
+      const validImages: Array<{ mimeType: string; dataBase64: string }> = [];
+
+      for (const filePath of sourcePaths) {
+        if (!existsSync(filePath)) {
+          errors.push(`File not found: ${filePath}`);
+          continue;
+        }
+        const file = Bun.file(filePath);
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const mimeType =
+          file.type !== "application/octet-stream"
+            ? file.type
+            : mimeForExtension(filePath);
+        validImages.push({
+          mimeType,
+          dataBase64: buffer.toString("base64"),
+        });
+      }
+
+      if (validImages.length === 0) {
+        const errorMsg = `No source images could be read.\n${errors.join("\n")}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: errorMsg }) + "\n",
+          );
+        } else {
+          log.error(errorMsg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+      sourceImages = validImages;
+    }
+
+    // --- Resolve model ---
+    const model = modelOverride ?? config.services["image-generation"].model;
+
+    // --- Generate image ---
+    try {
+      const result = await generateImage(credentials, {
+        prompt,
+        mode,
+        sourceImages,
+        model,
+        variants,
+      });
+
+      // --- Ensure output directory exists ---
+      if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+      }
+
+      // --- Write images to disk ---
+      const imageOutputs: Array<{
+        path: string;
+        mimeType: string;
+        sizeBytes: number;
+      }> = [];
+
+      for (let i = 0; i < result.images.length; i++) {
+        const img = result.images[i];
+        const ext = extensionForMime(img.mimeType);
+        const fileName = `image-${i + 1}.${ext}`;
+        const filePath = join(outputDir, fileName);
+        const buffer = Buffer.from(img.dataBase64, "base64");
+        writeFileSync(filePath, buffer);
+        imageOutputs.push({
+          path: filePath,
+          mimeType: img.mimeType,
+          sizeBytes: buffer.length,
+        });
+      }
+
+      // --- Output ---
+      if (jsonOutput) {
+        const output: Record<string, unknown> = {
+          images: imageOutputs,
+          model: result.resolvedModel,
+        };
+        if (result.text) {
+          output.text = result.text;
+        }
+        process.stdout.write(JSON.stringify(output) + "\n");
+      } else {
+        for (const img of imageOutputs) {
+          process.stdout.write(img.path + "\n");
+        }
+      }
+    } catch (error) {
+      const errorMsg = mapGeminiError(error);
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: errorMsg }) + "\n",
+        );
+      } else {
+        log.error(errorMsg);
+      }
+      process.exitCode = 1;
+    }
+  });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -26,6 +26,7 @@ import { registerCredentialsCommand } from "./commands/credentials.js";
 import { registerDefaultAction } from "./commands/default-action.js";
 import { registerDomainCommand } from "./commands/domain.js";
 import { registerEmailCommand } from "./commands/email.js";
+import { registerImageGenerationCommand } from "./commands/image-generation.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
 import { registerMemoryCommand } from "./commands/memory.js";
@@ -96,6 +97,7 @@ Examples:
   registerSkillsCommand(program);
   registerUsageCommand(program);
 
+  registerImageGenerationCommand(program);
   registerUiCommand(program);
 
   registerShotgunCommand(program);


### PR DESCRIPTION
## Summary
- Add `assistant image-generation` command group with `generate` subcommand
- Generates or edits images via the configured image generation provider (Gemini)
- Supports managed and your-own credential modes, edit mode with source images, variants, and --json output

Part of plan: service-cli-commands.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
