### PR TITLE
fix(ci): resolve MIGRATION_ID constant in migration-ceilings script

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -663,8 +663,16 @@ jobs:
             const relPath = importMap[lastVar];
             const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
-            const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
-            console.log(idMatch[1]);
+            let id;
+            const litMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            if (litMatch) {
+              id = litMatch[1];
+            } else {
+              const refMatch = src.match(/id:\s*(\w+)/);
+              const constLine = src.split('\n').find(l => l.includes('const ' + refMatch[1] + ' ='));
+              id = constLine.match(/['\x22]([^'\x22]+)['\x22]/)[1];
+            }
+            console.log(id);
           ")
           echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1080,8 +1080,16 @@ jobs:
             const relPath = importMap[lastVar];
             const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
-            const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
-            console.log(idMatch[1]);
+            let id;
+            const litMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            if (litMatch) {
+              id = litMatch[1];
+            } else {
+              const refMatch = src.match(/id:\s*(\w+)/);
+              const constLine = src.split('\n').find(l => l.includes('const ' + refMatch[1] + ' ='));
+              id = constLine.match(/['\x22]([^'\x22]+)['\x22]/)[1];
+            }
+            console.log(id);
           ")
           echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
           echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"


### PR DESCRIPTION
## Summary
- Dev Release job **Compute migration ceilings** was crashing because the last workspace migration (`045-release-notes-meet-avatar`) declares `id: MIGRATION_ID` (a reference to a local constant) rather than an inline string literal. The inline node script's regex `/id:\s*['"]([^'"]+)['"]/` returned null and the job errored with `TypeError: Cannot read properties of null (reading '1')`.
- Fix the extractor in both `release.yml` and `dev-release.yaml`: try the literal-string match first; if it misses, pull the identifier name and resolve it against `const <name> = "..."` in the same file.
- Verified locally against `045-release-notes-meet-avatar.ts` (constant ref) and `044-bump-stale-provider-stream-timeout.ts` (inline literal) — both now yield the expected migration ID.

## Original prompt
resolve whatever is going on here: https://github.com/vellum-ai/vellum-assistant/actions/runs/24669793558/job/72138444486
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
