### PR TITLE
fix(meet): defer meet flag read until post-config-merge; document bootstrap exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ Each LLM call site has a stable identifier (`LLMCallSite` from `assistant/src/co
 
 The `assistant/` module must not import from `skills/` via relative paths (e.g. `../skills/meet-join/...`). The Docker build copies `assistant/` and `packages/` but not `skills/`, so any such import breaks at runtime. Skills wire into the assistant through registries (`registerShutdownHook`, `registerSkillRoute`, `registerExternalTools`) — the assistant provides the hooks, the skill calls them. See `skills/meet-join/AGENTS.md` for the meet-join isolation rules.
 
+There is one narrow exception: `assistant/src/daemon/external-skills-bootstrap.ts` is the single file in `assistant/` permitted to import from `skills/`, and only as side-effect imports of a first-party skill's `register.ts`. The exception exists because `bun --compile` only traces statically analyzed imports into the final binary (dynamic relative imports fail inside `/$bunfs/`), so a skill whose tools must be visible to the LLM at daemon startup has to be reachable from a static import somewhere in `assistant/`. Any skill referenced from this file must (a) be first-party, (b) have its source copied into the assistant image by `assistant/Dockerfile`, and (c) expose only a side-effect `register.ts` — no named exports consumed from `assistant/`. All other `assistant/` → `skills/` imports remain forbidden.
+
 ## Tooling Direction
 
 New non-skill tool registrations are strongly discouraged — prefer skills instead. See `assistant/src/tools/AGENTS.md` for rationale, approved CES exceptions, and alternatives.

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -19,24 +19,43 @@ const tools = new Map<string, Tool>();
 // ── External tool registry ───────────────────────────────────────────
 // Skills register their tools here at initialization time so the tool
 // manifest can include them without importing from `../skills/`.
-const externalTools: Tool[] = [];
+//
+// Each registration is stored as a provider closure. Closures are
+// resolved at `getExternalTools()` time (which `initializeTools()`
+// calls), not at registration time — this lets a skill defer its
+// feature-flag check until after the daemon has run
+// `mergeDefaultWorkspaceConfig()`, so skills see the merged config
+// instead of forcing an early `loadConfig()` against unmerged defaults.
+const externalToolProviders: Array<() => Tool[]> = [];
 
 /**
  * Register tools provided by an external skill. Called during skill
  * initialization (e.g. meet-join bootstrap).
+ *
+ * Accepts either a concrete `Tool[]` (resolved eagerly at the caller)
+ * or a `() => Tool[]` closure (resolved lazily inside
+ * `getExternalTools()`). Skills that perform feature-flag or config
+ * reads to decide which tools to surface must pass a closure so the
+ * read happens after daemon-startup config merging.
  *
  * Lives in registry.ts (not tool-manifest.ts) to avoid a circular
  * dependency: skills/load.ts → … → meet-join/register.ts → tool-manifest.ts
  * → skills/load.ts. Keeping it here lets external skill bootstraps import
  * from registry.ts, which is already a leaf in the dependency graph.
  */
-export function registerExternalTools(tools: Tool[]): void {
-  externalTools.push(...tools);
+export function registerExternalTools(
+  toolsOrProvider: Tool[] | (() => Tool[]),
+): void {
+  const provider =
+    typeof toolsOrProvider === "function"
+      ? toolsOrProvider
+      : () => toolsOrProvider;
+  externalToolProviders.push(provider);
 }
 
 /** Return all externally registered tools. */
 export function getExternalTools(): Tool[] {
-  return [...externalTools];
+  return externalToolProviders.flatMap((provider) => provider());
 }
 
 // Snapshot of core tools captured after initializeTools() completes.

--- a/skills/meet-join/AGENTS.md
+++ b/skills/meet-join/AGENTS.md
@@ -11,6 +11,19 @@ The `assistant/` module must **never** import from `skills/meet-join/` via
 relative paths. The Docker build copies `assistant/` and `packages/` but not
 `skills/`, so any such import breaks at runtime.
 
+There is one narrow exception:
+`assistant/src/daemon/external-skills-bootstrap.ts` may do a single
+side-effect import of `skills/meet-join/register.js` so that
+`registerExternalTools()` fires before `initializeTools()`. The
+exception exists because `bun --compile` only bundles statically
+analyzed imports — a dynamic relative import would fail inside the
+compiled binary's `/$bunfs/` layer. It is limited to that one file,
+that one side-effect import, and requires the skill's source to be
+copied into the assistant image by `assistant/Dockerfile` (including
+`register.ts`). Named-export consumption from `skills/meet-join/` in
+`assistant/` code remains forbidden. See the root `AGENTS.md` "Skill
+Isolation" section for the full rule.
+
 Skills wire into the assistant through registries:
 
 - **Tools**: `registerExternalTools()` in `assistant/src/tools/registry.ts`

--- a/skills/meet-join/__tests__/register.test.ts
+++ b/skills/meet-join/__tests__/register.test.ts
@@ -24,7 +24,18 @@ let flagEnabled = true;
 let captured: Array<{ name: string }> | null = null;
 
 mock.module("../../../assistant/src/tools/registry.js", () => ({
-  registerExternalTools: (tools: Array<{ name: string }>) => {
+  registerExternalTools: (
+    toolsOrProvider:
+      | Array<{ name: string }>
+      | (() => Array<{ name: string }>),
+  ) => {
+    // register.ts registers a lazy provider so the flag read happens
+    // after daemon startup's default-config merge. Resolve the provider
+    // here to assert the tools it would produce at initializeTools() time.
+    const tools =
+      typeof toolsOrProvider === "function"
+        ? toolsOrProvider()
+        : toolsOrProvider;
     captured = tools.map((t) => ({ name: t.name }));
   },
 }));

--- a/skills/meet-join/register.ts
+++ b/skills/meet-join/register.ts
@@ -13,12 +13,19 @@
  *
  * ## Feature-flag semantics
  *
- * Registration is gated by the `meet` feature flag at module-load time,
- * mirroring the CES-tools pattern in `registry.ts` — tools only
- * enter the registry (and therefore only occupy LLM tool-list tokens)
- * when the flag is on. Toggling the flag requires a daemon restart to
- * take effect, which is acceptable because the same is true for every
- * other feature-flag-gated capability on the daemon.
+ * Registration is gated by the `meet` feature flag, mirroring the
+ * CES-tools pattern in `tool-manifest.ts` — tools only enter the
+ * registry (and therefore only occupy LLM tool-list tokens) when the
+ * flag is on. Toggling the flag requires a daemon restart to take
+ * effect, which is acceptable because the same is true for every other
+ * feature-flag-gated capability on the daemon.
+ *
+ * The flag read is wrapped in a **lazy provider closure** passed to
+ * `registerExternalTools()`. The closure is invoked inside
+ * `getExternalTools()` — which `initializeTools()` calls after
+ * `mergeDefaultWorkspaceConfig()` — so the flag resolution sees the
+ * merged workspace config rather than forcing an early `loadConfig()`
+ * against unmerged defaults.
  *
  * Each tool also performs a defensive in-`execute()` flag check so
  * stale tool definitions cached by a long-running agent turn can't
@@ -37,20 +44,20 @@ import { meetLeaveTool } from "./tools/meet-leave-tool.js";
 import { meetSendChatTool } from "./tools/meet-send-chat-tool.js";
 import { meetCancelSpeakTool, meetSpeakTool } from "./tools/meet-speak-tool.js";
 
-function tryRegisterMeetTools(): void {
+registerExternalTools(() => {
   try {
     const config = getConfig();
     if (!isAssistantFeatureFlagEnabled(MEET_FLAG_KEY, config)) {
-      return;
+      return [];
     }
   } catch {
     // Config not yet loaded (e.g. during certain test setups) — treat as
     // flag off so tool definitions don't leak into test scopes that
     // haven't opted in.
-    return;
+    return [];
   }
 
-  registerExternalTools([
+  return [
     meetJoinTool,
     meetLeaveTool,
     meetSendChatTool,
@@ -58,7 +65,5 @@ function tryRegisterMeetTools(): void {
     meetCancelSpeakTool,
     meetEnableAvatarTool,
     meetDisableAvatarTool,
-  ]);
-}
-
-tryRegisterMeetTools();
+  ];
+});


### PR DESCRIPTION
## Summary

Address review feedback on #26687 (merged).

### Codex P2 — early config load
skills/meet-join/register.ts called getConfig() during module evaluation,
which kicked off loadConfig() before the daemon ran
mergeDefaultWorkspaceConfig(). The result was cached, so defaults supplied
via VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH did not make it into the in-memory
config for that boot.

Fix: registerExternalTools() now accepts a lazy () => Tool[] provider in
addition to an eager Tool[]. Providers are invoked inside
getExternalTools(), which initializeTools() calls after the merge.
register.ts passes a closure so the flag resolution runs at the correct
lifecycle point.

### Devin — skill-isolation rule
Documented the narrow bootstrap exception:
- AGENTS.md "Skill Isolation" — spells out the one permitted place
  (external-skills-bootstrap.ts), the three conditions (first-party,
  copied into Dockerfile, side-effect-only), and reiterates that all
  other assistant/ -> skills/ imports stay forbidden.
- skills/meet-join/AGENTS.md — mirrors the exception alongside the
  existing isolation rule.

### Dockerfile COPY gap (both reviewers)
Already fixed in #26762 — the assistant Dockerfile now copies
skills/meet-join/register.ts.

## Test plan
- [x] bunx tsc --noEmit in assistant/ — clean
- [x] cd skills/meet-join && bun test __tests__/register.test.ts — 1 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
