### PR TITLE
fix(macos): harden attemptRePair against stale token file and refreshTask race

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -228,9 +228,20 @@ extension AppDelegate {
     /// the existing credential first so `performInitialBootstrap()` is forced
     /// to re-provision from scratch. Intended as a recovery primitive for
     /// stale/invalid credentials (see `GatewayConnectionManager.attemptRePair()`).
+    ///
+    /// In Docker/cloud hatches, the CLI-persisted `guardian-token.json` on
+    /// disk can still contain the same revoked token that produced the auth
+    /// failures. `performInitialBootstrap()` imports that file ahead of any
+    /// HTTP path, so without deleting it we would silently re-arm the bad
+    /// credential and the re-pair would "succeed" only to fall right back
+    /// into 401s. Delete the file here so the bootstrap is forced down a
+    /// genuine reprovision path.
     func forceReBootstrap() async {
         log.info("forceReBootstrap: clearing stored credentials and re-running bootstrap")
         ActorTokenManager.deleteAllCredentials()
+        if let assistantId = LockfileAssistant.loadActiveAssistantId() {
+            GuardianTokenFileReader.deleteTokenFile(assistantId: assistantId)
+        }
         await performInitialBootstrap()
     }
 

--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -187,6 +187,24 @@ public enum GuardianTokenFileReader {
             : .importValid(creds)
     }
 
+    /// Deletes any CLI-persisted guardian token on disk for the given
+    /// assistant. Used by forced re-bootstrap paths to avoid re-importing a
+    /// stale/revoked token that shares the same file. A missing file is
+    /// treated as success.
+    @discardableResult
+    public static func deleteTokenFile(assistantId: String) -> Bool {
+        let path = guardianTokenPath(for: assistantId)
+        guard FileManager.default.fileExists(atPath: path) else { return true }
+        do {
+            try FileManager.default.removeItem(atPath: path)
+            log.info("Deleted guardian token file at \(path, privacy: .public)")
+            return true
+        } catch {
+            log.warning("Failed to delete guardian token file at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
     // MARK: - Path Resolution
 
     /// Resolves `$XDG_CONFIG_HOME/vellum{-env}/assistants/<id>/guardian-token.json`,

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -758,6 +758,19 @@ public final class GatewayConnectionManager {
         defer { isAttemptingRePair = false }
 
         log.info("attemptRePair: started")
+
+        // Cancel and drain any in-flight `refreshTask`. Without this, a 401
+        // refresh that concludes as a terminal error AFTER the new bootstrap
+        // has provisioned fresh credentials will call
+        // `ActorTokenManager.deleteAllCredentials()` and clobber them,
+        // putting the app right back in the stuck `isAuthFailed` state we
+        // were trying to exit.
+        if let inFlightRefresh = refreshTask {
+            log.info("attemptRePair: cancelling in-flight refresh task")
+            inFlightRefresh.cancel()
+            await inFlightRefresh.value
+        }
+
         let handler = bootstrap ?? rePairHandler
         guard let handler else {
             log.error("attemptRePair: failed — no bootstrap handler configured")


### PR DESCRIPTION
## Summary

Address Codex P1 and P2 feedback on #26491 (credential-lifecycle fix).

- **P1 — stale guardian-token file reuse.** `forceReBootstrap()` called `performInitialBootstrap()`, which imports `GuardianTokenFileReader.importIfAvailable()` ahead of any HTTP path. In Docker/cloud hatches that file can still contain the same revoked token that tripped the auth failures, so re-pair would "succeed" only to fall right back into 401s. `forceReBootstrap()` now deletes the CLI-persisted token file via a new `GuardianTokenFileReader.deleteTokenFile(assistantId:)` before re-running the bootstrap, forcing a genuine reprovision path.
- **P2 — race with in-flight refreshTask.** `attemptRePair()` did not coordinate with the 401-driven `refreshTask`. A refresh that concluded as a terminal error after the new bootstrap had already provisioned fresh credentials would call `ActorTokenManager.deleteAllCredentials()` and clobber them. `attemptRePair()` now cancels and awaits any in-flight `refreshTask` before running the handler.

## Test plan

- [ ] Re-pair on a Docker/cloud instance whose `guardian-token.json` still holds a revoked token — confirm the file is removed and bootstrap succeeds via the HTTP path rather than silently re-arming the bad token.
- [ ] Trigger a 401 → refreshTask in flight, then user-invoke re-pair — confirm the refresh is cancelled/awaited and fresh credentials survive (no clobber from a late terminal-error path).
- [ ] Existing `GatewayConnectionManagerAuthTests` still pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
