### PR TITLE
fix(slack): align metadata docstring with flat serialization and preserve unrelated keys on merge

### DIFF
--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -35,6 +35,55 @@ describe("readSlackMetadata", () => {
     expect(readSlackMetadata(raw)).toBeNull();
   });
 
+  test("rejects payloads with malformed optional fields", () => {
+    const badThreadTs = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+      threadTs: 42, // should be string
+    });
+    const badReactionOp = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "reaction",
+      reaction: {
+        emoji: "thumbsup",
+        targetChannelTs: "1700000000.000100",
+        op: "bogus",
+      },
+    });
+    const badEditedAt = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+      editedAt: "not-a-number",
+    });
+    expect(readSlackMetadata(badThreadTs)).toBeNull();
+    expect(readSlackMetadata(badReactionOp)).toBeNull();
+    expect(readSlackMetadata(badEditedAt)).toBeNull();
+  });
+
+  test("strips unknown top-level keys from the returned object", () => {
+    const raw = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+      userMessageChannel: "channel:abc",
+      provenanceTrustClass: "trusted_contact",
+    });
+    const parsed = readSlackMetadata(raw);
+    expect(parsed).toEqual({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
+  });
+
   test("rejects payloads missing required fields", () => {
     const noChannelId = JSON.stringify({
       source: "slack",
@@ -202,6 +251,46 @@ describe("mergeSlackMetadata", () => {
     const parsed = readSlackMetadata(merged);
     expect(parsed?.source).toBe("slack");
     expect(parsed?.displayName).toBe("Mallory");
+  });
+
+  test("preserves unrelated non-slack top-level keys from the existing blob", () => {
+    const existing = JSON.stringify({
+      userMessageChannel: "channel:abc",
+      provenanceTrustClass: "trusted_contact",
+      forkSourceMessageId: "msg-parent-1",
+    });
+    const merged = mergeSlackMetadata(existing, {
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
+    const rawParsed = JSON.parse(merged) as Record<string, unknown>;
+    expect(rawParsed.userMessageChannel).toBe("channel:abc");
+    expect(rawParsed.provenanceTrustClass).toBe("trusted_contact");
+    expect(rawParsed.forkSourceMessageId).toBe("msg-parent-1");
+    expect(rawParsed.source).toBe("slack");
+    expect(rawParsed.channelId).toBe("C123");
+    expect(readSlackMetadata(merged)).toEqual({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
+  });
+
+  test("preserves non-slack keys when patching an already-slack-tagged blob", () => {
+    const existing = JSON.stringify({
+      ...baseMeta,
+      userMessageChannel: "channel:abc",
+    });
+    const merged = mergeSlackMetadata(existing, { editedAt: 1700000999 });
+    const rawParsed = JSON.parse(merged) as Record<string, unknown>;
+    expect(rawParsed.userMessageChannel).toBe("channel:abc");
+    expect(readSlackMetadata(merged)).toEqual({
+      ...baseMeta,
+      editedAt: 1700000999,
+    });
   });
 
   test("preserves nested reaction metadata across a patch", () => {

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -1,12 +1,15 @@
+import { z } from "zod";
+
 /**
- * Typed Slack message metadata stored in the `messages.metadata` column for
- * thread-aware context rendering.
+ * Typed Slack message metadata stored flat in the `messages.metadata` column
+ * alongside whatever other top-level keys the broader metadata envelope
+ * carries (see `messageMetadataSchema` in `memory/conversation-crud.ts`).
  *
- * The full metadata column may contain other unrelated keys; Slack-specific
- * metadata lives under a `slackMeta` sub-key written via `writeSlackMetadata`
- * and read via `readSlackMetadata`. `mergeSlackMetadata` performs partial
- * updates (for edits, deletions, display-name refreshes) without disturbing
- * unrelated fields.
+ * Slack-specific fields are serialized directly onto the top-level object
+ * (no sub-key); `source: "slack"` acts as the discriminator. `readSlackMetadata`
+ * parses and validates those fields via Zod; `writeSlackMetadata` emits a
+ * Slack-only blob for fresh writes; `mergeSlackMetadata` patches Slack fields
+ * while preserving unrelated keys on the existing JSON.
  *
  * This file is a pure library addition — no consumers wire into it yet; that
  * happens in later PRs of the slack-thread-aware-context plan.
@@ -14,31 +17,37 @@
 
 export type SlackEventKind = "message" | "reaction";
 
-export interface SlackReactionMetadata {
-  readonly emoji: string;
-  readonly actorDisplayName?: string;
-  readonly targetChannelTs: string;
-  readonly op: "added" | "removed";
-}
+export const slackReactionMetadataSchema = z.object({
+  emoji: z.string(),
+  actorDisplayName: z.string().optional(),
+  targetChannelTs: z.string(),
+  op: z.enum(["added", "removed"]),
+});
 
-export interface SlackMessageMetadata {
-  readonly source: "slack";
-  readonly channelId: string;
-  readonly channelTs: string; // Slack's own ts for this record
-  readonly threadTs?: string; // parent ts, absent for top-level
-  readonly displayName?: string; // cached sender name
-  readonly eventKind: SlackEventKind; // "message" or "reaction"
-  readonly reaction?: SlackReactionMetadata;
-  readonly editedAt?: number;
-  readonly deletedAt?: number;
-}
+export const slackMessageMetadataSchema = z.object({
+  source: z.literal("slack"),
+  channelId: z.string(),
+  channelTs: z.string(),
+  threadTs: z.string().optional(),
+  displayName: z.string().optional(),
+  eventKind: z.enum(["message", "reaction"]),
+  reaction: slackReactionMetadataSchema.optional(),
+  editedAt: z.number().optional(),
+  deletedAt: z.number().optional(),
+});
+
+export type SlackReactionMetadata = z.infer<typeof slackReactionMetadataSchema>;
+export type SlackMessageMetadata = z.infer<typeof slackMessageMetadataSchema>;
 
 /**
  * Parse a JSON string into `SlackMessageMetadata`. Returns `null` on parse
- * error, when the payload is not an object, or when `source !== "slack"`.
+ * error, on non-object payloads, when `source !== "slack"`, or when any
+ * field fails Zod validation (including malformed optional fields like a
+ * non-string `threadTs` or a nested `reaction` with the wrong `op`).
  *
  * Tolerates `null` and `undefined` inputs (returns `null`) so callers can pass
- * raw column values without pre-checks.
+ * raw column values without pre-checks. Unknown top-level keys (from unrelated
+ * metadata co-tenants) are stripped from the returned object.
  */
 export function readSlackMetadata(
   raw: string | null | undefined,
@@ -52,57 +61,63 @@ export function readSlackMetadata(
   } catch {
     return null;
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return null;
-  }
-  const obj = parsed as Record<string, unknown>;
-  if (obj.source !== "slack") {
-    return null;
-  }
-  if (typeof obj.channelId !== "string" || typeof obj.channelTs !== "string") {
-    return null;
-  }
-  if (obj.eventKind !== "message" && obj.eventKind !== "reaction") {
-    return null;
-  }
-  return obj as unknown as SlackMessageMetadata;
+  const result = slackMessageMetadataSchema.safeParse(parsed);
+  return result.success ? result.data : null;
 }
 
 /**
- * Serialize `SlackMessageMetadata` to a JSON string suitable for storage in
- * the `messages.metadata` column (or as a sub-value within a larger metadata
- * envelope).
+ * Serialize `SlackMessageMetadata` to a JSON string suitable for a fresh
+ * write to the `messages.metadata` column. Use `mergeSlackMetadata` when an
+ * existing blob may already carry unrelated keys that must be preserved.
  */
 export function writeSlackMetadata(meta: SlackMessageMetadata): string {
   return JSON.stringify(meta);
 }
 
+function parseRawObject(
+  raw: string | null | undefined,
+): Record<string, unknown> {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through to empty base
+  }
+  return {};
+}
+
 /**
- * Apply a partial patch to existing serialized Slack metadata. Used for
- * incremental updates such as marking a message edited or deleted, or
- * refreshing a cached display name.
+ * Apply a partial Slack patch to an existing metadata blob. Preserves every
+ * top-level key on the existing JSON (including unrelated non-Slack fields
+ * written by other subsystems — `userMessageChannel`, `provenanceTrustClass`,
+ * etc.), overlays patch fields, and forces `source: "slack"` so subsequent
+ * `readSlackMetadata` calls accept the result.
  *
- * If `existing` is `null`/`undefined` or fails to parse as Slack metadata,
- * the patch must contain enough fields to construct a valid
- * `SlackMessageMetadata` (`source`, `channelId`, `channelTs`, `eventKind`).
- * The function does not validate that case beyond what `JSON.stringify`
- * accepts — readers will reject invalid output via `readSlackMetadata`.
- *
- * Unrelated fields on the existing metadata are preserved; the patch's
- * defined fields override them. `undefined` fields in the patch are ignored
- * (use a sentinel like `0` if a numeric field needs an explicit reset).
+ * `undefined` patch fields are ignored (use a sentinel like `0` to explicitly
+ * reset a numeric field). If `existing` is `null`/`undefined` or does not
+ * parse as a JSON object, the base is empty and the patch must supply the
+ * required Slack fields (`channelId`, `channelTs`, `eventKind`) for the
+ * output to round-trip through `readSlackMetadata`.
  */
 export function mergeSlackMetadata(
   existing: string | null | undefined,
   patch: Partial<SlackMessageMetadata>,
 ): string {
-  const base = readSlackMetadata(existing) ?? {};
+  const base = parseRawObject(existing);
   const cleanedPatch: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(patch)) {
     if (value !== undefined) {
       cleanedPatch[key] = value;
     }
   }
-  const merged = { ...base, ...cleanedPatch, source: "slack" as const };
-  return JSON.stringify(merged);
+  return JSON.stringify({ ...base, ...cleanedPatch, source: "slack" });
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #26608.

- **Docstring/code mismatch (Devin BUG):** the file-level doc previously described a `slackMeta` sub-key envelope, but the helpers flat-serialize Slack fields directly onto `messages.metadata`. Picked the flat-serialization path (matches the existing `messageMetadataSchema.passthrough()` envelope at `memory/conversation-crud.ts`) and updated the docstring to describe that shape.
- **Merge drops unrelated keys (Codex P1):** `mergeSlackMetadata` now parses the raw existing JSON as a record and preserves every non-Slack top-level key (e.g. `userMessageChannel`, `provenanceTrustClass`, `forkSourceMessageId`) instead of silently erasing them whenever the existing blob wasn't authored by `writeSlackMetadata`.
- **No runtime validation of optional fields (Codex P2):** added `slackMessageMetadataSchema` (Zod) so `readSlackMetadata` rejects malformed optional fields (`threadTs`, `editedAt`, `deletedAt`, nested `reaction`) instead of casting through.

## Test plan
- [x] `bun test src/messaging/providers/slack/message-metadata.test.ts` — 21 pass
- [x] `bunx tsc --noEmit` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
