### PR TITLE
fix(clients/Network): use monotonic clock in AuthFailureTracker

### DIFF
--- a/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthFailureTrackerTests.swift
@@ -2,14 +2,18 @@ import XCTest
 @testable import VellumAssistantShared
 
 final class AuthFailureTrackerTests: XCTestCase {
-    /// Helper that exposes a mutable `Date` the tracker reads via its injected clock.
+    /// Helper that exposes a mutable monotonic `TimeInterval` the tracker reads
+    /// via its injected clock. The tracker uses a monotonic clock source (not
+    /// `Date`) to stay robust against NTP / wall-clock jumps, so the test fake
+    /// models elapsed seconds since an arbitrary fixed reference rather than a
+    /// wall-clock instant.
     private final class Clock {
-        var now: Date
-        init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+        var now: TimeInterval
+        init(_ start: TimeInterval = 1_700_000_000) {
             self.now = start
         }
         func advance(_ seconds: TimeInterval) {
-            now = now.addingTimeInterval(seconds)
+            now += seconds
         }
     }
 

--- a/clients/shared/Network/AuthFailureTracker.swift
+++ b/clients/shared/Network/AuthFailureTracker.swift
@@ -16,20 +16,25 @@ import Foundation
 /// jitter. A 30s window (the original default) could hold at most 3 such
 /// entries and so could never trip the detector.
 ///
-/// The clock is injected so tests can drive time deterministically without
-/// relying on `sleep`. All mutation is serialized through a private
+/// The clock source is **monotonic** (backed by `DispatchTime.now()`), not
+/// wall-clock (`Date()`). Pruning compares elapsed seconds since an arbitrary
+/// fixed reference, so NTP adjustments, manual clock changes, and daylight-
+/// savings transitions cannot corrupt the window — a backward wall-clock jump
+/// would otherwise keep stale failures live, and a forward jump would prune
+/// real ones. The clock is injected so tests can drive time deterministically
+/// without relying on `sleep`. All mutation is serialized through a private
 /// `DispatchQueue` so the tracker is safe to call from a periodic health-check
 /// task and from request-completion callbacks concurrently.
 public final class AuthFailureTracker {
     private struct Entry {
-        let timestamp: Date
+        let timestamp: TimeInterval
         let statusCode: Int
         let path: String
     }
 
     public let windowSeconds: TimeInterval
     public let minFailures: Int
-    private let now: () -> Date
+    private let now: () -> TimeInterval
     private let queue = DispatchQueue(label: "ai.vellum.AuthFailureTracker")
 
     private var entries: [Entry] = []
@@ -39,11 +44,18 @@ public final class AuthFailureTracker {
     public init(
         windowSeconds: TimeInterval = 90,
         minFailures: Int = 4,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> TimeInterval = AuthFailureTracker.monotonicNow
     ) {
         self.windowSeconds = windowSeconds
         self.minFailures = minFailures
         self.now = now
+    }
+
+    /// Default monotonic clock: seconds since an arbitrary fixed reference,
+    /// sourced from `DispatchTime.now()` (which wraps Apple's monotonic
+    /// mach clock). Immune to wall-clock jumps.
+    public static func monotonicNow() -> TimeInterval {
+        TimeInterval(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
     }
 
     /// Record a completed HTTP response. Only 401 and 429 contribute to the
@@ -89,8 +101,8 @@ public final class AuthFailureTracker {
 
     // MARK: - Private
 
-    private func pruneLocked(relativeTo current: Date) {
-        let cutoff = current.addingTimeInterval(-windowSeconds)
+    private func pruneLocked(relativeTo current: TimeInterval) {
+        let cutoff = current - windowSeconds
         entries.removeAll { $0.timestamp < cutoff }
     }
 }


### PR DESCRIPTION
## Summary
- Switches `AuthFailureTracker` from `Date()` to a monotonic clock source backed by `DispatchTime.now().uptimeNanoseconds` so sliding-window pruning is immune to NTP adjustments, manual clock changes, and DST transitions.
- Previously, a backward wall-clock jump kept stale failures in-window and a forward jump pruned live ones, corrupting the 401/429 auth-failure detector.
- Updates the injected-clock test fake from `Date` to `TimeInterval` (monotonic seconds since an arbitrary reference); all existing test semantics are preserved.

Addresses Codex P2 feedback on #26486.

## Test plan
- [ ] `AuthFailureTrackerTests` pass locally
- [ ] `GatewayConnectionManager` continues to trip the detector after four 401 health-checks in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
