### PR TITLE
fix(home): move email editor Send button to a bottom footer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -4,22 +4,23 @@ import VellumAssistantShared
 /// Pure body content for the Home detail side panel's email composer
 /// variant.
 ///
-/// Matches Figma node `3216:63021` — formatting toolbar, divider,
-/// To/Subject labeled fields, editable body text, and a horizontal
-/// scroll of attachment chips at the bottom. The enclosing
-/// `HomeDetailPanel` chrome supplies the header, title, action buttons,
-/// and dismiss affordance, so this component takes no header / title /
-/// action / dismiss props — it's slotted directly into the panel's
-/// `content:` closure.
+/// Matches Figma node `3496:72522` — formatting toolbar, To/Subject
+/// labeled fields, editable body text, and at the bottom a two-row
+/// footer: a horizontal scroll of attachment chips (only when
+/// attachments are present) followed by a primary `Send` button. The
+/// enclosing `HomeDetailPanel` chrome supplies the header title +
+/// optional dismiss; the `Send` action lives on this component rather
+/// than on the panel header because the mock puts it at the bottom of
+/// the panel, not in the header.
 ///
 /// The body text field expands to fill all vertical space between the
-/// subject divider and the attachments footer, so the attachments row
+/// subject divider and the attachments/send footer, so the footer
 /// always anchors to the bottom of the panel regardless of how much
 /// body text is present. This requires the enclosing `HomeDetailPanel`
 /// to be constructed with `scrollable: false` so that the editor's own
 /// vertical growth can be honored. With the default `scrollable: true`
 /// the body falls back to its intrinsic height (no fill), which reads
-/// fine but leaves whitespace between the body and the attachments.
+/// fine but leaves whitespace between the body and the footer.
 struct HomeEmailEditor: View {
 
     struct Attachment: Identifiable, Hashable {
@@ -33,6 +34,8 @@ struct HomeEmailEditor: View {
     @Binding var bodyText: String
     let attachments: [Attachment]
     let onAttachmentTap: (Attachment) -> Void
+    /// Fired when the user taps the footer `Send` button.
+    let onSend: () -> Void
     var onFormatAction: (VFormattingToolbar.Action) -> Void = { _ in }
 
     var body: some View {
@@ -69,39 +72,74 @@ struct HomeEmailEditor: View {
                     .frame(height: 1)
                     .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Attachments")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .accessibilityAddTraits(.isHeader)
+                attachmentsRow
+            }
 
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: VSpacing.sm) {
-                            ForEach(attachments) { att in
-                                Button {
-                                    onAttachmentTap(att)
-                                } label: {
-                                    HomeLinkFileRow(
-                                        icon: .file,
-                                        fileName: att.fileName,
-                                        fileSize: att.fileSize
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityElement(children: .combine)
-                                .accessibilityLabel("\(att.fileName), \(att.fileSize)")
-                            }
+            VColor.borderBase
+                .frame(height: 1)
+                .accessibilityHidden(true)
+
+            sendFooter
+        }
+    }
+
+    // MARK: - Footer sub-views
+
+    /// Horizontal chip row matching Figma node `3496:72524-29`. Rendered
+    /// above the send button when `attachments` is non-empty.
+    private var attachmentsRow: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Attachments")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .accessibilityAddTraits(.isHeader)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: VSpacing.sm) {
+                    ForEach(attachments) { att in
+                        Button {
+                            onAttachmentTap(att)
+                        } label: {
+                            HomeLinkFileRow(
+                                icon: .file,
+                                fileName: att.fileName,
+                                fileSize: att.fileSize
+                            )
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(att.fileName), \(att.fileSize)")
                     }
                 }
-                .padding(EdgeInsets(
-                    top: VSpacing.sm,
-                    leading: VSpacing.lg,
-                    bottom: VSpacing.lg,
-                    trailing: VSpacing.lg
-                ))
             }
         }
+        .padding(EdgeInsets(
+            top: VSpacing.sm,
+            leading: VSpacing.lg,
+            bottom: VSpacing.sm,
+            trailing: VSpacing.lg
+        ))
+    }
+
+    /// Primary send action anchored to the bottom of the panel. Uses
+    /// `VButton.Size.regular` (32pt tall, 8pt corners) to match the
+    /// Figma spec exactly (node `3496:72533`).
+    private var sendFooter: some View {
+        HStack(spacing: 0) {
+            VButton(
+                label: "Send",
+                style: .primary,
+                size: .regular,
+                action: onSend
+            )
+            Spacer(minLength: 0)
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.lg,
+            bottom: VSpacing.lg,
+            trailing: VSpacing.lg
+        ))
     }
 
     // MARK: - Labeled field

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -385,7 +385,6 @@ private struct HomeEmailEditorDemo: View {
         HomeDetailPanel(
             icon: nil,
             title: "Thread Name Here",
-            primaryAction: .init(label: "Send", action: {}),
             onDismiss: {},
             scrollable: false
         ) {
@@ -394,7 +393,8 @@ private struct HomeEmailEditorDemo: View {
                 subject: $subject,
                 bodyText: $bodyText,
                 attachments: Self.sampleAttachments,
-                onAttachmentTap: { _ in }
+                onAttachmentTap: { _ in },
+                onSend: {}
             )
         }
         .frame(height: 640)
@@ -471,7 +471,6 @@ private struct HomeSplitLayoutDemo: View {
             HomeDetailPanel(
                 icon: nil,
                 title: "Thread Name Here",
-                primaryAction: .init(label: "Send", action: {}),
                 onDismiss: {},
                 scrollable: false
             ) {
@@ -480,7 +479,8 @@ private struct HomeSplitLayoutDemo: View {
                     subject: $subject,
                     bodyText: $bodyText,
                     attachments: Self.sampleAttachments,
-                    onAttachmentTap: { _ in }
+                    onAttachmentTap: { _ in },
+                    onSend: {}
                 )
             }
         case .invoice:


### PR DESCRIPTION
## Summary
Matches Figma node [3496:72522](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=3496-72522) — the email editor's Send button is now a bottom-anchored primary pill rather than a trailing header action. The panel header keeps only the thread title + dismiss.

### What changed
- `HomeEmailEditor`: add a required `onSend: () -> Void` prop. The body now renders: toolbar → divider → to/subject fields → expanding body → optional attachments row → divider → Send footer (leading-aligned `.primary` + `.regular` VButton with 8pt corners to match the mock).
- Gallery: both the standalone email-editor demo and the email branch of the split-layout demo drop `primaryAction` from `HomeDetailPanel` and wire `onSend: {}` on the editor.

## Test plan
- [x] `swift build` from `clients/` green
- [ ] Gallery → `HomeEmailEditor` section: Send sits at the bottom-left of the panel, below the attachments row; header has only title + X
- [ ] Split-layout demo → "Email editor": same layout
- [ ] Invoice branch of split-layout demo: unchanged (Authorise/Deny stay in the header, scrollable stays default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
