### PR TITLE
fix(token-estimator): gate tool_result error-image drop on Anthropic only

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -472,7 +472,9 @@ describe("token estimator", () => {
       },
     ];
 
-    const total = estimateMessagesTokens(messages, { providerName: "anthropic" });
+    const total = estimateMessagesTokens(messages, {
+      providerName: "anthropic",
+    });
 
     // Each image: ~73 tokens. 100 images + message overhead ≈ 7,304
     // Old behavior: 100 * ~1,043 = ~104,300 (14x overestimate)
@@ -603,6 +605,48 @@ describe("tool_result estimation mirrors Anthropic wire format", () => {
     expect(errorWithImage).toBe(errorNoImage);
   });
 
+  test("image sub-block IS counted on error for non-Anthropic providers", () => {
+    // OpenAI and Gemini serializers forward error-result images (as a
+    // follow-up user message / parts entry), so the estimator must count
+    // them regardless of is_error under those providers.
+    const pngBase64 = makePngBase64(512, 512);
+    const build = (providerName: string) =>
+      estimateContentBlockTokens(
+        {
+          type: "tool_result",
+          tool_use_id: "call_err_img",
+          content: "operation failed",
+          is_error: true,
+          contentBlocks: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: pngBase64,
+              },
+            },
+          ],
+        },
+        { providerName },
+      );
+    const buildPlain = (providerName: string) =>
+      estimateContentBlockTokens(
+        {
+          type: "tool_result",
+          tool_use_id: "call_err_img",
+          content: "operation failed",
+          is_error: true,
+        },
+        { providerName },
+      );
+    for (const providerName of ["openai", "gemini"]) {
+      const withImage = build(providerName);
+      const withoutImage = buildPlain(providerName);
+      expect(withImage - withoutImage).toBeGreaterThan(0);
+    }
+  });
+
   test("unknown sub-block types are NOT counted", () => {
     // The Anthropic serializer only forwards image/text sub-blocks. Anything
     // else (thinking, tool_use, etc.) is dropped — the estimator must not
@@ -630,9 +674,9 @@ describe("tool_result estimation mirrors Anthropic wire format", () => {
   test("text sub-block beyond block.content is counted once", () => {
     // Handlers (e.g. secret-detection) may populate contentBlocks with an
     // additional text entry distinct from block.content. The serializer
-    // forwards both, so the estimator counts both — but this is not the
-    // pre-fix 2x double-count where content was summed once for the string
-    // and again for an echoing text sub-block.
+    // forwards both, so the estimator counts block.content once and each
+    // text sub-block once — never doubling the content string against an
+    // echoing text sub-block.
     const extraText = "x".repeat(4000);
     const tokens = estimateContentBlockTokens({
       type: "tool_result",
@@ -648,11 +692,9 @@ describe("tool_result estimation mirrors Anthropic wire format", () => {
   });
 
   test("regression: tool_result with thinking sub-block does not inflate estimate by 3x+", () => {
-    // Simulates the pathological shape that was inflating the estimator on
-    // real conversations — a modest tool_result whose contentBlocks happen
-    // to carry a large sub-block the serializer discards. Prior to the fix
-    // the estimator would add the full thinking payload; after the fix it
-    // matches the plain shape.
+    // A modest tool_result whose contentBlocks carry a large sub-block the
+    // serializer discards must not inflate the estimate: the estimator
+    // skips the thinking payload, matching the plain wire shape.
     const content = "y".repeat(2000);
     const inflated = estimateContentBlockTokens({
       type: "tool_result",

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -103,7 +103,9 @@ function estimateAnthropicImageTokens(width: number, height: number): number {
     scaledHeight = Math.round(scaledHeight * mpScale);
   }
 
-  return Math.ceil(scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL);
+  return Math.ceil(
+    scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL,
+  );
 }
 
 function estimateImageTokens(
@@ -146,6 +148,10 @@ export function estimateContentBlockTokens(
       // is_error is true. Counting every contentBlocks entry regardless
       // of type overestimates the wire size and can trigger spurious
       // compaction on conversations that carry e.g. thinking sub-blocks.
+      // OpenAI and Gemini forward error-result images normally, so the
+      // is_error image drop is Anthropic-specific.
+      const anthropicDropsErrorImage =
+        options?.providerName === "anthropic" && block.is_error === true;
       let tokens =
         TOOL_BLOCK_OVERHEAD_TOKENS +
         estimateTextTokens(block.tool_use_id) +
@@ -154,7 +160,7 @@ export function estimateContentBlockTokens(
         for (const cb of block.contentBlocks) {
           if (cb.type === "text") {
             tokens += estimateContentBlockTokens(cb, options);
-          } else if (cb.type === "image" && !block.is_error) {
+          } else if (cb.type === "image" && !anthropicDropsErrorImage) {
             tokens += estimateContentBlockTokens(cb, options);
           }
         }


### PR DESCRIPTION
## Summary
- `estimatePromptTokens` now only drops error-result image sub-blocks when `providerName === "anthropic"`. OpenAI and Gemini forward error-result images normally, so counting them unconditionally matches the wire.
- Adds a regression test that error-result images are counted under OpenAI and Gemini providers.
- Rewrites two test comments that narrated pre-fix history ("pre-fix 2x double-count", "Prior to the fix") to describe current behavior only.

Addresses Codex P1 and Devin feedback on #26745.

## Test plan
- [x] `bun test src/__tests__/context-token-estimator.test.ts` (24 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
