### PR TITLE
refactor(skills): move browser skill to skills/vellum-browser-use with status-aware setup

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -60,12 +60,13 @@ describe("browser CLI-only architecture end-state", () => {
 
   // ── 2. Browser skill directory exists with SKILL.md ──────────────
 
-  test("bundled browser skill directory exists with SKILL.md but no TOOLS.json", async () => {
+  test("managed browser skill directory exists with SKILL.md but no TOOLS.json", async () => {
     const path = await import("node:path");
     const fs = await import("node:fs");
+    // Browser skill lives in skills/browser/ (managed), not bundled-skills/.
     const skillDir = path.resolve(
       import.meta.dirname,
-      "../config/bundled-skills/browser",
+      "../../../skills/vellum-browser-use",
     );
     expect(fs.existsSync(path.join(skillDir, "SKILL.md"))).toBe(true);
     // Browser operations are dispatched via the CLI, not via skill tools.
@@ -79,7 +80,7 @@ describe("browser CLI-only architecture end-state", () => {
     const fs = await import("node:fs");
     const toolsDir = path.resolve(
       import.meta.dirname,
-      "../config/bundled-skills/browser/tools",
+      "../../../skills/vellum-browser-use/tools",
     );
     // Browser operations are dispatched via CLI commands,
     // not via per-tool executor files.

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -1760,13 +1760,15 @@ describe("bundled skill: browser — CLI-only projection", () => {
   });
 
   test("browser skill loads without projecting any skill tools", () => {
-    mockCatalog = [makeSkill("browser", "/path/to/bundled-skills/browser")];
+    mockCatalog = [
+      makeSkill("vellum-browser-use", "/path/to/skills/vellum-browser-use"),
+    ];
     // Browser skill has no TOOLS.json manifest — operations are
     // dispatched via `assistant browser` CLI commands.
     mockManifests = {};
 
     const history: Message[] = [
-      ...buildSkillLoadHistory("browser", "v1:testhash"),
+      ...buildSkillLoadHistory("vellum-browser-use", "v1:testhash"),
     ];
 
     const result = projectSkillTools(history, {

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -520,9 +520,16 @@ describe("includes frontmatter parsing", () => {
   });
 });
 
-describe("bundled browser skill", () => {
+describe("managed browser skill", () => {
+  const BROWSER_SKILL_MD = readFileSync(
+    join(import.meta.dirname, "../../../skills/vellum-browser-use/SKILL.md"),
+    "utf-8",
+  );
+
   beforeEach(() => {
-    mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+    const skillDir = join(TEST_DIR, "skills", "vellum-browser-use");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), BROWSER_SKILL_MD);
   });
 
   afterEach(() => {
@@ -531,18 +538,17 @@ describe("bundled browser skill", () => {
       rmSync(skillsDir, { recursive: true, force: true });
   });
 
-  test("browser skill appears in full catalog (including bundled)", () => {
+  test("browser skill appears in full catalog", () => {
     const catalog = loadSkillCatalog();
-    const browserSkill = catalog.find((s) => s.id === "browser");
+    const browserSkill = catalog.find((s) => s.id === "vellum-browser-use");
     expect(browserSkill).toBeDefined();
-    expect(browserSkill!.name).toBe("browser");
+    expect(browserSkill!.name).toBe("vellum-browser-use");
     expect(browserSkill!.displayName).toBe("Browser");
-    expect(browserSkill!.bundled).toBe(true);
   });
 
   test("browser skill has correct metadata", () => {
     const catalog = loadSkillCatalog();
-    const browserSkill = catalog.find((s) => s.id === "browser");
+    const browserSkill = catalog.find((s) => s.id === "vellum-browser-use");
     expect(browserSkill).toBeDefined();
     expect(browserSkill!.description).toBe(
       "Browse the web using `assistant browser` CLI commands",
@@ -551,7 +557,7 @@ describe("bundled browser skill", () => {
 
   test("browser skill has no tool manifest", () => {
     const catalog = loadSkillCatalog();
-    const browserSkill = catalog.find((s) => s.id === "browser");
+    const browserSkill = catalog.find((s) => s.id === "vellum-browser-use");
     expect(browserSkill).toBeDefined();
     // Browser tools are dispatched via skill_execute and do not use
     // a skill-tool manifest.

--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -1,7 +1,7 @@
 import type { Message } from "../../providers/types.js";
 
-/** Skill ID for the bundled browser skill. */
-export const BROWSER_SKILL_ID = "browser";
+/** Skill ID for the browser skill. */
+export const BROWSER_SKILL_ID = "vellum-browser-use";
 
 let toolUseCounter = 0;
 

--- a/skills/amazon/SKILL.md
+++ b/skills/amazon/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   emoji: "🛒"
   vellum:
     display-name: "Amazon"
-    includes: ["browser"]
+    includes: ["vellum-browser-use"]
 ---
 
 Use browser automation for all Amazon actions. All browser operations are executed through the `assistant browser` CLI, invoked via `host_bash`. Use helper scripts with `host_bash` to normalize extraction results and decide the next step.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -561,6 +561,22 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "vellum-browser-use",
+      "name": "vellum-browser-use",
+      "description": "Browse the web using `assistant browser` CLI commands",
+      "metadata": {
+        "emoji": "🌐",
+        "vellum": {
+          "display-name": "Browser",
+          "feature-flag": "browser",
+          "activation-hints": [
+            "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "vellum-github-app-setup",
       "name": "vellum-github-app-setup",
       "description": "Create and configure a GitHub App so the assistant can push commits, open PRs, and comment under its own bot identity. Use when the user wants the assistant to have its own GitHub identity, or when setting up git push access for the first time.",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -11,7 +11,7 @@
         "vellum": {
           "display-name": "Amazon",
           "includes": [
-            "browser"
+            "vellum-browser-use"
           ]
         }
       },
@@ -252,7 +252,7 @@
         "vellum": {
           "display-name": "Influencer Research",
           "includes": [
-            "browser"
+            "vellum-browser-use"
           ]
         }
       },
@@ -393,7 +393,7 @@
         "vellum": {
           "display-name": "Restaurant Reservation Booking",
           "includes": [
-            "browser"
+            "vellum-browser-use"
           ]
         }
       },
@@ -627,7 +627,7 @@
         "vellum": {
           "display-name": "Vercel Token Setup",
           "includes": [
-            "browser"
+            "vellum-browser-use"
           ]
         }
       },

--- a/skills/influencer/SKILL.md
+++ b/skills/influencer/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   emoji: "🔍"
   vellum:
     display-name: "Influencer Research"
-    includes: ["browser"]
+    includes: ["vellum-browser-use"]
 ---
 
 Use browser automation for collection and `host_bash` helper scripts for deterministic parsing, scoring, and comparison. All browser operations are executed through the `assistant browser` CLI, invoked via `host_bash`.

--- a/skills/restaurant-reservation/SKILL.md
+++ b/skills/restaurant-reservation/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   emoji: "🍽️"
   vellum:
     display-name: "Restaurant Reservation Booking"
-    includes: ["browser"]
+    includes: ["vellum-browser-use"]
 ---
 
 Book restaurant reservations on OpenTable or Resy using browser automation. All browser operations are executed through the `assistant browser` CLI, invoked via `host_bash`.

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -13,25 +13,25 @@ metadata:
 
 Use this skill to browse the web. All browser operations are executed through the `assistant browser` CLI, invoked via `bash` or `host_bash`. Each operation is a subcommand:
 
-| Command | Description |
-|---|---|
-| `assistant browser navigate` | Navigate to a URL |
-| `assistant browser snapshot` | List interactive elements on the current page |
-| `assistant browser screenshot` | Take a visual screenshot |
-| `assistant browser click` | Click an element |
-| `assistant browser type` | Type text into an input |
-| `assistant browser press-key` | Press a keyboard key |
-| `assistant browser scroll` | Scroll the page or a specific element |
-| `assistant browser select-option` | Select an option from a native `<select>` element |
-| `assistant browser hover` | Hover over an element to reveal menus/tooltips |
-| `assistant browser wait-for` | Wait for a condition |
-| `assistant browser extract` | Extract page text content |
-| `assistant browser wait-for-download` | Wait for a file download to complete |
-| `assistant browser fill-credential` | Fill a stored credential into a form field |
-| `assistant browser attach` | Attach the Chrome debugger to the active tab |
-| `assistant browser detach` | Detach the Chrome debugger from the active tab |
-| `assistant browser close` | Close the browser page |
-| `assistant browser status` | Diagnose browser backend readiness and setup steps |
+| Command                               | Description                                        |
+| ------------------------------------- | -------------------------------------------------- |
+| `assistant browser navigate`          | Navigate to a URL                                  |
+| `assistant browser snapshot`          | List interactive elements on the current page      |
+| `assistant browser screenshot`        | Take a visual screenshot                           |
+| `assistant browser click`             | Click an element                                   |
+| `assistant browser type`              | Type text into an input                            |
+| `assistant browser press-key`         | Press a keyboard key                               |
+| `assistant browser scroll`            | Scroll the page or a specific element              |
+| `assistant browser select-option`     | Select an option from a native `<select>` element  |
+| `assistant browser hover`             | Hover over an element to reveal menus/tooltips     |
+| `assistant browser wait-for`          | Wait for a condition                               |
+| `assistant browser extract`           | Extract page text content                          |
+| `assistant browser wait-for-download` | Wait for a file download to complete               |
+| `assistant browser fill-credential`   | Fill a stored credential into a form field         |
+| `assistant browser attach`            | Attach the Chrome debugger to the active tab       |
+| `assistant browser detach`            | Detach the Chrome debugger from the active tab     |
+| `assistant browser close`             | Close the browser page                             |
+| `assistant browser status`            | Diagnose browser backend readiness and setup steps |
 
 ## Getting Started — Check Browser Readiness
 
@@ -42,6 +42,7 @@ assistant browser --json status
 ```
 
 The response includes:
+
 - `recommendedMode` — the best available backend (use this)
 - `modes[]` — per-mode status with `available`, `summary`, and `userActions` (remediation steps)
 
@@ -49,12 +50,12 @@ The response includes:
 
 Use `--browser-mode <mode>` on the `assistant browser` parent command to pin the browser backend:
 
-| Value | Backend | Description |
-|---|---|---|
-| `auto` | Automatic | Default. Picks the best available backend based on context. |
-| `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
-| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via DevTools Protocol. |
-| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. |
+| Value         | Backend          | Description                                                           |
+| ------------- | ---------------- | --------------------------------------------------------------------- |
+| `auto`        | Automatic        | Default. Picks the best available backend based on context.           |
+| `extension`   | Chrome extension | Routes through the user's Chrome browser via the extension debugger.  |
+| `cdp-inspect` | CDP inspect      | Connects to an already-running Chrome instance via DevTools Protocol. |
+| `local`       | Playwright       | Drives a dedicated Playwright-managed Chromium instance.              |
 
 ```bash
 assistant browser --browser-mode extension navigate --url http://www.example.com
@@ -63,6 +64,7 @@ assistant browser --browser-mode extension navigate --url http://www.example.com
 ### Prefer the Chrome Extension
 
 The **Chrome extension** (`extension` mode) is the preferred browser backend. It is:
+
 - More secure than Chrome's native remote debugging
 - Uses the user's real browser profile (cookies, sessions, saved logins)
 - Best experience for interacting with the user's actual browsing context
@@ -77,6 +79,7 @@ The status response's `userActions` array for the `extension` mode provides thes
 ### Fallback Modes
 
 If the user declines to install the extension:
+
 - **`cdp-inspect`** — Connects to an already-running Chrome instance via DevTools Protocol (Chrome 146+). Requires enabling remote debugging in Chrome settings.
 - **`local`** — Drives a dedicated Playwright-managed Chromium instance. Last resort — does not use the user's browser profile.
 
@@ -127,7 +130,6 @@ assistant browser --json screenshot
 ```
 
 The response includes a `screenshots` array with `mediaType` and `data` (base64) fields.
-
 
 ## Typical Workflow
 

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: browser
+name: vellum-browser-use
 description: Browse the web using `assistant browser` CLI commands
 compatibility: "Designed for Vellum personal assistants"
 metadata:
@@ -33,9 +33,54 @@ Use this skill to browse the web. All browser operations are executed through th
 | `assistant browser close` | Close the browser page |
 | `assistant browser status` | Diagnose browser backend readiness and setup steps |
 
-## Capabilities
+## Getting Started — Check Browser Readiness
 
-This browser runs **full Chromium with JavaScript enabled**. It can handle SPAs, React/Vue/Angular apps, dynamic content, date pickers, booking systems, reservation flows, and any JavaScript-heavy interactive site. Never tell the user you "can't handle interactive JavaScript" - you can.
+Before using any browser commands, run `assistant browser --json status` first to check which browser backends are available. The status command returns JSON with readiness information for each backend mode:
+
+```bash
+assistant browser --json status
+```
+
+The response includes:
+- `recommendedMode` — the best available backend (use this)
+- `modes[]` — per-mode status with `available`, `summary`, and `userActions` (remediation steps)
+
+## Browser Modes
+
+Use `--browser-mode <mode>` on the `assistant browser` parent command to pin the browser backend:
+
+| Value | Backend | Description |
+|---|---|---|
+| `auto` | Automatic | Default. Picks the best available backend based on context. |
+| `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
+| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via DevTools Protocol. |
+| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. |
+
+```bash
+assistant browser --browser-mode extension navigate --url http://www.example.com
+```
+
+### Prefer the Chrome Extension
+
+The **Chrome extension** (`extension` mode) is the preferred browser backend. It is:
+- More secure than Chrome's native remote debugging
+- Uses the user's real browser profile (cookies, sessions, saved logins)
+- Best experience for interacting with the user's actual browsing context
+
+If the status check shows the extension is **not available**, encourage the user to install and pair it:
+
+1. Install the **Vellum Assistant Chrome Extension** from the Chrome Web Store: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
+2. Open the extension in Chrome and pair it with the assistant.
+
+The status response's `userActions` array for the `extension` mode provides these same steps when the extension is not connected.
+
+### Fallback Modes
+
+If the user declines to install the extension:
+- **`cdp-inspect`** — Connects to an already-running Chrome instance via DevTools Protocol (Chrome 146+). Requires enabling remote debugging in Chrome settings.
+- **`local`** — Drives a dedicated Playwright-managed Chromium instance. Last resort — does not use the user's browser profile.
+
+Only fall back to these if the user explicitly indicates they do not want to install the extension. Prefer `cdp-inspect` over `local`.
 
 ## Session Management
 
@@ -83,37 +128,16 @@ assistant browser --json screenshot
 
 The response includes a `screenshots` array with `mediaType` and `data` (base64) fields.
 
-## Browser Mode
-
-Use `--browser-mode <mode>` on the `assistant browser` parent command to pin the browser backend:
-
-| Value | Backend | Description |
-|---|---|---|
-| `auto` | Automatic | Default. Picks the best available backend based on context. |
-| `extension` | Chrome extension | Routes through the user's Chrome browser via the extension debugger. |
-| `cdp-inspect` | CDP inspect | Connects to an already-running Chrome instance via DevTools Protocol. |
-| `local` | Playwright | Drives a dedicated Playwright-managed Chromium instance. |
-
-```bash
-assistant browser --browser-mode local navigate --url http://localhost:3000
-```
-
-**When to use `auto`**: Prefer `auto` (or omit `--browser-mode` entirely) unless you have a specific reason to pin. The automatic backend selection handles extension availability, fallback, and session reuse.
-
-**When to pin a mode**: Pin explicitly when:
-- The user requests interaction with their own browser (use `extension` or `cdp-inspect`).
-- A command only works on a specific backend (e.g. `wait-for-download` requires `local`).
-- You want to avoid fallback behavior for diagnostic clarity.
 
 ## Typical Workflow
 
-1. (Optional) `assistant browser status` to diagnose backend availability
-2. (Optional) `assistant browser attach` to establish the debugger session (extension path)
+1. `assistant browser --json status` to check backend readiness — if the extension is not available, help the user install it
+2. (Optional) `assistant browser attach` to establish the session
 3. `assistant browser navigate --url <url>` to load a page
 4. `assistant browser snapshot` to discover interactive elements
 5. Use `click`, `type`, `press-key`, `scroll`, `select-option`, or `hover` to interact
 6. `assistant browser extract` or `assistant browser screenshot --output <path>` to capture results
-7. `assistant browser detach` to end the session, or `assistant browser close` to close the page
+7. **Always** `assistant browser detach` when you are done — this releases the debugger so the user can browse freely
 
 ## Interaction Strategies
 

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   emoji: "▲"
   vellum:
     display-name: "Vercel Token Setup"
-    includes: ["browser"]
+    includes: ["vellum-browser-use"]
 ---
 
 You are helping your user set up a Vercel API token so they can publish apps to the web.


### PR DESCRIPTION
## Summary
- Moved the browser skill from `assistant/src/config/bundled-skills/browser/` to `skills/vellum-browser-use/` (managed skill), renaming the skill ID from `browser` to `vellum-browser-use`
- Enhanced SKILL.md with a "Getting Started" section that runs `assistant browser --json status` first and guides users to install the Chrome extension when unavailable
- Added emphasis on always running `assistant browser detach` when done to release the debugger
- Updated all references: `catalog.json` (4 includes), `amazon/SKILL.md`, test harness, and end-state tests

## Original prompt
Move browser skill into skills/, update it to be aware of `assistant browser status`, encourage Chrome extension use, and encourage detaching when done.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
