### PR TITLE
fix(slack): skip indexing for persisted reaction sentinels

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1192,6 +1192,7 @@ async function persistSlackReactionAsMessage(params: {
     "user",
     "[reaction]",
     { slackMeta: writeSlackMetadata(slackMeta) },
+    { skipIndexing: true },
   );
   deliveryCrud.linkMessage(params.eventId, persisted.id);
   deliveryStatus.markProcessed(params.eventId);


### PR DESCRIPTION
## Summary
- Pass `{ skipIndexing: true }` to `addMessage` in `persistSlackReactionAsMessage` so reaction sentinel rows do not trigger graph-extract, summarization-debounce, or auto-analysis idle pipelines.

## Context
Addresses Devin review feedback on #26620. Although the `[reaction]` sentinel content is short enough that embeddings aren't stored, the graph-extract and summarization job pipelines still fire — triggering pending counter increments, auto-analysis idle triggers, and debounced `build_conversation_summary` calls on every reaction. Matches the pattern used by other synthetic-sentinel `addMessage` callers.

## Test plan
- [x] Type-check passes
- [ ] Manual: react to a Slack message and confirm no spurious summarization/graph-extract activity in logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
