### PR TITLE
fix(compact): walk below keep floor under force when over budget

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -835,6 +835,83 @@ describe("ContextWindowManager", () => {
     );
   });
 
+  test("force=true compacts below minFloor when a kept turn exceeds target", async () => {
+    // A giant paste in the last user turn means minFloor=1 alone exceeds target.
+    // Under force, pickKeepBoundary should walk keepTurns below minFloor (down to
+    // 0) so the huge block falls into the compacted region and gets summarized
+    // instead of being kept at full size.
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- compressed large paste" }],
+      model: "mock-model",
+      usage: { inputTokens: 120, outputTokens: 20 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ maxInputTokens: 600, targetBudgetRatio: 0.2 }),
+    });
+    const hugePaste = "p".repeat(4000); // ~1000 tokens, well above targetInputTokens
+    const history: Message[] = [
+      message("user", "u1 small"),
+      message("assistant", "a1 small"),
+      message("user", `u2 ${hugePaste}`),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+    });
+
+    expect(result.compacted).toBe(true);
+    // With force=true the kept region is empty; all turns including the oversized
+    // paste were summarized, so the compacted result is just the summary.
+    expect(result.messages).toHaveLength(1);
+    expect(result.compactedMessages).toBe(history.length);
+    expect(getSummaryFromContextMessage(result.messages[0])).toContain(
+      "compressed large paste",
+    );
+    expect(result.estimatedInputTokens).toBeLessThan(
+      result.previousEstimatedInputTokens,
+    );
+  });
+
+  test("force=false honors minFloor even when the kept turn exceeds target", async () => {
+    // Same oversized paste, but without force the algorithm must preserve the
+    // minFloor=1 recent turn (auto mid-loop compaction needs the in-flight turn
+    // intact). Anything compactable before the floor still gets summarized.
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 10 },
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ maxInputTokens: 600, targetBudgetRatio: 0.2 }),
+    });
+    const hugePaste = "p".repeat(4000);
+    const history: Message[] = [
+      message("user", "u1 small"),
+      message("assistant", "a1 small"),
+      message("user", "u2 small"),
+      message("assistant", "a2 small"),
+      message("user", `u3 ${hugePaste}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+
+    expect(result.compacted).toBe(true);
+    // The oversized last user turn is retained verbatim; the kept array starts
+    // with the summary followed by the messages from that turn onward.
+    const lastUser = result.messages
+      .filter((m) => m.role === "user")
+      .map((m) => (m.content[0].type === "text" ? m.content[0].text : ""))
+      .find((t) => t.startsWith("u3 "));
+    expect(lastUser).toBeDefined();
+    expect(lastUser!.length).toBeGreaterThan(hugePaste.length);
+  });
+
   test("shouldCompact returns needed=false with estimatedTokens when below threshold", () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -283,6 +283,7 @@ export class ContextWindowManager {
       minKeepRecentUserTurns: options?.minKeepRecentUserTurns,
       targetInputTokensOverride: options?.targetInputTokensOverride,
       conversationOriginChannel: options?.conversationOriginChannel,
+      force: options?.force,
     });
     if (keepPlan.keepFromIndex <= summaryOffset) {
       // All turns fit after truncation projection, but the real in-memory
@@ -560,6 +561,7 @@ export class ContextWindowManager {
       minKeepRecentUserTurns?: number;
       targetInputTokensOverride?: number;
       conversationOriginChannel?: string;
+      force?: boolean;
     },
   ): { keepFromIndex: number; keepTurns: number } {
     // Slack-originated conversations rely on multi-turn thread context
@@ -613,6 +615,32 @@ export class ContextWindowManager {
       }
     } else {
       lo = hi;
+    }
+
+    // Under forced compaction with only the implicit default floor in play,
+    // that floor stops being an absolute override when the kept region still
+    // exceeds the target. Walk keepTurns below the floor — down to 0 if
+    // needed — so /compact can always drive the conversation toward target,
+    // even when the floor turn itself is oversized (e.g. a huge paste in the
+    // last user message). Exceptions that still treat the floor as hard:
+    //   - Explicit `minKeepRecentUserTurns` (the caller opted in to that
+    //     floor; emergency recovery already passes 0 when it wants to go all
+    //     the way down).
+    //   - Slack origin (the bumped 8-turn floor protects thread reply chains
+    //     and quoted-message context that the next reply may directly cite).
+    // Automatic mid-loop compaction (force !== true) always honors the floor
+    // so the in-flight agent turn isn't summarized away.
+    const floorIsImplicitDefault =
+      opts?.minKeepRecentUserTurns === undefined &&
+      opts?.conversationOriginChannel !== "slack";
+    if (
+      opts?.force &&
+      floorIsImplicitDefault &&
+      projectedTokensForKeep(lo) > targetTokens
+    ) {
+      while (lo > 0 && projectedTokensForKeep(lo) > targetTokens) {
+        lo--;
+      }
     }
 
     const keepTurns = lo;


### PR DESCRIPTION
## Summary

- `pickKeepBoundary`'s binary search never verified that `projection(minFloor)` fit the target, so a single oversized block in the floor turn (e.g. a big paste) could pin post-compact tokens far above the target.
- Under forced compaction with only the implicit default floor, walk `keepTurns` below the floor when the kept region still exceeds the target — down to 0 if needed. Slack's channel-bumped floor and explicit `minKeepRecentUserTurns` remain hard.
- Added regression tests: `force=true` with an oversized last-turn paste now compacts the whole history into a summary; `force=false` still preserves the last turn verbatim; existing Slack-floor behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
