### PR TITLE
fix(slack): carry per-turn memory injection through transcript replacement

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2495,6 +2495,152 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).not.toContain("DM question");
   });
 
+  // ── Memory-injection carry-through on slack replacement ──────────────
+  // `graphMemory.prepareMemory` prepends `<memory __injected>` (and
+  // optional memory-image groups) to the last user message BEFORE the
+  // runtime assembly runs. When the Slack branch replaces `runMessages`
+  // with the chronological transcript, the prepended blocks must be
+  // carried onto the new tail so the model still sees recalled memory.
+  // The final order inside the tail user message is:
+  //   channel_capabilities → [carried memory blocks] → slack transcript tail.
+  test("slack replacement preserves prepended memory block", async () => {
+    const slackCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "im",
+    };
+    const runMessagesWithMemory: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<memory __injected>\nrecalled fact about Sidd\n</memory>",
+          },
+          { type: "text", text: "hey kitten" },
+        ],
+      },
+    ];
+    const result = await applyRuntimeInjections(runMessagesWithMemory, {
+      channelCapabilities: slackCaps,
+      slackChronologicalMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "[19:55 sidd]: hey kitten" }],
+        },
+      ],
+    });
+    const tail = result[result.length - 1];
+    expect(tail.role).toBe("user");
+    const allText = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("<memory __injected>");
+    expect(allText).toContain("recalled fact about Sidd");
+    expect(allText).toContain("[19:55 sidd]: hey kitten");
+    // Memory block must appear before the Slack transcript tail so the
+    // model sees recalled context ahead of the conversation view.
+    const memoryIdx = allText.indexOf("<memory __injected>");
+    const transcriptIdx = allText.indexOf("[19:55 sidd]: hey kitten");
+    expect(memoryIdx).toBeLessThan(transcriptIdx);
+    // The pre-replacement "hey kitten" text from the original runMessages
+    // must NOT leak through — only the Slack-rendered line appears.
+    expect(allText.match(/hey kitten/g)?.length).toBe(1);
+  });
+
+  test("slack replacement preserves memory-image groups + text block", async () => {
+    const slackCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "im",
+    };
+    const runMessagesWithMemory: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<memory_image __injected>\nimage description",
+          },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "AAAA",
+            },
+          },
+          { type: "text", text: "</memory_image>" },
+          {
+            type: "text",
+            text: "<memory __injected>\nrecalled text\n</memory>",
+          },
+          { type: "text", text: "original turn text" },
+        ],
+      },
+    ];
+    const result = await applyRuntimeInjections(runMessagesWithMemory, {
+      channelCapabilities: slackCaps,
+      slackChronologicalMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "[19:55 sidd]: transcript line" }],
+        },
+      ],
+    });
+    const tail = result[result.length - 1];
+    expect(tail.role).toBe("user");
+    // The memory-image block is carried through as an `image` content
+    // block; the transcript-only replacement would have none.
+    const imageBlocks = tail.content.filter((b) => b.type === "image");
+    expect(imageBlocks.length).toBe(1);
+    const allText = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("<memory_image __injected>");
+    expect(allText).toContain("</memory_image>");
+    expect(allText).toContain("<memory __injected>");
+    expect(allText).toContain("[19:55 sidd]: transcript line");
+    // The original turn text (before the Slack replacement) must NOT
+    // leak through — only the memory prefix + transcript tail are kept.
+    expect(allText).not.toContain("original turn text");
+  });
+
+  test("slack replacement is a no-op when the tail has no memory prefix", async () => {
+    const slackCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "im",
+    };
+    const result = await applyRuntimeInjections(
+      [{ role: "user", content: [{ type: "text", text: "inbound" }] }],
+      {
+        channelCapabilities: slackCaps,
+        slackChronologicalMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "[19:55 sidd]: only transcript" }],
+          },
+        ],
+      },
+    );
+    const tail = result[result.length - 1];
+    const allText = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).not.toContain("<memory __injected>");
+    expect(allText).toContain("[19:55 sidd]: only transcript");
+  });
+
   // ── transport_hints suppression for slack channels ────────────────────
   test("slack channel conversations skip <transport_hints> injection", async () => {
     const slackChannelCaps: ChannelCapabilities = {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -14,6 +14,7 @@ import {
   getMessages as defaultGetMessages,
   type MessageRow,
 } from "../memory/conversation-crud.js";
+import { extractMemoryPrefixBlocks } from "../memory/graph/conversation-graph-memory.js";
 import { searchPkbFiles } from "../memory/pkb/pkb-search.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
@@ -1697,7 +1698,25 @@ export async function applyRuntimeInjections(
     options.slackChronologicalMessages &&
     options.slackChronologicalMessages.length > 0
   ) {
+    // `graphMemory.prepareMemory` prepends a `<memory __injected>` block
+    // (and any memory-image groups) to the last user message before
+    // runtime assembly runs. The Slack transcript is freshly rendered
+    // from persisted rows and has no such prefix, so swap it in and then
+    // re-prepend the captured prefix onto the new tail user message.
+    const carriedMemoryBlocks = extractMemoryPrefixBlocks(runMessages);
     result = options.slackChronologicalMessages;
+    if (carriedMemoryBlocks.length > 0) {
+      const slackTail = result[result.length - 1];
+      if (slackTail && slackTail.role === "user") {
+        result = [
+          ...result.slice(0, -1),
+          {
+            ...slackTail,
+            content: [...carriedMemoryBlocks, ...slackTail.content],
+          },
+        ];
+      }
+    }
   }
 
   // For non-interactive conversations (scheduled jobs, work items), instruct the

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -559,30 +559,18 @@ export class ConversationGraphMemory {
 // ---------------------------------------------------------------------------
 
 /**
- * Remove all memory-injected blocks from the last user message.
- *
- * `injectMemoryBlock` always prepends blocks in this order:
- *   1. For each image: `<memory_image __injected>…` text + `image` + `</memory_image>` text (3-block group)
- *   2. `<memory __injected>…</memory>` text block
- *
- * We strip all leading blocks that match this pattern so that
- * `reinjectCachedMemory` is idempotent — no duplicate images after compaction.
+ * Count the leading content blocks on a user message that were added by
+ * `injectMemoryBlock`. Memory-injected images use a 3-block pattern
+ * (opening `<memory_image>` text + image + closing `</memory_image>` text),
+ * followed by a `<memory __injected>…</memory>` text block. A legacy
+ * 2-block image pattern (no closing tag) is also accepted for backward
+ * compatibility. The injection prefix is always contiguous at the start,
+ * so we stop at the first non-memory block.
  */
-export function stripExistingMemoryInjections(messages: Message[]): Message[] {
-  if (messages.length === 0) return messages;
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return messages;
-
-  // Walk from the front and skip all memory-injected blocks.
-  // The injection prefix is always contiguous at the start of content.
-  // Memory-injected images use a 3-block pattern: opening <memory_image> text,
-  // image block, closing </memory_image> text (see injectMemoryBlock).
-  // Legacy 2-block pattern (no closing tag) is also handled for backward compat.
-  // Only strip image blocks that follow a marker — user-attached images must be preserved.
+export function countMemoryPrefixBlocks(content: ContentBlock[]): number {
   let firstNonMemory = 0;
   let prevWasMemoryImageMarker = false;
   let prevWasInjectedImage = false;
-  const content = last.content;
   while (firstNonMemory < content.length) {
     const block = content[firstNonMemory];
     if (
@@ -608,21 +596,53 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
       block.text === "</memory_image>" &&
       prevWasInjectedImage
     ) {
-      // Closing tag from the 3-block pattern — only strip after an injected image
       firstNonMemory++;
       prevWasInjectedImage = false;
     } else {
       break;
     }
   }
+  return firstNonMemory;
+}
 
-  // Nothing to strip
+/**
+ * Remove all memory-injected blocks from the last user message.
+ *
+ * `injectMemoryBlock` always prepends blocks in this order:
+ *   1. For each image: `<memory_image __injected>…` text + `image` + `</memory_image>` text (3-block group)
+ *   2. `<memory __injected>…</memory>` text block
+ *
+ * We strip all leading blocks that match this pattern so that
+ * `reinjectCachedMemory` is idempotent — no duplicate images after compaction.
+ */
+export function stripExistingMemoryInjections(messages: Message[]): Message[] {
+  if (messages.length === 0) return messages;
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "user") return messages;
+
+  const firstNonMemory = countMemoryPrefixBlocks(last.content);
   if (firstNonMemory === 0) return messages;
 
   return [
     ...messages.slice(0, -1),
-    { ...last, content: content.slice(firstNonMemory) },
+    { ...last, content: last.content.slice(firstNonMemory) },
   ];
+}
+
+/**
+ * Return the memory-injected prefix blocks from the last user message, or
+ * an empty array when there is none. Used by runtime assembly to carry the
+ * memory block through transcript replacements (e.g. Slack chronological
+ * rendering) that otherwise discard the prepended content.
+ */
+export function extractMemoryPrefixBlocks(
+  messages: Message[],
+): ContentBlock[] {
+  if (messages.length === 0) return [];
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "user") return [];
+  const count = countMemoryPrefixBlocks(last.content);
+  return count === 0 ? [] : last.content.slice(0, count);
 }
 
 function injectTextBlock(messages: Message[], text: string): Message[] {


### PR DESCRIPTION
## Summary

- Graph-memory blocks prepended by `ConversationGraphMemory.prepareMemory` were dropped on every Slack turn because `applyRuntimeInjections` replaces `runMessages` with the Slack chronological transcript, which is freshly rendered from persisted rows and has no memory prefix. PKB reminder + turn_context survived because they run after the replacement.
- `extractMemoryPrefixBlocks` (new) + `countMemoryPrefixBlocks` (factored from `stripExistingMemoryInjections`) let the runtime assembly capture the memory prefix from the pre-replacement tail and re-prepend it onto the Slack transcript's tail user message. Final tail order: `channel_capabilities → carried memory blocks → Slack transcript tail`.
- New unit tests cover text-only memory carry, memory-image group carry (image block count + tag ordering), and the no-op path for tails without a memory prefix. Non-Slack channels remain untouched.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
