### PR TITLE
fix(meet-ext): defer ready handshake until native port (re)connects

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -28,6 +28,9 @@ function makeFakePort(): FakePort {
     onMessage(cb) {
       messageCallbacks.push(cb);
     },
+    onConnect() {
+      /* no-op */
+    },
     onDisconnect() {
       /* no-op */
     },

--- a/skills/meet-join/meet-controller-ext/src/__tests__/native-port.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/native-port.test.ts
@@ -218,6 +218,25 @@ describe("openNativePort", () => {
     handle.close();
   });
 
+  test("onConnect fires after each successful (re)connect", async () => {
+    const baseMs = 20;
+    const handle = openNativePort({ reconnectBaseMs: baseMs });
+    let connects = 0;
+    handle.onConnect(() => {
+      connects += 1;
+    });
+    // Subscribing after `connect()` has already run should fire immediately
+    // so late subscribers still get the startup signal.
+    expect(connects).toBe(1);
+
+    disconnect(fake.connectCalls[0]!.port);
+    await sleep(baseMs + 20);
+    expect(fake.connectCalls.length).toBe(2);
+    expect(connects).toBe(2);
+
+    handle.close();
+  });
+
   test("close() prevents further reconnect attempts", async () => {
     const baseMs = 20;
     const handle = openNativePort({ reconnectBaseMs: baseMs });

--- a/skills/meet-join/meet-controller-ext/src/background.ts
+++ b/skills/meet-join/meet-controller-ext/src/background.ts
@@ -36,10 +36,23 @@ port.onMessage((msg) => {
   }
 });
 
-// Emit the ready handshake as soon as the port is open. The bot uses this as
-// the signal that the in-container extension is attached and ready to
-// receive join/leave/send_chat commands.
-port.post({
-  type: "ready",
-  extensionVersion: chrome.runtime.getManifest().version,
+// Emit the ready handshake on every (re)connect. The bot uses this as the
+// signal that the in-container extension is attached and ready to receive
+// join/leave/send_chat commands. We route through `onConnect` rather than
+// posting synchronously at module scope so a transient `connectNative`
+// failure (which leaves the port disconnected) can't throw out of the
+// service-worker entrypoint and abort startup before the reconnect loop
+// gets a chance to engage.
+port.onConnect(() => {
+  try {
+    port.post({
+      type: "ready",
+      extensionVersion: chrome.runtime.getManifest().version,
+    });
+  } catch (err) {
+    // The port may have torn down between the onConnect fire and this post
+    // (e.g. the native host disconnected immediately). The reconnect loop
+    // will try again and fire onConnect once the port is back.
+    console.warn("[meet-ext] failed to send ready handshake", err);
+  }
 });

--- a/skills/meet-join/meet-controller-ext/src/messaging/native-port.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/native-port.ts
@@ -44,6 +44,12 @@ export interface NativePort {
   /** Register a callback for every validated inbound {@link BotToExtensionMessage}. */
   onMessage(cb: (msg: BotToExtensionMessage) => void): void;
   /**
+   * Register a callback fired after every successful `connectNative` call,
+   * including reconnects. Use this to (re-)send any handshake the native host
+   * expects on a fresh connection.
+   */
+  onConnect(cb: () => void): void;
+  /**
    * Register a callback fired whenever the underlying port disconnects, whether
    * via transport failure, protocol error, or explicit {@link NativePort.close}.
    */
@@ -61,6 +67,7 @@ export function openNativePort(opts: OpenNativePortOptions = {}): NativePort {
   const maxMs = opts.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
 
   const messageCallbacks: Array<(msg: BotToExtensionMessage) => void> = [];
+  const connectCallbacks: Array<() => void> = [];
   const disconnectCallbacks: Array<(reason: string) => void> = [];
 
   let closed = false;
@@ -138,6 +145,18 @@ export function openNativePort(opts: OpenNativePortOptions = {}): NativePort {
       emitDisconnect(reason);
       scheduleReconnect();
     });
+
+    // Notify listeners after the port is fully wired. This is the confirmed
+    // "connection is usable" signal that callers use to post handshake
+    // frames — posting synchronously at module scope risks racing with a
+    // transient connectNative failure and killing the service worker.
+    for (const cb of connectCallbacks) {
+      try {
+        cb();
+      } catch (err) {
+        console.warn("[meet-ext] onConnect callback threw", err);
+      }
+    }
   }
 
   connect();
@@ -153,6 +172,18 @@ export function openNativePort(opts: OpenNativePortOptions = {}): NativePort {
     },
     onMessage(cb: (msg: BotToExtensionMessage) => void): void {
       messageCallbacks.push(cb);
+    },
+    onConnect(cb: () => void): void {
+      connectCallbacks.push(cb);
+      // If we're already connected by the time the caller subscribes, fire
+      // immediately so the handshake still goes out.
+      if (currentPort !== null) {
+        try {
+          cb();
+        } catch (err) {
+          console.warn("[meet-ext] onConnect callback threw", err);
+        }
+      }
     },
     onDisconnect(cb: (reason: string) => void): void {
       disconnectCallbacks.push(cb);


### PR DESCRIPTION
## Summary
- Address Codex P1 on #26573: the startup `port.post({ type: 'ready', ... })` in `background.ts` throws synchronously when `openNativePort` returns with `currentPort === null` (e.g. `connectNative` threw, or the port disconnected in the same tick). At module scope that uncaught throw aborts service-worker startup before the reconnect loop can engage, losing the extension for the rest of the session.
- Add an `onConnect(cb)` hook to `NativePort` that fires after every successful `connectNative` (initial boot and every reconnect). Late subscribers get fired immediately if the port is already connected.
- Move the `ready` handshake in `background.ts` into `port.onConnect(...)` with a `try/catch` safety net. This also means the bot gets a fresh `ready` after every reconnect, which matches the 'extension is attached and ready' semantics the handshake is supposed to carry.

## Test plan
- [x] New unit test: `onConnect` fires on initial connect and again after a forced reconnect.
- [x] `bun test` on `native-port.test.ts` + `content-bridge.test.ts` — all 12 tests pass.
- [x] `bunx tsc --noEmit` clean in `meet-controller-ext`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
