### PR TITLE
fix(chat): bind latest-turn section height to viewport synchronously

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -85,24 +85,14 @@ Older history still renders through the existing `displayedItems.reversed()` pat
 
 When `pinnedLatestTurnAnchorMessageId` is set, the newest turn is carved out into a dedicated `PinnedLatestTurnSection`:
 
-- latest-edge sentinel
-- computed spacer
+- anchor user row
 - response cluster (assistant rows, placeholder, latest-edge indicators, orphan subagents, queued marker content)
-- anchor user row
+- `Spacer(minLength: 0)`
+- latest-edge sentinel
 
-The section is flipped as a single unit, so the visual order becomes:
+The section is flipped as a single unit (cancelling the outer ScrollView flip), so the visual order matches source order: anchor at the visual top, response below, the spacer fills the rest, sentinel at the bottom.
 
-- anchor user row
-- assistant response cluster
-- spacer
-
-`LatestTurnSpacerCalculator` computes:
-
-```swift
-max(0, viewportHeight - anchorHeight - responseHeight)
-```
-
-The response cluster is measured after the single anchor-to-response gap is applied, so the formula stays exact without reviving `turnMinHeight` or any height estimates.
+The section's height is bound to the scroll viewport via SwiftUI's `containerRelativeFrame(.vertical, alignment: .top) { length, _ in length - VSpacing.md * 2 }` (subtracting the outer LazyVStack's vertical padding). Because `containerRelativeFrame` reads the nearest scroll container's visible height during layout, the section resizes in the **same** layout pass as composer-induced viewport changes. The remaining empty space is absorbed by the `Spacer`, eliminating the previous `LatestTurnSpacerCalculator` + `viewportHeight` `@State` pipeline (which lagged one frame and caused the anchor row to briefly clip on every Enter keystroke in the composer).
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -45,7 +45,6 @@ struct MessageListContentView: View, Equatable {
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.subagentDetailStore === rhs.subagentDetailStore
             && lhs.assistantStatusText == rhs.assistantStatusText
-            && lhs.viewportHeight == rhs.viewportHeight
             && lhs.pinnedLatestTurnAnchorMessageId == rhs.pinnedLatestTurnAnchorMessageId
     }
 
@@ -70,7 +69,6 @@ struct MessageListContentView: View, Equatable {
     let configuredProviders: Set<String>
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
-    let viewportHeight: CGFloat
     let pinnedLatestTurnAnchorMessageId: UUID?
 
     // MARK: - Closures (skipped in ==)
@@ -354,7 +352,6 @@ struct MessageListContentView: View, Equatable {
                let anchorRow = rowsByMessageId[anchorMessage.id] {
                 PinnedLatestTurnSection(
                     contentView: self,
-                    viewportHeight: viewportHeight,
                     partition: pinnedTurnPartition,
                     rowsByMessageId: rowsByMessageId,
                     anchorRow: anchorRow,
@@ -418,22 +415,6 @@ struct MessageListContentView: View, Equatable {
 
 // MARK: - Pinned Latest Turn
 
-struct LatestTurnSpacerCalculator {
-    static func spacerHeight(
-        viewportHeight: CGFloat,
-        anchorHeight: CGFloat,
-        responseHeight: CGFloat,
-        contentInsets: CGFloat = 0
-    ) -> CGFloat {
-        guard viewportHeight.isFinite, viewportHeight > 0 else { return 0 }
-
-        let safeAnchorHeight = anchorHeight.isFinite ? max(0, anchorHeight) : 0
-        let safeResponseHeight = responseHeight.isFinite ? max(0, responseHeight) : 0
-        let safeInsets = contentInsets.isFinite ? max(0, contentInsets) : 0
-        return max(0, viewportHeight - safeAnchorHeight - safeResponseHeight - safeInsets)
-    }
-}
-
 struct PinnedLatestTurnPartition: Equatable {
     let historyItems: [TranscriptItem]
     let anchorMessage: ChatMessage?
@@ -472,15 +453,11 @@ struct PinnedLatestTurnPartition: Equatable {
 
 private struct PinnedLatestTurnSection: View {
     let contentView: MessageListContentView
-    let viewportHeight: CGFloat
     let partition: PinnedLatestTurnPartition
     let rowsByMessageId: [UUID: TranscriptRowModel]
     let anchorRow: TranscriptRowModel
     let isUnanchoredThinking: Bool
     let thinkingLabel: String
-
-    @State private var anchorHeight: CGFloat = 0
-    @State private var responseHeight: CGFloat = 0
 
     private var hasResponseContent: Bool {
         contentView.showsStandaloneLatestEdgeActivity
@@ -488,22 +465,18 @@ private struct PinnedLatestTurnSection: View {
             || !partition.responseItems.isEmpty
     }
 
-    /// Vertical content insets from the outer LazyVStack padding (top + bottom).
-    private static let contentVerticalInsets: CGFloat = VSpacing.md * 2
-
-    private var spacerHeight: CGFloat {
-        LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: viewportHeight,
-            anchorHeight: anchorHeight,
-            responseHeight: responseHeight,
-            contentInsets: Self.contentVerticalInsets
-        )
-    }
-
     var body: some View {
         // Two flips (ScrollView + section) cancel out, so source order
         // equals visual order: anchor at top, response below, spacer
         // fills remaining viewport, sentinel marks the latest edge.
+        //
+        // The section's height is bound to the scroll viewport via
+        // `containerRelativeFrame` so it tracks the chat area's height in
+        // the SAME layout pass as composer-induced viewport changes. A
+        // previous `viewportHeight` @State + computed-spacer pattern lagged
+        // one frame behind the AppKit clip-view frame change and caused the
+        // anchor row's top to briefly clip on every Enter keystroke in the
+        // composer.
         VStack(alignment: .leading, spacing: 0) {
             contentView.transcriptRow(
                 row: anchorRow,
@@ -512,26 +485,18 @@ private struct PinnedLatestTurnSection: View {
                 isFlipped: false
             )
             .id(anchorRow.id)
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.height
-            } action: { newHeight in
-                if abs(anchorHeight - newHeight) > 0.5 {
-                    anchorHeight = newHeight
-                }
-            }
 
             responseCluster
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.height
-                } action: { newHeight in
-                    if abs(responseHeight - newHeight) > 0.5 {
-                        responseHeight = newHeight
-                    }
-                }
 
-            Color.clear.frame(height: spacerHeight)
+            Spacer(minLength: 0)
 
             contentView.latestEdgeSentinel(isFlipped: false)
+        }
+        .containerRelativeFrame(.vertical, alignment: .top) { length, _ in
+            // Subtract the outer LazyVStack's vertical padding (top + bottom
+            // of `MessageListContentView.body`) so the anchor row ends with
+            // the intentional VSpacing.md visual gap above it.
+            length - VSpacing.md * 2
         }
         .flipped()
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -170,7 +170,6 @@ extension MessageListView {
             configuredProviders: configuredProviders,
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
-            viewportHeight: viewportHeight,
             pinnedLatestTurnAnchorMessageId: scrollState.pinnedLatestTurnAnchorMessageId,
             onConfirmationAllow: onConfirmationAllow,
             onConfirmationDeny: onConfirmationDeny,

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -465,55 +465,6 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertEqual(state.scrollContentHeight, 0)
     }
 
-    // MARK: - Latest-turn spacer
-
-    func testLatestTurnSpacerLeavesRemainingViewportForShortResponse() {
-        let spacerHeight = LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: 600,
-            anchorHeight: 120,
-            responseHeight: 180
-        )
-
-        XCTAssertEqual(spacerHeight, 300)
-    }
-
-    func testLatestTurnSpacerShrinksAsResponseGrows() {
-        let shortResponseSpacer = LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: 600,
-            anchorHeight: 120,
-            responseHeight: 100
-        )
-        let tallResponseSpacer = LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: 600,
-            anchorHeight: 120,
-            responseHeight: 240
-        )
-
-        XCTAssertGreaterThan(shortResponseSpacer, tallResponseSpacer)
-        XCTAssertEqual(shortResponseSpacer, 380)
-        XCTAssertEqual(tallResponseSpacer, 240)
-    }
-
-    func testLatestTurnSpacerClampsToZeroForTallResponse() {
-        let spacerHeight = LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: 500,
-            anchorHeight: 150,
-            responseHeight: 480
-        )
-
-        XCTAssertEqual(spacerHeight, 0)
-    }
-
-    func testLatestTurnSpacerUsesFullRemainingViewportForEmptyResponse() {
-        let spacerHeight = LatestTurnSpacerCalculator.spacerHeight(
-            viewportHeight: 480,
-            anchorHeight: 140,
-            responseHeight: 0
-        )
-
-        XCTAssertEqual(spacerHeight, 340)
-    }
-
     // MARK: - Latest-turn pinning lifecycle
 
     func testPinnedLatestTurnAnchorSetOnRealUserSend() {

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,7 +49,6 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
-            viewportHeight: 600,
             pinnedLatestTurnAnchorMessageId: nil
         )
     }


### PR DESCRIPTION
## Summary

- The chat history visibly "jumped up and down" on every Enter keystroke in the composer. When the composer grew by one line, the chat clip view shrunk in the same layout pass — but the `PinnedLatestTurnSection`'s spacer (driven by a `@State viewportHeight` that propagated through `ScrollGeometryUpdateDispatcher`'s deferred drain) didn't recompute until the next frame, so for one frame the section was taller than the new viewport and the anchor row's top got clipped.
- Replaces the computed-spacer pattern with `.containerRelativeFrame(.vertical, alignment: .top) { length, _ in length - VSpacing.md * 2 }` + `Spacer(minLength: 0)`. `containerRelativeFrame` reads the scroll container's visible height during layout, so the section tracks viewport changes in the **same** layout pass — no intermediate frame.
- Drops `LatestTurnSpacerCalculator`, `viewportHeight` on `MessageListContentView` (and its `Equatable` field + pass-through in `MessageListView+DerivedState`), and the four `testLatestTurnSpacer*` cases (new behavior is layout-driven, not unit-testable without rendering). Updates `clients/macos/SCROLL_STRATEGY.md` to describe the new approach.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
