### PR TITLE
fix(cli): stt error handling — exitCode, JSON errors, CLI logger

### DIFF
--- a/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
+++ b/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
@@ -27,10 +27,23 @@ let mockSpawnResult = {
   stderr: "",
 };
 let mockFileSize = 1024;
+let logErrorMessages: string[] = [];
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before module-under-test import
 // ---------------------------------------------------------------------------
+
+mock.module("../../logger.js", () => ({
+  log: {
+    error: (msg: string) => {
+      logErrorMessages.push(msg);
+      process.stderr.write(msg + "\n");
+    },
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+  },
+}));
 
 mock.module("node:fs/promises", () => ({
   access: async () => {
@@ -145,6 +158,7 @@ beforeEach(() => {
   mockTranscriber = null;
   mockSpawnResult = { exitCode: 0, stdout: "120.5", stderr: "" };
   mockFileSize = 1024;
+  logErrorMessages = [];
   process.exitCode = 0;
 });
 
@@ -218,6 +232,58 @@ describe("error cases", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Unsupported file type");
+  });
+
+  test("nonexistent file with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = new Error("ENOENT");
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/nonexistent/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("File not found");
+  });
+
+  test("no STT provider with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = null;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No speech-to-text provider is configured");
+  });
+
+  test("unsupported file type with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/document.pdf",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unsupported file type");
   });
 });
 
@@ -354,5 +420,33 @@ describe("transcription failure", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Transcription failed");
+  });
+
+  test("ffmpeg failure with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => ({ text: "ok" }),
+    };
+    mockSpawnResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ffmpeg error: codec not found",
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Transcription failed");
   });
 });

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -19,6 +19,7 @@ import {
   FFPROBE_TIMEOUT_MS,
   spawnWithTimeout,
 } from "../../util/spawn.js";
+import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -230,8 +231,16 @@ Examples:
       try {
         await access(filePath);
       } catch {
-        process.stderr.write(`File not found: ${filePath}\n`);
-        process.exit(1);
+        const msg = `File not found: ${filePath}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       // Validate file extension
@@ -239,19 +248,32 @@ Examples:
       const isVideo = VIDEO_EXTENSIONS.has(ext);
       const isAudio = AUDIO_EXTENSIONS.has(ext);
       if (!isVideo && !isAudio) {
-        process.stderr.write(
-          `Unsupported file type: ${ext}. Only audio and video files can be transcribed.\n`,
-        );
-        process.exit(1);
+        const msg = `Unsupported file type: ${ext}. Only audio and video files can be transcribed.`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       // Resolve STT provider
       const transcriber = await resolveBatchTranscriber();
       if (!transcriber) {
-        process.stderr.write(
-          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.\n",
-        );
-        process.exit(1);
+        const msg =
+          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.";
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       let wavPath: string | null = null;
@@ -290,10 +312,15 @@ Examples:
           process.stdout.write(text + "\n");
         }
       } catch (err) {
-        process.stderr.write(
-          `Transcription failed: ${(err as Error).message}\n`,
-        );
-        process.exit(1);
+        const msg = `Transcription failed: ${(err as Error).message}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
       } finally {
         if (wavPath) {
           try {


### PR DESCRIPTION
## Summary
Fixes review gaps in stt.ts:
- Replace process.exit(1) with process.exitCode=1 to allow async cleanup
- Output JSON errors to stdout when --json is active
- Use CLI logger instead of raw process.stderr.write

Part of plan: service-cli-commands.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
