### PR TITLE
client(macos): use flat migration paths in teleport/transfer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -282,7 +282,7 @@ struct AssistantTransferSection: View {
             currentStep = "Importing data..."
             let importResponse = try await GatewayHTTPClient.withAssistant(resolvedLocal.assistantId) {
                 try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/migrations/import",
+                    path: "migrations/import",
                     body: bundleData,
                     contentType: "application/octet-stream",
                     timeout: 120
@@ -329,7 +329,7 @@ struct AssistantTransferSection: View {
     /// Exports the local assistant's data as a `.vbundle` binary archive.
     private func exportAssistantBundle() async throws -> Data {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/export",
+            path: "migrations/export",
             timeout: 60
         )
         guard response.isSuccess else {

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -479,7 +479,7 @@ struct TeleportSection: View {
         phase = .transferring(step: "Importing data to Docker...")
         let importResponse = try await GatewayHTTPClient.withAssistant(resolvedDocker.assistantId) {
             try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/migrations/import",
+                path: "migrations/import",
                 body: bundleData,
                 contentType: "application/octet-stream",
                 timeout: 120
@@ -625,13 +625,13 @@ struct TeleportSection: View {
         let response: GatewayHTTPClient.Response
         if let onProgress {
             response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/migrations/export",
+                path: "migrations/export",
                 timeout: 60,
                 onProgress: onProgress
             )
         } else {
             response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/migrations/export",
+                path: "migrations/export",
                 timeout: 60
             )
         }


### PR DESCRIPTION
## Summary
- `TeleportSection.swift` and `AssistantTransferSection.swift` were calling the scoped `assistants/{assistantId}/migrations/export|import` paths, which don't match the gateway's dedicated migration-proxy route. Requests fell through the generic `runtime-proxy` catch-all and inherited its 30s `runtimeTimeoutMs`, surfacing as 504s on larger bundles.
- Flipping these 5 call sites to the flat `migrations/export` / `migrations/import` form routes them through the dedicated handler (5m timeout after #26184). The local gateway only registers the flat form; matches how `AssistantBackupsSection` and the CLI already call these endpoints.
- The platform's migration API is entirely flat too (`/v1/migrations/export`, `upload-url`, `import-from-gcs`, etc.) — confirmed against `vellum-assistant-platform` — so no regression for managed callers.

## Original prompt
okay make the change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
