### PR TITLE
fix(slack): chronological overflow trailers + singular reaction grammar

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -130,7 +130,10 @@ describe("renderSlackTranscript — basics", () => {
       userMsg(TS_14_25, "@alice", "hi (revised)", { editedAt: MS_14_30 }),
     ]);
     expect(out).toEqual([
-      textMsg("user", "[11/14/23 14:25 @alice, edited 11/14/23 14:30]: hi (revised)"),
+      textMsg(
+        "user",
+        "[11/14/23 14:25 @alice, edited 11/14/23 14:30]: hi (revised)",
+      ),
     ]);
   });
 
@@ -141,7 +144,9 @@ describe("renderSlackTranscript — basics", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_25, "@alice", "v2", { editedAt: MS_14_32 }),
     ]);
-    expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice, edited 11/14/23 14:32]: v2")]);
+    expect(out).toEqual([
+      textMsg("user", "[11/14/23 14:25 @alice, edited 11/14/23 14:32]: v2"),
+    ]);
   });
 
   test("edited message in a thread renders both arrow and edit suffix", () => {
@@ -153,7 +158,10 @@ describe("renderSlackTranscript — basics", () => {
     ]);
     const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
-      textMsg("user", `[11/14/23 14:28 @bob → ${alias}, edited 11/14/23 14:30]: got it (edit)`),
+      textMsg(
+        "user",
+        `[11/14/23 14:28 @bob → ${alias}, edited 11/14/23 14:30]: got it (edit)`,
+      ),
     ]);
   });
 
@@ -418,9 +426,83 @@ describe("renderSlackTranscript — reaction cap", () => {
     const out = renderSlackTranscript(messages, { maxReactionsPerMessage: 2 });
     // 1 msg + 2 reactions + 1 trailer for 1 excess.
     expect(out.length).toBe(4);
+    // Singular "reaction" when excess is exactly 1.
     expect(extractTagLineTexts(out)[out.length - 1]).toMatch(
-      /…and 1 more reactions to M[0-9a-f]{6}\]/,
+      /…and 1 more reaction to M[0-9a-f]{6}\]/,
     );
+  });
+
+  test("overflow trailer uses plural 'reactions' when excess > 1", () => {
+    const messages: RenderableSlackMessage[] = [
+      userMsg(TS_14_25, "@alice", "hi"),
+      reactionMsg("1700000800.000001", "@u1", "👍", TS_14_25),
+      reactionMsg("1700000800.000002", "@u2", "🎉", TS_14_25),
+      reactionMsg("1700000800.000003", "@u3", "🔥", TS_14_25),
+      reactionMsg("1700000800.000004", "@u4", "💯", TS_14_25),
+    ];
+    const out = renderSlackTranscript(messages, { maxReactionsPerMessage: 2 });
+    // 1 msg + 2 reactions + 1 trailer for 2 excess.
+    expect(out.length).toBe(4);
+    expect(extractTagLineTexts(out)[out.length - 1]).toMatch(
+      /…and 2 more reactions to M[0-9a-f]{6}\]/,
+    );
+  });
+
+  test("overflow trailer lands in chronological position, before later non-reaction messages", () => {
+    // Reactions overflow the cap, then a later message arrives. The trailer
+    // must be emitted at the point the overflow window closes — immediately
+    // before the later message — so chronology is preserved.
+    const alias = parentAlias(TS_14_25);
+    const messages: RenderableSlackMessage[] = [
+      userMsg(TS_14_25, "@alice", "hi"),
+      // Cap is 2 — first two reactions render inline.
+      reactionMsg("1699971950.000001", "@u1", "👍", TS_14_25), // 14:25:50
+      reactionMsg("1699971955.000002", "@u2", "🎉", TS_14_25), // 14:25:55
+      // Next two reactions overflow.
+      reactionMsg("1699971960.000003", "@u3", "🔥", TS_14_25), // 14:26
+      reactionMsg("1699971965.000004", "@u4", "💯", TS_14_25), // 14:26:05
+      // A later top-level message — trailer must land BEFORE this line.
+      userMsg(TS_14_30, "@bob", "later"),
+    ];
+    const out = renderSlackTranscript(messages, { maxReactionsPerMessage: 2 });
+    expect(extractTagLineTexts(out)).toEqual([
+      "[11/14/23 14:25 @alice]: hi",
+      `[11/14/23 14:25 @u1 reacted 👍 to ${alias}]`,
+      `[11/14/23 14:25 @u2 reacted 🎉 to ${alias}]`,
+      `[…and 2 more reactions to ${alias}]`,
+      "[11/14/23 14:30 @bob]: later",
+    ]);
+  });
+
+  test("overflow trailer for one target flushes before reaction event on a different target", () => {
+    // Two independent reaction streams. The first target overflows, then a
+    // reaction arrives for a second target. The first target's trailer must
+    // close its window before the second target's reaction is emitted.
+    const parentA_ts = "1700000000.000001";
+    const parentB_ts = "1700000000.000002";
+    const aliasA = parentAlias(parentA_ts);
+    const aliasB = parentAlias(parentB_ts);
+    const messages: RenderableSlackMessage[] = [
+      userMsg(parentA_ts, "@alice", "A"),
+      userMsg(parentB_ts, "@bob", "B"),
+      // Overflow the cap on A.
+      reactionMsg("1700000100.000001", "@u1", "👍", parentA_ts),
+      reactionMsg("1700000100.000002", "@u2", "🎉", parentA_ts),
+      reactionMsg("1700000100.000003", "@u3", "🔥", parentA_ts), // excess 1
+      reactionMsg("1700000100.000004", "@u4", "💯", parentA_ts), // excess 2
+      // Reaction on B arrives chronologically after the overflow — A's
+      // trailer should flush here, before B's reaction renders.
+      reactionMsg("1700000100.000005", "@u5", "👏", parentB_ts),
+    ];
+    const out = renderSlackTranscript(messages, { maxReactionsPerMessage: 2 });
+    expect(extractTagLineTexts(out)).toEqual([
+      "[11/14/23 22:13 @alice]: A",
+      "[11/14/23 22:13 @bob]: B",
+      `[11/14/23 22:15 @u1 reacted 👍 to ${aliasA}]`,
+      `[11/14/23 22:15 @u2 reacted 🎉 to ${aliasA}]`,
+      `[…and 2 more reactions to ${aliasA}]`,
+      `[11/14/23 22:15 @u5 reacted 👏 to ${aliasB}]`,
+    ]);
   });
 
   test("caps are tracked per-target message independently", () => {
@@ -582,7 +664,9 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const out = renderSlackTranscript(messages);
     const carolAlias = parentAlias(carolTopTs);
     const texts = extractTagLineTexts(out);
-    expect(texts[texts.length - 1]).toBe(`[11/14/23 14:28 @frank → ${carolAlias}]: +1`);
+    expect(texts[texts.length - 1]).toBe(
+      `[11/14/23 14:28 @frank → ${carolAlias}]: +1`,
+    );
   });
 
   test("scenario: new top-level message (no threadTs)", () => {
@@ -593,7 +677,9 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
     const out = renderSlackTranscript(messages);
     const texts = extractTagLineTexts(out);
     // No arrow on the new top-level row.
-    expect(texts[texts.length - 1]).toBe("[11/14/23 14:31 @gina]: anyone in office?");
+    expect(texts[texts.length - 1]).toBe(
+      "[11/14/23 14:31 @gina]: anyone in office?",
+    );
   });
 });
 
@@ -957,7 +1043,12 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     expect(out).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]" }],
+        content: [
+          {
+            type: "text",
+            text: "[11/14/23 14:25 @alice — deleted 11/14/23 14:32]",
+          },
+        ],
       },
     ]);
   });
@@ -979,7 +1070,9 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
       contentBlocks: [],
     };
     const out = renderSlackTranscript([base]);
-    expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice]: empty blocks")]);
+    expect(out).toEqual([
+      textMsg("user", "[11/14/23 14:25 @alice]: empty blocks"),
+    ]);
   });
 
   test("reaction row ignores contentBlocks and renders the single reaction tag line", () => {
@@ -1031,9 +1124,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
     expect(out).toEqual([
       {
         role: "assistant",
-        content: [
-          { type: "text", text: "[11/14/23 14:25]: looking it up" },
-        ],
+        content: [{ type: "text", text: "[11/14/23 14:25]: looking it up" }],
       },
     ]);
   });
@@ -1113,11 +1204,7 @@ describe("renderSlackTranscript — orphan tool_use / tool_result filter", () =>
       ],
     };
     // A normal neighbour row to confirm we don't accidentally drop it too.
-    const neighbour: RenderableSlackMessage = userMsg(
-      TS_14_26,
-      "@bob",
-      "hi",
-    );
+    const neighbour: RenderableSlackMessage = userMsg(TS_14_26, "@bob", "hi");
     const out = renderSlackTranscript([orphanResultRow, neighbour]);
     expect(out).toEqual([textMsg("user", "[11/14/23 14:26 @bob]: hi")]);
     // Sanity: the output contains no {role, content: []} placeholder.

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -247,8 +247,11 @@ function buildMessageContentBlocks(
  *
  * Reactions are rendered as their own lines (`[time @actor reacted ... to Mxxx]`),
  * but capped per-target at `opts.maxReactionsPerMessage` (default 5). Excess
- * reactions on the same target are collapsed into a single trailer line:
- * `[…and N more reactions to Mxxx]`.
+ * reactions on the same target are collapsed into a single trailer line
+ * (`[…and N more reactions to Mxxx]`, singular `reaction` when N===1), emitted
+ * at the point the overflow window closes — i.e. immediately before the next
+ * event that is not an overflowing reaction for the same target — so trailers
+ * stay in chronological position instead of batching at the tail.
  */
 export function renderSlackTranscript(
   messages: RenderableSlackMessage[],
@@ -271,13 +274,35 @@ export function renderSlackTranscript(
 
   // Per-target reaction counters used to enforce the cap.
   const reactionCount = new Map<string, number>();
-  // Accumulate excess reactions per target so we can emit one trailer line
-  // each at the end. Map insertion order is the discovery order during the
-  // chronological walk, which keeps trailer emission deterministic.
+  // Open per-target overflow windows. Excess reactions accumulate here; the
+  // window is closed (trailer emitted) as soon as the chronological walk
+  // reaches an event that is not an overflowing reaction for that target.
   const overflowAccumulator = new Map<
     string,
     { excess: number; role: "user" | "assistant" }
   >();
+
+  const trailerMessage = (
+    target: string,
+    acc: { excess: number; role: "user" | "assistant" },
+  ): Message => ({
+    role: acc.role,
+    content: [
+      {
+        type: "text" as const,
+        text: `[…and ${acc.excess} more ${acc.excess === 1 ? "reaction" : "reactions"} to ${parentAlias(target)}]`,
+      },
+    ],
+  });
+
+  const flushOverflowExcept = (out: Message[], keepTarget: string | null) => {
+    for (const target of Array.from(overflowAccumulator.keys())) {
+      if (target === keepTarget) continue;
+      const acc = overflowAccumulator.get(target)!;
+      out.push(trailerMessage(target, acc));
+      overflowAccumulator.delete(target);
+    }
+  };
 
   const out: Message[] = [];
   for (const m of sorted) {
@@ -286,6 +311,9 @@ export function renderSlackTranscript(
       const target = meta.reaction.targetChannelTs;
       const seen = reactionCount.get(target) ?? 0;
       if (seen < maxReactions) {
+        // Reaction fits under the cap for `target`. Any open overflow windows
+        // for other targets are now behind us chronologically — close them.
+        flushOverflowExcept(out, null);
         reactionCount.set(target, seen + 1);
         const line = renderReaction(m);
         if (line !== null) {
@@ -295,6 +323,9 @@ export function renderSlackTranscript(
           });
         }
       } else {
+        // Reaction overflows for `target`. Close any other open windows, then
+        // extend this target's open window.
+        flushOverflowExcept(out, target);
         const acc = overflowAccumulator.get(target) ?? {
           excess: 0,
           role: m.role,
@@ -304,6 +335,8 @@ export function renderSlackTranscript(
       }
       continue;
     }
+    // Non-reaction event: every open overflow window closes here.
+    flushOverflowExcept(out, null);
     const tagLine = renderMessage(m);
     const blocks = buildMessageContentBlocks(m, tagLine);
     if (blocks.length === 0) continue;
@@ -313,17 +346,8 @@ export function renderSlackTranscript(
     });
   }
 
-  for (const [target, acc] of overflowAccumulator) {
-    out.push({
-      role: acc.role,
-      content: [
-        {
-          type: "text" as const,
-          text: `[…and ${acc.excess} more reactions to ${parentAlias(target)}]`,
-        },
-      ],
-    });
-  }
+  // End of the walk: flush any still-open overflow windows.
+  flushOverflowExcept(out, null);
 
   return filterOrphanToolPairs(out);
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #26614 (the chronological Slack transcript renderer):

- **Overflow trailer ordering (Codex P1):** The renderer was batching every `[…and N more reactions to Mxxx]` trailer at the tail of the output, so any non-reaction message that arrived chronologically after an overflow window closed would incorrectly sort *before* its trailer in the rendered transcript — breaking the chronological contract the function advertises. Now each trailer is flushed at the moment its overflow window closes: immediately before the next event that is not an overflowing reaction for the same target.
- **Singular vs plural grammar (Devin):** Trailer now reads `…and 1 more reaction` when excess is exactly 1, and `…and N more reactions` otherwise.

Ignored Devin's analysis-only note about deleted thread-reply thread context per task brief.

## Test plan

- [x] Updated `respects custom maxReactionsPerMessage` test to expect singular grammar for excess=1.
- [x] Added regression for plural grammar when excess > 1.
- [x] Added regression for trailer landing before a later non-reaction message (the Codex scenario).
- [x] Added regression for trailer flushing before a reaction event on a different target.
- [x] `bun test src/messaging/providers/slack/render-transcript.test.ts` — 68/68 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
