### PR TITLE
refactor(trust): derive DefaultRuleTemplate from TrustRuleBase for type safety

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,20 +1,32 @@
 import { join } from "node:path";
 
+import type {
+  ScopedTrustRule,
+  TrustRuleBase,
+} from "@vellumai/ces-contracts";
+import {
+  MANAGED_SKILL_TOOLS,
+  SKILL_LOAD_TOOL,
+} from "@vellumai/ces-contracts";
+
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { getBundledSkillsDir } from "../config/skills.js";
 import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
 import { getWorkspaceDir } from "../util/platform.js";
 
-export interface DefaultRuleTemplate {
-  id: string;
-  tool: string;
-  pattern: string;
-  scope: string;
-  decision: "allow" | "deny" | "ask";
-  priority: number;
+/**
+ * A default rule template is structurally identical to TrustRuleBase
+ * minus `createdAt` (set at backfill time) and `userModifiedAt` (set
+ * when users explicitly override defaults), plus the optional
+ * `allowHighRisk` field that some tool families support.
+ */
+export type DefaultRuleTemplate = Omit<
+  TrustRuleBase,
+  "createdAt" | "userModifiedAt"
+> & {
   allowHighRisk?: boolean;
-}
+};
 
 /**
  * Escape minimatch metacharacters so a literal path is matched literally when
@@ -26,7 +38,7 @@ function escapeMinimatchPath(p: string): string {
   return p.replace(/[?*[\]{}()!|\\]/g, "\\$&");
 }
 
-const HOST_FILE_TOOLS = [
+const HOST_FILE_TOOLS: readonly ScopedTrustRule["tool"][] = [
   "host_file_read",
   "host_file_write",
   "host_file_edit",
@@ -110,10 +122,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
 
   // Managed skill authoring tools — scaffold and delete modify ~/.vellum/workspace/skills/
   // and should require explicit user approval.
-  const MANAGED_SKILL_TOOLS = [
-    "scaffold_managed_skill",
-    "delete_managed_skill",
-  ] as const;
   const managedSkillRules = MANAGED_SKILL_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
@@ -133,7 +141,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     "BOOTSTRAP.md",
     "UPDATES.md",
   ] as const;
-  const WORKSPACE_FILE_TOOLS = [
+  const WORKSPACE_FILE_TOOLS: readonly ScopedTrustRule["tool"][] = [
     "file_read",
     "file_write",
     "file_edit",
@@ -211,7 +219,10 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     "/",
   );
   const bundledSkillsDir = getBundledSkillsDir().replaceAll("\\", "/");
-  const SKILL_MUTATION_TOOLS = ["file_write", "file_edit"] as const;
+  const SKILL_MUTATION_TOOLS: readonly ScopedTrustRule["tool"][] = [
+    "file_write",
+    "file_edit",
+  ] as const;
   const skillDirs: { dir: string; label: string }[] = [
     { dir: managedSkillsDir, label: "managed" },
     { dir: bundledSkillsDir, label: "bundled" },
@@ -247,7 +258,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // priority ensures this rule wins when both could match.
   const skillLoadDynamicRule: DefaultRuleTemplate = {
     id: "default:ask-skill_load_dynamic-global",
-    tool: "skill_load",
+    tool: SKILL_LOAD_TOOL,
     pattern: "skill_load_dynamic:*",
     scope: "everywhere",
     decision: "ask",
@@ -256,7 +267,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
 
   const skillLoadRule: DefaultRuleTemplate = {
     id: "default:allow-skill_load-global",
-    tool: "skill_load",
+    tool: SKILL_LOAD_TOOL,
     pattern: "skill_load:*",
     scope: "everywhere",
     decision: "allow",

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -251,21 +251,13 @@ function backfillDefaults(rules: TrustRule[]): boolean {
 
   for (const template of getDefaultRuleTemplates()) {
     if (!existingIds.has(template.id)) {
-      // Default rules may carry allowHighRisk (e.g. bash container rules).
-      // Build as GenericTrustRule to accommodate all optional fields.
-      const rule: TrustRule = {
-        id: template.id,
-        tool: template.tool,
-        pattern: template.pattern,
-        scope: template.scope,
-        decision: template.decision,
-        priority: template.priority,
+      // Canonicalize through parseTrustRule so family-specific field
+      // validation is applied (consistent with fileAddRule/fileUpdateRule).
+      const { rule } = parseTrustRule({
+        ...template,
         createdAt: Date.now(),
-        ...(template.allowHighRisk != null
-          ? { allowHighRisk: template.allowHighRisk }
-          : {}),
-      };
-      rules.push(rule);
+      });
+      rules.push(rule as TrustRule);
       changed = true;
       log.info({ ruleId: template.id }, "Backfilled default trust rule");
     }


### PR DESCRIPTION
## Summary
- Replace standalone `DefaultRuleTemplate` interface with `Omit<TrustRuleBase, "createdAt" | "userModifiedAt"> & { allowHighRisk?: boolean }` to align with the ces-contracts type system
- Type-narrow local tool constant arrays against `ScopedTrustRule["tool"]` so tool name typos are caught at compile time
- Import `MANAGED_SKILL_TOOLS` and `SKILL_LOAD_TOOL` from ces-contracts, eliminating local duplication
- Use `parseTrustRule()` in `backfillDefaults()` for canonical normalization, consistent with `fileAddRule()`/`fileUpdateRule()`

## Original prompt
Implement cleaner design: type-narrow tool using the same constants and use something like Omit<TrustRule, 'createdAt' | 'id'> as the base for DefaultRuleTemplate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
