### PR TITLE
feat(design-system): add VAppCard, migrate in-chat app-created card to it

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VAppCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VAppCard.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// App-tile card that matches the Figma `App Card` component. Shows a preview
+/// thumbnail at the top, a title + short description, and a button row with a
+/// primary "Open" action, an outlined "Pin" toggle, and an icon-only
+/// secondary action slot.
+///
+/// The preview is supplied as a view builder so callers can use cached remote
+/// images, icon placeholders, or any other content.
+public struct VAppCard<Preview: View>: View {
+    public let title: String
+    public let description: String?
+    public var icon: VIcon?
+    public var isPinned: Bool
+    public var isOpenDisabled: Bool
+    public var pinLabel: String
+    public var unpinLabel: String
+    public var secondaryIcon: VIcon
+    public var onOpen: (() -> Void)?
+    public var onPin: (() -> Void)?
+    public var onSecondary: (() -> Void)?
+    @ViewBuilder public let preview: () -> Preview
+
+    public init(
+        title: String,
+        description: String? = nil,
+        icon: VIcon? = nil,
+        isPinned: Bool = false,
+        isOpenDisabled: Bool = false,
+        pinLabel: String = "Pin",
+        unpinLabel: String = "Unpin",
+        secondaryIcon: VIcon = .arrowUp,
+        onOpen: (() -> Void)? = nil,
+        onPin: (() -> Void)? = nil,
+        onSecondary: (() -> Void)? = nil,
+        @ViewBuilder preview: @escaping () -> Preview
+    ) {
+        self.title = title
+        self.description = description
+        self.icon = icon
+        self.isPinned = isPinned
+        self.isOpenDisabled = isOpenDisabled
+        self.pinLabel = pinLabel
+        self.unpinLabel = unpinLabel
+        self.secondaryIcon = secondaryIcon
+        self.onOpen = onOpen
+        self.onPin = onPin
+        self.onSecondary = onSecondary
+        self.preview = preview
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            preview()
+                .frame(maxWidth: .infinity)
+                .frame(height: 187)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    if let icon {
+                        VIconView(icon, size: 16)
+                            .foregroundStyle(VColor.contentEmphasized)
+                    }
+                    Text(title)
+                        .font(VFont.bodyLargeEmphasised)
+                        .foregroundStyle(VColor.contentEmphasized)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let description, !description.isEmpty {
+                    Text(description)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                if let onOpen {
+                    VButton(
+                        label: "Open App",
+                        leftIcon: VIcon.externalLink.rawValue,
+                        style: .primary,
+                        isDisabled: isOpenDisabled,
+                        action: onOpen
+                    )
+                }
+                if let onPin {
+                    VButton(
+                        label: isPinned ? unpinLabel : pinLabel,
+                        leftIcon: isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
+                        style: .outlined,
+                        action: onPin
+                    )
+                }
+                Spacer(minLength: 0)
+                if let onSecondary {
+                    VButton(
+                        label: "",
+                        iconOnly: secondaryIcon.rawValue,
+                        style: .outlined,
+                        action: onSecondary
+                    )
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceOverlay)
+        )
+    }
+}

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -71,6 +71,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
         case .display:
             return [
                 GalleryComponent("vCard", "VCard", keywords: ["card"], description: "Container with surface background, border, and configurable padding. Use .vCard() modifier for simple wrapping.", useInsteadOf: "Manual padding + background + cornerRadius"),
+                GalleryComponent("vAppCard", "VAppCard", keywords: ["app card", "app tile", "skill card"], description: "App-tile card with preview thumbnail, title, description, and a button row (Open / Pin / secondary icon). Matches the Figma App Card spec."),
 
                 GalleryComponent("vEmptyState", "VEmptyState", keywords: ["empty state"], description: "Centered placeholder with icon, title, subtitle, and optional action button for empty content areas."),
                 GalleryComponent("vDisclosureSection", "VDisclosureSection", keywords: ["disclosure", "collapsible"], description: "Full-row clickable disclosure with animated chevron. Replaces DisclosureGroup.", useInsteadOf: "Raw DisclosureGroup"),

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -98,6 +98,51 @@ struct DisplayGallerySection: View {
 
             }
 
+            if filter == nil || filter == "vAppCard" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VAppCard
+                GallerySectionHeader(
+                    title: "VAppCard",
+                    description: "App-tile card with preview thumbnail, title, short description, and a button row. Matches the Figma App Card spec — primary Open action, outlined Pin toggle, and an outlined icon-only secondary slot."
+                )
+
+                HStack(alignment: .top, spacing: VSpacing.lg) {
+                    VAppCard(
+                        title: "Kanban Board",
+                        description: "Here's a simple and easy to use dashboard, so you can keep your eye on me Big Man.",
+                        icon: .layers,
+                        onOpen: {},
+                        onPin: {},
+                        onSecondary: {}
+                    ) {
+                        ZStack {
+                            VColor.surfaceActive
+                            VIconView(.layers, size: 32)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    }
+                    .frame(maxWidth: 382)
+
+                    VAppCard(
+                        title: "Notes",
+                        description: "Minimal variant — no secondary icon button, pinned state.",
+                        icon: .fileText,
+                        isPinned: true,
+                        onOpen: {},
+                        onPin: {}
+                    ) {
+                        ZStack {
+                            VColor.surfaceActive
+                            VIconView(.fileText, size: 32)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    }
+                    .frame(maxWidth: 382)
+                }
+            }
+
             if filter == nil || filter == "vEmptyState" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
@@ -694,6 +739,7 @@ extension DisplayGallerySection {
     static func componentPage(_ id: String) -> some View {
         switch id {
         case "vCard": DisplayGallerySection(filter: "vCard")
+        case "vAppCard": DisplayGallerySection(filter: "vAppCard")
 
         case "vEmptyState": DisplayGallerySection(filter: "vEmptyState")
         case "vDisclosureSection": DisplayGallerySection(filter: "vDisclosureSection")

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -2,7 +2,8 @@
 import SwiftUI
 
 /// Rich card shown inline in chat when a new app is created via `app_create`.
-/// Displays a preview image, icon + title + description, metrics, and action buttons.
+/// Wraps the shared `VAppCard` and adds the preview-capture + pin-state
+/// plumbing specific to the app-builder flow.
 struct InlineAppCreatedCard: View {
     let preview: DynamicPagePreview
     let appId: String?
@@ -13,72 +14,33 @@ struct InlineAppCreatedCard: View {
     let isToolCallComplete: Bool
     let onOpenApp: () -> Void
     var onTogglePin: ((_ isPinned: Bool) -> Void)?
+
     @State private var previewImage: String?
     @State private var isPinned: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Preview image
+        VAppCard(
+            title: preview.title,
+            description: preview.description ?? preview.subtitle,
+            icon: VAppIconGenerator.generate(from: preview.title, type: appId),
+            isPinned: isPinned,
+            isOpenDisabled: !isToolCallComplete,
+            pinLabel: "Pin to Nav",
+            onOpen: onOpenApp,
+            onPin: onTogglePin.map { handler in
+                { handler(isPinned) }
+            }
+        ) {
             if let base64 = previewImage,
                let data = Data(base64Encoded: base64),
                let nsImage = NSImage(data: data) {
                 Image(nsImage: nsImage)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(height: 140)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            }
-
-            // Icon + title row
-            HStack(spacing: VSpacing.sm) {
-                if let icon = preview.icon {
-                    Text(icon)
-                        .font(.system(size: 14))
-                }
-
-                Text(preview.title)
-                    .font(VFont.bodyMediumEmphasised)
-                    .foregroundStyle(VColor.contentDefault)
-                    .lineLimit(2)
-            }
-
-            if let description = preview.description, !description.isEmpty {
-                Text(description)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .lineLimit(3)
-            }
-
-            if let metrics = preview.metrics, !metrics.isEmpty {
-                HStack(spacing: VSpacing.sm) {
-                    ForEach(Array(metrics.prefix(3).enumerated()), id: \.offset) { _, metric in
-                        metricPill(label: metric.label, value: metric.value)
-                    }
-                }
-            }
-
-            // Action buttons
-            HStack(spacing: VSpacing.sm) {
-                VButton(label: "Open App", leftIcon: VIcon.arrowUpRight.rawValue, style: .primary, isDisabled: !isToolCallComplete) {
-                    onOpenApp()
-                }
-
-                if let onTogglePin = onTogglePin {
-                    VButton(
-                        label: isPinned ? "Unpin" : "Pin to Nav",
-                        leftIcon: isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
-                        style: .outlined
-                    ) {
-                        onTogglePin(isPinned)
-                    }
-                }
-
-                Spacer()
+            } else {
+                VColor.surfaceActive
             }
         }
-        .padding(16)
-        .background(RoundedRectangle(cornerRadius: VRadius.lg).fill(VColor.surfaceOverlay))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
             previewImage = preview.previewImage
             // Fallback request: fires ONLY for history-loaded surfaces where the
@@ -138,22 +100,6 @@ struct InlineAppCreatedCard: View {
                   let pinned = notification.userInfo?["isPinned"] as? Bool else { return }
             isPinned = pinned
         }
-    }
-
-    private func metricPill(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            Text(label)
-                .font(VFont.labelSmall)
-                .foregroundStyle(VColor.contentTertiary)
-            Text(value)
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentDefault)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(VColor.surfaceOverlay)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 }
 #endif


### PR DESCRIPTION
## Summary
Introduces a reusable `VAppCard` component that matches the [Figma App Card spec](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=1305-4582), and migrates the existing in-chat "app is ready" card to use it.

- **New component**: `clients/shared/DesignSystem/Components/Display/VAppCard.swift` — 187pt preview slot (view-builder), inline title + optional icon row, optional description, and a primary / outlined / icon-only button row on `surfaceOverlay` chrome.
- **Gallery**: registered under Display with two demo variants (full button set + pinned minimal variant).
- **Chat migration**: `InlineAppCreatedCard` now wraps `VAppCard`. All existing preview-capture / pin-state `NotificationCenter` plumbing is preserved. A `VAppIconGenerator` icon is rendered inline beside the title so every built app has a visible glyph, even when `preview.icon` is nil.
- **Dropped**: the old metrics row — not in the Figma spec.

## Test plan
- [ ] Build a new app in chat; card renders with icon + title inline, description below, and buttons styled per Figma
- [ ] Pin / unpin toggle updates label and icon
- [ ] "Open App" is disabled until tool call completes
- [ ] Gallery → Display → VAppCard renders the two demo cards correctly in light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
