### PR TITLE
fix(meet-bot): drop extension events from foreign Meet tabs

### DIFF
--- a/skills/meet-join/bot/__tests__/main.test.ts
+++ b/skills/meet-join/bot/__tests__/main.test.ts
@@ -513,7 +513,9 @@ describe("runBot — extension message routing", () => {
     const before = handles.daemonEvents.length;
     handles.fireExtensionMessage({
       type: "lifecycle",
-      meetingId: "m-1",
+      // Extension stamps `meetingId = location.pathname` — the Meet URL
+      // code from MEET_URL, not the env UUID.
+      meetingId: "abc-defg-hij",
       timestamp: new Date().toISOString(),
       state: "joined",
     });
@@ -534,7 +536,7 @@ describe("runBot — extension message routing", () => {
     const before = handles.daemonEvents.length;
     handles.fireExtensionMessage({
       type: "participant.change",
-      meetingId: "m-1",
+      meetingId: "abc-defg-hij",
       timestamp: new Date().toISOString(),
       joined: [{ id: "p-1", name: "Alice" }],
       left: [],
@@ -553,14 +555,14 @@ describe("runBot — extension message routing", () => {
     const before = handles.daemonEvents.length;
     handles.fireExtensionMessage({
       type: "speaker.change",
-      meetingId: "m-1",
+      meetingId: "abc-defg-hij",
       timestamp: new Date().toISOString(),
       speakerId: "p-1",
       speakerName: "Alice",
     });
     handles.fireExtensionMessage({
       type: "chat.inbound",
-      meetingId: "m-1",
+      meetingId: "abc-defg-hij",
       timestamp: new Date().toISOString(),
       fromId: "p-2",
       fromName: "Bob",
@@ -1131,6 +1133,108 @@ describe("runBot — Gap A: meetingId rewrite at bot boundary", () => {
       expect(event.meetingId).toBe("m-1");
       expect(event.state).toBe("joined");
     }
+  });
+});
+
+/** -----------------------------------------------------------------------
+ * Foreign-tab source gate
+ * -----------------------------------------------------------------------
+ * The background service worker fans every bot command out to every open
+ * Meet tab in the Chrome profile. A stray tab (prior bot session, user-
+ * opened Meet, etc.) could otherwise emit lifecycle / telemetry events
+ * that we'd stamp with the session UUID and treat as authoritative —
+ * clearing the join-deadline timer, firing spurious `joined` / `error`
+ * at the daemon, and mixing telemetry across meetings. The bot compares
+ * each event's extension-supplied `meetingId` (the source tab's URL
+ * code) against the code derived from MEET_URL and drops mismatches.
+ */
+describe("runBot — foreign-tab source gate", () => {
+  test("lifecycle event from a foreign tab is dropped", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      // Wrong Meet code — a stray tab pointed at a different meeting.
+      meetingId: "zzz-yyyy-xxx",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+
+    // No daemon event enqueued.
+    expect(handles.daemonEvents.length).toBe(before);
+    // Diagnostic logged via logInfo.
+    expect(
+      handles.infos.some((m) =>
+        m.includes("dropping lifecycle event from foreign tab"),
+      ),
+    ).toBe(true);
+  });
+
+  test("foreign-tab lifecycle:joined does not clear the join-deadline timer", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps({ extensionJoinedTimeoutMs: 50 });
+    const running = runBot(deps);
+    await new Promise((r) => setTimeout(r, 5));
+    handles.fireExtensionReady();
+    await running;
+
+    // A stray tab's `joined` must NOT cancel the deadline.
+    handles.fireExtensionMessage({
+      type: "lifecycle",
+      meetingId: "zzz-yyyy-xxx",
+      timestamp: new Date().toISOString(),
+      state: "joined",
+    });
+
+    // Wait past the deadline — the timer should still trip.
+    const deadline = Date.now() + 1_000;
+    while (handles.exitCode() === null && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(handles.exitCode()).toBe(1);
+
+    const lifecycleStates = handles.daemonEvents
+      .filter((e): e is LifecycleEvent => e.type === "lifecycle")
+      .map((e) => ({ state: e.state, detail: e.detail }));
+    const errState = lifecycleStates.find((s) => s.state === "error");
+    expect(errState?.detail).toContain(
+      "extension did not reach joined state within 50ms",
+    );
+  });
+
+  test("participant.change / speaker.change / chat.inbound from foreign tabs are dropped", async () => {
+    BotState.__resetForTests();
+    const { deps, handles } = makeDeps();
+    await bootHappyPath(deps, handles);
+
+    const before = handles.daemonEvents.length;
+    handles.fireExtensionMessage({
+      type: "participant.change",
+      meetingId: "zzz-yyyy-xxx",
+      timestamp: new Date().toISOString(),
+      joined: [{ id: "p-1", name: "Alice" }],
+      left: [],
+    });
+    handles.fireExtensionMessage({
+      type: "speaker.change",
+      meetingId: "zzz-yyyy-xxx",
+      timestamp: new Date().toISOString(),
+      speakerId: "p-1",
+      speakerName: "Alice",
+    });
+    handles.fireExtensionMessage({
+      type: "chat.inbound",
+      meetingId: "zzz-yyyy-xxx",
+      timestamp: new Date().toISOString(),
+      fromId: "p-2",
+      fromName: "Bob",
+      text: "hello",
+    });
+
+    expect(handles.daemonEvents.length).toBe(before);
   });
 });
 

--- a/skills/meet-join/bot/src/main.ts
+++ b/skills/meet-join/bot/src/main.ts
@@ -435,6 +435,32 @@ export async function runBot(deps: BotDeps): Promise<void> {
 
   BotState.setMeeting(meetingId);
 
+  // Derive the Meet URL code (e.g. `abc-defg-hij`) from `MEET_URL`. The
+  // Chrome extension stamps every outbound event with `meetingId =
+  // location.pathname` from the page it's injected into, so this code
+  // is the authoritative filter on whether an event belongs to our
+  // session.
+  //
+  // The background service worker fans every bot command out to every
+  // open `meet.google.com/*` tab in the Chrome profile, and content-
+  // script-side gating (see `meet-controller-ext/src/content.ts`) only
+  // stops the `join` flow from spinning up on stray tabs. If a user had
+  // a prior Meet tab open in the same profile — or a second bot session
+  // leaked a tab — its content script would still emit lifecycle /
+  // telemetry events into the shared `chrome.runtime.sendMessage` pipe,
+  // which the background forwards to the NMH socket. Without this
+  // filter we would happily stamp the env UUID onto those frames and
+  // treat them as authoritative for the current session — clearing the
+  // join-deadline timer, firing spurious `lifecycle:joined` / `error`
+  // at the daemon, and mixing participant / speaker / chat telemetry
+  // across meetings.
+  //
+  // A non-matching `meetingId` gets logged at diagnostic level and
+  // dropped; a genuinely missing / unparseable code falls back to
+  // "accept" so we don't silently blackhole the intended session when
+  // the URL has an unusual shape.
+  const expectedMeetingCode = extractMeetingCodeFromUrl(meetUrl);
+
   // Shared shutdown state — read by signal handlers, `/leave`, and boot
   // error paths. We construct it up-front so the error-reporting path can
   // still produce a usable shutdown even if the daemon client never gets
@@ -492,6 +518,19 @@ export async function runBot(deps: BotDeps): Promise<void> {
       clearTimeout(extensionJoinedTimer);
       extensionJoinedTimer = null;
     }
+  };
+
+  /**
+   * Return true when an inbound extension event belongs to the tab
+   * driving this bot's Meet session. Compares the event's
+   * extension-supplied `meetingId` (= `location.pathname` code, e.g.
+   * `abc-defg-hij`) against the code derived from `MEET_URL`. Falls
+   * back to `true` when we couldn't derive an expected code, so an
+   * unusually-shaped URL doesn't blackhole the intended session.
+   */
+  const isFromOurTab = (extMeetingId: string): boolean => {
+    if (expectedMeetingCode === null) return true;
+    return extMeetingId === expectedMeetingCode;
   };
 
   /**
@@ -889,6 +928,16 @@ export async function runBot(deps: BotDeps): Promise<void> {
         );
         return;
       case "lifecycle": {
+        // Source-tab gate. See `expectedMeetingCode` at boot time for
+        // the full rationale: a stray Meet tab's lifecycle events would
+        // otherwise clear our join-deadline timer and fire spurious
+        // `joined` / `error` at the daemon.
+        if (!isFromOurTab(msg.meetingId)) {
+          deps.logInfo(
+            `meet-bot: dropping lifecycle event from foreign tab (meetingId=${msg.meetingId}, state=${msg.state}, expected=${expectedMeetingCode ?? "<none>"})`,
+          );
+          return;
+        }
         const state: LifecycleState = msg.state;
         // Drive local bot-state on `joined` / terminal states; the
         // `joining` emitted by the extension is informational — we already
@@ -919,6 +968,13 @@ export async function runBot(deps: BotDeps): Promise<void> {
       case "participant.change":
       case "speaker.change":
       case "chat.inbound":
+        // Source-tab gate — see lifecycle case above.
+        if (!isFromOurTab(msg.meetingId)) {
+          deps.logInfo(
+            `meet-bot: dropping ${msg.type} from foreign tab (meetingId=${msg.meetingId}, expected=${expectedMeetingCode ?? "<none>"})`,
+          );
+          return;
+        }
         // Belt-and-suspenders: overwrite meetingId with the authoritative
         // UUID before forwarding. See lifecycle case above for rationale.
         if (subsystems.daemonClient) {
@@ -1045,6 +1101,28 @@ export async function runBot(deps: BotDeps): Promise<void> {
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Extract the Meet code (e.g. `abc-defg-hij`) from a Meet URL like
+ * `https://meet.google.com/abc-defg-hij`. Mirrors the content script's
+ * own `deriveMeetingId` / `extractMeetingIdFromUrl` helpers so the bot
+ * can compare whichever code the extension stamped on an inbound event
+ * against the code derived from our own `MEET_URL`.
+ *
+ * Returns `null` when the URL cannot be parsed or has no leading path
+ * segment; callers treat `null` as "cannot filter" and fall through to
+ * accepting the event rather than blackholing the session.
+ */
+function extractMeetingCodeFromUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const segment = parsed.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
+  return segment || null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on #26590. The Chrome extension background service worker broadcasts every bot command to every open `meet.google.com/*` tab. #26793 fixed the join-command side by making content-script start-session gating tab-aware, but lifecycle/telemetry events emitted by stray tabs still reach the bot's NMH socket and get stamped with the session UUID — clearing the join-deadline timer, firing spurious `lifecycle:joined`/`error` at the daemon, and mixing participant / speaker / chat telemetry across meetings.

Fix on the bot side (the alternative from the task brief): derive the Meet code from `MEET_URL` at boot, compare against the extension-supplied `meetingId` on every inbound event, drop mismatches. Falls back to accept when we can't derive a code so an unusual URL shape doesn't blackhole the intended session.

## Test plan
- [x] New tests verify foreign-tab lifecycle / participant.change / speaker.change / chat.inbound are dropped and the join-deadline timer is not cleared by a foreign `joined`.
- [x] Legacy tests that used the env UUID as the extension meetingId updated to use the URL code (matches how the extension actually stamps events — Gap A tests already did this).
- [x] `bun test __tests__/main.test.ts` — 35 pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
