### PR TITLE
fix(meet-tts): make amplitude tap a pass-through Transform so it doesn't steal bytes from the bot

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-lipsync.test.ts
@@ -116,6 +116,8 @@ interface RecordedViseme {
 interface FakeBot {
   url: string;
   visemes: RecordedViseme[];
+  /** Total bytes received on `/play_audio` POSTs across all streams. */
+  playAudioBytes: number;
   /**
    * When set, every `/avatar/viseme` POST replies with this status. Used
    * to verify 4xx/5xx tolerance.
@@ -129,6 +131,7 @@ function startFakeBot(): FakeBot {
   const state: FakeBot = {
     url: "",
     visemes,
+    playAudioBytes: 0,
     visemeStatusOverride: null,
     stop: async () => {
       /* set below */
@@ -163,8 +166,9 @@ function startFakeBot(): FakeBot {
         if (req.body) {
           const reader = req.body.getReader();
           while (true) {
-            const { done } = await reader.read();
+            const { done, value } = await reader.read();
             if (done) break;
+            if (value) state.playAudioBytes += value.byteLength;
           }
         }
         return new Response("", { status: 200 });
@@ -435,6 +439,38 @@ describe("MeetTtsBridge.onViseme — amplitude fallback path", () => {
     // Allow a small epsilon for float accumulation.
     expect(events[0]!.weight).toBeGreaterThan(0.4);
     expect(events[0]!.weight).toBeLessThan(0.6);
+  });
+
+  test("amplitude tap does not steal bytes from the bot's /play_audio body", async () => {
+    // Regression: the tap was previously a `.on("data")` listener on a
+    // PassThrough that was then converted to the HTTP body — two flowing-
+    // mode consumers raced for chunks and some bytes were dropped. Sending
+    // a large payload with subscribers active must still deliver every
+    // byte to the bot.
+    const amplitude = 16_384;
+    const payload = [makeConstantPcm(500, amplitude)];
+    const expectedBytes = payload[0]!.byteLength;
+    const provider = makePlainProvider(payload);
+    const { spawn } = makeSpawnMock();
+
+    const bridge = new MeetTtsBridge(
+      { meetingId: MEETING_ID, botBaseUrl: fakeBot.url, botApiToken: TOKEN },
+      {
+        providerFactory: () => provider,
+        spawn,
+        newStreamId: () => "stream-no-steal",
+      },
+    );
+
+    bridge.onViseme(() => {
+      /* presence of a subscriber activates the tap */
+    });
+
+    const before = fakeBot.playAudioBytes;
+    const { completion } = await bridge.speak({ text: "no-steal" });
+    await completion;
+
+    expect(fakeBot.playAudioBytes - before).toBe(expectedBytes);
   });
 
   test("does not run the amplitude tap when no subscribers are registered", async () => {

--- a/skills/meet-join/daemon/tts-bridge.ts
+++ b/skills/meet-join/daemon/tts-bridge.ts
@@ -32,7 +32,7 @@
 
 import { spawn as nodeSpawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { PassThrough, Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 
 import { getLogger } from "../../../assistant/src/util/logger.js";
 import type {
@@ -520,15 +520,14 @@ export class MeetTtsBridge {
     // Node's undici-backed fetch accepts a `ReadableStream` body; convert
     // the node-stream `ffmpeg.stdout` into a web stream so we can hand it
     // off to fetch with `duplex: "half"`. When the amplitude fallback is
-    // active we splice a PassThrough into the pipeline so we can observe
-    // every PCM byte without buffering the whole stream ourselves — the
-    // tap runs RMS over 50 ms windows and emits viseme events without
-    // delaying the outbound HTTP body.
+    // active we splice a pass-through Transform into the pipeline so the
+    // tap observes every PCM byte without diverting it — a `data` listener
+    // on a PassThrough would put it in flowing mode and race with the
+    // fetch body reader, truncating the audio that reaches the bot.
     let httpBodySource: NodeJS.ReadableStream = ffmpeg.stdout;
     if (useAmplitudeFallback) {
-      const tap = new PassThrough();
+      const tap = this.createAmplitudeTap(abort.signal);
       ffmpeg.stdout.pipe(tap);
-      this.attachAmplitudeTap(tap, abort.signal);
       httpBodySource = tap;
     }
     const bodyStream = Readable.toWeb(
@@ -665,22 +664,28 @@ export class MeetTtsBridge {
   }
 
   /**
-   * Wire an amplitude-envelope extractor over a PCM stream. The stream is
-   * expected to be `s16le` mono at {@link BOT_AUDIO_SAMPLE_RATE_HZ}, matching
-   * the ffmpeg transcode pipeline's stdout. For every 50 ms window of bytes
-   * the tap computes a normalized RMS and emits a `{ phoneme: "amp", ... }`
-   * viseme event with the window's start timestamp (milliseconds from the
-   * beginning of this utterance).
+   * Build a pass-through Transform that observes PCM bytes flowing to the
+   * bot and emits amplitude-envelope viseme events without diverting the
+   * stream. The input is expected to be `s16le` mono at
+   * {@link BOT_AUDIO_SAMPLE_RATE_HZ}, matching the ffmpeg transcode
+   * pipeline's stdout. For every 50 ms window of bytes the tap computes a
+   * normalized RMS and emits a `{ phoneme: "amp", ... }` viseme event with
+   * the window's start timestamp (milliseconds from the beginning of this
+   * utterance).
+   *
+   * Implementing the tap as a Transform (rather than a `data` listener on
+   * a PassThrough) is load-bearing: the Transform forwards every chunk
+   * downstream via `callback(null, chunk)` so `Readable.toWeb` sees the
+   * full audio, while a `data` listener would switch the PassThrough into
+   * flowing mode and race with the fetch body reader, causing truncated
+   * or dropped audio at the bot.
    *
    * The tap tolerates any amount of trailing bytes that don't fill a full
    * window — leftover audio under 50 ms just doesn't emit a final event,
    * which keeps the calculation self-consistent and spares consumers a
    * ragged-edge weight.
    */
-  private attachAmplitudeTap(
-    stream: NodeJS.ReadableStream,
-    signal: AbortSignal,
-  ): void {
+  private createAmplitudeTap(signal: AbortSignal): Transform {
     let totalBytesConsumed = 0;
     let windowBuffer = Buffer.alloc(0);
 
@@ -713,20 +718,25 @@ export class MeetTtsBridge {
       }
     };
 
-    stream.on("data", (chunk: Buffer) => {
-      if (signal.aborted) return;
-      windowBuffer =
-        windowBuffer.length === 0
-          ? Buffer.from(chunk)
-          : Buffer.concat([windowBuffer, chunk]);
-      try {
-        flushWindow();
-      } catch (err) {
-        log.warn(
-          { err, meetingId: this.meetingId },
-          "amplitude tap window flush threw — suppressing",
-        );
-      }
+    const meetingId = this.meetingId;
+    return new Transform({
+      transform(chunk: Buffer, _encoding, callback): void {
+        if (!signal.aborted) {
+          windowBuffer =
+            windowBuffer.length === 0
+              ? Buffer.from(chunk)
+              : Buffer.concat([windowBuffer, chunk]);
+          try {
+            flushWindow();
+          } catch (err) {
+            log.warn(
+              { err, meetingId },
+              "amplitude tap window flush threw — suppressing",
+            );
+          }
+        }
+        callback(null, chunk);
+      },
     });
   }
 


### PR DESCRIPTION
Addresses Codex P2 on #26650.

The previous `attachAmplitudeTap` subscribed to `stream.on("data")` on the same PassThrough that was then handed to `Readable.toWeb(...)` as the `/play_audio` upload body. Two consumers in flowing mode raced for chunks — the amplitude tap could drain bytes before the fetch body reader saw them, causing audio truncation or dropped audio at the bot.

Replace the tap with a pass-through `Transform` stream that forwards every chunk downstream via `callback(null, chunk)` while observing the bytes for RMS computation. The stream is never diverted, just observed.

Adds a regression test that asserts the bot receives the full byte count of the audio sent when the amplitude tap is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
