### PR TITLE
test(meet): use spawnSync with result.error for ffmpeg probe

### DIFF
--- a/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
+++ b/skills/meet-join/daemon/__tests__/tts-bridge.test.ts
@@ -771,16 +771,14 @@ function buildPcmWavBuffer(options: {
 }
 
 function isFfmpegOnPath(): boolean {
-  try {
-    // Use execFileSync for the probe instead of spawn — Bun's spawn
-    // throws a synchronous error that leaks as an "unhandled error
-    // between tests" even inside try/catch at module scope.
-    const { execFileSync } = require("node:child_process");
-    execFileSync("ffmpeg", ["-version"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
+  // spawnSync returns a result object with `error` set to ENOENT when
+  // the binary is missing — no reliance on sync-throw semantics, and
+  // no "unhandled error between tests" leakage from async spawn.
+  const { spawnSync } = require("node:child_process");
+  const result = spawnSync("ffmpeg", ["-version"], {
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return result.error == null && result.status === 0;
 }
 
 describe("MeetTtsBridge resampling hot-path (real ffmpeg)", () => {


### PR DESCRIPTION
## Summary
- Addresses review feedback on #26647 from both Codex and Devin
- Switches `isFfmpegOnPath()` from `execFileSync` (sync-throw reliant) to `spawnSync` (returns `result.error`)
- Matches Devin's suggested pattern exactly and removes try/catch

## Why
PR #26647's original code used async `spawn()` which delivers ENOENT asynchronously — the probe always returned true. Follow-up #26694 switched to `execFileSync` which is functionally correct (throws sync on ENOENT) but still leans on throw semantics. `spawnSync` with `result.error` is the cleanest form and lets us drop the try/catch entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
