### PR TITLE
feat(cli): add service-level CLI commands (stt, inference/llm, image-generation)

### DIFF
--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Tests for the `assistant image-generation` CLI command.
+ *
+ * Validates:
+ *   - Help text for `image-generation` and `image-generation generate`
+ *   - Required --prompt enforcement
+ *   - Managed vs your-own credential resolution
+ *   - Error when no credentials are available
+ *   - Generate mode success (file written, path on stdout)
+ *   - --json output format
+ *   - Edit mode with --source (source images passed through)
+ *   - --variants passed through
+ *   - --model override
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** Config returned by getConfig() */
+let mockConfig = {
+  services: {
+    "image-generation": {
+      mode: "your-own" as "managed" | "your-own",
+      provider: "gemini" as const,
+      model: "gemini-3.1-flash-image-preview",
+    },
+  },
+};
+
+/** Result returned by buildManagedBaseUrl() */
+let mockManagedBaseUrl: string | undefined = undefined;
+
+/** Context returned by resolveManagedProxyContext() */
+let mockManagedProxyContext = {
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+};
+
+/** Key returned by getProviderKeyAsync() */
+let mockProviderKey: string | undefined = undefined;
+
+/** Result returned by generateImage() */
+let mockGenerateResult: {
+  images: Array<{ mimeType: string; dataBase64: string; title?: string }>;
+  text?: string;
+  resolvedModel: string;
+} = {
+  images: [
+    {
+      mimeType: "image/png",
+      dataBase64: Buffer.from("fake-png-data").toString("base64"),
+    },
+  ],
+  resolvedModel: "gemini-3.1-flash-image-preview",
+};
+
+/** Error to throw from generateImage() (if set) */
+let mockGenerateError: Error | undefined = undefined;
+
+/** Captured generateImage call args */
+let lastGenerateCall: {
+  credentials: unknown;
+  request: unknown;
+} | null = null;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  getConfigReadOnly: () => mockConfig,
+}));
+
+mock.module("../../../providers/managed-proxy/context.js", () => ({
+  buildManagedBaseUrl: async () => mockManagedBaseUrl,
+  resolveManagedProxyContext: async () => mockManagedProxyContext,
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async () => mockProviderKey,
+}));
+
+mock.module("../../../media/gemini-image-service.js", () => ({
+  generateImage: async (credentials: unknown, request: unknown) => {
+    lastGenerateCall = { credentials, request };
+    if (mockGenerateError) throw mockGenerateError;
+    return mockGenerateResult;
+  },
+  mapGeminiError: (error: unknown) => {
+    if (error instanceof Error) return `Mapped error: ${error.message}`;
+    return "An unexpected error occurred during image generation.";
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerImageGenerationCommand } =
+  await import("../image-generation.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerImageGenerationCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockConfig = {
+    services: {
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+    },
+  };
+  mockManagedBaseUrl = undefined;
+  mockManagedProxyContext = {
+    enabled: false,
+    platformBaseUrl: "",
+    assistantApiKey: "",
+  };
+  mockProviderKey = undefined;
+  mockGenerateResult = {
+    images: [
+      {
+        mimeType: "image/png",
+        dataBase64: Buffer.from("fake-png-data").toString("base64"),
+      },
+    ],
+    resolvedModel: "gemini-3.1-flash-image-preview",
+  };
+  mockGenerateError = undefined;
+  lastGenerateCall = null;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("image-generation --help renders mode explanation and examples", async () => {
+    const { stdout } = await runCommand(["image-generation", "--help"]);
+    expect(stdout).toContain("AI image generation and editing");
+    expect(stdout).toContain("managed");
+    expect(stdout).toContain("your-own");
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("generate");
+  });
+
+  test("image-generation generate --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--help",
+    ]);
+    expect(stdout).toContain("--prompt");
+    expect(stdout).toContain("--mode");
+    expect(stdout).toContain("--source");
+    expect(stdout).toContain("--variants");
+    expect(stdout).toContain("--output-dir");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("Examples:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Required --prompt enforcement
+// ---------------------------------------------------------------------------
+
+describe("required arguments", () => {
+  test("generate requires --prompt", async () => {
+    mockProviderKey = "test-key";
+    const { exitCode } = await runCommand(["image-generation", "generate"]);
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No credentials error
+// ---------------------------------------------------------------------------
+
+describe("credential errors", () => {
+  test("exits with code 1 when no credentials in your-own mode", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = undefined;
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits with code 1 when no credentials in managed mode", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = undefined;
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs error when no credentials in your-own mode", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Gemini API key");
+  });
+
+  test("--json outputs error when no credentials in managed mode", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Managed proxy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential resolution paths
+// ---------------------------------------------------------------------------
+
+describe("credential resolution", () => {
+  test("your-own mode uses getProviderKeyAsync for direct credentials", async () => {
+    mockConfig.services["image-generation"].mode = "your-own";
+    mockProviderKey = "test-gemini-key";
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      os.tmpdir(),
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      apiKey: string;
+    };
+    expect(creds.type).toBe("direct");
+    expect(creds.apiKey).toBe("test-gemini-key");
+  });
+
+  test("managed mode uses buildManagedBaseUrl + resolveManagedProxyContext", async () => {
+    mockConfig.services["image-generation"].mode = "managed";
+    mockManagedBaseUrl = "https://platform.example.com/proxy/gemini";
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-api-key",
+    };
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      os.tmpdir(),
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const creds = lastGenerateCall!.credentials as {
+      type: string;
+      assistantApiKey: string;
+      baseUrl: string;
+    };
+    expect(creds.type).toBe("managed-proxy");
+    expect(creds.assistantApiKey).toBe("managed-api-key");
+    expect(creds.baseUrl).toBe("https://platform.example.com/proxy/gemini");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generate mode success
+// ---------------------------------------------------------------------------
+
+describe("generate mode", () => {
+  test("generates image and prints file path to stdout", async () => {
+    mockProviderKey = "test-key";
+    const outDir = join(os.tmpdir(), `img-gen-test-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "A sunset over the ocean",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    const outputPath = stdout.trim();
+    expect(outputPath).toContain("image-1.png");
+    expect(existsSync(outputPath)).toBe(true);
+
+    // Verify file content matches decoded base64
+    const written = readFileSync(outputPath);
+    const expected = Buffer.from(
+      mockGenerateResult.images[0].dataBase64,
+      "base64",
+    );
+    expect(written).toEqual(expected);
+  });
+
+  test("--json produces structured output with paths, MIME types, and sizes", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("test-data").toString("base64"),
+        },
+      ],
+      text: "A beautiful sunset",
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+    const outDir = join(os.tmpdir(), `img-gen-json-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      outDir,
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.model).toBe("gemini-3.1-flash-image-preview");
+    expect(parsed.text).toBe("A beautiful sunset");
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.images[0].path).toContain("image-1.png");
+    expect(parsed.images[0].mimeType).toBe("image/png");
+    expect(typeof parsed.images[0].sizeBytes).toBe("number");
+    expect(parsed.images[0].sizeBytes).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode with --source
+// ---------------------------------------------------------------------------
+
+describe("edit mode", () => {
+  test("passes source images to generateImage in edit mode", async () => {
+    mockProviderKey = "test-key";
+
+    // Use a real temp file for the source image
+    const sourceDir = join(os.tmpdir(), `img-src-test-${Date.now()}`);
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(sourceDir, { recursive: true });
+    const sourcePath = join(sourceDir, "input.png");
+    writeFileSync(sourcePath, Buffer.from("fake-source-png"));
+
+    const outDir = join(os.tmpdir(), `img-edit-test-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Remove background",
+      "--mode",
+      "edit",
+      "--source",
+      sourcePath,
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as {
+      mode: string;
+      sourceImages: Array<{ mimeType: string; dataBase64: string }>;
+    };
+    expect(req.mode).toBe("edit");
+    expect(req.sourceImages).toBeDefined();
+    expect(req.sourceImages).toHaveLength(1);
+    expect(req.sourceImages[0].dataBase64).toBe(
+      Buffer.from("fake-source-png").toString("base64"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --variants
+// ---------------------------------------------------------------------------
+
+describe("variants", () => {
+  test("--variants is passed through to generateImage", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img1").toString("base64"),
+        },
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img2").toString("base64"),
+        },
+        {
+          mimeType: "image/png",
+          dataBase64: Buffer.from("img3").toString("base64"),
+        },
+      ],
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+    const outDir = join(os.tmpdir(), `img-variants-test-${Date.now()}`);
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Logo design",
+      "--variants",
+      "3",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { variants: number };
+    expect(req.variants).toBe(3);
+
+    // Should output 3 file paths
+    const lines = stdout.trim().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("image-1.png");
+    expect(lines[1]).toContain("image-2.png");
+    expect(lines[2]).toContain("image-3.png");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --model override
+// ---------------------------------------------------------------------------
+
+describe("model override", () => {
+  test("--model overrides config model", async () => {
+    mockProviderKey = "test-key";
+    const outDir = join(os.tmpdir(), `img-model-test-${Date.now()}`);
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--model",
+      "gemini-3-pro-image-preview",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gemini-3-pro-image-preview");
+  });
+
+  test("falls back to config model when --model is not provided", async () => {
+    mockProviderKey = "test-key";
+    mockConfig.services["image-generation"].model =
+      "gemini-3.1-flash-image-preview";
+    const outDir = join(os.tmpdir(), `img-model-fallback-${Date.now()}`);
+
+    await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { model: string };
+    expect(req.model).toBe("gemini-3.1-flash-image-preview");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("error handling", () => {
+  test("maps generateImage error and exits with code 1", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateError = new Error("API rate limit exceeded");
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json outputs mapped error on generateImage failure", async () => {
+    mockProviderKey = "test-key";
+    mockGenerateError = new Error("Connection timeout");
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Connection timeout");
+  });
+});

--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -514,6 +514,27 @@ describe("edit mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("variants", () => {
+  test("non-numeric --variants defaults to 1", async () => {
+    mockProviderKey = "test-key";
+    const outDir = join(os.tmpdir(), `img-nan-variants-${Date.now()}`);
+
+    const { exitCode } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Test",
+      "--variants",
+      "abc",
+      "--output-dir",
+      outDir,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastGenerateCall).toBeDefined();
+    const req = lastGenerateCall!.request as { variants: number };
+    expect(req.variants).toBe(1);
+  });
+
   test("--variants is passed through to generateImage", async () => {
     mockProviderKey = "test-key";
     mockGenerateResult = {

--- a/assistant/src/cli/commands/__tests__/image-generation.test.ts
+++ b/assistant/src/cli/commands/__tests__/image-generation.test.ts
@@ -432,6 +432,7 @@ describe("generate mode", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
     expect(parsed.model).toBe("gemini-3.1-flash-image-preview");
     expect(parsed.text).toBe("A beautiful sunset");
     expect(parsed.images).toHaveLength(1);
@@ -447,6 +448,27 @@ describe("generate mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("edit mode", () => {
+  test("exits with code 1 when --mode edit is used without --source", async () => {
+    mockProviderKey = "test-key";
+
+    const { exitCode, stdout } = await runCommand([
+      "image-generation",
+      "generate",
+      "--prompt",
+      "Remove background",
+      "--mode",
+      "edit",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe(
+      "Edit mode requires at least one --source image file.",
+    );
+  });
+
   test("passes source images to generateImage in edit mode", async () => {
     mockProviderKey = "test-key";
 

--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Tests for the `assistant inference send` and `assistant llm send` CLI
+ * commands.
+ *
+ * Validates:
+ *   - Help text renders for both `inference send` and `llm send`
+ *   - Error when no LLM provider is configured
+ *   - Error when no message is provided (no args, no stdin)
+ *   - Success with mocked provider (response text on stdout)
+ *   - `--system-prompt` is passed through to the provider call
+ *   - `--json` output format
+ *   - `--model` override is passed through
+ *   - `llm send` produces the same result as `inference send`
+ */
+
+import {
+  existsSync as actualExistsSync,
+  readFileSync as actualReadFileSync,
+} from "node:fs";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../../../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** Whether `getConfiguredProvider` returns a mock provider or null. */
+let mockProviderAvailable = true;
+
+/** The response the mock provider will return. */
+let mockProviderResponse: ProviderResponse = {
+  content: [{ type: "text", text: "42" }],
+  model: "claude-test-1",
+  usage: { inputTokens: 10, outputTokens: 5 },
+  stopReason: "end_turn",
+};
+
+/** Captures the last `sendMessage` call for assertions. */
+let lastSendMessageCall: {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  systemPrompt?: string;
+  options?: SendMessageOptions;
+} | null = null;
+
+/** Simulated stdin content for the next command run. */
+let mockStdinContent: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockProvider: Provider = {
+  name: "mock-provider",
+  sendMessage: async (
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ) => {
+    lastSendMessageCall = { messages, tools, systemPrompt, options };
+    return mockProviderResponse;
+  },
+};
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () =>
+    mockProviderAvailable ? mockProvider : null,
+  extractAllText: (response: ProviderResponse) => {
+    return response.content
+      .filter(
+        (
+          b,
+        ): b is Extract<(typeof response.content)[number], { type: "text" }> =>
+          b.type === "text",
+      )
+      .map((b) => b.text)
+      .join(" ");
+  },
+  userMessage: (text: string): Message => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  readFileSync: (path: string, encoding?: BufferEncoding) => {
+    if (path === "/dev/stdin") {
+      if (mockStdinContent === null) {
+        throw new Error("EAGAIN: resource temporarily unavailable");
+      }
+      return mockStdinContent;
+    }
+    return actualReadFileSync(path, encoding);
+  },
+  existsSync: actualExistsSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerInferenceCommand } = await import("../inference.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerInferenceCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockProviderAvailable = true;
+  mockProviderResponse = {
+    content: [{ type: "text", text: "42" }],
+    model: "claude-test-1",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+  lastSendMessageCall = null;
+  mockStdinContent = null;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("inference send --help renders argument docs", async () => {
+    const { stdout } = await runCommand(["inference", "send", "--help"]);
+    expect(stdout).toContain("send");
+    expect(stdout).toContain("--system-prompt");
+    expect(stdout).toContain("--model");
+    expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("[message...]");
+  });
+
+  test("llm send --help renders argument docs", async () => {
+    const { stdout } = await runCommand(["llm", "send", "--help"]);
+    expect(stdout).toContain("send");
+    expect(stdout).toContain("--system-prompt");
+    expect(stdout).toContain("--model");
+    expect(stdout).toContain("--max-tokens");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("[message...]");
+  });
+
+  test("inference --help renders with examples", async () => {
+    const { stdout } = await runCommand(["inference", "--help"]);
+    expect(stdout).toContain("inference");
+    expect(stdout).toContain("Examples:");
+  });
+
+  test("llm --help renders with examples", async () => {
+    const { stdout } = await runCommand(["llm", "--help"]);
+    expect(stdout).toContain("llm");
+    expect(stdout).toContain("Examples:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error: no provider configured
+// ---------------------------------------------------------------------------
+
+describe("no provider configured", () => {
+  test("exits with code 1 and actionable error when no provider", async () => {
+    mockProviderAvailable = false;
+
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "Hello",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No LLM provider is configured");
+    expect(parsed.error).toContain("assistant config set");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error: no message provided
+// ---------------------------------------------------------------------------
+
+describe("no message provided", () => {
+  test("exits with code 1 when no args and no stdin", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No message provided");
+  });
+
+  test("exits with code 1 when empty stdin", async () => {
+    mockStdinContent = "   ";
+
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("No message provided");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success: positional args
+// ---------------------------------------------------------------------------
+
+describe("success with positional args", () => {
+  test("sends message and prints response text", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "What",
+      "is",
+      "2+2?",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("42");
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.messages[0].content[0]).toEqual({
+      type: "text",
+      text: "What is 2+2?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success: stdin
+// ---------------------------------------------------------------------------
+
+describe("success with stdin", () => {
+  test("reads message from stdin when no positional args", async () => {
+    mockStdinContent = "What is 2+2?";
+
+    const { exitCode, stdout } = await runCommand(["inference", "send"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("42");
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.messages[0].content[0]).toEqual({
+      type: "text",
+      text: "What is 2+2?",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --system-prompt
+// ---------------------------------------------------------------------------
+
+describe("--system-prompt", () => {
+  test("passes system prompt through to provider", async () => {
+    await runCommand([
+      "inference",
+      "send",
+      "--system-prompt",
+      "You are a poet",
+      "Write a haiku",
+    ]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.systemPrompt).toBe("You are a poet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --json output
+// ---------------------------------------------------------------------------
+
+describe("--json output", () => {
+  test("produces structured JSON with response, model, and usage", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.response).toBe("42");
+    expect(parsed.model).toBe("claude-test-1");
+    expect(parsed.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --model override
+// ---------------------------------------------------------------------------
+
+describe("--model override", () => {
+  test("passes model override through to provider config", async () => {
+    await runCommand([
+      "inference",
+      "send",
+      "--model",
+      "claude-sonnet-4-20250514",
+      "Hello",
+    ]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.options?.config?.model).toBe(
+      "claude-sonnet-4-20250514",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --max-tokens
+// ---------------------------------------------------------------------------
+
+describe("--max-tokens", () => {
+  test("passes max tokens through to provider config", async () => {
+    await runCommand(["inference", "send", "--max-tokens", "1024", "Hello"]);
+
+    expect(lastSendMessageCall).toBeDefined();
+    expect(lastSendMessageCall!.options?.config?.max_tokens).toBe(1024);
+  });
+
+  test("errors on invalid max-tokens value", async () => {
+    const { exitCode, stdout } = await runCommand([
+      "inference",
+      "send",
+      "--max-tokens",
+      "abc",
+      "--json",
+      "Hello",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("Invalid --max-tokens");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// llm alias equivalence
+// ---------------------------------------------------------------------------
+
+describe("llm alias", () => {
+  test("llm send produces the same result as inference send", async () => {
+    const inferenceResult = await runCommand([
+      "inference",
+      "send",
+      "--json",
+      "Hello",
+    ]);
+
+    // Reset for the second call
+    lastSendMessageCall = null;
+
+    const llmResult = await runCommand(["llm", "send", "--json", "Hello"]);
+
+    expect(inferenceResult.exitCode).toBe(0);
+    expect(llmResult.exitCode).toBe(0);
+    expect(inferenceResult.stdout).toBe(llmResult.stdout);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -248,6 +248,7 @@ describe("no provider configured", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No LLM provider is configured");
     expect(parsed.error).toContain("assistant config set");
   });
@@ -267,6 +268,7 @@ describe("no message provided", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No message provided");
   });
 
@@ -281,6 +283,7 @@ describe("no message provided", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No message provided");
   });
 });
@@ -363,6 +366,7 @@ describe("--json output", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
     expect(parsed.response).toBe("42");
     expect(parsed.model).toBe("claude-test-1");
     expect(parsed.usage).toEqual({
@@ -417,6 +421,7 @@ describe("--max-tokens", () => {
 
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Invalid --max-tokens");
   });
 });

--- a/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
+++ b/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
@@ -27,10 +27,23 @@ let mockSpawnResult = {
   stderr: "",
 };
 let mockFileSize = 1024;
+let logErrorMessages: string[] = [];
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before module-under-test import
 // ---------------------------------------------------------------------------
+
+mock.module("../../logger.js", () => ({
+  log: {
+    error: (msg: string) => {
+      logErrorMessages.push(msg);
+      process.stderr.write(msg + "\n");
+    },
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+  },
+}));
 
 mock.module("node:fs/promises", () => ({
   access: async () => {
@@ -145,6 +158,7 @@ beforeEach(() => {
   mockTranscriber = null;
   mockSpawnResult = { exitCode: 0, stdout: "120.5", stderr: "" };
   mockFileSize = 1024;
+  logErrorMessages = [];
   process.exitCode = 0;
 });
 
@@ -218,6 +232,58 @@ describe("error cases", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Unsupported file type");
+  });
+
+  test("nonexistent file with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = new Error("ENOENT");
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/nonexistent/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("File not found");
+  });
+
+  test("no STT provider with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = null;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No speech-to-text provider is configured");
+  });
+
+  test("unsupported file type with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/document.pdf",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unsupported file type");
   });
 });
 
@@ -354,5 +420,33 @@ describe("transcription failure", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Transcription failed");
+  });
+
+  test("ffmpeg failure with --json outputs JSON error to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => ({ text: "ok" }),
+    };
+    mockSpawnResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ffmpeg error: codec not found",
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Transcription failed");
   });
 });

--- a/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
+++ b/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
@@ -330,7 +330,7 @@ describe("success cases", () => {
     expect(stdout).toContain("Hello, this is a test transcript.");
   });
 
-  test("--json output contains expected fields", async () => {
+  test("--json output contains expected fields including ok: true", async () => {
     mockAccessResult = "ok";
     mockTranscriber = fakeTranscriber;
     mockFileSize = 1024;
@@ -345,6 +345,7 @@ describe("success cases", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
     expect(parsed.transcript).toBe("Hello, this is a test transcript.");
     expect(parsed.provider).toBe("openai-whisper");
     expect(typeof parsed.durationSeconds).toBe("number");
@@ -369,7 +370,7 @@ describe("success cases", () => {
     expect(stdout).toContain("No speech detected");
   });
 
-  test("no speech detected with --json returns empty transcript", async () => {
+  test("no speech detected with --json returns empty transcript with ok: true", async () => {
     mockAccessResult = "ok";
     mockTranscriber = {
       ...fakeTranscriber,
@@ -387,6 +388,7 @@ describe("success cases", () => {
 
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
     expect(parsed.transcript).toBe("");
     expect(parsed.provider).toBe("openai-whisper");
   });

--- a/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
+++ b/assistant/src/cli/commands/__tests__/stt-transcribe.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the `assistant stt transcribe` CLI command.
+ *
+ * Validates:
+ *   - Help text renders correctly for `stt` and `stt transcribe`
+ *   - Error when --file points to a nonexistent file
+ *   - Error when no STT provider is configured
+ *   - Success case with mocked transcriber
+ *   - --json output format
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import type { BatchTranscriber } from "../../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockAccessResult: "ok" | Error = "ok";
+let mockTranscriber: BatchTranscriber | null = null;
+let mockSpawnResult = {
+  exitCode: 0,
+  stdout: "120.5",
+  stderr: "",
+};
+let mockFileSize = 1024;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before module-under-test import
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs/promises", () => ({
+  access: async () => {
+    if (mockAccessResult !== "ok") throw mockAccessResult;
+  },
+  readFile: async () => Buffer.from("fake-audio-data"),
+  unlink: async () => {},
+  mkdir: async () => {},
+  readdir: async () => [],
+  rm: async () => {},
+}));
+
+mock.module("../../../providers/speech-to-text/resolve.js", () => ({
+  resolveBatchTranscriber: async () => mockTranscriber,
+}));
+
+mock.module("../../../util/spawn.js", () => ({
+  FFMPEG_TRANSCODE_TIMEOUT_MS: 120_000,
+  FFPROBE_TIMEOUT_MS: 15_000,
+  spawnWithTimeout: async () => mockSpawnResult,
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ services: { stt: { provider: "openai-whisper" } } }),
+  getConfigReadOnly: () => ({
+    services: { stt: { provider: "openai-whisper" } },
+  }),
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  initFeatureFlagOverrides: async () => {},
+  _setOverridesForTesting: () => {},
+  isFeatureEnabled: () => true,
+}));
+
+// Mock Bun.file for file size checks
+const _originalBunFile = Bun.file;
+Bun.file = ((_path: string) => ({
+  size: mockFileSize,
+})) as typeof Bun.file;
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerSttCommand } = await import("../stt.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  // Mock process.exit to throw so we can capture it
+  const originalExit = process.exit;
+  process.exit = ((code?: number) => {
+    process.exitCode = code ?? 0;
+    throw new Error(`__EXIT_${code ?? 0}__`);
+  }) as typeof process.exit;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerSttCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    /* commander exit override or process.exit mock throws */
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockAccessResult = "ok";
+  mockTranscriber = null;
+  mockSpawnResult = { exitCode: 0, stdout: "120.5", stderr: "" };
+  mockFileSize = 1024;
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("stt --help renders command group with examples", async () => {
+    const { stdout } = await runCommand(["stt", "--help"]);
+    expect(stdout).toContain("Speech-to-text operations");
+    expect(stdout).toContain("assistant config set services.stt.provider");
+    expect(stdout).toContain("assistant stt transcribe");
+  });
+
+  test("stt transcribe --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand(["stt", "transcribe", "--help"]);
+    expect(stdout).toContain("--file <path>");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("Supported audio formats");
+    expect(stdout).toContain("Supported video formats");
+    expect(stdout).toContain("ffmpeg");
+    expect(stdout).toContain("assistant stt transcribe --file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe("error cases", () => {
+  test("nonexistent file exits with code 1 and actionable error", async () => {
+    mockAccessResult = new Error("ENOENT");
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/nonexistent/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("File not found: /nonexistent/audio.wav");
+  });
+
+  test("no STT provider configured exits with code 1 and actionable error", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = null;
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No speech-to-text provider is configured");
+    expect(stderr).toContain("assistant config set services.stt.provider");
+  });
+
+  test("unsupported file type exits with code 1", async () => {
+    mockAccessResult = "ok";
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/document.pdf",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unsupported file type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+describe("success cases", () => {
+  const fakeTranscriber: BatchTranscriber = {
+    providerId: "openai-whisper",
+    boundaryId: "daemon-batch",
+    transcribe: async () => ({ text: "Hello, this is a test transcript." }),
+  };
+
+  test("transcribes audio file and prints transcript to stdout", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Hello, this is a test transcript.");
+  });
+
+  test("transcribes video file (auto-extracts audio)", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/video.mp4",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Hello, this is a test transcript.");
+  });
+
+  test("--json output contains expected fields", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = fakeTranscriber;
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.transcript).toBe("Hello, this is a test transcript.");
+    expect(parsed.provider).toBe("openai-whisper");
+    expect(typeof parsed.durationSeconds).toBe("number");
+  });
+
+  test("no speech detected prints appropriate message", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      ...fakeTranscriber,
+      transcribe: async () => ({ text: "" }),
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/silence.wav",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No speech detected");
+  });
+
+  test("no speech detected with --json returns empty transcript", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      ...fakeTranscriber,
+      transcribe: async () => ({ text: "" }),
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stdout } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/silence.wav",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.transcript).toBe("");
+    expect(parsed.provider).toBe("openai-whisper");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcription failure
+// ---------------------------------------------------------------------------
+
+describe("transcription failure", () => {
+  test("ffmpeg failure exits with code 1 and error message", async () => {
+    mockAccessResult = "ok";
+    mockTranscriber = {
+      providerId: "openai-whisper",
+      boundaryId: "daemon-batch",
+      transcribe: async () => ({ text: "ok" }),
+    };
+    mockSpawnResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ffmpeg error: codec not found",
+    };
+    mockFileSize = 1024;
+
+    const { exitCode, stderr } = await runCommand([
+      "stt",
+      "transcribe",
+      "--file",
+      "/path/to/audio.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Transcription failed");
+  });
+});

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -132,6 +132,18 @@ Examples:
     const variants: number = Math.max(1, Math.min(opts.variants ?? 1, 4));
     const outputDir: string = opts.outputDir ?? os.tmpdir();
 
+    // --- Validate edit mode requires --source ---
+    if (mode === "edit" && (!sourcePaths || sourcePaths.length === 0)) {
+      const msg = "Edit mode requires at least one --source image file.";
+      if (jsonOutput) {
+        process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
+      } else {
+        log.error(msg);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
     // --- Resolve credentials ---
     const config = getConfig();
     const imageGenMode = config.services["image-generation"].mode;
@@ -253,6 +265,7 @@ Examples:
       // --- Output ---
       if (jsonOutput) {
         const output: Record<string, unknown> = {
+          ok: true,
           images: imageOutputs,
           model: result.resolvedModel,
         };

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -1,0 +1,280 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+import { Command } from "commander";
+
+import { getConfig } from "../../config/loader.js";
+import {
+  generateImage,
+  type ImageGenCredentials,
+  mapGeminiError,
+} from "../../media/gemini-image-service.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../../providers/managed-proxy/context.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { log } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// MIME type → file extension mapping
+// ---------------------------------------------------------------------------
+
+function extensionForMime(mimeType: string): string {
+  switch (mimeType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MIME type from file extension (for source images)
+// ---------------------------------------------------------------------------
+
+function mimeForExtension(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerImageGenerationCommand(program: Command): void {
+  const imageGen = program
+    .command("image-generation")
+    .description("AI image generation and editing");
+
+  imageGen.addHelpText(
+    "after",
+    `
+Modes:
+  managed    — Uses platform-managed credentials (requires login to Vellum).
+  your-own   — Uses your own Gemini API key configured in settings.
+
+Supported models:
+  gemini-3.1-flash-image-preview (default)
+  gemini-3-pro-image-preview
+
+Examples:
+  $ assistant image-generation generate --prompt "A sunset over the ocean"
+  $ assistant image-generation generate --prompt "Remove background" --mode edit --source photo.png
+  $ assistant image-generation generate --prompt "Logo design" --variants 3 --output-dir ./output
+  $ assistant image-generation generate --prompt "A cat" --json`,
+  );
+
+  const generate = imageGen
+    .command("generate")
+    .description("Generate or edit images using AI")
+    .requiredOption(
+      "--prompt <text>",
+      "Description of the image to generate or edits to apply",
+    )
+    .option("--mode <mode>", "generate (default) or edit", "generate")
+    .option(
+      "--source <path...>",
+      "Source image file path for edit mode (repeatable)",
+    )
+    .option("--model <model-id>", "Model override")
+    .option(
+      "--variants <n>",
+      "Number of variants (1-4, default 1)",
+      (v: string) => parseInt(v, 10),
+      1,
+    )
+    .option("--output-dir <dir>", "Directory to save images")
+    .option("--json", "Output structured JSON");
+
+  generate.addHelpText(
+    "after",
+    `
+Notes:
+  Edit mode (--mode edit) requires at least one --source image file.
+  Output files are named image-1.png, image-2.png, etc. (extension matches MIME type).
+  Default output directory is the system temp directory.
+
+Examples:
+  $ assistant image-generation generate --prompt "A mountain landscape at dawn"
+  $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
+  $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
+  $ assistant image-generation generate --prompt "A robot" --model gemini-3-pro-image-preview --json`,
+  );
+
+  generate.action(async (opts) => {
+    const jsonOutput = opts.json === true;
+    const prompt: string = opts.prompt;
+    const mode: "generate" | "edit" =
+      opts.mode === "edit" ? "edit" : "generate";
+    const sourcePaths: string[] | undefined = opts.source;
+    const modelOverride: string | undefined = opts.model;
+    const variants: number = Math.max(1, Math.min(opts.variants ?? 1, 4));
+    const outputDir: string = opts.outputDir ?? os.tmpdir();
+
+    // --- Resolve credentials ---
+    const config = getConfig();
+    const imageGenMode = config.services["image-generation"].mode;
+
+    let credentials: ImageGenCredentials | undefined;
+
+    if (imageGenMode === "managed") {
+      const managedBaseUrl = await buildManagedBaseUrl("gemini");
+      if (managedBaseUrl) {
+        const ctx = await resolveManagedProxyContext();
+        credentials = {
+          type: "managed-proxy",
+          assistantApiKey: ctx.assistantApiKey,
+          baseUrl: managedBaseUrl,
+        };
+      }
+    } else {
+      const apiKey = await getProviderKeyAsync("gemini");
+      if (apiKey) {
+        credentials = { type: "direct", apiKey };
+      }
+    }
+
+    if (!credentials) {
+      const hint =
+        imageGenMode === "managed"
+          ? "Managed proxy is not available. Please log in to Vellum or switch to your-own mode:\n  Run 'assistant auth login' to authenticate, or set services.image-generation.mode to 'your-own' in config."
+          : "No Gemini API key configured. Add your Gemini API key:\n  Run 'assistant keys set gemini' or configure it in Settings > Models & Services.";
+
+      if (jsonOutput) {
+        process.stdout.write(JSON.stringify({ ok: false, error: hint }) + "\n");
+      } else {
+        log.error(hint);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    // --- Read source images for edit mode ---
+    let sourceImages:
+      | Array<{ mimeType: string; dataBase64: string }>
+      | undefined;
+
+    if (mode === "edit" && sourcePaths && sourcePaths.length > 0) {
+      const errors: string[] = [];
+      const validImages: Array<{ mimeType: string; dataBase64: string }> = [];
+
+      for (const filePath of sourcePaths) {
+        if (!existsSync(filePath)) {
+          errors.push(`File not found: ${filePath}`);
+          continue;
+        }
+        const file = Bun.file(filePath);
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const mimeType =
+          file.type !== "application/octet-stream"
+            ? file.type
+            : mimeForExtension(filePath);
+        validImages.push({
+          mimeType,
+          dataBase64: buffer.toString("base64"),
+        });
+      }
+
+      if (validImages.length === 0) {
+        const errorMsg = `No source images could be read.\n${errors.join("\n")}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: errorMsg }) + "\n",
+          );
+        } else {
+          log.error(errorMsg);
+        }
+        process.exitCode = 1;
+        return;
+      }
+      sourceImages = validImages;
+    }
+
+    // --- Resolve model ---
+    const model = modelOverride ?? config.services["image-generation"].model;
+
+    // --- Generate image ---
+    try {
+      const result = await generateImage(credentials, {
+        prompt,
+        mode,
+        sourceImages,
+        model,
+        variants,
+      });
+
+      // --- Ensure output directory exists ---
+      if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+      }
+
+      // --- Write images to disk ---
+      const imageOutputs: Array<{
+        path: string;
+        mimeType: string;
+        sizeBytes: number;
+      }> = [];
+
+      for (let i = 0; i < result.images.length; i++) {
+        const img = result.images[i];
+        const ext = extensionForMime(img.mimeType);
+        const fileName = `image-${i + 1}.${ext}`;
+        const filePath = join(outputDir, fileName);
+        const buffer = Buffer.from(img.dataBase64, "base64");
+        writeFileSync(filePath, buffer);
+        imageOutputs.push({
+          path: filePath,
+          mimeType: img.mimeType,
+          sizeBytes: buffer.length,
+        });
+      }
+
+      // --- Output ---
+      if (jsonOutput) {
+        const output: Record<string, unknown> = {
+          images: imageOutputs,
+          model: result.resolvedModel,
+        };
+        if (result.text) {
+          output.text = result.text;
+        }
+        process.stdout.write(JSON.stringify(output) + "\n");
+      } else {
+        for (const img of imageOutputs) {
+          process.stdout.write(img.path + "\n");
+        }
+      }
+    } catch (error) {
+      const errorMsg = mapGeminiError(error);
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify({ ok: false, error: errorMsg }) + "\n",
+        );
+      } else {
+        log.error(errorMsg);
+      }
+      process.exitCode = 1;
+    }
+  });
+}

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -129,7 +129,10 @@ Examples:
       opts.mode === "edit" ? "edit" : "generate";
     const sourcePaths: string[] | undefined = opts.source;
     const modelOverride: string | undefined = opts.model;
-    const variants: number = Math.max(1, Math.min(opts.variants ?? 1, 4));
+    const rawVariants = opts.variants ?? 1;
+    const variants: number = Number.isNaN(rawVariants)
+      ? 1
+      : Math.max(1, Math.min(rawVariants, 4));
     const outputDir: string = opts.outputDir ?? os.tmpdir();
 
     // --- Validate edit mode requires --source ---
@@ -196,16 +199,20 @@ Examples:
           errors.push(`File not found: ${filePath}`);
           continue;
         }
-        const file = Bun.file(filePath);
-        const buffer = Buffer.from(await file.arrayBuffer());
-        const mimeType =
-          file.type !== "application/octet-stream"
-            ? file.type
-            : mimeForExtension(filePath);
-        validImages.push({
-          mimeType,
-          dataBase64: buffer.toString("base64"),
-        });
+        try {
+          const file = Bun.file(filePath);
+          const buffer = Buffer.from(await file.arrayBuffer());
+          const mimeType =
+            file.type !== "application/octet-stream"
+              ? file.type
+              : mimeForExtension(filePath);
+          validImages.push({
+            mimeType,
+            dataBase64: buffer.toString("base64"),
+          });
+        } catch (err) {
+          errors.push(`Could not read ${filePath}: ${(err as Error).message}`);
+        }
       }
 
       if (validImages.length === 0) {

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from "node:fs";
+
+import type { Command } from "commander";
+
+import {
+  extractAllText,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { log } from "../logger.js";
+
+/**
+ * Attach the `send` subcommand to the given command group (`inference` or
+ * `llm`). Both groups share the same implementation.
+ */
+function attachSendSubcommand(group: Command): void {
+  group
+    .command("send")
+    .description("Send a message to the configured LLM and print the response")
+    .option("--system-prompt <text>", "System prompt for the model")
+    .option("--model <model-id>", "Model override")
+    .option("--max-tokens <n>", "Max response tokens", undefined)
+    .option("--json", "Output structured JSON")
+    .argument("[message...]", "User message (joined with spaces)")
+    .addHelpText(
+      "after",
+      `
+Behavioral notes:
+  - If no message argument is provided, reads from stdin.
+  - If --model is omitted, uses the configured default model.
+  - Requires a configured LLM provider (see 'assistant config set').
+
+Examples:
+  $ assistant inference send "What is 2+2?"
+  $ echo "Summarize this" | assistant inference send
+  $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"`,
+    )
+    .action(
+      async (
+        messageParts: string[],
+        opts: {
+          systemPrompt?: string;
+          model?: string;
+          maxTokens?: string;
+          json?: boolean;
+        },
+      ) => {
+        const { systemPrompt, model, json: jsonOutput } = opts;
+        const maxTokens = opts.maxTokens
+          ? parseInt(opts.maxTokens, 10)
+          : undefined;
+
+        if (
+          opts.maxTokens !== undefined &&
+          (!Number.isFinite(maxTokens) || maxTokens! < 1)
+        ) {
+          const msg = "Invalid --max-tokens value. Must be a positive integer.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Determine user message: positional args or stdin.
+        let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
+
+        if (!messageText) {
+          try {
+            messageText = readFileSync("/dev/stdin", "utf-8").trim();
+          } catch {
+            // stdin not available or empty
+          }
+        }
+
+        if (!messageText) {
+          const msg =
+            "No message provided. Pass a message as an argument or pipe via stdin.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Resolve provider.
+        const provider = await getConfiguredProvider("inference");
+        if (!provider) {
+          const msg =
+            "No LLM provider is configured. Run 'assistant config set llm.default.provider <provider>' to set one up.";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        try {
+          const response = await provider.sendMessage(
+            [userMessage(messageText)],
+            undefined,
+            systemPrompt,
+            {
+              config: {
+                callSite: "inference",
+                max_tokens: maxTokens,
+                model,
+              },
+            },
+          );
+
+          const text = extractAllText(response);
+
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                response: text,
+                model: response.model,
+                usage: {
+                  inputTokens: response.usage.inputTokens,
+                  outputTokens: response.usage.outputTokens,
+                },
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write(text + "\n");
+          }
+        } catch (err) {
+          const msg =
+            err instanceof Error ? err.message : "Unknown error occurred";
+          if (jsonOutput) {
+            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+          } else {
+            log.error(msg);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
+}
+
+/**
+ * Register `inference` and `llm` command groups on the top-level program.
+ * Both expose the same subcommands — `llm` is an alias for `inference`.
+ */
+export function registerInferenceCommand(program: Command): void {
+  const inference = program
+    .command("inference")
+    .description("LLM inference operations");
+
+  inference.addHelpText(
+    "after",
+    `
+The inference command group sends requests to your configured LLM provider.
+The provider is resolved from your assistant config (llm.default.provider).
+
+Examples:
+  $ assistant inference send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant inference send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"`,
+  );
+
+  attachSendSubcommand(inference);
+
+  const llm = program
+    .command("llm")
+    .description("LLM inference operations (alias for 'inference')");
+
+  llm.addHelpText(
+    "after",
+    `
+The llm command group is an alias for 'inference'. It sends requests to your
+configured LLM provider, resolved from your assistant config (llm.default.provider).
+
+Examples:
+  $ assistant llm send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant llm send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant llm send --model claude-sonnet-4-20250514 --json "Hello"`,
+  );
+
+  attachSendSubcommand(llm);
+}

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -57,7 +57,9 @@ Examples:
         ) {
           const msg = "Invalid --max-tokens value. Must be a positive integer.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -80,7 +82,9 @@ Examples:
           const msg =
             "No message provided. Pass a message as an argument or pipe via stdin.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -94,7 +98,9 @@ Examples:
           const msg =
             "No LLM provider is configured. Run 'assistant config set llm.default.provider <provider>' to set one up.";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }
@@ -121,6 +127,7 @@ Examples:
           if (jsonOutput) {
             process.stdout.write(
               JSON.stringify({
+                ok: true,
                 response: text,
                 model: response.model,
                 usage: {
@@ -136,7 +143,9 @@ Examples:
           const msg =
             err instanceof Error ? err.message : "Unknown error occurred";
           if (jsonOutput) {
-            process.stdout.write(JSON.stringify({ error: msg }) + "\n");
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
           } else {
             log.error(msg);
           }

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -289,6 +289,7 @@ Examples:
           if (jsonOutput) {
             process.stdout.write(
               JSON.stringify({
+                ok: true,
                 transcript: "",
                 provider: transcriber.providerId,
                 durationSeconds,
@@ -303,6 +304,7 @@ Examples:
         if (jsonOutput) {
           process.stdout.write(
             JSON.stringify({
+              ok: true,
               transcript: text,
               provider: transcriber.providerId,
               durationSeconds,

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -19,6 +19,7 @@ import {
   FFPROBE_TIMEOUT_MS,
   spawnWithTimeout,
 } from "../../util/spawn.js";
+import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -230,8 +231,16 @@ Examples:
       try {
         await access(filePath);
       } catch {
-        process.stderr.write(`File not found: ${filePath}\n`);
-        process.exit(1);
+        const msg = `File not found: ${filePath}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       // Validate file extension
@@ -239,19 +248,32 @@ Examples:
       const isVideo = VIDEO_EXTENSIONS.has(ext);
       const isAudio = AUDIO_EXTENSIONS.has(ext);
       if (!isVideo && !isAudio) {
-        process.stderr.write(
-          `Unsupported file type: ${ext}. Only audio and video files can be transcribed.\n`,
-        );
-        process.exit(1);
+        const msg = `Unsupported file type: ${ext}. Only audio and video files can be transcribed.`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       // Resolve STT provider
       const transcriber = await resolveBatchTranscriber();
       if (!transcriber) {
-        process.stderr.write(
-          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.\n",
-        );
-        process.exit(1);
+        const msg =
+          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.";
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
       }
 
       let wavPath: string | null = null;
@@ -290,10 +312,15 @@ Examples:
           process.stdout.write(text + "\n");
         }
       } catch (err) {
-        process.stderr.write(
-          `Transcription failed: ${(err as Error).message}\n`,
-        );
-        process.exit(1);
+        const msg = `Transcription failed: ${(err as Error).message}`;
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: msg }) + "\n",
+          );
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
       } finally {
         if (wavPath) {
           try {

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -1,0 +1,307 @@
+/**
+ * CLI command group: `assistant stt`
+ *
+ * Speech-to-text operations using the configured STT provider.
+ * Stateless, request-response commands — no daemon dependency.
+ */
+
+import { randomUUID } from "node:crypto";
+import { access, mkdir, readdir, readFile, rm, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
+
+import type { Command } from "commander";
+
+import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
+import type { BatchTranscriber } from "../../stt/types.js";
+import {
+  FFMPEG_TRANSCODE_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../util/spawn.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+  ".webm",
+  ".m4v",
+  ".mpeg",
+  ".mpg",
+]);
+const AUDIO_EXTENSIONS = new Set([
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".aac",
+  ".ogg",
+  ".flac",
+  ".aiff",
+  ".wma",
+]);
+
+/** Max file size for a single STT chunk request (25MB). */
+const STT_CHUNK_MAX_BYTES = 25 * 1024 * 1024;
+
+/** Duration per chunk when splitting for large files (10 minutes). */
+const CHUNK_DURATION_SECS = 600;
+
+/** Timeout for a single STT transcription request. */
+const STT_REQUEST_TIMEOUT_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAudioDuration(audioPath: string): Promise<number> {
+  const result = await spawnWithTimeout(
+    [
+      "ffprobe",
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "csv=p=0",
+      audioPath,
+    ],
+    FFPROBE_TIMEOUT_MS,
+  );
+  if (result.exitCode !== 0) return 0;
+  return parseFloat(result.stdout.trim()) || 0;
+}
+
+async function splitAudio(
+  audioPath: string,
+  chunkDir: string,
+  chunkDurationSecs: number,
+): Promise<string[]> {
+  const chunkPattern = join(chunkDir, "chunk-%03d.wav");
+  const result = await spawnWithTimeout(
+    [
+      "ffmpeg",
+      "-y",
+      "-i",
+      audioPath,
+      "-f",
+      "segment",
+      "-segment_time",
+      String(chunkDurationSecs),
+      "-acodec",
+      "pcm_s16le",
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      chunkPattern,
+    ],
+    FFMPEG_TRANSCODE_TIMEOUT_MS,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to split audio: ${result.stderr.slice(0, 300)}`);
+  }
+  const files = await readdir(chunkDir);
+  return files
+    .filter((f) => f.startsWith("chunk-") && f.endsWith(".wav"))
+    .sort()
+    .map((f) => join(chunkDir, f));
+}
+
+/** Convert source to 16kHz mono WAV for consistent processing. */
+async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
+  const wavPath = join(tmpdir(), `vellum-transcribe-${randomUUID()}.wav`);
+  const args = ["ffmpeg", "-y", "-i", inputPath];
+  if (isVideo) args.push("-vn");
+  args.push("-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", wavPath);
+  const result = await spawnWithTimeout(args, FFMPEG_TRANSCODE_TIMEOUT_MS);
+  if (result.exitCode !== 0) {
+    throw new Error(`ffmpeg failed: ${result.stderr.slice(0, 500)}`);
+  }
+  return wavPath;
+}
+
+async function transcribeWithProvider(
+  audioPath: string,
+  transcriber: BatchTranscriber,
+): Promise<string> {
+  const duration = await getAudioDuration(audioPath);
+  const fileSize = Bun.file(audioPath).size;
+
+  // If small enough, send directly
+  if (fileSize <= STT_CHUNK_MAX_BYTES) {
+    const audioBuffer = await readFile(audioPath);
+    const result = await transcriber.transcribe({
+      audio: audioBuffer,
+      mimeType: "audio/wav",
+      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+    });
+    return result.text;
+  }
+
+  // Split into chunks for large files
+  const chunkDir = join(tmpdir(), `vellum-transcribe-chunks-${randomUUID()}`);
+  await mkdir(chunkDir, { recursive: true });
+
+  try {
+    process.stderr.write(
+      `Large file (${Math.round(duration / 60)}min) - splitting into chunks...\n`,
+    );
+    const chunks = await splitAudio(audioPath, chunkDir, CHUNK_DURATION_SECS);
+    const parts: string[] = [];
+
+    for (let i = 0; i < chunks.length; i++) {
+      process.stderr.write(
+        `  Transcribing chunk ${i + 1}/${chunks.length}...\n`,
+      );
+      const audioBuffer = await readFile(chunks[i]);
+      const result = await transcriber.transcribe({
+        audio: audioBuffer,
+        mimeType: "audio/wav",
+        signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+      });
+      if (result.text) parts.push(result.text);
+    }
+
+    return parts.join(" ");
+  } finally {
+    await rm(chunkDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerSttCommand(program: Command): void {
+  const sttCmd = program
+    .command("stt")
+    .description("Speech-to-text operations");
+
+  sttCmd.addHelpText(
+    "after",
+    `
+Speech-to-text commands use your configured STT provider to transcribe
+audio and video files. The provider is set via:
+
+  $ assistant config set services.stt.provider <provider>
+
+Supported providers include openai-whisper, deepgram, and google-gemini.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/meeting.wav
+  $ assistant stt transcribe --file /path/to/video.mp4 --json`,
+  );
+
+  // ── transcribe ──────────────────────────────────────────────────────
+
+  sttCmd
+    .command("transcribe")
+    .description("Transcribe an audio or video file to text")
+    .requiredOption("--file <path>", "Absolute path to the audio/video file")
+    .option("--json", "Output structured JSON instead of plain transcript text")
+    .addHelpText(
+      "after",
+      `
+Transcribes an audio or video file using the configured speech-to-text
+provider. Video files automatically have their audio extracted via ffmpeg.
+Large files (>25MB as WAV) are automatically split into chunks and
+transcribed sequentially.
+
+Supported audio formats: .mp3, .wav, .m4a, .aac, .ogg, .flac, .aiff, .wma
+Supported video formats: .mp4, .mov, .avi, .mkv, .webm, .m4v, .mpeg, .mpg
+
+Requires ffmpeg and ffprobe to be installed and on PATH.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/recording.wav
+  $ assistant stt transcribe --file /path/to/meeting.mp4
+  $ assistant stt transcribe --file /path/to/podcast.mp3 --json`,
+    )
+    .action(async (opts: { file: string; json?: boolean }) => {
+      const filePath = opts.file;
+      const jsonOutput = opts.json ?? false;
+
+      // Validate file exists
+      try {
+        await access(filePath);
+      } catch {
+        process.stderr.write(`File not found: ${filePath}\n`);
+        process.exit(1);
+      }
+
+      // Validate file extension
+      const ext = extname(filePath).toLowerCase();
+      const isVideo = VIDEO_EXTENSIONS.has(ext);
+      const isAudio = AUDIO_EXTENSIONS.has(ext);
+      if (!isVideo && !isAudio) {
+        process.stderr.write(
+          `Unsupported file type: ${ext}. Only audio and video files can be transcribed.\n`,
+        );
+        process.exit(1);
+      }
+
+      // Resolve STT provider
+      const transcriber = await resolveBatchTranscriber();
+      if (!transcriber) {
+        process.stderr.write(
+          "No speech-to-text provider is configured. Run 'assistant config set services.stt.provider <provider>' to set one up.\n",
+        );
+        process.exit(1);
+      }
+
+      let wavPath: string | null = null;
+      try {
+        // Convert to WAV
+        wavPath = await toWav(filePath, isVideo);
+
+        const startTime = Date.now();
+        const text = await transcribeWithProvider(wavPath, transcriber);
+        const durationSeconds = (Date.now() - startTime) / 1000;
+
+        if (!text.trim()) {
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                transcript: "",
+                provider: transcriber.providerId,
+                durationSeconds,
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write("No speech detected in the audio.\n");
+          }
+          return;
+        }
+
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({
+              transcript: text,
+              provider: transcriber.providerId,
+              durationSeconds,
+            }) + "\n",
+          );
+        } else {
+          process.stdout.write(text + "\n");
+        }
+      } catch (err) {
+        process.stderr.write(
+          `Transcription failed: ${(err as Error).message}\n`,
+        );
+        process.exit(1);
+      } finally {
+        if (wavPath) {
+          try {
+            await unlink(wavPath);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -36,6 +36,7 @@ import { registerRoutesCommand } from "./commands/routes.js";
 import { registerSequenceCommand } from "./commands/sequence.js";
 import { registerShotgunCommand } from "./commands/shotgun.js";
 import { registerSkillsCommand } from "./commands/skills.js";
+import { registerSttCommand } from "./commands/stt.js";
 import { registerTrustCommand } from "./commands/trust.js";
 import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
@@ -100,6 +101,7 @@ Examples:
 
   registerShotgunCommand(program);
   registerSequenceCommand(program);
+  registerSttCommand(program);
 
   // Fail fast when no assistant workspace exists on disk. The workspace is
   // created by `vellum hatch` and must be present for any command to work.

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -26,6 +26,7 @@ import { registerCredentialsCommand } from "./commands/credentials.js";
 import { registerDefaultAction } from "./commands/default-action.js";
 import { registerDomainCommand } from "./commands/domain.js";
 import { registerEmailCommand } from "./commands/email.js";
+import { registerInferenceCommand } from "./commands/inference.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
 import { registerMemoryCommand } from "./commands/memory.js";
@@ -102,6 +103,8 @@ Examples:
   registerShotgunCommand(program);
   registerSequenceCommand(program);
   registerSttCommand(program);
+
+  registerInferenceCommand(program);
 
   // Fail fast when no assistant workspace exists on disk. The workspace is
   // created by `vellum hatch` and must be present for any command to work.

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -26,6 +26,7 @@ import { registerCredentialsCommand } from "./commands/credentials.js";
 import { registerDefaultAction } from "./commands/default-action.js";
 import { registerDomainCommand } from "./commands/domain.js";
 import { registerEmailCommand } from "./commands/email.js";
+import { registerImageGenerationCommand } from "./commands/image-generation.js";
 import { registerInferenceCommand } from "./commands/inference.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
@@ -98,6 +99,7 @@ Examples:
   registerSkillsCommand(program);
   registerUsageCommand(program);
 
+  registerImageGenerationCommand(program);
   registerUiCommand(program);
 
   registerShotgunCommand(program);

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -65,6 +65,7 @@ export const LLMCallSiteEnum = z.enum([
   "skillCategoryInference",
   "meetConsentMonitor",
   "meetChatOpportunity",
+  "inference",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 
@@ -297,9 +298,7 @@ export const LLMSchema = z
     // every call site). Latency-optimized defaults for background call sites
     // are seeded into the user's on-disk config by migration 040, not at
     // schema level, so `LLMSchema.parse({})` yields an empty map.
-    callSites: z
-      .partialRecord(LLMCallSiteEnum, LLMCallSiteConfig)
-      .default({}),
+    callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
     pricingOverrides: z.array(PricingOverrideSchema).default([]),
   })
   .superRefine((config, ctx) => {


### PR DESCRIPTION
## Summary
Add three new CLI command groups that expose the assistant's configured service providers as standalone CLI operations:
- `assistant stt transcribe` — transcribe audio/video via configured STT provider
- `assistant inference send` / `assistant llm send` — send messages to configured LLM provider
- `assistant image-generation generate` — generate/edit images via configured image generation provider

These are stateless, request-response commands that read config from disk and credentials from the secure key store, with no IPC or daemon dependency. They unlock migrating the `transcribe` and `image-studio` bundled skills to portable `skills/` directory skills.

## Self-review result
GAPS FOUND — 5 gaps fixed across 2 fix PRs

## PRs merged into feature branch
- #26711: feat(cli): add `assistant stt transcribe` command
- #26710: feat(cli): add `assistant inference send` command with `assistant llm` alias
- #26712: feat(cli): add `assistant image-generation generate` command

### Fix PRs
- #26717: fix(cli): stt error handling — exitCode, JSON errors, CLI logger
- #26716: fix(cli): consistent JSON error shape and edit mode validation

Part of plan: service-cli-commands.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
