### PR TITLE
fix(meet-join): add '--' end-of-options marker before xdotool type text

### DIFF
--- a/skills/meet-join/bot/__tests__/xdotool-type.test.ts
+++ b/skills/meet-join/bot/__tests__/xdotool-type.test.ts
@@ -83,9 +83,38 @@ describe("xdotoolType", () => {
       "--delay",
       "25",
       "--clearmodifiers",
+      "--",
       "hello world",
     ]);
     expect(fake.calls[0]!.options.env?.DISPLAY).toBe(":99");
+  });
+
+  test("passes text starting with '-' safely via the '--' end-of-options marker", async () => {
+    // Regression: without `--` before the text token, xdotool parses
+    // anything starting with `-` as an option flag (e.g. a negative number
+    // like `-14.7873` would be rejected as an unknown option).
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const pending = xdotoolType({
+      text: "-14.7873",
+      display: ":99",
+      spawn: fake.spawn,
+    });
+    child.__simulateExit(0);
+    await pending;
+
+    expect(fake.calls[0]!.args).toEqual([
+      "type",
+      "--delay",
+      "25",
+      "--clearmodifiers",
+      "--",
+      "-14.7873",
+    ]);
+    // The `--` token must appear immediately before the user-supplied text.
+    const args = fake.calls[0]!.args;
+    expect(args.indexOf("--")).toBe(args.length - 2);
   });
 
   test("honours custom delayMs", async () => {
@@ -106,6 +135,7 @@ describe("xdotoolType", () => {
       "--delay",
       "100",
       "--clearmodifiers",
+      "--",
       "abc",
     ]);
   });

--- a/skills/meet-join/bot/src/browser/xdotool-type.ts
+++ b/skills/meet-join/bot/src/browser/xdotool-type.ts
@@ -15,7 +15,7 @@
  * a single argv token, NOT shell-interpolated, so arbitrary user content
  * is safe):
  *
- *     DISPLAY=:99 xdotool type --delay 25 --clearmodifiers "hello world"
+ *     DISPLAY=:99 xdotool type --delay 25 --clearmodifiers -- "hello world"
  *
  * Callers are responsible for ensuring the target element has keyboard
  * focus before invoking (e.g. via a prior `xdotoolClick` to focus the
@@ -91,15 +91,18 @@ export async function xdotoolType(opts: XdotoolTypeOptions): Promise<void> {
   const delayMs = opts.delayMs ?? DEFAULT_DELAY_MS;
 
   // `--clearmodifiers` ensures we don't accidentally inherit a stuck
-  // modifier key (Shift/Ctrl/Alt) from a prior input event. `text` is the
-  // final positional argv token; it is passed as a single argv entry so
-  // the shell is never involved and arbitrary content (including quotes,
-  // spaces, backticks) is handled safely.
+  // modifier key (Shift/Ctrl/Alt) from a prior input event. The `--`
+  // end-of-options marker is required before `text` so that arbitrary
+  // content starting with `-` (e.g. a negative number like `-14.7873`)
+  // is not re-parsed by xdotool as an option flag. `text` is passed as
+  // a single argv entry so the shell is never involved and arbitrary
+  // content (including quotes, spaces, backticks) is handled safely.
   const args = [
     "type",
     "--delay",
     String(delayMs),
     "--clearmodifiers",
+    "--",
     opts.text,
   ];
 


### PR DESCRIPTION
## Summary
Addresses Codex review feedback on #26641.

The argv passed to `spawn('xdotool', [...])` in the `xdotoolType` primitive was missing the `--` end-of-options marker before the user-supplied text token. Any text beginning with `-` (e.g. a negative number like \`-14.7873\`) would be parsed by xdotool as an option flag and fail.

- Insert \`'--'\` immediately before \`opts.text\` in the argv array.
- Update existing tests to expect the marker.
- Add a regression test with a leading-dash input (\`-14.7873\`) that asserts the \`--\` appears immediately before the text.

## Test plan
- [x] \`bun test skills/meet-join/bot/__tests__/xdotool-type.test.ts\` — 9 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
