### PR TITLE
feat(cli): add IPC-backed attachment register and lookup commands

### DIFF
--- a/assistant/src/cli/commands/__tests__/attachment.test.ts
+++ b/assistant/src/cli/commands/__tests__/attachment.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for the `assistant attachment` CLI command.
+ *
+ * Validates:
+ *   - Subcommand registration (register, lookup)
+ *   - Help text rendering with examples
+ *   - `register` success and error paths (JSON + plain)
+ *   - `lookup` success and error paths (JSON + plain)
+ *   - Exit codes on IPC failures
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+/** The last `cliIpcCall` invocation captured for assertions. */
+let lastIpcCall: {
+  method: string;
+  params?: Record<string, unknown>;
+} | null = null;
+
+/** The result that cliIpcCall will return. */
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: { id: "att-123" } };
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerAttachmentCommand } = await import("../attachment.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerAttachmentCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: { id: "att-123" } };
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("attachment help", () => {
+  test("attachment --help renders the command group with examples", async () => {
+    const { stdout } = await runCommand(["attachment", "--help"]);
+    expect(stdout).toContain("Manage file attachments");
+    expect(stdout).toContain("register");
+    expect(stdout).toContain("lookup");
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("assistant attachment register");
+    expect(stdout).toContain("assistant attachment lookup");
+  });
+
+  test("attachment register --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand(["attachment", "register", "--help"]);
+    expect(stdout).toContain("--path");
+    expect(stdout).toContain("--mime");
+    expect(stdout).toContain("--filename");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("file must remain on disk");
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("assistant attachment register --path");
+  });
+
+  test("attachment lookup --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand(["attachment", "lookup", "--help"]);
+    expect(stdout).toContain("--source");
+    expect(stdout).toContain("--conversation");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("assistant conversations list");
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("assistant attachment lookup");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// register — success
+// ---------------------------------------------------------------------------
+
+describe("attachment register", () => {
+  test("success: calls IPC and prints attachment ID", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "att-123",
+        originalFilename: "clip.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 1024,
+        kind: "video",
+        filePath: "/tmp/clip.mp4",
+        createdAt: 1700000000000,
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/clip.mp4",
+      "--mime",
+      "video/mp4",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("attachment/register");
+    expect(lastIpcCall!.params).toEqual({
+      path: "/tmp/clip.mp4",
+      mimeType: "video/mp4",
+      filename: undefined,
+    });
+    expect(stdout).toContain("att-123");
+  });
+
+  test("success with --json: outputs structured result", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "att-456",
+        originalFilename: "screen.png",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        kind: "image",
+        filePath: "/tmp/screen.png",
+        createdAt: 1700000000000,
+      },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/screen.png",
+      "--mime",
+      "image/png",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.id).toBe("att-456");
+    expect(parsed.originalFilename).toBe("screen.png");
+    expect(parsed.mimeType).toBe("image/png");
+    expect(parsed.sizeBytes).toBe(2048);
+    expect(parsed.kind).toBe("image");
+    expect(parsed.filePath).toBe("/tmp/screen.png");
+  });
+
+  test("passes --filename to IPC params", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        id: "att-789",
+        originalFilename: "recording.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 4096,
+        kind: "video",
+        filePath: "/tmp/clip.mp4",
+        createdAt: 1700000000000,
+      },
+    };
+
+    await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/clip.mp4",
+      "--mime",
+      "video/mp4",
+      "--filename",
+      "recording.mp4",
+    ]);
+
+    expect(lastIpcCall!.params!.filename).toBe("recording.mp4");
+  });
+
+  // ── register errors ──────────────────────────────────────────────
+
+  test("error (daemon not running): exits 1 with error message", async () => {
+    mockIpcResult = {
+      ok: false,
+      error:
+        "Could not connect to assistant. Is it running? Try 'vellum wake'.",
+    };
+
+    const { exitCode } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/clip.mp4",
+      "--mime",
+      "video/mp4",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("error (daemon not running) --json: outputs structured error", async () => {
+    mockIpcResult = {
+      ok: false,
+      error:
+        "Could not connect to assistant. Is it running? Try 'vellum wake'.",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/clip.mp4",
+      "--mime",
+      "video/mp4",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Could not connect");
+  });
+
+  test("error (file not found): exits 1 with actionable error", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "File not found: /tmp/nonexistent.mp4",
+    };
+
+    const { exitCode } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/nonexistent.mp4",
+      "--mime",
+      "video/mp4",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("error (file not found) --json: outputs structured error", async () => {
+    mockIpcResult = {
+      ok: false,
+      error: "File not found: /tmp/nonexistent.mp4",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "register",
+      "--path",
+      "/tmp/nonexistent.mp4",
+      "--mime",
+      "video/mp4",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("File not found");
+    expect(parsed.error).toContain("/tmp/nonexistent.mp4");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lookup — success
+// ---------------------------------------------------------------------------
+
+describe("attachment lookup", () => {
+  test("success: calls IPC and prints file path", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { filePath: "/path/to/stored/file.mp4" },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "lookup",
+      "--source",
+      "/original/path/file.mp4",
+      "--conversation",
+      "conv_123",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).toBeDefined();
+    expect(lastIpcCall!.method).toBe("attachment/lookup");
+    expect(lastIpcCall!.params).toEqual({
+      sourcePath: "/original/path/file.mp4",
+      conversationId: "conv_123",
+    });
+    expect(stdout).toContain("/path/to/stored/file.mp4");
+  });
+
+  test("success with --json: outputs structured result", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { filePath: "/path/to/stored/file.mp4" },
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "lookup",
+      "--source",
+      "/original/path/file.mp4",
+      "--conversation",
+      "conv_123",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.filePath).toBe("/path/to/stored/file.mp4");
+  });
+
+  // ── lookup errors ────────────────────────────────────────────────
+
+  test("error (not found): exits 1 with error", async () => {
+    mockIpcResult = {
+      ok: false,
+      error:
+        "No attachment found for source path: /tmp/missing.mp4 in conversation conv_456. Run 'assistant attachment register' to register a file first.",
+    };
+
+    const { exitCode } = await runCommand([
+      "attachment",
+      "lookup",
+      "--source",
+      "/tmp/missing.mp4",
+      "--conversation",
+      "conv_456",
+    ]);
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("error (not found) --json: outputs structured error", async () => {
+    mockIpcResult = {
+      ok: false,
+      error:
+        "No attachment found for source path: /tmp/missing.mp4 in conversation conv_456. Run 'assistant attachment register' to register a file first.",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "attachment",
+      "lookup",
+      "--source",
+      "/tmp/missing.mp4",
+      "--conversation",
+      "conv_456",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No attachment found");
+  });
+});

--- a/assistant/src/cli/commands/__tests__/attachment.test.ts
+++ b/assistant/src/cli/commands/__tests__/attachment.test.ts
@@ -135,7 +135,8 @@ describe("attachment help", () => {
     expect(stdout).toContain("--mime");
     expect(stdout).toContain("--filename");
     expect(stdout).toContain("--json");
-    expect(stdout).toContain("file must remain on disk");
+    expect(stdout).toContain("must remain");
+    expect(stdout).toContain("on disk");
     expect(stdout).toContain("Examples:");
     expect(stdout).toContain("assistant attachment register --path");
   });

--- a/assistant/src/cli/commands/attachment.ts
+++ b/assistant/src/cli/commands/attachment.ts
@@ -105,6 +105,7 @@ Examples:
         if (jsonOutput) {
           writeOutput(cmd, { ok: true, ...record });
         } else {
+          process.stdout.write(`${record.id}\n`);
           log.info(`Attachment registered: ${record.id}`);
           log.info(`  Filename: ${record.originalFilename}`);
           log.info(`  MIME:     ${record.mimeType}`);

--- a/assistant/src/cli/commands/attachment.ts
+++ b/assistant/src/cli/commands/attachment.ts
@@ -1,0 +1,181 @@
+/**
+ * `assistant attachment` CLI namespace.
+ *
+ * Subcommands: register, lookup — thin wrappers over the daemon's
+ * attachment IPC routes (`attachment/register`, `attachment/lookup`).
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
+
+// ── Registration ──────────────────────────────────────────────────────
+
+export function registerAttachmentCommand(program: Command): void {
+  const attachment = program
+    .command("attachment")
+    .description("Manage file attachments for conversations");
+
+  attachment.addHelpText(
+    "after",
+    `
+Attachments come in two flavours:
+
+  File-backed   Large files stored by path reference (no memory copy).
+                The file must remain on disk for the lifetime of the
+                attachment.
+  Inline        Small payloads encoded directly (handled internally).
+
+Use 'register' to record a file-backed attachment and 'lookup' to
+retrieve its stored path by the original source location.
+
+Examples:
+  $ assistant attachment register --path /tmp/clip.mp4 --mime video/mp4
+  $ assistant attachment register --path /tmp/clip.mp4 --mime video/mp4 --filename recording.mp4
+  $ assistant attachment lookup --source /tmp/clip.mp4 --conversation conv_abc123`,
+  );
+
+  // ── register ─────────────────────────────────────────────────────
+
+  attachment
+    .command("register")
+    .description("Register a file-backed attachment with the assistant")
+    .requiredOption("--path <file>", "Absolute path to the file (required)")
+    .requiredOption("--mime <type>", "MIME type of the file (required)")
+    .option(
+      "--filename <name>",
+      "Display filename (defaults to basename of path)",
+    )
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Registers a file on disk as a file-backed attachment in the assistant's
+attachment store. The file must exist at the given path and must remain
+on disk for the lifetime of the attachment — the assistant stores a
+path reference, not a copy.
+
+Returns the attachment ID and metadata on success.
+
+Examples:
+  $ assistant attachment register --path /tmp/clip.mp4 --mime video/mp4
+  $ assistant attachment register --path /tmp/screen.png --mime image/png --filename screenshot.png
+  $ assistant attachment register --path /tmp/audio.wav --mime audio/wav --json`,
+    )
+    .action(
+      async (
+        opts: {
+          path: string;
+          mime: string;
+          filename?: string;
+          json?: boolean;
+        },
+        cmd: Command,
+      ) => {
+        const jsonOutput = opts.json || shouldOutputJson(cmd);
+
+        const result = await cliIpcCall<{
+          id: string;
+          originalFilename: string;
+          mimeType: string;
+          sizeBytes: number;
+          kind: string;
+          filePath: string;
+          createdAt: number;
+        }>("attachment/register", {
+          path: opts.path,
+          mimeType: opts.mime,
+          filename: opts.filename,
+        });
+
+        if (!result.ok) {
+          if (jsonOutput) {
+            writeOutput(cmd, { ok: false, error: result.error });
+          } else {
+            log.error(result.error ?? "Unknown error");
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const record = result.result!;
+
+        if (jsonOutput) {
+          writeOutput(cmd, { ok: true, ...record });
+        } else {
+          log.info(`Attachment registered: ${record.id}`);
+          log.info(`  Filename: ${record.originalFilename}`);
+          log.info(`  MIME:     ${record.mimeType}`);
+          log.info(`  Size:     ${record.sizeBytes} bytes`);
+          log.info(`  Kind:     ${record.kind}`);
+          log.info(`  Path:     ${record.filePath}`);
+        }
+      },
+    );
+
+  // ── lookup ───────────────────────────────────────────────────────
+
+  attachment
+    .command("lookup")
+    .description("Look up a stored attachment by its original source path")
+    .requiredOption(
+      "--source <path>",
+      "Original source path of the file (required)",
+    )
+    .requiredOption(
+      "--conversation <id>",
+      "Conversation ID to search within (required) — run 'assistant conversations list' to find it",
+    )
+    .option("--json", "Output result as machine-readable JSON.")
+    .addHelpText(
+      "after",
+      `
+Searches for an attachment that was previously registered with the
+given source path, scoped to a specific conversation. Returns the
+stored file path on success.
+
+Attachments are linked to messages within conversations. Use
+'assistant conversations list' to find the conversation ID.
+
+Examples:
+  $ assistant attachment lookup --source /tmp/clip.mp4 --conversation conv_abc123
+  $ assistant attachment lookup --source /path/to/recording.mp4 --conversation conv_xyz --json`,
+    )
+    .action(
+      async (
+        opts: { source: string; conversation: string; json?: boolean },
+        cmd: Command,
+      ) => {
+        const jsonOutput = opts.json || shouldOutputJson(cmd);
+
+        const result = await cliIpcCall<{ filePath: string }>(
+          "attachment/lookup",
+          {
+            sourcePath: opts.source,
+            conversationId: opts.conversation,
+          },
+        );
+
+        if (!result.ok) {
+          if (jsonOutput) {
+            writeOutput(cmd, { ok: false, error: result.error });
+          } else {
+            log.error(result.error ?? "Unknown error");
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (jsonOutput) {
+          writeOutput(cmd, {
+            ok: true,
+            filePath: result.result!.filePath,
+          });
+        } else {
+          process.stdout.write(result.result!.filePath + "\n");
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -8,6 +8,7 @@ import { isEmailEnabled } from "../email/feature-gate.js";
 import { registerHooksCommand } from "../hooks/cli.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
+import { registerAttachmentCommand } from "./commands/attachment.js";
 import { registerAuditCommand } from "./commands/audit.js";
 import { registerAuthCommand } from "./commands/auth.js";
 import { registerAutonomyCommand } from "./commands/autonomy.js";
@@ -82,6 +83,7 @@ Examples:
   registerMemoryCommand(program);
   registerAuditCommand(program);
   registerAuthCommand(program);
+  registerAttachmentCommand(program);
   registerAvatarCommand(program);
   registerHooksCommand(program);
   registerMcpCommand(program);

--- a/assistant/src/ipc/__tests__/attachment-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/attachment-ipc.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for the attachment IPC routes.
+ *
+ * Exercises the full IPC round-trip: CliIpcServer + cliIpcCall over
+ * the Unix domain socket, with the real SQLite attachment store backing
+ * the route handlers.
+ */
+
+import { unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../../memory/db.js";
+import { cliIpcCall } from "../cli-client.js";
+import { CliIpcServer } from "../cli-server.js";
+
+// ---------------------------------------------------------------------------
+// DB setup (attachment store needs SQLite)
+// ---------------------------------------------------------------------------
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: CliIpcServer | null = null;
+const tempFiles: string[] = [];
+
+function createTempFile(content: string, filename?: string): string {
+  const name = filename ?? `test-attachment-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), name);
+  writeFileSync(filePath, content);
+  tempFiles.push(filePath);
+  return filePath;
+}
+
+beforeEach(async () => {
+  server = new CliIpcServer();
+  server.start();
+  // Allow the server socket to bind.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+
+  // Clean up temp files.
+  for (const filePath of tempFiles) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      /* file may already be gone */
+    }
+  }
+  tempFiles.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StoredAttachmentResult {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("attachment IPC routes", () => {
+  // -- attachment/register success ----------------------------------------
+
+  test("attachment/register returns stored attachment for valid file", async () => {
+    const filePath = createTempFile("hello world");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment/register",
+      {
+        path: filePath,
+        mimeType: "text/plain",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(typeof result.result!.id).toBe("string");
+    expect(result.result!.id.length).toBeGreaterThan(0);
+    expect(result.result!.originalFilename).toContain("test-attachment-");
+    expect(result.result!.mimeType).toBe("text/plain");
+    expect(result.result!.sizeBytes).toBe(11); // "hello world".length
+    expect(result.result!.kind).toBe("document");
+    expect(typeof result.result!.createdAt).toBe("number");
+  });
+
+  test("attachment/register uses custom filename when provided", async () => {
+    const filePath = createTempFile("custom name test");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment/register",
+      {
+        path: filePath,
+        mimeType: "image/png",
+        filename: "screenshot.png",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result!.originalFilename).toBe("screenshot.png");
+    expect(result.result!.mimeType).toBe("image/png");
+    expect(result.result!.kind).toBe("image");
+  });
+
+  // -- attachment/register errors -----------------------------------------
+
+  test("attachment/register errors when file does not exist", async () => {
+    const result = await cliIpcCall("attachment/register", {
+      path: "/tmp/nonexistent-file-that-should-not-exist-12345.txt",
+      mimeType: "text/plain",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("File not found");
+  });
+
+  test("attachment/register rejects missing path", async () => {
+    const result = await cliIpcCall("attachment/register", {
+      mimeType: "text/plain",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("attachment/register rejects missing mimeType", async () => {
+    const filePath = createTempFile("missing mime type");
+
+    const result = await cliIpcCall("attachment/register", {
+      path: filePath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // -- attachment/lookup errors -------------------------------------------
+
+  test("attachment/lookup errors when no attachment matches", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      sourcePath: "/nonexistent/path/to/file.txt",
+      conversationId: "nonexistent-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("No attachment found");
+  });
+
+  test("attachment/lookup rejects missing sourcePath", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      conversationId: "some-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test("attachment/lookup rejects missing conversationId", async () => {
+    const result = await cliIpcCall("attachment/lookup", {
+      sourcePath: "/some/path",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  // -- Underscore aliases -------------------------------------------------
+
+  test("attachment_register alias works identically to attachment/register", async () => {
+    const filePath = createTempFile("alias test content");
+
+    const result = await cliIpcCall<StoredAttachmentResult>(
+      "attachment_register",
+      {
+        path: filePath,
+        mimeType: "text/plain",
+        filename: "alias-test.txt",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.result).toBeDefined();
+    expect(result.result!.originalFilename).toBe("alias-test.txt");
+    expect(result.result!.mimeType).toBe("text/plain");
+    expect(typeof result.result!.id).toBe("string");
+  });
+
+  test("attachment_lookup alias works identically to attachment/lookup", async () => {
+    const result = await cliIpcCall("attachment_lookup", {
+      sourcePath: "/nonexistent/path/to/file.txt",
+      conversationId: "nonexistent-conversation-id",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("No attachment found");
+  });
+});

--- a/assistant/src/ipc/routes/attachment.ts
+++ b/assistant/src/ipc/routes/attachment.ts
@@ -1,0 +1,99 @@
+/**
+ * IPC routes for attachment operations.
+ *
+ * Exposes register and lookup operations so CLI commands and external
+ * processes can interact with the attachment store.
+ *
+ * Each operation is registered under both a slash-style method name
+ * (e.g. `attachment/register`) and an underscore alias (`attachment_register`)
+ * for ergonomics.
+ */
+
+import { statSync } from "node:fs";
+import { basename } from "node:path";
+
+import { z } from "zod";
+
+import {
+  getFilePathBySourcePath,
+  uploadFileBackedAttachment,
+} from "../../memory/attachments-store.js";
+import type { IpcRoute } from "../cli-server.js";
+
+// -- Param schemas --------------------------------------------------------
+
+const AttachmentRegisterParams = z.object({
+  path: z.string().min(1),
+  mimeType: z.string().min(1),
+  filename: z.string().optional(),
+});
+
+const AttachmentLookupParams = z.object({
+  sourcePath: z.string().min(1),
+  conversationId: z.string().min(1),
+});
+
+// -- Handlers -------------------------------------------------------------
+
+function handleAttachmentRegister(params?: Record<string, unknown>) {
+  const { path, mimeType, filename } = AttachmentRegisterParams.parse(params);
+
+  let sizeBytes: number;
+  try {
+    const stat = statSync(path);
+    sizeBytes = stat.size;
+  } catch {
+    throw new Error(`File not found: ${path}`);
+  }
+
+  const resolvedFilename = filename ?? basename(path);
+  return uploadFileBackedAttachment(
+    resolvedFilename,
+    mimeType,
+    path,
+    sizeBytes,
+  );
+}
+
+function handleAttachmentLookup(params?: Record<string, unknown>) {
+  const { sourcePath, conversationId } = AttachmentLookupParams.parse(params);
+
+  const result = getFilePathBySourcePath(sourcePath, conversationId);
+  if (result === null) {
+    throw new Error(
+      `No attachment found for source path: ${sourcePath} in conversation ${conversationId}. Run 'assistant attachment register' to register a file first.`,
+    );
+  }
+
+  return { filePath: result };
+}
+
+// -- Route definitions ----------------------------------------------------
+
+export const attachmentRegisterRoute: IpcRoute = {
+  method: "attachment/register",
+  handler: handleAttachmentRegister,
+};
+
+const attachmentRegisterAliasRoute: IpcRoute = {
+  method: "attachment_register",
+  handler: handleAttachmentRegister,
+};
+
+export const attachmentLookupRoute: IpcRoute = {
+  method: "attachment/lookup",
+  handler: handleAttachmentLookup,
+};
+
+const attachmentLookupAliasRoute: IpcRoute = {
+  method: "attachment_lookup",
+  handler: handleAttachmentLookup,
+};
+
+/** All attachment IPC routes (canonical + aliases). */
+export const attachmentRoutes: IpcRoute[] = [
+  attachmentRegisterRoute,
+  attachmentRegisterAliasRoute,
+  attachmentLookupRoute,
+  attachmentLookupAliasRoute,
+];

--- a/assistant/src/ipc/routes/attachment.ts
+++ b/assistant/src/ipc/routes/attachment.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import {
   getFilePathBySourcePath,
   uploadFileBackedAttachment,
+  validateAttachmentUpload,
 } from "../../memory/attachments-store.js";
 import type { IpcRoute } from "../cli-server.js";
 
@@ -41,12 +42,26 @@ function handleAttachmentRegister(params?: Record<string, unknown>) {
   let sizeBytes: number;
   try {
     const stat = statSync(path);
+    if (!stat.isFile()) {
+      throw new Error(
+        `Path is not a regular file: ${path}. Provide a path to a file, not a directory.`,
+      );
+    }
     sizeBytes = stat.size;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Path is not")) {
+      throw err;
+    }
     throw new Error(`File not found: ${path}`);
   }
 
   const resolvedFilename = filename ?? basename(path);
+
+  const validation = validateAttachmentUpload(resolvedFilename, mimeType);
+  if (!validation.ok) {
+    throw new Error(validation.error);
+  }
+
   return uploadFileBackedAttachment(
     resolvedFilename,
     mimeType,

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -1,4 +1,5 @@
 import type { IpcRoute } from "../cli-server.js";
+import { attachmentRoutes } from "./attachment.js";
 import { browserExecuteRoute } from "./browser.js";
 import { cacheRoutes } from "./cache.js";
 import { uiRequestRoute } from "./ui-request.js";
@@ -7,6 +8,7 @@ import { watcherRoutes } from "./watcher.js";
 
 /** All built-in CLI IPC routes. */
 export const cliIpcRoutes: IpcRoute[] = [
+  ...attachmentRoutes,
   browserExecuteRoute,
   uiRequestRoute,
   wakeConversationRoute,


### PR DESCRIPTION
## Summary
Add `assistant attachment register` and `assistant attachment lookup` CLI commands backed by IPC routes that communicate with the daemon over the Unix socket.

- `assistant attachment register --path <file> --mime <type>` — registers a local file as an in-chat attachment
- `assistant attachment lookup --source <path> --conversation <id>` — finds an attachment's stored file path by source path

These unlock migrating `image-studio` and `media-processing` bundled skills to portable `skills/` directory skills.

## PRs merged into feature branch
- #26727: feat(ipc): add attachment register and lookup IPC routes
- #26728: feat(cli): add `assistant attachment register` and `assistant attachment lookup` commands

Part of plan: attachment-ipc-cli.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
