### PR TITLE
refactor(slack): drop redundant @assistant/@user labels from transcripts

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2409,11 +2409,15 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(lines[1]).not.toContain("→ M");
     // Post-upgrade row carries its thread tag.
     expect(lines[2]).toContain(`→ ${ALIAS_T0}`);
-    // Sender labels: legacy users fall back to "@user" (the row mapper
-    // intentionally does not mine outer metadata for displayName hints —
-    // the renderer's flat fallback handles them uniformly).
-    expect(lines[0]).toContain("@user");
-    expect(lines[1]).toContain("@assistant");
+    // Sender labels: legacy rows carry no structured displayName, and the
+    // role slot already conveys user-vs-assistant identity, so the row
+    // mapper emits `null` senderLabel and the renderer omits the label
+    // entirely. Real Slack usernames are only rendered for post-upgrade
+    // user rows where `slackMeta.displayName` is populated.
+    expect(lines[0]).not.toContain("@user");
+    expect(lines[0]).not.toContain("@assistant");
+    expect(lines[1]).not.toContain("@assistant");
+    expect(lines[1]).not.toContain("@user");
   });
 
   // ── Branch isolation: non-Slack channels untouched ───────────────────
@@ -2474,7 +2478,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         },
         {
           role: "assistant",
-          content: [{ type: "text", text: "[11/14/23 14:26 @assistant]: prior reply" }],
+          content: [{ type: "text", text: "[11/14/23 14:26]: prior reply" }],
         },
       ],
     });
@@ -3353,7 +3357,7 @@ describe("assembleSlackChronologicalMessages", () => {
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:26 @assistant]: hi back!" }],
+        content: [{ type: "text", text: "[11/14/23 14:26]: hi back!" }],
       },
       {
         role: "user",
@@ -3401,10 +3405,10 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).not.toBeNull();
     expect(result!.map((m) => (m.content[0] as { text: string }).text)).toEqual(
       [
-        "[11/14/23 14:25 @user]: old hi",
-        "[11/14/23 14:26 @assistant]: old reply",
+        "[11/14/23 14:25]: old hi",
+        "[11/14/23 14:26]: old reply",
         "[11/14/23 14:28 @alice]: fresh hi",
-        "[11/14/23 14:30 @assistant]: fresh reply",
+        "[11/14/23 14:30]: fresh reply",
       ],
     );
     expect(result!.map((m) => m.role)).toEqual([
@@ -3431,7 +3435,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[11/14/23 14:25 @user]: hello" }],
+        content: [{ type: "text", text: "[11/14/23 14:25]: hello" }],
       },
     ]);
   });
@@ -3490,7 +3494,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(rendered[1]!).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 14:26 @assistant]: looking it up" },
+        { type: "text", text: "[11/14/23 14:26]: looking it up" },
         {
           type: "tool_use",
           id: "tu_1",
@@ -3816,7 +3820,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result![1]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 23:03 @assistant]: checking..." },
+        { type: "text", text: "[11/14/23 23:03]: checking..." },
         {
           type: "tool_use",
           id: "tu_abc",
@@ -3836,7 +3840,7 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result![3]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 23:03 @assistant]: one more lookup..." },
+        { type: "text", text: "[11/14/23 23:03]: one more lookup..." },
         {
           type: "tool_use",
           id: "tu_def",
@@ -3855,7 +3859,7 @@ describe("assembleSlackChronologicalMessages", () => {
     // Row 6: assistant final text-only answer, rendered as tag line only.
     expect(result![5]).toEqual({
       role: "assistant",
-      content: [{ type: "text", text: "[11/14/23 23:03 @assistant]: all done" }],
+      content: [{ type: "text", text: "[11/14/23 23:03]: all done" }],
     });
     // Row 7: user follow-up tag line.
     expect(result![6]).toEqual({

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1243,10 +1243,15 @@ function extractPlainText(rawContent: string): string {
  * yield `metadata: null`; the renderer then takes its flat-render fallback
  * path and the row stays in chronological order via `createdAt`.
  *
- * Sender labels:
- * - assistant rows: always `"@assistant"`.
- * - user rows: prefer `slackMeta.displayName`, otherwise fall back to a
- *   generic `"@user"` label so the renderer's tag template still parses.
+ * Sender labels are emitted only when they add information beyond the role
+ * slot:
+ * - Reaction rows: always labeled — `@assistant` for the assistant, the real
+ *   `slackMeta.displayName` for a known user, or `@user` as a last-resort
+ *   subject so the rendered `[time X reacted ...]` line still parses.
+ * - Assistant message rows: `null` — the role slot already says "assistant".
+ * - User message rows: real `slackMeta.displayName` when available (to
+ *   disambiguate speakers in multi-party channels); `null` otherwise so the
+ *   renderer drops the redundant `@user` placeholder.
  */
 function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
   let slackMeta: ReturnType<typeof readSlackMetadata> = null;
@@ -1261,10 +1266,18 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
     }
   }
 
-  const senderLabel =
-    row.role === "assistant"
-      ? "@assistant"
-      : (slackMeta?.displayName ?? "@user");
+  const isReaction = slackMeta?.eventKind === "reaction";
+  let senderLabel: string | null;
+  if (isReaction) {
+    senderLabel =
+      row.role === "assistant"
+        ? "@assistant"
+        : (slackMeta?.displayName ?? "@user");
+  } else if (row.role === "assistant") {
+    senderLabel = null;
+  } else {
+    senderLabel = slackMeta?.displayName ?? null;
+  }
 
   let contentBlocks: ContentBlock[] = [];
   try {

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -35,7 +35,7 @@ const CHANNEL = "C0001";
 
 function userMsg(
   ts: string,
-  sender: string,
+  sender: string | null,
   content: string,
   opts: {
     threadTs?: string;
@@ -64,7 +64,7 @@ function userMsg(
 
 function reactionMsg(
   ts: string,
-  actor: string,
+  actor: string | null,
   emoji: string,
   targetTs: string,
   op: "added" | "removed" = "added",
@@ -91,7 +91,7 @@ function reactionMsg(
 
 function legacyMsg(
   createdAt: number,
-  sender: string,
+  sender: string | null,
   content: string,
   role: "user" | "assistant" = "user",
 ): RenderableSlackMessage {
@@ -217,6 +217,76 @@ describe("renderSlackTranscript — basics", () => {
     ]);
     expect(out).toEqual([
       textMsg("user", `[11/14/23 14:28 @bob removed 👍 from ${alias}]`),
+    ]);
+  });
+
+  test("omits sender label for assistant-role message (role slot conveys identity)", () => {
+    const out = renderSlackTranscript([
+      userMsg(TS_14_25, null, "yo 👋", { role: "assistant" }),
+    ]);
+    expect(out).toEqual([textMsg("assistant", "[11/14/23 14:25]: yo 👋")]);
+  });
+
+  test("omits sender label for user-role message with null senderLabel (no displayName)", () => {
+    const out = renderSlackTranscript([userMsg(TS_14_25, null, "yo")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:25]: yo")]);
+  });
+
+  test("omits sender label on legacy user row with null senderLabel", () => {
+    const out = renderSlackTranscript([legacyMsg(MS_14_25, null, "hi")]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:25]: hi")]);
+  });
+
+  test("omits sender label in thread-reply tag for assistant row", () => {
+    const alias = parentAlias(TS_14_25);
+    const out = renderSlackTranscript([
+      userMsg(TS_14_28, null, "got it", {
+        threadTs: TS_14_25,
+        role: "assistant",
+      }),
+    ]);
+    expect(out).toEqual([
+      textMsg("assistant", `[11/14/23 14:28 → ${alias}]: got it`),
+    ]);
+  });
+
+  test("omits sender label in deleted tag for assistant row", () => {
+    const out = renderSlackTranscript([
+      userMsg(TS_14_25, null, "(removed)", {
+        deletedAt: MS_14_32,
+        role: "assistant",
+      }),
+    ]);
+    expect(out).toEqual([
+      textMsg("assistant", "[11/14/23 14:25 — deleted 11/14/23 14:32]"),
+    ]);
+  });
+
+  test("omits sender label in edited tag for assistant row", () => {
+    const out = renderSlackTranscript([
+      userMsg(TS_14_25, null, "v2", {
+        editedAt: MS_14_30,
+        role: "assistant",
+      }),
+    ]);
+    expect(out).toEqual([
+      textMsg("assistant", "[11/14/23 14:25, edited 11/14/23 14:30]: v2"),
+    ]);
+  });
+
+  test("reaction with null senderLabel falls back on role-derived subject", () => {
+    // Defensive: reactions always need a grammatical subject. If a caller
+    // accidentally passes null, the renderer falls back on a role-derived
+    // label so the tag line still parses.
+    const alias = parentAlias(TS_14_25);
+    const out = renderSlackTranscript([
+      reactionMsg(TS_14_28, null, "👍", TS_14_25, "added", "assistant"),
+    ]);
+    expect(out).toEqual([
+      textMsg(
+        "assistant",
+        `[11/14/23 14:28 @assistant reacted 👍 to ${alias}]`,
+      ),
     ]);
   });
 });
@@ -700,7 +770,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     // Assistant tool_use is paired with a follow-up user tool_result so the
     // PR 4 orphan filter leaves both blocks intact.
     const assistantRow: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "looking it up", {
+      ...userMsg(TS_14_25, null, "looking it up", {
         role: "assistant",
       }),
       contentBlocks: [
@@ -718,7 +788,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out[0]).toEqual({
       role: "assistant",
       content: [
-        { type: "text", text: "[11/14/23 14:25 @assistant]: looking it up" },
+        { type: "text", text: "[11/14/23 14:25]: looking it up" },
         { type: "tool_use", id: "tu_1", name: "search", input: { q: "x" } },
       ],
     });
@@ -729,7 +799,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     // PR 4 orphan filter leaves the row intact; the assertion still pins
     // the shape of the user row specifically (no tag line, single block).
     const assistantRow: RenderableSlackMessage = {
-      ...userMsg(TS_14_24, "@assistant", "", { role: "assistant" }),
+      ...userMsg(TS_14_24, null, "", { role: "assistant" }),
       contentBlocks: [
         { type: "tool_use", id: "tu_1", name: "search", input: {} },
       ],
@@ -752,7 +822,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
 
   test("[thinking, text] assistant row preserves thinking before tag line (order preserved)", () => {
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "here's the answer", {
+      ...userMsg(TS_14_25, null, "here's the answer", {
         role: "assistant",
       }),
       contentBlocks: [
@@ -766,7 +836,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
         role: "assistant",
         content: [
           { type: "thinking", thinking: "let me think", signature: "sig-abc" },
-          { type: "text", text: "[11/14/23 14:25 @assistant]: here's the answer" },
+          { type: "text", text: "[11/14/23 14:25]: here's the answer" },
         ],
       },
     ]);
@@ -777,7 +847,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     // that carry both tool_use and tool_result in the same message. The
     // renderer passes them through in order.
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "doing a thing", {
+      ...userMsg(TS_14_25, null, "doing a thing", {
         role: "assistant",
       }),
       contentBlocks: [
@@ -791,7 +861,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25 @assistant]: doing a thing" },
+          { type: "text", text: "[11/14/23 14:25]: doing a thing" },
           { type: "tool_use", id: "tu_A", name: "op", input: {} },
           { type: "tool_result", tool_use_id: "tu_A", content: "ok" },
         ],
@@ -801,7 +871,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
 
   test("[text, ui_surface] assistant row strips ui_surface — only tag line remains", () => {
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "reply body", { role: "assistant" }),
+      ...userMsg(TS_14_25, null, "reply body", { role: "assistant" }),
       contentBlocks: [
         { type: "text", text: "reply body" },
         // ui_surface is local-only UI scaffolding and must not leak into
@@ -814,14 +884,14 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:25 @assistant]: reply body" }],
+        content: [{ type: "text", text: "[11/14/23 14:25]: reply body" }],
       },
     ]);
   });
 
   test("[text, server_tool_use] assistant row strips server_tool_use (unknown to replay)", () => {
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "web search", { role: "assistant" }),
+      ...userMsg(TS_14_25, null, "web search", { role: "assistant" }),
       contentBlocks: [
         { type: "text", text: "web search" },
         {
@@ -836,7 +906,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:25 @assistant]: web search" }],
+        content: [{ type: "text", text: "[11/14/23 14:25]: web search" }],
       },
     ]);
   });
@@ -944,7 +1014,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
     // anywhere in the transcript. The tool_use must be stripped; the tag
     // line (derived from the text block) stays.
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "looking it up", {
+      ...userMsg(TS_14_25, null, "looking it up", {
         role: "assistant",
       }),
       contentBlocks: [
@@ -962,7 +1032,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25 @assistant]: looking it up" },
+          { type: "text", text: "[11/14/23 14:25]: looking it up" },
         ],
       },
     ]);
@@ -993,7 +1063,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
 
   test("fully-paired tool_use/tool_result — both preserved", () => {
     const assistantRow: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "running op", { role: "assistant" }),
+      ...userMsg(TS_14_25, null, "running op", { role: "assistant" }),
       contentBlocks: [
         { type: "text", text: "running op" },
         { type: "tool_use", id: "tu_paired", name: "op", input: { a: 1 } },
@@ -1014,7 +1084,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25 @assistant]: running op" },
+          { type: "text", text: "[11/14/23 14:25]: running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: { a: 1 } },
         ],
       },
@@ -1065,7 +1135,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
     const fixture: RenderableSlackMessage[] = [
       // Paired tool call.
       {
-        ...userMsg(TS_14_25, "@assistant", "running op", { role: "assistant" }),
+        ...userMsg(TS_14_25, null, "running op", { role: "assistant" }),
         contentBlocks: [
           { type: "text", text: "running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: {} },
@@ -1079,7 +1149,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       },
       // Orphan tool_use on the assistant side.
       {
-        ...userMsg(TS_14_28, "@assistant", "looking", { role: "assistant" }),
+        ...userMsg(TS_14_28, null, "looking", { role: "assistant" }),
         contentBlocks: [
           { type: "text", text: "looking" },
           { type: "tool_use", id: "tu_orphan", name: "op", input: {} },
@@ -1108,7 +1178,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       {
         role: "assistant",
         content: [
-          { type: "text", text: "[11/14/23 14:25 @assistant]: running op" },
+          { type: "text", text: "[11/14/23 14:25]: running op" },
           { type: "tool_use", id: "tu_paired", name: "op", input: {} },
         ],
       },
@@ -1120,7 +1190,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "[11/14/23 14:28 @assistant]: looking" }],
+        content: [{ type: "text", text: "[11/14/23 14:28]: looking" }],
       },
       {
         role: "user",
@@ -1131,7 +1201,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
 
   test("filter does not touch thinking, image, file, or text blocks", () => {
     const base: RenderableSlackMessage = {
-      ...userMsg(TS_14_25, "@assistant", "here you go", { role: "assistant" }),
+      ...userMsg(TS_14_25, null, "here you go", { role: "assistant" }),
       contentBlocks: [
         { type: "thinking", thinking: "ponder", signature: "sig" },
         {
@@ -1177,7 +1247,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
               filename: "doc.pdf",
             },
           },
-          { type: "text", text: "[11/14/23 14:25 @assistant]: here you go" },
+          { type: "text", text: "[11/14/23 14:25]: here you go" },
         ],
       },
     ]);

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -24,8 +24,14 @@ export interface RenderableSlackMessage {
   content: string;
   /** `null` indicates a legacy pre-upgrade row stored without Slack metadata. */
   metadata: SlackMessageMetadata | null;
-  /** Display name or fallback (e.g. "@alice" or "@U12345"). */
-  senderLabel: string;
+  /**
+   * Sender display name to prepend to the tag line (e.g. `"@alice"`), or
+   * `null` to omit the label entirely. Callers should pass `null` when the
+   * label would be redundant with the `role` slot — i.e. assistant rows and
+   * user rows with no real Slack displayName. Reaction rows always need a
+   * subject, so they receive a role-derived fallback if `null` is passed.
+   */
+  senderLabel: string | null;
   /** Fallback sort key for legacy rows; ignored when metadata.channelTs is set. */
   createdAt: number;
   /**
@@ -53,7 +59,7 @@ const DEFAULT_MAX_REACTIONS = 5;
  * persisted row when rendering the Slack chronological transcript.
  *
  * `text` is intentionally omitted — text content is subsumed into the tag
- * line (e.g. `[11/14/23 14:25 @assistant]: ...`) so callers reading the
+ * line (e.g. `[11/14/23 14:25 @alice]: ...`) so callers reading the
  * rendered output see one human-readable line per row rather than a raw
  * text block stripped of thread context.
  *
@@ -133,20 +139,21 @@ function sortKey(msg: RenderableSlackMessage): number {
  */
 function renderMessage(msg: RenderableSlackMessage): string {
   const meta = msg.metadata;
+  const senderPart = msg.senderLabel ? ` ${msg.senderLabel}` : "";
   if (!meta) {
     // Legacy pre-upgrade row: flat render, no thread tag.
     const time = formatEpochMs(msg.createdAt);
-    return `[${time} ${msg.senderLabel}]: ${msg.content}`;
+    return `[${time}${senderPart}]: ${msg.content}`;
   }
 
   const time = formatSlackTs(meta.channelTs);
 
   if (meta.deletedAt !== undefined) {
     const dtime = formatEpochMs(meta.deletedAt);
-    return `[${time} ${msg.senderLabel} — deleted ${dtime}]`;
+    return `[${time}${senderPart} — deleted ${dtime}]`;
   }
 
-  let head = `[${time} ${msg.senderLabel}`;
+  let head = `[${time}${senderPart}`;
   if (meta.threadTs && meta.threadTs !== meta.channelTs) {
     head += ` → ${parentAlias(meta.threadTs)}`;
   }
@@ -167,10 +174,12 @@ function renderReaction(msg: RenderableSlackMessage): string | null {
   const meta = msg.metadata;
   if (!meta || meta.eventKind !== "reaction" || !meta.reaction) return null;
   const time = formatSlackTs(meta.channelTs);
+  const actor =
+    msg.senderLabel ?? (msg.role === "assistant" ? "@assistant" : "@user");
   const verb = meta.reaction.op === "added" ? "reacted" : "removed";
   const prep = meta.reaction.op === "added" ? "to" : "from";
   const target = parentAlias(meta.reaction.targetChannelTs);
-  return `[${time} ${msg.senderLabel} ${verb} ${meta.reaction.emoji} ${prep} ${target}]`;
+  return `[${time} ${actor} ${verb} ${meta.reaction.emoji} ${prep} ${target}]`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rendered Slack transcripts previously prefixed every message tag line with `@assistant` or `@user`, which is redundant with the LLM role slot.
- Tag lines now drop the label for assistant-role messages and user-role messages without a real Slack `displayName`. Real displayNames (e.g. `@alice`) are preserved so multi-party channels still disambiguate speakers.
- Reaction event lines keep their actor label (they need a grammatical subject), with a defensive role-based fallback.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
