### PR TITLE
fix(browser): late-timeout guard in cdp-inspect discovery

### DIFF
--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/discovery.ts
@@ -420,6 +420,19 @@ export async function probeDevToolsJsonVersion(opts: {
         err,
       );
     }
+
+    // Late-timeout guard: Bun's `response.text()` can resolve with the
+    // already-buffered bytes when the underlying socket is cut off by
+    // our abort, rather than rejecting. Without this check, a truncated
+    // body from a stalled server would reach the JSON parser and be
+    // classified as `invalid_response` instead of `timeout`.
+    if (handle.timedOut || opts.signal?.aborted === true) {
+      throw classifyFetchError(
+        new Error("Discovery body read returned before completion."),
+        handle.timedOut,
+        opts.signal?.aborted === true,
+      );
+    }
   } finally {
     handle.cleanup();
   }
@@ -523,6 +536,15 @@ export async function listDevToolsTargets(opts: {
         "invalid_response",
         "Failed to read /json/list response body.",
         err,
+      );
+    }
+
+    // See the matching comment in probeDevToolsJsonVersion.
+    if (handle.timedOut || opts.signal?.aborted === true) {
+      throw classifyFetchError(
+        new Error("Discovery body read returned before completion."),
+        handle.timedOut,
+        opts.signal?.aborted === true,
       );
     }
   } finally {


### PR DESCRIPTION
## Summary
- Add a late-timeout guard after `readResponseText()` returns in both `probeDevToolsJsonVersion` and `listDevToolsTargets`.
- Fixes flaky CI failure where Bun's `response.text()` resolves with a truncated partial body (e.g. `[`) when the abort signal fires, causing the truncated bytes to reach the JSON parser and be classified as `invalid_response` instead of `timeout`.
- Observed in [this failing job](https://github.com/vellum-ai/vellum-assistant/actions/runs/24679072935/job/72171088581) on the `stalled response body during listDevToolsTargets triggers timeout` regression test from PR #24601.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24679072935/job/72171088581
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
