### PR TITLE
fix(meet-ext): gate join command by tab meeting id

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -65,6 +65,31 @@ function deriveMeetingId(): string {
 }
 
 /**
+ * Extract the meeting id from a Meet join URL.
+ *
+ * The background bridge fans every bot command out to every open
+ * `https://meet.google.com/*` tab, so a stray lobby tab in the same
+ * Chrome profile would otherwise start its own speaker scraper and mix
+ * `speaker.change` events from an unrelated meeting into the session
+ * stream. Tabs self-filter by comparing this value against
+ * {@link deriveMeetingId} before acting on a `join` command.
+ *
+ * Returns `null` when the URL cannot be parsed or has no path segment;
+ * callers treat that as "does not match any tab" so a malformed command
+ * cannot inadvertently drive every Meet tab.
+ */
+function extractMeetingIdFromUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const segment = parsed.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
+  return segment || null;
+}
+
+/**
  * Build a timestamped, meeting-scoped lifecycle message.
  *
  * Extracted to a helper so every lifecycle emit site (joining, joined,
@@ -188,6 +213,21 @@ chrome.runtime.onMessage.addListener(
     const msg: BotToExtensionMessage = parsed.data;
 
     if (msg.type === "join") {
+      // The background bridge broadcasts every bot command to every open
+      // Meet tab. Only the tab whose URL matches the target meeting
+      // should start a session — otherwise a stray lobby tab in the same
+      // Chrome profile would spin up its own speaker scraper and mix
+      // telemetry from unrelated meetings into the bot's event stream.
+      const targetMeetingId = extractMeetingIdFromUrl(msg.meetingUrl);
+      const currentMeetingId = deriveMeetingId();
+      if (targetMeetingId === null || targetMeetingId !== currentMeetingId) {
+        console.debug(
+          "[meet-ext] ignoring join for non-matching tab:",
+          `target=${targetMeetingId ?? "<unparseable>"}`,
+          `current=${currentMeetingId}`,
+        );
+        return false;
+      }
       void handleJoin(msg.meetingUrl, msg.displayName, msg.consentMessage);
       return false;
     }


### PR DESCRIPTION
## Summary
- Addresses Codex P1 feedback on #26578: the background content-bridge broadcasts every bot command to every open `meet.google.com/*` tab, so a stray lobby tab would start its own speaker scraper and emit `speaker.change` events into the session stream.
- Extracts the target meeting id from the `join` command's `meetingUrl` and compares it to the current tab's `deriveMeetingId()` before invoking `handleJoin`. Non-matching tabs log at debug and drop the command.
- Malformed URLs (failing `new URL()` or with no path segment) resolve to `null` and are treated as non-matching, so a bad command cannot inadvertently drive every Meet tab.

## Test plan
- [x] `bunx tsc --noEmit` in `skills/meet-join/meet-controller-ext` reports no new errors in `content.ts`.
- [ ] In a Chrome profile with two Meet tabs open, verify that only the tab matching the join command's meeting id starts a session (other tab logs the skip).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
