### PR TITLE
fix(chrome-extension): make host_browser_result transport robust in self-hosted mode

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -5,12 +5,13 @@
  * `RelayConnection` so we can exercise both transport branches without
  * standing up a real socket or local daemon. Covers:
  *
- *   - self-hosted mode: POSTs to `${baseUrl}/v1/host-browser-result`
- *     with `Authorization: Bearer <token>` and the JSON-serialised
- *     result envelope as the body.
- *   - cloud mode with an OPEN connection: sends a JSON-stringified
+ *   - open relay socket (cloud + self-hosted): sends a JSON-stringified
  *     `host_browser_result` frame via `connection.send` and never
  *     touches `fetch`.
+ *   - self-hosted mode fallback: POSTs to
+ *     `${baseUrl}/v1/host-browser-result` with
+ *     `Authorization: Bearer <token>` when no open relay socket is
+ *     available.
  *   - cloud mode with a closed or null connection: logs a warning,
  *     never touches `fetch`, and never throws.
  *
@@ -156,7 +157,26 @@ afterEach(() => {
 // ── Self-hosted mode ────────────────────────────────────────────────
 
 describe('postHostBrowserResult — self-hosted mode', () => {
-  test('POSTs to ${baseUrl}/v1/host-browser-result with bearer auth', async () => {
+  test('uses an open relay connection and skips fetch', async () => {
+    const conn = makeFakeConnection(true);
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:9999',
+      token: 'tok-1',
+    };
+
+    await postHostBrowserResult(mode, conn, exampleResult);
+
+    expect(fetchHandle.calls).toEqual([]);
+    expect(conn.sent.length).toBe(1);
+    const parsed = JSON.parse(conn.sent[0]) as Record<string, unknown>;
+    expect(parsed.type).toBe('host_browser_result');
+    expect(parsed.requestId).toBe(exampleResult.requestId);
+    expect(parsed.content).toBe(exampleResult.content);
+    expect(parsed.isError).toBe(exampleResult.isError);
+  });
+
+  test('falls back to POST with bearer auth when no relay connection is provided', async () => {
     const mode: RelayMode = {
       kind: 'self-hosted',
       baseUrl: 'http://127.0.0.1:9999',
@@ -173,6 +193,38 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     expect(headers?.authorization).toBe('Bearer tok-1');
     expect(headers?.['content-type']).toBe('application/json');
     expect(call.init?.body).toBe(JSON.stringify(exampleResult));
+  });
+
+  test('falls back to POST when the supplied connection is not open', async () => {
+    const conn = makeFakeConnection(false);
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:9999',
+      token: 'tok-1',
+    };
+
+    await postHostBrowserResult(mode, conn, exampleResult);
+
+    expect(fetchHandle.calls.length).toBe(1);
+    expect(conn.sent).toEqual([]);
+  });
+
+  test('falls back to POST when WS send throws in self-hosted mode', async () => {
+    const conn = makeFakeConnection(true);
+    conn.send = () => {
+      throw new Error('socket send failed');
+    };
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:9999',
+      token: 'tok-1',
+    };
+
+    await postHostBrowserResult(mode, conn, exampleResult);
+
+    expect(fetchHandle.calls.length).toBe(1);
+    const flat = consoleSpy.warnings.flat().join(' ');
+    expect(flat).toContain('falling back to HTTP POST');
   });
 
   test('omits the authorization header when no token is configured', async () => {
@@ -234,20 +286,6 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     expect(payload.url).toBe('http://127.0.0.1:9999/v1/host-browser-result');
     expect(String(payload.responseBodySnippet)).toContain('not found');
   });
-
-  test('ignores the supplied connection in self-hosted mode', async () => {
-    const conn = makeFakeConnection(true);
-    const mode: RelayMode = {
-      kind: 'self-hosted',
-      baseUrl: 'http://127.0.0.1:9999',
-      token: 'tok-1',
-    };
-
-    await postHostBrowserResult(mode, conn, exampleResult);
-
-    expect(fetchHandle.calls.length).toBe(1);
-    expect(conn.sent).toEqual([]);
-  });
 });
 
 // ── Cloud mode ──────────────────────────────────────────────────────
@@ -303,6 +341,25 @@ describe('postHostBrowserResult — cloud mode', () => {
     const flat = consoleSpy.warnings.flat().join(' ');
     expect(flat).toContain('cloud relay not connected');
   });
+
+  test('warns and no-ops when cloud WS send throws', async () => {
+    const conn = makeFakeConnection(true);
+    conn.send = () => {
+      throw new Error('socket send failed');
+    };
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://api.vellum.ai',
+      token: 'cloud-token',
+    };
+
+    const returned = await postHostBrowserResult(mode, conn, exampleResult);
+    expect(returned).toBeUndefined();
+
+    expect(fetchHandle.calls).toEqual([]);
+    const flat = consoleSpy.warnings.flat().join(' ');
+    expect(flat).toContain('cloud relay send failed');
+  });
 });
 
 // ── Live mode read (stale-token regression) ─────────────────────────
@@ -333,8 +390,10 @@ async function dispatchViaConnection(
 }
 
 describe('postHostBrowserResult — live mode read via getCurrentMode()', () => {
-  test('self-hosted: second dispatch picks up a refreshed token from the connection', async () => {
-    const conn = makeFakeConnection(true, {
+  test('self-hosted HTTP fallback: second dispatch picks up a refreshed token from the connection', async () => {
+    // Force HTTP fallback by marking the connection closed so the token
+    // carried in mode is still exercised.
+    const conn = makeFakeConnection(false, {
       kind: 'self-hosted',
       baseUrl: 'http://127.0.0.1:9999',
       token: 'tok-old',
@@ -374,6 +433,9 @@ describe('postHostBrowserResult — live mode read via getCurrentMode()', () => 
       token: 'tok-old',
     });
 
+    // Start disconnected to force self-hosted HTTP fallback for the
+    // first dispatch, then flip to cloud + open for the second.
+    conn.open = false;
     await dispatchViaConnection(conn, exampleResult);
     expect(fetchHandle.calls.length).toBe(1);
     expect(conn.sent.length).toBe(0);
@@ -383,6 +445,7 @@ describe('postHostBrowserResult — live mode read via getCurrentMode()', () => 
       baseUrl: 'https://api.vellum.ai',
       token: 'cloud-token',
     };
+    conn.open = true;
 
     await dispatchViaConnection(conn, exampleResult);
 

--- a/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-host-browser-result.test.ts
@@ -107,6 +107,7 @@ function makeFakeConnection(open: boolean, mode?: RelayMode): FakeConnection {
     },
     send(data) {
       sent.push(data);
+      return true;
     },
     getCurrentMode() {
       return this.mode;
@@ -225,6 +226,22 @@ describe('postHostBrowserResult — self-hosted mode', () => {
     expect(fetchHandle.calls.length).toBe(1);
     const flat = consoleSpy.warnings.flat().join(' ');
     expect(flat).toContain('falling back to HTTP POST');
+  });
+
+  test('falls back to POST when send reports not-delivered after open-check race', async () => {
+    const conn = makeFakeConnection(true);
+    conn.send = () => false;
+    const mode: RelayMode = {
+      kind: 'self-hosted',
+      baseUrl: 'http://127.0.0.1:9999',
+      token: 'tok-1',
+    };
+
+    await postHostBrowserResult(mode, conn, exampleResult);
+
+    expect(fetchHandle.calls.length).toBe(1);
+    const flat = consoleSpy.warnings.flat().join(' ');
+    expect(flat).toContain('send was not delivered');
   });
 
   test('omits the authorization header when no token is configured', async () => {

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -260,14 +260,17 @@ export class RelayConnection {
   }
 
   /**
-   * Send a raw string payload. No-op if the socket is not currently OPEN
-   * — matches the existing worker.ts semantics where heartbeats and
-   * responses silently drop when the socket is mid-reconnect.
+   * Send a raw string payload.
+   *
+   * Returns `true` when the frame was passed to WebSocket.send, `false`
+   * when no OPEN socket was available at send time.
    */
-  send(data: string): void {
+  send(data: string): boolean {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(data);
+      return true;
     }
+    return false;
   }
 
   /**
@@ -569,15 +572,14 @@ function normaliseReconnectResult(
 // ── host_browser result poster ─────────────────────────────────────
 //
 // The host-browser dispatcher needs a way to ship CDP result envelopes
-// back to the daemon. The transport depends on the relay mode:
+// back to the daemon.
 //
-//   - self-hosted: POST to the local daemon's
-//     `/v1/host-browser-result` endpoint, authenticated with the
-//     stored capability token.
-//   - cloud: send the envelope as a `host_browser_result` frame over
-//     the existing browser-relay WebSocket. The gateway proxies the
-//     frame straight through to the runtime, which resolves it through
-//     the same shared resolver used by `/v1/host-browser-result`.
+// Preferred path (self-hosted + cloud): send a `host_browser_result`
+// frame over the live browser-relay WebSocket.
+//
+// Fallback path (self-hosted only): POST to the local daemon's
+// `/v1/host-browser-result` endpoint when no open socket is available
+// or a send race drops the frame before it reaches the wire.
 
 /**
  * Minimal subset of {@link RelayConnection} that {@link postHostBrowserResult}
@@ -591,7 +593,14 @@ function normaliseReconnectResult(
  */
 export interface RelayConnectionLike {
   isOpen(): boolean;
-  send(data: string): void;
+  /**
+   * Best-effort frame send.
+   *
+   * Returns `true` when the frame was handed to WebSocket.send, `false`
+   * when no OPEN socket was available at send time (race between
+   * caller-side open check and underlying socket state transition).
+   */
+  send(data: string): boolean;
   getCurrentMode(): RelayMode;
 }
 
@@ -622,6 +631,7 @@ export function postHostBrowserEvent(
     return;
   }
   try {
+    // Drop silently on send races — events are lossy by design.
     connection.send(JSON.stringify(event));
   } catch (err) {
     // Same swallow-and-log posture as the other fire-and-forget
@@ -650,6 +660,7 @@ export function postHostBrowserSessionInvalidated(
     return;
   }
   try {
+    // Drop silently on send races — invalidation is advisory.
     connection.send(JSON.stringify(event));
   } catch (err) {
     console.warn(
@@ -680,8 +691,25 @@ export async function postHostBrowserResult(
 ): Promise<void> {
   if (connection && connection.isOpen()) {
     try {
-      connection.send(JSON.stringify({ type: 'host_browser_result', ...result }));
-      return;
+      const delivered = connection.send(
+        JSON.stringify({ type: 'host_browser_result', ...result }),
+      );
+      if (delivered) {
+        return;
+      }
+      if (mode.kind === 'cloud') {
+        // Cloud has no HTTP fallback path — keep existing drop semantics.
+        console.warn(
+          '[vellum-relay] host-browser-result dropped: cloud relay not connected',
+        );
+        return;
+      }
+      // Self-hosted: if send() reports not delivered, fall back to
+      // loopback POST. This covers the race where a close lands between
+      // caller-side isOpen() and actual send.
+      console.warn(
+        '[vellum-relay] host-browser-result relay send was not delivered in self-hosted mode; falling back to HTTP POST',
+      );
     } catch (err) {
       if (mode.kind === 'cloud') {
         // Cloud has no HTTP fallback path — keep existing drop semantics.

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -16,10 +16,10 @@
  *
  * This module also exports {@link postHostBrowserResult}, the relay-aware
  * helper used by the host-browser dispatcher to ship CDP result envelopes
- * back to the daemon. In self-hosted mode the result is POSTed to the
- * local `/v1/host-browser-result` HTTP endpoint; in cloud mode it
- * round-trips back through the gateway WebSocket — see the function
- * docstring for the full behaviour.
+ * back to the daemon. It prefers sending result envelopes over the live
+ * `/v1/browser-relay` WebSocket for both self-hosted and cloud sessions,
+ * with a self-hosted-only HTTP fallback to `/v1/host-browser-result` when
+ * no open socket is available — see the function docstring for details.
  */
 
 import type {
@@ -662,30 +662,48 @@ export function postHostBrowserSessionInvalidated(
 /**
  * Ship a host_browser result envelope back to the daemon.
  *
- * In self-hosted mode this POSTs to `${mode.baseUrl}/v1/host-browser-result`
- * with `Authorization: Bearer <mode.token>`. In cloud mode it sends a
+ * Preferred path (both cloud + self-hosted): send a
  * `{ type: 'host_browser_result', ...result }` frame over the supplied
- * relay connection.
+ * relay WebSocket when it is currently open.
  *
- * The cloud branch is a no-op (with a console.warn) when the connection
- * is missing or not currently open. We deliberately do NOT throw — the
- * dispatcher's error path catches and logs synchronously, but a thrown
- * rejection here would bubble up to the service worker as an unhandled
- * promise rejection.
+ * Fallback path (self-hosted only): when there is no open relay socket,
+ * POST to `${mode.baseUrl}/v1/host-browser-result` with
+ * `Authorization: Bearer <mode.token>`.
+ *
+ * Cloud mode has no HTTP fallback; when the socket is missing/not open we
+ * warn and drop.
  */
 export async function postHostBrowserResult(
   mode: RelayMode,
   connection: RelayConnectionLike | null,
   result: HostBrowserResultEnvelope,
 ): Promise<void> {
-  if (mode.kind === 'cloud') {
-    if (!connection || !connection.isOpen()) {
-      console.warn(
-        '[vellum-relay] host-browser-result dropped: cloud relay not connected',
-      );
+  if (connection && connection.isOpen()) {
+    try {
+      connection.send(JSON.stringify({ type: 'host_browser_result', ...result }));
       return;
+    } catch (err) {
+      if (mode.kind === 'cloud') {
+        // Cloud has no HTTP fallback path — keep existing drop semantics.
+        console.warn(
+          '[vellum-relay] host-browser-result dropped: cloud relay send failed',
+          err,
+        );
+        return;
+      }
+      // Self-hosted can fall back to loopback POST when WS send races
+      // with disconnect/worker suspension.
+      console.warn(
+        '[vellum-relay] host-browser-result WS send failed in self-hosted mode; falling back to HTTP POST',
+        err,
+      );
     }
-    connection.send(JSON.stringify({ type: 'host_browser_result', ...result }));
+  }
+
+  if (mode.kind === 'cloud') {
+    console.warn(
+      '[vellum-relay] host-browser-result dropped: cloud relay not connected',
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
- Route `host_browser_result` over the live browser-relay WebSocket for self-hosted sessions when the connection is open, matching cloud behavior and avoiding token-expiry-induced HTTP callback failures.
- Keep self-hosted HTTP POST fallback for disconnected/error races, including explicit fallback behavior when WS send throws.
- Update and expand `worker-host-browser-result` coverage to pin open-WS, fallback, error, and live-mode regression paths.

## Original prompt
Go ahead and [$do](/Users/noaflaherty/Repos/vellum-ai/claude-skills/skills/do/SKILL.md) a fix that will make this more robust
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
