### PR TITLE
fix: ensure CLI login/teleport always inject assistant API key

### DIFF
--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -9,6 +9,9 @@ import { getPlatformAssistantId } from "../config/env.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("platform-client");
 
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
@@ -66,7 +69,17 @@ export class VellumPlatformClient {
         )?.trim() ?? "";
     }
 
-    if (!baseUrl || !apiKey) return null;
+    if (!baseUrl || !apiKey) {
+      log.debug(
+        {
+          hasBaseUrl: !!baseUrl,
+          hasApiKey: !!apiKey,
+          managedProxyEnabled: ctx.enabled,
+        },
+        "Platform client prerequisites missing — returning null",
+      );
+      return null;
+    }
 
     return new VellumPlatformClient(baseUrl, apiKey, assistantId);
   }

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -157,6 +157,15 @@ export class UsageTelemetryReporter {
       // Resolve auth context — authenticated path uses client, anonymous path
       // sends unauthenticated (telemetry endpoints are public).
       const client = await VellumPlatformClient.create();
+      log.debug(
+        {
+          authenticated: !!client,
+          usageCount: events.length,
+          turnCount: turnEvents.length,
+          lifecycleCount: lifecycleEvents.length,
+        },
+        "Telemetry flush: resolved auth context",
+      );
 
       // Build payload
       const typedEvents: TelemetryEvent[] = [
@@ -222,9 +231,9 @@ export class UsageTelemetryReporter {
       }
 
       if (!resp.ok) {
-        await resp.text(); // consume body to release connection
+        const body = await resp.text();
         log.warn(
-          { status: resp.status },
+          { status: resp.status, authenticated: !!client, body },
           "Usage telemetry POST failed — will retry next cycle",
         );
         return;

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -15,7 +15,9 @@ import {
   fetchOrganizationId,
   getPlatformUrl,
   injectCredentialsIntoAssistant,
+  readGatewayCredential,
   readPlatformToken,
+  reprovisionAssistantApiKey,
   savePlatformToken,
 } from "../lib/platform-client";
 
@@ -193,12 +195,40 @@ export async function login(): Promise<void> {
           `Registered assistant: ${registration.assistant.name} (${registration.assistant.id})`,
         );
 
+        // Resolve the API key to inject, mirroring the macOS app's
+        // LocalAssistantBootstrapService 3-step flow:
+        // 1. Use fresh key from registration (first-time only)
+        // 2. Use existing key from the daemon's credential store
+        // 3. Reprovision (rotate) as a last resort — this revokes the
+        //    old key server-side, so we avoid it when possible.
+        let assistantApiKey = registration.assistant_api_key;
+        if (!assistantApiKey) {
+          const existingKey = await readGatewayCredential(
+            entry.runtimeUrl,
+            "vellum:assistant_api_key",
+            entry.bearerToken,
+          );
+          if (existingKey) {
+            assistantApiKey = existingKey;
+          } else {
+            console.log("No API key available locally — reprovisioning...");
+            const reprovision = await reprovisionAssistantApiKey(
+              token,
+              orgId,
+              clientInstallationId,
+              entry.assistantId,
+              "cli",
+            );
+            assistantApiKey = reprovision.provisioning.assistant_api_key;
+          }
+        }
+
         // Inject credentials into the running assistant via the gateway,
         // mirroring the desktop app's LocalAssistantBootstrapService flow.
         const allInjected = await injectCredentialsIntoAssistant({
           gatewayUrl: entry.runtimeUrl,
           bearerToken: entry.bearerToken,
-          assistantApiKey: registration.assistant_api_key,
+          assistantApiKey,
           platformAssistantId: registration.assistant.id,
           platformBaseUrl: getPlatformUrl(),
           organizationId: orgId,

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -27,6 +27,8 @@ import {
   platformImportBundleFromGcs,
   platformPollImportStatus,
   ensureSelfHostedLocalRegistration,
+  readGatewayCredential,
+  reprovisionAssistantApiKey,
   injectCredentialsIntoAssistant,
   fetchCurrentUser,
   fetchOrganizationId,
@@ -1135,10 +1137,33 @@ async function tryInjectPlatformCredentials(
       "cli",
     );
 
+    // Resolve the API key: 1) fresh from registration, 2) existing from
+    // daemon credential store, 3) reprovision as last resort (revokes old key).
+    let assistantApiKey = registration.assistant_api_key;
+    if (!assistantApiKey) {
+      const existingKey = await readGatewayCredential(
+        entry.runtimeUrl,
+        "vellum:assistant_api_key",
+        entry.bearerToken,
+      );
+      if (existingKey) {
+        assistantApiKey = existingKey;
+      } else {
+        const reprovision = await reprovisionAssistantApiKey(
+          token,
+          orgId,
+          clientInstallationId,
+          entry.assistantId,
+          "cli",
+        );
+        assistantApiKey = reprovision.provisioning.assistant_api_key;
+      }
+    }
+
     const allInjected = await injectCredentialsIntoAssistant({
       gatewayUrl: entry.runtimeUrl,
       bearerToken: entry.bearerToken,
-      assistantApiKey: registration.assistant_api_key,
+      assistantApiKey,
       platformAssistantId: registration.assistant.id,
       platformBaseUrl: getPlatformUrl(),
       organizationId: orgId,

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -223,6 +223,111 @@ export async function ensureSelfHostedLocalRegistration(
 }
 
 // ---------------------------------------------------------------------------
+// API key reprovisioning
+// ---------------------------------------------------------------------------
+
+export interface ReprovisionApiKeyResponse {
+  provisioning: {
+    assistant_api_key: string;
+  };
+}
+
+/**
+ * Reprovision (rotate) the API key for a self-hosted local assistant.
+ *
+ * Calls `POST /v1/assistants/self-hosted-local/reprovision-api-key/`.
+ * Returns a fresh API key. The previous key is revoked server-side.
+ */
+export async function reprovisionAssistantApiKey(
+  token: string,
+  organizationId: string,
+  clientInstallationId: string,
+  runtimeAssistantId: string,
+  clientPlatform: string,
+  assistantVersion?: string,
+  platformUrl?: string,
+): Promise<ReprovisionApiKeyResponse> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const body: Record<string, string> = {
+    client_installation_id: clientInstallationId,
+    runtime_assistant_id: runtimeAssistantId,
+    client_platform: clientPlatform,
+  };
+  if (assistantVersion) {
+    body.assistant_version = assistantVersion;
+  }
+
+  const response = await fetch(
+    `${resolvedUrl}/v1/assistants/self-hosted-local/reprovision-api-key/`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "X-Session-Token": token,
+        "Vellum-Organization-Id": organizationId,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("Authentication required for API key reprovisioning.");
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `API key reprovisioning failed (${response.status}): ${detail || response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as ReprovisionApiKeyResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Credential reading from running assistant via gateway
+// ---------------------------------------------------------------------------
+
+/**
+ * Read an existing credential from the assistant's secret store via the
+ * gateway-proxied `POST /v1/secrets/read` endpoint (with `reveal: true`).
+ *
+ * Returns the credential value if found, or `null` if the credential is
+ * missing or the assistant is unreachable. Never throws — failures are
+ * treated as "not found" so the caller can fall through to reprovisioning.
+ */
+export async function readGatewayCredential(
+  gatewayUrl: string,
+  name: string,
+  bearerToken?: string,
+): Promise<string | null> {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (bearerToken) {
+      headers["Authorization"] = `Bearer ${bearerToken}`;
+    }
+
+    const response = await fetch(`${gatewayUrl}/v1/secrets/read`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ type: "credential", name, reveal: true }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) return null;
+
+    const json = (await response.json()) as { found: boolean; value?: string };
+    return json.found && json.value ? json.value : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Credential injection into running assistant via gateway
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **Root cause**: The platform's `ensure-registration` endpoint only returns the API key on the first call; subsequent calls return `null`. The CLI passed `null` directly to credential injection, leaving the daemon without an API key — all telemetry reported as `auth_mode: "anonymous"`.
- **Fix**: Mirror the macOS app's 3-step API key resolution: use fresh key from registration → read existing key from daemon credential store → reprovision as last resort. Added `readGatewayCredential()` and `reprovisionAssistantApiKey()` to the CLI's platform client.
- **Observability**: Added debug logging to `VellumPlatformClient.create()` and the telemetry reporter to surface which auth path is taken on each flush cycle.

## Test plan
- [ ] `vellum login` on a fresh assistant injects the API key from registration (step 1)
- [ ] `vellum login` on a re-registered assistant reads the existing key from the daemon (step 2)
- [ ] `vellum login` after `vellum platform disconnect` reprovisions a fresh key (step 3)
- [ ] Telemetry events appear with `auth_mode: "api_key"` after login
- [ ] `npx tsc --noEmit` passes for both `assistant/` and `cli/` packages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
