### PR TITLE
fix(memory): source context-load capabilities from semantic search

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -29,7 +29,12 @@ import {
   weightsForContextLoad,
 } from "./scoring.js";
 import { sampleSerendipity } from "./serendipity.js";
-import { getEdgesForNode, getNodesByIds, queryNodes } from "./store.js";
+import {
+  getEdgesForNode,
+  getNodesByIds,
+  queryCapabilityNodes,
+  queryNodes,
+} from "./store.js";
 import { getActiveTriggersByType } from "./store.js";
 import {
   evaluateEventTriggers,
@@ -635,63 +640,66 @@ export async function loadContextMemory(
   // Sort by score descending
   scored.sort((a, b) => b.score - a.score);
 
-  // 5b. Reserve slots for skill/CLI capabilities. Queried directly from
-  // SQLite — no Qdrant vectors needed — so capabilities surface even on
-  // fresh assistants whose embedding jobs haven't completed yet.
+  // 5b. Reserve slots for skill/CLI capabilities.
+  //
+  // Source candidates primarily from the semantic-search candidate set
+  // (the same strategy `retrieveForTurn` uses). A prior approach pulled
+  // top-N procedural rows ordered by significance, but organic procedural
+  // memories share `type = 'procedural'` with capability nodes and
+  // dominate the significance ordering on mature assistants, starving
+  // the capability slots entirely.
+  //
+  // For cold-start cases (capability nodes exist in SQLite but their
+  // embeddings haven't landed in Qdrant yet), fall back to a narrow
+  // SQL pull that matches only capability-shaped content so organic
+  // procedurals can't crowd the pool.
   const capabilityReserve = ctxLoadCfg.capabilityReserve;
-  const rawCapabilityNodes =
-    capabilityReserve > 0
-      ? queryNodes({
-          scopeId: opts.scopeId,
-          types: ["procedural"],
-          fidelityNot: ["gone"],
-          limit: capabilityReserve * 4,
-        })
-      : [];
+  const capabilityEntries: { node: MemoryNode; sim: number }[] = [];
+  if (capabilityReserve > 0) {
+    for (const [nodeId, node] of nodeMap) {
+      if (node.fidelity === "gone") continue;
+      if (!isCapabilityNode(node)) continue;
+      const sim =
+        userQueryCandidateIds.get(nodeId) ??
+        semanticCandidateIds.get(nodeId) ??
+        0;
+      capabilityEntries.push({ node, sim });
+    }
+
+    if (capabilityEntries.length < capabilityReserve) {
+      const alreadySeen = new Set(capabilityEntries.map((e) => e.node.id));
+      const fallback = queryCapabilityNodes(
+        opts.scopeId,
+        capabilityReserve * 4,
+      );
+      for (const node of fallback) {
+        if (alreadySeen.has(node.id)) continue;
+        const sim =
+          userQueryCandidateIds.get(node.id) ??
+          semanticCandidateIds.get(node.id) ??
+          0;
+        capabilityEntries.push({ node, sim });
+      }
+    }
+  }
+
+  capabilityEntries.sort((a, b) => b.sim - a.sim);
 
   // Dedup: both seeding systems may create nodes for the same capability.
   // Extract capability ID from content and keep only the first node per ID.
   const seenCapabilityIds = new Set<string>();
-  const capabilityNodes = rawCapabilityNodes
-    .filter(isCapabilityNode)
-    .filter((node) => {
-      const match = node.content.match(
-        /^skill:(\S+)\n|^cli:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)|^\s*The "assistant (\S+)" CLI command/,
-      );
-      const capId = match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4];
-      if (capId) {
-        if (seenCapabilityIds.has(capId)) return false;
-        seenCapabilityIds.add(capId);
-      }
-      return true;
-    });
-
-  // Rank by semantic similarity when a query vector exists.
-  // (PR 3) When a dedicated user-query vector is available, prefer its
-  // scores over the summary vector's for capability-reserve ranking —
-  // capability picks should align with the user's current intent, not
-  // the conversation-summary topic.
-  let selectedCapabilities: MemoryNode[];
-  if (userQueryCandidateIds.size > 0 && capabilityNodes.length > capabilityReserve) {
-    selectedCapabilities = capabilityNodes
-      .map((node) => ({
-        node,
-        sim:
-          userQueryCandidateIds.get(node.id) ??
-          semanticCandidateIds.get(node.id) ??
-          0,
-      }))
-      .sort((a, b) => b.sim - a.sim)
-      .slice(0, capabilityReserve)
-      .map((e) => e.node);
-  } else if (queryVector && capabilityNodes.length > capabilityReserve) {
-    selectedCapabilities = capabilityNodes
-      .map((node) => ({ node, sim: semanticCandidateIds.get(node.id) ?? 0 }))
-      .sort((a, b) => b.sim - a.sim)
-      .slice(0, capabilityReserve)
-      .map((e) => e.node);
-  } else {
-    selectedCapabilities = capabilityNodes.slice(0, capabilityReserve);
+  const selectedCapabilities: MemoryNode[] = [];
+  for (const { node } of capabilityEntries) {
+    if (selectedCapabilities.length >= capabilityReserve) break;
+    const match = node.content.match(
+      /^skill:(\S+)\n|^cli:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)|^\s*The "assistant (\S+)" CLI command/,
+    );
+    const capId = match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4];
+    if (capId) {
+      if (seenCapabilityIds.has(capId)) continue;
+      seenCapabilityIds.add(capId);
+    }
+    selectedCapabilities.push(node);
   }
 
   const reservedCapabilities: ScoredNode[] = selectedCapabilities.map(

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -358,6 +358,47 @@ export function queryNodes(filters: NodeQueryFilters): MemoryNode[] {
   return query.all().map(rowToNode);
 }
 
+/**
+ * Pull capability (skill / CLI) nodes directly from SQLite, ordered by
+ * significance DESC. Matches the content shapes produced by both the
+ * legacy (`skill:{id}\n`, `cli:{name}\n`) and current
+ * (`The "..." skill (id) is available.`, `The "assistant ..." CLI command`)
+ * seeding systems — keeping the SQL filter in sync with `isCapabilityNode`.
+ *
+ * Used as a cold-start fallback for context-load capability injection when
+ * no semantic-search candidates are capability nodes (e.g. fresh assistants
+ * whose embedding jobs haven't completed yet). The content-pattern filter
+ * prevents organic procedural memories from crowding out real capabilities.
+ */
+export function queryCapabilityNodes(
+  scopeId: string,
+  limit: number,
+): MemoryNode[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memoryGraphNodes)
+    .where(
+      and(
+        eq(memoryGraphNodes.scopeId, scopeId),
+        eq(memoryGraphNodes.type, "procedural"),
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
+        or(
+          sql`${memoryGraphNodes.content} LIKE 'skill:%'`,
+          sql`${memoryGraphNodes.content} LIKE 'cli:%'`,
+          and(
+            sql`${memoryGraphNodes.content} LIKE 'The "%'`,
+            sql`${memoryGraphNodes.content} LIKE '% is available.%'`,
+          ),
+        ),
+      ),
+    )
+    .orderBy(sql`${memoryGraphNodes.significance} DESC`)
+    .limit(limit)
+    .all();
+  return rows.map(rowToNode);
+}
+
 /** Count all non-gone nodes in a scope. */
 export function countNodes(scopeId: string): number {
   const db = getDb();


### PR DESCRIPTION
## Summary
- On context-load, \`loadContextMemory\` built its capability candidate pool via a significance-ordered SQL pull across all procedural rows. On mature assistants, high-significance organic procedural memories crowd out actual capability nodes, so the \"Skills You Can Use\" block routinely surfaces only 0-1 skills regardless of the user's intent.
- Switched to sourcing capability candidates from the hydrated semantic-search set (\`nodeMap\`) — the same strategy \`retrieveForTurn\` already uses for per-turn injection — and ranking them by user-query / summary vector similarity.
- Added \`queryCapabilityNodes\` to \`store.ts\` as a narrow content-pattern fallback so cold-start cases (capability rows exist in SQLite but their embeddings haven't landed in Qdrant yet) still surface capabilities without competing against organic procedurals.

## Original prompt
Yeah let's go with (a) source rawCapabilityNodes from the semantic-search candidate set the way retrieveForTurn does
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
