### PR TITLE
fix(gateway): infer DM from channel ID prefix in normalizeSlackMessageDelete

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1106,6 +1106,25 @@ describe("normalizeSlackMessageDelete", () => {
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe("ast-1");
   });
+
+  it("infers DM from channel ID prefix when channel_type is absent", () => {
+    const config = makeConfig({ unmappedPolicy: "reject" });
+    const event = makeMessageDeletedEvent({
+      channel: "D789",
+      channel_type: undefined,
+    });
+    const result = normalizeSlackMessageDelete(
+      event,
+      "evt-del-dm-infer",
+      config,
+    );
+
+    // Without the DM-prefix fallback this would be null (unmapped + reject).
+    expect(result).not.toBeNull();
+    expect(result!.routing.assistantId).toBe("ast-1");
+    // DMs should not be tagged as channel chat even when inferred.
+    expect(result!.event.source.chatType).toBeUndefined();
+  });
 });
 
 // --- source.threadId propagation ---

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -877,7 +877,12 @@ export function normalizeSlackMessageDelete(
   // back to a synthetic identifier so routing/trust still has something to key on.
   const actorId = event.previous_message?.user ?? "slack-system";
 
-  const isDm = event.channel_type === "im";
+  // Slack's `message_deleted` payload frequently omits `channel_type`, but DM
+  // channel IDs always start with "D". Fall back to the ID prefix so deletes
+  // from DMs still take the defaultAssistantId routing branch.
+  const isDm =
+    event.channel_type === "im" ||
+    (event.channel_type === undefined && event.channel.startsWith("D"));
   let routing = resolveAssistant(config, event.channel, actorId);
   if (isRejection(routing) && isDm && config.defaultAssistantId) {
     routing = {


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #26612. Slack's `message_deleted` payload frequently omits `channel_type`, so DM deletes were dropped under the default `unmappedPolicy: reject` routing. Falls back to the channel-ID prefix (`D...`) to infer DMs when `channel_type` is absent, matching how Slack allocates DM channel IDs.

Codex's P1 (routing delete sentinels through the approval/callback pipeline) is already resolved — `inbound-message-handler.ts` short-circuits on `callbackData === "message_deleted"` at lines 268-379, well before approval interception at line 780+.

## Test plan
- [x] `bun test src/slack/normalize.test.ts` — 69 pass, includes new `infers DM from channel ID prefix when channel_type is absent`
- [x] `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
