### PR TITLE
docs(skills): document getCatalog vs resolveCatalog asymmetry

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -51,13 +51,31 @@ export function getSkillsIndexPath(): string {
   return join(getWorkspaceSkillsDir(), "SKILLS.md");
 }
 
+/**
+ * Resolve the directory containing a `catalog.json` and first-party skill
+ * sources — either bundled next to a compiled binary or in the dev repo.
+ *
+ * Catalog asymmetry note: when this returns a path, `getCatalog()` in
+ * `catalog-cache.ts` reads that local catalog exclusively and does not merge
+ * with remote. This means a compiled-binary install sees a catalog frozen at
+ * build time for listing and file-preview flows. `resolveCatalog()` below is
+ * smarter — it falls back to remote when a specific skill id is missing —
+ * so `autoInstallFromCatalog()` can still discover platform-only skills.
+ * This asymmetry is intentional: listings should be fast and work offline,
+ * while install-on-demand paths are allowed to pay the network cost.
+ */
 export function getRepoSkillsDir(): string | undefined {
   const importDir = import.meta.dir;
 
   if (importDir.startsWith("/$bunfs/")) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary in Contents/MacOS/, resources in Contents/Resources/
-    const resourcesPath = join(execDir, "..", "Resources", "first-party-skills");
+    const resourcesPath = join(
+      execDir,
+      "..",
+      "Resources",
+      "first-party-skills",
+    );
     if (existsSync(join(resourcesPath, "catalog.json"))) {
       return resourcesPath;
     }


### PR DESCRIPTION
## Summary
- Add a doc comment on `getRepoSkillsDir()` explaining that `getCatalog()` reads the bundled local catalog exclusively (frozen at build time) while `resolveCatalog()` falls back to remote on miss
- Addresses review feedback on #26743 flagging the asymmetry as potentially surprising to future contributors
- The typo flagged in the same review was already fixed in #26747
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
