### PR TITLE
fix(docker): copy skills/meet-join/shared into assistant and bot images

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -31,6 +31,7 @@ RUN cd /app/assistant && bun install --frozen-lockfile
 COPY skills/meet-join/contracts ./skills/meet-join/contracts
 COPY skills/meet-join/config-schema.ts skills/meet-join/meet-config.ts skills/meet-join/register.ts ./skills/meet-join/
 COPY skills/meet-join/daemon ./skills/meet-join/daemon
+COPY skills/meet-join/shared ./skills/meet-join/shared
 COPY skills/meet-join/tools ./skills/meet-join/tools
 COPY skills/meet-join/routes ./skills/meet-join/routes
 

--- a/skills/meet-join/bot/Dockerfile
+++ b/skills/meet-join/bot/Dockerfile
@@ -91,6 +91,13 @@ WORKDIR /app/bot
 # so the `file:../contracts` dep in package.json resolves.
 COPY skills/meet-join/contracts /app/contracts
 
+# Copy the sibling `shared/` module. The bot's chrome-launcher and
+# video-device modules import `AVATAR_DEVICE_PATH_DEFAULT` via
+# `../../../shared/avatar-device-path.js`, which resolves to `/app/shared/`
+# from `/app/bot/src/{browser,media}/…`. Without this the bot crashes at
+# startup with "Cannot find module './shared/avatar-device-path.js'".
+COPY skills/meet-join/shared /app/shared
+
 # Install JS dependencies first so Docker can cache the layer when only
 # source files change.
 COPY skills/meet-join/bot/package.json skills/meet-join/bot/bun.lock skills/meet-join/bot/tsconfig.json ./

--- a/skills/meet-join/bot/Dockerfile.dockerignore
+++ b/skills/meet-join/bot/Dockerfile.dockerignore
@@ -39,6 +39,16 @@ skills/meet-join/contracts/node_modules
 skills/meet-join/contracts/dist
 skills/meet-join/contracts/__tests__
 
+# Un-ignore the sibling `shared/` directory. The bot's chrome-launcher and
+# video-device modules import `AVATAR_DEVICE_PATH_DEFAULT` from
+# `../../../shared/avatar-device-path.js`, which resolves to `/app/shared/`
+# inside the image (see the `COPY skills/meet-join/shared /app/shared` step
+# in the Dockerfile). Without this allow-list entry, the file is excluded
+# from the build context and the bot crashes at startup with
+# "Cannot find module './shared/avatar-device-path.js'".
+!skills/meet-join/shared
+!skills/meet-join/shared/**
+
 # Un-ignore the sibling extension package. The Dockerfile needs both the
 # manifest.json (copied to /tmp so the render script can extract the
 # public key and derive the extension ID that pins `allowed_origins` in

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -10,9 +10,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import type {
-  BotToExtensionMessage,
-} from "../../../contracts/native-messaging.js";
+import type { BotToExtensionMessage } from "../../../contracts/native-messaging.js";
 
 import { startContentBridge } from "../messaging/content-bridge.js";
 import type { NativePort } from "../messaging/native-port.js";


### PR DESCRIPTION
## Summary
- Add `COPY skills/meet-join/shared` to `assistant/Dockerfile` so `config-schema.ts` can resolve its `./shared/avatar-device-path.js` import. The .dockerignore allowlist from #26764 made the files available to the build context but nothing copied them into the image, so pods still crash at startup.
- Add the matching `COPY skills/meet-join/shared /app/shared` to `skills/meet-join/bot/Dockerfile` — the bot's `chrome-launcher.ts` and `video-device.ts` import `AVATAR_DEVICE_PATH_DEFAULT` via `../../../shared/avatar-device-path.js`, which resolves to `/app/shared/` from `/app/bot/src/`. Without this the meet-bot container would crash with the same error.
- Allow-list `skills/meet-join/shared/` in `skills/meet-join/bot/Dockerfile.dockerignore` so the new bot COPY has a populated build context.

## Original prompt
fix this and any other related errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
