### PR TITLE
refactor(trust-rules): make scope optional on TrustRuleBase and add ruleScope() helper

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1327,7 +1327,7 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("deny");
     });
 
-    test("network_request rule is scoped to working directory", async () => {
+    test("network_request rule ignores scope (URL tools are not scoped)", async () => {
       addRule(
         "network_request",
         "network_request:https://api.example.com/*",
@@ -1339,12 +1339,15 @@ describe("Permission Checker", () => {
         "/home/user/project",
       );
       expect(allowed.decision).toBe("allow");
-      const notAllowed = await check(
+      // URL tools (network_request) do not support scope — the rule matches
+      // regardless of working directory because scope is stripped during
+      // normalization.
+      const alsoAllowed = await check(
         "network_request",
         { url: "https://api.example.com/v1/data" },
         "/tmp/other",
       );
-      expect(notAllowed.decision).toBe("prompt");
+      expect(alsoAllowed.decision).toBe("allow");
     });
 
     test("network_request rules do not cross-match web_fetch rules", async () => {

--- a/assistant/src/__tests__/starter-bundle.test.ts
+++ b/assistant/src/__tests__/starter-bundle.test.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { ruleScope } from "@vellumai/ces-contracts";
+
 // Set up a temp directory before importing trust-store
 const TEST_ROOT = join(
   import.meta.dirname ?? __dirname,
@@ -148,8 +150,10 @@ describe("Starter approval bundle", () => {
     expect(starterRules.length).toBe(getStarterBundleRules().length);
 
     for (const rule of starterRules) {
-      // Canonical shape: scope is always present and set to "everywhere"
-      expect(rule.scope).toBe("everywhere");
+      // Effective scope is always "everywhere" — scoped and generic tools
+      // carry an explicit scope field, while URL tools omit it (ruleScope
+      // returns "everywhere" for rules without a scope field).
+      expect(ruleScope(rule)).toBe("everywhere");
 
       // Starter rules are all allow decisions — they should not carry
       // family-specific metadata signals (allowHighRisk, executionTarget).

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -2,6 +2,8 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { ruleScope } from "@vellumai/ces-contracts";
+
 // Create a temp directory for the trust file
 const testDir = process.env.VELLUM_WORKSPACE_DIR!;
 
@@ -774,9 +776,12 @@ describe("Trust Store", () => {
           rule.id === "default:allow-bash-rm-bootstrap" ||
           rule.id === "default:allow-bash-rm-updates"
         ) {
-          expect(rule.scope).toBe(testDir);
+          expect(ruleScope(rule)).toBe(testDir);
         } else {
-          expect(rule.scope).toBe("everywhere");
+          // Non-scoped tool families (managed skill tools, skill_load) no
+          // longer carry an explicit scope field after normalization, but
+          // ruleScope() returns "everywhere" for rules without scope.
+          expect(ruleScope(rule)).toBe("everywhere");
         }
       }
     });
@@ -1676,7 +1681,7 @@ describe("Trust Store", () => {
       expect(rule!.decision).toBe("allow");
     });
 
-    test("scope restricts network_request rule matching", () => {
+    test("network_request rules match regardless of working directory (URL tools ignore scope)", () => {
       addRule(
         "network_request",
         "network_request:https://api.example.com/*",
@@ -1689,12 +1694,15 @@ describe("Trust Store", () => {
       );
       expect(inScope).not.toBeNull();
 
+      // URL tools (network_request) do not support scope — the rule matches
+      // regardless of working directory because scope is stripped during
+      // normalization.
       const outOfScope = findHighestPriorityRule(
         "network_request",
         ["network_request:https://api.example.com/*"],
         "/tmp/other",
       );
-      expect(outOfScope).toBeNull();
+      expect(outOfScope).not.toBeNull();
     });
   });
 });

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -1076,7 +1076,7 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
     const rule = trustClient.addRuleSync({
       tool: canonical.tool,
       pattern: canonical.pattern,
-      scope: canonical.scope,
+      scope: canonical.scope || "everywhere",
       decision: canonical.decision,
       priority: canonical.priority,
       allowHighRisk: canonicalOpts.allowHighRisk,

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -8,7 +8,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { parseTrustFileData, parseTrustRule } from "@vellumai/ces-contracts";
+import {
+  parseTrustFileData,
+  parseTrustRule,
+  ruleScope,
+} from "@vellumai/ces-contracts";
 import { Minimatch } from "minimatch";
 import { v4 as uuid } from "uuid";
 
@@ -212,7 +216,7 @@ function backfillDefaults(rules: TrustRule[]): boolean {
         rule &&
         (rule.priority !== template.priority ||
           rule.pattern !== template.pattern ||
-          rule.scope !== template.scope ||
+          ruleScope(rule) !== (template.scope ?? "everywhere") ||
           rule.decision !== template.decision ||
           rule.allowHighRisk !== template.allowHighRisk)
       ) {
@@ -230,14 +234,16 @@ function backfillDefaults(rules: TrustRule[]): boolean {
             newPriority: template.priority,
             oldPattern: rule.pattern,
             newPattern: template.pattern,
-            oldScope: rule.scope,
-            newScope: template.scope,
+            oldScope: ruleScope(rule),
+            newScope: template.scope ?? "everywhere",
           },
           "Migrated default rule to updated template values",
         );
         rule.priority = template.priority;
         rule.pattern = template.pattern;
-        rule.scope = template.scope;
+        if (template.scope != null) {
+          rule.scope = template.scope;
+        }
         rule.decision = template.decision;
         if (template.allowHighRisk != null) {
           rule.allowHighRisk = template.allowHighRisk;
@@ -499,7 +505,7 @@ function fileUpdateRule(
     const diverges =
       merged.tool !== template.tool ||
       merged.pattern !== template.pattern ||
-      merged.scope !== template.scope ||
+      ruleScope(merged) !== (template.scope ?? "everywhere") ||
       merged.decision !== template.decision ||
       merged.priority !== template.priority ||
       merged.allowHighRisk !== template.allowHighRisk;

--- a/packages/ces-contracts/src/__tests__/trust-rules.test.ts
+++ b/packages/ces-contracts/src/__tests__/trust-rules.test.ts
@@ -18,6 +18,7 @@ import {
   isUrlRule,
   parseTrustFileData,
   parseTrustRule,
+  ruleScope,
   SCOPED_TOOLS,
   URL_TOOLS,
   MANAGED_SKILL_TOOLS,
@@ -111,6 +112,22 @@ describe("parseTrustRule — URL tools strip invalid fields", () => {
     const { rule, normalized } = parseTrustRule(raw);
     expect(normalized).toBe(false);
     expect(rule.tool).toBe("web_fetch");
+    // scope is stripped even though it was present in raw input
+    expect("scope" in rule).toBe(false);
+  });
+
+  test("URL tool with scope 'everywhere' strips scope without normalization flag", () => {
+    const raw = makeRaw({ tool: "web_fetch", scope: "everywhere" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect("scope" in rule).toBe(false);
+  });
+
+  test("URL tool with non-'everywhere' scope strips scope and sets normalized", () => {
+    const raw = makeRaw({ tool: "web_fetch", scope: "/some/dir" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect("scope" in rule).toBe(false);
   });
 
   test("type guard isUrlRule narrows correctly", () => {
@@ -135,6 +152,20 @@ describe("parseTrustRule — managed skill tools strip invalid fields", () => {
       expect((rule as ManagedSkillTrustRule).allowHighRisk).toBe(false);
     },
   );
+
+  test("managed skill tool with scope 'everywhere' strips scope without normalization flag", () => {
+    const raw = makeRaw({ tool: "scaffold_managed_skill", scope: "everywhere" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect("scope" in rule).toBe(false);
+  });
+
+  test("managed skill tool with non-'everywhere' scope strips scope and sets normalized", () => {
+    const raw = makeRaw({ tool: "delete_managed_skill", scope: "/some/dir" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect("scope" in rule).toBe(false);
+  });
 
   test("type guard isManagedSkillRule narrows correctly", () => {
     const { rule } = parseTrustRule(makeRaw({ tool: "scaffold_managed_skill" }));
@@ -162,6 +193,21 @@ describe("parseTrustRule — skill_load strips invalid fields", () => {
     const { rule, normalized } = parseTrustRule(raw);
     expect(normalized).toBe(false);
     expect(rule.tool).toBe(SKILL_LOAD_TOOL);
+    expect("scope" in rule).toBe(false);
+  });
+
+  test("skill_load with scope 'everywhere' strips scope without normalization flag", () => {
+    const raw = makeRaw({ tool: SKILL_LOAD_TOOL, scope: "everywhere" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(false);
+    expect("scope" in rule).toBe(false);
+  });
+
+  test("skill_load with non-'everywhere' scope strips scope and sets normalized", () => {
+    const raw = makeRaw({ tool: SKILL_LOAD_TOOL, scope: "/some/dir" });
+    const { rule, normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+    expect("scope" in rule).toBe(false);
   });
 
   test("type guard isSkillLoadRule narrows correctly", () => {
@@ -236,6 +282,33 @@ describe("parseTrustRule — normalization flag", () => {
     const { rule, normalized } = parseTrustRule(raw);
     expect(normalized).toBe(false);
     expect("executionTarget" in rule).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ruleScope helper
+// ---------------------------------------------------------------------------
+
+describe("ruleScope", () => {
+  test("returns scope for scoped rules", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "bash", scope: "/projects" }));
+    expect(ruleScope(rule)).toBe("/projects");
+  });
+
+  test("returns 'everywhere' for non-scoped rules without scope", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "web_fetch" }));
+    expect("scope" in rule).toBe(false);
+    expect(ruleScope(rule)).toBe("everywhere");
+  });
+
+  test("returns scope for generic rules that have scope", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "future_tool", scope: "/custom" }));
+    expect(ruleScope(rule)).toBe("/custom");
+  });
+
+  test("returns 'everywhere' for scoped rules with default scope", () => {
+    const { rule } = parseTrustRule(makeRaw({ tool: "file_read", scope: "everywhere" }));
+    expect(ruleScope(rule)).toBe("everywhere");
   });
 });
 
@@ -333,7 +406,6 @@ describe("type-level compatibility", () => {
       id: "u1",
       tool: "web_fetch",
       pattern: "web_fetch:*",
-      scope: "everywhere",
       decision: "allow",
       priority: 90,
       createdAt: 0,
@@ -342,7 +414,6 @@ describe("type-level compatibility", () => {
       id: "m1",
       tool: "scaffold_managed_skill",
       pattern: "scaffold_managed_skill:*",
-      scope: "everywhere",
       decision: "ask",
       priority: 1000,
       createdAt: 0,
@@ -351,7 +422,6 @@ describe("type-level compatibility", () => {
       id: "sl1",
       tool: "skill_load",
       pattern: "skill_load:*",
-      scope: "everywhere",
       decision: "allow",
       priority: 100,
       createdAt: 0,
@@ -360,7 +430,6 @@ describe("type-level compatibility", () => {
       id: "g1",
       tool: "computer_use_click",
       pattern: "**",
-      scope: "everywhere",
       decision: "ask",
       priority: 1000,
       createdAt: 0,

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -83,7 +83,7 @@ export interface TrustRuleBase {
   id: string;
   tool: string;
   pattern: string;
-  scope: string;
+  scope?: string;
   decision: TrustDecision;
   priority: number;
   createdAt: number;
@@ -105,6 +105,7 @@ export interface TrustRuleBase {
  */
 export interface ScopedTrustRule extends TrustRuleBase {
   tool: (typeof SCOPED_TOOLS)[number];
+  scope: string;
   executionTarget?: string;
   allowHighRisk?: boolean;
 }
@@ -193,6 +194,22 @@ export function isSkillLoadRule(rule: TrustRule): rule is SkillLoadTrustRule {
 }
 
 // ---------------------------------------------------------------------------
+// Scope helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the effective scope for any trust rule. Scoped rules carry a
+ * required `scope` field; non-scoped rules may or may not have one. When
+ * absent, the effective scope is `"everywhere"`.
+ */
+export function ruleScope(rule: TrustRule): string {
+  if ("scope" in rule && typeof rule.scope === "string") {
+    return rule.scope;
+  }
+  return "everywhere";
+}
+
+// ---------------------------------------------------------------------------
 // Canonical parse / normalize
 // ---------------------------------------------------------------------------
 
@@ -211,14 +228,13 @@ export interface ParsedTrustRule {
  * Parse and normalize a raw trust rule object into a canonical `TrustRule`.
  *
  * Normalization strips fields that are invalid for the rule's tool family:
- * - URL rules: `executionTarget` is stripped (URL tools don't support it).
- * - Managed skill rules: `executionTarget` is stripped.
- * - Skill load rules: `executionTarget` is stripped.
- * - Scoped rules, generic rules, and all families with `allowHighRisk`: the
- *   field is preserved when it is a boolean.
- *
- * Unknown tools (generic family) preserve all fields for forward compatibility
- * — we don't know what semantics future tools may require.
+ * - URL rules: `executionTarget` and `scope` are stripped.
+ * - Managed skill rules: `executionTarget` and `scope` are stripped.
+ * - Skill load rules: `executionTarget` and `scope` are stripped.
+ * - Scoped rules: `scope` is preserved (defaulting to `"everywhere"`),
+ *   `executionTarget` and `allowHighRisk` are preserved when valid.
+ * - Generic (unknown) rules: all optional fields including `scope` are
+ *   preserved for forward compatibility.
  */
 export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   let normalized = false;
@@ -230,10 +246,6 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     typeof raw.tool === "string" ? raw.tool : ((normalized = true), "");
   const pattern =
     typeof raw.pattern === "string" ? raw.pattern : ((normalized = true), "");
-  const scope =
-    typeof raw.scope === "string"
-      ? raw.scope
-      : ((normalized = true), "everywhere");
   const decision = isValidDecision(raw.decision)
     ? raw.decision
     : ((normalized = true), "ask" as const);
@@ -246,12 +258,12 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   const userModifiedAt =
     typeof raw.userModifiedAt === "number" ? raw.userModifiedAt : undefined;
 
-  // Build the base rule
+  // Build the base rule — scope is NOT included here; it is added only by
+  // the scoped and generic branches below.
   const base: TrustRuleBase = {
     id,
     tool,
     pattern,
-    scope,
     decision,
     priority,
     createdAt,
@@ -260,9 +272,11 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
 
   // Determine the family and strip invalid fields
   if (URL_TOOLS_SET.has(tool)) {
-    // URL rules must not carry executionTarget, but allowHighRisk is preserved
-    // for backward compatibility with persistent high-risk allow rules.
+    // URL rules must not carry executionTarget or scope.
     if (raw.executionTarget !== undefined) {
+      normalized = true;
+    }
+    if (typeof raw.scope === "string" && raw.scope !== "everywhere") {
       normalized = true;
     }
     const rule: UrlTrustRule = { ...base, tool: tool as UrlTrustRule["tool"] };
@@ -275,9 +289,11 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   }
 
   if (MANAGED_SKILL_TOOLS_SET.has(tool)) {
-    // Managed skill rules must not carry executionTarget, but allowHighRisk is
-    // preserved for backward compatibility.
+    // Managed skill rules must not carry executionTarget or scope.
     if (raw.executionTarget !== undefined) {
+      normalized = true;
+    }
+    if (typeof raw.scope === "string" && raw.scope !== "everywhere") {
       normalized = true;
     }
     const rule: ManagedSkillTrustRule = {
@@ -293,9 +309,11 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   }
 
   if (tool === SKILL_LOAD_TOOL) {
-    // Skill-load rules must not carry executionTarget, but allowHighRisk is
-    // preserved for backward compatibility.
+    // Skill-load rules must not carry executionTarget or scope.
     if (raw.executionTarget !== undefined) {
+      normalized = true;
+    }
+    if (typeof raw.scope === "string" && raw.scope !== "everywhere") {
       normalized = true;
     }
     const rule: SkillLoadTrustRule = { ...base, tool: SKILL_LOAD_TOOL };
@@ -308,10 +326,16 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   }
 
   if (SCOPED_TOOLS_SET.has(tool)) {
-    // Scoped rules preserve executionTarget and allowHighRisk
+    // Scoped rules include scope (defaulting to "everywhere") and preserve
+    // executionTarget and allowHighRisk.
+    const scope =
+      typeof raw.scope === "string"
+        ? raw.scope
+        : ((normalized = true), "everywhere");
     const rule: ScopedTrustRule = {
       ...base,
       tool: tool as ScopedTrustRule["tool"],
+      scope,
     };
     if (
       typeof raw.executionTarget === "string" &&
@@ -329,8 +353,12 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     return { rule, normalized };
   }
 
-  // Generic (unknown) tool — preserve all optional fields for forward compat
+  // Generic (unknown) tool — preserve all optional fields for forward compat,
+  // including scope when present.
   const rule: GenericTrustRule = { ...base };
+  if (typeof raw.scope === "string") {
+    rule.scope = raw.scope;
+  }
   if (
     typeof raw.executionTarget === "string" &&
     raw.executionTarget.length > 0


### PR DESCRIPTION
## Summary
- Make scope optional on TrustRuleBase, required on ScopedTrustRule
- Add ruleScope() helper for safe scope extraction from any TrustRule
- Update parseTrustRule to strip scope from non-scoped rule families during normalization

Part of plan: rm-scope-non-scoped-rules.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
