### PR TITLE
fix(docker): allowlist skills/meet-join/shared/ in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@
 !skills/meet-join/tools/**
 !skills/meet-join/routes/
 !skills/meet-join/routes/**
+!skills/meet-join/shared/
+!skills/meet-join/shared/**
 
 # Exclude local dependencies and build outputs from included directories.
 assistant/node_modules/


### PR DESCRIPTION
## Summary
- Pods were failing to start with \`Cannot find module './shared/avatar-device-path.js' from '/app/skills/meet-join/config-schema.ts'\`.
- \`.dockerignore\` allowlists individual files and subdirectories under \`skills/meet-join/\` but omitted \`shared/\`, so \`avatar-device-path.ts\` never made it into the image even though \`config-schema.ts\` imports it.
- Adds \`!skills/meet-join/shared/\` and \`!skills/meet-join/shared/**\` to the allowlist, following the same pattern as the recent \`register.ts\` fix (#26762).

## Original prompt
our pods are failing to start do to the following error: error: Cannot find module './shared/avatar-device-path.js' from '/app/skills/meet-join/config-schema.ts'. Fix this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
