### PR TITLE
fix(slack-edit): tolerant metadata parse + drop historical PR references

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -23,6 +23,7 @@ import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import { UserError } from "../util/errors.js";
+import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
@@ -420,9 +421,7 @@ export function findAnalysisConversationFor(
  * not found. Tiny convenience used by the recursion guard in the
  * auto-analyze loop.
  */
-export function getConversationSource(
-  conversationId: string,
-): string | null {
+export function getConversationSource(conversationId: string): string | null {
   const db = getDb();
   const row = db
     .select({ source: conversations.source })
@@ -1478,7 +1477,7 @@ export function updateMessageContentAndMetadata(
       .from(messages)
       .where(eq(messages.id, messageId))
       .get();
-    const existing = row?.metadata ? JSON.parse(row.metadata) : {};
+    const existing = row?.metadata ? safeParseRecord(row.metadata) : {};
     tx.update(messages)
       .set({
         content: newContent,

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -26,6 +26,7 @@ import {
   mergeSlackMetadata,
   readSlackMetadata,
 } from "../../../messaging/providers/slack/message-metadata.js";
+import { safeParseRecord } from "../../../util/json.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("runtime-http");
@@ -146,8 +147,8 @@ export async function handleEditIntercept(
     if (sourceChannel === "slack") {
       // Slack edits stamp `slackMeta.editedAt` so the chronological
       // transcript renderer can surface the edited marker. The merge
-      // tolerates rows that pre-date PR 11's slackMeta enrichment by
-      // synthesizing the minimum-required fields from the lookup data.
+      // tolerates rows that lack slackMeta enrichment by synthesizing
+      // the minimum-required fields from the lookup data.
       applySlackEditMetadata({
         messageId: original.messageId,
         conversationExternalId,
@@ -200,8 +201,8 @@ export async function handleEditIntercept(
  * `slackMeta.editedAt` in the same transaction.
  *
  * If the row already has a valid `slackMeta` sub-object, the merge preserves
- * all existing fields and only sets/refreshes `editedAt`. If the row has no
- * `slackMeta` envelope, the helper synthesizes the minimum-required fields
+ * all existing fields and only sets/refreshes `editedAt`. If the row lacks
+ * `slackMeta` enrichment, the helper synthesizes the minimum-required fields
  * (`source`, `channelId`, `channelTs`, `eventKind`) from the values that
  * brought us here so the resulting metadata is still readable by
  * `readSlackMetadata`.
@@ -226,7 +227,7 @@ function applySlackEditMetadata(params: {
   const editedAt = Date.now();
   const parsedExisting = readSlackMetadata(existingSlackMeta ?? null);
 
-  // For pre-PR-11 rows (no valid existing slackMeta), `mergeSlackMetadata`
+  // When the row has no valid existing slackMeta, `mergeSlackMetadata`
   // would produce a record missing the required fields and fail subsequent
   // `readSlackMetadata` calls. Seed defaults from the lookup-derived facts
   // so the post-merge value is always a valid `SlackMessageMetadata`.
@@ -245,21 +246,4 @@ function applySlackEditMetadata(params: {
   updateMessageContentAndMetadata(messageId, newContent, {
     slackMeta: mergedSlackMeta,
   });
-}
-
-/** Tolerant JSON.parse that returns `{}` for invalid or non-object payloads. */
-function safeParseRecord(raw: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(raw);
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed)
-    ) {
-      return {};
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    return {};
-  }
 }

--- a/assistant/src/util/json.ts
+++ b/assistant/src/util/json.ts
@@ -8,3 +8,20 @@ export function parseJsonSafe<T = unknown>(text: string): T | null {
     return null;
   }
 }
+
+/** Tolerant JSON parse that returns `{}` for invalid or non-object payloads. */
+export function safeParseRecord(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #26618 addressing two pieces of review feedback.

**1. Codex P2 — tolerate malformed metadata (prevent dropped edits)**

`updateMessageContentAndMetadata` did a raw `JSON.parse(row.metadata)` before writing Slack edit metadata. A malformed legacy/corrupted `messages.metadata` value would throw and abort the edit write path. In `handleEditIntercept` that throw happens *after* `recordInbound(...)` has persisted the edit dedup row — webhook retries would then be treated as duplicates and the edit would be effectively dropped permanently.

Swapped the raw `JSON.parse` for the existing tolerant `safeParseRecord` helper (promoted from `edit-intercept.ts` into `util/json.ts` so both call sites share it), which returns `{}` on malformed input. Malformed metadata now fails soft and the edit still lands.

**2. Devin — drop historical PR references from comments**

Three comments in `edit-intercept.ts` referenced `PR 11` / `pre-PR-11` / `post-PR-11`, which violates the `assistant/AGENTS.md` no-history-in-comments rule. Rewrote each to describe the current state of the code.

## Test plan
- [x] `bunx tsc --noEmit` clean (for files in scope)
- [x] `bun test src/__tests__/edit-propagation.test.ts` — 4/4 pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
