### PR TITLE
fix(slack): short-circuit no-op Slack edits (unfurls, re-fires)

### DIFF
--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -61,9 +61,14 @@ async function seedSlackMessage(opts: {
 }): Promise<SeededFixture> {
   const { conversationExternalId, channelTs, initialContent } = opts;
 
-  const inboundResult = recordInbound("slack", conversationExternalId, channelTs, {
-    sourceMessageId: channelTs,
-  });
+  const inboundResult = recordInbound(
+    "slack",
+    conversationExternalId,
+    channelTs,
+    {
+      sourceMessageId: channelTs,
+    },
+  );
 
   const inserted = await addMessage(
     inboundResult.conversationId,
@@ -83,7 +88,10 @@ async function seedSlackMessage(opts: {
   };
 }
 
-function readMessageRow(messageId: string): { content: string; metadata: string | null } {
+function readMessageRow(messageId: string): {
+  content: string;
+  metadata: string | null;
+} {
   const db = getDb();
   const row = db
     .select({ content: messages.content, metadata: messages.metadata })
@@ -172,9 +180,8 @@ describe("Slack edit propagation", () => {
     const afterFirst = readMessageRow(seeded.messageId);
     expect(afterFirst.content).toBe("first edit");
     const firstSlackMeta = readSlackMetadata(
-      (JSON.parse(afterFirst.metadata!) as Record<string, unknown>).slackMeta as
-        | string
-        | null,
+      (JSON.parse(afterFirst.metadata!) as Record<string, unknown>)
+        .slackMeta as string | null,
     );
     expect(firstSlackMeta).not.toBeNull();
     const firstEditedAt = firstSlackMeta!.editedAt!;
@@ -196,9 +203,8 @@ describe("Slack edit propagation", () => {
     const afterSecond = readMessageRow(seeded.messageId);
     expect(afterSecond.content).toBe("second edit");
     const secondSlackMeta = readSlackMetadata(
-      (JSON.parse(afterSecond.metadata!) as Record<string, unknown>).slackMeta as
-        | string
-        | null,
+      (JSON.parse(afterSecond.metadata!) as Record<string, unknown>)
+        .slackMeta as string | null,
     );
     expect(secondSlackMeta).not.toBeNull();
     expect(secondSlackMeta!.editedAt!).toBeGreaterThan(firstEditedAt);
@@ -208,38 +214,67 @@ describe("Slack edit propagation", () => {
     expect(secondSlackMeta!.eventKind).toBe("message");
   });
 
+  test("no-op edit (identical text, e.g. unfurl) skips DB write", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+
+    const before = readMessageRow(seeded.messageId);
+
+    const resp = await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      // Same text as stored -- simulates a Slack unfurl `message_changed`
+      // where only attachments changed.
+      content: "original text",
+    });
+
+    expect(resp.status).toBe(200);
+    const respJson = (await resp.json()) as Record<string, unknown>;
+    expect(respJson.accepted).toBe(true);
+    expect(respJson.duplicate).toBe(false);
+    expect(respJson.noop).toBe(true);
+
+    const after = readMessageRow(seeded.messageId);
+    expect(after.content).toBe(before.content);
+    // No metadata mutation either -- the write is fully skipped.
+    expect(after.metadata).toBe(before.metadata);
+  });
+
   // The lookup retries 5 times with 2s backoff (~10s total) before giving up,
   // so this test legitimately needs to outrun the default 5s per-test timeout.
-  test(
-    "missing-target edit is a no-op (no throw, no row changed)",
-    async () => {
-      const seeded = await seedSlackMessage({
-        conversationExternalId: "C0123CHANNEL",
-        channelTs: "1234.5678",
-        initialContent: "original text",
-      });
-      const beforeUnknown = readMessageRow(seeded.messageId);
+  test("missing-target edit is a no-op (no throw, no row changed)", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+    const beforeUnknown = readMessageRow(seeded.messageId);
 
-      const resp = await handleEditIntercept({
-        sourceChannel: "slack",
-        conversationExternalId: seeded.conversationExternalId,
-        // sourceMessageId points at a ts that was never stored.
-        externalMessageId: nextEditEventId(),
-        sourceMessageId: "9999.0000",
-        canonicalAssistantId: "self",
-        assistantId: "self",
-        content: "new text",
-      });
+    const resp = await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      // sourceMessageId points at a ts that was never stored.
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: "9999.0000",
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      content: "new text",
+    });
 
-      expect(resp.status).toBe(200);
-      const respJson = (await resp.json()) as Record<string, unknown>;
-      expect(respJson.accepted).toBe(true);
-      expect(respJson.duplicate).toBe(false);
+    expect(resp.status).toBe(200);
+    const respJson = (await resp.json()) as Record<string, unknown>;
+    expect(respJson.accepted).toBe(true);
+    expect(respJson.duplicate).toBe(false);
 
-      const afterUnknown = readMessageRow(seeded.messageId);
-      expect(afterUnknown.content).toBe(beforeUnknown.content);
-      expect(afterUnknown.metadata).toBe(beforeUnknown.metadata);
-    },
-    30_000,
-  );
+    const afterUnknown = readMessageRow(seeded.messageId);
+    expect(afterUnknown.content).toBe(beforeUnknown.content);
+    expect(afterUnknown.metadata).toBe(beforeUnknown.metadata);
+  }, 30_000);
 });

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -118,6 +118,31 @@ export async function handleEditIntercept(
   }
 
   if (original) {
+    const newContent = content ?? "";
+    // Short-circuit no-op edits: Slack fires `message_changed` for link
+    // unfurls and other decorations where the text is identical to the
+    // previous revision. Skipping the DB write here covers that case and
+    // also drops trivially-redundant edit webhooks. We only have the
+    // authoritative previous text once the original row is located, so
+    // this check lives after the lookup.
+    const existingRow = getMessageById(original.messageId);
+    if (existingRow && existingRow.content === newContent) {
+      log.debug(
+        {
+          assistantId,
+          sourceChannel,
+          sourceMessageId,
+          messageId: original.messageId,
+        },
+        "Edit text unchanged; skipping update",
+      );
+      return Response.json({
+        accepted: true,
+        duplicate: false,
+        noop: true,
+        eventId: editResult.eventId,
+      });
+    }
     if (sourceChannel === "slack") {
       // Slack edits stamp `slackMeta.editedAt` so the chronological
       // transcript renderer can surface the edited marker. The merge
@@ -127,10 +152,10 @@ export async function handleEditIntercept(
         messageId: original.messageId,
         conversationExternalId,
         sourceMessageId,
-        newContent: content ?? "",
+        newContent,
       });
     } else {
-      updateMessageContent(original.messageId, content ?? "");
+      updateMessageContent(original.messageId, newContent);
     }
     log.info(
       { assistantId, sourceMessageId, messageId: original.messageId },
@@ -226,7 +251,11 @@ function applySlackEditMetadata(params: {
 function safeParseRecord(raw: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(raw);
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
       return {};
     }
     return parsed as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Addresses review feedback on #26611, which broadened `message_changed` admission to every subscribed Slack channel. Two concerns were raised:

- **Load/lookup flood (Codex):** trivial/duplicate edits hit the runtime retry-lookup path (~10s).
- **Unfurl phantom edits (Devin):** Slack fires `message_changed` for link unfurls where the text is unchanged, producing phantom edits.

This PR short-circuits the daemon edit consumer when the new text equals the stored content: we return `{ accepted: true, duplicate: false, noop: true }` without touching the DB (no content rewrite, no `slackMeta.editedAt` re-stamp). The check runs after the lookup (we need the authoritative previous text) but before any mutation, so:

- Unfurls are naturally dropped (attachments-only change → text identical).
- Re-fired `message_changed` events for already-stored content are free.
- Real typo fixes still flow through the existing update path untouched.

## Test plan

- [x] Added `no-op edit (identical text, e.g. unfurl) skips DB write` to `edit-propagation.test.ts`.
- [x] Existing edit-propagation tests (update, idempotent successive edits, missing-target no-op) still pass.
- [x] `bunx tsc --noEmit` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
