### PR TITLE
fix(pkb): normalize separators before archive prefix check

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1379,9 +1379,7 @@ export function loadSlackChronologicalMessages(
  *
  * Pure: takes pre-mapped renderable rows and returns the ts string only.
  */
-function detectActiveThreadTs(
-  rows: RenderableSlackMessage[],
-): string | null {
+function detectActiveThreadTs(rows: RenderableSlackMessage[]): string | null {
   for (let i = rows.length - 1; i >= 0; i--) {
     const row = rows[i];
     if (row.role !== "user") continue;
@@ -1806,7 +1804,9 @@ export async function applyRuntimeInjections(
             .filter((r) => {
               const abs = resolve(pkbRoot, r.path);
               if (inContext.has(abs)) return false;
-              const threshold = r.path.startsWith("archive/")
+              const threshold = r.path
+                .replace(/\\/g, "/")
+                .startsWith("archive/")
                 ? PKB_HINT_ARCHIVE_THRESHOLD
                 : PKB_HINT_THRESHOLD;
               return r.score >= threshold;


### PR DESCRIPTION
The stricter 0.7 score threshold for PKB archive paths used `r.path.startsWith("archive/")`. On Windows, PKB paths come from `path.relative(...)` and contain backslashes, so the POSIX-style prefix check never matched — the stricter archive threshold was silently bypassed.

Normalize separators before the check so Windows paths like `archive\foo.md` apply the archive threshold correctly.

Addresses Codex P2 feedback on #26744.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
