### PR TITLE
fix(meet): keep /dev/video10 default-path constants in sync across bot/cli/config

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -6,6 +6,13 @@ import { dirname, join } from "path";
 // Direct import — bun embeds this at compile time so it works in compiled binaries.
 import cliPkg from "../../package.json";
 
+// Pulled from skills/ — the Meet avatar device-path default is owned by the
+// meet-join skill; importing here keeps the CLI's Docker wiring locked to the
+// same value the bot and config schema use. The shared module is deliberately
+// zero-dep so this import cannot drag unrelated surface into the compiled CLI
+// binary.
+import { AVATAR_DEVICE_PATH_DEFAULT } from "../../../skills/meet-join/shared/avatar-device-path.js";
+
 import {
   findAssistantByName,
   saveAssistantEntry,
@@ -48,12 +55,16 @@ export const DOCKER_READY_TIMEOUT_MS = 3 * 60 * 1000;
 
 /**
  * Default virtual-camera device path when the Meet avatar feature is
- * enabled. Matches the `video_nr=10` value in the README's host-setup
- * section (`skills/meet-join/bot/README.md`). Operators can override the
- * path by setting `VELLUM_MEET_AVATAR_DEVICE` to something other than the
- * default (e.g. `/dev/video11` if a different `video_nr` was used).
+ * enabled. Re-exports the shared
+ * {@link ../../../skills/meet-join/shared/avatar-device-path.js AVATAR_DEVICE_PATH_DEFAULT}
+ * so the CLI's device-passthrough wiring cannot drift from the bot's
+ * Chrome-flag wiring or the workspace config default. Matches the
+ * `video_nr=10` value in the README's host-setup section
+ * (`skills/meet-join/bot/README.md`). Operators can override the path by
+ * setting `VELLUM_MEET_AVATAR_DEVICE` to something other than the default
+ * (e.g. `/dev/video11` if a different `video_nr` was used).
  */
-export const DEFAULT_MEET_AVATAR_DEVICE_PATH = "/dev/video10";
+export const DEFAULT_MEET_AVATAR_DEVICE_PATH = AVATAR_DEVICE_PATH_DEFAULT;
 
 /**
  * Env-var opt-in for bind-mounting the v4l2loopback virtual-camera device

--- a/skills/meet-join/bot/src/browser/chrome-launcher.ts
+++ b/skills/meet-join/bot/src/browser/chrome-launcher.ts
@@ -24,6 +24,8 @@
 
 import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
 
+import { AVATAR_DEVICE_PATH_DEFAULT } from "../../../shared/avatar-device-path.js";
+
 export interface ChromeLauncherLogger {
   info: (message: string) => void;
   error: (message: string) => void;
@@ -76,10 +78,12 @@ export interface LaunchChromeOptions {
   /**
    * Absolute path to the v4l2loopback character-device node consumed when
    * `avatarEnabled` is true. Defaults to {@link DEFAULT_AVATAR_DEVICE_PATH}
-   * (`/dev/video10`), matching PR 2's `DEFAULT_VIDEO_DEVICE_PATH` in
-   * `src/media/video-device.ts` and the CLI's `VELLUM_MEET_AVATAR_DEVICE`
-   * default (see `cli/src/lib/docker.ts:resolveMeetAvatarDevicePath`).
-   * Only consulted when `avatarEnabled` is true.
+   * (`/dev/video10`), which is the shared
+   * {@link ../../../shared/avatar-device-path.js AVATAR_DEVICE_PATH_DEFAULT}
+   * — the same source of truth used by `src/media/video-device.ts` and the
+   * CLI's `VELLUM_MEET_AVATAR_DEVICE` default (see
+   * `cli/src/lib/docker.ts:resolveMeetAvatarDevicePath`). Only consulted
+   * when `avatarEnabled` is true.
    */
   avatarDevicePath?: string;
 }
@@ -103,13 +107,14 @@ const DEFAULT_SIGKILL_GRACE_MS = 5_000;
 /**
  * Default v4l2loopback device path consumed when `avatarEnabled` is true.
  *
- * Kept as a local constant rather than imported from
- * `src/media/video-device.ts` so the launcher stays independent of the
- * video-device module's `node:fs` / `v4l2-ctl` surface. The two modules
- * must agree on the string; see {@link LaunchChromeOptions.avatarDevicePath}
- * and `DEFAULT_VIDEO_DEVICE_PATH` in `video-device.ts` for the mirror.
+ * Re-exports the zero-dependency constant from
+ * {@link ../../../shared/avatar-device-path.js AVATAR_DEVICE_PATH_DEFAULT}
+ * so the launcher stays independent of `src/media/video-device.ts`'s
+ * `node:fs` / `v4l2-ctl` surface while still guaranteeing the two modules
+ * (and the workspace config default, and the CLI device-passthrough
+ * default) cannot drift.
  */
-export const DEFAULT_AVATAR_DEVICE_PATH = "/dev/video10";
+export const DEFAULT_AVATAR_DEVICE_PATH = AVATAR_DEVICE_PATH_DEFAULT;
 
 /** No-op logger used when caller doesn't supply one. */
 const NOOP_LOGGER: ChromeLauncherLogger = {

--- a/skills/meet-join/bot/src/media/video-device.ts
+++ b/skills/meet-join/bot/src/media/video-device.ts
@@ -36,8 +36,16 @@ import { stat, open as fsOpen, type FileHandle } from "node:fs/promises";
 import type { WriteStream } from "node:fs";
 import type { Subprocess } from "bun";
 
-/** Default device path for the virtual camera — loaded by host modprobe. */
-export const DEFAULT_VIDEO_DEVICE_PATH = "/dev/video10";
+import { AVATAR_DEVICE_PATH_DEFAULT } from "../../../shared/avatar-device-path.js";
+
+/**
+ * Default device path for the virtual camera — loaded by host modprobe.
+ * Re-exports the shared
+ * {@link ../../../shared/avatar-device-path.js AVATAR_DEVICE_PATH_DEFAULT}
+ * so this value stays locked to the launcher's `DEFAULT_AVATAR_DEVICE_PATH`,
+ * the workspace config default, and the CLI's device-passthrough default.
+ */
+export const DEFAULT_VIDEO_DEVICE_PATH = AVATAR_DEVICE_PATH_DEFAULT;
 
 /**
  * Default frame geometry. 720p matches what the renderer produces today and

--- a/skills/meet-join/config-schema.ts
+++ b/skills/meet-join/config-schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { AVATAR_DEVICE_PATH_DEFAULT } from "./shared/avatar-device-path.js";
+
 /**
  * Default keywords that signal an objection to the assistant's presence in a
  * meeting. When any of these (case-insensitive substring match) appear in
@@ -82,14 +84,13 @@ export const AVATAR_RENDERER_IDS = [
 ] as const;
 
 /**
- * Default v4l2loopback device node the renderer pushes frames into. Matches
- * {@link DEFAULT_AVATAR_DEVICE_PATH} in `bot/src/browser/chrome-launcher.ts`
- * and {@link DEFAULT_MEET_AVATAR_DEVICE_PATH} in `cli/src/lib/docker.ts` —
- * all three must agree so the Chrome camera-flag wiring, the
- * device-passthrough wiring, and the renderer's writer all target the same
- * node.
+ * Default v4l2loopback device node the renderer pushes frames into. Re-exports
+ * the single source of truth from
+ * {@link ./shared/avatar-device-path.js AVATAR_DEVICE_PATH_DEFAULT} so this
+ * value cannot drift from its peers in `bot/src/browser/chrome-launcher.ts`,
+ * `bot/src/media/video-device.ts`, and `cli/src/lib/docker.ts`.
  */
-export const DEFAULT_AVATAR_DEVICE_PATH = "/dev/video10";
+export const DEFAULT_AVATAR_DEVICE_PATH = AVATAR_DEVICE_PATH_DEFAULT;
 
 /**
  * Per-renderer option block for TalkingHead.js (WebGL) renderer. All fields

--- a/skills/meet-join/shared/avatar-device-path.ts
+++ b/skills/meet-join/shared/avatar-device-path.ts
@@ -1,0 +1,33 @@
+/**
+ * Single source of truth for the default v4l2loopback virtual-camera
+ * device path used by the Meet bot's avatar pipeline.
+ *
+ * Four separate modules depend on this value agreeing across boundaries:
+ *
+ *   1. `skills/meet-join/config-schema.ts` — workspace config default for
+ *      `services.meet.avatar.devicePath`.
+ *   2. `skills/meet-join/bot/src/browser/chrome-launcher.ts` — fallback for
+ *      Chrome's `--use-file-for-fake-video-capture` camera-source flag when
+ *      the caller doesn't override.
+ *   3. `skills/meet-join/bot/src/media/video-device.ts` — fallback device
+ *      path the renderer opens for `write()`-ing raw Y4M frames.
+ *   4. `cli/src/lib/docker.ts` — default path bind-mounted into the
+ *      assistant container via `--device` when `VELLUM_MEET_AVATAR=1`.
+ *
+ * If one bumps to `/dev/video11` and the others don't, Chrome, the renderer,
+ * and the device-passthrough wiring silently disagree — Meet either gets a
+ * black frame, ENOENT on the device open, or both. Previously each module
+ * declared the string locally with comments pointing at the others; this
+ * file replaces those comment-driven pacts with a hard import so drift is
+ * impossible by construction.
+ *
+ * This module is intentionally zero-dependency (no `zod`, no `node:fs`, no
+ * package-local imports) so every consumer — including the CLI, which
+ * compiles to a standalone `bun build --compile` binary — can import it
+ * without pulling in unrelated module surface.
+ *
+ * To change the default, bump the string here and rebuild. The value must
+ * match the `video_nr=` option used when loading v4l2loopback on the host
+ * (see `skills/meet-join/bot/README.md` § host setup).
+ */
+export const AVATAR_DEVICE_PATH_DEFAULT = "/dev/video10";


### PR DESCRIPTION
## Summary
Four separate modules declared `/dev/video10` as a module-local constant with only inline comments keeping them in sync — `DEFAULT_AVATAR_DEVICE_PATH` in `skills/meet-join/config-schema.ts` and `skills/meet-join/bot/src/browser/chrome-launcher.ts`, `DEFAULT_VIDEO_DEVICE_PATH` in `skills/meet-join/bot/src/media/video-device.ts`, and `DEFAULT_MEET_AVATAR_DEVICE_PATH` in `cli/src/lib/docker.ts`. If one bumped to `/dev/video11`, drift would silently misroute the avatar's frames — Chrome, the renderer's v4l2 writer, and the device passthrough would all target different nodes.

This PR consolidates to a single shared import. A new zero-dependency module `skills/meet-join/shared/avatar-device-path.ts` exports `AVATAR_DEVICE_PATH_DEFAULT`, and the four existing constants become thin re-exports of it. The shared module intentionally has no runtime imports so it can be pulled into the CLI's `bun build --compile` binary without dragging in unrelated module surface (zod, `node:fs`, v4l2-ctl).

## Test plan
- [x] `bun test skills/meet-join/__tests__/config-schema.test.ts` (23 pass)
- [x] `bun test skills/meet-join/bot/__tests__/chrome-launcher-avatar-flag.test.ts skills/meet-join/bot/__tests__/video-device.test.ts` (20 pass)
- [x] `bun test cli/src/lib/__tests__/docker.test.ts` (14 pass)
- [x] Full bot suite `bun test skills/meet-join/bot/__tests__/` (268 pass)
- [x] `cli/ bunx tsc --noEmit` clean
- [x] `cli/ bun build --compile` produces a working binary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
