### PR TITLE
fix(slack): exclude reaction rows and inbound ts from thread backfill dedup

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -58,7 +58,7 @@ mock.module("../runtime/gateway-client.js", () => ({
 import { v4 as uuid } from "uuid";
 
 import { upsertContactChannel } from "../contacts/contacts-write.js";
-import { getDb,initializeDb } from "../memory/db.js";
+import { getDb, initializeDb } from "../memory/db.js";
 import type { Message as MessagingMessage } from "../messaging/provider-types.js";
 import * as slackBackfill from "../messaging/providers/slack/backfill.js";
 import {
@@ -487,9 +487,10 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
 
     const persisted = readPersistedSlackRows(conv.id);
     expect(persisted.length).toBe(2);
-    expect(
-      persisted.map((p) => p.channelTs).sort(),
-    ).toEqual(["1234.0", "5678.0"]);
+    expect(persisted.map((p) => p.channelTs).sort()).toEqual([
+      "1234.0",
+      "5678.0",
+    ]);
   });
 
   test("backfilled message without text is persisted with empty content", async () => {
@@ -533,6 +534,97 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted[0].channelTs).toBe("1234.0");
   });
 
+  test("reaction row targeting the thread parent does not short-circuit ancestor backfill", async () => {
+    const conv = createTestConversation();
+
+    // A reaction on the thread parent stores the parent's ts as `channelTs`
+    // (the reaction *targets* that message). If the dedup scan includes
+    // reaction rows, ancestor backfill wrongly believes the parent is
+    // already persisted and skips the network fetch.
+    const db = getDb();
+    messageCounter++;
+    const now = Date.now() + messageCounter;
+    db.$client
+      .prepare(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        uuid(),
+        conv.id,
+        "user",
+        "+1",
+        now,
+        JSON.stringify({
+          slackMeta: writeSlackMetadata({
+            source: "slack",
+            channelId: SLACK_CHANNEL_ID,
+            channelTs: "1234.0",
+            eventKind: "reaction",
+            reaction: {
+              emoji: "+1",
+              targetChannelTs: "1234.0",
+              op: "added",
+            },
+          }),
+        }),
+      );
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({ id: "1234.0", text: "parent" }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    const persisted = readPersistedSlackRows(conv.id);
+    // Reaction row + newly backfilled parent message row.
+    expect(persisted.length).toBe(2);
+    expect(
+      persisted.find((p) => p.channelTs === "1234.0" && p.content === "parent"),
+    ).toBeDefined();
+  });
+
+  test("excludeChannelTs pre-seeds the dedup set so the inbound message is not re-persisted", async () => {
+    const conv = createTestConversation();
+
+    // Simulate Slack's conversations.replies returning the just-received
+    // inbound message alongside the thread parent — this is the normal
+    // response shape. Without excludeChannelTs, the inbound row (persisted
+    // concurrently in the background) would race the backfill and produce
+    // a duplicate.
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "parent",
+        threadId: undefined,
+      }),
+      makeBackfillMessage({
+        id: "1234.5",
+        text: "inbound reply — must be skipped",
+        threadId: "1234.0",
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+      excludeChannelTs: "1234.5",
+    });
+
+    const persisted = readPersistedSlackRows(conv.id);
+    // Only the parent should be persisted by backfill; the inbound (1234.5)
+    // is owned by the concurrent inbound-processing path.
+    expect(persisted.length).toBe(1);
+    expect(persisted[0].channelTs).toBe("1234.0");
+    expect(persisted.find((p) => p.channelTs === "1234.5")).toBeUndefined();
+  });
+
   test("messages with malformed metadata in the conversation are tolerated when scanning", async () => {
     const conv = createTestConversation();
 
@@ -541,7 +633,9 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     insertMessage(conv.id, "user", "malformed", { foo: "bar" });
     const db = getDb();
     db.$client
-      .prepare("UPDATE messages SET metadata = 'not-json' WHERE conversation_id = ?")
+      .prepare(
+        "UPDATE messages SET metadata = 'not-json' WHERE conversation_id = ?",
+      )
       .run(conv.id);
 
     backfillThreadMock.mockImplementation(async () => [
@@ -558,9 +652,9 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     const persisted = readPersistedSlackRows(conv.id);
     // Two rows: the malformed row + the newly backfilled parent.
     expect(persisted.length).toBe(2);
-    expect(
-      persisted.find((p) => p.channelTs === "1234.0")?.content,
-    ).toBe("parent");
+    expect(persisted.find((p) => p.channelTs === "1234.0")?.content).toBe(
+      "parent",
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1051,6 +1051,7 @@ export async function handleChannelInbound(
           conversationId: result.conversationId,
           channelId: conversationExternalId,
           threadTs: slackThreadTs,
+          excludeChannelTs: slackInbound?.channelTs,
         });
       }
 
@@ -1263,7 +1264,11 @@ function readStoredSlackChannelTs(conversationId: string): Set<string> {
     const raw = parent.slackMeta;
     if (typeof raw !== "string") continue;
     const meta = readSlackMetadata(raw);
-    if (meta) seen.add(meta.channelTs);
+    // Only message rows represent stored Slack messages. Reaction rows carry
+    // `channelTs` equal to the target message's ts, so including them would
+    // make a reaction on a thread parent wrongly short-circuit ancestor
+    // backfill (the parent itself may still be unseen).
+    if (meta && meta.eventKind === "message") seen.add(meta.channelTs);
   }
   return seen;
 }
@@ -1458,8 +1463,17 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
   conversationId: string;
   channelId: string;
   threadTs: string;
+  /**
+   * The inbound message's own `channelTs`. Pre-seeded into the dedup set so
+   * this helper does not re-persist the just-received message when Slack's
+   * `conversations.replies` returns it in the thread window. Necessary
+   * because thread backfill runs concurrently with
+   * `processChannelMessageInBackground`, so the inbound row may not yet be
+   * in the DB when `readStoredSlackChannelTs` snapshots the conversation.
+   */
+  excludeChannelTs?: string;
 }): Promise<void> {
-  const { conversationId, channelId, threadTs } = params;
+  const { conversationId, channelId, threadTs, excludeChannelTs } = params;
   const cacheKey = `${conversationId}:${threadTs}`;
 
   try {
@@ -1468,6 +1482,7 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     }
 
     const storedChannelTs = readStoredSlackChannelTs(conversationId);
+    if (excludeChannelTs) storedChannelTs.add(excludeChannelTs);
     if (storedChannelTs.has(threadTs)) {
       // Parent is already in the conversation; mark the cache so a burst of
       // replies in this thread does not redo the DB scan for each one.


### PR DESCRIPTION
## Summary

Follow-up to #26629 (PR 22 of slack-thread-aware-context). Two bugs in the
thread-ancestor backfill dedup set:

1. **Reaction rows were treated as stored messages (Codex P2).**
   Reaction rows store channelTs equal to the target message's ts. The
   dedup scan pulled every slackMeta row in, so a reaction on the thread
   parent wrongly short-circuited ancestor backfill. Fixed by filtering
   readStoredSlackChannelTs to eventKind === "message".

2. **Inbound message re-persisted by backfill (Devin BUG).**
   triggerSlackThreadBackfillIfNeeded runs concurrently with
   processChannelMessageInBackground, so the inbound's own row is not
   yet in the DB when the dedup set is built. Slack's
   conversations.replies then returns the inbound message and the
   backfill helper persists a duplicate. Fixed by threading an
   excludeChannelTs parameter in from the caller and pre-adding it to
   storedChannelTs before iterating.

## Test plan
- [x] Added thread-backfill.test.ts cases covering both fixes.
- [x] bun test src/__tests__/thread-backfill.test.ts — all 16 pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
