### PR TITLE
fix(macos/chat): defer flushText until $$ close is confirmed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -147,8 +147,12 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
             continue
         }
         if trimmed == "$$" {
-            // Multi-line block — scan forward for the closing `$$`.
-            flushText()
+            // Multi-line block — scan forward for the closing `$$` BEFORE
+            // flushing `currentText`. If we flushed eagerly and the close
+            // never came, the preceding prose would ship as one `.text`
+            // segment and the verbatim fallback as another, which the
+            // renderer joins with a blank line — producing a visible
+            // streaming regression each tick before the close arrives.
             var mathLines: [String] = []
             var j = i + 1
             var closed = false
@@ -161,16 +165,16 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
                 j += 1
             }
             if closed {
+                flushText()
                 let latex = mathLines.joined(separator: "\n")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 segments.append(.math(latex: latex, display: true))
                 i = j + 1
                 continue
             } else {
-                // Unclosed — fall back to plain text. Restore the opening `$$`
-                // and any collected lines to `currentText` so they render
-                // verbatim (mirrors the unclosed-fence behavior of emitting
-                // what we have instead of dropping content).
+                // Unclosed — fold the opening `$$` and any collected lines
+                // back into `currentText` so the whole run flushes as one
+                // contiguous `.text` segment with whatever came before.
                 currentText.append(lines[i])
                 for line in mathLines {
                     currentText.append(line)

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -482,6 +482,29 @@ final class MarkdownSegmentViewTests: XCTestCase {
         }
     }
 
+    /// Regression: during streaming, we see `before\n$$\n<partial>` before the
+    /// closing `$$` arrives. The parser must not emit the prefix prose and
+    /// the verbatim fallback as two separate `.text` segments — the renderer
+    /// joins adjacent text with a blank line, producing a visible flicker
+    /// each streaming tick until the close arrives.
+    func testBlockMath_unclosedWithPrecedingProseStaysOneTextSegment() {
+        let segments = parseMarkdownSegments("before\n$$\nx^2")
+        var textSegments = 0
+        for segment in segments {
+            if case .text = segment { textSegments += 1 }
+            if case .math = segment {
+                XCTFail("Unclosed `$$` must not emit a .math segment")
+            }
+        }
+        XCTAssertEqual(textSegments, 1, "Verbatim fallback must flush as a single .text segment; got \(segments)")
+        guard case .text(let content) = segments.first else {
+            return XCTFail("Expected a .text segment, got \(segments)")
+        }
+        XCTAssertTrue(content.contains("before"))
+        XCTAssertTrue(content.contains("$$"))
+        XCTAssertTrue(content.contains("x^2"))
+    }
+
     func testBlockMath_emptyDelimitersAreText() {
         let segments = parseMarkdownSegments("$$$$")
         XCTAssertEqual(segments, [.text("$$$$")])


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #26678. `flushText()` was being called unconditionally when encountering a `$$` line, which split the verbatim fallback for unclosed block math across two `.text` segments. Adjacent text segments render with a blank line between them, producing a visible streaming regression each tick before the closing `$$` arrives.

The fix scans forward for the closing `$$` before flushing — if closed, flush and emit `.math`; if unclosed, fold the opener and collected lines back into `currentText` so everything flushes as one contiguous `.text` segment.

## Test plan

- [x] Added `testBlockMath_unclosedWithPrecedingProseStaysOneTextSegment` regression covering the streaming scenario
- [x] Existing `testBlockMath_unclosedFallsBackToText` still passes
- [x] Existing closed-block tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
