### PR TITLE
fix(scripts): address PR #26750 review feedback

### DIFF
--- a/scripts/check-generic-examples.ts
+++ b/scripts/check-generic-examples.ts
@@ -67,7 +67,7 @@ const SHAPE_PATTERNS: Pattern[] = [
     // digits do NOT fall in the reserved 555-0100..555-0199 range that IANA
     // allocates for fiction. Matches common formats including (xxx) xxx-xxxx.
     regex:
-      /["'`](?:\+?1[-. ]?)?\(?(?!555\)?[-. ]?01\d\d)\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}["'`]/,
+      /["'`](?:\+?1[-. ]?)?\(?\d{3}\)?[-. ]?(?!555[-. ]?01\d\d)\d{3}[-. ]?\d{4}["'`]/,
     severity: "WARN",
     description:
       "phone number outside the reserved 555-01XX range (use 555-01xx in fixtures)",
@@ -194,7 +194,7 @@ function parseUnifiedDiff(diff: string): AddedLine[] {
 
 function getDiff(mode: "staged" | "ci"): string {
   if (mode === "staged") {
-    return execSync("git diff --cached --unified=0 --no-color", {
+    return execSync("git diff --cached --unified=1 --no-color", {
       maxBuffer: 64 * 1024 * 1024,
     }).toString();
   }
@@ -211,7 +211,7 @@ function getDiff(mode: "staged" | "ci"): string {
     ? `origin/${process.env.GITHUB_BASE_REF}`
     : base;
   return execSync(
-    `git diff ${baseRef}...HEAD --unified=0 --no-color`,
+    `git diff ${baseRef}...HEAD --unified=1 --no-color`,
     {
       maxBuffer: 64 * 1024 * 1024,
     },
@@ -325,13 +325,23 @@ const TEST_CASES: TestCase[] = [
     expectPatterns: ["non-example-email"],
   },
   {
-    name: "reserved phone is OK",
-    content: `const n = "555-0142";`,
+    name: "reserved 10-digit phone is OK",
+    content: `const n = "212-555-0142";`,
     expectPatterns: [],
   },
   {
-    name: "real phone is flagged",
+    name: "reserved 10-digit phone with parens is OK",
+    content: `const n = "(212) 555-0142";`,
+    expectPatterns: [],
+  },
+  {
+    name: "real 10-digit phone is flagged",
     content: `const n = "212-555-1234";`,
+    expectPatterns: ["non-reserved-phone"],
+  },
+  {
+    name: "real 10-digit phone with parens is flagged",
+    content: `const n = "(212) 555-9999";`,
     expectPatterns: ["non-reserved-phone"],
   },
   {


### PR DESCRIPTION
Addresses Codex and Devin feedback on #26750.

## Summary
- **Phone regex:** the negative lookahead sat before the area-code group, so it matched the area code instead of the exchange — every 10-digit reserved number like \`212-555-0142\` was falsely flagged. Moved the lookahead to after \`\\(?\\d{3}\\)?[-. ]?\` so it now gates the exchange.
- **Self-test:** \"reserved phone is OK\" used a 7-digit input that can't match the 10-digit regex, so it passed vacuously. Replaced with 10-digit reserved inputs (plain and parenthesized) and added 10-digit non-reserved flagged cases.
- **Suppression gap:** \`git diff --unified=0\` drops all context, so a pre-existing \`generic-examples:ignore-next-line\` above an edited line never appeared in the diff and silently failed to suppress. Switched both staged and CI diff captures to \`--unified=1\`, which includes one line of context and lets \`parseUnifiedDiff\` populate \`previousContent\` correctly.

## Test plan
- [x] \`bun scripts/check-generic-examples.ts --self-test\` — 8/8 pass
- [x] Manual regex sanity check against common formats (dashed, parenthesized, dotted, +1 prefix, 800 area) — all correctly classify reserved vs non-reserved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
