### PR TITLE
fix(docker): copy packages/ into gateway runner so ces-contracts symlinks resolve

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -36,6 +36,14 @@ RUN groupadd --system --gid 1001 gateway && \
     useradd --system --uid 1001 --gid gateway --create-home gateway
 
 COPY --from=builder --chown=gateway:gateway /app/gateway /app
+# `bun install` materializes `file:../packages/ces-contracts` as a
+# `node_modules/@vellumai/ces-contracts/` directory whose files are symlinks
+# pointing at absolute `/app/packages/ces-contracts/...` source paths in
+# the builder. Those absolute targets have to exist in the runner too, or
+# every `@vellumai/ces-contracts[/…]` import resolves to a dangling link
+# and the gateway crashes with "Cannot find module ..." at first use.
+# Copy the sibling package into the runner so the symlinks resolve.
+COPY --from=builder --chown=gateway:gateway /app/packages /app/packages
 
 RUN mkdir -p /gateway-security && chown gateway:gateway /gateway-security
 


### PR DESCRIPTION
## Summary
- The gateway pod crashes at first trust-rule access with `Cannot find module '@vellumai/ces-contracts/trust-rules' from '/app/src/trust-store.ts'`. Root cause: PR #26274 switched the runner COPY from `/app /app` to `/app/gateway /app`, so `packages/ces-contracts/` never lands in the runtime image.
- `bun install` installs `file:../packages/ces-contracts` as a `node_modules/@vellumai/ces-contracts/` directory whose files are absolute-path symlinks into `/app/packages/ces-contracts/...` (the builder's copy location). With those symlinks' targets missing from the runner, every `@vellumai/ces-contracts[/subpath]` import dangles.
- Fix: `COPY --from=builder /app/packages /app/packages` alongside the existing `/app/gateway` COPY so the symlinks resolve. Comment added explaining the constraint so this pattern doesn't regress again.

## Original prompt
Also seeing this in the gateway: error: Cannot find module '@vellumai/ces-contracts/trust-rules' from '/app/src/trust-store.ts'. Investigate and solve any issues with gateway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
