### PR TITLE
fix(meet-ext): serialize sendChat + React controlled-input bypass

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -506,6 +506,62 @@ describe("sendChat", () => {
     }
   });
 
+  test("writes the textarea via the prototype value setter (React controlled-input bypass)", async () => {
+    // Meet's composer is a React-controlled textarea: React 16+ wraps the
+    // element's `.value` setter with an instance-level interceptor so
+    // direct assignment (`input.value = "x"`) updates React's tracker in
+    // lockstep with the DOM, and the subsequent synthetic `input` event
+    // sees "no change" and skips onChange. `sendChat` must therefore go
+    // through `HTMLTextAreaElement.prototype`'s native setter (the
+    // prototype descriptor, which the React shim shadows at the instance
+    // level) to drive a real value change. This regression test installs
+    // an instance-level setter that records whether it was hit — if the
+    // old `input.value = text` code path regresses, the instance setter
+    // fires and the assertion flips.
+    const doc = installed!.dom.window.document;
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT)!;
+
+    let instanceSetterHits = 0;
+    let lastProtoWrite = "";
+    // Shadow the prototype `value` setter at the instance level the same
+    // way React's `inputValueTracking` does. The native prototype setter
+    // (which `sendChat` must call) bypasses this shim entirely, while the
+    // old `.value = text` assignment goes through it.
+    const protoDesc = Object.getOwnPropertyDescriptor(
+      installed!.dom.window.HTMLTextAreaElement.prototype,
+      "value",
+    );
+    if (!protoDesc || !protoDesc.set || !protoDesc.get) {
+      throw new Error("jsdom HTMLTextAreaElement.prototype has no value descriptor");
+    }
+    const protoSetter = protoDesc.set;
+    const protoGetter = protoDesc.get;
+    Object.defineProperty(input, "value", {
+      configurable: true,
+      get() {
+        return protoGetter.call(input);
+      },
+      set(v: string) {
+        instanceSetterHits += 1;
+        // Forward to the prototype so the textarea still receives the
+        // value — we only care about counting instance-level hits.
+        protoSetter.call(input, v);
+      },
+    });
+
+    // Record every input event's captured value so we can cross-check
+    // that the native-setter write landed before the synthetic event.
+    input.addEventListener("input", () => {
+      lastProtoWrite = protoGetter.call(input);
+    });
+
+    await sendChat("react-controlled");
+
+    expect(instanceSetterHits).toBe(0);
+    expect(lastProtoWrite).toBe("react-controlled");
+    expect(protoGetter.call(input)).toBe("react-controlled");
+  });
+
   test("accepts exactly 2000 characters", async () => {
     const doc = installed!.dom.window.document;
     const sendButton = doc.querySelector<HTMLButtonElement>(

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
@@ -37,21 +37,23 @@ const CHAT_FIXTURE = readFileSync(
   "utf8",
 );
 
+type OnMessageListener = (
+  raw: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean;
+
 interface FakeChrome {
   runtime: {
     sendMessage: (msg: unknown) => void;
     onMessage: {
-      addListener: (
-        cb: (
-          raw: unknown,
-          sender: unknown,
-          sendResponse: (response?: unknown) => void,
-        ) => boolean,
-      ) => void;
+      addListener: (cb: OnMessageListener) => void;
     };
   };
   /** Log of every frame the handler forwarded to the bot via sendMessage. */
   sent: unknown[];
+  /** Listeners registered on `chrome.runtime.onMessage` (drives the queue). */
+  listeners: OnMessageListener[];
 }
 
 interface InstalledHarness {
@@ -76,16 +78,22 @@ function installHarness(): InstalledHarness {
   const document = window.document;
 
   const sent: unknown[] = [];
+  const listeners: OnMessageListener[] = [];
   const chrome: FakeChrome = {
     sent,
+    listeners,
     runtime: {
       sendMessage: (msg) => {
         sent.push(msg);
       },
       onMessage: {
-        // content.ts calls addListener at module-load time; we just
-        // record that it happened by accepting any callback here.
-        addListener: () => {},
+        // Capture the listener so tests that need to exercise the
+        // listener-level serialization queue can dispatch raw frames
+        // through it (and the exported `__handleSendChat` remains
+        // available for tests that don't care about the queue).
+        addListener: (cb) => {
+          listeners.push(cb);
+        },
       },
     },
   };
@@ -137,6 +145,13 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
         requestId: string;
       }) => Promise<void>)
     | null = null;
+  let enqueueSendChat:
+    | ((cmd: {
+        type: "send_chat";
+        text: string;
+        requestId: string;
+      }) => Promise<void>)
+    | null = null;
 
   beforeEach(async () => {
     harness = installHarness();
@@ -145,8 +160,10 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
     // instead of the bare Bun runtime.
     const mod = (await import("../content.js")) as {
       __handleSendChat: typeof handleSendChat;
+      __enqueueSendChat: typeof enqueueSendChat;
     };
     handleSendChat = mod.__handleSendChat;
+    enqueueSendChat = mod.__enqueueSendChat;
   });
 
   afterEach(() => {
@@ -155,6 +172,7 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
       harness = null;
     }
     handleSendChat = null;
+    enqueueSendChat = null;
   });
 
   test("emits trusted_type + trusted_click and a send_chat_result when Meet accepts the send", async () => {
@@ -311,5 +329,71 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
     const trustedClicks = sent.filter((e) => e.type === "trusted_click");
     expect(trustedTypes.length).toBe(0);
     expect(trustedClicks.length).toBe(0);
+  });
+
+  test("serializes overlapping send_chat commands so the wrong text is never posted", async () => {
+    // `sendChat` mutates a single shared textarea (`.value = text`) before
+    // clicking the send button, so two overlapping invocations would race
+    // on the composer: the second call's value-write lands before the
+    // first call's `.click()` fires, posting the wrong text while both
+    // requests still report ok=true. The fix chains `handleSendChat`
+    // invocations onto a per-tab Promise inside the `chrome.runtime
+    // .onMessage` listener, so the second call can't touch the DOM until
+    // the first has fully completed its send-button click.
+    //
+    // This regression test drives two `send_chat` frames into the
+    // exported `__enqueueSendChat` helper (the same entry point the
+    // listener uses) back-to-back and records the textarea value
+    // observed at each send-button click. With serialization, the clicks
+    // see "first" and "second" in order. Without it, both clicks see
+    // "second" because the second call's value-write clobbers the first
+    // before its click lands.
+    const doc = harness!.dom.window.document;
+    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT)!;
+    const sendButton = doc.querySelector<HTMLButtonElement>(
+      chatSelectors.SEND_BUTTON,
+    )!;
+
+    const clickValues: string[] = [];
+    sendButton.addEventListener("click", () => {
+      clickValues.push(input.value);
+    });
+
+    // Fire both frames synchronously into the queue, then wait for it to
+    // drain. If the handler still `void`-launched each `handleSendChat`,
+    // both would run concurrently — the `setTimeout(250)` inside
+    // `sendChat` (onEvent-path delay before clicking send) would
+    // interleave the two calls and the second's value-write would
+    // clobber the first before click-1 fires.
+    const p1 = enqueueSendChat!({
+      type: "send_chat",
+      text: "first",
+      requestId: "req-a",
+    });
+    const p2 = enqueueSendChat!({
+      type: "send_chat",
+      text: "second",
+      requestId: "req-b",
+    });
+    await Promise.all([p1, p2]);
+
+    expect(clickValues).toEqual(["first", "second"]);
+
+    // Both results must still be emitted in order, each correlated with
+    // the right requestId.
+    const sent = harness!.chrome.sent as ExtensionToBotMessage[];
+    const results = sent.filter((e) => e.type === "send_chat_result");
+    expect(results.length).toBe(2);
+    const r0 = results[0]!;
+    const r1 = results[1]!;
+    if (
+      r0.type === "send_chat_result" &&
+      r1.type === "send_chat_result"
+    ) {
+      expect(r0.requestId).toBe("req-a");
+      expect(r0.ok).toBe(true);
+      expect(r1.requestId).toBe("req-b");
+      expect(r1.ok).toBe(true);
+    }
   });
 });

--- a/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/join.test.ts
@@ -304,20 +304,45 @@ function insertChatSurface(doc: Document): {
  */
 function installGlobalDoc(doc: Document): () => void {
   const win = (doc as unknown as { defaultView: Window }).defaultView;
-  const prevDoc = (globalThis as Record<string, unknown>).document;
-  const prevWin = (globalThis as Record<string, unknown>).window;
+  // Mirror the chat.test.ts harness: `chat.ts` references the textarea
+  // prototype's native `value` setter (the React-controlled-input
+  // bypass), so tests that drive `postConsentMessage` via the full join
+  // flow must expose jsdom's `HTMLTextAreaElement` / `Event` / `window`
+  // on `globalThis`. Without this, `Object.getOwnPropertyDescriptor(
+  // HTMLTextAreaElement.prototype, 'value')` resolves against Bun's
+  // bare runtime (where HTMLTextAreaElement may be unavailable or
+  // prototype-incompatible with the jsdom instance), the native setter
+  // call no-ops, and the composer stays empty.
+  const keys = [
+    "document",
+    "window",
+    "Event",
+    "HTMLTextAreaElement",
+    "HTMLButtonElement",
+    "MutationObserver",
+  ] as const;
+  const prev: Partial<Record<(typeof keys)[number], unknown>> = {};
+  for (const k of keys) {
+    prev[k] = (globalThis as Record<string, unknown>)[k];
+  }
   (globalThis as Record<string, unknown>).document = doc;
   (globalThis as Record<string, unknown>).window = win;
+  const winRec = win as unknown as Record<string, unknown>;
+  (globalThis as Record<string, unknown>).Event = winRec.Event;
+  (globalThis as Record<string, unknown>).HTMLTextAreaElement =
+    winRec.HTMLTextAreaElement;
+  (globalThis as Record<string, unknown>).HTMLButtonElement =
+    winRec.HTMLButtonElement;
+  (globalThis as Record<string, unknown>).MutationObserver =
+    winRec.MutationObserver;
   return () => {
-    if (prevDoc === undefined) {
-      delete (globalThis as Record<string, unknown>).document;
-    } else {
-      (globalThis as Record<string, unknown>).document = prevDoc;
-    }
-    if (prevWin === undefined) {
-      delete (globalThis as Record<string, unknown>).window;
-    } else {
-      (globalThis as Record<string, unknown>).window = prevWin;
+    for (const k of keys) {
+      const v = prev[k];
+      if (v === undefined) {
+        delete (globalThis as Record<string, unknown>)[k];
+      } else {
+        (globalThis as Record<string, unknown>)[k] = v;
+      }
     }
   };
 }

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -193,6 +193,37 @@ function startMeetingSession(
  */
 let activeSession: MeetingSessionHandle | null = null;
 
+/**
+ * Per-tab serialization chain for `send_chat` handling. `sendChat` mutates
+ * a single shared textarea (`.value = text`) and then clicks the send
+ * button, so overlapping requests would otherwise race on the composer.
+ * Chaining onto this promise forces strict arrival-order processing while
+ * leaving the `onMessage` listener synchronous (the listener returns
+ * immediately; handling happens off-thread).
+ */
+let sendChatQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Chain a `send_chat` invocation onto the per-tab queue so it runs
+ * strictly after any prior in-flight `sendChat` call has completed.
+ * Extracted from the inline listener wiring so tests can drive the queue
+ * directly (Bun caches ESM modules across tests, so the listener's
+ * `chrome.runtime.onMessage.addListener` registration happens once at
+ * first-import time — not re-runnable against a fresh fake chrome on
+ * each test).
+ */
+function enqueueSendChat(cmd: BotSendChatCommand): Promise<void> {
+  sendChatQueue = sendChatQueue
+    .catch(() => {
+      // A prior `handleSendChat` rejection must not poison subsequent
+      // sends — the handler catches its own errors and reports them via
+      // `send_chat_result(ok=false)`, so any rejection here is a bug we
+      // still want to isolate from the next request.
+    })
+    .then(() => handleSendChat(cmd));
+  return sendChatQueue;
+}
+
 chrome.runtime.onMessage.addListener(
   (
     raw: unknown,
@@ -239,7 +270,14 @@ chrome.runtime.onMessage.addListener(
     }
 
     if (msg.type === "send_chat") {
-      void handleSendChat(msg);
+      // Serialize send_chat handling per tab. `sendChat` mutates a single
+      // shared textarea (`.value = text`) and then clicks the send button,
+      // so two overlapping commands would race on the composer — the
+      // second call's value-write can clobber the first before its click
+      // lands, posting the wrong text while both requests still report
+      // ok=true. `enqueueSendChat` chains invocations onto a per-tab
+      // Promise so they run strictly in arrival order.
+      void enqueueSendChat(msg);
       return false;
     }
 
@@ -442,3 +480,9 @@ async function handleCameraToggle(
 // extension's public surface — the background SW never imports content.ts.
 export { handleSendChat as __handleSendChat };
 export { handleCameraToggle as __handleCameraToggle };
+// Exported so the per-tab serialization queue can be exercised directly
+// by tests. The `chrome.runtime.onMessage` listener is registered once at
+// module-load time (Bun's ESM cache prevents re-running module top level
+// across tests), so tests that want to assert ordering for overlapping
+// `send_chat` frames drive this helper instead of the raw listener.
+export { enqueueSendChat as __enqueueSendChat };

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -244,12 +244,37 @@ export async function sendChat(
     );
   }
 
-  // Meet's composer is a React-controlled textarea. Simply setting `.value`
-  // doesn't update React's internal state — we have to dispatch a synthetic
-  // `input` event so React's onChange handler picks up the new value. This
-  // mirrors the technique the bot-side `page.fill` ultimately uses under the
-  // hood through Playwright's element-handle bindings.
-  input.value = text;
+  // Meet's composer is a React-controlled textarea. React 16+ installs an
+  // instance-level property-descriptor interceptor (`inputValueTracking`)
+  // that hijacks `.value = ...`: when the synthetic `input` event fires,
+  // React compares the DOM value to its internal tracker and — because the
+  // interceptor updated the tracker in lockstep with the assignment —
+  // observes no change and skips the onChange dispatch. The result is a
+  // composer that visually shows the text but never commits to React state,
+  // so Send posts empty/stale content.
+  //
+  // The workaround is Playwright's `page.fill` trick: grab the native
+  // setter off `HTMLTextAreaElement.prototype` (which the React interceptor
+  // shadows at the instance level) and invoke it with `.call(input, text)`.
+  // That routes through the prototype setter without touching React's
+  // tracker, so the subsequent `input` event fires with a genuine value
+  // change and onChange runs normally. We still dispatch the synthetic
+  // `input` event ourselves — React relies on it as the trigger for
+  // onChange even after the value has been updated.
+  //
+  // If the native setter isn't resolvable for any reason (e.g. a jsdom
+  // build that doesn't expose the prototype descriptor), fall back to the
+  // direct `.value = ...` assignment. That path is adequate for the test
+  // harness and any pre-React-tracker Meet build.
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  if (nativeSetter) {
+    nativeSetter.call(input, text);
+  } else {
+    input.value = text;
+  }
   input.dispatchEvent(new Event("input", { bubbles: true }));
 
   // If the caller wired up an `onEvent` sink, also drive the composer via


### PR DESCRIPTION
## Summary

Addresses review feedback on #26579:

- **Codex P1 (concurrent send race):** two back-to-back \`send_chat\` commands raced on the shared textarea — the second \`.value\` write could clobber the first before its click fired. Chain \`handleSendChat\` invocations onto a per-tab Promise via a new exported \`enqueueSendChat\` helper.
- **Devin BUG (React controlled-input bypass):** \`input.value = text\` doesn't trigger React's onChange on Meet's controlled textarea — React 16+'s instance-level \`inputValueTracking\` interceptor updates the tracker in lockstep with the assignment, so the synthetic \`input\` event sees no change. Route through \`HTMLTextAreaElement.prototype\`'s native setter (the Playwright \`page.fill\` trick) to bypass the shim.

(Codex P2 "self-filter empty selfName" is already addressed on main — \`displayName\` from the join command threads through \`startMeetingSession\` into \`startChatReader\` via \`opts.displayName\`.)

## Tests

- Regression tests for both fixes in \`chat.test.ts\` + \`content-send-chat.test.ts\`.
- \`installGlobalDoc\` in \`join.test.ts\` now wires \`HTMLTextAreaElement\` / \`Event\` onto \`globalThis\` so the native-setter prototype lookup resolves against the jsdom window.
- All 127 meet-controller-ext tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
