### PR TITLE
feat(ipc): add attachment register and lookup IPC routes

### DIFF
--- a/assistant/src/ipc/__tests__/attachment-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/attachment-ipc.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for the attachment IPC routes.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with the real SQLite attachment store backing
+ * the route handlers.
+ */
+
+import { unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../../memory/db.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// DB setup (attachment store needs SQLite)
+// ---------------------------------------------------------------------------
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+const tempFiles: string[] = [];
+
+function createTempFile(content: string, filename?: string): string {
+  const name = filename ?? `test-attachment-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), name);
+  writeFileSync(filePath, content);
+  tempFiles.push(filePath);
+  return filePath;
+}
+
+beforeEach(async () => {
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+
+  // Clean up temp files.
+  for (const filePath of tempFiles) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      /* file may already be gone */
+    }
+  }
+  tempFiles.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StoredAttachmentResult {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("attachment IPC routes", () => {
+  // -- attachment/register success ----------------------------------------
+
+  test("attachment/register returns stored attachment for valid file", async () => {
+    const filePath = createTempFile("hello world");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment/register",
+      {
+        path: filePath,
+        mimeType: "text/plain",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(typeof result.result!.id).toBe("string");
+    expect(result.result!.id.length).toBeGreaterThan(0);
+    expect(result.result!.originalFilename).toContain("test-attachment-");
+    expect(result.result!.mimeType).toBe("text/plain");
+    expect(result.result!.sizeBytes).toBe(11); // "hello world".length
+    expect(result.result!.kind).toBe("document");
+    expect(typeof result.result!.createdAt).toBe("number");
+  });
+
+  test("attachment/register uses custom filename when provided", async () => {
+    const filePath = createTempFile("custom name test");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment/register",
+      {
+        path: filePath,
+        mimeType: "image/png",
+        filename: "screenshot.png",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result!.originalFilename).toBe("screenshot.png");
+    expect(result.result!.mimeType).toBe("image/png");
+    expect(result.result!.kind).toBe("image");
+  });
+
+  // -- attachment/register errors -----------------------------------------
+
+  test("attachment/register errors when file does not exist", async () => {
+    const result = await cliIpcCall("attachment/register", {
+      path: "/tmp/nonexistent-file-that-should-not-exist-12345.txt",
+      mimeType: "text/plain",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("File not found");
+  });
+
+  test("attachment/register rejects missing path", async () => {
+    const result = await cliIpcCall("attachment/register", {
+      mimeType: "text/plain",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("attachment/register rejects missing mimeType", async () => {
+    const filePath = createTempFile("missing mime type");
+
+    const result = await cliIpcCall("attachment/register", {
+      path: filePath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // -- attachment/lookup errors -------------------------------------------
+
+  test("attachment/lookup errors when no attachment matches", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      sourcePath: "/nonexistent/path/to/file.txt",
+      conversationId: "nonexistent-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("No attachment found");
+  });
+
+  test("attachment/lookup rejects missing sourcePath", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      conversationId: "some-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("attachment/lookup rejects missing conversationId", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      sourcePath: "/some/path",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // -- Underscore aliases -------------------------------------------------
+
+  test("attachment_register alias works identically to attachment/register", async () => {
+    const filePath = createTempFile("alias test content");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment_register",
+      {
+        path: filePath,
+        mimeType: "text/plain",
+        filename: "alias-test.txt",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.originalFilename).toBe("alias-test.txt");
+    expect(result.result!.mimeType).toBe("text/plain");
+    expect(typeof result.result!.id).toBe("string");
+  });
+
+  test("attachment_lookup alias works identically to attachment/lookup", async () => {
+    const result = await cliIpcCall("attachment_lookup", {
+      sourcePath: "/nonexistent/path/to/file.txt",
+      conversationId: "nonexistent-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("No attachment found");
+  });
+});

--- a/assistant/src/ipc/routes/attachment.ts
+++ b/assistant/src/ipc/routes/attachment.ts
@@ -1,0 +1,99 @@
+/**
+ * IPC routes for attachment operations.
+ *
+ * Exposes register and lookup operations so CLI commands and external
+ * processes can interact with the attachment store.
+ *
+ * Each operation is registered under both a slash-style method name
+ * (e.g. `attachment/register`) and an underscore alias (`attachment_register`)
+ * for ergonomics.
+ */
+
+import { statSync } from "node:fs";
+import { basename } from "node:path";
+
+import { z } from "zod";
+
+import {
+  getFilePathBySourcePath,
+  uploadFileBackedAttachment,
+} from "../../memory/attachments-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// -- Param schemas --------------------------------------------------------
+
+const AttachmentRegisterParams = z.object({
+  path: z.string().min(1),
+  mimeType: z.string().min(1),
+  filename: z.string().optional(),
+});
+
+const AttachmentLookupParams = z.object({
+  sourcePath: z.string().min(1),
+  conversationId: z.string().min(1),
+});
+
+// -- Handlers -------------------------------------------------------------
+
+function handleAttachmentRegister(params?: Record<string, unknown>) {
+  const { path, mimeType, filename } = AttachmentRegisterParams.parse(params);
+
+  let sizeBytes: number;
+  try {
+    const stat = statSync(path);
+    sizeBytes = stat.size;
+  } catch {
+    throw new Error(`File not found: ${path}`);
+  }
+
+  const resolvedFilename = filename ?? basename(path);
+  return uploadFileBackedAttachment(
+    resolvedFilename,
+    mimeType,
+    path,
+    sizeBytes,
+  );
+}
+
+function handleAttachmentLookup(params?: Record<string, unknown>) {
+  const { sourcePath, conversationId } = AttachmentLookupParams.parse(params);
+
+  const result = getFilePathBySourcePath(sourcePath, conversationId);
+  if (result === null) {
+    throw new Error(
+      `No attachment found for source path: ${sourcePath} in conversation ${conversationId}. Run 'assistant attachment register' to register a file first.`,
+    );
+  }
+
+  return { filePath: result };
+}
+
+// -- Route definitions ----------------------------------------------------
+
+export const attachmentRegisterRoute: IpcRoute = {
+  method: "attachment/register",
+  handler: handleAttachmentRegister,
+};
+
+const attachmentRegisterAliasRoute: IpcRoute = {
+  method: "attachment_register",
+  handler: handleAttachmentRegister,
+};
+
+export const attachmentLookupRoute: IpcRoute = {
+  method: "attachment/lookup",
+  handler: handleAttachmentLookup,
+};
+
+const attachmentLookupAliasRoute: IpcRoute = {
+  method: "attachment_lookup",
+  handler: handleAttachmentLookup,
+};
+
+/** All attachment IPC routes (canonical + aliases). */
+export const attachmentRoutes: IpcRoute[] = [
+  attachmentRegisterRoute,
+  attachmentRegisterAliasRoute,
+  attachmentLookupRoute,
+  attachmentLookupAliasRoute,
+];

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,4 +1,5 @@
 import type { IpcRoute } from "../cli-server.js";
+import { attachmentRoutes } from "./attachment.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
 import { uiRequestRoute } from "./ui-request.js";
@@ -7,6 +8,7 @@ import { watcherRoutes } from "./watcher.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
+  ...attachmentRoutes,
   browserExecuteRoute,
   uiRequestRoute,
   wakeConversationRoute,


### PR DESCRIPTION
## Summary
- Add attachment/register and attachment/lookup IPC routes with Zod validation
- Server-side file existence check before registering attachments
- Integration tests covering success, error, and alias cases

Part of plan: attachment-ipc-cli.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
