### PR TITLE
feat(slack): include MM/DD/YY date in transcript timestamp tags

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2469,12 +2469,12 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         {
           role: "user",
           content: [
-            { type: "text", text: "[14:25 @alice]: earlier DM line" },
+            { type: "text", text: "[11/14/23 14:25 @alice]: earlier DM line" },
           ],
         },
         {
           role: "assistant",
-          content: [{ type: "text", text: "[14:26 @assistant]: prior reply" }],
+          content: [{ type: "text", text: "[11/14/23 14:26 @assistant]: prior reply" }],
         },
       ],
     });
@@ -2850,7 +2850,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         { type: "text", text: "actual user content from prior turn" },
         {
           type: "text",
-          text: "<active_thread>\n[14:25 @alice]: old focus\n</active_thread>",
+          text: "<active_thread>\n[11/14/23 14:25 @alice]: old focus\n</active_thread>",
         },
       ],
     };
@@ -3349,15 +3349,15 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @alice]: hi assistant" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @alice]: hi assistant" }],
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[14:26 @assistant]: hi back!" }],
+        content: [{ type: "text", text: "[11/14/23 14:26 @assistant]: hi back!" }],
       },
       {
         role: "user",
-        content: [{ type: "text", text: "[14:28 @alice]: another one" }],
+        content: [{ type: "text", text: "[11/14/23 14:28 @alice]: another one" }],
       },
     ]);
     // Sanity: no thread-tag arrow ever appears in DM output.
@@ -3401,10 +3401,10 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).not.toBeNull();
     expect(result!.map((m) => (m.content[0] as { text: string }).text)).toEqual(
       [
-        "[14:25 @user]: old hi",
-        "[14:26 @assistant]: old reply",
-        "[14:28 @alice]: fresh hi",
-        "[14:30 @assistant]: fresh reply",
+        "[11/14/23 14:25 @user]: old hi",
+        "[11/14/23 14:26 @assistant]: old reply",
+        "[11/14/23 14:28 @alice]: fresh hi",
+        "[11/14/23 14:30 @assistant]: fresh reply",
       ],
     );
     expect(result!.map((m) => m.role)).toEqual([
@@ -3431,7 +3431,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @user]: hello" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @user]: hello" }],
       },
     ]);
   });
@@ -3490,7 +3490,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(rendered[1]!).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[14:26 @assistant]: looking it up" },
+        { type: "text", text: "[11/14/23 14:26 @assistant]: looking it up" },
         {
           type: "tool_use",
           id: "tu_1",
@@ -3810,13 +3810,13 @@ describe("assembleSlackChronologicalMessages", () => {
     // Row 1: user tag line only.
     expect(result![0]).toEqual({
       role: "user",
-      content: [{ type: "text", text: "[23:03 @alice]: hi" }],
+      content: [{ type: "text", text: "[11/14/23 23:03 @alice]: hi" }],
     });
     // Row 2: assistant tag line + tool_use(abc).
     expect(result![1]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[23:03 @assistant]: checking..." },
+        { type: "text", text: "[11/14/23 23:03 @assistant]: checking..." },
         {
           type: "tool_use",
           id: "tu_abc",
@@ -3836,7 +3836,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result![3]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[23:03 @assistant]: one more lookup..." },
+        { type: "text", text: "[11/14/23 23:03 @assistant]: one more lookup..." },
         {
           type: "tool_use",
           id: "tu_def",
@@ -3855,12 +3855,12 @@ describe("assembleSlackChronologicalMessages", () => {
     // Row 6: assistant final text-only answer, rendered as tag line only.
     expect(result![5]).toEqual({
       role: "assistant",
-      content: [{ type: "text", text: "[23:03 @assistant]: all done" }],
+      content: [{ type: "text", text: "[11/14/23 23:03 @assistant]: all done" }],
     });
     // Row 7: user follow-up tag line.
     expect(result![6]).toEqual({
       role: "user",
-      content: [{ type: "text", text: "[23:03 @alice]: follow-up" }],
+      content: [{ type: "text", text: "[11/14/23 23:03 @alice]: follow-up" }],
     });
   });
 });

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -20,7 +20,7 @@ import {
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 // Anchor times: 14:25:00 UTC on 2023-11-14 = 1699971900 (Slack ts seconds).
-// We work entirely in UTC because the renderer formats UTC HH:MM.
+// We work entirely in UTC because the renderer formats UTC MM/DD/YY HH:MM.
 const TS_14_24 = "1699971840.000050"; // 14:24 UTC
 const TS_14_25 = "1699971900.000100"; // 14:25 UTC
 const TS_14_26 = "1699971960.000200"; // 14:26 UTC
@@ -110,9 +110,9 @@ describe("renderSlackTranscript — basics", () => {
     expect(renderSlackTranscript([])).toEqual([]);
   });
 
-  test("renders top-level message with HH:MM tag", () => {
+  test("renders top-level message with MM/DD/YY HH:MM tag", () => {
     const out = renderSlackTranscript([userMsg(TS_14_25, "@alice", "hi")]);
-    expect(out).toEqual([textMsg("user", "[14:25 @alice]: hi")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice]: hi")]);
   });
 
   test("renders thread reply with parent alias arrow", () => {
@@ -121,7 +121,7 @@ describe("renderSlackTranscript — basics", () => {
     ]);
     const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob → ${alias}]: got it`),
+      textMsg("user", `[11/14/23 14:28 @bob → ${alias}]: got it`),
     ]);
   });
 
@@ -130,7 +130,7 @@ describe("renderSlackTranscript — basics", () => {
       userMsg(TS_14_25, "@alice", "hi (revised)", { editedAt: MS_14_30 }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice, edited 14:30]: hi (revised)"),
+      textMsg("user", "[11/14/23 14:25 @alice, edited 11/14/23 14:30]: hi (revised)"),
     ]);
   });
 
@@ -141,7 +141,7 @@ describe("renderSlackTranscript — basics", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_25, "@alice", "v2", { editedAt: MS_14_32 }),
     ]);
-    expect(out).toEqual([textMsg("user", "[14:25 @alice, edited 14:32]: v2")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice, edited 11/14/23 14:32]: v2")]);
   });
 
   test("edited message in a thread renders both arrow and edit suffix", () => {
@@ -153,7 +153,7 @@ describe("renderSlackTranscript — basics", () => {
     ]);
     const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob → ${alias}, edited 14:30]: got it (edit)`),
+      textMsg("user", `[11/14/23 14:28 @bob → ${alias}, edited 11/14/23 14:30]: got it (edit)`),
     ]);
   });
 
@@ -162,7 +162,7 @@ describe("renderSlackTranscript — basics", () => {
       userMsg(TS_14_25, "@alice", "(removed)", { deletedAt: MS_14_32 }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice — deleted 14:32]"),
+      textMsg("user", "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]"),
     ]);
   });
 
@@ -176,7 +176,7 @@ describe("renderSlackTranscript — basics", () => {
       }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice — deleted 14:32]"),
+      textMsg("user", "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]"),
     ]);
     const text0 = extractTagLineTexts(out)[0];
     // No "edited" suffix should leak through.
@@ -194,9 +194,9 @@ describe("renderSlackTranscript — basics", () => {
       userMsg(TS_14_30, "@carol", "third"),
     ]);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @alice]: first",
-      "[14:28 @bob — deleted 14:30]",
-      "[14:30 @carol]: third",
+      "[11/14/23 14:25 @alice]: first",
+      "[11/14/23 14:28 @bob — deleted 11/14/23 14:30]",
+      "[11/14/23 14:30 @carol]: third",
     ]);
   });
 
@@ -206,7 +206,7 @@ describe("renderSlackTranscript — basics", () => {
       reactionMsg(TS_14_28, "@bob", "👍", TS_14_25, "added"),
     ]);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob reacted 👍 to ${alias}]`),
+      textMsg("user", `[11/14/23 14:28 @bob reacted 👍 to ${alias}]`),
     ]);
   });
 
@@ -216,7 +216,7 @@ describe("renderSlackTranscript — basics", () => {
       reactionMsg(TS_14_28, "@bob", "👍", TS_14_25, "removed"),
     ]);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob removed 👍 from ${alias}]`),
+      textMsg("user", `[11/14/23 14:28 @bob removed 👍 from ${alias}]`),
     ]);
   });
 });
@@ -235,7 +235,7 @@ describe("renderSlackTranscript — edited marker", () => {
       }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice — deleted 14:32]"),
+      textMsg("user", "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]"),
     ]);
     expect(extractTagLineTexts(out)[0].includes("edited")).toBe(false);
   });
@@ -265,7 +265,7 @@ describe("renderSlackTranscript — edited marker", () => {
     const out = renderSlackTranscript([reaction]);
     const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob reacted 👍 to ${alias}]`),
+      textMsg("user", `[11/14/23 14:28 @bob reacted 👍 to ${alias}]`),
     ]);
     expect(extractTagLineTexts(out)[0].includes("edited")).toBe(false);
   });
@@ -277,7 +277,7 @@ describe("renderSlackTranscript — edited marker", () => {
       userMsg(TS_14_25, "@alice", "v2", { editedAt: 0 }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice, edited 00:00]: v2"),
+      textMsg("user", "[11/14/23 14:25 @alice, edited 01/01/70 00:00]: v2"),
     ]);
   });
 });
@@ -391,10 +391,10 @@ describe("renderSlackTranscript — mixed message + reaction chronology", () => 
       userMsg(TS_14_26, "@bob", "yes"),
     ]);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @alice]: lunch?",
-      "[14:26 @bob]: yes",
-      `[14:28 @carol reacted 👍 to ${aliasParent}]`,
-      "[14:30 @dan]: later",
+      "[11/14/23 14:25 @alice]: lunch?",
+      "[11/14/23 14:26 @bob]: yes",
+      `[11/14/23 14:28 @carol reacted 👍 to ${aliasParent}]`,
+      "[11/14/23 14:30 @dan]: later",
     ]);
   });
 
@@ -410,10 +410,10 @@ describe("renderSlackTranscript — mixed message + reaction chronology", () => 
       reactionMsg(TS_14_30, "@carol", "👍", TS_14_25, "removed"),
     ]);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @alice]: lunch?",
-      `[14:26 @carol reacted 👍 to ${aliasParent}]`,
-      "[14:28 @bob]: yes",
-      `[14:30 @carol removed 👍 from ${aliasParent}]`,
+      "[11/14/23 14:25 @alice]: lunch?",
+      `[11/14/23 14:26 @carol reacted 👍 to ${aliasParent}]`,
+      "[11/14/23 14:28 @bob]: yes",
+      `[11/14/23 14:30 @carol removed 👍 from ${aliasParent}]`,
     ]);
   });
 });
@@ -428,9 +428,9 @@ describe("renderSlackTranscript — sort", () => {
       userMsg(TS_14_28, "@mid", "middle"),
     ]);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @early]: earlier",
-      "[14:28 @mid]: middle",
-      "[14:30 @late]: later",
+      "[11/14/23 14:25 @early]: earlier",
+      "[11/14/23 14:28 @mid]: middle",
+      "[11/14/23 14:30 @late]: later",
     ]);
   });
 
@@ -442,9 +442,9 @@ describe("renderSlackTranscript — sort", () => {
       userMsg(sameTs, "@third", "3"),
     ]);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @first]: 1",
-      "[14:25 @second]: 2",
-      "[14:25 @third]: 3",
+      "[11/14/23 14:25 @first]: 1",
+      "[11/14/23 14:25 @second]: 2",
+      "[11/14/23 14:25 @third]: 3",
     ]);
   });
 });
@@ -477,11 +477,11 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const out = renderSlackTranscript(messages);
     const aliceAlias = parentAlias(aliceTopTs);
     expect(extractTagLineTexts(out)).toEqual([
-      "[14:25 @alice]: lunch?",
-      `[14:26 @bob → ${aliceAlias}]: yes!`,
-      `[14:27 @alice → ${aliceAlias}]: 12:30 ok?`,
-      "[14:28 @carol]: standup soon",
-      `[14:28 @dan → ${aliceAlias}]: I'll join`,
+      "[11/14/23 14:25 @alice]: lunch?",
+      `[11/14/23 14:26 @bob → ${aliceAlias}]: yes!`,
+      `[11/14/23 14:27 @alice → ${aliceAlias}]: 12:30 ok?`,
+      "[11/14/23 14:28 @carol]: standup soon",
+      `[11/14/23 14:28 @dan → ${aliceAlias}]: I'll join`,
     ]);
   });
 
@@ -497,9 +497,9 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const texts = extractTagLineTexts(out);
     // The reply tag points at carol's alias; carol's top stays untagged.
     expect(texts[texts.length - 1]).toBe(
-      `[14:28 @ed → ${carolAlias}]: joining now`,
+      `[11/14/23 14:28 @ed → ${carolAlias}]: joining now`,
     );
-    expect(texts[3]).toBe("[14:28 @carol]: standup soon");
+    expect(texts[3]).toBe("[11/14/23 14:28 @carol]: standup soon");
   });
 
   test("scenario: reply to the most recent top-level message", () => {
@@ -512,7 +512,7 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const out = renderSlackTranscript(messages);
     const carolAlias = parentAlias(carolTopTs);
     const texts = extractTagLineTexts(out);
-    expect(texts[texts.length - 1]).toBe(`[14:28 @frank → ${carolAlias}]: +1`);
+    expect(texts[texts.length - 1]).toBe(`[11/14/23 14:28 @frank → ${carolAlias}]: +1`);
   });
 
   test("scenario: new top-level message (no threadTs)", () => {
@@ -523,7 +523,7 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const out = renderSlackTranscript(messages);
     const texts = extractTagLineTexts(out);
     // No arrow on the new top-level row.
-    expect(texts[texts.length - 1]).toBe("[14:31 @gina]: anyone in office?");
+    expect(texts[texts.length - 1]).toBe("[11/14/23 14:31 @gina]: anyone in office?");
   });
 });
 
@@ -545,9 +545,9 @@ describe("renderSlackTranscript — mixed legacy + post-upgrade", () => {
 
     const texts = extractTagLineTexts(out);
     expect(texts).toEqual([
-      "[14:25 @alice]: lunch?",
-      "[14:26 @dana]: drive-by note",
-      `[14:28 @bob → ${alias}]: yes!`,
+      "[11/14/23 14:25 @alice]: lunch?",
+      "[11/14/23 14:26 @dana]: drive-by note",
+      `[11/14/23 14:28 @bob → ${alias}]: yes!`,
     ]);
     // Ensure the legacy row has no arrow.
     expect(texts[1].includes("→")).toBe(false);
@@ -557,7 +557,7 @@ describe("renderSlackTranscript — mixed legacy + post-upgrade", () => {
     const out = renderSlackTranscript([
       legacyMsg(MS_14_25, "@bot", "ack", "assistant"),
     ]);
-    expect(out).toEqual([textMsg("assistant", "[14:25 @bot]: ack")]);
+    expect(out).toEqual([textMsg("assistant", "[11/14/23 14:25 @bot]: ack")]);
   });
 
   test("preserves message role faithfully across mixed inputs", () => {
@@ -612,7 +612,7 @@ describe("renderSlackTranscript — Message[] shape", () => {
     expect(out).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @alice]: hi" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @alice]: hi" }],
       },
     ]);
   });
@@ -626,11 +626,11 @@ describe("renderSlackTranscript — Message[] shape", () => {
     expect(out).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @first]: 1" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @first]: 1" }],
       },
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @second]: 2" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @second]: 2" }],
       },
     ]);
   });
@@ -718,7 +718,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out[0]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[14:25 @assistant]: looking it up" },
+        { type: "text", text: "[11/14/23 14:25 @assistant]: looking it up" },
         { type: "tool_use", id: "tu_1", name: "search", input: { q: "x" } },
       ],
     });
@@ -766,7 +766,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
         role: "assistant",
         content: [
           { type: "thinking", thinking: "let me think", signature: "sig-abc" },
-          { type: "text", text: "[14:25 @assistant]: here's the answer" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: here's the answer" },
         ],
       },
     ]);
@@ -791,7 +791,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[14:25 @assistant]: doing a thing" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: doing a thing" },
           { type: "tool_use", id: "tu_A", name: "op", input: {} },
           { type: "tool_result", tool_use_id: "tu_A", content: "ok" },
         ],
@@ -814,7 +814,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[14:25 @assistant]: reply body" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @assistant]: reply body" }],
       },
     ]);
   });
@@ -836,7 +836,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[14:25 @assistant]: web search" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @assistant]: web search" }],
       },
     ]);
   });
@@ -869,7 +869,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
               data: "base64data==",
             },
           },
-          { type: "text", text: "[14:25 @alice]: check this out" },
+          { type: "text", text: "[11/14/23 14:25 @alice]: check this out" },
         ],
       },
     ]);
@@ -887,7 +887,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @alice — deleted 14:32]" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]" }],
       },
     ]);
   });
@@ -899,7 +899,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(base.contentBlocks).toBeUndefined();
     const out = renderSlackTranscript([base]);
     expect(out).toEqual([
-      textMsg("user", "[14:25 @alice]: legacy plain"),
+      textMsg("user", "[11/14/23 14:25 @alice]: legacy plain"),
     ]);
   });
 
@@ -909,7 +909,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
       contentBlocks: [],
     };
     const out = renderSlackTranscript([base]);
-    expect(out).toEqual([textMsg("user", "[14:25 @alice]: empty blocks")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice]: empty blocks")]);
   });
 
   test("reaction row ignores contentBlocks and renders the single reaction tag line", () => {
@@ -926,7 +926,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     const out = renderSlackTranscript([withBlocks]);
     const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
-      textMsg("user", `[14:28 @bob reacted 👍 to ${alias}]`),
+      textMsg("user", `[11/14/23 14:28 @bob reacted 👍 to ${alias}]`),
     ]);
   });
 });
@@ -962,7 +962,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[14:25 @assistant]: looking it up" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: looking it up" },
         ],
       },
     ]);
@@ -986,7 +986,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
     expect(out).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[14:25 @alice]: follow up" }],
+        content: [{ type: "text", text: "[11/14/23 14:25 @alice]: follow up" }],
       },
     ]);
   });
@@ -1014,7 +1014,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[14:25 @assistant]: running op" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: { a: 1 } },
         ],
       },
@@ -1049,7 +1049,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       "hi",
     );
     const out = renderSlackTranscript([orphanResultRow, neighbour]);
-    expect(out).toEqual([textMsg("user", "[14:26 @bob]: hi")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:26 @bob]: hi")]);
     // Sanity: the output contains no {role, content: []} placeholder.
     for (const m of out) {
       expect(m.content.length).toBeGreaterThan(0);
@@ -1108,7 +1108,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[14:25 @assistant]: running op" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: {} },
         ],
       },
@@ -1120,11 +1120,11 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[14:28 @assistant]: looking" }],
+        content: [{ type: "text", text: "[11/14/23 14:28 @assistant]: looking" }],
       },
       {
         role: "user",
-        content: [{ type: "text", text: "[14:30 @alice]: stray" }],
+        content: [{ type: "text", text: "[11/14/23 14:30 @alice]: stray" }],
       },
     ]);
   });
@@ -1177,7 +1177,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
               filename: "doc.pdf",
             },
           },
-          { type: "text", text: "[14:25 @assistant]: here you go" },
+          { type: "text", text: "[11/14/23 14:25 @assistant]: here you go" },
         ],
       },
     ]);

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -53,9 +53,9 @@ const DEFAULT_MAX_REACTIONS = 5;
  * persisted row when rendering the Slack chronological transcript.
  *
  * `text` is intentionally omitted — text content is subsumed into the tag
- * line (e.g. `[14:25 @assistant]: ...`) so callers reading the rendered
- * output see one human-readable line per row rather than a raw text block
- * stripped of thread context.
+ * line (e.g. `[11/14/23 14:25 @assistant]: ...`) so callers reading the
+ * rendered output see one human-readable line per row rather than a raw
+ * text block stripped of thread context.
  *
  * Non-replayable types (`ui_surface`, `server_tool_use`,
  * `web_search_tool_result`, unknown types) are dropped: `ui_surface` blocks
@@ -86,26 +86,29 @@ export function parentAlias(channelTs: string): string {
 }
 
 /**
- * Format a Slack ts (`"1700000000.000100"`) as `HH:MM` (UTC).
+ * Format a Slack ts (`"1700000000.000100"`) as `MM/DD/YY HH:MM` (UTC).
  *
  * Slack ts is `<unix-seconds>.<microseconds>`; we treat it as a unix epoch
  * second value for display purposes. Pure — derives only from the ts string.
  */
 function formatSlackTs(channelTs: string): string {
   const seconds = Number.parseFloat(channelTs);
-  if (!Number.isFinite(seconds)) return "??:??";
+  if (!Number.isFinite(seconds)) return "??/??/?? ??:??";
   return formatEpochMs(seconds * 1000);
 }
 
 /**
- * Format an epoch millisecond timestamp as `HH:MM` (UTC).
+ * Format an epoch millisecond timestamp as `MM/DD/YY HH:MM` (UTC).
  */
 function formatEpochMs(ms: number): string {
-  if (!Number.isFinite(ms)) return "??:??";
+  if (!Number.isFinite(ms)) return "??/??/?? ??:??";
   const d = new Date(ms);
+  const mo = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const da = String(d.getUTCDate()).padStart(2, "0");
+  const yy = String(d.getUTCFullYear() % 100).padStart(2, "0");
   const hh = String(d.getUTCHours()).padStart(2, "0");
   const mm = String(d.getUTCMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  return `${mo}/${da}/${yy} ${hh}:${mm}`;
 }
 
 /**
@@ -157,8 +160,8 @@ function renderMessage(msg: RenderableSlackMessage): string {
 /**
  * Render a single reaction event as one tagged line.
  *
- * `[14:28 @bob reacted 👍 to M1a2b3c]` or
- * `[14:28 @bob removed 👍 from M1a2b3c]`.
+ * `[11/14/23 14:28 @bob reacted 👍 to M1a2b3c]` or
+ * `[11/14/23 14:28 @bob removed 👍 from M1a2b3c]`.
  */
 function renderReaction(msg: RenderableSlackMessage): string | null {
   const meta = msg.metadata;
@@ -173,7 +176,7 @@ function renderReaction(msg: RenderableSlackMessage): string | null {
 /**
  * Build the content blocks for a single non-reaction message.
  *
- * Emits the tag line (`[HH:MM @sender ...]: body`) inline at the position of
+ * Emits the tag line (`[MM/DD/YY HH:MM @sender ...]: body`) inline at the position of
  * the first `text` block in `contentBlocks`, and preserves any replayable
  * blocks (`tool_use`, `tool_result`, `thinking`, `redacted_thinking`,
  * `image`, `file`) in their original order. Non-replayable blocks


### PR DESCRIPTION
## Summary
- Render Slack transcript timestamps as `MM/DD/YY HH:MM` (UTC) instead of just `HH:MM` so the model can disambiguate messages across days. The change applies uniformly to message tag lines, edit suffixes, delete markers, and reaction lines, and propagates to the `<active_thread>` focus block since it shares the same renderer.
- Update `formatSlackTs`/`formatEpochMs` in `assistant/src/messaging/providers/slack/render-transcript.ts` and refresh fixtures in `render-transcript.test.ts` and `conversation-runtime-assembly.test.ts`.

## Original prompt
[Image #1] this timestamp should include the date in MM/DD/YY format in addition to the time
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
