### PR TITLE
fix(meet-bot): terminal extension lifecycle events drive shutdown

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -1209,7 +1209,7 @@ describe("runBot — Gap B: extension-joined deadline", () => {
     expect(handles.daemonStopped()).toBe(false);
   });
 
-  test("lifecycle:error from extension clears the timer (no duplicate shutdown)", async () => {
+  test("lifecycle:error from extension triggers shutdown with exit code 1", async () => {
     BotState.__resetForTests();
     const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
     const running = runBot(deps);
@@ -1217,10 +1217,10 @@ describe("runBot — Gap B: extension-joined deadline", () => {
     handles.fireExtensionReady();
     await running;
 
-    // Fire `error` — handler updates state and clears the timer, but does
-    // not itself initiate shutdown (that's the extension's signal the
-    // meet-side died; shutdown is a separate path we're validating is
-    // idempotent).
+    // Fire `error` — the extension is signaling the meet-side died. The
+    // handler must drive a graceful shutdown so subsystems tear down
+    // promptly and the chrome-exit watcher doesn't misclassify the
+    // subsequent clean Chrome exit as an unexpected crash.
     handles.fireExtensionMessage({
       type: "lifecycle",
       meetingId: "abc-defg-hij",
@@ -1229,18 +1229,76 @@ describe("runBot — Gap B: extension-joined deadline", () => {
       detail: "prejoin captcha",
     });
 
-    // Give the timer plenty of time to fire if it wasn't cleared.
-    await new Promise((r) => setTimeout(r, 100));
+    // Wait for shutdown to complete.
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
 
-    // The error lifecycle event was forwarded.
-    const lifecycleStates = handles.daemonEvents
+    expect(handles.exitCode()).toBe(1);
+
+    // shutdown() publishes lifecycle:error to the daemon with the detail
+    // forwarded from the extension; the handler itself no longer emits a
+    // separate error event, so we see exactly one.
+    const errEvents = handles.daemonEvents
       .filter((e): e is LifecycleEvent => e.type === "lifecycle")
-      .map((e) => e.state);
-    expect(lifecycleStates).toContain("error");
+      .filter((e) => e.state === "error");
+    expect(errEvents.length).toBe(1);
+    expect(errEvents[0]?.detail).toBe("prejoin captcha");
 
-    // But no timer-driven shutdown should have fired.
-    // exitCode remains null because nothing else triggered shutdown.
-    expect(handles.exitCode()).toBeNull();
+    // Full shutdown should have run.
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.chrome).toBe(1);
+    expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
+  });
+
+  test("lifecycle:left from extension triggers shutdown with exit code 0", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
+    const running = runBot(deps);
+    await new Promise((r) => setTimeout(r, 5));
+    handles.fireExtensionReady();
+    await running;
+
+    // Fire `left` — the meeting ended naturally (host ended it, bot was
+    // kicked, etc.). The handler must drive a graceful shutdown and exit 0
+    // so the clean leave isn't misclassified as an error.
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "abc-defg-hij",
+      timestamp: new Date().toISOString(),
+      state: "left",
+      detail: "meeting ended",
+    });
+
+    // Wait for shutdown to complete.
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(handles.exitCode()).toBe(0);
+
+    // Exactly one lifecycle:left event (published by shutdown, not the
+    // handler, so there's no duplicate).
+    const leftEvents = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .filter((e) => e.state === "left");
+    expect(leftEvents.length).toBe(1);
+    expect(leftEvents[0]?.detail).toBe("meeting ended");
+
+    // Full shutdown should have run.
+    const counts = handles.stopCounts();
+    expect(counts.httpServer).toBe(1);
+    expect(counts.chrome).toBe(1);
+    expect(counts.audio).toBe(1);
+    expect(counts.xvfb).toBe(1);
+    expect(counts.socketServer).toBe(1);
+    expect(handles.daemonStopped()).toBe(true);
   });
 });
 

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -890,16 +890,36 @@ export async function runBot(deps: BotDeps): Promise<void> {
         return;
       case "lifecycle": {
         const state: LifecycleState = msg.state;
-        // Drive local bot-state on `joined` / terminal states; the
-        // `joining` emitted by the extension is informational — we already
-        // set BotState before `waitForReady` returned.
+        // If shutdown is already in progress (SIGTERM, /leave, chrome-exit
+        // watcher, daemon-error), this lifecycle is either the extension
+        // echoing our own `leave` or a race with another trigger. shutdown()
+        // publishes the terminal lifecycle itself, so swallow here to avoid
+        // duplicate daemon events and double-firing the exit path.
+        if (shutdownInProgress) return;
+        // Drive local bot-state on `joined`; terminal states (`left`/`error`)
+        // delegate phase management to shutdown() below so we don't
+        // double-set. `joining` emitted by the extension is informational —
+        // we already set BotState before `waitForReady` returned.
         if (state === "joined") BotState.setPhase("joined");
-        if (state === "error") BotState.setPhase("error");
-        if (state === "left") BotState.setPhase("leaving");
         // Clear the extension-joined deadline as soon as the extension
         // reaches a terminal post-prejoin state. Idempotent.
-        if (state === "joined" || state === "error") {
+        if (state === "joined" || state === "error" || state === "left") {
           clearExtensionJoinedTimer();
+        }
+        // Terminal states from the extension — the meeting ended or the
+        // join irrecoverably failed. Fire a graceful shutdown so subsystems
+        // tear down promptly; otherwise the subsequent Chrome exit trips
+        // the unexpected-exit watcher and misclassifies a clean leave as
+        // an error. shutdown() publishes lifecycle:<state> itself, so we
+        // skip the forward-publish below to avoid a duplicate event.
+        if (state === "left" || state === "error") {
+          const exitCode = state === "error" ? 1 : 0;
+          void shutdown(state, msg.detail).then(() => {
+            detachSigterm();
+            detachSigint();
+            deps.exit(exitCode);
+          });
+          return;
         }
         // Rewrite meetingId to the authoritative UUID from env. The
         // extension derives its `meetingId` from `location.pathname` (the


### PR DESCRIPTION
## Summary

Addresses Devin's BUG finding on #26586: when the Meet extension emits `lifecycle:left` (natural meeting end, kicked by host) or `lifecycle:error` (admission denied, selector drift, etc.), `handleExtensionMessage` was only forwarding the event and updating local `BotState` — it never called `shutdown()`. The subsystems (audio, HTTP, socket server, Xvfb) kept running, and when Chrome exited moments later the watcher saw \`shutdownInProgress === false\` and fired a spurious \`shutdown("error", "chrome exited unexpectedly with code 0")\` + \`exit(1)\`.

Consequences that actually hit users:
- The daemon received \`lifecycle:left\` immediately followed by \`lifecycle:error\`, leaving the session in conflicting state.
- The bot process exited with code 1 on every clean meeting end.
- Subsystem teardown was delayed until Chrome died on its own.

## Fix

In the \`lifecycle\` case of \`handleExtensionMessage\`:

- Swallow the event outright when \`shutdownInProgress\` is already true — the shutdown path publishes the terminal lifecycle itself, so forwarding here would double-emit.
- On \`state === "left"\`, fire-and-forget \`shutdown("left", msg.detail)\` then \`detachSigterm\` / \`detachSigint\` / \`exit(0)\` — same pattern SIGTERM and \`/leave\` already use.
- On \`state === "error"\`, same pattern with \`exit(1)\`.
- Dropped the explicit \`BotState.setPhase("error" | "leaving")\` calls in the handler; \`shutdown()\` sets the phase at start and end, so the handler setting it first races with the finalizer.
- Added \`left\` to the \`clearExtensionJoinedTimer()\` condition for symmetry (\`shutdown()\` also clears it, but this keeps the handler self-consistent).

\`shutdown()\` is already idempotent (\`shutdownInProgress\` + cached \`shutdownDonePromise\`), so a second call arriving from \`/leave\` or SIGTERM during teardown just awaits the same promise.

## Tests

- Inverted the existing \`lifecycle:error ... no duplicate shutdown\` test to assert that \`lifecycle:error\` now triggers a full shutdown with exit code 1 and exactly one \`lifecycle:error\` reaches the daemon (published by shutdown, no duplicate from the handler).
- Added a companion test for \`lifecycle:left\`: asserts exit code 0, exactly one \`lifecycle:left\` event forwarded, and all subsystems torn down.
- All 33 tests in \`bot/__tests__/main.test.ts\` pass locally.

## Test plan
- [x] \`cd skills/meet-join/bot && bun test __tests__/main.test.ts\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
