### PR TITLE
docs(slack): drop history-narrating comments in runtime assembly

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2682,9 +2682,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   });
 
   // ── transport_hints suppression for slack DMs ─────────────────────────
-  // PR 25 removed the gateway-side `fetchDmContext` helper that produced
-  // DM hints; defensively suppress on the daemon side too so any stale
-  // hint forwarded from older paths cannot leak into the LLM input.
+  // Slack DMs assemble context from persisted message rows; defensively
+  // suppress transport hints on the daemon side too so any stale hint
+  // cannot leak into the LLM input.
   test("slack DM conversations skip <transport_hints> injection", async () => {
     const slackDmCaps: ChannelCapabilities = {
       channel: "slack",

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1754,10 +1754,8 @@ export async function applyRuntimeInjections(
   const mode = options.mode ?? "full";
   const slackChannel = isSlackChannelConversation(options.channelCapabilities);
   // Slack DMs and channels both assemble context from persisted message
-  // rows now (PR 25 removed the gateway-side `fetchThreadContext` /
-  // `fetchDmContext` helpers that produced `<transport_hints>` entries),
-  // so suppress hint injection for any Slack conversation. Other channels
-  // (telegram, email, etc.) keep the generic hint pipeline.
+  // rows, so suppress hint injection for any Slack conversation. Other
+  // channels (telegram, email, etc.) keep the generic hint pipeline.
   const slackConversation = options.channelCapabilities?.channel === "slack";
   let result = runMessages;
   // Slack channels AND DMs both override `runMessages` with a pre-rendered


### PR DESCRIPTION
## Summary
- Rewrite two comments in `applyRuntimeInjections` and its DM test so they describe current behavior instead of referencing removed `fetchThreadContext` / `fetchDmContext` helpers and a specific PR number.
- The pre-existing "DM cleanup happens in a later PR" JSDoc was already rewritten on main.
- Codex's cold-thread first-turn concern is already addressed — both `tryBackfillSlackDmIfCold` and `triggerSlackThreadBackfillIfNeeded` in `inbound-message-handler.ts` are awaited before the agent loop dispatches.

Addresses review feedback on #26630.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
