### PR TITLE
fix(meet-bot): handle chrome spawn error and clear SIGKILL grace timer

### DIFF
--- a/skills/meet-join/bot/__tests__/chrome-launcher.test.ts
+++ b/skills/meet-join/bot/__tests__/chrome-launcher.test.ts
@@ -197,4 +197,23 @@ describe("launchChrome", () => {
     // no-ops that await the already-settled exit promise.
     expect(child.__killSignals).toEqual(["SIGTERM"]);
   });
+
+  test("child 'error' event does not crash and resolves exitPromise", async () => {
+    // Without an 'error' listener, Node would escalate the event to an
+    // uncaught exception and kill the bot process. The launcher must attach
+    // the listener itself so ENOENT-style spawn failures are observable via
+    // `exitPromise` rather than fatal.
+    const child = makeFakeChild();
+    const fake = makeFakeSpawn(child);
+
+    const handle = await launchChrome({ ...BASE_OPTS, spawn: fake.spawn });
+
+    // Emit the async 'error' event the real child_process would produce on
+    // e.g. ENOENT. If no listener were attached, this would throw here.
+    child.emit("error", new Error("spawn ENOENT"));
+
+    // exitPromise must still settle so callers awaiting it don't hang.
+    const code = await handle.exitPromise;
+    expect(code).toBe(0);
+  });
 });

--- a/skills/meet-join/bot/src/browser/chrome-launcher.ts
+++ b/skills/meet-join/bot/src/browser/chrome-launcher.ts
@@ -206,6 +206,25 @@ export async function launchChrome(
     stdio: ["ignore", "pipe", "pipe"],
   });
 
+  // Attach `error` handler before anything else can throw. `spawn()` can emit
+  // `error` asynchronously (ENOENT on missing binary, EACCES on permission
+  // failures, or runtime signal-delivery errors) and an unhandled `error`
+  // event crashes the entire process — the pid guard below would throw
+  // synchronously, but the async event still fires on the next tick.
+  const exitPromise = new Promise<number>((resolve) => {
+    child.on("exit", (code) => {
+      // `code` is null when the process was killed by a signal. Report 0 in
+      // that case so downstream callers can treat "clean shutdown" uniformly.
+      resolve(typeof code === "number" ? code : 0);
+    });
+    child.on("error", (err) => {
+      logger.error(
+        `[chrome] spawn error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      resolve(0);
+    });
+  });
+
   // Forward stdout/stderr through the logger. Chrome emits many benign
   // warnings (DBus, etc.); we route everything to `info` rather than split
   // stderr into `error`, because the split is noisy and not useful in
@@ -229,14 +248,6 @@ export async function launchChrome(
       `launchChrome: spawn returned a child with no pid (binary=${chromeBinary})`,
     );
   }
-
-  const exitPromise = new Promise<number>((resolve) => {
-    child.on("exit", (code) => {
-      // `code` is null when the process was killed by a signal. Report 0 in
-      // that case so downstream callers can treat "clean shutdown" uniformly.
-      resolve(typeof code === "number" ? code : 0);
-    });
-  });
 
   let stopCalled = false;
   const stop = async (): Promise<void> => {
@@ -265,9 +276,12 @@ export async function launchChrome(
     }
 
     // Race the exit against the grace timer. If Chrome hasn't exited in 5s,
-    // escalate to SIGKILL.
+    // escalate to SIGKILL. Hoist the timer handle so we can clear it when
+    // Chrome exits cleanly; otherwise it pins the event loop for up to
+    // `sigkillGraceMs` after shutdown, delaying process exit.
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
     const timer = new Promise<"timeout">((resolve) => {
-      setTimeout(() => resolve("timeout"), sigkillGraceMs);
+      graceTimer = setTimeout(() => resolve("timeout"), sigkillGraceMs);
     });
     const raced = await Promise.race([
       exitPromise.then(() => "exited" as const),
@@ -283,6 +297,8 @@ export async function launchChrome(
         );
       }
       await exitPromise;
+    } else if (graceTimer !== undefined) {
+      clearTimeout(graceTimer);
     }
   };
 


### PR DESCRIPTION
Addresses review feedback on #26583 (both Codex and Devin converged on the same two issues).

## Changes

**1. Missing 'error' listener on spawned ChildProcess.** `spawn()` can emit an async `error` event (ENOENT on missing binary, EACCES, runtime signal-delivery failures) on the next tick. Without a listener, Node escalates it to an uncaught exception that kills the bot process — even though the pid guard below throws synchronously, the async event still fires. Attach `child.on('error', ...)` immediately after spawn and wire it into `exitPromise` so callers awaiting the promise don't hang when spawn fails.

**2. SIGKILL grace-timer leak in stop().** When Chrome exits cleanly before the grace window, the `setTimeout` was never cleared and kept the event loop alive for up to `sigkillGraceMs` (5s in production) after shutdown, adding avoidable teardown latency. Hoist the timer handle and `clearTimeout()` it once `exitPromise` resolves.

## Test plan
- [x] New unit test emits 'error' on the fake child and asserts `exitPromise` resolves instead of crashing.
- [x] All existing chrome-launcher tests still pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
