### PR TITLE
fix: broadcast tasks_changed from IPC queue mutation routes

### DIFF
--- a/assistant/src/cli/commands/task.ts
+++ b/assistant/src/cli/commands/task.ts
@@ -76,7 +76,7 @@ Examples:
     .description("Save the current conversation as a task template")
     .option(
       "--conversation-id <id>",
-      "Conversation ID to save as a template. Falls back to env vars.",
+      "Conversation ID to save as a template -- run 'assistant conversations list' to find it. Falls back to env vars.",
     )
     .option("--title <title>", "Title for the task template.")
     .option("--json", "Output result as machine-readable JSON.")

--- a/assistant/src/ipc/routes/task-queue.ts
+++ b/assistant/src/ipc/routes/task-queue.ts
@@ -10,6 +10,7 @@
 
 import { z } from "zod";
 
+import { broadcastToAllClients } from "../../acp/index.js";
 import type { ToolContext } from "../../tools/types.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import type { IpcRoute } from "../cli-server.js";
@@ -110,6 +111,9 @@ async function handleTaskQueueAdd(params?: Record<string, unknown>) {
     input as Record<string, unknown>,
     queueToolContext(),
   );
+  if (!result.isError) {
+    broadcastToAllClients?.({ type: "tasks_changed" });
+  }
   return { content: result.content, isError: result.isError };
 }
 
@@ -121,6 +125,9 @@ async function handleTaskQueueUpdate(params?: Record<string, unknown>) {
     input as Record<string, unknown>,
     queueToolContext(),
   );
+  if (!result.isError) {
+    broadcastToAllClients?.({ type: "tasks_changed" });
+  }
   return { content: result.content, isError: result.isError };
 }
 
@@ -132,6 +139,9 @@ async function handleTaskQueueRemove(params?: Record<string, unknown>) {
     input as Record<string, unknown>,
     queueToolContext(),
   );
+  if (!result.isError) {
+    broadcastToAllClients?.({ type: "tasks_changed" });
+  }
   return { content: result.content, isError: result.isError };
 }
 
@@ -143,6 +153,9 @@ async function handleTaskQueueRun(params?: Record<string, unknown>) {
     input as Record<string, unknown>,
     queueToolContext(),
   );
+  if (!result.isError) {
+    broadcastToAllClients?.({ type: "tasks_changed" });
+  }
   return { content: result.content, isError: result.isError };
 }
 

--- a/assistant/src/ipc/routes/task.ts
+++ b/assistant/src/ipc/routes/task.ts
@@ -10,6 +10,7 @@
 
 import { z } from "zod";
 
+import { broadcastToAllClients } from "../../acp/index.js";
 import { executeTaskDelete } from "../../tools/tasks/task-delete.js";
 import { executeTaskList } from "../../tools/tasks/task-list.js";
 import { executeTaskRun } from "../../tools/tasks/task-run.js";
@@ -111,6 +112,9 @@ async function handleTaskDelete(
   if (result.isError) {
     throw new Error(result.content);
   }
+  // Deletion can also remove associated work items, so broadcast to refresh
+  // the macOS Tasks window.
+  broadcastToAllClients?.({ type: "tasks_changed" });
   return { ok: true, content: result.content };
 }
 


### PR DESCRIPTION
## Summary
- Add `tasks_changed` broadcast to task queue IPC mutation handlers (add, update, remove, run) so the macOS Tasks window auto-refreshes when tasks are mutated via CLI
- Add discovery hint to `--conversation-id` option on `task save` per CLI AGENTS.md conventions

## Original prompt
Address two review findings on PR #26722: (1) IPC task queue mutation routes don't broadcast `tasks_changed`, breaking real-time UI updates; (2) Missing discovery hint for `--conversation-id` option.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
