### PR TITLE
chore: de-personalize test fixtures and tune filing prompt

### DIFF
--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -67,7 +67,7 @@ describe("upsertContact user_file selection", () => {
 
   test("reuses an existing sibling's userFile when principalId matches", () => {
     const primary = upsertContact({
-      displayName: "Sidd",
+      displayName: "Chris",
       role: "guardian",
       principalId: "principal-abc",
       channels: [
@@ -78,12 +78,12 @@ describe("upsertContact user_file selection", () => {
         },
       ],
     });
-    expect(primary.userFile).toBe("sidd.md");
+    expect(primary.userFile).toBe("chris.md");
 
     // Second contact for the same principal on Slack — must inherit the
-    // first contact's userFile, NOT auto-increment to sidd-2.md.
+    // first contact's userFile, NOT auto-increment to chris-2.md.
     const slack = upsertContact({
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-abc",
       channels: [
@@ -95,7 +95,7 @@ describe("upsertContact user_file selection", () => {
         },
       ],
     });
-    expect(slack.userFile).toBe("sidd.md");
+    expect(slack.userFile).toBe("chris.md");
     expect(slack.id).not.toBe(primary.id);
   });
 
@@ -203,18 +203,18 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     const now = Date.now();
     insertContact({
       id: "c1",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-x",
-      userFile: "sidd.md",
+      userFile: "chris.md",
       createdAt: now - 1000,
     });
     insertContact({
       id: "c2",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-x",
-      userFile: "sidd-2.md",
+      userFile: "chris-2.md",
       createdAt: now,
     });
 
@@ -222,23 +222,23 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
 
     const rows = fetchUserFilesByPrincipal("principal-x");
     expect(rows).toHaveLength(2);
-    expect(rows[0]?.user_file).toBe("sidd.md");
-    expect(rows[1]?.user_file).toBe("sidd.md");
+    expect(rows[0]?.user_file).toBe("chris.md");
+    expect(rows[1]?.user_file).toBe("chris.md");
   });
 
   test("propagates a sibling's user_file to NULL rows", () => {
     const now = Date.now();
     insertContact({
       id: "c1",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-y",
-      userFile: "sidd.md",
+      userFile: "chris.md",
       createdAt: now - 1000,
     });
     insertContact({
       id: "c2",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-y",
       userFile: null,
@@ -248,8 +248,8 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     migrateNormalizeUserFileByPrincipal(getDb());
 
     const rows = fetchUserFilesByPrincipal("principal-y");
-    expect(rows[0]?.user_file).toBe("sidd.md");
-    expect(rows[1]?.user_file).toBe("sidd.md");
+    expect(rows[0]?.user_file).toBe("chris.md");
+    expect(rows[1]?.user_file).toBe("chris.md");
   });
 
   test("prefers non-auto-incremented candidate over auto-incremented older row", () => {
@@ -258,26 +258,26 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     const now = Date.now();
     insertContact({
       id: "c1",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-z",
-      userFile: "sidd-3.md",
+      userFile: "chris-3.md",
       createdAt: now - 2000,
     });
     insertContact({
       id: "c2",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-z",
-      userFile: "sidd.md",
+      userFile: "chris.md",
       createdAt: now,
     });
 
     migrateNormalizeUserFileByPrincipal(getDb());
 
     const rows = fetchUserFilesByPrincipal("principal-z");
-    expect(rows[0]?.user_file).toBe("sidd.md");
-    expect(rows[1]?.user_file).toBe("sidd.md");
+    expect(rows[0]?.user_file).toBe("chris.md");
+    expect(rows[1]?.user_file).toBe("chris.md");
   });
 
   test("leaves untouched when only one contact exists for a principal", () => {
@@ -488,18 +488,18 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     const now = Date.now();
     insertContact({
       id: "c1",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-i",
-      userFile: "sidd.md",
+      userFile: "chris.md",
       createdAt: now - 1000,
     });
     insertContact({
       id: "c2",
-      displayName: "sidd",
+      displayName: "chris",
       role: "guardian",
       principalId: "principal-i",
-      userFile: "sidd-2.md",
+      userFile: "chris-2.md",
       createdAt: now,
     });
 
@@ -507,6 +507,6 @@ describe("migrateNormalizeUserFileByPrincipal", () => {
     migrateNormalizeUserFileByPrincipal(getDb());
 
     const rows = fetchUserFilesByPrincipal("principal-i");
-    for (const row of rows) expect(row.user_file).toBe("sidd.md");
+    for (const row of rows) expect(row.user_file).toBe("chris.md");
   });
 });

--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -70,13 +70,13 @@ describe("createGuardianBinding seeds users/<slug>.md", () => {
   test("writes the persona template scaffold on first creation", () => {
     createGuardianBinding({
       channel: "telegram",
-      guardianExternalUserId: "Sidd",
-      guardianDeliveryChatId: "chat-sidd",
-      guardianPrincipalId: "principal-sidd",
+      guardianExternalUserId: "Chris",
+      guardianDeliveryChatId: "chat-chris",
+      guardianPrincipalId: "principal-chris",
       verifiedVia: "challenge",
     });
 
-    const expectedPath = userFilePath("sidd.md");
+    const expectedPath = userFilePath("chris.md");
     expect(existsSync(expectedPath)).toBe(true);
 
     const content = readFileSync(expectedPath, "utf-8");

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2589,7 +2589,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       slackChronologicalMessages: [
         {
           role: "user",
-          content: [{ type: "text", text: "[19:55 sidd]: transcript line" }],
+          content: [{ type: "text", text: "[19:55 alice]: transcript line" }],
         },
       ],
     });
@@ -2606,7 +2606,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).toContain("<memory_image __injected>");
     expect(allText).toContain("</memory_image>");
     expect(allText).toContain("<memory __injected>");
-    expect(allText).toContain("[19:55 sidd]: transcript line");
+    expect(allText).toContain("[19:55 alice]: transcript line");
     // The original turn text (before the Slack replacement) must NOT
     // leak through — only the memory prefix + transcript tail are kept.
     expect(allText).not.toContain("original turn text");
@@ -2627,7 +2627,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         slackChronologicalMessages: [
           {
             role: "user",
-            content: [{ type: "text", text: "[19:55 sidd]: only transcript" }],
+            content: [{ type: "text", text: "[19:55 alice]: only transcript" }],
           },
         ],
       },
@@ -2638,7 +2638,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       .map((b) => b.text)
       .join("\n");
     expect(allText).not.toContain("<memory __injected>");
-    expect(allText).toContain("[19:55 sidd]: only transcript");
+    expect(allText).toContain("[19:55 alice]: only transcript");
   });
 
   // ── transport_hints suppression for slack channels ────────────────────

--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -103,12 +103,12 @@ describe("resolveGuardianPersonaPath", () => {
 
   test("returns absolute path when guardian has userFile set", () => {
     mockVellumGuardian = {
-      contact: { userFile: "sidd.md" },
+      contact: { userFile: "alice.md" },
       channel: {},
     };
 
     const result = resolveGuardianPersonaPath();
-    expect(result).toBe(join(mockWorkspaceDir, "users", "sidd.md"));
+    expect(result).toBe(join(mockWorkspaceDir, "users", "alice.md"));
   });
 });
 
@@ -116,7 +116,7 @@ describe("resolveGuardianPersonaPath", () => {
 
 describe("ensureGuardianPersonaFile", () => {
   test("writes the template when the file is missing", () => {
-    const userFile = "sidd.md";
+    const userFile = "alice.md";
     const filePath = join(mockWorkspaceDir, "users", userFile);
 
     expect(existsSync(filePath)).toBe(false);
@@ -135,7 +135,7 @@ describe("ensureGuardianPersonaFile", () => {
   });
 
   test("is a no-op when the file already exists (does not clobber)", () => {
-    const userFile = "sidd.md";
+    const userFile = "alice.md";
     const dir = join(mockWorkspaceDir, "users");
     const filePath = join(dir, userFile);
     const existingContent = "# Existing user notes\n\n- Likes sparkling water\n";
@@ -162,11 +162,11 @@ describe("resolveGuardianPersonaStrict", () => {
 
   test("returns null when the guardian's own file is missing, even if default.md exists", () => {
     mockVellumGuardian = {
-      contact: { userFile: "sidd.md" },
+      contact: { userFile: "alice.md" },
       channel: {},
     };
 
-    // default.md is populated but sidd.md is not on disk.
+    // default.md is populated but alice.md is not on disk.
     const usersDir = join(mockWorkspaceDir, "users");
     mkdirSync(usersDir, { recursive: true });
     writeFileSync(
@@ -184,19 +184,19 @@ describe("resolveGuardianPersonaStrict", () => {
 
   test("returns guardian file content when present", () => {
     mockVellumGuardian = {
-      contact: { userFile: "sidd.md" },
+      contact: { userFile: "alice.md" },
       channel: {},
     };
 
     const usersDir = join(mockWorkspaceDir, "users");
     mkdirSync(usersDir, { recursive: true });
     writeFileSync(
-      join(usersDir, "sidd.md"),
-      "- Preferred name/reference: Sidd\n",
+      join(usersDir, "alice.md"),
+      "- Preferred name/reference: Alice\n",
       "utf-8",
     );
 
-    expect(resolveGuardianPersonaStrict()).toContain("Sidd");
+    expect(resolveGuardianPersonaStrict()).toContain("Alice");
   });
 });
 
@@ -209,7 +209,7 @@ describe("isGuardianPersonaCustomized", () => {
   });
 
   test("returns false for the bare scaffold template (no user edits)", () => {
-    const userFile = "sidd.md";
+    const userFile = "alice.md";
     const filePath = join(mockWorkspaceDir, "users", userFile);
 
     // ensureGuardianPersonaFile writes the canonical template — the
@@ -220,7 +220,7 @@ describe("isGuardianPersonaCustomized", () => {
   });
 
   test("returns false when the file contains only comment lines", () => {
-    const userFile = "sidd.md";
+    const userFile = "alice.md";
     const dir = join(mockWorkspaceDir, "users");
     const filePath = join(dir, userFile);
 
@@ -235,7 +235,7 @@ describe("isGuardianPersonaCustomized", () => {
   });
 
   test("returns true when the file has user-authored content", () => {
-    const userFile = "sidd.md";
+    const userFile = "alice.md";
     const dir = join(mockWorkspaceDir, "users");
     const filePath = join(dir, userFile);
 

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -676,7 +676,7 @@ describe("ensurePromptFiles", () => {
     // SOUL.md and IDENTITY.md are absent (they will be freshly seeded from
     // templates, but onboarding should not re-trigger).
     mkdirSync(join(TEST_DIR, "users"), { recursive: true });
-    writeFileSync(join(TEST_DIR, "users", "sidd.md"), "# Sidd persona");
+    writeFileSync(join(TEST_DIR, "users", "alice.md"), "# Alice persona");
 
     ensurePromptFiles();
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -639,7 +639,7 @@ describe("ToolExecutor lifecycle events", () => {
     const result = await executor.execute(
       "file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
+        path: "/Users/alice/.vellum/workspace/users/alice.md",
         old_string: "old",
         new_string: "new",
       },

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1232,7 +1232,7 @@ describe("isSideEffectTool", () => {
 // would cause this test to fail instead of being masked by a blanket
 // mock-allow.
 describe("ToolExecutor baseline: allow rule auto-allows file_edit guardian persona", () => {
-  const guardianPersonaPath = "/Users/sidd/.vellum/workspace/users/sidd.md";
+  const guardianPersonaPath = "/Users/alice/.vellum/workspace/users/alice.md";
   let ruleSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
@@ -1554,7 +1554,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     const result = await executor.execute(
       "file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
+        path: "/Users/alice/.vellum/workspace/users/alice.md",
         old_string: "old pref",
         new_string: "new pref",
       },
@@ -1573,7 +1573,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     const result = await executor.execute(
       "host_file_edit",
       {
-        path: "/Users/sidd/.vellum/workspace/users/sidd.md",
+        path: "/Users/alice/.vellum/workspace/users/alice.md",
         old_string: "x",
         new_string: "y",
       },

--- a/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-user-md.test.ts
@@ -144,8 +144,8 @@ function customizedContent(): string {
 
 # USER.md
 
-- Preferred name/reference: Sidd
-- Pronouns: he/him
+- Preferred name/reference: Chris
+- Pronouns: they/them
 - Work role: Engineer
 - Daily tools: Vellum, vim, tmux
 `;
@@ -195,7 +195,7 @@ describe("workspace migration 031-drop-user-md", () => {
     mockVellumGuardian = {
       contact: {
         id: "guardian-1",
-        displayName: "Sidd",
+        displayName: "Chris",
         userFile: null,
       },
       channel: { type: "vellum" },
@@ -210,10 +210,10 @@ describe("workspace migration 031-drop-user-md", () => {
     // Backfill happened: drizzle update was called with the generated slug.
     expect(updatedUserFiles).toHaveLength(1);
     expect(updatedUserFiles[0].contactId).toBe("guardian-1");
-    expect(updatedUserFiles[0].userFile).toBe("sidd.md");
+    expect(updatedUserFiles[0].userFile).toBe("chris.md");
 
-    // Content was migrated into users/sidd.md.
-    const destPath = join(workspaceDir, "users", "sidd.md");
+    // Content was migrated into users/chris.md.
+    const destPath = join(workspaceDir, "users", "chris.md");
     expect(existsSync(destPath)).toBe(true);
     expect(readFileSync(destPath, "utf-8")).toBe(content);
 
@@ -226,8 +226,8 @@ describe("workspace migration 031-drop-user-md", () => {
     mockVellumGuardian = {
       contact: {
         id: "guardian-2",
-        displayName: "Sidd",
-        userFile: "sidd.md",
+        displayName: "Chris",
+        userFile: "chris.md",
       },
       channel: { type: "vellum" },
     };
@@ -235,8 +235,8 @@ describe("workspace migration 031-drop-user-md", () => {
     // Pre-populated persona file (post-017 state).
     const usersDir = join(workspaceDir, "users");
     mkdirSync(usersDir, { recursive: true });
-    const destPath = join(usersDir, "sidd.md");
-    const existingPersona = "# Sidd's Profile\n\n- Loves kayaking\n";
+    const destPath = join(usersDir, "chris.md");
+    const existingPersona = "# Chris's Profile\n\n- Loves kayaking\n";
     writeFileSync(destPath, existingPersona, "utf-8");
 
     // Leftover template-shape USER.md at workspace root.
@@ -245,7 +245,7 @@ describe("workspace migration 031-drop-user-md", () => {
 
     dropUserMdMigration.run(workspaceDir);
 
-    // users/sidd.md is untouched.
+    // users/chris.md is untouched.
     expect(readFileSync(destPath, "utf-8")).toBe(existingPersona);
 
     // USER.md is gone.

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -17,23 +17,24 @@ const FILING_PROMPT_TEMPLATE = `You are running a periodic knowledge base filing
 ## Part 1: File the buffer
 
 Read \`pkb/buffer.md\`. For each item in the buffer:
-1. Determine which topic file it belongs in. Check \`pkb/INDEX.md\` to see what topic files exist.
-2. Read the target topic file, then append or integrate the new fact.
+1. Determine which topic file(s) it belongs in. Check \`pkb/INDEX.md\` to see what topic files exist.
+2. Read the target topic file(s), then integrate the new fact.
 3. If the fact is important enough to always be in context, add it to \`pkb/essentials.md\` instead.
 4. If the fact is a commitment, follow-up, or active project, add it to \`pkb/threads.md\`.
 5. If no existing topic file fits, create a new one and update \`pkb/INDEX.md\`.
+6. If the topic file is getting too long (>1500 tokens), compress it or split it into multiple topic files.
 
 After all items are filed, clear the processed items from \`pkb/buffer.md\` (leave the file empty, don't delete it).
 
-## Part 2: Nest
+## Part 2: Review
 
-Pick 1-2 topic files from your knowledge base and review them:
+Pick 3 random topic files from your knowledge base and review them:
 - Is the information still accurate and up to date?
 - Are there duplicates that should be consolidated?
 - Is anything important enough to promote to \`pkb/essentials.md\`?
 - Is anything in \`pkb/essentials.md\` that's no longer essential? Demote it to a topic file.
 - Are any threads in \`pkb/threads.md\` completed or stale? Remove them.
-- Is any file getting too long? Consider splitting it.
+- Is any file getting too long (>1500 tokens)? Strongly consider compressing it or splitting it into multiple topic files.
 - Should any topic file be restructured for clarity?
 
 Make improvements as you see fit. This is your knowledge base — keep it sharp.`;

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -161,7 +161,7 @@ export async function computeRelationshipState(): Promise<RelationshipState> {
   //   1. The guardian contact's per-user file (`users/<slug>.md`), resolved
   //      via `resolveGuardianPersonaPath()` — this is the canonical location
   //      after workspace migration 031 and handles slugged userFiles like
-  //      `users/sidd.md` that were invisible to a hardcoded `default.md`
+  //      `users/alice.md` that were invisible to a hardcoded `default.md`
   //      lookup.
   //   2. Legacy workspace-root `USER.md` as a last-ditch fallback for very
   //      old workspaces that never ran migration 031.
@@ -361,7 +361,7 @@ export async function backfillRelationshipStateIfMissing(): Promise<void> {
  * user content:
  *
  *   1. `resolveGuardianPersonaPath()` via contact-store — the canonical
- *      per-guardian slugged file (e.g. `users/sidd.md`).
+ *      per-guardian slugged file (e.g. `users/alice.md`).
  *   2. `users/default.md` — the default-guardian persona file that the
  *      workspace migration leaves in place. Catches the window where
  *      the resolver throws or returns null but the file-backed content

--- a/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
+++ b/assistant/src/memory/migrations/220-normalize-user-file-by-principal.ts
@@ -63,8 +63,8 @@ export function isAutoIncrementedUserFile(
  * Multiple contact rows may represent the same principal (one per channel:
  * desktop, phone, Slack, etc.). When a new row was created for a second
  * channel, `generateUserFileSlug(displayName)` auto-incremented to avoid a
- * filename collision (e.g. `sidd.md` → `sidd-2.md`), even though no
- * `sidd-2.md` file ever existed on disk. The persona resolver then silently
+ * filename collision (e.g. `alice.md` → `alice-2.md`), even though no
+ * `alice-2.md` file ever existed on disk. The persona resolver then silently
  * fell back to `users/default.md` for that channel's messages — and the same
  * slug is used for the journal directory, so the user lost per-principal
  * continuity on every non-primary channel.

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -76,7 +76,7 @@ function readPersonaFile(filePath: string): string | null {
 
 /**
  * Resolve the raw userFile filename for the current actor's contact.
- * Returns the validated filename (e.g. "sidd.md") or null.
+ * Returns the validated filename (e.g. "alice.md") or null.
  */
 function resolveUserFilename(
   trustContext: TrustContext | undefined,
@@ -127,7 +127,7 @@ function resolveUserFilename(
 
 /**
  * Resolve the absolute on-disk path to the guardian's per-user persona
- * file (e.g. `<workspace>/users/sidd.md`). Returns `null` when no
+ * file (e.g. `<workspace>/users/alice.md`). Returns `null` when no
  * guardian is resolvable (no guardian contact, or its `userFile` is
  * unusable / fails basename validation).
  *
@@ -264,7 +264,7 @@ export function resolveGuardianPersonaStrict(): string | null {
  *
  * @param userFile - A filename (not a bare slug), matching the shape
  *   of `Contact.userFile` — a basename with a `.md` suffix
- *   (e.g. `"sidd.md"`). The path traversal guard rejects values that
+ *   (e.g. `"alice.md"`). The path traversal guard rejects values that
  *   are not a clean basename.
  *
  * Creates the parent `users/` directory if missing.

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -324,8 +324,8 @@ export function getWorkspaceDir(): string {
  * so paths stay concise and portable across machines.
  *
  * Examples:
- *   /Users/sidd/.vellum/workspace → ~/.vellum/workspace
- *   /data/.vellum/workspace       → /data/.vellum/workspace
+ *   /Users/alice/.vellum/workspace → ~/.vellum/workspace
+ *   /data/.vellum/workspace        → /data/.vellum/workspace
  */
 export function getWorkspaceDirDisplay(): string {
   const abs = getWorkspaceDir();

--- a/clients/shared/Tests/ToolCallDataDisplayTests.swift
+++ b/clients/shared/Tests/ToolCallDataDisplayTests.swift
@@ -28,7 +28,7 @@ final class ToolCallDataDisplayTests: XCTestCase {
     /// so `interpretBashCommand` saw a final token like `"pkb/N..."` and produced
     /// `"Listed N..."`. Sourcing from `inputRawValue` avoids that.
     func testBashActionDescriptionUsesInputRawValueNotTruncatedSummary() {
-        let fullCmd = #"cd ~/.vellum/workspace && ls pkb/sidd/ 2>/dev/null && echo "---" && cat pkb/NOW.md 2>/dev/null | head -50"#
+        let fullCmd = #"cd ~/.vellum/workspace && ls pkb/alice/ 2>/dev/null && echo "---" && cat pkb/NOW.md 2>/dev/null | head -50"#
         let truncatedSummary = String(fullCmd.prefix(77)) + "..."
         let tc = ToolCallData(
             toolName: "bash",

--- a/skills/meet-join/contracts/__tests__/native-messaging.test.ts
+++ b/skills/meet-join/contracts/__tests__/native-messaging.test.ts
@@ -520,7 +520,7 @@ describe("BotJoinCommandSchema", () => {
       meetingUrl: "https://meet.google.com/abc-defg-hij",
       displayName: "Vellum Bot",
       consentMessage:
-        "Hi, I'm here on behalf of Sidd to take notes. Reply STOP to have me leave.",
+        "Hi, I'm here on behalf of Alice to take notes. Reply STOP to have me leave.",
     };
     const parsed = BotJoinCommandSchema.parse(input);
     expect(parsed).toEqual(input);

--- a/skills/meet-join/daemon/__tests__/consent-monitor-live.test.ts
+++ b/skills/meet-join/daemon/__tests__/consent-monitor-live.test.ts
@@ -3,13 +3,13 @@
  * judgement path. Unlike `consent-monitor.test.ts`, this suite drives the
  * REAL `defaultLLMAsk` — backed by `getConfiguredProvider` under the
  * `meetConsentMonitor` call site — against a small fixture set of
- * transcript/chat excerpts so Sidd can calibrate the model's rationale by
- * eye.
+ * transcript/chat excerpts so a maintainer can calibrate the model's
+ * rationale by eye.
  *
  * **Gating.** The entire suite is gated on `MEET_CONSENT_MONITOR_LIVE=1`.
  * CI and every other test run must leave the env flag unset; the suite
  * then skips cleanly without ever constructing a provider or hitting the
- * network. Sidd invokes it manually:
+ * network. A maintainer invokes it manually:
  *
  *     MEET_CONSENT_MONITOR_LIVE=1 bun test daemon/__tests__/consent-monitor-live.test.ts
  *

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-chat.html
@@ -7,7 +7,7 @@
   approximation — see README § "Refreshing Meet DOM fixtures".
 
   TODO(meet-dom): The next live refresh is expected during the Phase 1.12
-  smoke test, driven by Sidd against a real Meet session. This file was
+  smoke test, driven by a maintainer against a real Meet session. This file was
   last verified (selector tests green) on 2026-04-19 but has not been
   replaced with a fresh outer-HTML capture since authorship. When the
   smoke test runs, replace this block with the captured DOM and bump

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-ingame.html
@@ -8,7 +8,7 @@
   fixtures" before relying on it as a production reference.
 
   TODO(meet-dom): The next live refresh is expected during the Phase 1.12
-  smoke test, driven by Sidd against a real Meet session. This file was
+  smoke test, driven by a maintainer against a real Meet session. This file was
   last verified (selector tests green) on 2026-04-19 but has not been
   replaced with a fresh outer-HTML capture since authorship. When the
   smoke test runs, replace this block with the captured DOM and bump

--- a/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
+++ b/skills/meet-join/meet-controller-ext/src/dom/__tests__/fixtures/meet-dom-prejoin.html
@@ -8,7 +8,7 @@
   Meet's DOM drifts (see README § "Refreshing Meet DOM fixtures").
 
   TODO(meet-dom): The next live refresh is expected during the Phase 1.12
-  smoke test, driven by Sidd against a real Meet session. This file was
+  smoke test, driven by a maintainer against a real Meet session. This file was
   last verified (selector tests green) on 2026-04-19 but has not been
   replaced with a fresh outer-HTML capture since authorship. When the
   smoke test runs, replace this block with the captured DOM and bump


### PR DESCRIPTION
## Summary

- Replace personal-name references (\`Sidd\`, \`sidd.md\`, \`/Users/sidd/...\`) with generic placeholders (\`Alice\`/\`alice.md\`, \`Chris\`/\`chris.md\`) across 18 files — test fixtures, JSDoc examples, and inline comments — to conform to the Generic Examples rule in AGENTS.md/CLAUDE.md.
- Leaves operational identifiers untouched: \`.github/CODEOWNERS\`, \`.github/config/github_slack_mapping.yaml\`, and \`meta/feature-flags/PENDING_PLATFORM_PRS.md\` owner field require real handles/emails to function. The \`sid\` token in \`011-call-sessions-provider-sid-dedup.ts\` (and siblings) refers to Twilio Session IDs, not a person.
- Bundled with a small PKB filing prompt refinement in \`assistant/src/filing/filing-service.ts\`: clarify that a buffer item can land in multiple topic files, add an explicit >1500-token budget that should trigger compression/splits, and rename \`Part 2: Nest\` → \`Part 2: Review\` with 3 random files per run.

## Test plan

- [x] \`bunx tsc --noEmit\` in \`assistant/\` shows no new errors in the edited files (only pre-existing missing \`@vellumai/*\` module errors).
- [ ] CI green (waiting on GitHub Actions).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
