### PR TITLE
chrome-extension: resolve effective environment in worker and build defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,7 @@ jobs:
         working-directory: clients/chrome-extension
         env:
           VERSION: ${{ needs.extract-version.outputs.version }}
+          VELLUM_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
         run: bash build.sh
 
       - name: Verify manifest version

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -30,6 +30,11 @@ import { type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';
 import { isCloudTokenStale, type StoredCloudToken } from '../cloud-auth.js';
 import type { StoredLocalToken } from '../self-hosted-auth.js';
+import {
+  type ExtensionEnvironment,
+  cloudUrlsForEnvironment,
+  resolveBuildDefaultEnvironment,
+} from '../extension-environment.js';
 
 // ── Types mirroring worker.ts internals ─────────────────────────────
 
@@ -73,16 +78,21 @@ interface PreflightDeps {
   refreshCloudToken: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
   getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
   getRelayPort: () => Promise<number>;
+  /** The effective environment used to resolve cloud URLs. Defaults to build default. */
+  effectiveEnvironment: ExtensionEnvironment;
 }
 
-const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
-const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 /**
  * Standalone preflight implementation that mirrors the worker's
  * `connectPreflight` function but accepts injectable deps so tests
  * can control the auth function outcomes without mocking globals.
+ *
+ * Cloud URLs are resolved from `deps.effectiveEnvironment` using the
+ * same `cloudUrlsForEnvironment` helper the worker uses, verifying
+ * that sign-in/refresh configs use the environment-resolved web URL
+ * and that the fallback gateway URL is derived from the environment.
  */
 async function connectPreflight(
   assistant: AssistantDescriptor | null,
@@ -122,13 +132,16 @@ async function connectPreflight(
       throw new MissingTokenError(missingTokenMessage(null));
     }
 
+    // Resolve cloud URLs from the effective environment — mirrors worker's getCloudUrls()
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment(deps.effectiveEnvironment);
+
     if (!options.interactive) {
       const refreshed = await deps.refreshCloudToken(assistantId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
-        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
       }
       // If the token is stale but still technically valid, fall back to
@@ -141,10 +154,10 @@ async function connectPreflight(
     }
 
     const stored = await deps.signInCloud(assistantId, {
-      webBaseUrl: CLOUD_WEB_BASE_URL,
+      webBaseUrl,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
-    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
     return { kind: 'cloud', baseUrl, token: stored.token };
   }
 
@@ -211,6 +224,8 @@ function makeDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
     refreshCloudToken: async () => null,
     getStoredCloudToken: async () => null,
     getRelayPort: async () => 7830,
+    // Default to the build-time default environment (typically 'dev' in tests)
+    effectiveEnvironment: resolveBuildDefaultEnvironment(),
     ...overrides,
   };
 }
@@ -582,9 +597,10 @@ describe('connectPreflight — edge cases', () => {
   });
 
   test('null assistant throws MissingTokenError for cloud profile', async () => {
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
     const mode: RelayMode = {
       kind: 'cloud',
-      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      baseUrl: apiBaseUrl,
       token: null,
     };
     const deps = makeDeps();
@@ -621,11 +637,12 @@ describe('connectPreflight — edge cases', () => {
     }
   });
 
-  test('cloud interactive falls back to default gateway for relay baseUrl when no runtimeUrl', async () => {
+  test('cloud interactive falls back to environment-resolved gateway for relay baseUrl when no runtimeUrl', async () => {
     const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
     const mode: RelayMode = {
       kind: 'cloud',
-      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      baseUrl: apiBaseUrl,
       token: null,
     };
     const signedIn = makeStoredCloudToken({ token: 'fallback-jwt' });
@@ -641,7 +658,8 @@ describe('connectPreflight — edge cases', () => {
       deps,
     );
 
-    expect(result.baseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    // The fallback baseUrl should match the environment-resolved API URL
+    expect(result.baseUrl).toBe(apiBaseUrl);
     expect(result.token).toBe('fallback-jwt');
   });
 });
@@ -920,5 +938,150 @@ describe('reconnect: silent recovery for self-hosted mode', () => {
       'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.';
     expect(abortError).toContain('Pair');
     expect(abortError).toContain('extension popup');
+  });
+});
+
+// ── Environment-resolved URL tests ──────────────────────────────────
+//
+// Verify that the preflight (and by extension the worker's cloud auth
+// paths) uses environment-resolved URLs rather than fixed production
+// constants. Each environment should yield different gateway/web URLs.
+
+describe('connectPreflight — environment-resolved cloud URLs', () => {
+  test('production environment uses production gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: prodApi } = cloudUrlsForEnvironment('production');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: prodApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'prod-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'production',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://api.vellum.ai');
+    expect(result.token).toBe('prod-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://www.vellum.ai');
+  });
+
+  test('staging environment uses staging gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: stagingApi } = cloudUrlsForEnvironment('staging');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: stagingApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'staging-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://staging-api.vellum.ai');
+    expect(result.token).toBe('staging-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('dev environment uses dev gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: devApi } = cloudUrlsForEnvironment('dev');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: devApi, token: null };
+    const refreshed = makeStoredCloudToken({ token: 'dev-refreshed-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'dev',
+      refreshCloudToken: async (_id, config) => {
+        capturedConfig = config;
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: false }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://dev-api.vellum.ai');
+    expect(result.token).toBe('dev-refreshed-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://dev-assistant.vellum.ai');
+  });
+
+  test('local environment uses localhost gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: localApi } = cloudUrlsForEnvironment('local');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: localApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'local-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'local',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('http://localhost:8080');
+    expect(result.token).toBe('local-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('http://localhost:3000');
+  });
+
+  test('non-interactive refresh also uses environment-resolved URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: stagingApi } = cloudUrlsForEnvironment('staging');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: stagingApi, token: null };
+    const refreshed = makeStoredCloudToken({ token: 'staging-refreshed' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      refreshCloudToken: async (_id, config) => {
+        capturedConfig = config;
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: false }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://staging-api.vellum.ai');
+    expect(capturedConfig!.webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('runtimeUrl takes precedence over environment-resolved gateway', async () => {
+    const assistant = makeCloudAssistant({
+      runtimeUrl: 'https://custom-runtime.example.com',
+    });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://custom-runtime.example.com',
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'custom-jwt' });
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      signInCloud: async () => signedIn,
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    // runtimeUrl should still take precedence over the environment gateway
+    expect(result.baseUrl).toBe('https://custom-runtime.example.com');
   });
 });

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -32,6 +32,10 @@ import { describe, test, expect } from 'bun:test';
 
 import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';
+import {
+  cloudUrlsForEnvironment,
+  resolveBuildDefaultEnvironment,
+} from '../extension-environment.js';
 
 // ── Fixtures ────────────────────────────────────────────────────────
 
@@ -181,16 +185,20 @@ describe('relay mode derivation from assistant descriptor', () => {
     expect(assistant.runtimeUrl).toBe('https://custom-gateway.vellum.cloud');
   });
 
-  test('cloud-oauth assistant without runtimeUrl falls back to default gateway', () => {
+  test('cloud-oauth assistant without runtimeUrl falls back to environment-resolved gateway', () => {
     const assistant = makeCloudAssistant({ runtimeUrl: '' });
     const profile = resolveAuthProfile({
       cloud: assistant.cloud,
       runtimeUrl: assistant.runtimeUrl,
     });
     expect(profile).toBe('cloud-oauth');
-    // Empty runtimeUrl triggers the CLOUD_GATEWAY_BASE_URL fallback
-    // in buildRelayModeForAssistant.
+    // Empty runtimeUrl triggers the environment-resolved apiBaseUrl fallback
+    // in buildRelayModeForAssistant. The gateway URL depends on the effective
+    // environment (e.g. dev -> dev-api.vellum.ai, production -> api.vellum.ai).
     expect(assistant.runtimeUrl).toBe('');
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
+    expect(typeof apiBaseUrl).toBe('string');
+    expect(apiBaseUrl.length).toBeGreaterThan(0);
   });
 });
 
@@ -249,5 +257,70 @@ describe('assistant switch behavior', () => {
       runtimeUrl: unsupported.runtimeUrl,
     });
     expect(profile).toBe('unsupported');
+  });
+});
+
+// ── Environment-resolved URL contract ────────────────────────────────
+//
+// The worker no longer uses hardcoded production constants for cloud auth
+// config. All cloud URL derivation flows through `cloudUrlsForEnvironment`
+// backed by the effective environment. These tests verify the contract
+// that sign-in/refresh configs use the correct URLs per environment.
+
+describe('environment-resolved cloud auth URLs', () => {
+  test('production environment resolves production cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('production');
+    expect(apiBaseUrl).toBe('https://api.vellum.ai');
+    expect(webBaseUrl).toBe('https://www.vellum.ai');
+  });
+
+  test('staging environment resolves staging cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('staging');
+    expect(apiBaseUrl).toBe('https://staging-api.vellum.ai');
+    expect(webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('dev environment resolves dev cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('dev');
+    expect(apiBaseUrl).toBe('https://dev-api.vellum.ai');
+    expect(webBaseUrl).toBe('https://dev-assistant.vellum.ai');
+  });
+
+  test('local environment resolves localhost URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('local');
+    expect(apiBaseUrl).toBe('http://localhost:8080');
+    expect(webBaseUrl).toBe('http://localhost:3000');
+  });
+
+  test('build default environment resolves to dev when VELLUM_ENVIRONMENT is unset', () => {
+    // In test environments (unbundled), process.env.VELLUM_ENVIRONMENT is
+    // typically unset, so resolveBuildDefaultEnvironment returns 'dev'.
+    const buildDefault = resolveBuildDefaultEnvironment();
+    expect(buildDefault).toBe('dev');
+  });
+
+  test('cloud auth sign-in config uses environment-resolved web URL (not hardcoded production)', () => {
+    // Simulates what the worker does: resolve webBaseUrl from the effective
+    // environment and pass it to signInCloud / refreshCloudToken configs.
+    const envs = ['local', 'dev', 'staging', 'production'] as const;
+    for (const env of envs) {
+      const { webBaseUrl } = cloudUrlsForEnvironment(env);
+      // The webBaseUrl should differ per environment — not always production
+      if (env !== 'production') {
+        expect(webBaseUrl).not.toBe('https://www.vellum.ai');
+      }
+    }
+  });
+
+  test('cloud relay fallback gateway uses environment-resolved API URL (not hardcoded production)', () => {
+    // Simulates what the worker does: when assistant has no runtimeUrl,
+    // the relay base URL falls back to apiBaseUrl from the effective env.
+    const envs = ['local', 'dev', 'staging', 'production'] as const;
+    for (const env of envs) {
+      const { apiBaseUrl } = cloudUrlsForEnvironment(env);
+      if (env !== 'production') {
+        expect(apiBaseUrl).not.toBe('https://api.vellum.ai');
+      }
+    }
   });
 });

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -1508,6 +1508,14 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     // Validates and persists an environment override. Pass
     // `environment: null` to clear the override and revert to the
     // build default.
+    //
+    // NOTE: This handler intentionally only persists the override — it
+    // does NOT disconnect or reconnect the active relay connection. The
+    // caller (popup) is responsible for orchestrating disconnect/reconnect
+    // after receiving the response if it wants the new environment to take
+    // effect immediately. `getCloudUrls()` is called fresh on each
+    // connect/reconnect cycle, so the persisted override is picked up
+    // automatically on the next connection without any additional plumbing.
     const rawEnv = message.environment;
     if (rawEnv === null || rawEnv === undefined) {
       // Clear override

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -50,6 +50,12 @@ import {
   decideCloudReconnectAction,
 } from './cloud-reconnect-decision.js';
 import {
+  type ExtensionEnvironment,
+  parseExtensionEnvironment,
+  resolveBuildDefaultEnvironment,
+  cloudUrlsForEnvironment,
+} from './extension-environment.js';
+import {
   listAssistants,
   type AssistantDescriptor,
   type AssistantCatalog,
@@ -85,12 +91,66 @@ import {
   type RelayReconnectDecision,
 } from './relay-connection.js';
 
-// Cloud OAuth defaults — kept here so the popup can stay a thin client and the
-// service worker is the single owner of the launchWebAuthFlow lifecycle. This
-// avoids the MV3 popup teardown race where closing the popup mid-auth kills
-// the awaited promise before the token is persisted.
-const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
-const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
+// ── Environment resolution ──────────────────────────────────────────
+//
+// The effective environment drives all cloud auth URLs. Precedence:
+//   1. Popup override persisted in chrome.storage.local
+//   2. Build-time default injected via `--define` at bundle time
+//   3. Fallback to 'dev' (see resolveBuildDefaultEnvironment)
+//
+// The popup can read and write the override via `environment-get` and
+// `environment-set` worker messages without requiring an extension reload.
+
+const ENVIRONMENT_OVERRIDE_KEY = 'vellum.environmentOverride';
+
+/**
+ * Resolve the effective environment by checking for a popup-persisted
+ * override first, then falling back to the build-time default.
+ */
+async function getEffectiveEnvironment(): Promise<ExtensionEnvironment> {
+  const result = await chrome.storage.local.get(ENVIRONMENT_OVERRIDE_KEY);
+  const override = result[ENVIRONMENT_OVERRIDE_KEY];
+  if (typeof override === 'string') {
+    const parsed = parseExtensionEnvironment(override);
+    if (parsed) return parsed;
+  }
+  return resolveBuildDefaultEnvironment();
+}
+
+/**
+ * Read the raw override value from storage (null when unset).
+ */
+async function getOverrideEnvironment(): Promise<ExtensionEnvironment | null> {
+  const result = await chrome.storage.local.get(ENVIRONMENT_OVERRIDE_KEY);
+  const override = result[ENVIRONMENT_OVERRIDE_KEY];
+  if (typeof override === 'string') {
+    return parseExtensionEnvironment(override);
+  }
+  return null;
+}
+
+/**
+ * Persist an environment override. Pass `null` to clear.
+ */
+async function setOverrideEnvironment(env: ExtensionEnvironment | null): Promise<void> {
+  if (env === null) {
+    await chrome.storage.local.remove(ENVIRONMENT_OVERRIDE_KEY);
+  } else {
+    await chrome.storage.local.set({ [ENVIRONMENT_OVERRIDE_KEY]: env });
+  }
+}
+
+/**
+ * Resolve cloud URLs for the current effective environment.
+ * Replaces the old hardcoded CLOUD_GATEWAY_BASE_URL / CLOUD_WEB_BASE_URL
+ * constants — every call site now gets environment-appropriate URLs.
+ */
+async function getCloudUrls(): Promise<{ apiBaseUrl: string; webBaseUrl: string }> {
+  const env = await getEffectiveEnvironment();
+  return cloudUrlsForEnvironment(env);
+}
+
+// Cloud OAuth client ID — not environment-dependent.
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 const DEFAULT_RELAY_PORT = 7830;
@@ -588,9 +648,10 @@ async function buildRelayModeForAssistant(
     }
     const cloud = await getLegacyCloudToken();
     if (cloud) {
+      const { apiBaseUrl } = await getCloudUrls();
       return {
         kind: 'cloud',
-        baseUrl: CLOUD_GATEWAY_BASE_URL,
+        baseUrl: apiBaseUrl,
         token: cloud.token,
       };
     }
@@ -653,8 +714,9 @@ async function buildRelayModeForAssistant(
     const stored = await getStoredCloudToken(assistant.assistantId);
     // Use the assistant's runtime URL as the relay base when available.
     // This allows cloud-managed assistants to point to their specific
-    // gateway endpoint. Fall back to the default cloud gateway.
-    const baseUrl = assistant.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    // gateway endpoint. Fall back to the environment-resolved cloud gateway.
+    const { apiBaseUrl } = await getCloudUrls();
+    const baseUrl = assistant.runtimeUrl || apiBaseUrl;
     return {
       kind: 'cloud',
       baseUrl,
@@ -756,9 +818,10 @@ async function cloudReconnectHook(
   // token under the correct scoped key. When no assistant is selected
   // we can't scope the refresh, so we skip it — the user will be
   // prompted to sign in again (abort path on the next reconnect).
+  const { webBaseUrl } = await getCloudUrls();
   const refreshed = selectedId
     ? await refreshCloudToken(selectedId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       })
     : null;
@@ -1025,15 +1088,17 @@ async function connectPreflight(
       throw new MissingTokenError(missingTokenMessage(null));
     }
 
+    const { apiBaseUrl, webBaseUrl } = await getCloudUrls();
+
     if (!options.interactive) {
       // Non-interactive: attempt a silent refresh first.
       const refreshed = await refreshCloudToken(assistantId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         runtimeBaseUrl: assistant?.runtimeUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
-        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
       }
       // If the token is stale but still technically valid, fall back to
@@ -1047,11 +1112,11 @@ async function connectPreflight(
 
     // Interactive: launch the full OAuth sign-in flow.
     const stored = await signInCloud(assistantId, {
-      webBaseUrl: CLOUD_WEB_BASE_URL,
+      webBaseUrl,
       runtimeBaseUrl: assistant?.runtimeUrl,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
-    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
     return { kind: 'cloud', baseUrl, token: stored.token };
   }
 
@@ -1264,8 +1329,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         }
         const descriptor =
           assistants.find((assistant) => assistant.assistantId === resolvedId) ?? null;
+        const { webBaseUrl } = await getCloudUrls();
         const config: CloudAuthConfig = {
-          webBaseUrl: CLOUD_WEB_BASE_URL,
+          webBaseUrl,
           runtimeBaseUrl: descriptor?.runtimeUrl,
           clientId:
             typeof message.clientId === 'string' ? message.clientId : CLOUD_OAUTH_CLIENT_ID,
@@ -1407,6 +1473,82 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
           ok: true,
           selected: match,
           authProfile,
+        });
+      })
+      .catch((err) =>
+        sendResponseFn({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    return true; // async
+  }
+  if (message.type === 'environment-get') {
+    // Returns the effective environment and its components so the popup
+    // can display which environment is active and whether an override is
+    // in effect.
+    Promise.all([getEffectiveEnvironment(), getOverrideEnvironment()])
+      .then(([effectiveEnvironment, overrideEnvironment]) => {
+        sendResponseFn({
+          ok: true,
+          effectiveEnvironment,
+          overrideEnvironment,
+          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+        });
+      })
+      .catch((err) =>
+        sendResponseFn({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    return true; // async
+  }
+  if (message.type === 'environment-set') {
+    // Validates and persists an environment override. Pass
+    // `environment: null` to clear the override and revert to the
+    // build default.
+    const rawEnv = message.environment;
+    if (rawEnv === null || rawEnv === undefined) {
+      // Clear override
+      setOverrideEnvironment(null)
+        .then(async () => {
+          const effectiveEnvironment = await getEffectiveEnvironment();
+          sendResponseFn({
+            ok: true,
+            effectiveEnvironment,
+            overrideEnvironment: null,
+            buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+          });
+        })
+        .catch((err) =>
+          sendResponseFn({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      return true; // async
+    }
+    if (typeof rawEnv !== 'string') {
+      sendResponseFn({ ok: false, error: 'environment must be a string or null' });
+      return false;
+    }
+    const parsed = parseExtensionEnvironment(rawEnv);
+    if (!parsed) {
+      sendResponseFn({
+        ok: false,
+        error: `Invalid environment: "${rawEnv}". Must be one of: local, dev, staging, production`,
+      });
+      return false;
+    }
+    setOverrideEnvironment(parsed)
+      .then(async () => {
+        const effectiveEnvironment = await getEffectiveEnvironment();
+        sendResponseFn({
+          ok: true,
+          effectiveEnvironment,
+          overrideEnvironment: parsed,
+          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
         });
       })
       .catch((err) =>

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -19,6 +19,11 @@ else
   EXT_VERSION=$(jq -r '.version' "$SCRIPT_DIR/manifest.json")
 fi
 
+# Resolve environment for bundle-time injection. The release workflow sets
+# VELLUM_ENVIRONMENT to 'staging' or 'production'; local dev builds
+# default to 'dev' when the variable is unset.
+VELLUM_ENV="${VELLUM_ENVIRONMENT:-dev}"
+
 # Chrome manifest requires 1-4 dot-separated integers. Strip any
 # prerelease suffix (e.g. "0.6.0-staging.3" -> "0.6.0") so staging
 # builds produce a valid extension zip.
@@ -40,12 +45,14 @@ mkdir -p "$DIST_DIR/icons"
 
 # Build service worker
 echo "Bundling service worker with bun build..."
+echo "  Environment: $VELLUM_ENV"
 bun build \
   "$SCRIPT_DIR/background/worker.ts" \
   --outdir "$DIST_DIR/background" \
   --target browser \
   --format esm \
-  --minify
+  --minify \
+  --define "process.env.VELLUM_ENVIRONMENT=\"$VELLUM_ENV\""
 
 # Build popup script
 echo "Bundling popup script with bun build..."
@@ -54,7 +61,8 @@ bun build \
   --outdir "$DIST_DIR/popup" \
   --target browser \
   --format esm \
-  --minify
+  --minify \
+  --define "process.env.VELLUM_ENVIRONMENT=\"$VELLUM_ENV\""
 
 # Copy static assets
 cp "$SCRIPT_DIR/manifest.json" "$DIST_DIR/manifest.json"


### PR DESCRIPTION
## Summary
- Replace hardcoded cloud URL constants with environment-driven resolution
- Add environment-get/set worker messages for popup consumption
- Update build.sh and release workflow with VELLUM_ENVIRONMENT injection

Part of plan: chrome-extension-env-selector.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
