### PR TITLE
fix: correct stale comment in browser-skill-endstate test

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -63,7 +63,7 @@ describe("browser CLI-only architecture end-state", () => {
   test("managed browser skill directory exists with SKILL.md but no TOOLS.json", async () => {
     const path = await import("node:path");
     const fs = await import("node:fs");
-    // Browser skill lives in skills/browser/ (managed), not bundled-skills/.
+    // Browser skill lives in skills/vellum-browser-use/ (managed), not bundled-skills/.
     const skillDir = path.resolve(
       import.meta.dirname,
       "../../../skills/vellum-browser-use",


### PR DESCRIPTION
## Summary
- Fixed comment in `browser-skill-endstate.test.ts` that referenced `skills/browser/` instead of the actual path `skills/vellum-browser-use/`

## Original prompt
Follow up on PR #26726 review feedback — fix stale comment in browser-skill-endstate.test.ts line 66.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
