### PR TITLE
chrome-extension: add canonical environment model and URL mapping

### DIFF
--- a/clients/chrome-extension/background/__tests__/extension-environment.test.ts
+++ b/clients/chrome-extension/background/__tests__/extension-environment.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the canonical extension environment contract.
+ *
+ * Covers:
+ *   - parseExtensionEnvironment: alias normalization, trimming, case-
+ *     insensitivity, and rejection of invalid values.
+ *   - resolveBuildDefaultEnvironment: fallback to 'dev' when the
+ *     bundler-defined env var is missing or invalid.
+ *   - cloudUrlsForEnvironment: full URL mapping table for every
+ *     supported environment.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+
+import {
+  parseExtensionEnvironment,
+  resolveBuildDefaultEnvironment,
+  cloudUrlsForEnvironment,
+  type ExtensionEnvironment,
+} from '../extension-environment.js';
+
+// ── parseExtensionEnvironment ───────────────────────────────────────
+
+describe('parseExtensionEnvironment', () => {
+  test('parses each canonical environment value', () => {
+    expect(parseExtensionEnvironment('local')).toBe('local');
+    expect(parseExtensionEnvironment('dev')).toBe('dev');
+    expect(parseExtensionEnvironment('staging')).toBe('staging');
+    expect(parseExtensionEnvironment('production')).toBe('production');
+  });
+
+  test('"prod" is an alias for "production"', () => {
+    expect(parseExtensionEnvironment('prod')).toBe('production');
+  });
+
+  test('is case-insensitive', () => {
+    expect(parseExtensionEnvironment('LOCAL')).toBe('local');
+    expect(parseExtensionEnvironment('Dev')).toBe('dev');
+    expect(parseExtensionEnvironment('STAGING')).toBe('staging');
+    expect(parseExtensionEnvironment('PRODUCTION')).toBe('production');
+    expect(parseExtensionEnvironment('Prod')).toBe('production');
+    expect(parseExtensionEnvironment('PROD')).toBe('production');
+  });
+
+  test('trims whitespace', () => {
+    expect(parseExtensionEnvironment('  dev  ')).toBe('dev');
+    expect(parseExtensionEnvironment('\tproduction\n')).toBe('production');
+    expect(parseExtensionEnvironment(' prod ')).toBe('production');
+  });
+
+  test('returns null for undefined', () => {
+    expect(parseExtensionEnvironment(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseExtensionEnvironment('')).toBeNull();
+  });
+
+  test('returns null for whitespace-only string', () => {
+    expect(parseExtensionEnvironment('   ')).toBeNull();
+    expect(parseExtensionEnvironment('\t')).toBeNull();
+  });
+
+  test('returns null for unrecognized values', () => {
+    expect(parseExtensionEnvironment('test')).toBeNull();
+    expect(parseExtensionEnvironment('unknown')).toBeNull();
+    expect(parseExtensionEnvironment('release')).toBeNull();
+    expect(parseExtensionEnvironment('development')).toBeNull();
+    expect(parseExtensionEnvironment('prod-us')).toBeNull();
+  });
+});
+
+// ── resolveBuildDefaultEnvironment ──────────────────────────────────
+
+describe('resolveBuildDefaultEnvironment', () => {
+  const savedEnv = process.env.VELLUM_ENVIRONMENT;
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+  });
+
+  test('returns the environment when VELLUM_ENVIRONMENT is a valid value', () => {
+    process.env.VELLUM_ENVIRONMENT = 'staging';
+    expect(resolveBuildDefaultEnvironment()).toBe('staging');
+  });
+
+  test('resolves "prod" alias via build env', () => {
+    process.env.VELLUM_ENVIRONMENT = 'prod';
+    expect(resolveBuildDefaultEnvironment()).toBe('production');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is unset', () => {
+    delete process.env.VELLUM_ENVIRONMENT;
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is empty', () => {
+    process.env.VELLUM_ENVIRONMENT = '';
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is invalid', () => {
+    process.env.VELLUM_ENVIRONMENT = 'bogus';
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+});
+
+// ── cloudUrlsForEnvironment ─────────────────────────────────────────
+
+describe('cloudUrlsForEnvironment', () => {
+  const cases: Array<{
+    env: ExtensionEnvironment;
+    expectedApiBaseUrl: string;
+    expectedWebBaseUrl: string;
+  }> = [
+    {
+      env: 'production',
+      expectedApiBaseUrl: 'https://api.vellum.ai',
+      expectedWebBaseUrl: 'https://www.vellum.ai',
+    },
+    {
+      env: 'staging',
+      expectedApiBaseUrl: 'https://staging-api.vellum.ai',
+      expectedWebBaseUrl: 'https://staging-assistant.vellum.ai',
+    },
+    {
+      env: 'dev',
+      expectedApiBaseUrl: 'https://dev-api.vellum.ai',
+      expectedWebBaseUrl: 'https://dev-assistant.vellum.ai',
+    },
+    {
+      env: 'local',
+      expectedApiBaseUrl: 'http://localhost:8080',
+      expectedWebBaseUrl: 'http://localhost:3000',
+    },
+  ];
+
+  for (const { env, expectedApiBaseUrl, expectedWebBaseUrl } of cases) {
+    test(`${env}: apiBaseUrl is ${expectedApiBaseUrl}`, () => {
+      const urls = cloudUrlsForEnvironment(env);
+      expect(urls.apiBaseUrl).toBe(expectedApiBaseUrl);
+    });
+
+    test(`${env}: webBaseUrl is ${expectedWebBaseUrl}`, () => {
+      const urls = cloudUrlsForEnvironment(env);
+      expect(urls.webBaseUrl).toBe(expectedWebBaseUrl);
+    });
+  }
+
+  test('production parity: "prod" alias and "production" resolve to same URLs', () => {
+    const fromProd = cloudUrlsForEnvironment('production');
+    // Verify the canonical production values match what worker.ts currently uses
+    expect(fromProd.apiBaseUrl).toBe('https://api.vellum.ai');
+    expect(fromProd.webBaseUrl).toBe('https://www.vellum.ai');
+  });
+});

--- a/clients/chrome-extension/background/extension-environment.ts
+++ b/clients/chrome-extension/background/extension-environment.ts
@@ -1,0 +1,129 @@
+/**
+ * Canonical environment contract for the Vellum Chrome extension.
+ *
+ * This module is the single source of truth for:
+ *   - the set of valid extension environments
+ *   - parsing / normalizing raw environment strings (including aliases)
+ *   - resolving the build-time default from `process.env.VELLUM_ENVIRONMENT`
+ *   - mapping each environment to its cloud API and web base URLs
+ *
+ * All other extension code that needs environment awareness should import
+ * from this module rather than hard-coding URLs or re-implementing parsing.
+ */
+
+// ── Environment type ────────────────────────────────────────────────
+
+/**
+ * The four deployment environments the extension can target.
+ *
+ * - `local`      — developer's machine (`vel up`), local gateway + relay
+ * - `dev`        — artifacts built from `main`, dev platform
+ * - `staging`    — QA against staging platform before production rollout
+ * - `production` — full production behavior
+ */
+export type ExtensionEnvironment = 'local' | 'dev' | 'staging' | 'production';
+
+const VALID_ENVIRONMENTS: ReadonlySet<string> = new Set<ExtensionEnvironment>([
+  'local',
+  'dev',
+  'staging',
+  'production',
+]);
+
+/** Aliases that map to a canonical {@link ExtensionEnvironment}. */
+const ENVIRONMENT_ALIASES: Readonly<Record<string, ExtensionEnvironment>> = {
+  prod: 'production',
+};
+
+// ── Parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw string into a validated {@link ExtensionEnvironment}.
+ *
+ * - Trims whitespace and lowercases before matching.
+ * - Accepts `"prod"` as an alias for `"production"`.
+ * - Returns `null` for `undefined`, empty, or unrecognized values.
+ */
+export function parseExtensionEnvironment(raw: string | undefined): ExtensionEnvironment | null {
+  if (raw === undefined) return null;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return null;
+
+  if (VALID_ENVIRONMENTS.has(normalized)) {
+    return normalized as ExtensionEnvironment;
+  }
+
+  const aliased = ENVIRONMENT_ALIASES[normalized];
+  if (aliased !== undefined) {
+    return aliased;
+  }
+
+  return null;
+}
+
+// ── Build-time default ──────────────────────────────────────────────
+
+/**
+ * Resolve the build-time default environment from the bundler-defined
+ * `process.env.VELLUM_ENVIRONMENT` constant.
+ *
+ * Falls back to `"dev"` when the variable is missing, empty, or set to
+ * an unrecognized value. This matches the convention that local extension
+ * builds (where the bundler does not inject a value) default to `dev`.
+ */
+export function resolveBuildDefaultEnvironment(): ExtensionEnvironment {
+  // `process.env.VELLUM_ENVIRONMENT` is replaced at bundle time by the
+  // build tool (e.g. `bun build --define`). At runtime in a bundled
+  // extension it becomes a string literal. In tests or unbundled
+  // contexts it may be the actual env var or undefined.
+  let raw: string | undefined;
+  try {
+    raw = process.env.VELLUM_ENVIRONMENT;
+  } catch {
+    // In some browser runtimes `process` is not defined at all.
+    raw = undefined;
+  }
+  return parseExtensionEnvironment(raw) ?? 'dev';
+}
+
+// ── Cloud URL mapping ───────────────────────────────────────────────
+
+export interface CloudUrls {
+  /** Gateway / API base URL (e.g. `https://api.vellum.ai`). */
+  apiBaseUrl: string;
+  /** Web app base URL for browser-facing pages (e.g. `https://www.vellum.ai`). */
+  webBaseUrl: string;
+}
+
+/**
+ * Return the cloud API and web base URLs for the given environment.
+ *
+ * Production uses the canonical Vellum production hosts. Non-production
+ * environments use environment-prefixed subdomains following the
+ * convention `<env>-api.vellum.ai` / `<env>-assistant.vellum.ai`, with
+ * `local` using `localhost` origins for both.
+ */
+export function cloudUrlsForEnvironment(env: ExtensionEnvironment): CloudUrls {
+  switch (env) {
+    case 'production':
+      return {
+        apiBaseUrl: 'https://api.vellum.ai',
+        webBaseUrl: 'https://www.vellum.ai',
+      };
+    case 'staging':
+      return {
+        apiBaseUrl: 'https://staging-api.vellum.ai',
+        webBaseUrl: 'https://staging-assistant.vellum.ai',
+      };
+    case 'dev':
+      return {
+        apiBaseUrl: 'https://dev-api.vellum.ai',
+        webBaseUrl: 'https://dev-assistant.vellum.ai',
+      };
+    case 'local':
+      return {
+        apiBaseUrl: 'http://localhost:8080',
+        webBaseUrl: 'http://localhost:3000',
+      };
+  }
+}

--- a/clients/chrome-extension/background/extension-environment.ts
+++ b/clients/chrome-extension/background/extension-environment.ts
@@ -83,6 +83,13 @@ export function resolveBuildDefaultEnvironment(): ExtensionEnvironment {
     // In some browser runtimes `process` is not defined at all.
     raw = undefined;
   }
+  // Intentional `dev` default: when the env var is absent it means we are in
+  // an unbundled local build where no `--define` injection has occurred. The
+  // release build pipeline (build.sh + release.yml) is responsible for setting
+  // `process.env.VELLUM_ENVIRONMENT` to `staging` or `production` at bundle
+  // time via `--define`. If that injection is ever accidentally omitted from a
+  // release build, it will surface as a clear "targeting dev" mismatch in
+  // pre-release smoke tests rather than silently hitting production.
   return parseExtensionEnvironment(raw) ?? 'dev';
 }
 

--- a/clients/chrome-extension/types/chrome-globals.d.ts
+++ b/clients/chrome-extension/types/chrome-globals.d.ts
@@ -303,3 +303,16 @@ interface ChromeGlobal {
 }
 
 declare const chrome: ChromeGlobal;
+
+/**
+ * Minimal ambient declaration for `process.env` so bundler-injected
+ * constants like `process.env.VELLUM_ENVIRONMENT` can be referenced
+ * without pulling in the full `@types/node` package.
+ *
+ * At bundle time `bun build --define` replaces these references with
+ * string literals. In test contexts (bun:test) the real Node/Bun
+ * `process` global satisfies this shape.
+ */
+declare const process: {
+  env: Record<string, string | undefined>;
+};


### PR DESCRIPTION
## Summary
- Add ExtensionEnvironment type and parsing with alias support (prod → production)
- Add cloudUrlsForEnvironment() mapping for all environments
- Add unit tests for alias normalization, invalid fallback, and URL mapping

Part of plan: chrome-extension-env-selector.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
