### PR TITLE
fix(slack): retry delete-lookup on race with linkMessage

### DIFF
--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -32,6 +32,7 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
+import { _setDeleteLookupConfigForTests } from "../runtime/routes/inbound-message-handler.js";
 
 initializeDb();
 
@@ -159,6 +160,11 @@ describe("Slack delete propagation", () => {
   beforeEach(() => {
     resetState();
     seedActiveDeleteActor("C0123CHANNEL");
+    // Keep the lookup retry-loop fast by default so the "no such message"
+    // paths don't pay the full production backoff. The race-test below
+    // overrides this to a longer delay so the first retry can observe
+    // the deferred linkMessage.
+    _setDeleteLookupConfigForTests(2, 20);
   });
 
   test("marks slackMeta.deletedAt and leaves content untouched", async () => {
@@ -317,6 +323,75 @@ describe("Slack delete propagation", () => {
     const parsed = JSON.parse(row!.metadata!) as Record<string, unknown>;
     const slackMeta = readSlackMetadata(parsed.slackMeta as string);
     expect(slackMeta!.deletedAt).toBeUndefined();
+  });
+
+  test("delete that races ahead of linkMessage is retried until the link lands", async () => {
+    // Simulates the race: a delete webhook arrives after `recordInbound`
+    // has inserted the original event row but before the agent-loop path
+    // has called `linkMessage` to bind it to a stored message. Without
+    // the retry loop the delete would silently no-op and the deletion
+    // signal would be lost.
+    const db = getDb();
+    const externalChatId = "C0123CHANNEL";
+    const originalTs = "5555.5555";
+    const inbound = recordInbound("slack", externalChatId, originalTs, {
+      sourceMessageId: originalTs,
+    });
+
+    const messageId = `msg-${originalTs}`;
+    const slackMeta = writeSlackMetadata({
+      source: "slack",
+      channelId: externalChatId,
+      channelTs: originalTs,
+      eventKind: "message",
+      displayName: "Test User",
+    });
+    db.insert(messages)
+      .values({
+        id: messageId,
+        conversationId: inbound.conversationId,
+        role: "user",
+        content: "Original text",
+        createdAt: Date.now(),
+        metadata: JSON.stringify({
+          userMessageChannel: "slack",
+          userMessageInterface: "slack",
+          slackMeta,
+        }),
+      })
+      .run();
+
+    // Shorten retries to a handful of small backoffs so the test is fast
+    // while still exercising the loop.
+    _setDeleteLookupConfigForTests(5, 50);
+
+    // Link the message after a short delay — this lands during one of the
+    // retry backoffs. Intentionally not awaited.
+    const LINK_DELAY_MS = 120;
+    setTimeout(() => {
+      linkMessage(inbound.eventId, messageId);
+    }, LINK_DELAY_MS);
+
+    const req = buildSlackDeleteRequest({
+      externalChatId,
+      deletedTs: originalTs,
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(resp.status).toBe(200);
+    expect(json.accepted).toBe(true);
+    expect(json.deleted).toBe(true);
+    expect(json.messageId).toBe(messageId);
+
+    const row = db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .get();
+    const parsed = JSON.parse(row!.metadata!) as Record<string, unknown>;
+    const parsedSlackMeta = readSlackMetadata(parsed.slackMeta as string);
+    expect(parsedSlackMeta!.deletedAt).toBeDefined();
   });
 
   test("delete from non-member actor is rejected by ACL and does not apply", async () => {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -69,6 +69,28 @@ import { handleVerificationIntercept } from "./inbound-stages/verification-inter
 
 const log = getLogger("runtime-http");
 
+// Delete-lookup retry configuration. Delete webhooks can race ahead of
+// the inbound handler's `linkMessage` call when the original message's
+// agent loop is still running. Retrying buys time for the link to land
+// before we drop the deletion signal. Mirrors the edit-intercept path's
+// EDIT_LOOKUP_RETRIES / EDIT_LOOKUP_DELAY_MS constants.
+let deleteLookupRetries = 5;
+let deleteLookupDelayMs = 2000;
+
+/**
+ * Test-only override for the delete-lookup retry timings. Used by
+ * tests that exercise the "no such message" path without waiting
+ * through the full production backoff. Not exported from any barrel
+ * file — only the test file imports it directly.
+ */
+export function _setDeleteLookupConfigForTests(
+  retries: number,
+  delayMs: number,
+): void {
+  deleteLookupRetries = retries;
+  deleteLookupDelayMs = delayMs;
+}
+
 export async function handleChannelInbound(
   req: Request,
   processMessage?: MessageProcessor,
@@ -283,16 +305,39 @@ export async function handleChannelInbound(
     // The original message's externalMessageId may differ from its ts
     // (Slack populates client_msg_id when present), so we join via the
     // sourceMessageId column which records the ts explicitly.
-    const original = deliveryCrud.findMessageBySourceId(
-      sourceChannel,
-      conversationExternalId,
-      deletedMessageTs,
-    );
+    //
+    // Retry with backoff mirrors the edit-intercept path: delete webhooks
+    // can race ahead of `linkMessage` when the original message's agent
+    // loop is still running. Without retries a delete that arrives in
+    // that window is silently dropped and the deletion signal is lost.
+    let original: { messageId: string; conversationId: string } | null = null;
+    for (let attempt = 0; attempt <= deleteLookupRetries; attempt++) {
+      original = deliveryCrud.findMessageBySourceId(
+        sourceChannel,
+        conversationExternalId,
+        deletedMessageTs,
+      );
+      if (original) break;
+      if (attempt < deleteLookupRetries) {
+        log.info(
+          {
+            conversationExternalId,
+            deletedMessageTs,
+            attempt: attempt + 1,
+            maxAttempts: deleteLookupRetries,
+          },
+          "Original message not linked yet, retrying delete lookup",
+        );
+        await new Promise((resolve) =>
+          setTimeout(resolve, deleteLookupDelayMs),
+        );
+      }
+    }
 
     if (!original) {
       log.debug(
         { conversationExternalId, deletedMessageTs },
-        "No stored message found for Slack delete; ignoring",
+        "No stored message found for Slack delete after retries; ignoring",
       );
       return Response.json({ accepted: true, deleted: false });
     }


### PR DESCRIPTION
Codex flagged that delete webhooks can race ahead of `linkMessage`: if the delete arrives before the original inbound message's agent loop has linked the stored row, `findMessageBySourceId` returns null and the handler returns `deleted: false` — permanently losing the deletion signal.

Mirror the edit-intercept retry loop (5 attempts × 2s) in the delete handler so the lookup has a window to catch up with the link. Adds a regression test that defers `linkMessage` past the initial attempt and verifies the delete still lands.

The retry timings are module-level vars with a test-only override to keep the "no such ts" unit tests fast.

Addresses https://github.com/vellum-ai/vellum-assistant/pull/26619#discussion_r3106271939
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
