### PR TITLE
fix(slack): thread account selector through backfill helpers; rethrow channel_not_found

### DIFF
--- a/assistant/src/messaging/providers/slack/backfill.test.ts
+++ b/assistant/src/messaging/providers/slack/backfill.test.ts
@@ -6,8 +6,12 @@
  *  - Default limit of 50 when none is supplied; explicit limits override.
  *  - resolveConnection() is invoked once per call so any cached read/write
  *    auth mutation lands before the adapter method runs.
- *  - All failure modes (timeout, 401, Slack API error, missing connection)
- *    return [] instead of propagating the error.
+ *  - Transient failure modes (timeout, 401, generic Slack API error, missing
+ *    connection) return [] instead of propagating the error.
+ *  - `channel_not_found` errors are rethrown so wrong-workspace configuration
+ *    bugs in multi-account setups surface loudly rather than silently
+ *    dropping context.
+ *  - `account` is threaded through to resolveConnection() when provided.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -118,12 +122,29 @@ describe("backfillThread", () => {
     expect(opts).toEqual({ limit: 10 });
   });
 
-  test("returns [] when getThreadReplies throws (Slack API error)", async () => {
+  test("returns [] when getThreadReplies throws (generic Slack API error)", async () => {
     getThreadRepliesMock.mockImplementation(async () => {
-      throw new Error("Slack API error: channel_not_found");
+      throw new Error("Slack API error: ratelimited");
     });
     const out = await backfillThread("C123", "1700000000.000100");
     expect(out).toEqual([]);
+  });
+
+  test("rethrows channel_not_found so wrong-workspace config surfaces", async () => {
+    getThreadRepliesMock.mockImplementation(async () => {
+      throw new Error("Slack API error: channel_not_found");
+    });
+    await expect(backfillThread("C123", "1700000000.000100")).rejects.toThrow(
+      /channel_not_found/,
+    );
+  });
+
+  test("threads `account` through to resolveConnection", async () => {
+    await backfillThread("C123", "1700000000.000100", {
+      account: "team-acme",
+    });
+    expect(resolveConnectionMock).toHaveBeenCalledTimes(1);
+    expect(resolveConnectionMock.mock.calls[0][0]).toBe("team-acme");
   });
 
   test("returns [] when getThreadReplies throws (auth error)", async () => {
@@ -186,12 +207,25 @@ describe("backfillDm", () => {
     expect(opts).toEqual({ limit: 25, before: "1700000000.000099" });
   });
 
-  test("returns [] when getHistory throws (Slack API error)", async () => {
+  test("returns [] when getHistory throws (generic Slack API error)", async () => {
     getHistoryMock.mockImplementation(async () => {
       throw new Error("Slack API error: not_in_channel");
     });
     const out = await backfillDm("D123");
     expect(out).toEqual([]);
+  });
+
+  test("rethrows channel_not_found so wrong-workspace config surfaces", async () => {
+    getHistoryMock.mockImplementation(async () => {
+      throw new Error("Slack API error: channel_not_found");
+    });
+    await expect(backfillDm("D123")).rejects.toThrow(/channel_not_found/);
+  });
+
+  test("threads `account` through to resolveConnection", async () => {
+    await backfillDm("D123", { account: "team-acme" });
+    expect(resolveConnectionMock).toHaveBeenCalledTimes(1);
+    expect(resolveConnectionMock.mock.calls[0][0]).toBe("team-acme");
   });
 
   test("returns [] when getHistory throws (auth error)", async () => {

--- a/assistant/src/messaging/providers/slack/backfill.ts
+++ b/assistant/src/messaging/providers/slack/backfill.ts
@@ -5,10 +5,15 @@
  * recovery, DM context hydration) can fetch a small window of recent messages
  * without re-implementing connection resolution or token routing.
  *
- * Best-effort semantics: any failure (timeout, auth error, missing connection,
- * Slack API error) is logged at WARN and yields an empty array. Callers must
- * proceed without backfill rather than propagating the error — backfill is a
- * convenience, not a precondition.
+ * Best-effort semantics: transient or auth failures (timeout, 401, missing
+ * connection, generic Slack API errors) are logged at WARN and yield an empty
+ * array. Callers proceed without backfill rather than propagating the error.
+ *
+ * Exception: `channel_not_found` is rethrown. In multi-account Slack setups it
+ * typically signals that the resolved connection points at the wrong
+ * workspace, and silently returning [] would mask that misconfiguration. Pass
+ * the conversation's own account via `opts.account` so resolveConnection()
+ * picks the right workspace.
  */
 import { getLogger } from "../../../util/logger.js";
 import type { Message } from "../../provider-types.js";
@@ -18,22 +23,27 @@ const log = getLogger("slack-backfill");
 
 const DEFAULT_LIMIT = 50;
 
+function isChannelNotFound(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /channel_not_found/i.test(msg);
+}
+
 /**
  * Fetch the most recent messages in a Slack thread.
  *
  * Resolves the cached Slack connection, then delegates to
  * `slackProvider.getThreadReplies()`. Returns the messages mapped to the
  * platform-agnostic `Message` shape (with `threadId` already populated from
- * `thread_ts`). Returns `[]` on any error.
+ * `thread_ts`). Returns `[]` on transient errors; rethrows `channel_not_found`.
  */
 export async function backfillThread(
   channelId: string,
   threadTs: string,
-  opts?: { limit?: number },
+  opts?: { limit?: number; account?: string },
 ): Promise<Message[]> {
   const limit = opts?.limit ?? DEFAULT_LIMIT;
   try {
-    const connection = await slackProvider.resolveConnection?.();
+    const connection = await slackProvider.resolveConnection?.(opts?.account);
     if (!slackProvider.getThreadReplies) {
       log.warn(
         { channelId, threadTs },
@@ -48,8 +58,11 @@ export async function backfillThread(
       { limit },
     );
   } catch (err) {
+    if (isChannelNotFound(err)) {
+      throw err;
+    }
     log.warn(
-      { channelId, threadTs, err },
+      { channelId, threadTs, account: opts?.account, err },
       "Slack thread backfill failed — returning []",
     );
     return [];
@@ -62,22 +75,25 @@ export async function backfillThread(
  * Resolves the cached Slack connection, then delegates to
  * `slackProvider.getHistory()`. The `before` option, when provided, is passed
  * through as Slack's `latest` cursor so callers can paginate backwards.
- * Returns `[]` on any error.
+ * Returns `[]` on transient errors; rethrows `channel_not_found`.
  */
 export async function backfillDm(
   channelId: string,
-  opts?: { limit?: number; before?: string },
+  opts?: { limit?: number; before?: string; account?: string },
 ): Promise<Message[]> {
   const limit = opts?.limit ?? DEFAULT_LIMIT;
   try {
-    const connection = await slackProvider.resolveConnection?.();
+    const connection = await slackProvider.resolveConnection?.(opts?.account);
     return await slackProvider.getHistory(connection, channelId, {
       limit,
       before: opts?.before,
     });
   } catch (err) {
+    if (isChannelNotFound(err)) {
+      throw err;
+    }
     log.warn(
-      { channelId, before: opts?.before, err },
+      { channelId, before: opts?.before, account: opts?.account, err },
       "Slack DM backfill failed — returning []",
     );
     return [];


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #26609.

`backfillThread` and `backfillDm` previously called `slackProvider.resolveConnection()` with no `account`. In multi-account Slack setups the resolver picks the most recently created active connection, which may not be the one tied to the current conversation, so backfill could read from the wrong workspace — or hit `channel_not_found` and silently return `[]` because all errors were swallowed.

## Changes

- `opts.account?: string` on both helpers; threaded through to `resolveConnection(account)`.
- Rethrow errors whose message matches `/channel_not_found/` so wrong-workspace misconfig surfaces loudly. Transient errors (timeout, 401, ratelimited, missing connection, generic Slack API errors) still return `[]`.
- Include `account` in the WARN log payload.
- Tests cover both new behaviors.

## Test plan

- [x] `bun test src/messaging/providers/slack/backfill.test.ts`
- [x] `bunx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
