### PR TITLE
style(design-system): QA sweep wave 1 — slider, inputs, pill, file browser, segment control

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -498,6 +498,13 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
         return "Tap to \(isExpanded ? "collapse" : "expand")"
     }
 
+    /// Whether a directory chevron should be shown. Suppress the chevron for
+    /// directories that have no loaded children — they appear as leaf rows
+    /// until the user expands them and content loads.
+    private var showChevron: Bool {
+        node.isDirectory && (!node.children.isEmpty || isExpanded)
+    }
+
     /// Selected state always wins over hovered state, and drop-targeted state
     /// wins over hover so the user gets the strongest feedback for the action
     /// they're performing.
@@ -506,10 +513,10 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
             return VColor.surfaceActive
         }
         if isDropTargeted {
-            return VColor.surfaceBase
+            return VColor.surfaceActive.opacity(0.6)
         }
         if isHovered {
-            return VColor.surfaceBase
+            return VColor.surfaceActive.opacity(0.5)
         }
         return Color.clear
     }
@@ -517,8 +524,8 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: VSpacing.xs) {
-                // Expand/collapse chevron for directories, spacer for files
-                if node.isDirectory {
+                // Expand/collapse chevron for directories with children, spacer otherwise
+                if showChevron {
                     VIconView(isExpanded ? .chevronDown : .chevronRight, size: 9)
                         .foregroundStyle(VColor.contentTertiary)
                         .frame(width: 12)
@@ -556,9 +563,10 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
                 bottom: VSpacing.xs,
                 trailing: VSpacing.sm
             ))
+            .padding(.horizontal, VSpacing.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
+                RoundedRectangle(cornerRadius: VRadius.md)
                     .fill(rowBackground)
             )
             .opacity(node.isDimmed ? 0.6 : 1.0)

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -80,14 +80,15 @@ public struct VSkillTypePill: View {
     public var body: some View {
         HStack(spacing: VSpacing.xs) {
             VIconView(type.vIcon, size: 10)
+                .foregroundStyle(type.foregroundColor)
             Text(type.label)
-                .font(VFont.labelDefault)
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentDefault)
         }
-        .foregroundStyle(type.foregroundColor)
-        .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xxs)
         .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
+            RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(type.backgroundColor)
         )
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -15,13 +15,14 @@ public struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 32
-    private let thumbWidth: CGFloat = 32
+    private let trackHeight: CGFloat = 8
+    private let thumbSize: CGFloat = 20
+    private let hitAreaHeight: CGFloat = 28
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 14
-    private let gripLineSpacing: CGFloat = 2.5
+    private let gripLineHeight: CGFloat = 8
+    private let gripLineSpacing: CGFloat = 2
 
     // MARK: - State
 
@@ -31,7 +32,7 @@ public struct VSlider: View {
 
     public var body: some View {
         GeometryReader { geometry in
-            let trackWidth = geometry.size.width - thumbWidth
+            let trackWidth = geometry.size.width - thumbSize
             let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
             let thumbOffset = trackWidth * fraction
 
@@ -48,13 +49,13 @@ public struct VSlider: View {
                 thumbView
                     .offset(x: thumbOffset)
             }
-            .frame(height: trackHeight)
+            .frame(height: hitAreaHeight)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { drag in
                         isDragging = true
-                        let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
+                        let newFraction = (drag.location.x - thumbSize / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
                         let snapped = round(rawValue / step) * step
@@ -65,7 +66,7 @@ public struct VSlider: View {
                     }
             )
         }
-        .frame(height: trackHeight)
+        .frame(height: hitAreaHeight)
     }
 
     // MARK: - Track
@@ -73,40 +74,41 @@ public struct VSlider: View {
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
         ZStack(alignment: .leading) {
             // Unfilled track (edge-to-edge)
-            Rectangle()
+            RoundedRectangle(cornerRadius: VRadius.pill)
                 .fill(VColor.borderBase)
                 .frame(height: trackHeight)
 
             // Filled track (from left edge to thumb center)
-            Rectangle()
+            RoundedRectangle(cornerRadius: VRadius.pill)
                 .fill(VColor.primaryBase)
-                .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
+                .frame(width: thumbOffset + thumbSize / 2, height: trackHeight)
         }
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+        .frame(height: hitAreaHeight)
     }
 
     // MARK: - Thumb
 
     private var thumbView: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: VRadius.xs)
+            Circle()
                 .fill(VColor.primaryHover)
-                .frame(width: thumbWidth, height: trackHeight)
+                .frame(width: thumbSize, height: thumbSize)
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.xs)
+                    Circle()
                         .stroke(VColor.borderActive, lineWidth: 1)
                 )
+                .shadow(color: VColor.auxBlack.opacity(0.1), radius: 2, x: 0, y: 1)
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(VColor.systemPositiveWeak)
+                        .fill(VColor.contentTertiary.opacity(0.5))
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }
         }
-        .scaleEffect(isDragging ? 1.05 : 1.0)
+        .scaleEffect(isDragging ? 1.08 : 1.0)
         .animation(VAnimation.fast, value: isDragging)
     }
 
@@ -128,7 +130,7 @@ public struct VSlider: View {
 
                     // Only render tick marks in the unfilled portion, excluding the rightmost
                     if tickFraction > fraction && tickValue < range.upperBound {
-                        let tickX = trackWidth * tickFraction + thumbWidth / 2
+                        let tickX = trackWidth * tickFraction + thumbSize / 2
 
                         RoundedRectangle(cornerRadius: 0.5)
                             .fill(VColor.surfaceActive)

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -95,7 +95,7 @@ public struct VInputChromeModifier: ViewModifier {
         if isFocused {
             return VColor.borderActive
         }
-        return VColor.borderBase
+        return colorScheme == .dark ? VColor.borderBase : VColor.borderElement
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -73,12 +73,19 @@ public struct VInputChromeModifier: ViewModifier {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         content
-            .background(shape.fill(VColor.surfaceLift))
+            .background(shape.fill(backgroundFill))
             .overlay(
                 shape.strokeBorder(borderColor, lineWidth: 1)
             )
             .clipShape(shape)
             .opacity(isDisabled ? 0.6 : 1.0)
+    }
+
+    // Inputs use `surfaceLift` in light mode (cleaner white field on the warm
+    // page surface) but `contentBackground` in dark mode (the Figma spec color
+    // for dark inputs — `surfaceLift` dark is too close to the page bg).
+    private var backgroundFill: Color {
+        colorScheme == .dark ? VColor.contentBackground : VColor.surfaceLift
     }
 
     private var borderColor: Color {
@@ -88,7 +95,7 @@ public struct VInputChromeModifier: ViewModifier {
         if isFocused {
             return VColor.borderActive
         }
-        return colorScheme == .dark ? Color.clear : VColor.borderElement
+        return VColor.borderBase
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
@@ -65,14 +65,14 @@ private struct Segment: View {
                     VIconView(.resolve(icon), size: 12)
                 } else {
                     Text(label)
-                        .font(VFont.bodyMediumDefault)
+                        .font(VFont.bodySmallDefault)
                         .fixedSize()
                 }
             }
             .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, VSpacing.sm)
             .frame(maxWidth: .infinity)
-            .frame(height: 28)
+            .frame(height: 24)
             .background(
                 RoundedRectangle(cornerRadius: 6)
                     .fill(segmentBackground)


### PR DESCRIPTION
## Summary
QA sweep polish across five design-system primitives.

- **VSlider** — modernized: thin 8pt track with a circular 20pt thumb, wider hit area, softer grip lines, subtle drop shadow.
- **Input chrome** (`VTextField`, `VDropdown`, `VSearchBar`, `VTextEditor`) — unified background: `surfaceLift` in light, `contentBackground` in dark; single `borderBase` when unfocused (drops the prior light/dark split + transparent-in-dark case).
- **VSkillTypePill** — tighter: smaller radius, xxs/sm padding, `bodySmallDefault` font, label uses `contentDefault`.
- **VFileBrowser** — row chevrons suppressed for empty/unloaded directories; softer drop/hover backgrounds (`surfaceActive` with opacity) and a slightly larger corner radius on a tighter-padded row.
- **VSegmentControl** — smaller body font and 24pt height to match the new input proportions.

No new tokens added — reused existing `contentBackground` (F2F0EE / 2D3339) already in the system.

## Test plan
- [ ] Slider drag + tick marks in both modes
- [ ] Text field / dropdown / search / text editor backgrounds in light and dark
- [ ] Skill type pills render with new proportions
- [ ] File browser directory rows: empty dirs have no chevron, hover/drop bg is readable
- [ ] Segment control height + font in queue drawer and elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
