### PR TITLE
style(slider): match Figma spec — thicker track, rounded-rect thumb, content colors

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -15,8 +15,9 @@ public struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 8
-    private let thumbSize: CGFloat = 20
+    private let trackHeight: CGFloat = 16
+    private let thumbWidth: CGFloat = 19
+    private let thumbHeight: CGFloat = 20
     private let hitAreaHeight: CGFloat = 28
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
@@ -32,7 +33,7 @@ public struct VSlider: View {
 
     public var body: some View {
         GeometryReader { geometry in
-            let trackWidth = geometry.size.width - thumbSize
+            let trackWidth = geometry.size.width - thumbWidth
             let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
             let thumbOffset = trackWidth * fraction
 
@@ -55,7 +56,7 @@ public struct VSlider: View {
                 DragGesture(minimumDistance: 0)
                     .onChanged { drag in
                         isDragging = true
-                        let newFraction = (drag.location.x - thumbSize / 2) / trackWidth
+                        let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
                         let snapped = round(rawValue / step) * step
@@ -74,14 +75,14 @@ public struct VSlider: View {
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
         ZStack(alignment: .leading) {
             // Unfilled track (edge-to-edge)
-            RoundedRectangle(cornerRadius: VRadius.pill)
-                .fill(VColor.borderBase)
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.contentBackground)
                 .frame(height: trackHeight)
 
             // Filled track (from left edge to thumb center)
-            RoundedRectangle(cornerRadius: VRadius.pill)
-                .fill(VColor.primaryBase)
-                .frame(width: thumbOffset + thumbSize / 2, height: trackHeight)
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.contentSecondary)
+                .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
         }
         .frame(height: hitAreaHeight)
     }
@@ -90,20 +91,16 @@ public struct VSlider: View {
 
     private var thumbView: some View {
         ZStack {
-            Circle()
-                .fill(VColor.primaryHover)
-                .frame(width: thumbSize, height: thumbSize)
-                .overlay(
-                    Circle()
-                        .stroke(VColor.borderActive, lineWidth: 1)
-                )
-                .shadow(color: VColor.auxBlack.opacity(0.1), radius: 2, x: 0, y: 1)
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.contentDefault)
+                .frame(width: thumbWidth, height: thumbHeight)
+                .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1, x: 0, y: 1)
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(VColor.contentTertiary.opacity(0.5))
+                        .fill(VColor.contentDisabled)
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }
@@ -130,7 +127,7 @@ public struct VSlider: View {
 
                     // Only render tick marks in the unfilled portion, excluding the rightmost
                     if tickFraction > fraction && tickValue < range.upperBound {
-                        let tickX = trackWidth * tickFraction + thumbSize / 2
+                        let tickX = trackWidth * tickFraction + thumbWidth / 2
 
                         RoundedRectangle(cornerRadius: 0.5)
                             .fill(VColor.surfaceActive)


### PR DESCRIPTION
## Summary
Brings VSlider to 1:1 parity with the Figma spec ([node 3038-38844](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=3038-38844)).

- **Track**: 16pt tall (was 8), `VRadius.sm` corners (was `pill`), unfilled = `contentBackground`, filled = `contentSecondary` (was `borderBase` / `primaryBase`).
- **Thumb**: 19×20 `RoundedRectangle` with `VRadius.sm` (was 20pt `Circle`), `contentDefault` fill, no stroke. Shadow tightened to 1px blur to match Figma.
- **Grip**: three 1×8 lines using `contentDisabled` (was `contentTertiary@50%`).

Hit-area height kept at 28pt so drag targets stay comfortable.

## Test plan
- [ ] Settings → Sounds: drag the volume slider in both light and dark
- [ ] Memory item importance sheet: drag the importance slider
- [ ] DS Gallery: Inputs section — default, tick marks, small-range variants all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
