### PR TITLE
fix(meet-ext): guard participants onEvent and stop toggling panel every tick

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/features/participants.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/participants.ts
@@ -155,17 +155,35 @@ export function startParticipantScraper(
   let previous: Map<string, Participant> = new Map();
   let firstPollComplete = false;
   let stopped = false;
+  // Only try to open the panel when we can't find the list. Calling
+  // `ensurePanelOpen()` on every tick fights with sibling features
+  // (`chat.ts` opens its own panel on start) because Meet closes whichever
+  // side panel isn't currently showing when a new toggle is clicked.
+  let panelOpenAttempted = false;
 
   const poll = (): void => {
     if (stopped) return;
 
     let rows: ScrapedRow[];
     try {
-      ensurePanelOpen();
+      if (!panelOpenAttempted) {
+        ensurePanelOpen();
+        panelOpenAttempted = true;
+      }
       rows = scrapeRows();
+      // If the panel was closed out from under us (e.g. the chat reader
+      // toggled its panel and Meet auto-collapsed participants), retry
+      // opening on the next tick.
+      if (
+        rows.length === 0 &&
+        !document.querySelector(selectors.INGAME_PARTICIPANT_LIST)
+      ) {
+        panelOpenAttempted = false;
+      }
     } catch {
       // Transient DOM error (navigation, panel auto-closed, etc.). Skip this
       // tick and try again next interval.
+      panelOpenAttempted = false;
       return;
     }
 
@@ -218,13 +236,20 @@ export function startParticipantScraper(
     if (joined.length === 0 && left.length === 0) return;
     if (stopped) return;
 
-    onEvent({
-      type: "participant.change",
-      meetingId,
-      timestamp: new Date().toISOString(),
-      joined,
-      left,
-    });
+    try {
+      onEvent({
+        type: "participant.change",
+        meetingId,
+        timestamp: new Date().toISOString(),
+        joined,
+        left,
+      });
+    } catch {
+      // Never let a subscriber error crash the polling loop — matches the
+      // defensive pattern in speaker.ts and chat.ts. Also guards the
+      // synchronous first poll below from leaking the `setInterval` handle
+      // if `onEvent` throws before `startParticipantScraper` returns.
+    }
   };
 
   const timer = setInterval(poll, pollMs);


### PR DESCRIPTION
## Summary
Addresses review feedback on #26580:

- **Devin (BUG)**: wrap `onEvent` in try/catch so a subscriber error cannot crash the polling loop. Matches the defensive pattern already used in `speaker.ts` and `chat.ts`. Without this, the synchronous first `poll()` call (which runs before `startParticipantScraper()` returns) could leak the `setInterval` handle and abort `startMeetingSession()` in `content.ts`.
- **Codex (P1)** / **Devin (ANALYSIS)**: stop calling `ensurePanelOpen()` on every poll tick. The chat reader opens its own panel on start, and Meet collapses whichever side panel is not currently showing when a new toggle click fires — the participants scraper was re-opening the participants panel every ~2s and closing the chat panel each time. Now we only attempt to open the panel once at start, and reset the flag if the list later disappears (e.g. the chat panel reopened and Meet collapsed participants).

## Test plan
- [x] `bun test src/__tests__/participants.test.ts` passes (15 tests)
- Existing 'opens panel when it starts closed' and 'does not re-click toggle when panel is already open' tests still pass — behavior on first tick is unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
