### PR TITLE
fix(home): anchor email editor attachments row to the panel bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -33,6 +33,13 @@ struct HomeDetailPanel<Content: View>: View {
     var primaryAction: Action?   = nil
     var secondaryAction: Action? = nil
     var onDismiss: (() -> Void)? = nil
+    /// When `true` (default), the content area is wrapped in a vertical
+    /// `ScrollView` so tall content like invoice images scrolls naturally.
+    /// Pass `false` for bodies that want to fill the panel height and
+    /// manage their own overflow — e.g. the email editor, which pins an
+    /// attachments footer to the bottom and wants the body text field to
+    /// expand into the empty space above it.
+    var scrollable: Bool = true
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -43,11 +50,17 @@ struct HomeDetailPanel<Content: View>: View {
                 .frame(height: 1)
                 .accessibilityHidden(true)
 
-            ScrollView {
+            if scrollable {
+                ScrollView {
+                    content()
+                        .frame(maxWidth: .infinity, alignment: .top)
+                }
+                .layoutPriority(1)
+            } else {
                 content()
-                    .frame(maxWidth: .infinity, alignment: .top)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .layoutPriority(1)
             }
-            .layoutPriority(1)
         }
         .frame(width: Self.defaultWidth)
         .frame(maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -11,6 +11,15 @@ import VellumAssistantShared
 /// and dismiss affordance, so this component takes no header / title /
 /// action / dismiss props — it's slotted directly into the panel's
 /// `content:` closure.
+///
+/// The body text field expands to fill all vertical space between the
+/// subject divider and the attachments footer, so the attachments row
+/// always anchors to the bottom of the panel regardless of how much
+/// body text is present. This requires the enclosing `HomeDetailPanel`
+/// to be constructed with `scrollable: false` so that the editor's own
+/// vertical growth can be honored. With the default `scrollable: true`
+/// the body falls back to its intrinsic height (no fill), which reads
+/// fine but leaves whitespace between the body and the attachments.
 struct HomeEmailEditor: View {
 
     struct Attachment: Identifiable, Hashable {
@@ -37,14 +46,14 @@ struct HomeEmailEditor: View {
             VStack(alignment: .leading, spacing: 0) {
                 labeledField("to:", $toAddress)
 
-                Divider()
-                    .background(VColor.borderBase)
+                VColor.borderBase
+                    .frame(height: 1)
                     .accessibilityHidden(true)
 
                 labeledField("subject:", $subject)
 
-                Divider()
-                    .background(VColor.borderBase)
+                VColor.borderBase
+                    .frame(height: 1)
                     .accessibilityHidden(true)
             }
 
@@ -52,12 +61,12 @@ struct HomeEmailEditor: View {
                 .textFieldStyle(.plain)
                 .font(VFont.bodyMediumEmphasised)
                 .foregroundStyle(VColor.contentDefault)
-                .frame(minHeight: 240, alignment: .topLeading)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .padding(VSpacing.md)
 
             if !attachments.isEmpty {
-                Divider()
-                    .background(VColor.borderBase)
+                VColor.borderBase
+                    .frame(height: 1)
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -386,7 +386,8 @@ private struct HomeEmailEditorDemo: View {
             icon: nil,
             title: "Thread Name Here",
             primaryAction: .init(label: "Send", action: {}),
-            onDismiss: {}
+            onDismiss: {},
+            scrollable: false
         ) {
             HomeEmailEditor(
                 toAddress: $toAddress,
@@ -471,7 +472,8 @@ private struct HomeSplitLayoutDemo: View {
                 icon: nil,
                 title: "Thread Name Here",
                 primaryAction: .init(label: "Send", action: {}),
-                onDismiss: {}
+                onDismiss: {},
+                scrollable: false
             ) {
                 HomeEmailEditor(
                     toAddress: $toAddress,


### PR DESCRIPTION
## Summary
The email editor had too much empty space between the bottom of the attachment chips and the bottom edge of the panel — the body TextField's intrinsic `minHeight: 240` kept it short while the rest of the panel height was unused, and the whole content was wrapped in a vertical ScrollView that gave the TextField no reason to grow.

- `HomeDetailPanel`: add `scrollable: Bool = true`. Default preserves existing callers (invoice preview benefits from scrolling). When `false`, content is placed in a VStack sized to the full remaining panel height so its own `.frame(maxHeight: .infinity)` subviews work.
- `HomeEmailEditor`: body TextField now claims `maxHeight: .infinity`, so the attachments row anchors to the bottom of the panel. Also migrated the two remaining `Divider().background()` hairlines (to/subject separators) to the themed `VColor.borderBase` hairline pattern that was missed in #26244.
- Gallery: the email-editor demo and the email branch of the split-layout demo pass `scrollable: false` so you can actually see the new layout in the gallery.

## Test plan
- [x] `swift build` from `clients/` is green
- [ ] Open the gallery → `HomeEmailEditor` section: the attachments divider + row sit at the bottom of the 640pt demo frame, with the body text field expanding into the space above
- [ ] Split-layout demo → "Email editor" branch: same bottom-anchor
- [ ] Invoice preview still scrolls when the image is tall (default `scrollable: true` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
