### PR TITLE
fix(slack-transcript): emit placeholder tag line for attachment-only rows

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3624,6 +3624,76 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).toEqual([]);
   });
 
+  test("attachment-only user rows emit a placeholder tag line so sender/timestamp attribution is preserved", () => {
+    // Before the placeholder, a row whose content is only an image or file
+    // would render without any tag line at all — the model would see the
+    // attachment block but lose all sender/timestamp attribution. Emit a
+    // synthetic tag line with an `[image]` / `[file]` placeholder so the
+    // attribution survives while the image/file block itself is still
+    // preserved alongside it.
+    const userMeta1: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_25,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    const userMeta2: SlackMessageMetadata = {
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs: TS_14_28,
+      eventKind: "message",
+      displayName: "@alice",
+    };
+    const imageOnlyContent = JSON.stringify([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+    ]);
+    const mixedImageAndFileContent = JSON.stringify([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+      { type: "file", source: { type: "file_id", file_id: "file_1" } },
+    ]);
+    const rows: SlackTranscriptInputRow[] = [
+      {
+        role: "user",
+        content: imageOnlyContent,
+        createdAt: MS_14_25,
+        metadata: metadataEnvelope(userMeta1),
+      },
+      {
+        role: "user",
+        content: mixedImageAndFileContent,
+        createdAt: MS_14_28,
+        metadata: metadataEnvelope(userMeta2),
+      },
+    ];
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    const firstTag = (result![0]!.content[0] as { type: "text"; text: string })
+      .text;
+    const secondTag = (result![1]!.content[0] as { type: "text"; text: string })
+      .text;
+    expect(firstTag).toBe("[11/14/23 14:25 @alice]: [image]");
+    expect(secondTag).toBe("[11/14/23 14:28 @alice]: [image] [file]");
+    // The attachment blocks themselves must still be preserved alongside.
+    expect(result![0]!.content.some((b) => b.type === "image")).toBe(true);
+    expect(
+      result![1]!.content.some((b) => b.type === "image") &&
+        result![1]!.content.some((b) => b.type === "file"),
+    ).toBe(true);
+    // No empty-body render like `[... @alice]: ` should ever appear.
+    for (const msg of result!) {
+      const head = (msg.content[0] as { type: "text"; text: string }).text;
+      expect(head).not.toMatch(/]:\s*$/);
+    }
+  });
+
   test("row content with interleaved text + tool_use preserves tool_use alongside tag line (PR 3)", () => {
     // PR 3 preserves replayable content blocks (tool_use, tool_result,
     // thinking, etc.) alongside the tag line. A row persisted with

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1238,12 +1238,45 @@ function extractPlainText(rawContent: string): string {
     return typeof parsed === "string" ? parsed : rawContent;
   }
   const parts: string[] = [];
+  const placeholderLabels: string[] = [];
   for (const block of parsed as ContentBlock[]) {
-    if (block && typeof block === "object" && block.type === "text") {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text") {
       parts.push(block.text);
+      continue;
+    }
+    const label = placeholderForBlockType(block.type);
+    if (label && !placeholderLabels.includes(label)) {
+      placeholderLabels.push(label);
     }
   }
-  return parts.join("\n");
+  if (parts.length > 0) {
+    return parts.join("\n");
+  }
+  // Rows with no text blocks (e.g. images, file uploads, pure tool turns)
+  // would otherwise render as an empty transcript line like
+  // `[14:25 @alice]: `. Surface the attachment/tool context instead so the
+  // model can tell something was actually said on that turn.
+  return placeholderLabels.join(" ");
+}
+
+function placeholderForBlockType(type: ContentBlock["type"]): string | null {
+  switch (type) {
+    case "image":
+      return "[image]";
+    case "file":
+      return "[file]";
+    case "tool_use":
+    case "server_tool_use":
+      return "[tool call]";
+    case "tool_result":
+    case "web_search_tool_result":
+      return "[tool result]";
+    case "thinking":
+    case "redacted_thinking":
+    case "text":
+      return null;
+  }
 }
 
 /**
@@ -1300,9 +1333,28 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
     // Plain string row (legacy) — no structured blocks to preserve.
   }
 
+  const plainText = extractPlainText(row.content);
+
+  // Attachment-only rows (images, files) carry no text block, so the
+  // transcript renderer would normally emit them *without* a tag line —
+  // the model sees the image but loses sender/timestamp attribution.
+  // Synthesize a leading text block carrying the placeholder so the
+  // renderer emits `[14:25 @alice]: [image]` and then the image itself.
+  // Pure tool-only rows (tool_use / tool_result) are intentionally
+  // excluded — those are synthetic turn continuations that should stay
+  // tag-line-free, matching the documented behaviour in
+  // `buildMessageContentBlocks`.
+  const hasTextBlock = contentBlocks.some((b) => b?.type === "text");
+  const hasAttachmentBlock = contentBlocks.some(
+    (b) => b?.type === "image" || b?.type === "file",
+  );
+  if (!hasTextBlock && hasAttachmentBlock && plainText !== "") {
+    contentBlocks = [{ type: "text", text: plainText }, ...contentBlocks];
+  }
+
   return {
     role: row.role,
-    content: extractPlainText(row.content),
+    content: plainText,
     metadata: slackMeta,
     senderLabel,
     createdAt: row.createdAt,


### PR DESCRIPTION
## Summary

Addresses Codex's P2 feedback on [#26627](https://github.com/vellum-ai/vellum-assistant/pull/26627).

Before this change, a Slack DM row whose persisted content was only non-text blocks (image, file) rendered without any tag line at all — the attachment block was preserved but all sender/timestamp attribution was lost.

- `extractPlainText` now returns ordered, deduplicated placeholders (`[image]`, `[file]`, `[tool call]`, `[tool result]`) when no text block is present.
- `rowToRenderable` prepends a synthetic text block carrying that placeholder when the row has image/file attachments but no text block, so the renderer emits `[14:25 @alice]: [image]` followed by the image block itself.
- Pure tool-only rows (`tool_use` / `tool_result`) are intentionally left tag-line-free — they are synthetic turn continuations, not user-visible messages.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/conversation-runtime-assembly.test.ts` — 150 pass, new attachment-attribution test covers image-only, image+file, and regression-guards against empty `]:` bodies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
