### PR TITLE
fix: rename WatcherEvent.type to eventType in CLI watchers command

### DIFF
--- a/assistant/src/cli/commands/__tests__/watchers.test.ts
+++ b/assistant/src/cli/commands/__tests__/watchers.test.ts
@@ -670,7 +670,7 @@ describe("watchers digest", () => {
           {
             id: "e-1",
             watcherId: "w-1",
-            type: "issue_created",
+            eventType: "issue_created",
             summary: "New bug",
             createdAt: 1700000000000,
           },

--- a/assistant/src/cli/commands/watchers.ts
+++ b/assistant/src/cli/commands/watchers.ts
@@ -29,7 +29,7 @@ interface WatcherRecord {
 interface WatcherEvent {
   id: string;
   watcherId: string;
-  type: string;
+  eventType: string;
   summary: string | null;
   createdAt: number;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for watcher-skill-migrate.md.

**Gap:** WatcherEvent interface type vs eventType mismatch
**What was expected:** Interface field should be eventType to match watcher-store.ts
**What was found:** Interface had type but code accessed e.eventType
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
