### PR TITLE
fix(meet-join): align native-messaging schemas with daemon-side parity

### DIFF
--- a/skills/meet-join/contracts/__tests__/native-messaging.test.ts
+++ b/skills/meet-join/contracts/__tests__/native-messaging.test.ts
@@ -98,7 +98,13 @@ describe("ExtensionReadyMessageSchema", () => {
 
 describe("ExtensionLifecycleMessageSchema", () => {
   test("parses every lifecycle state", () => {
-    for (const state of ["joining", "joined", "left", "error"] as const) {
+    for (const state of [
+      "joining",
+      "joined",
+      "leaving",
+      "left",
+      "error",
+    ] as const) {
       const input = {
         type: "lifecycle" as const,
         state,
@@ -551,6 +557,12 @@ describe("BotJoinCommandSchema", () => {
 describe("BotLeaveCommandSchema", () => {
   test("parses a leave with reason", () => {
     const input = { type: "leave" as const, reason: "host ended meeting" };
+    const parsed = BotLeaveCommandSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  test("parses a leave without reason", () => {
+    const input = { type: "leave" as const };
     const parsed = BotLeaveCommandSchema.parse(input);
     expect(parsed).toEqual(input);
   });

--- a/skills/meet-join/contracts/native-messaging.ts
+++ b/skills/meet-join/contracts/native-messaging.ts
@@ -42,10 +42,16 @@ export const ExtensionReadyMessageSchema = z.object({
 });
 export type ExtensionReadyMessage = z.infer<typeof ExtensionReadyMessageSchema>;
 
-/** Lifecycle state values reported by the extension to the bot. */
+/**
+ * Lifecycle state values reported by the extension to the bot. Mirrors
+ * {@link ./events.js}'s `LifecycleStateSchema` — keep these enums in sync so
+ * the extension-side and daemon-side lifecycle telemetry share a single
+ * vocabulary.
+ */
 export const ExtensionLifecycleStateSchema = z.enum([
   "joining",
   "joined",
+  "leaving",
   "left",
   "error",
 ]);
@@ -387,11 +393,16 @@ export const BotJoinCommandSchema = z.object({
 });
 export type BotJoinCommand = z.infer<typeof BotJoinCommandSchema>;
 
-/** Ask the extension to cleanly leave the current meeting. */
+/**
+ * Ask the extension to cleanly leave the current meeting. Mirrors the
+ * daemon-facing `LeaveCommandSchema` in {@link ./commands.js} — `reason` is
+ * optional there, so it is optional here too (a native-messaging bridge
+ * that forwards a reasonless leave must not be rejected).
+ */
 export const BotLeaveCommandSchema = z.object({
   type: z.literal("leave"),
-  /** Human-readable reason, surfaced in logs/telemetry. */
-  reason: z.string().min(1),
+  /** Optional human-readable reason, surfaced in logs/telemetry. */
+  reason: z.string().min(1).optional(),
 });
 export type BotLeaveCommand = z.infer<typeof BotLeaveCommandSchema>;
 


### PR DESCRIPTION
## Summary
- Add `leaving` to `ExtensionLifecycleStateSchema` so it matches `LifecycleStateSchema` in `contracts/events.ts` (the doc comment already claims parity).
- Make `reason` optional on `BotLeaveCommandSchema` to match the daemon-facing `LeaveCommandSchema` in `contracts/commands.ts`. Still rejects empty strings when provided.
- Extend `native-messaging.test.ts`: lifecycle round-trip now covers `leaving`, plus a new reasonless-leave case.

Follow-up to #26565 — addresses review comments from Codex and Devin.

## Test plan
- [x] `bun test contracts/__tests__/native-messaging.test.ts` (55 pass)
- [x] `bunx tsc --noEmit` in `skills/meet-join/contracts` (clean)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
