### PR TITLE
fix(gateway): prune loopback auth-failure state to avoid unbounded growth

### DIFF
--- a/gateway/src/__tests__/rate-limit-loopback.test.ts
+++ b/gateway/src/__tests__/rate-limit-loopback.test.ts
@@ -55,4 +55,19 @@ describe("checkAuthRateLimit loopback exemption", () => {
     );
     expect(res).toBeNull();
   });
+
+  test("prunes accumulated failure state for loopback IPs", () => {
+    const ip = "127.0.0.1";
+    const limiter = blockedLimiter(ip, 500);
+    // Internal failures map holds the array of timestamps for this IP before
+    // the check runs; since isBlocked is never reached for loopback, clearIp
+    // must prune explicitly.
+    const failures = (limiter as unknown as { failures: Map<string, number[]> })
+      .failures;
+    expect(failures.get(ip)?.length ?? 0).toBe(500);
+
+    expect(checkAuthRateLimit(URL_V1, limiter, ip)).toBeNull();
+
+    expect(failures.has(ip)).toBe(false);
+  });
 });

--- a/gateway/src/http/middleware/rate-limit.ts
+++ b/gateway/src/http/middleware/rate-limit.ts
@@ -16,6 +16,13 @@ const log = getLogger("rate-limit");
  * `$INTERNAL_GATEWAY_BASE_URL`, etc.). The auth middleware already bypasses
  * loopback for token validation; this keeps the rate limiter consistent
  * with that policy.
+ *
+ * The limiter still accumulates failure timestamps for loopback IPs via
+ * `wrapWithAuthFailureTracking` and other upstream callers of
+ * `recordFailure`. Since loopback peers never get the 429, `isBlocked` is
+ * never invoked for them — which is the only path that prunes expired
+ * timestamps — so we explicitly `clearIp` here on every check to keep
+ * the per-IP failure map from growing unboundedly.
  */
 export function checkAuthRateLimit(
   url: URL,
@@ -23,7 +30,10 @@ export function checkAuthRateLimit(
   clientIp: string,
 ): Response | null {
   if (!isRateLimitedRoute(url)) return null;
-  if (isLoopbackAddress(clientIp)) return null;
+  if (isLoopbackAddress(clientIp)) {
+    authRateLimiter.clearIp(clientIp);
+    return null;
+  }
 
   if (authRateLimiter.isBlocked(clientIp)) {
     log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");


### PR DESCRIPTION
## Summary

Follow-up to #26468 addressing Codex P2 feedback.

`checkAuthRateLimit` exempts loopback peers from the 429 path but returned early *before* calling `AuthRateLimiter.isBlocked()`, which is the only code path that prunes expired failure timestamps. Since `wrapWithAuthFailureTracking` and other call sites still invoke `recordFailure()` for loopback failures, per-loopback-IP timestamp arrays would grow without bound.

Call `clearIp()` on every loopback check. Entries accumulate between checks but each check wipes state, capping per-loopback-IP memory at one request's worth.

## Test plan

- [x] Added regression test that seeds 500 loopback failures, invokes `checkAuthRateLimit`, and asserts the internal failures map entry is cleared.
- [x] Existing loopback-exemption tests still pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
