### PR TITLE
fix(test): add image-generation CLI command to secure-keys allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -201,6 +201,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
       "oauth/manual-token-connection.ts", // manual-token provider backfill (credential store existence check)
       "workspace/provider-commit-message-generator.ts", // commit message generation provider key lookup
+      "cli/commands/image-generation.ts", // CLI image-generation command API key lookup
       "config/bundled-skills/image-studio/tools/media-generate-image.ts", // image generation tool API key lookup
       "config/bundled-skills/media-processing/tools/analyze-keyframes.ts", // keyframe analysis tool API key lookup
       "providers/registry.ts", // provider registry API key lookup for initialization


### PR DESCRIPTION
## Summary
- Add `cli/commands/image-generation.ts` to the `ALLOWED_IMPORTERS` set in the credential security invariants test
- This file legitimately imports `getProviderKeyAsync` from `secure-keys` to look up the user's Gemini API key in "your-own" mode — same pattern as the bundled image-studio skill and other authorized callers
- Fixes CI failure in PR #26718

## Original prompt
fix the CI failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/24636635379/job/72033146552?pr=26718
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
