### PR TITLE
fix(slack): gate active-thread focus block on full context mode

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1995,6 +1995,7 @@ export async function applyRuntimeInjections(
   // interleaved. Stripped on subsequent rebuilds via the
   // `RUNTIME_INJECTION_PREFIXES` list so focus blocks never accumulate.
   if (
+    mode === "full" &&
     slackChannel &&
     typeof options.slackActiveThreadFocusBlock === "string" &&
     options.slackActiveThreadFocusBlock.length > 0


### PR DESCRIPTION
## Summary
Addresses review feedback on #26631 (Codex P1 + Devin).

The non-persisted `<active_thread>` focus block was being appended to the current user turn unconditionally whenever `slackChannel` was set. Every other optional injection in `applyRuntimeInjections` (NOW.md, active surface, transport hints, PKB context, workspace top-level) is gated on `mode === "full"` so that when the reducer downgrades to `minimal` during overflow recovery to shed tokens, those injections are dropped. The focus block lacked that guard — high-token thread content could re-blow the budget right after the reducer had trimmed it.

Fix: add the `mode === "full"` guard to the focus-block condition so minimal-mode rebuilds stay lean.

## Test plan
- [ ] Type-check passes
- [ ] Existing tests in `conversation-runtime-assembly.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
