### PR TITLE
test(workspace-injection): mock workspace git-service to fix CI timeout

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -33,7 +33,7 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    
+
     llm: {
       default: {
         provider: "mock-provider",
@@ -205,6 +205,20 @@ mock.module("../workspace/top-level-scanner.js", () => ({
       truncated: false,
     };
   },
+}));
+
+// Avoid real workspace-git initialization on /tmp — on CI runners,
+// `git add -A` under /tmp hits permission errors on systemd-private dirs,
+// which blocks the agent loop for long enough to trip the 5s test timeout
+// on the first test case before the circuit breaker opens.
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
 }));
 
 mock.module("../agent/loop.js", () => ({


### PR DESCRIPTION
## Summary
- Mock `../workspace/git-service.js` and `../workspace/turn-commit.js` in `conversation-workspace-injection.test.ts` so the agent loop doesn't run real git operations on `/tmp` during the test.
- Fixes the `runtime messages include workspace top-level context` failure on CI: `git add -A` under `/tmp` walks systemd-private dirs (EACCES), takes 4+ seconds to fail, and trips the 5000ms test timeout on the first test case before the init circuit breaker opens. Reuses the exact pattern (and rationale comment) already in `conversation-workspace-tool-tracking.test.ts`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24680226495/job/72175182930
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
