### PR TITLE
feat(pkb): threshold-filter PKB injection hints

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -630,6 +630,16 @@ const AUTOINJECT_FILENAME = "_autoinject.md";
 /** Max buffer.md lines injected into prompts — keeps context bounded even when filing is off. */
 const MAX_BUFFER_LINES = 50;
 
+/** Minimum hybrid-search score for a PKB path to surface as an injection hint. */
+const PKB_HINT_THRESHOLD = 0.5;
+
+/**
+ * Stricter hint threshold for PKB entries under `archive/`. Archive files are
+ * date-indexed dumps of older notes — they match loosely and are rarely the
+ * most relevant read, so require a higher bar before recommending them.
+ */
+const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
+
 /**
  * Read `_autoinject.md` from the PKB directory and return the list of
  * filenames to inject.
@@ -1795,7 +1805,11 @@ export async function applyRuntimeInjections(
           hints = results
             .filter((r) => {
               const abs = resolve(pkbRoot, r.path);
-              return !inContext.has(abs);
+              if (inContext.has(abs)) return false;
+              const threshold = r.path.startsWith("archive/")
+                ? PKB_HINT_ARCHIVE_THRESHOLD
+                : PKB_HINT_THRESHOLD;
+              return r.score >= threshold;
             })
             .slice(0, 3)
             .map((r) => r.path);


### PR DESCRIPTION
## Summary
- Add a 0.5 hybrid-search score floor to the PKB injection recommendation list in `conversation-runtime-assembly.ts`, so low-relevance paths stop landing in the `<system_reminder>` hint bullets.
- Apply a stricter 0.7 floor for entries under `archive/`, since the date-indexed daily dumps match loosely and are rarely the best next read.
- Constants live next to the other PKB injection knobs for discoverability.

## Original prompt
increase the threshold to 0.5 in general, and 0.7 for pkb entries in \`archive/\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
