### PR TITLE
fix(home): polish email editor — inset dividers, visible to/subject prefixes, grouped toolbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeEmailEditor.swift
@@ -42,6 +42,9 @@ struct HomeEmailEditor: View {
         VStack(alignment: .leading, spacing: 0) {
             VFormattingToolbar(onAction: onFormatAction)
 
+            // The first hairline, directly under the toolbar, sits flush
+            // against the panel edges — matches the Figma mock's full-bleed
+            // divider beneath the header.
             VColor.borderBase
                 .frame(height: 1)
                 .accessibilityHidden(true)
@@ -49,15 +52,11 @@ struct HomeEmailEditor: View {
             VStack(alignment: .leading, spacing: 0) {
                 labeledField("to:", $toAddress)
 
-                VColor.borderBase
-                    .frame(height: 1)
-                    .accessibilityHidden(true)
+                insetHairline
 
                 labeledField("subject:", $subject)
 
-                VColor.borderBase
-                    .frame(height: 1)
-                    .accessibilityHidden(true)
+                insetHairline
             }
 
             TextField("Compose your reply…", text: $bodyText, axis: .vertical)
@@ -68,19 +67,26 @@ struct HomeEmailEditor: View {
                 .padding(VSpacing.md)
 
             if !attachments.isEmpty {
-                VColor.borderBase
-                    .frame(height: 1)
-                    .accessibilityHidden(true)
+                insetHairline
 
                 attachmentsRow
             }
 
-            VColor.borderBase
-                .frame(height: 1)
-                .accessibilityHidden(true)
+            insetHairline
 
             sendFooter
         }
+    }
+
+    /// 1pt hairline inset by `VSpacing.lg` on each side so it stops short
+    /// of the panel's rounded edges — matches the Figma mock, where every
+    /// divider except the one directly under the header is held in from
+    /// the panel edges.
+    private var insetHairline: some View {
+        VColor.borderBase
+            .frame(height: 1)
+            .padding(.horizontal, VSpacing.lg)
+            .accessibilityHidden(true)
     }
 
     // MARK: - Footer sub-views
@@ -144,12 +150,25 @@ struct HomeEmailEditor: View {
 
     // MARK: - Labeled field
 
+    /// Row that renders a fixed prefix (e.g. `to:`, `subject:`) followed
+    /// by an editable text field. The prefix is rendered as real text, not
+    /// a `TextField` placeholder, so it stays visible once the user has
+    /// typed a value — matches the Figma mock's "to: john@johnstown.com"
+    /// single-line rendering.
     @ViewBuilder
     private func labeledField(_ label: String, _ value: Binding<String>) -> some View {
-        TextField(label, text: value)
-            .textFieldStyle(.plain)
-            .font(VFont.bodyMediumLighter)
-            .foregroundStyle(VColor.contentSecondary)
-            .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
+        HStack(spacing: VSpacing.xs) {
+            Text(label)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .accessibilityHidden(true)
+
+            TextField("", text: value)
+                .textFieldStyle(.plain)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .accessibilityLabel(Text(label))
+        }
+        .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
     }
 }

--- a/clients/shared/DesignSystem/Core/Inputs/VFormattingToolbar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VFormattingToolbar.swift
@@ -26,30 +26,63 @@ public struct VFormattingToolbar: View {
         case quote
     }
 
-    public let actions: [Action]
+    /// Actions organized into visual groups. Each inner array is rendered
+    /// as a tight cluster of buttons; between clusters a flexible spacer
+    /// is inserted so the groups distribute across the available width
+    /// (leading / middle / trailing for a 3-group toolbar, matching the
+    /// Figma mock).
+    public let groups: [[Action]]
     public let onAction: (Action) -> Void
 
+    /// Default 3-group layout from the email composer mock
+    /// (Figma `3496:72522`): text style, alignment, misc.
     public init(
-        actions: [Action] = [.bold, .italic, .underline, .alignLeft, .alignCenter, .alignRight, .link],
+        groups: [[Action]] = [
+            [.bold, .italic, .underline],
+            [.alignLeft, .alignCenter, .alignRight],
+            [.link, .quote]
+        ],
         onAction: @escaping (Action) -> Void
     ) {
-        self.actions = actions
+        self.groups = groups
         self.onAction = onAction
     }
 
+    /// Convenience for callers that want a single flat group of actions
+    /// (e.g. a trimmed bold/italic/underline/link bar). Renders the
+    /// actions as one cluster pushed to the leading edge.
+    public init(
+        actions: [Action],
+        onAction: @escaping (Action) -> Void
+    ) {
+        self.init(groups: [actions], onAction: onAction)
+    }
+
     public var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            ForEach(actions, id: \.self) { action in
-                VButton(
-                    label: label(for: action),
-                    iconOnly: iconName(for: action),
-                    style: .ghost,
-                    size: .pill
-                ) {
-                    onAction(action)
+        HStack(spacing: 0) {
+            ForEach(Array(groups.enumerated()), id: \.offset) { idx, group in
+                if idx > 0 {
+                    Spacer(minLength: VSpacing.md)
+                }
+                HStack(spacing: VSpacing.xs) {
+                    ForEach(group, id: \.self) { action in
+                        VButton(
+                            label: label(for: action),
+                            iconOnly: iconName(for: action),
+                            style: .ghost,
+                            size: .pill
+                        ) {
+                            onAction(action)
+                        }
+                    }
                 }
             }
-            Spacer(minLength: 0)
+            // When there's only one group, keep it pinned to the leading
+            // edge — callers passing a flat `actions:` array expect the
+            // original "left-aligned row" layout.
+            if groups.count < 2 {
+                Spacer(minLength: 0)
+            }
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)


### PR DESCRIPTION
## Summary
Three mock-matching corrections to the email editor ([Figma 3496:72522](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=3496-72522)):

1. **Inset dividers.** Every hairline except the one directly under the header is now inset by `VSpacing.lg` on each side so it stops short of the panel's rounded edges, matching the mock's held-in dividers. Extracted a tiny `insetHairline` helper inside `HomeEmailEditor` to keep the `body` readable.
2. **Visible `to:` / `subject:` prefixes.** These were being rendered via the `TextField(label, text:)` placeholder, which disappears as soon as the user types. They're now a real `Text` prefix inside an `HStack` alongside the editable field, matching the mock's `to: john@johnstown.com` single-line rendering. The prefix is `.accessibilityHidden(true)` and the `TextField` carries the `.accessibilityLabel`.
3. **Grouped formatting toolbar.** `VFormattingToolbar` gained a primary `init(groups: [[Action]])` that renders each inner array as a tight cluster and inserts flexible spacers between clusters so the groups distribute across the available width. The new default is a 3-group layout (`bold/italic/underline`, `alignLeft/Center/Right`, `link/quote`) — leading / middle / trailing, matching the mock. The convenience `init(actions:)` is preserved for callers that want a single flat row (the existing Inputs gallery demo still compiles).

## Test plan
- [x] `swift build` from `clients/` is green
- [ ] Gallery → `HomeEmailEditor`: prefixes stay visible after typing; dividers stop short of the rounded edges; toolbar icons are in three distributed groups
- [ ] Inputs gallery → `VFormattingToolbar`: "Default action set" renders the 3-group layout; "Trimmed subset" still renders as a single leading cluster
- [ ] Invoice preview section: unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
