### PR TITLE
fix(migrations): make 044 provider stream timeout bump forward-only

### DIFF
--- a/assistant/src/workspace/migrations/044-bump-stale-provider-stream-timeout.ts
+++ b/assistant/src/workspace/migrations/044-bump-stale-provider-stream-timeout.ts
@@ -38,27 +38,14 @@ export const bumpStaleProviderStreamTimeoutMigration: WorkspaceMigration = {
     timeoutsObj.providerStreamTimeoutSec = 1800;
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
-  down(workspaceDir: string): void {
-    const configPath = join(workspaceDir, "config.json");
-    if (!existsSync(configPath)) return;
-
-    let config: Record<string, unknown>;
-    try {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
-      config = raw as Record<string, unknown>;
-    } catch {
-      return;
-    }
-
-    const timeouts = config.timeouts;
-    if (!timeouts || typeof timeouts !== "object" || Array.isArray(timeouts))
-      return;
-    const timeoutsObj = timeouts as Record<string, unknown>;
-
-    if (timeoutsObj.providerStreamTimeoutSec !== 1800) return;
-
-    timeoutsObj.providerStreamTimeoutSec = 300;
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  down(_workspaceDir: string): void {
+    // Forward-only: the runner marks migrations as applied even when `run()`
+    // was a no-op (e.g. workspaces that already had 1800 from the new schema
+    // default, or that never had the key at all). A `down()` that blindly
+    // rewrote 1800 → 300 would silently downgrade those workspaces and
+    // resurrect the "stream timed out after 300s" bug this migration fixes.
+    // We can't distinguish "this migration set 1800" from "the value was
+    // always 1800" without an extra state marker, so we treat the bump as
+    // irreversible. Users who genuinely want 300s can set it in config.
   },
 };


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #26688.

Migration 044 rewrites `timeouts.providerStreamTimeoutSec: 300` → `1800`. Its previous `down()` unconditionally rewrote `1800` back to `300`, but `runWorkspaceMigrations()` marks migrations as applied even on no-op runs. On rollback, workspaces that already had `1800` (from the new schema default) would be silently downgraded to `300`, resurrecting the very bug this migration fixes.

Marks `down()` as a no-op with an inline comment explaining why, matching the forward-only pattern already used by migrations 040, 042, and 043.

## Test plan

- [x] `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
