### PR TITLE
fix(daemon): strip web_search_tool_result on convergence-loop retries

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -899,8 +899,7 @@ export async function runAgentLoopImpl(
     // model sees one channel-wide view instead of the gateway's per-turn
     // hints. DMs render as a flat sequence (no thread tags), channels
     // include sibling threads.
-    const isSlackConversation =
-      ctx.channelCapabilities?.channel === "slack";
+    const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
     const slackChronologicalMessages = isSlackConversation
       ? loadSlackChronologicalMessages(
           ctx.conversationId,
@@ -1535,6 +1534,14 @@ export async function runAgentLoopImpl(
         if (isTrustedActor && currentInjectionMode !== "minimal") {
           ctx.graphMemory.retrackCachedNodes();
         }
+        const convergenceStrip = stripHistoricalWebSearchResults(runMessages);
+        if (convergenceStrip.stats.blocksStripped > 0) {
+          rlog.info(
+            { phase: "convergence", ...convergenceStrip.stats },
+            "Converted historical web_search_tool_result blocks to text summaries",
+          );
+          runMessages = convergenceStrip.messages;
+        }
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
         state.contextTooLargeDetected = false;
@@ -1663,6 +1670,14 @@ export async function runAgentLoopImpl(
             if (isTrustedActor && currentInjectionMode !== "minimal") {
               ctx.graphMemory.retrackCachedNodes();
             }
+            const emergencyStrip = stripHistoricalWebSearchResults(runMessages);
+            if (emergencyStrip.stats.blocksStripped > 0) {
+              rlog.info(
+                { phase: "emergency_compact", ...emergencyStrip.stats },
+                "Converted historical web_search_tool_result blocks to text summaries",
+              );
+              runMessages = emergencyStrip.messages;
+            }
             preRepairMessages = runMessages;
             preRunHistoryLength = runMessages.length;
             state.contextTooLargeDetected = false;
@@ -1786,6 +1801,14 @@ export async function runAgentLoopImpl(
           });
           if (isTrustedActor && currentInjectionMode !== "minimal") {
             ctx.graphMemory.retrackCachedNodes();
+          }
+          const fallbackStrip = stripHistoricalWebSearchResults(runMessages);
+          if (fallbackStrip.stats.blocksStripped > 0) {
+            rlog.info(
+              { phase: "fail_gracefully_compact", ...fallbackStrip.stats },
+              "Converted historical web_search_tool_result blocks to text summaries",
+            );
+            runMessages = fallbackStrip.messages;
           }
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;


### PR DESCRIPTION
Follow-up to #26587. The pre-run strip and ordering-error retry strip covered the two initial agent-loop entry points, but the convergence (context-too-large) recovery loop rebuilds `runMessages` from `ctx.messages` via `applyRuntimeInjections` at three additional sites — the main convergence rerun, emergency-compaction rerun, and fail-gracefully fallback rerun — without re-stripping. On those paths, stale `web_search_tool_result` blocks (whose opaque `encrypted_content` tokens have expired) could re-enter the replay and trigger a provider rejection.

Add `stripHistoricalWebSearchResults` after each `applyRuntimeInjections` call in the convergence paths so the strip is consistent across every rebuild site.

Devin review: https://github.com/vellum-ai/vellum-assistant/pull/26587#discussion_r3106161210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
