### PR TITLE
feat(macos): ship first-party skill catalog with the app bundle

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -52,14 +52,43 @@ export function getSkillsIndexPath(): string {
 }
 
 /**
- * Resolve the repo-level skills/ directory when running in dev mode.
- * Returns the path if VELLUM_DEV is set and the directory exists, or undefined.
+ * Resolve a local first-party skill catalog directory, if one is available.
+ *
+ * Two resolution paths:
+ *
+ * 1. **Compiled-binary layout (e.g. Velissa.app)**: when `import.meta.dir` is
+ *    inside bun's virtual `/$bunfs/` fs, look for a sibling `first-party-skills`
+ *    next to the executable (`Contents/Resources/first-party-skills` for
+ *    `.app` bundles, or alongside the binary otherwise). `clients/macos/build.sh`
+ *    copies the repo's `skills/` tree into this location so the catalog and
+ *    skill sources ship with the app.
+ * 2. **Dev-mode from-source**: when `VELLUM_DEV=1` is set (CLI-spawned daemon),
+ *    resolve the repo's `skills/` directory relative to this file.
+ *
+ * Either way, the returned directory must contain `catalog.json`.
  */
 export function getRepoSkillsDir(): string | undefined {
+  const importDir = import.meta.dir;
+
+  if (importDir.startsWith("/$bunfs/")) {
+    const execDir = dirname(process.execPath);
+    // macOS .app bundle: binary in Contents/MacOS/, resources in Contents/Resources/
+    const resourcesPath = join(execDir, "..", "Resources", "first-party-skills");
+    if (existsSync(join(resourcesPath, "catalog.json"))) {
+      return resourcesPath;
+    }
+    // Next to the binary (non-app-bundle compiled deployments)
+    const execDirPath = join(execDir, "first-party-skills");
+    if (existsSync(join(execDirPath, "catalog.json"))) {
+      return execDirPath;
+    }
+    return undefined;
+  }
+
   if (!process.env.VELLUM_DEV) return undefined;
 
   // assistant/src/skills/catalog-install.ts -> ../../../skills/
-  const candidate = join(import.meta.dir, "..", "..", "..", "skills");
+  const candidate = join(importDir, "..", "..", "..", "skills");
   if (existsSync(join(candidate, "catalog.json"))) {
     return candidate;
   }

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -224,6 +224,10 @@ CLI_SRC_DIR="$SCRIPT_DIR/../../cli"
 GATEWAY_SRC_DIR="$SCRIPT_DIR/../../gateway"
 NATIVE_HOST_SRC_DIR="$SCRIPT_DIR/../chrome-extension/native-host"
 CES_SRC_DIR="$SCRIPT_DIR/../../credential-executor"
+# Repo-level first-party skill catalog (skills/catalog.json + skill dirs).
+# Shipped with the app so the daemon can install catalog skills without a
+# running platform. node_modules and build artifacts are excluded.
+SKILLS_SRC_DIR="$SCRIPT_DIR/../../skills"
 
 # Chrome extension allowlist IDs injected into compiled binaries as a fallback
 # for packaged runs where repo-relative `meta/browser-extension/...` paths are
@@ -413,6 +417,14 @@ build_binaries() {
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
+    rm -rf "$SCRIPT_DIR/daemon-bin/first-party-skills"
+    rsync -a \
+        --exclude='node_modules/' \
+        --exclude='*.tsbuildinfo' \
+        --exclude='dist/' \
+        --exclude='build/' \
+        --exclude='.git/' \
+        "$SKILLS_SRC_DIR/" "$SCRIPT_DIR/daemon-bin/first-party-skills/"
     rm -rf "$SCRIPT_DIR/daemon-bin/templates"
     cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" "$SCRIPT_DIR/daemon-bin/templates"
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
@@ -727,6 +739,20 @@ if [ -d "$ASSISTANT_SRC_DIR/src/config/bundled-skills" ]; then
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
 fi
 
+# Always refresh first-party catalog skills from the repo-level skills/ dir
+# so the daemon can install catalog entries without a running platform.
+if [ -d "$SKILLS_SRC_DIR" ] && [ -f "$SKILLS_SRC_DIR/catalog.json" ]; then
+    mkdir -p "$SCRIPT_DIR/daemon-bin"
+    rm -rf "$SCRIPT_DIR/daemon-bin/first-party-skills"
+    rsync -a \
+        --exclude='node_modules/' \
+        --exclude='*.tsbuildinfo' \
+        --exclude='dist/' \
+        --exclude='build/' \
+        --exclude='.git/' \
+        "$SKILLS_SRC_DIR/" "$SCRIPT_DIR/daemon-bin/first-party-skills/"
+fi
+
 # Always refresh non-JS assets from source (not embedded by bun --compile)
 mkdir -p "$SCRIPT_DIR/daemon-bin"
 if [ -d "$ASSISTANT_SRC_DIR/src/prompts/templates" ]; then
@@ -993,6 +1019,12 @@ fi
 if [ -d "$SCRIPT_DIR/daemon-bin/bundled-skills" ]; then
     rm -rf "$RESOURCES_DIR/bundled-skills"
     cp -R "$SCRIPT_DIR/daemon-bin/bundled-skills" "$RESOURCES_DIR/bundled-skills"
+fi
+
+# Always refresh first-party catalog skills in the app bundle.
+if [ -d "$SCRIPT_DIR/daemon-bin/first-party-skills" ]; then
+    rm -rf "$RESOURCES_DIR/first-party-skills"
+    cp -R "$SCRIPT_DIR/daemon-bin/first-party-skills" "$RESOURCES_DIR/first-party-skills"
 fi
 
 # Always refresh non-JS assets in app bundle (not embedded by bun --compile)


### PR DESCRIPTION
## Summary
- Copy the repo's `skills/` catalog (minus `node_modules/`, `dist/`, `build/`, `*.tsbuildinfo`) into `Velissa.app/Contents/Resources/first-party-skills/` at build time
- Teach `getRepoSkillsDir()` to resolve that sibling path when `import.meta.dir` is inside bun's `/$bunfs/`, so catalog auto-install works without a running platform
- Prior behavior: `Skill("vellum-github-app-setup")` failed with "No skill matched" because the skill wasn't bundled, not installed, and the platform at localhost:8000 was unreachable

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
