### PR TITLE
fix(cli): consistent JSON error shape and edit mode validation

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -432,6 +432,7 @@ describe("generate mode", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
     expect(parsed.model).toBe("gemini-3.1-flash-image-preview");
     expect(parsed.text).toBe("A beautiful sunset");
     expect(parsed.images).toHaveLength(1);
@@ -447,6 +448,27 @@ describe("generate mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("edit mode", () => {
+  test("exits with code 1 when --mode edit is used without --source", async () => {
+    mockProviderKey = "test-key";
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Remove background",
+      "--mode",
+      "edit",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe(
+      "Edit mode requires at least one --source image file.",
+    );
+  });
+
   test("passes source images to generateImage in edit mode", async () => {
     mockProviderKey = "test-key";
 

--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -248,6 +248,7 @@ describe("no provider configured", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No LLM provider is configured");
     expect(parsed.error).toContain("assistant config set");
   });
@@ -267,6 +268,7 @@ describe("no message provided", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No message provided");
   });
 
@@ -281,6 +283,7 @@ describe("no message provided", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No message provided");
   });
 });
@@ -363,6 +366,7 @@ describe("--json output", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
     expect(parsed.response).toBe("42");
     expect(parsed.model).toBe("claude-test-1");
     expect(parsed.usage).toEqual({
@@ -417,6 +421,7 @@ describe("--max-tokens", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --max-tokens");
   });
 });

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -132,6 +132,18 @@ Examples:
     const variants: number = Math.max(1, Math.min(opts.variants ?? 1, 4));
     const outputDir: string = opts.outputDir ?? os.tmpdir();
 
+    // --- Validate edit mode requires --source ---
+    if (mode === "edit" && (!sourcePaths || sourcePaths.length === 0)) {
+      const msg = "Edit mode requires at least one --source image file.";
+      if (jsonOutput) {
+        process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
+      } else {
+        log.error(msg);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
     // --- Resolve credentials ---
     const config = getConfig();
     const imageGenMode = config.services["image-generation"].mode;
@@ -253,6 +265,7 @@ Examples:
       // --- Output ---
       if (jsonOutput) {
         const output: Record<string, unknown> = {
+          ok: true,
           images: imageOutputs,
           model: result.resolvedModel,
         };

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -57,7 +57,9 @@ Examples:
         ) {
           const msg = "Invalid --max-tokens value. Must be a positive integer.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -80,7 +82,9 @@ Examples:
           const msg =
             "No message provided. Pass a message as an argument or pipe via stdin.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -94,7 +98,9 @@ Examples:
           const msg =
             "No LLM provider is configured. Run 'assistant config set llm.default.provider <provider>' to set one up.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -121,6 +127,7 @@ Examples:
           if (jsonOutput) {
             process.stdout.write(
               JSON.stringify({
+                ok: true,
                 response: text,
                 model: response.model,
                 usage: {
@@ -136,7 +143,9 @@ Examples:
           const msg =
             err instanceof Error ? err.message : "Unknown error occurred";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }


### PR DESCRIPTION
## Summary
Fixes review gaps:
- Standardize JSON error shape to { ok: false, error } across inference and image-generation
- Add ok: true to success JSON outputs for both commands
- Validate --mode edit requires --source in image-generation

Part of plan: service-cli-commands.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
