### PR TITLE
test: mock workspace-git in conversation-workspace-tool-tracking

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -191,6 +191,20 @@ mock.module("../memory/app-store.js", () => ({
   updateApp: () => {},
 }));
 
+// Avoid real workspace-git initialization on /tmp — on CI runners,
+// `git add -A` under /tmp hits permission errors on systemd-private dirs,
+// which blocks the agent loop for long enough to trip the 5s test timeout
+// on the first test case before the circuit breaker opens.
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
 mock.module("../agent/loop.js", () => ({
   AgentLoop: class {
     constructor() {}


### PR DESCRIPTION
## Summary
- First test (`successful file_write marks workspace dirty`) was timing out at 5s on Linux CI because the Conversation's workspaceDir is `/tmp`, and the real workspace-git service runs `git add -A` from that path, which walks into systemd-private and other protected dirs before finally failing.
- Mock `workspace/git-service.js` and `workspace/turn-commit.js` to short-circuit the expensive git initialization, matching the existing pattern in `conversation-slash-queue.test.ts`.
- All 6 tests now pass in ~500ms locally (down from timing out at 5s on CI).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24638138037/job/72037157706
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
