### PR TITLE
fix(docker): copy skills/meet-join/register.ts so tool registration works in Docker mode

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /app/assistant && bun install --frozen-lockfile
 
 # Copy meet-join skill source (contracts + daemon + config) needed at runtime
 COPY skills/meet-join/contracts ./skills/meet-join/contracts
-COPY skills/meet-join/config-schema.ts skills/meet-join/meet-config.ts ./skills/meet-join/
+COPY skills/meet-join/config-schema.ts skills/meet-join/meet-config.ts skills/meet-join/register.ts ./skills/meet-join/
 COPY skills/meet-join/daemon ./skills/meet-join/daemon
 COPY skills/meet-join/tools ./skills/meet-join/tools
 COPY skills/meet-join/routes ./skills/meet-join/routes


### PR DESCRIPTION
## Summary
PR #26687 added register.ts as the bootstrap side-effect module that calls registerExternalTools, but the assistant Dockerfile never COPYed it. In Docker mode, the daemon hits the static import and fails to find the file, silently losing all meet_* tools from the LLM-visible tool list.

This PR adds register.ts to the existing COPY line on Dockerfile:32.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
