### PR TITLE
fix(slack): clear stale thread mapping on channel-root inbound

### DIFF
--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -96,7 +96,7 @@ import {
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { setThreadTs } from "../memory/slack-thread-store.js";
+import { clearThreadTs, setThreadTs } from "../memory/slack-thread-store.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -134,9 +134,13 @@ function makeDeps(
     } as EventHandlerDeps["turnChannelContext"],
     turnInterfaceContext: {
       userMessageInterface:
-        assistantMessageChannel === "vellum" ? "macos" : assistantMessageChannel,
+        assistantMessageChannel === "vellum"
+          ? "macos"
+          : assistantMessageChannel,
       assistantMessageInterface:
-        assistantMessageChannel === "vellum" ? "macos" : assistantMessageChannel,
+        assistantMessageChannel === "vellum"
+          ? "macos"
+          : assistantMessageChannel,
     } as EventHandlerDeps["turnInterfaceContext"],
   } as EventHandlerDeps;
 }
@@ -240,6 +244,34 @@ describe("outbound assistant Slack metadata persistence", () => {
     expect(slackMeta.threadTs).toBeUndefined();
     // channelTs is still absent for the same persistence-vs-send reason.
     expect(slackMeta.channelTs).toBeUndefined();
+  });
+
+  test("does NOT stamp a stale threadTs after the mapping is cleared", async () => {
+    const conversationId = "conv-slack-cleared";
+    const channelId = "C789CLEARED";
+    // Simulate an earlier threaded turn that seeded the mapping, followed
+    // by a channel-root turn whose inbound path cleared it.
+    setThreadTs(conversationId, channelId, "1111.2222");
+    clearThreadTs(conversationId);
+
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "slack",
+      requesterChatId: channelId,
+    });
+    await handleMessageComplete(
+      state,
+      deps,
+      makeMessageCompleteEvent("root reply"),
+    );
+
+    const persisted = lastAssistantPersisted();
+    const slackMetaRaw = persisted.metadata?.slackMeta;
+    expect(typeof slackMetaRaw).toBe("string");
+    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
+      string,
+      unknown
+    >;
+    expect(slackMeta.threadTs).toBeUndefined();
   });
 
   test("does NOT stamp slackMeta on non-Slack outbound assistant messages", async () => {

--- a/assistant/src/memory/slack-thread-store.ts
+++ b/assistant/src/memory/slack-thread-store.ts
@@ -74,6 +74,18 @@ export function getThreadTs(conversationId: string): string | null {
 }
 
 /**
+ * Drop any thread mapping associated with this conversation. Called on
+ * inbound Slack turns that arrive at the channel root (no `threadTs` on
+ * the callback URL) so that a stale mapping from a prior in-thread turn
+ * cannot be copied onto the outbound reply's `slackMeta`. Without this,
+ * a channel-root reply following an earlier thread turn would be
+ * persisted as if it belonged to the old thread.
+ */
+export function clearThreadTs(conversationId: string): void {
+  threadMappings.delete(conversationId);
+}
+
+/**
  * Extract the threadTs from a Slack reply callback URL, if present.
  * The gateway encodes threadTs as a query parameter on the callback URL.
  */

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -10,8 +10,8 @@
  * `opts.now` only when needed for relative formatting. Sort and tag rendering
  * are deterministic.
  *
- * Wiring lands in PR 17 (inbound history rendering) and PR 21 (compaction
- * boundary).
+ * Consumers wire this into inbound history rendering and the compaction
+ * boundary.
  */
 
 import { createHash } from "node:crypto";

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -14,6 +14,7 @@ import * as deliveryChannels from "../../../memory/delivery-channels.js";
 import * as deliveryCrud from "../../../memory/delivery-crud.js";
 import * as deliveryStatus from "../../../memory/delivery-status.js";
 import {
+  clearThreadTs,
   extractChannelFromCallbackUrl,
   extractMessageTsFromCallbackUrl,
   extractThreadTsFromCallbackUrl,
@@ -171,12 +172,19 @@ export function processChannelMessageInBackground(
         })
       : undefined;
 
-    // Track Slack thread mapping so replies go to the correct thread
+    // Align the Slack thread mapping with this turn's inbound state:
+    // set it when the inbound arrived in a thread, clear it when the
+    // inbound arrived at the channel root. `getThreadTs` is consulted
+    // at outbound-persistence time, so the mapping must reflect the
+    // current turn — a lingering mapping from a prior thread turn
+    // would otherwise be stamped onto a channel-root reply.
     if (sourceChannel === "slack" && replyCallbackUrl) {
       const inboundThreadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
       const inboundChannel = extractChannelFromCallbackUrl(replyCallbackUrl);
       if (inboundThreadTs && inboundChannel) {
         setThreadTs(conversationId, inboundChannel, inboundThreadTs);
+      } else {
+        clearThreadTs(conversationId);
       }
     }
 
@@ -352,7 +360,10 @@ export function setSlackThinkingStatus(
       },
       mintBearerToken(),
     ).catch((err) => {
-      log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
+      log.debug(
+        { err, chatId, messageTs },
+        "Failed to add Slack eyes reaction",
+      );
     });
 
     const clearReaction = () => {
@@ -377,7 +388,10 @@ export function setSlackThinkingStatus(
       );
     };
 
-    const safetyTimer = setTimeout(clearReaction, SLACK_THINKING_MAX_DURATION_MS);
+    const safetyTimer = setTimeout(
+      clearReaction,
+      SLACK_THINKING_MAX_DURATION_MS,
+    );
     (safetyTimer as { unref?: () => void }).unref?.();
 
     return clearReaction;

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -199,12 +199,12 @@ export async function handleEditIntercept(
  * Apply a Slack edit to the stored message: update content and stamp
  * `slackMeta.editedAt` in the same transaction.
  *
- * If the row already has a valid `slackMeta` sub-object (post-PR-11
- * messages), the merge preserves all existing fields and only sets/refreshes
- * `editedAt`. If the row pre-dates `slackMeta` enrichment, the helper
- * synthesizes the minimum-required fields (`source`, `channelId`,
- * `channelTs`, `eventKind`) from the values that brought us here so the
- * resulting metadata is still readable by `readSlackMetadata`.
+ * If the row already has a valid `slackMeta` sub-object, the merge preserves
+ * all existing fields and only sets/refreshes `editedAt`. If the row has no
+ * `slackMeta` envelope, the helper synthesizes the minimum-required fields
+ * (`source`, `channelId`, `channelTs`, `eventKind`) from the values that
+ * brought us here so the resulting metadata is still readable by
+ * `readSlackMetadata`.
  */
 function applySlackEditMetadata(params: {
   messageId: string;


### PR DESCRIPTION
## Summary
- Adds `clearThreadTs` and wires it into inbound dispatch so channel-root Slack turns drop any stale thread mapping before outbound persistence consults it.
- Rewrites three AGENTS.md-violating comments (`PR 17`, `PR 21`, `post-PR-11`) to describe current state.
- Adds a regression test covering the cleared-mapping path.

Addresses review feedback on #26617.

## Test plan
- [x] `bun test src/__tests__/outbound-slack-persistence.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
