### PR TITLE
ci(macos): retry GitHub App token on build job after api.github.com timeouts

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -112,6 +112,21 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+
+      - name: Wait before token retry
+        if: steps.app-token.outcome == 'failure'
+        run: |
+          echo "::warning::Initial GitHub App token generation failed (likely transient api.github.com timeout from macOS runner). Retrying after 30s."
+          sleep 30
+
+      - name: Generate GitHub App token (retry)
+        id: app-token-retry
+        if: steps.app-token.outcome == 'failure'
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
@@ -120,7 +135,7 @@ jobs:
       - name: Cancel if superseded by a newer run
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-retry.outputs.token }}
           script: |
             const branch = context.ref.replace('refs/heads/', '');
             for (const status of ['queued', 'waiting', 'in_progress']) {
@@ -150,7 +165,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || steps.app-token-retry.outputs.token }}
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -206,7 +221,7 @@ jobs:
 
       - name: Configure GitHub auth for SPM binary downloads
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-retry.outputs.token }}
         run: |
           printf "machine github.com\nlogin oauth2\npassword %s\n" "${GH_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc


### PR DESCRIPTION
## Summary
- The macOS Build job in run 24680008124 failed at the `Generate GitHub App token` step with four back-to-back `Connect Timeout Error` (10000ms) against `api.github.com` — a transient network flake between the macOS runner and GitHub's API edge. The action retries internally but all 4 attempts share the same process and DNS state, so a bad first resolution takes the job down.
- Add a fallback retry **scoped to the `build` job only** (per the requested scope): first invocation runs with `continue-on-error: true`, a 30s sleep step lets the network issue clear, then a second identical invocation re-runs the action. Downstream consumers of `steps.app-token.outputs.token` now use `steps.app-token.outputs.token || steps.app-token-retry.outputs.token` so either token flows through.
- Test job in the same workflow is intentionally untouched — it hasn't hit this failure and the user asked to fix only the specific failing job.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24680008124/job/72174444051
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
