### PR TITLE
docs(meet-join): require explicit consent for avatar enable

### DIFF
--- a/skills/meet-join/SKILL.md
+++ b/skills/meet-join/SKILL.md
@@ -123,9 +123,9 @@ Barge-in is automatic: if a human speaks while the assistant is talking, the ass
 Enable the avatar when:
 
 - The user explicitly asks the assistant to be on camera (e.g. "turn your video on", "show your avatar").
-- The meeting context expects video participation (e.g. a presentation or 1:1 where other participants are on camera and have signalled they welcome a visual presence).
+- A participant in the meeting explicitly invites the assistant to turn on video and the user has signalled that kind of participation is welcome.
 
 Avoid enabling the avatar when:
 
-- The user has not asked for it. Do not turn it on proactively.
+- The user has not asked for it. Do not turn it on proactively based on ambient meeting context (e.g. others being on camera) alone.
 - The assistant is not actively speaking. Most participants read "video on" as presence and attention — the avatar is not a watching observer. Disable it during long stretches of silence and re-enable it when the assistant is about to speak again.


### PR DESCRIPTION
## Summary

Codex and Devin both flagged a contradiction in `skills/meet-join/SKILL.md` Video avatar section: one enable bullet allowed enabling based on ambient meeting context (e.g. others on camera), while a later avoid bullet said 'Do not turn it on proactively'. The LLM would see both and behave non-deterministically.

Rewrote the second enable bullet to require an explicit participant invitation + user signal, and tightened the avoid bullet to explicitly call out that ambient context is not enough. Mirrors the internally-consistent voice section above it.

## Test plan
- [x] Read over final text for internal consistency against the voice section
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
