### PR TITLE
feat(design-system): add borderOverlay token for divider lines on overlay surfaces

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -106,7 +106,7 @@ struct DrawerMenuView: View {
     /// used for sections that should sit tight against neighboring rows.
     private var tightDividerLine: some View {
         Rectangle()
-            .fill(VColor.borderBase)
+            .fill(VColor.borderOverlay)
             .frame(height: 1)
     }
 

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -799,7 +799,7 @@ public struct VMenuDivider: View {
     public init() {}
 
     public var body: some View {
-        VColor.borderHover.frame(height: 1)
+        VColor.borderOverlay.frame(height: 1)
             .padding(.horizontal, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)
             .accessibilityHidden(true)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -65,6 +65,7 @@ public enum VSemanticColorToken: String, CaseIterable {
     case borderHover
     case borderActive
     case borderElement
+    case borderOverlay
 
     case contentEmphasized
     case contentDefault
@@ -134,6 +135,8 @@ private enum FigmaRawColor {
     static let borderDarkActive = Color(hex: 0xF6F5F4)
     static let borderLightElement = Color(hex: 0xCFCCC9)
     static let borderDarkElement = Color(hex: 0x5A6672)
+    static let borderLightOverlay = Color(hex: 0xE9E6E2)
+    static let borderDarkOverlay = Color(hex: 0x2D3339)
 
     // Content
     static let contentLightEmphasized = Color(hex: 0x161616)
@@ -187,6 +190,7 @@ public enum VColor {
         .borderHover: .init(lightHex: "#F6F5F4", darkHex: "#2D3339"),
         .borderActive: .init(lightHex: "#2D3339", darkHex: "#F6F5F4"),
         .borderElement: .init(lightHex: "#CFCCC9", darkHex: "#5A6672"),
+        .borderOverlay: .init(lightHex: "#E9E6E2", darkHex: "#2D3339"),
 
         .contentEmphasized: .init(lightHex: "#161616", darkHex: "#FDFDFC"),
         .contentDefault: .init(lightHex: "#24292E", darkHex: "#F6F5F4"),
@@ -227,6 +231,7 @@ public enum VColor {
     public static let borderHover = adaptiveColor(light: FigmaRawColor.borderLightHover, dark: FigmaRawColor.borderDarkHover)
     public static let borderActive = adaptiveColor(light: FigmaRawColor.borderLightActive, dark: FigmaRawColor.borderDarkActive)
     public static let borderElement = adaptiveColor(light: FigmaRawColor.borderLightElement, dark: FigmaRawColor.borderDarkElement)
+    public static let borderOverlay = adaptiveColor(light: FigmaRawColor.borderLightOverlay, dark: FigmaRawColor.borderDarkOverlay)
 
     // Content
     public static let contentEmphasized = adaptiveColor(light: FigmaRawColor.contentLightEmphasized, dark: FigmaRawColor.contentDarkEmphasized)


### PR DESCRIPTION
## Summary
Adds a new semantic color token `VColor.borderOverlay` sized for hair-line dividers on lifted surfaces (menus, modals, popovers). Light `#E9E6E2`, dark `#2D3339`.

### Why
`borderBase` resolves to `#24292E` in dark mode — the same value as `surfaceLift`. Dividers drawn in `borderBase` inside a menu were therefore invisible (see drawer-menu screenshot: three dividers completely missing in dark). `borderOverlay` is tuned so a 1pt line reads against a lifted surface in both modes.

### Changes
- New `borderOverlay` token in `ColorTokens.swift` (raw pairs, semantic case, adaptive color, and `semanticPairs` mapping).
- `VMenuDivider` (`VMenu.swift:802`) → `borderOverlay`.
- `DrawerMenuView.tightDividerLine` (`DrawerMenuView.swift`) → `borderOverlay`.

## Test plan
- [ ] Open the user drawer menu in light mode — three dividers between Theme/credits/Earn credits/Settings read clearly without being heavy
- [ ] Same in dark mode — previously invisible dividers are now visible
- [ ] Any other `VMenuDivider` usage (context menus, right-click menus) still looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
