### PR TITLE
fix(macos): keep progress card duration monotonic across .complete transition

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -40,6 +40,11 @@ struct AssistantProgressView: View {
     /// When the thinking phase ended (card transitioned to `.complete`).
     /// Nil while thinking is still in progress.
     @State private var thinkingAfterToolsEndDate: Date?
+    /// When the card first transitioned to `.complete`. Independent of the
+    /// thinking anchors — captured for every completion so the header total
+    /// duration stays monotonic across the `.toolsCompleteThinking` → `.complete`
+    /// transition even when the daemon never emitted `.processing`.
+    @State private var cardCompletedAt: Date?
 
     // MARK: - Init
 
@@ -129,6 +134,10 @@ struct AssistantProgressView: View {
         _processingStartDate = State(initialValue: initialProcessingStartDate)
         _thinkingAfterToolsStartDate = State(initialValue: initialThinkingStart)
         _thinkingAfterToolsEndDate = State(initialValue: initialThinkingEnd)
+        // On rehydration the card is already complete; fall back to latestCompletedAt
+        // so the header duration matches what it displayed before recycling.
+        let initialCardCompletedAt: Date? = model.phase == .complete ? model.latestCompletedAt : nil
+        _cardCompletedAt = State(initialValue: initialCardCompletedAt)
     }
 
     /// Stable key for this progress card in `progressUIState.cardExpansionOverrides`.
@@ -324,6 +333,13 @@ struct AssistantProgressView: View {
                     let duration = now.timeIntervalSince(thinkingStart)
                     progressUIState.setThinkingDuration(for: key, duration: duration)
                 }
+            }
+            // Anchor the card's completion time on the first `.complete` transition.
+            // Unlike the thinking anchor above this fires regardless of whether
+            // `.processing` was ever observed, keeping the header total monotonic
+            // when the daemon skips straight from `.toolsCompleteThinking`.
+            if newPhase == .complete, cardCompletedAt == nil {
+                cardCompletedAt = Date()
             }
             if shouldAutoExpandOnPhaseChange, !isExpanded {
                 ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
@@ -531,10 +547,12 @@ struct AssistantProgressView: View {
     @ViewBuilder
     private func completedDurationLabel(model: ProgressCardPresentationModel) -> some View {
         if let start = model.earliestStartedAt {
-            // Use thinkingAfterToolsEndDate as the effective end time when present,
-            // so the parent total includes thinking time and matches the sum of
-            // sub-activity durations (tool steps + thinking row).
-            let effectiveEnd = thinkingAfterToolsEndDate ?? model.latestCompletedAt
+            // Prefer thinkingAfterToolsEndDate (when real thinking was tracked) so the
+            // parent total matches the sum of sub-activity durations. Otherwise fall
+            // back to cardCompletedAt, captured at the `.complete` transition, so the
+            // live elapsed timer doesn't drop back to tool-runtime-only when the card
+            // passes through `.toolsCompleteThinking` without ever hitting `.processing`.
+            let effectiveEnd = thinkingAfterToolsEndDate ?? cardCompletedAt ?? model.latestCompletedAt
             if let end = effectiveEnd {
                 let seconds = end.timeIntervalSince(start)
                 Text(formatStepDuration(seconds))


### PR DESCRIPTION
Follow-up to #26285 addressing Codex P2 feedback on `AssistantProgressView.swift:314`.

## Problem

#26285 gated the thinking-after-tools anchor on `newPhase == .processing`. Cards that transitioned `.toolsCompleteThinking` → `.complete` without ever entering `.processing` never set `thinkingAfterToolsStartDate`/`EndDate`, so `completedDurationLabel` fell back to `model.latestCompletedAt`. The header total then dropped from the live-elapsed timer to just tool runtime — a user-visible duration regression.

## Fix

Introduce a separate `cardCompletedAt` anchor, captured at the first `.complete` phase transition regardless of whether thinking was observed. Use it as the fallback end-time in `completedDurationLabel` so the displayed total stays monotonic.

The `ThinkingStepRow` gating is untouched — it still only renders when the daemon explicitly emitted `.processing` (real extended thinking), preserving the intent of #26285.

## Test plan

- [ ] Card runs tools then streams text with no explicit `thinking_delta` → elapsed timer does not drop when card lands on `.complete`.
- [ ] Card with real thinking → `ThinkingStepRow` still appears, header total still matches sum of sub-activities.
- [ ] Card rehydrated post-completion → duration displays correctly (seeds `cardCompletedAt` from `latestCompletedAt`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
