### PR TITLE
fix(meet-join): harden NMH shim — UTF-8 decoder, listener cleanup, buffer cap

### DIFF
--- a/skills/meet-join/bot/__tests__/nmh-shim.test.ts
+++ b/skills/meet-join/bot/__tests__/nmh-shim.test.ts
@@ -271,6 +271,95 @@ describe("nmh-shim", () => {
     expect(elapsed).toBeLessThan(1500);
   });
 
+  test("preserves multibyte UTF-8 split across socket chunk boundaries", async () => {
+    const socketPath = freshSocketPath();
+    handle = await startServer(socketPath);
+
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const shimDone = runShim({
+      socketPath,
+      stdin,
+      stdout,
+      connectRetries: 3,
+      connectRetryDelayMs: 20,
+    });
+    shimDone.catch(() => {
+      // Swallow; asserted by stdout shape below.
+    });
+
+    const client = await handle.onClient;
+
+    // Build a payload whose JSON encoding contains characters that span
+    // multiple UTF-8 bytes (here: an emoji that requires a 4-byte sequence
+    // and CJK characters that require 3 bytes). Splitting the byte stream
+    // mid-codepoint would corrupt this if the shim decoded chunks
+    // independently.
+    const message = "héllo 🌍 世界";
+    const payload = { type: "diagnostic", level: "info", message };
+    const lineBytes = Buffer.from(`${JSON.stringify(payload)}\n`, "utf8");
+
+    // Split such that at least one multibyte codepoint straddles the seam.
+    const splitAt = lineBytes.indexOf(0xf0); // first byte of the 4-byte 🌍
+    expect(splitAt).toBeGreaterThan(0);
+    client.write(lineBytes.subarray(0, splitAt + 1));
+    await sleep(20);
+    client.write(lineBytes.subarray(splitAt + 1));
+
+    const deadline = Date.now() + 1000;
+    let collected: unknown[] = [];
+    while (Date.now() < deadline && collected.length < 1) {
+      const buf = stdout.collected();
+      if (buf.byteLength > 0) {
+        collected = createFrameReader().push(buf);
+      }
+      if (collected.length < 1) await sleep(10);
+    }
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toEqual(payload);
+
+    stdin.finish();
+    await shimDone;
+  });
+
+  test("settles cleanly on socket close without leaking stdin listeners", async () => {
+    const socketPath = freshSocketPath();
+    handle = await startServer(socketPath);
+
+    const stdin = new ManualReadable();
+    const stdout = new CollectingWritable();
+
+    const before = stdin.listenerCount("data");
+
+    const shimDone = runShim({
+      socketPath,
+      stdin,
+      stdout,
+      connectRetries: 3,
+      connectRetryDelayMs: 20,
+    });
+
+    const client = await handle.onClient;
+    // Give the shim a tick to finish wiring listeners after its connect
+    // callback resolves on this side.
+    await sleep(10);
+    expect(stdin.listenerCount("data")).toBeGreaterThan(before);
+    expect(stdin.listenerCount("end")).toBeGreaterThan(0);
+    expect(stdin.listenerCount("error")).toBeGreaterThan(0);
+
+    // Server closes — runShim should resolve and detach every stdin
+    // listener it attached, so the host process's event loop isn't
+    // pinned alive by the shim's references.
+    client.end();
+    await shimDone;
+
+    expect(stdin.listenerCount("data")).toBe(before);
+    expect(stdin.listenerCount("end")).toBe(0);
+    expect(stdin.listenerCount("error")).toBe(0);
+  });
+
   test("resolves cleanly when the server closes the connection", async () => {
     const socketPath = freshSocketPath();
     handle = await startServer(socketPath);

--- a/skills/meet-join/bot/src/native-messaging/nmh-shim.ts
+++ b/skills/meet-join/bot/src/native-messaging/nmh-shim.ts
@@ -29,6 +29,7 @@
  */
 
 import { connect, type Socket } from "node:net";
+import { StringDecoder } from "node:string_decoder";
 
 import { createFrameReader, encodeFrame } from "./nmh-protocol.js";
 
@@ -52,6 +53,15 @@ export interface RunShimOptions {
 
 const DEFAULT_CONNECT_RETRIES = 5;
 const DEFAULT_CONNECT_RETRY_DELAY_MS = 200;
+
+/**
+ * Hard cap on the socket→stdout decode buffer. Mirrors the per-frame ceiling
+ * the protocol layer enforces: a single bot→Chrome message can't legitimately
+ * exceed `MAX_FRAME_SIZE`, so a buffer that grows past 2× without yielding a
+ * complete newline-terminated line means the upstream is malformed (no
+ * newlines, oversized line) and we abort rather than grow unbounded.
+ */
+const MAX_SOCKET_BUFFER_BYTES = 2_000_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -130,21 +140,12 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;
-    const settle = (err?: Error): void => {
-      if (settled) return;
-      settled = true;
-      try {
-        socket.end();
-      } catch {
-        // socket may already be torn down — nothing actionable.
-      }
-      if (err) reject(err);
-      else resolve();
-    };
 
-    // ----------------------- Chrome stdin → socket -----------------------
-    const frameReader = createFrameReader();
-    stdin.on("data", (chunk: Buffer | string) => {
+    // Named handlers so `settle()` can detach them. Without detach, the shim
+    // process would keep the event loop alive after socket close (hanging on
+    // exit) and any later writes from a still-open stdin would silently land
+    // on a destroyed socket.
+    const onStdinData = (chunk: Buffer | string): void => {
       const buf =
         typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
       let frames: unknown[];
@@ -155,6 +156,10 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
         process.stderr.write(
           `nmh-shim: failed to parse Chrome frame: ${msg}\n`,
         );
+        // Frame-reader buffer is in an indeterminate state after a length /
+        // JSON parse failure — we can't resync, so tear down. (The socket
+        // direction below is newline-delimited and CAN resync at the next
+        // newline, which is why that path only logs.)
         settle(err instanceof Error ? err : new Error(msg));
         return;
       }
@@ -162,21 +167,28 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
         const line = `${JSON.stringify(frame)}\n`;
         socket.write(line);
       }
-    });
-    stdin.on("end", () => {
+    };
+    const onStdinEnd = (): void => {
       // Chrome closed its side: drain the socket and resolve cleanly.
       settle();
-    });
-    stdin.on("error", (err: unknown) => {
+    };
+    const onStdinError = (err: unknown): void => {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`nmh-shim: stdin error: ${msg}\n`);
       settle(err instanceof Error ? err : new Error(msg));
-    });
-
-    // ----------------------- socket → Chrome stdout -----------------------
-    let socketBuffer = "";
-    socket.on("data", (chunk: Buffer) => {
-      socketBuffer += chunk.toString("utf8");
+    };
+    const onSocketData = (chunk: Buffer): void => {
+      // Decode incrementally so a multibyte UTF-8 codepoint split across
+      // chunk boundaries is reassembled instead of corrupted into U+FFFDs.
+      socketBuffer += socketDecoder.write(chunk);
+      if (socketBuffer.length > MAX_SOCKET_BUFFER_BYTES) {
+        const err = new Error(
+          `nmh-shim: socket buffer exceeded ${MAX_SOCKET_BUFFER_BYTES} bytes without a newline`,
+        );
+        process.stderr.write(`${err.message}\n`);
+        settle(err);
+        return;
+      }
       // Drain complete newline-delimited JSON objects. The remainder (after
       // the last newline) stays in the buffer for the next read.
       let newlineIdx = socketBuffer.indexOf("\n");
@@ -189,6 +201,8 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
             const frame = encodeFrame(parsed);
             stdout.write(frame);
           } catch (err) {
+            // Newline-delimited stream — drop the bad line and resync at the
+            // next newline rather than tearing the shim down.
             const msg = err instanceof Error ? err.message : String(err);
             process.stderr.write(
               `nmh-shim: failed to encode bot→extension frame: ${msg}\n`,
@@ -197,16 +211,49 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
         }
         newlineIdx = socketBuffer.indexOf("\n");
       }
-    });
-    socket.on("error", (err) => {
+    };
+    const onSocketError = (err: unknown): void => {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`nmh-shim: socket error: ${msg}\n`);
       settle(err instanceof Error ? err : new Error(msg));
-    });
-    socket.on("close", () => {
+    };
+    const onSocketClose = (): void => {
       // Remote end closed: graceful exit.
       settle();
-    });
+    };
+
+    const settle = (err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      // Detach every listener we attached so the event loop can exit and so
+      // late-arriving stdin chunks don't try to write to a torn-down socket.
+      stdin.off("data", onStdinData);
+      stdin.off("end", onStdinEnd);
+      stdin.off("error", onStdinError);
+      socket.off("data", onSocketData);
+      socket.off("error", onSocketError);
+      socket.off("close", onSocketClose);
+      try {
+        socket.end();
+      } catch {
+        // socket may already be torn down — nothing actionable.
+      }
+      if (err) reject(err);
+      else resolve();
+    };
+
+    // ----------------------- Chrome stdin → socket -----------------------
+    const frameReader = createFrameReader();
+    stdin.on("data", onStdinData);
+    stdin.on("end", onStdinEnd);
+    stdin.on("error", onStdinError);
+
+    // ----------------------- socket → Chrome stdout -----------------------
+    const socketDecoder = new StringDecoder("utf8");
+    let socketBuffer = "";
+    socket.on("data", onSocketData);
+    socket.on("error", onSocketError);
+    socket.on("close", onSocketClose);
   });
 }
 
@@ -215,10 +262,16 @@ export async function runShim(opts: RunShimOptions): Promise<void> {
 // -------------------------------------------------------------------------
 if (import.meta.main) {
   const socketPath = process.env.NMH_SOCKET_PATH ?? "/run/nmh.sock";
-  runShim({ socketPath }).catch((err) => {
-    process.stderr.write(
-      `nmh-shim: ${err instanceof Error ? err.message : String(err)}\n`,
-    );
-    process.exit(1);
-  });
+  runShim({ socketPath })
+    .then(() => {
+      // Force exit on success so the process terminates even if some stdio
+      // handle still has a ref keeping the event loop alive.
+      process.exit(0);
+    })
+    .catch((err) => {
+      process.stderr.write(
+        `nmh-shim: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary

Address review feedback on #26571.

- **UTF-8 boundary (Codex P1):** `socket.on('data', chunk => chunk.toString('utf8'))` corrupted multibyte codepoints split across chunk boundaries. Switched to `StringDecoder` so transcript / chat text with emoji or CJK characters survives intact.
- **Process hang + silent message drop (Devin P1):** `settle()` no longer leaves stdin/socket listeners attached, and the entrypoint now calls `process.exit(0)` on success. Without these, after a remote socket close the shim kept the event loop alive on a torn-down socket and silently dropped any later Chrome→bot writes (`ERR_STREAM_WRITE_AFTER_END`).
- **Bounded `socketBuffer` (Devin nit):** capped at 2 MB so a misbehaving bot sending newline-less data can't grow the string indefinitely.
- **Asymmetric parse-error handling (Devin nit):** kept the asymmetry (Chrome-frame errors are unrecoverable; newline-JSON errors are resyncable) and documented why inline.

Added tests for the UTF-8 split case and for listener cleanup on socket close.

## Test plan

- [x] \`bun test skills/meet-join/bot/__tests__/nmh-shim.test.ts\` (6 pass — 2 new)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
