### PR TITLE
fix(docker): allowlist skills/meet-join/register.ts in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@
 !skills/meet-join/bun.lock
 !skills/meet-join/config-schema.ts
 !skills/meet-join/meet-config.ts
+!skills/meet-join/register.ts
 !skills/meet-join/contracts/
 !skills/meet-join/contracts/**
 !skills/meet-join/daemon/


### PR DESCRIPTION
## Summary
- .dockerignore uses an allowlist pattern (top-level \`**\` then explicit \`!\` rules); \`register.ts\` was added to the Dockerfile COPY in #26752 but never re-included here, so Docker stripped it from the build context and the image shipped without \`/app/skills/meet-join/register.ts\`.
- Platform hatches fail on startup with \`Cannot find module '../../../skills/meet-join/register.js' from /app/assistant/src/daemon/external-skills-bootstrap.ts\`.
- Add \`!skills/meet-join/register.ts\` to the allowlist so the next image build includes the file and daemon startup can resolve the external-skills bootstrap import.

## Original prompt
create a pr to fix this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
