### PR TITLE
fix(gateway): propagate source.threadId in normalizeSlackBlockActions

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1233,6 +1233,31 @@ describe("source.threadId propagation", () => {
     });
   });
 
+  describe("normalizeSlackBlockActions", () => {
+    it("populates source.threadId when message.thread_ts is present", () => {
+      const config = makeConfig();
+      const payload = makeBlockActionsPayload();
+      payload.message = {
+        ts: "1234567890.999999",
+        thread_ts: "1234567890.000001",
+        text: "Choose an option",
+      };
+      const result = normalizeSlackBlockActions(payload, "env-tid-1", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.source.threadId).toBe("1234567890.000001");
+    });
+
+    it("omits source.threadId when message.thread_ts is absent", () => {
+      const config = makeConfig();
+      const payload = makeBlockActionsPayload();
+      const result = normalizeSlackBlockActions(payload, "env-tid-2", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.source.threadId).toBeUndefined();
+    });
+  });
+
   describe("normalizeSlackMessageDelete", () => {
     it("populates source.threadId for deletes of threaded messages", () => {
       const config = makeConfig();

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -654,6 +654,9 @@ export function normalizeSlackBlockActions(
       source: {
         updateId: envelopeId,
         messageId: messageTs,
+        ...(payload.message?.thread_ts
+          ? { threadId: payload.message.thread_ts }
+          : {}),
       },
       raw: payload as unknown as Record<string, unknown>,
     },


### PR DESCRIPTION
## Summary

Addresses review feedback on #26613: `normalizeSlackBlockActions` was not propagating `payload.message.thread_ts` into `source.threadId`, even though it already used it for the outer `threadTs` field. Block-actions on a threaded message would lose thread context downstream.

(The sibling `normalizeSlackMessageDelete` gap was already addressed in #26632.)

## Changes
- `gateway/src/slack/normalize.ts`: populate `source.threadId` from `payload.message?.thread_ts` in `normalizeSlackBlockActions`.
- `gateway/src/slack/normalize.test.ts`: extend the `source.threadId propagation` describe block with coverage for block-actions (present + absent).

## Test plan
- [x] `bun test src/slack/normalize.test.ts` (68 pass)
- [x] `bunx tsc --noEmit` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
