### PR TITLE
fix(slack): slash-command branches lose slackMeta on user row

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -227,7 +227,7 @@ function extractTurnInterfaceContext(
  * voice, etc.) never get a `slackMeta` key even if a stale plumbing field
  * leaks through.
  */
-function buildSlackMetaForPersistence(params: {
+export function buildSlackMetaForPersistence(params: {
   slackInbound: unknown;
   turnChannel: string | undefined;
 }): string | null {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -105,7 +105,7 @@ export interface RenderedHistoryContent {
 /**
  * Slack-specific metadata extracted at the inbound HTTP boundary and threaded
  * through to user-message persistence so the row can be tagged with a
- * `slackMeta` envelope (consumed by the chronological renderer in later PRs).
+ * `slackMeta` envelope for the chronological renderer.
  */
 export interface SlackInboundMessageMetadata {
   /** Slack channel id (conversation external id) — recorded as `channelId`. */

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -93,6 +93,7 @@ import {
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import { registerLaunchConversationDeps } from "./conversation-launch.js";
+import { buildSlackMetaForPersistence } from "./conversation-messaging.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
@@ -1522,6 +1523,16 @@ export class DaemonServer {
     };
     const slashResult = await resolveSlash(content, slashContext);
 
+    // Slack inbound metadata is materialized once here so every persistence
+    // branch below (slash-command bypass paths and the agent-loop path) writes
+    // the same `slackMeta` envelope. Without this, unknown-slash and /compact
+    // rows land without the envelope and the chronological renderer sees
+    // inconsistent metadata across a single conversation.
+    const slackMeta = buildSlackMetaForPersistence({
+      slackInbound: options?.slackInbound,
+      turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,
+    });
+
     if (slashResult.kind === "unknown") {
       const serverTurnCtx = conversation.getTurnChannelContext();
       const serverProvenance = provenanceFromTrustContext(
@@ -1553,13 +1564,20 @@ export class DaemonServer {
           ? { imageSourcePaths }
           : {}),
       };
+      // slackMeta encodes the inbound user message's ts/thread — it attaches
+      // to the user row only. The assistant's slash-command response does not
+      // originate from Slack and must not inherit the user's channelTs, which
+      // would break ordering in the chronological renderer.
+      const userMetaWithSlack = slackMeta
+        ? { ...serverChannelMeta, slackMeta }
+        : serverChannelMeta;
       const cleanMsg = createUserMessage(content, attachments);
       const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
         conversationId,
         "user",
         JSON.stringify(cleanMsg.content),
-        serverChannelMeta,
+        userMetaWithSlack,
       );
       conversation.getMessages().push(llmMsg);
 
@@ -1637,12 +1655,15 @@ export class DaemonServer {
             }
           : {}),
       };
+      const compactUserMeta = slackMeta
+        ? { ...compactChannelMeta, slackMeta }
+        : compactChannelMeta;
       const cleanMsg = createUserMessage(content, attachments);
       const persisted = await addMessage(
         conversationId,
         "user",
         JSON.stringify(cleanMsg.content),
-        compactChannelMeta,
+        compactUserMeta,
       );
       conversation.getMessages().push(cleanMsg);
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -952,11 +952,11 @@ export async function handleChannelInbound(
       }
 
       // Slack inbound metadata captured for thread-aware persistence. The
-      // gateway forwards `thread_ts` under `sourceMetadata.threadId` (PR 2)
-      // and the message's own ts under `sourceMetadata.messageId`. Persistence
-      // turns this into a `slackMeta` sub-object in the row's metadata column
-      // so the chronological renderer in later PRs can reconstruct thread
-      // structure without re-fetching from Slack.
+      // gateway forwards `thread_ts` under `sourceMetadata.threadId` and the
+      // message's own ts under `sourceMetadata.messageId`. Persistence turns
+      // this into a `slackMeta` sub-object in the row's metadata column so
+      // the chronological renderer can reconstruct thread structure without
+      // re-fetching from Slack.
       const slackThreadTs =
         sourceChannel === "slack" &&
         typeof sourceMetadata?.threadId === "string"


### PR DESCRIPTION
## Summary
Follow-up to #26621 (PR 11). Two issues raised in review:

1. **Slash-command bypass** (Codex P2 + Devin): the `slackInbound` carrier was only unpacked in the agent-loop path. `/compact` and unknown-`/` rows persisted via `addMessage` directly with `serverChannelMeta` / `compactChannelMeta`, so those user rows landed without `slackMeta` and the chronological renderer saw inconsistent envelopes in a single Slack conversation. Fixed by computing `slackMeta` once near the top of `processMessage` via the shared `buildSlackMetaForPersistence` helper and merging it into the user-row metadata for both slash branches. The assistant row is intentionally left pure — it does not originate from Slack and must not inherit the user's `channelTs`.

2. **AGENTS.md comment hygiene** (Devin): rewrote the `(PR 2)` / "in later PRs" references in `inbound-message-handler.ts` and `daemon/handlers/shared.ts` to describe current state only.

## Test plan
- [x] `bun test src/__tests__/inbound-slack-persistence.test.ts` — 8 pass
- [x] `bunx tsc --noEmit` clean for touched files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
