### PR TITLE
chrome-extension: add native-host frame environment override support

### DIFF
--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -466,6 +466,46 @@ describe('bootstrapLocalToken', () => {
     expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(result);
   });
 
+  test('includes environment in the frame when provided', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'env-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-env',
+        });
+      });
+    };
+
+    await bootstrapLocalToken(ASSISTANT_A, { environment: 'dev' });
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'request_token', assistantId: ASSISTANT_A, environment: 'dev' },
+    ]);
+  });
+
+  test('omits environment from the frame when not provided', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'no-env-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-no-env',
+        });
+      });
+    };
+
+    await bootstrapLocalToken(ASSISTANT_A);
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'request_token', assistantId: ASSISTANT_A },
+    ]);
+  });
+
   test('ignores unknown frame types until a recognised frame arrives', async () => {
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 

--- a/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
@@ -235,6 +235,40 @@ describe('listAssistants', () => {
     expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'list_assistants' }]);
   });
 
+  test('includes environment in the frame when provided', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'assistants_response',
+          assistants: [],
+          activeAssistantId: null,
+          protocolVersion: 1,
+        });
+      });
+    };
+
+    await listAssistants({ environment: 'dev' });
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'list_assistants', environment: 'dev' },
+    ]);
+  });
+
+  test('omits environment from the frame when not provided', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'assistants_response',
+          assistants: [],
+          activeAssistantId: null,
+          protocolVersion: 1,
+        });
+      });
+    };
+
+    await listAssistants();
+    expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'list_assistants' }]);
+  });
+
   test('returns empty catalog when native host reports no assistants', async () => {
     fakeRuntime.onConnect = (port) => {
       queueMicrotask(() => {

--- a/clients/chrome-extension/background/native-host-assistants.ts
+++ b/clients/chrome-extension/background/native-host-assistants.ts
@@ -57,6 +57,13 @@ export interface ListAssistantsOptions {
    * in the extension itself should rely on the default.
    */
   timeoutMs?: number;
+  /**
+   * Optional environment override. When provided, the native host uses
+   * this environment to resolve lockfile paths instead of the process-level
+   * `VELLUM_ENVIRONMENT`. This lets the extension switch environments
+   * (e.g. `dev`, `staging`, `production`) without restarting Chrome.
+   */
+  environment?: string;
 }
 
 /**
@@ -192,6 +199,10 @@ export async function listAssistants(
       finish(() => reject(new Error(message)));
     });
 
-    port.postMessage({ type: 'list_assistants' });
+    const listMessage: Record<string, unknown> = { type: 'list_assistants' };
+    if (options.environment) {
+      listMessage.environment = options.environment;
+    }
+    port.postMessage(listMessage);
   });
 }

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -104,6 +104,14 @@ export interface BootstrapLocalTokenOptions {
    * in the extension itself should rely on the default.
    */
   timeoutMs?: number;
+  /**
+   * Optional environment override. When provided, the native host uses
+   * this environment to resolve lockfile paths and daemon ports instead of
+   * the process-level `VELLUM_ENVIRONMENT`. This lets the extension switch
+   * environments (e.g. `dev`, `staging`, `production`) without restarting
+   * Chrome.
+   */
+  environment?: string;
 }
 
 /**
@@ -381,6 +389,9 @@ export async function bootstrapLocalToken(
     const pairMessage: Record<string, unknown> = { type: 'request_token' };
     if (assistantId) {
       pairMessage.assistantId = assistantId;
+    }
+    if (options.environment) {
+      pairMessage.environment = options.environment;
     }
     port.postMessage(pairMessage);
   });

--- a/clients/chrome-extension/native-host/src/__tests__/index.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/index.test.ts
@@ -27,6 +27,7 @@
 
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -524,6 +525,106 @@ describe("native host — list_assistants response framing", () => {
     expect(frame.activeAssistantId).toBeNull();
     expect(frame.protocolVersion).toBe(1);
   });
+
+  test("list_assistants with environment override reads from the correct lockfile", async () => {
+    // Write a dev lockfile under an XDG-style path.
+    const devDir = join(lockfileDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-one",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: 7821 },
+          },
+        ],
+        activeAssistant: "dev-one",
+      }),
+    );
+
+    // Also write a production lockfile — the override should bypass it.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-one",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7840",
+            resources: { daemonPort: 7831 },
+          },
+        ],
+        activeAssistant: "prod-one",
+      }),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({
+        type: "list_assistants",
+        environment: "dev",
+      }),
+      timeoutMs: 2000,
+      env: {
+        XDG_CONFIG_HOME: lockfileDir,
+        // Clear VELLUM_LOCKFILE_DIR so XDG path is used for non-prod
+        VELLUM_LOCKFILE_DIR: undefined,
+      },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: Array<{ assistantId: string }>;
+      activeAssistantId: string | null;
+    };
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.assistants).toHaveLength(1);
+    expect(frame.assistants[0]!.assistantId).toBe("dev-one");
+    expect(frame.activeAssistantId).toBe("dev-one");
+  });
+
+  test("list_assistants with invalid environment override falls back to production", async () => {
+    // Write only a production lockfile.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-fallback",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+          },
+        ],
+      }),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({
+        type: "list_assistants",
+        environment: "foobar",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: Array<{ assistantId: string }>;
+    };
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.assistants).toHaveLength(1);
+    expect(frame.assistants[0]!.assistantId).toBe("prod-fallback");
+  });
 });
 
 describe("native host — assistant-scoped token request", () => {
@@ -720,6 +821,134 @@ describe("native host — assistant-scoped token request", () => {
     const frame = result.frames[0] as { type: string; token: string };
     expect(frame.type).toBe("token_response");
     expect(frame.token).toBe("tok-unknown-fallback");
+    expect(srvA.requests).toHaveLength(1);
+  });
+
+  test("request_token with environment override resolves port from the correct lockfile", async () => {
+    const srvA = pairA!;
+    const srvB = pairB!;
+    srvA.requests.length = 0;
+    srvB.requests.length = 0;
+
+    srvA.nextResponseBody = () => ({
+      token: "tok-prod",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-prod",
+    });
+    srvB.nextResponseBody = () => ({
+      token: "tok-dev",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-dev",
+    });
+
+    // Write a dev lockfile with assistant pointing to srvB.
+    const devDir = join(lockfileDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7831",
+            resources: { daemonPort: srvB.port },
+          },
+        ],
+      }),
+    );
+
+    // Write a prod lockfile with assistant pointing to srvA.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: srvA.port },
+          },
+        ],
+      }),
+    );
+
+    // Send a request_token with environment=dev and assistantId=dev-assistant.
+    // The helper should resolve the daemon port from the dev lockfile.
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "dev-assistant",
+        environment: "dev",
+      }),
+      timeoutMs: 2000,
+      env: {
+        XDG_CONFIG_HOME: lockfileDir,
+        VELLUM_LOCKFILE_DIR: undefined,
+      },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      token: string;
+      assistantPort: number;
+    };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-dev");
+    expect(frame.assistantPort).toBe(srvB.port);
+
+    // srvB received the request (from the dev lockfile), not srvA.
+    expect(srvB.requests).toHaveLength(1);
+    expect(srvA.requests).toHaveLength(0);
+  });
+
+  test("request_token with 'prod' environment normalizes to 'production'", async () => {
+    const srvA = pairA!;
+    srvA.requests.length = 0;
+
+    srvA.nextResponseBody = () => ({
+      token: "tok-prod-short",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-prod-short",
+    });
+
+    // Write a production lockfile with an assistant pointing to srvA.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: srvA.port },
+          },
+        ],
+      }),
+    );
+
+    // Send environment="prod" — should be normalized to "production".
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "prod-assistant",
+        environment: "prod",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    const frame = result.frames[0] as { type: string; token: string };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-prod-short");
     expect(srvA.requests).toHaveLength(1);
   });
 });

--- a/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
@@ -583,4 +583,139 @@ describe("lockfile — resolveDaemonPort", () => {
   test("returns undefined when lockfile is missing", () => {
     expect(resolveDaemonPort("anything")).toBeUndefined();
   });
+
+  test("uses environmentOverride to resolve the lockfile path", () => {
+    // Set process env to production (which reads .vellum.lock.json) but
+    // write the lockfile under the dev path. The override should win.
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    const devDir = join(tempDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-target",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: 8888 },
+          },
+        ],
+      }),
+    );
+
+    // Without override, falls back to production path (no lockfile there)
+    expect(resolveDaemonPort("dev-target")).toBeUndefined();
+
+    // With override, reads from the dev lockfile
+    expect(resolveDaemonPort("dev-target", "dev")).toBe(8888);
+  });
+});
+
+describe("lockfile — environment override for readAssistantInventory", () => {
+  test("frame environment override takes precedence over process.env.VELLUM_ENVIRONMENT", () => {
+    // Set process env to production
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    // Write a prod lockfile with one assistant
+    const prodDir = tempDir;
+    process.env.VELLUM_LOCKFILE_DIR = prodDir;
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "prod-assistant",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+    });
+
+    // Write a dev lockfile with a different assistant
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    const devDir = join(tempDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7831",
+            resources: { daemonPort: 7822 },
+          },
+        ],
+      }),
+    );
+
+    // Without override, reads from production
+    process.env.VELLUM_LOCKFILE_DIR = prodDir;
+    const prodResult = readAssistantInventory();
+    expect(prodResult.assistants).toHaveLength(1);
+    expect(prodResult.assistants[0]!.assistantId).toBe("prod-assistant");
+
+    // With override "dev", reads from the dev lockfile
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    const devResult = readAssistantInventory("dev");
+    expect(devResult.assistants).toHaveLength(1);
+    expect(devResult.assistants[0]!.assistantId).toBe("dev-assistant");
+  });
+
+  test("empty string override falls through to process.env.VELLUM_ENVIRONMENT", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    writeLockfile("lockfile.json", {
+      assistants: [
+        {
+          assistantId: "env-dev",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    // Empty string override should be treated as "no override"
+    const result = readAssistantInventory("");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("env-dev");
+  });
+
+  test("whitespace-only override falls through to process.env.VELLUM_ENVIRONMENT", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    writeLockfile("lockfile.json", {
+      assistants: [
+        {
+          assistantId: "env-dev",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory("   ");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("env-dev");
+  });
+
+  test("invalid/unknown override falls back to production behavior", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "prod-fallback",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    // "foobar" is not a known environment, so falls back to production
+    const result = readAssistantInventory("foobar");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("prod-fallback");
+  });
 });

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -372,6 +372,27 @@ function fail(message: string, code = 1): never {
 }
 
 /**
+ * Normalize a frame-level environment override string.
+ *
+ * - Trims whitespace.
+ * - Normalizes the common `prod` shorthand to `production`.
+ * - Returns `undefined` for empty/whitespace-only strings so callers
+ *   can treat them as "no override".
+ *
+ * Invalid values (e.g. `foo`) are passed through rather than rejected
+ * here — the lockfile reader's `NON_PRODUCTION_ENVIRONMENTS` set
+ * handles the final gating and falls back to production for unknown
+ * values.
+ */
+export function normalizeFrameEnvironment(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed === "prod") return "production";
+  return trimmed;
+}
+
+/**
  * POST the extension origin to the assistant's pair endpoint and return the
  * issued capability token. Surfaces a uniform error message on failure so
  * the caller can wrap it in a native-messaging error frame.
@@ -385,6 +406,7 @@ async function requestToken(
   extensionOrigin: string,
   argv: readonly string[],
   assistantId?: string,
+  environmentOverride?: string,
 ): Promise<TokenResponse> {
   // When an assistantId is provided, attempt to resolve the daemon port
   // from the lockfile first. This lets the extension target a specific
@@ -394,7 +416,7 @@ async function requestToken(
   // for that assistant.
   let port: number;
   if (assistantId) {
-    const lockfilePort = resolveDaemonPort(assistantId);
+    const lockfilePort = resolveDaemonPort(assistantId, environmentOverride);
     if (lockfilePort !== undefined) {
       port = lockfilePort;
     } else {
@@ -523,8 +545,11 @@ async function main(): Promise<void> {
         if (frameType === "list_assistants") {
           // Return the assistant inventory from the lockfile. This is a
           // synchronous read — no network call needed.
+          const listEnv = normalizeFrameEnvironment(
+            (frame as { environment?: unknown }).environment,
+          );
           try {
-            const inventory = readAssistantInventory();
+            const inventory = readAssistantInventory(listEnv);
             await writeFrameAndExitAsync(
               {
                 type: "assistants_response",
@@ -546,10 +571,13 @@ async function main(): Promise<void> {
             typeof (frame as { assistantId?: unknown }).assistantId === "string"
               ? ((frame as { assistantId: string }).assistantId)
               : undefined;
+          const tokenEnv = normalizeFrameEnvironment(
+            (frame as { environment?: unknown }).environment,
+          );
 
           try {
             const { token, expiresAt, guardianId, assistantPort } =
-              await requestToken(extensionOrigin!, process.argv, assistantId);
+              await requestToken(extensionOrigin!, process.argv, assistantId, tokenEnv);
             await writeFrameAndExitAsync(
               {
                 type: "token_response",

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -102,10 +102,15 @@ interface RawAssistantEntry {
  * Mirrors `getLockfilePaths()` in `cli/src/lib/environments/paths.ts`.
  * Unknown env names fall back to production silently — browser users
  * don't see warnings.
+ *
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT`. Invalid/unknown values fall back
+ *   to production behavior.
  */
-function getLockfileCandidates(): string[] {
+function getLockfileCandidates(environmentOverride?: string): string[] {
   const lockfileDirOverride = process.env.VELLUM_LOCKFILE_DIR?.trim();
-  const rawEnv = process.env.VELLUM_ENVIRONMENT?.trim() || "production";
+  const rawEnv = environmentOverride?.trim() || process.env.VELLUM_ENVIRONMENT?.trim() || "production";
   const isNonProd = NON_PRODUCTION_ENVIRONMENTS.has(rawEnv);
 
   if (!isNonProd) {
@@ -123,8 +128,8 @@ function getLockfileCandidates(): string[] {
  * Read and parse the lockfile from the first candidate path that exists
  * and contains valid JSON. Returns `null` if no valid lockfile is found.
  */
-function readRawLockfile(): RawLockfile | null {
-  for (const filePath of getLockfileCandidates()) {
+function readRawLockfile(environmentOverride?: string): RawLockfile | null {
+  for (const filePath of getLockfileCandidates(environmentOverride)) {
     try {
       const raw = readFileSync(filePath, "utf8");
       const parsed: unknown = JSON.parse(raw);
@@ -180,9 +185,13 @@ function extractDaemonPort(entry: RawAssistantEntry): number | undefined {
  * - Filtering entries that lack required fields
  * - Extracting `daemonPort` from `resources` when present
  * - Resolving which assistant is active
+ *
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT` for lockfile path resolution.
  */
-export function readAssistantInventory(): LockfileInventory {
-  const raw = readRawLockfile();
+export function readAssistantInventory(environmentOverride?: string): LockfileInventory {
+  const raw = readRawLockfile(environmentOverride);
   if (!raw) {
     return { assistants: [], activeAssistantId: null };
   }
@@ -211,9 +220,14 @@ export function readAssistantInventory(): LockfileInventory {
  *
  * This is a convenience wrapper used by the `request_token` handler when
  * an `assistantId` is provided in the request frame.
+ *
+ * @param assistantId - The assistant to look up.
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT` for lockfile path resolution.
  */
-export function resolveDaemonPort(assistantId: string): number | undefined {
-  const { assistants } = readAssistantInventory();
+export function resolveDaemonPort(assistantId: string, environmentOverride?: string): number | undefined {
+  const { assistants } = readAssistantInventory(environmentOverride);
   const match = assistants.find((a) => a.assistantId === assistantId);
   return match?.daemonPort;
 }


### PR DESCRIPTION
## Summary
- Extend native-host request frames with optional environment field
- Add environment-aware lockfile resolution in native-host
- Update tests for frame payload changes and env-aware path resolution

Part of plan: chrome-extension-env-selector.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
