### PR TITLE
docs(memory): remove PR-number references from retriever JSDoc

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -355,9 +355,9 @@ export interface ContextLoadOpts {
   maxNodes?: number;
   /**
    * Optional dedicated user-message query text. When present and non-empty,
-   * `loadContextMemory` (PR 3) embeds this text independently of
+   * `loadContextMemory` embeds this text independently of
    * `recentSummaries` and uses the resulting vector to rank capability
-   * reserve slots. Leave `undefined` to preserve pre-PR-3 behavior.
+   * reserve slots. Leave `undefined` to use summary-only retrieval.
    */
   userQuery?: string;
 }
@@ -382,7 +382,7 @@ export interface ContextLoadResult {
    */
   sparseVector?: QdrantSparseVector;
   /**
-   * Dense query vector computed from `opts.userQuery` (PR 3). Surfaced so
+   * Dense query vector computed from `opts.userQuery`. Surfaced so
    * downstream callers (PKB hint search) can prefer it over the
    * summary-based `queryVector` for user-intent-aligned retrieval.
    * `undefined` when `userQuery` was not provided, was effectively empty,


### PR DESCRIPTION
## Summary

Addresses [Devin review feedback](https://github.com/vellum-ai/vellum-assistant/pull/26558) on #26558 flagging that JSDoc in `assistant/src/memory/graph/retriever.ts` referenced development-timeline PR numbers, violating the `assistant/AGENTS.md` rule:

> Comments should describe the current state of the codebase, not narrate its history. Avoid phrases like 'no longer does X', 'previously used Y', or 'was removed in PR Z'.

### Changes
- `ContextLoadOpts.userQuery` JSDoc: dropped `(PR 3)` and `pre-PR-3 behavior`, replaced with a description of current behavior.
- `ContextLoadResult.userQueryVector` JSDoc: dropped `(PR 3)`.

### Scope notes
Devin's third finding — a test named `"ignores userQuery when dual-query logic is not yet implemented (PR 2 baseline)"` — was already rewritten/removed by follow-ups #26566 and #26576, so no test change is needed here.

Other PR-number references in the same file (e.g. `(PR 3)` inside implementation comments at lines ~438 and ~488, and the `(PR 3)` describe block at `retriever.test.ts:237`) were introduced by #26561 / #26576 / #26739 and are intentionally left to their respective follow-ups per task scope.

## Test plan
- [x] `bunx tsc --noEmit` passes (comment-only change)
- [x] No behavior change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
