### PR TITLE
fix(slack-approvals): scope guardian reaction approvals to tracked prompt ts

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -939,7 +939,7 @@ describe("plain-text channel approval decisions", () => {
     const approvalSpy = spyOn(
       gatewayClient,
       "deliverApprovalPrompt",
-    ).mockResolvedValue(undefined);
+    ).mockResolvedValue({ ok: true });
 
     const initReq = makePlainTextInboundRequest({ content: "init" });
     await handleChannelInbound(initReq, noopProcessMessage);
@@ -2845,7 +2845,7 @@ describe("background channel processing approval prompts", () => {
     const deliverPromptSpy = spyOn(
       gatewayClient,
       "deliverApprovalPrompt",
-    ).mockResolvedValue(undefined);
+    ).mockResolvedValue({ ok: true });
     const processCalls: Array<{ options?: Record<string, unknown> }> = [];
 
     const processMessage = mock(
@@ -2908,7 +2908,7 @@ describe("background channel processing approval prompts", () => {
     const deliverPromptSpy = spyOn(
       gatewayClient,
       "deliverApprovalPrompt",
-    ).mockResolvedValue(undefined);
+    ).mockResolvedValue({ ok: true });
     const processCalls: Array<{ options?: Record<string, unknown> }> = [];
 
     const processMessage = mock(
@@ -3011,7 +3011,7 @@ describe("background channel processing approval prompts", () => {
     const deliverPromptSpy = spyOn(
       gatewayClient,
       "deliverApprovalPrompt",
-    ).mockResolvedValue(undefined);
+    ).mockResolvedValue({ ok: true });
     const processCalls: Array<{ options?: Record<string, unknown> }> = [];
 
     const processMessage = mock(

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -397,8 +397,8 @@ export async function deliverApprovalPrompt(
   approval: ApprovalUIMetadata,
   assistantId?: string,
   bearerToken?: string,
-): Promise<void> {
-  await deliverChannelReply(
+): Promise<ChannelDeliveryResult> {
+  return deliverChannelReply(
     callbackUrl,
     { chatId, text, approval, assistantId },
     bearerToken,

--- a/assistant/src/runtime/routes/approval-prompt-ts-tracker.ts
+++ b/assistant/src/runtime/routes/approval-prompt-ts-tracker.ts
@@ -1,0 +1,58 @@
+/**
+ * In-memory tracker for approval prompt message timestamps.
+ *
+ * Scopes guardian reaction approvals so only reactions on a known
+ * approval prompt can resolve a pending request. Without this, a stray
+ * 👍/✅ on any message in the guardian chat could approve a pending
+ * request (since reactions are now admitted from any subscribed channel,
+ * not just tracked bot threads).
+ *
+ * Entries expire after `APPROVAL_PROMPT_TS_TTL_MS` (matches the guardian
+ * approval TTL of 30 minutes, plus grace). Populated when an approval
+ * prompt is successfully delivered; consulted before applying a guardian
+ * reaction decision.
+ */
+
+const APPROVAL_PROMPT_TS_TTL_MS = 35 * 60 * 1000;
+
+const tracked = new Map<string, number>();
+
+function key(channel: string, chatId: string, ts: string): string {
+  return `${channel}\u0000${chatId}\u0000${ts}`;
+}
+
+function pruneExpired(now: number): void {
+  for (const [k, expiresAt] of tracked) {
+    if (expiresAt <= now) tracked.delete(k);
+  }
+}
+
+export function trackApprovalPromptTs(
+  channel: string,
+  chatId: string,
+  ts: string,
+): void {
+  const now = Date.now();
+  pruneExpired(now);
+  tracked.set(key(channel, chatId, ts), now + APPROVAL_PROMPT_TS_TTL_MS);
+}
+
+export function isTrackedApprovalPromptTs(
+  channel: string,
+  chatId: string,
+  ts: string,
+): boolean {
+  const k = key(channel, chatId, ts);
+  const expiresAt = tracked.get(k);
+  if (expiresAt === undefined) return false;
+  if (expiresAt <= Date.now()) {
+    tracked.delete(k);
+    return false;
+  }
+  return true;
+}
+
+/** @internal Test-only — clear all tracked entries. */
+export function _clearApprovalPromptTsTrackerForTesting(): void {
+  tracked.clear();
+}

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -31,6 +31,7 @@ import type {
   ApprovalCopyGenerator,
 } from "../http-types.js";
 import { parseApprovalIntent } from "../nl-approval-parser.js";
+import { isTrackedApprovalPromptTs } from "./approval-prompt-ts-tracker.js";
 import { handleGuardianCallbackDecision } from "./approval-strategies/guardian-callback-strategy.js";
 import { handleGuardianTextEngineDecision } from "./approval-strategies/guardian-text-engine-strategy.js";
 import {
@@ -139,13 +140,38 @@ export async function handleApprovalInterception(
   // so getChannelApprovalPrompt(conversationId) would return null.
   // Only guardians can approve via reaction — non-guardian reactions are
   // silently ignored to prevent self-approval.
-  if (callbackData?.startsWith("reaction:")) {
+  //
+  // `reaction_removed:` callbackData never expresses an approval intent, and
+  // `isSlackReactionEvent` short-circuits before reaching here for removals,
+  // but guard explicitly so a future refactor can't turn an un-react into an
+  // unintended approval.
+  if (
+    callbackData?.startsWith("reaction:") &&
+    !callbackData.startsWith("reaction_removed:")
+  ) {
     if (trustCtx.trustClass !== "guardian" || !actorExternalId) {
       return { handled: true, type: "stale_ignored" };
     }
     const reactionDecision = parseReactionCallbackData(callbackData);
     if (!reactionDecision) {
       // Unknown emoji — ignore silently
+      return { handled: true, type: "stale_ignored" };
+    }
+
+    // Require the reacted-to message to be a tracked approval prompt. Without
+    // this check, any unrelated 👍 reaction from the guardian in a subscribed
+    // channel would approve the outstanding pending request (now that
+    // reactions are admitted from any subscribed channel, not just tracked
+    // bot threads). `approvalMessageTs` is `item.ts` of the reacted-to
+    // Slack message, propagated from `sourceMetadata.messageId`.
+    if (
+      !approvalMessageTs ||
+      !isTrackedApprovalPromptTs(
+        sourceChannel,
+        conversationExternalId,
+        approvalMessageTs,
+      )
+    ) {
       return { handled: true, type: "stale_ignored" };
     }
 
@@ -493,8 +519,12 @@ export async function handleApprovalInterception(
   // ── Slack reaction path ──
   // Reactions produce `callbackData` of the form `reaction:<emoji_name>`.
   // Only guardians can approve via reaction — non-guardian reactions are
-  // silently ignored to prevent self-approval.
-  if (callbackData?.startsWith("reaction:")) {
+  // silently ignored to prevent self-approval. `reaction_removed:` never
+  // expresses an approval intent.
+  if (
+    callbackData?.startsWith("reaction:") &&
+    !callbackData.startsWith("reaction_removed:")
+  ) {
     if (trustCtx.trustClass !== "guardian") {
       return { handled: true, type: "stale_ignored" };
     }

--- a/assistant/src/runtime/routes/guardian-approval-prompt.ts
+++ b/assistant/src/runtime/routes/guardian-approval-prompt.ts
@@ -17,6 +17,7 @@ import {
 } from "../gateway-client.js";
 import { buildActionLegend } from "../guardian-decision-types.js";
 import type { ApprovalCopyGenerator } from "../http-types.js";
+import { trackApprovalPromptTs } from "./approval-prompt-ts-tracker.js";
 import { requiredDecisionKeywords } from "./channel-route-shared.js";
 
 const log = getLogger("runtime-http");
@@ -141,7 +142,7 @@ export async function deliverGeneratedApprovalPrompt(
     }
 
     try {
-      await deliverApprovalPrompt(
+      const deliveryResult = await deliverApprovalPrompt(
         replyCallbackUrl,
         chatId,
         enrichedText,
@@ -149,6 +150,9 @@ export async function deliverGeneratedApprovalPrompt(
         assistantId,
         bearerToken,
       );
+      if (deliveryResult.ts) {
+        trackApprovalPromptTs(sourceChannel, chatId, deliveryResult.ts);
+      }
       return true;
     } catch (err) {
       log.error(
@@ -168,7 +172,7 @@ export async function deliverGeneratedApprovalPrompt(
     const taggedFallback = `${plainTextFallback}\n[ref:${uiMetadata.requestId}]`;
 
     try {
-      await deliverChannelReply(
+      const fallbackResult = await deliverChannelReply(
         replyCallbackUrl,
         {
           chatId,
@@ -177,6 +181,9 @@ export async function deliverGeneratedApprovalPrompt(
         },
         bearerToken,
       );
+      if (fallbackResult.ts) {
+        trackApprovalPromptTs(sourceChannel, chatId, fallbackResult.ts);
+      }
       return true;
     } catch (err) {
       log.error(
@@ -197,7 +204,7 @@ export async function deliverGeneratedApprovalPrompt(
   const taggedPlainText = `${plainText}\n[ref:${uiMetadata.requestId}]`;
 
   try {
-    await deliverChannelReply(
+    const plainResult = await deliverChannelReply(
       replyCallbackUrl,
       {
         chatId,
@@ -206,6 +213,9 @@ export async function deliverGeneratedApprovalPrompt(
       },
       bearerToken,
     );
+    if (plainResult.ts) {
+      trackApprovalPromptTs(sourceChannel, chatId, plainResult.ts);
+    }
     return true;
   } catch (err) {
     log.error(

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -859,7 +859,13 @@ export async function handleChannelInbound(
     // of whether content/attachments are present — callback payloads always
     // have non-empty content (normalize.ts sets message.content to cbq.data),
     // so checking for empty content alone would miss stale callbacks.
-    if (hasCallbackData) {
+    //
+    // Reaction events (`reaction:` / `reaction_removed:`) are persisted by
+    // the earlier `isSlackReactionEvent` branch and never reach here; guard
+    // explicitly so a future refactor can't let a reaction ts drive a
+    // "This approval request has been resolved." edit that would clobber
+    // the user's reacted-to message.
+    if (hasCallbackData && !isSlackReactionEvent(body)) {
       // Record seen signal even for stale callbacks — the user still interacted
       if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {


### PR DESCRIPTION
## Summary

Addresses P1 review feedback on #26615.

- Guardian reaction approvals require the reaction's \`item.ts\` to match a tracked approval-prompt ts. Prevents stray 👍 in the guardian chat from resolving the outstanding pending approval now that reactions are admitted from any subscribed channel.
- Adds explicit \`reaction_removed:\` guards so removal events cannot trigger approval flows or fall through to the stale-callback path that clobbers user messages.

## Implementation

- New \`approval-prompt-ts-tracker.ts\` — TTL-bounded in-memory Map (35 min). Populated by \`guardian-approval-prompt.ts\` on every successful delivery (rich UI primary, plain-text fallback on rich-UI failure, plain-text when no rich UI); checked in \`guardian-approval-interception.ts\` before applying a reaction decision.
- \`deliverApprovalPrompt()\` now returns \`ChannelDeliveryResult\` (previously \`void\`) so callers can capture \`ts\`.
- \`guardian-approval-interception.ts\`: reaction branch requires tracked ts; all reaction checks exclude \`reaction_removed:\` callbacks explicitly.
- \`inbound-message-handler.ts\`: stale-callback clobber guard now skips reaction events defensively.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test src/__tests__/channel-approval-routes.test.ts\` — 61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
