### PR TITLE
fix(meet): fail fast when default-avatar.glb is placeholder

### DIFF
--- a/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
+++ b/skills/meet-join/bot/__tests__/talking-head-renderer.test.ts
@@ -242,6 +242,56 @@ describe("TalkingHeadRenderer", () => {
     expect(avatarErr.reason).toContain("did not ack");
   });
 
+  test("start() throws AvatarRendererUnavailableError when the ack reports a placeholder GLB", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 1_000,
+    });
+    const startPromise = r.start();
+
+    // Simulate the extension's ack with placeholderDetected=true,
+    // matching what avatar.ts posts when the resolved GLB is below
+    // AVATAR_GLB_MIN_SIZE_BYTES (e.g. the committed 0-byte stub).
+    nativeMessaging.emit({
+      type: "avatar.started",
+      placeholderDetected: true,
+      glbSize: 0,
+    });
+
+    let err: unknown;
+    try {
+      await startPromise;
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(AvatarRendererUnavailableError);
+    const avatarErr = err as AvatarRendererUnavailableError;
+    expect(avatarErr.rendererId).toBe(TALKING_HEAD_RENDERER_ID);
+    // The error message must point operators at the README so they
+    // can take action without spelunking through logs.
+    expect(avatarErr.reason).toContain("placeholder GLB");
+    expect(avatarErr.reason).toContain("README");
+    expect(avatarErr.reason).toContain("default-avatar.glb");
+    expect(avatarErr.reason).toContain("size=0");
+  });
+
+  test("start() resolves when the ack explicitly reports placeholderDetected=false", async () => {
+    const nativeMessaging = new FakeNativeMessaging();
+    const r = new TalkingHeadRenderer({
+      nativeMessaging,
+      startedAckTimeoutMs: 1_000,
+    });
+    const startPromise = r.start();
+    nativeMessaging.emit({
+      type: "avatar.started",
+      placeholderDetected: false,
+      glbSize: 2_000_000,
+    });
+    // Must not throw — a valid GLB passed the probe.
+    await startPromise;
+  });
+
   test("start() is a no-op on a second invocation against the same instance", async () => {
     const nativeMessaging = new FakeNativeMessaging();
     const r = new TalkingHeadRenderer({

--- a/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
+++ b/skills/meet-join/bot/src/media/avatar/talking-head/renderer.ts
@@ -256,7 +256,26 @@ export class TalkingHeadRenderer implements AvatarRenderer {
       sender: this.nativeMessaging,
       onExtensionMessage: this.nativeMessaging.onExtensionMessage,
       handlers: {
-        onStarted: () => {
+        onStarted: (msg) => {
+          // The extension tells us whether its configured GLB was the
+          // committed 0-byte placeholder (or another sub-threshold
+          // file). When it was, fail the start() promise with a
+          // pointer to the README so the session-manager can fall
+          // back to the noop renderer and the operator gets a clear
+          // error rather than a blank camera feed.
+          if (msg.placeholderDetected) {
+            this.rejectStartedWaiter(
+              new AvatarRendererUnavailableError(
+                TALKING_HEAD_RENDERER_ID,
+                `avatar tab reported placeholder GLB (size=${msg.glbSize ?? 0} bytes); ` +
+                  "replace skills/meet-join/meet-controller-ext/avatar/default-avatar.glb " +
+                  "with a real Ready Player Me GLB or set " +
+                  "services.meet.avatar.talkingHead.modelUrl — see " +
+                  "skills/meet-join/meet-controller-ext/avatar/README.md",
+              ),
+            );
+            return;
+          }
           this.resolveStartedWaiter();
         },
         onFrame: (msg) => {
@@ -446,6 +465,20 @@ export class TalkingHeadRenderer implements AvatarRenderer {
     if (!this.startedWaiter) return;
     clearTimeout(this.startedWaiter.timer);
     this.startedWaiter.resolve();
+    this.startedWaiter = null;
+  }
+
+  /**
+   * Reject the pending start-ack waiter with a structured error. Used
+   * when the extension reports that the resolved GLB was the placeholder
+   * (or sub-threshold) — the session-manager catches the resulting
+   * `AvatarRendererUnavailableError` and falls back to the noop
+   * renderer so the meeting continues with a clear diagnostic.
+   */
+  private rejectStartedWaiter(err: Error): void {
+    if (!this.startedWaiter) return;
+    clearTimeout(this.startedWaiter.timer);
+    this.startedWaiter.reject(err);
     this.startedWaiter = null;
   }
 

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -195,14 +195,48 @@ export type ExtensionSendChatResultMessage = z.infer<
 >;
 
 /**
+ * Minimum byte size a resolved GLB must have before the extension
+ * treats it as a real asset. The repo ships a 0-byte placeholder at
+ * `meet-controller-ext/avatar/default-avatar.glb` (see the README in
+ * that directory) that operators must replace before production use.
+ * A real Ready Player Me GLB is multi-MB; 1 KiB is well below any
+ * valid GLB header so the threshold is safe to use as a placeholder
+ * sentinel without false positives on legitimately-small models.
+ */
+export const AVATAR_GLB_MIN_SIZE_BYTES = 1024;
+
+/**
  * Ack emitted by the extension once its avatar tab has mounted and the
  * TalkingHead.js renderer is ready to receive visemes. This is the
  * extension-side counterpart to the bot's `avatar.start` command and lets
  * the bot's TalkingHead renderer complete its own `start()` promise with a
  * bounded wait (fallback to noop on timeout).
+ *
+ * `placeholderDetected` + `glbSize` are set by the avatar tab when it
+ * fetches the resolved GLB URL and observes a size below
+ * {@link AVATAR_GLB_MIN_SIZE_BYTES} (or the fetch fails entirely, in
+ * which case `glbSize` is `0`). The bot-side renderer inspects these
+ * fields on the ack and throws `AvatarRendererUnavailableError` with a
+ * pointer to the avatar README so operators who enabled the avatar
+ * without replacing the bundled placeholder get a clear error rather
+ * than a blank video stream. Both fields are optional for
+ * backwards-compatibility with older extension builds that predate the
+ * check — a missing `placeholderDetected` is treated as "no signal".
  */
 export const ExtensionAvatarStartedMessageSchema = z.object({
   type: z.literal("avatar.started"),
+  /**
+   * True when the avatar tab fetched its configured GLB at load time
+   * and found the file was smaller than {@link AVATAR_GLB_MIN_SIZE_BYTES}
+   * (or the fetch failed entirely).
+   */
+  placeholderDetected: z.boolean().optional(),
+  /**
+   * Byte size of the resolved GLB as observed by the avatar tab.
+   * `0` when the fetch failed entirely. Only present when
+   * `placeholderDetected` is also set.
+   */
+  glbSize: z.number().int().nonnegative().optional(),
 });
 export type ExtensionAvatarStartedMessage = z.infer<
   typeof ExtensionAvatarStartedMessageSchema

--- a/skills/meet-join/meet-controller-ext/avatar/README.md
+++ b/skills/meet-join/meet-controller-ext/avatar/README.md
@@ -20,10 +20,21 @@ in the repo.
 ## Replacing the placeholder GLB
 
 The shipped `default-avatar.glb` is a 0-byte placeholder. It is NOT a
-valid GLB file. With the placeholder in place, TalkingHead.js fails
-to load the model and the avatar tab falls back to streaming a
-static colored background — the Meet camera stream is still live,
-but there is no moving face.
+valid GLB file.
+
+**The avatar renderer now fails fast when the placeholder is in
+place.** At tab boot, the avatar page fetches the resolved GLB URL
+and reports its byte size to the bot over the `avatar.started` ack.
+When the size is below `AVATAR_GLB_MIN_SIZE_BYTES` (1 KiB — well
+below any real GLB), or the fetch fails entirely, the bot-side
+TalkingHead renderer throws `AvatarRendererUnavailableError` with a
+pointer back to this README. The session-manager catches that error
+and falls back to the noop renderer, so the meeting continues
+without a broken camera stream — but the operator gets a clear error
+in the logs rather than an invisible blank avatar.
+
+To run the TalkingHead.js renderer, replace the placeholder using
+one of the two options below.
 
 ### Option 1 — bundle a real model at build time
 

--- a/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
+++ b/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
@@ -55,6 +55,7 @@ import type {
   ExtensionAvatarFrameMessage,
   ExtensionAvatarStartedMessage,
 } from "../../../contracts/native-messaging.js";
+import { AVATAR_GLB_MIN_SIZE_BYTES } from "../../../contracts/native-messaging.js";
 
 /** Default capture cadence the avatar loop targets. */
 const DEFAULT_TARGET_FPS = 24;
@@ -140,11 +141,57 @@ function resolveModelUrl(): string {
 /**
  * Render-loop context. Keeps the active canvas and the TalkingHead.js
  * instance so the viseme handler and capture loop share state.
+ *
+ * `glbProbe` is the result of fetching the resolved GLB at boot — the
+ * `avatar.started` ack carries this through to the bot so the bot-side
+ * renderer can fail fast when the bundled placeholder is still in use
+ * instead of silently emitting a blank video stream. See
+ * `avatar/README.md` for the operator replacement procedure.
  */
 interface AvatarContext {
   canvas: HTMLCanvasElement;
   head: TalkingHeadInstance | null;
   targetFps: number;
+  glbProbe: GlbProbeResult;
+}
+
+/**
+ * Outcome of fetching the resolved GLB URL at boot time. Used only to
+ * annotate the `avatar.started` ack so the bot can detect the
+ * 0-byte-placeholder case and surface a clear operator error.
+ *
+ * `size` is `0` when the fetch failed outright (network error, 4xx,
+ * etc.) — a failed fetch is treated as a placeholder signal because
+ * TalkingHead.js will also fail to load the model in that case.
+ */
+interface GlbProbeResult {
+  placeholderDetected: boolean;
+  size: number;
+}
+
+/**
+ * Fetch the resolved GLB URL and check its byte size. Returns a
+ * best-effort signal the avatar tab attaches to `avatar.started` so
+ * the bot can fail fast when the bundled placeholder
+ * (`default-avatar.glb` — committed as a 0-byte stub) is still in
+ * place. Any fetch error is reported as `placeholderDetected: true,
+ * size: 0` because a GLB the tab can't even retrieve will not render.
+ */
+async function probeGlb(modelUrl: string): Promise<GlbProbeResult> {
+  try {
+    const response = await fetch(modelUrl);
+    if (!response.ok) {
+      return { placeholderDetected: true, size: 0 };
+    }
+    const blob = await response.blob();
+    return {
+      placeholderDetected: blob.size < AVATAR_GLB_MIN_SIZE_BYTES,
+      size: blob.size,
+    };
+  } catch (err) {
+    console.warn("[avatar-tab] GLB probe fetch failed:", err);
+    return { placeholderDetected: true, size: 0 };
+  }
 }
 
 /**
@@ -182,8 +229,18 @@ async function bootAvatar(): Promise<AvatarContext> {
   }
 
   const modelUrl = resolveModelUrl();
+
+  // Probe the GLB before attempting TalkingHead.js init so the ack
+  // carries a reliable placeholder signal back to the bot even when
+  // the module load below succeeds but the render ultimately fails.
+  // Running the probe in parallel with the module load keeps boot
+  // latency unchanged when the GLB is valid.
+  const [TalkingHeadCtor, glbProbe] = await Promise.all([
+    loadTalkingHeadCtor(),
+    probeGlb(modelUrl),
+  ]);
+
   let head: TalkingHeadInstance | null = null;
-  const TalkingHeadCtor = await loadTalkingHeadCtor();
   if (TalkingHeadCtor) {
     try {
       head = new TalkingHeadCtor(canvas, {
@@ -206,6 +263,7 @@ async function bootAvatar(): Promise<AvatarContext> {
     canvas,
     head,
     targetFps: DEFAULT_TARGET_FPS,
+    glbProbe,
   };
 }
 
@@ -323,6 +381,14 @@ function installVisemeListener(ctx: AvatarContext): void {
  * we never throw into the page runtime because the only thing that
  * would do is kill the tab and leave the bot stuck waiting for the
  * `avatar.started` ack.
+ *
+ * The ack carries `placeholderDetected` when the GLB probe observed a
+ * sub-threshold file (the repo's bundled `default-avatar.glb` is a
+ * 0-byte stub operators must replace). The bot-side renderer's
+ * `start()` inspects the flag and throws
+ * `AvatarRendererUnavailableError` so the session-manager can fall
+ * back to the noop renderer with a clear diagnostic instead of
+ * silently streaming a blank camera feed.
  */
 async function main(): Promise<void> {
   let ctx: AvatarContext;
@@ -330,9 +396,14 @@ async function main(): Promise<void> {
     ctx = await bootAvatar();
   } catch (err) {
     console.error("[avatar-tab] bootAvatar failed:", err);
-    // Post `avatar.started` anyway so the bot's renderer doesn't
-    // hit its timeout. The bot will just see a static canvas.
-    const ack: ExtensionAvatarStartedMessage = { type: "avatar.started" };
+    // bootAvatar never had a chance to probe the GLB. Treat this path
+    // as placeholder-equivalent so the bot fails fast with a clear
+    // pointer to the README rather than sitting on a static canvas.
+    const ack: ExtensionAvatarStartedMessage = {
+      type: "avatar.started",
+      placeholderDetected: true,
+      glbSize: 0,
+    };
     try {
       void chrome.runtime.sendMessage(ack);
     } catch {
@@ -345,8 +416,14 @@ async function main(): Promise<void> {
   startCaptureLoop(ctx);
 
   // Handshake: the bot's renderer awaits this ack before resolving
-  // start().
+  // start(). `placeholderDetected` is only attached when the probe
+  // actually flagged the GLB — omitting it keeps the wire payload
+  // compatible with older contract builds that don't know the field.
   const ack: ExtensionAvatarStartedMessage = { type: "avatar.started" };
+  if (ctx.glbProbe.placeholderDetected) {
+    ack.placeholderDetected = true;
+    ack.glbSize = ctx.glbProbe.size;
+  }
   try {
     void chrome.runtime.sendMessage(ack);
   } catch (err) {


### PR DESCRIPTION
## Summary
The bundled default-avatar.glb is a 0-byte placeholder operators must replace. Without this PR, operators who enable the avatar without reading the README get an invisible blank render instead of an error.

This PR adds a placeholder-detection check so the renderer throws AvatarRendererUnavailableError with a pointer to the README.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
