### PR TITLE
fix(slack): drop chronological override in post-compaction re-injection

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1070,8 +1070,14 @@ export async function runAgentLoopImpl(
         // When compaction ran it strips existing NOW.md / PKB blocks, so we
         // must re-inject the current content. Otherwise rely on the deduplicated
         // value from injectionOpts to avoid duplicate injection.
+        // Drop the Slack chronological override: the reducer has already
+        // shaped ctx.messages, and the transcript is rebuilt from ALL
+        // persisted rows (compaction doesn't delete rows), so re-applying
+        // it here would overwrite the reducer's output and the overflow
+        // loop would never converge.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          slackChronologicalMessages: null,
           ...(step.compactionResult?.compacted && {
             pkbContext: currentPkbContent,
           }),
@@ -1295,8 +1301,11 @@ export async function runAgentLoopImpl(
       // stripInjectionsForCompaction() unconditionally removed the existing
       // NOW.md block from ctx.messages above, so we must always re-inject
       // the current content regardless of whether compaction actually ran.
+      // Drop the Slack chronological override here too — see the preflight
+      // reducer loop above for the rationale.
       runMessages = await applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
+        slackChronologicalMessages: null,
         pkbContext: currentPkbContent,
         nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
@@ -1521,9 +1530,11 @@ export async function runAgentLoopImpl(
 
         // Only re-inject NOW.md when ctx.messages was actually stripped;
         // otherwise the existing NOW.md block is still present and
-        // re-injecting would duplicate it.
+        // re-injecting would duplicate it. Drop the Slack chronological
+        // override — the reducer has already shaped ctx.messages.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          slackChronologicalMessages: null,
           pkbContext: currentPkbContent,
           nowScratchpad: convergenceStripped ? currentNowContent : null,
           workspaceTopLevelContext: shouldInjectWorkspace
@@ -1657,9 +1668,12 @@ export async function runAgentLoopImpl(
             }
 
             // Only re-inject NOW.md when ctx.messages was actually stripped;
-            // otherwise the existing block is still present.
+            // otherwise the existing block is still present. Drop the Slack
+            // chronological override — emergency compaction has already
+            // shaped ctx.messages.
             runMessages = await applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
+              slackChronologicalMessages: null,
               pkbContext: currentPkbContent,
               nowScratchpad: convergenceStripped ? currentNowContent : null,
               workspaceTopLevelContext: shouldInjectWorkspace
@@ -1789,9 +1803,12 @@ export async function runAgentLoopImpl(
           }
 
           // Only re-inject NOW.md when ctx.messages was actually stripped;
-          // otherwise the existing block is still present.
+          // otherwise the existing block is still present. Drop the Slack
+          // chronological override — auto-compress has already shaped
+          // ctx.messages.
           runMessages = await applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
+            slackChronologicalMessages: null,
             pkbContext: currentPkbContent,
             nowScratchpad: convergenceStripped ? currentNowContent : null,
             workspaceTopLevelContext: shouldInjectWorkspace


### PR DESCRIPTION
## Summary

Addresses review feedback on #26633 from both Codex and Devin.

### Bug
After #26633 widened the chronological-transcript gate to Slack DMs (not just channels), the transcript is built once at turn start from **all** persisted message rows and threaded into `injectionOpts`. Every post-reducer/post-compaction `applyRuntimeInjections` call spreads `...injectionOpts`, so the override re-runs and overwrites the reducer's compacted `ctx.messages` with the full persisted transcript (compaction doesn't delete rows). Overflow recovery never converges.

### Fix (Option b from review)
Explicitly null `slackChronologicalMessages` at each post-reducer re-injection site:

- preflight reducer loop
- mid-loop compaction
- convergence loop
- context_too_large emergency compact
- auto_compress_latest_turn

Matches the existing pattern where other injections (PKB, NOW, workspace) are conditionally re-applied post-compaction.

## Test plan
- [x] `bun test src/__tests__/conversation-agent-loop-overflow.test.ts` — 3 pass, 7 todo, 0 fail
- [x] `bun test src/__tests__/conversation-runtime-assembly.test.ts` — 149 pass, 0 fail
- [x] `bunx tsc --noEmit` — no errors in edited files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
