### PR TITLE
fix(meet): honest comment on AVATAR_CONFIG_JSON credential pass-through

### DIFF
--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -956,7 +956,7 @@ class MeetSessionManagerImpl {
     // Avatar config → bot env.
     //
     // When the avatar feature is enabled we thread the config down to the
-    // bot via a trio of env vars:
+    // bot via four env vars:
     //
     //   - `AVATAR_ENABLED` — flips the bot's Chrome flags into
     //     v4l2loopback mode (added in PR 3) and mounts the `/avatar/*`
@@ -969,10 +969,16 @@ class MeetSessionManagerImpl {
     //     passes through to its Chrome launcher and `/avatar/enable`
     //     handler.
     //
-    // Credential fields inside the config are resolved to raw values in
-    // the daemon (via the vault) before being handed off — the bot has
-    // no vault access. Concrete renderer PRs extend this serialization
-    // step to substitute in their own vault-resolved credentials.
+    // Credential IDs in `services.meet.avatar.*CredentialId` fields are
+    // passed through as-is by the `JSON.stringify(meet.avatar)` below —
+    // this code does NOT resolve them to raw secrets. Today this is inert
+    // because the only shipping renderers (`noop`, `talking-head`) have no
+    // credential fields. TODO — when hosted-renderer PRs (Simli/HeyGen/
+    // Tavus) land, they MUST extend this serialization step to resolve
+    // `*CredentialId` values via the vault and substitute raw secrets
+    // into the config before stringifying. The bot has no vault access
+    // and will fail to reach hosted APIs otherwise. Do not ship a hosted
+    // renderer without first extending this.
     if (meet.avatar.enabled) {
       env.AVATAR_ENABLED = "1";
       env.AVATAR_RENDERER = meet.avatar.renderer;


### PR DESCRIPTION
## Summary
The session-manager comment claimed AVATAR_CONFIG_JSON performs vault resolution on credential IDs, but the code just JSON.stringifies the config as-is. Inert for v1 (TalkingHead.js has no credentials) but a foot-gun for hosted-renderer PRs.

This PR rewrites the comment to match reality and flags the extension point for when Simli/HeyGen/Tavus renderers land.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
