### PR TITLE
fix: CI failures and review feedback on tasks migration

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -46,17 +46,6 @@ mock.module("../config/loader.js", () => ({
 // ── Import after mocks ───────────────────────────────────────────────
 const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
 
-// Load task_list_add description from the bundled skill TOOLS.json
-const tasksToolsJson = JSON.parse(
-  readFileSync(
-    join(import.meta.dirname, "../config/bundled-skills/tasks/TOOLS.json"),
-    "utf-8",
-  ),
-);
-const taskListAddDef = tasksToolsJson.tools.find(
-  (t: { name: string }) => t.name === "task_list_add",
-);
-
 // Load schedule_create description from the bundled skill TOOLS.json
 const scheduleToolsJson = JSON.parse(
   readFileSync(
@@ -98,33 +87,6 @@ describe("Task/Schedule routing NOT in system prompt (moved to tool descriptions
 // =====================================================================
 // 2. Tool description content: routing keywords
 // =====================================================================
-
-describe("task_list_add tool description", () => {
-  test('mentions "add to my tasks" routing phrase', () => {
-    const def = taskListAddDef;
-    expect(def.description).toContain("add to my tasks");
-  });
-
-  test('mentions "add to my queue" routing phrase', () => {
-    const def = taskListAddDef;
-    expect(def.description).toContain("add to my queue");
-  });
-
-  test('mentions "put this on my task list" routing phrase', () => {
-    const def = taskListAddDef;
-    expect(def.description).toContain("put this on my task list");
-  });
-
-  test("mentions ad-hoc title-only mode", () => {
-    const def = taskListAddDef;
-    expect(def.description).toContain("just a title");
-  });
-
-  test("explicitly warns NOT to use schedule_create or reminder for task requests", () => {
-    const def = taskListAddDef;
-    expect(def.description).toContain("Do NOT use schedule_create or reminder");
-  });
-});
 
 describe("schedule_create tool description", () => {
   test("mentions recurring scheduled automation", () => {
@@ -169,8 +131,7 @@ describe("send_notification tool description", () => {
 // =====================================================================
 
 describe("cross-tool routing consistency", () => {
-  test("both tools reference task_list_add as the task-queue tool", () => {
-    expect(taskListAddDef.name).toBe("task_list_add");
+  test("schedule_create redirects task requests to task_list_add", () => {
     expect(scheduleCreateDef.description).toContain("task_list_add");
   });
 

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,8 +1,8 @@
 import type { IpcRoute } from "../cli-server.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
-import { taskQueueRoutes } from "./task-queue.js";
 import { taskTemplateRoutes } from "./task.js";
+import { taskQueueRoutes } from "./task-queue.js";
 import { uiRequestRoute } from "./ui-request.js";
 import { wakeConversationRoute } from "./wake-conversation.js";
 

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -48,7 +48,7 @@ Manage the queue with `assistant task queue`:
 assistant task queue show
 
 # Add an item to the queue (ad-hoc or from a template)
-assistant task queue add --title "Review Q2 metrics" --required-tools host_bash web_search
+assistant task queue add --title "Review Q2 metrics" --required-tools host_bash,web_search
 
 # Update a work item's status
 assistant task queue update --work-item-id <id> --status done
@@ -65,4 +65,4 @@ assistant task queue run --work-item-id <id>
 - When the user says "add to my tasks" or "add to my queue", use `assistant task queue add` (NOT schedule).
 - Use `assistant task save` only when the user wants to capture a conversation pattern as a reusable template.
 - `assistant task list` shows saved templates; `assistant task queue show` shows the active work queue.
-- **Always specify `--required-tools`** when running `assistant task queue add`. Think about what tools the task will need at execution time and list them explicitly (e.g. `host_bash` for shell commands, `host_file_read host_file_write` for file operations, `web_search web_fetch` for web lookups). The user must approve these tools before the task can run -- omitting them forces a fallback to all tools, which is noisy and may miss non-standard tools the task actually needs.
+- **Always specify `--required-tools`** when running `assistant task queue add`. Think about what tools the task will need at execution time and list them explicitly (e.g. `host_bash` for shell commands, `host_file_read,host_file_write` for file operations, `web_search,web_fetch` for web lookups). The user must approve these tools before the task can run -- omitting them forces a fallback to all tools, which is noisy and may miss non-standard tools the task actually needs.


### PR DESCRIPTION
## Summary
- Fix import sort in ipc/routes/index.ts
- Update intent-routing.test.ts to not reference deleted bundled-skills/tasks/TOOLS.json
- Fix SKILL.md --required-tools examples to use comma-separated format

Follow-up to migrate-tasks-to-skills plan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
