### PR TITLE
fix(macos): distinguish non-sRGB colors in math cache fallback key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -909,19 +909,26 @@ func clearMathImageCache() {
 
 /// Converts an `NSColor` to a stable hex cache-key component. Uses the
 /// sRGB-calibrated components so color-space shifts don't cause cache misses
-/// on logically identical colors. Returns a sentinel when the color cannot be
-/// bridged into sRGB (e.g. an asset-catalog pattern or named color whose
-/// component accessors would throw) so the caller falls back to a stable but
-/// non-RGB-derived key instead of crashing.
+/// on logically identical colors. When the color cannot be bridged into sRGB
+/// (e.g. an asset-catalog pattern or named color whose component accessors
+/// would throw), derives a distinguishing key from the `CGColor` color-space
+/// name and components so two unresolved colors do not collide on the same
+/// cache entry.
 private func mathCacheColorKey(_ color: NSColor) -> String {
-    guard let rgb = color.usingColorSpace(.sRGB) else {
-        return "unresolved"
+    if let rgb = color.usingColorSpace(.sRGB) {
+        let r = Int((rgb.redComponent * 255).rounded())
+        let g = Int((rgb.greenComponent * 255).rounded())
+        let b = Int((rgb.blueComponent * 255).rounded())
+        let a = Int((rgb.alphaComponent * 255).rounded())
+        return String(format: "%02X%02X%02X%02X", r, g, b, a)
     }
-    let r = Int((rgb.redComponent * 255).rounded())
-    let g = Int((rgb.greenComponent * 255).rounded())
-    let b = Int((rgb.blueComponent * 255).rounded())
-    let a = Int((rgb.alphaComponent * 255).rounded())
-    return String(format: "%02X%02X%02X%02X", r, g, b, a)
+    let cg = color.cgColor
+    let spaceName = (cg.colorSpace?.name as String?) ?? "unknown"
+    if let components = cg.components {
+        let joined = components.map { String(format: "%.6f", $0) }.joined(separator: ",")
+        return "unresolved:\(spaceName):\(joined)"
+    }
+    return "unresolved:\(spaceName):\(color.description)"
 }
 
 /// Renders a LaTeX block via `SwiftMath.MathImage`. Results are cached per


### PR DESCRIPTION
## Summary
- Codex flagged that `mathCacheColorKey` in `MarkdownSegmentView.swift` returned a single `"unresolved"` sentinel for every NSColor that failed `usingColorSpace(.sRGB)`. Two distinct non-sRGB colors collided on the same cache entry, so rendering the second color returned the first color's bitmap.
- Fallback now derives a key from the `CGColor` color-space name plus component values (with an `NSColor.description` backstop when components are unavailable), so unresolved colors get distinct cache entries.

Addresses P2 feedback on #26685.

## Test plan
- [ ] Type-check builds
- [ ] Visual spot check: math blocks render with correct colors under dark/light themes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
