### PR TITLE
chrome-extension: add Advanced environment selector and reconnect flow

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -66,6 +66,40 @@ For automated publishing, the `release.yml` GitHub Actions workflow builds, pack
 
 That's it. The extension auto-reconnects on browser restarts, network drops, and assistant restarts. Click **Pause** to intentionally stop the relay.
 
+## Environment Selector
+
+The popup's **Advanced** section includes an **Environment** dropdown that lets you switch between `local`, `dev`, `staging`, and `production` without rebuilding the extension. This controls which cloud API and web URLs are used for sign-in, pairing, and relay connections.
+
+### Precedence rules
+
+The effective environment is resolved in this order:
+
+| Priority | Source | Description |
+|---|---|---|
+| 1 (highest) | Popup override | Selected in the dropdown, persisted in `chrome.storage.local` |
+| 2 | Build-time default | Injected via `--define process.env.VELLUM_ENVIRONMENT=...` at bundle time |
+| 3 (fallback) | Hard-coded default | `dev` |
+
+### Expected defaults by context
+
+| Context | Build default | Notes |
+|---|---|---|
+| Local dev build (`bash build.sh`) | `dev` | No `--define` injection; falls back to `dev` |
+| `vel up` (local assistant) | `dev` build / `local` override | Build defaults to `dev`; use the popup dropdown to select `local` to target `localhost` endpoints |
+| Staging release artifact | `staging` | Set by `release.yml` via `--define` |
+| Production release artifact (CWS) | `production` | Set by `release.yml` via `--define` |
+
+### Behavior on change
+
+When you change the environment in the dropdown:
+
+1. The override is persisted immediately (survives popup close/reopen).
+2. The assistant catalog is refreshed (different environments may list different assistants).
+3. Local and cloud auth status panels are refreshed.
+4. If the extension is currently connected, it automatically disconnects and reconnects using the new environment's endpoints.
+
+To clear the override and revert to the build default, the dropdown simply selects the build-default value (no separate "reset" action needed since the worker treats selecting the same value as the build default equivalently).
+
 ## Debugging
 
 - **Service worker logs:** `chrome://extensions` > extension card > **Service worker** link

--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -27,6 +27,10 @@ import {
   deriveHealthStatusDisplay,
   shouldExpandTroubleshooting,
   hasTroubleshootingControls,
+  environmentLabel,
+  deriveEffectiveEnvironment,
+  deriveEnvironmentHint,
+  ENVIRONMENT_OPTIONS,
   type ConnectionPhase,
   type ConnectionHealthState,
   type ConnectionHealthDetail,
@@ -638,5 +642,122 @@ describe('integrated health-to-display scenarios', () => {
     expect(selectorDisplay.kind).toBe('visible');
     if (selectorDisplay.kind !== 'visible') throw new Error('unreachable');
     expect(selectorDisplay.options.length).toBe(2);
+  });
+});
+
+// ── environmentLabel ────────────────────────────────────────────────
+
+describe('environmentLabel', () => {
+  test('returns "Local" for local', () => {
+    expect(environmentLabel('local')).toBe('Local');
+  });
+
+  test('returns "Development" for dev', () => {
+    expect(environmentLabel('dev')).toBe('Development');
+  });
+
+  test('returns "Staging" for staging', () => {
+    expect(environmentLabel('staging')).toBe('Staging');
+  });
+
+  test('returns "Production" for production', () => {
+    expect(environmentLabel('production')).toBe('Production');
+  });
+
+  test('all environment options have labels', () => {
+    for (const env of ENVIRONMENT_OPTIONS) {
+      const label = environmentLabel(env);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── ENVIRONMENT_OPTIONS ─────────────────────────────────────────────
+
+describe('ENVIRONMENT_OPTIONS', () => {
+  test('contains exactly four environments', () => {
+    expect(ENVIRONMENT_OPTIONS.length).toBe(4);
+  });
+
+  test('includes local, dev, staging, production in order', () => {
+    expect(ENVIRONMENT_OPTIONS[0]).toBe('local');
+    expect(ENVIRONMENT_OPTIONS[1]).toBe('dev');
+    expect(ENVIRONMENT_OPTIONS[2]).toBe('staging');
+    expect(ENVIRONMENT_OPTIONS[3]).toBe('production');
+  });
+});
+
+// ── deriveEffectiveEnvironment ──────────────────────────────────────
+
+describe('deriveEffectiveEnvironment', () => {
+  test('returns override when present', () => {
+    expect(deriveEffectiveEnvironment('staging', 'dev')).toBe('staging');
+  });
+
+  test('returns build default when override is null', () => {
+    expect(deriveEffectiveEnvironment(null, 'staging')).toBe('staging');
+  });
+
+  test('returns build default when override is undefined', () => {
+    expect(deriveEffectiveEnvironment(undefined, 'production')).toBe('production');
+  });
+
+  test('falls back to dev when both override and build default are absent', () => {
+    expect(deriveEffectiveEnvironment(null, undefined)).toBe('dev');
+  });
+
+  test('falls back to dev when both are undefined', () => {
+    expect(deriveEffectiveEnvironment(undefined, undefined)).toBe('dev');
+  });
+
+  test('override takes precedence over build default', () => {
+    expect(deriveEffectiveEnvironment('local', 'production')).toBe('local');
+  });
+});
+
+// ── deriveEnvironmentHint ───────────────────────────────────────────
+
+describe('deriveEnvironmentHint', () => {
+  test('shows override message when override is active', () => {
+    const hint = deriveEnvironmentHint('staging', 'dev');
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('Development');
+  });
+
+  test('shows override with production default label', () => {
+    const hint = deriveEnvironmentHint('local', 'production');
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('Production');
+  });
+
+  test('shows build default message when no override', () => {
+    const hint = deriveEnvironmentHint(null, 'staging');
+    expect(hint).toBe('Using build default');
+  });
+
+  test('shows build default message when override is undefined', () => {
+    const hint = deriveEnvironmentHint(undefined, 'dev');
+    expect(hint).toBe('Using build default');
+  });
+
+  test('shows generic default when both are absent', () => {
+    const hint = deriveEnvironmentHint(null, undefined);
+    expect(hint).toBe('Using default');
+  });
+
+  test('shows generic default when both are undefined', () => {
+    const hint = deriveEnvironmentHint(undefined, undefined);
+    expect(hint).toBe('Using default');
+  });
+
+  test('override hint includes build default label in parentheses', () => {
+    const hint = deriveEnvironmentHint('production', 'dev');
+    expect(hint).toContain('(Development)');
+  });
+
+  test('override hint with no build default uses dev as fallback label', () => {
+    const hint = deriveEnvironmentHint('staging', undefined);
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('dev');
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -21,6 +21,7 @@
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
 import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+import type { ExtensionEnvironment } from '../background/extension-environment.js';
 
 // ── Health state types (mirrored from worker.ts) ───────────────────
 
@@ -402,4 +403,97 @@ export function hasTroubleshootingControls(
   authProfile: AssistantAuthProfile | null,
 ): boolean {
   return authProfile === 'local-pair' || authProfile === 'cloud-oauth';
+}
+
+// ── Environment display helpers ─────────────────────────────────────
+//
+// These functions derive user-facing labels and display state for the
+// environment selector dropdown in the popup's Advanced section.
+
+/**
+ * Response shape from the worker's `environment-get` and
+ * `environment-set` messages.
+ */
+export interface EnvironmentStateResponse {
+  ok: boolean;
+  effectiveEnvironment?: ExtensionEnvironment;
+  overrideEnvironment?: ExtensionEnvironment | null;
+  buildDefaultEnvironment?: ExtensionEnvironment;
+  error?: string;
+}
+
+/**
+ * The set of environments available in the dropdown.
+ */
+export const ENVIRONMENT_OPTIONS: readonly ExtensionEnvironment[] = [
+  'local',
+  'dev',
+  'staging',
+  'production',
+] as const;
+
+/**
+ * Map an environment value to a user-friendly display label.
+ *
+ * | Value        | Label       |
+ * |--------------|-------------|
+ * | local        | Local       |
+ * | dev          | Development |
+ * | staging      | Staging     |
+ * | production   | Production  |
+ */
+export function environmentLabel(env: ExtensionEnvironment): string {
+  switch (env) {
+    case 'local':
+      return 'Local';
+    case 'dev':
+      return 'Development';
+    case 'staging':
+      return 'Staging';
+    case 'production':
+      return 'Production';
+  }
+}
+
+/**
+ * Derive the effective environment to display, applying the precedence
+ * rules:
+ *   1. overrideEnvironment (popup-persisted selection)
+ *   2. buildDefaultEnvironment (compile-time define)
+ *   3. fallback to 'dev'
+ *
+ * This mirrors the worker's resolution logic but operates on the
+ * pre-resolved response fields for display purposes.
+ */
+export function deriveEffectiveEnvironment(
+  overrideEnvironment: ExtensionEnvironment | null | undefined,
+  buildDefaultEnvironment: ExtensionEnvironment | undefined,
+): ExtensionEnvironment {
+  if (overrideEnvironment) return overrideEnvironment;
+  if (buildDefaultEnvironment) return buildDefaultEnvironment;
+  return 'dev';
+}
+
+/**
+ * Derive a brief hint string explaining the current environment
+ * selection source.
+ *
+ * - When an override is active: "Overriding build default (<default>)"
+ * - When using build default: "Using build default"
+ * - When no info available: "Using default"
+ */
+export function deriveEnvironmentHint(
+  overrideEnvironment: ExtensionEnvironment | null | undefined,
+  buildDefaultEnvironment: ExtensionEnvironment | undefined,
+): string {
+  if (overrideEnvironment) {
+    const defaultLabel = buildDefaultEnvironment
+      ? environmentLabel(buildDefaultEnvironment)
+      : 'dev';
+    return `Overriding build default (${defaultLabel})`;
+  }
+  if (buildDefaultEnvironment) {
+    return 'Using build default';
+  }
+  return 'Using default';
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -601,6 +601,17 @@
 
     <div id="troubleshoot-body" hidden>
       <div class="advanced-setting">
+        <label for="environment-select">Environment</label>
+        <select id="environment-select">
+          <option value="local">Local</option>
+          <option value="dev">Development</option>
+          <option value="staging">Staging</option>
+          <option value="production">Production</option>
+        </select>
+        <p class="hint" id="environment-hint">Overrides the build default for this extension profile.</p>
+      </div>
+
+      <div class="advanced-setting">
         <label for="port-input">Connection port</label>
         <input
           type="text"

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -119,6 +119,13 @@ let currentAuthProfile: AssistantAuthProfile | null = null;
 let currentHealthState: ConnectionHealthState = 'paused';
 let currentDebugDetails: string | null = null;
 
+// ── Current environment state ───────────────────────────────────────
+//
+// Tracks the build-default environment so the change handler can
+// detect when the user re-selects the default and clear the override.
+
+let currentBuildDefaultEnvironment: string | undefined;
+
 // ── Connection phase management ─────────────────────────────────────
 
 /**
@@ -800,6 +807,8 @@ function loadEnvironmentState(): void {
   chrome.runtime.sendMessage({ type: 'environment-get' }, (response: EnvironmentStateResponse) => {
     if (chrome.runtime.lastError || !response?.ok) return;
 
+    currentBuildDefaultEnvironment = response.buildDefaultEnvironment;
+
     const effective = response.effectiveEnvironment ?? 'dev';
     environmentSelect.value = effective;
     environmentHint.textContent = deriveEnvironmentHint(
@@ -826,10 +835,16 @@ environmentSelect.addEventListener('change', async () => {
   errorText.style.display = 'none';
   hideDebugDetails();
 
+  // When the user selects the build-default environment, clear the
+  // override so future bundle updates can change the default without
+  // the user staying pinned to a stale value.
+  const isDefault = currentBuildDefaultEnvironment != null && newEnv === currentBuildDefaultEnvironment;
+  const overrideValue = isDefault ? null : newEnv;
+
   // Persist the environment override via the worker.
   const response = await new Promise<EnvironmentStateResponse>((resolve) => {
     chrome.runtime.sendMessage(
-      { type: 'environment-set', environment: newEnv },
+      { type: 'environment-set', environment: overrideValue },
       (r: EnvironmentStateResponse) => {
         if (chrome.runtime.lastError) {
           resolve({ ok: false, error: chrome.runtime.lastError.message ?? 'Unknown error' });

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -43,12 +43,14 @@ import {
   healthToPhase,
   shouldExpandTroubleshooting,
   hasTroubleshootingControls,
+  deriveEnvironmentHint,
   type ConnectionHealthState,
   type ConnectionHealthDetail,
   type ConnectionPhase,
   type GetStatusResponse,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
+  type EnvironmentStateResponse,
 } from './popup-state.js';
 
 const DEFAULT_RELAY_PORT = 7830;
@@ -93,6 +95,13 @@ const assistantSelectorGroup = document.getElementById(
 const assistantSelect = document.getElementById(
   'assistant-select',
 ) as HTMLSelectElement;
+
+const environmentSelect = document.getElementById(
+  'environment-select',
+) as HTMLSelectElement;
+const environmentHint = document.getElementById(
+  'environment-hint',
+) as HTMLParagraphElement;
 
 // ── Current assistant state ─────────────────────────────────────────
 //
@@ -772,3 +781,94 @@ btnCloudSignIn.addEventListener('click', async () => {
 });
 
 refreshCloudStatus();
+
+// ── Environment selector ────────────────────────────────────────────
+//
+// The environment dropdown allows developers to override the build-time
+// default environment for the current extension profile. This changes
+// which cloud API and web URLs are used for sign-in, pairing, and relay.
+//
+// On popup open we load the effective environment from the worker via
+// `environment-get` and render the selected value. On change we persist
+// the override via `environment-set`, refresh the assistant catalog and
+// auth status, and force a disconnect/reconnect if currently connected.
+
+/**
+ * Load environment state from the worker and render the selector.
+ */
+function loadEnvironmentState(): void {
+  chrome.runtime.sendMessage({ type: 'environment-get' }, (response: EnvironmentStateResponse) => {
+    if (chrome.runtime.lastError || !response?.ok) return;
+
+    const effective = response.effectiveEnvironment ?? 'dev';
+    environmentSelect.value = effective;
+    environmentHint.textContent = deriveEnvironmentHint(
+      response.overrideEnvironment,
+      response.buildDefaultEnvironment,
+    );
+  });
+}
+
+// Load on popup open.
+loadEnvironmentState();
+
+/**
+ * Handle environment dropdown changes.
+ *
+ * Orchestration after environment-set:
+ *   1. Refresh assistant catalog (endpoints may have changed).
+ *   2. Refresh local/cloud auth status panels.
+ *   3. If currently connected, disconnect and reconnect so the new
+ *      environment-sensitive endpoints take effect immediately.
+ */
+environmentSelect.addEventListener('change', async () => {
+  const newEnv = environmentSelect.value;
+  errorText.style.display = 'none';
+  hideDebugDetails();
+
+  // Persist the environment override via the worker.
+  const response = await new Promise<EnvironmentStateResponse>((resolve) => {
+    chrome.runtime.sendMessage(
+      { type: 'environment-set', environment: newEnv },
+      (r: EnvironmentStateResponse) => {
+        if (chrome.runtime.lastError) {
+          resolve({ ok: false, error: chrome.runtime.lastError.message ?? 'Unknown error' });
+          return;
+        }
+        resolve(r ?? { ok: false, error: 'No response from service worker' });
+      },
+    );
+  });
+
+  if (!response.ok) {
+    showError(response.error ?? 'Failed to set environment');
+    return;
+  }
+
+  // Update the hint to reflect the new state.
+  environmentHint.textContent = deriveEnvironmentHint(
+    response.overrideEnvironment,
+    response.buildDefaultEnvironment,
+  );
+
+  // Refresh the assistant catalog — environment change may affect
+  // which assistants are available and their auth endpoints.
+  loadAssistantCatalog();
+
+  // Refresh auth status panels.
+  void refreshLocalStatus();
+  void refreshCloudStatus();
+
+  // If currently connected, force disconnect then reconnect so the new
+  // environment-sensitive endpoints take effect immediately. The worker's
+  // `environment-set` handler does NOT auto-reconnect — the popup
+  // orchestrates this explicitly.
+  if (currentHealthState === 'connected' || currentHealthState === 'connecting' || currentHealthState === 'reconnecting') {
+    // Disconnect first.
+    await new Promise<void>((resolve) => {
+      chrome.runtime.sendMessage({ type: 'pause' }, () => resolve());
+    });
+    // Reconnect with the new environment.
+    await requestConnect();
+  }
+});


### PR DESCRIPTION
## Summary
- Add environment dropdown to popup Advanced section with persisted selection
- Wire environment changes to disconnect/reconnect for immediate effect
- Add popup-state helpers and tests for environment display logic
- Update README with environment selector docs and precedence rules

Part of plan: chrome-extension-env-selector.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
