### PR TITLE
fix: add toLowerCase to native-host normalizeFrameEnvironment

### DIFF
--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -386,7 +386,7 @@ function fail(message: string, code = 1): never {
  */
 export function normalizeFrameEnvironment(raw: unknown): string | undefined {
   if (typeof raw !== "string") return undefined;
-  const trimmed = raw.trim();
+  const trimmed = raw.trim().toLowerCase();
   if (trimmed.length === 0) return undefined;
   if (trimmed === "prod") return "production";
   return trimmed;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chrome-extension-env-selector.md.

**Gap:** normalizeFrameEnvironment missing toLowerCase
**What was expected:** Consistent case normalization with parseExtensionEnvironment
**What was found:** normalizeFrameEnvironment trims but does not lowercase, causing silent fallback to production for mixed-case inputs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
