### PR TITLE
docs(skills): drop redundant getRepoSkillsDir docstring

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -51,22 +51,6 @@ export function getSkillsIndexPath(): string {
   return join(getWorkspaceSkillsDir(), "SKILLS.md");
 }
 
-/**
- * Resolve a local first-party skill catalog directory, if one is available.
- *
- * Two resolution paths:
- *
- * 1. **Compiled-binary layout (e.g. Velissa.app)**: when `import.meta.dir` is
- *    inside bun's virtual `/$bunfs/` fs, look for a sibling `first-party-skills`
- *    next to the executable (`Contents/Resources/first-party-skills` for
- *    `.app` bundles, or alongside the binary otherwise). `clients/macos/build.sh`
- *    copies the repo's `skills/` tree into this location so the catalog and
- *    skill sources ship with the app.
- * 2. **Dev-mode from-source**: when `VELLUM_DEV=1` is set (CLI-spawned daemon),
- *    resolve the repo's `skills/` directory relative to this file.
- *
- * Either way, the returned directory must contain `catalog.json`.
- */
 export function getRepoSkillsDir(): string | undefined {
   const importDir = import.meta.dir;
 


### PR DESCRIPTION
## Summary
- Remove the JSDoc block from `getRepoSkillsDir()` in `assistant/src/skills/catalog-install.ts`. The inline comments at each branch already explain the `/$bunfs/` compiled-binary resolution and the `VELLUM_DEV=1` dev-mode fallback, so the docstring was redundant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
