### PR TITLE
fix(macos/math): align math maxWidth contract and restore VoiceOver labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -1004,7 +1004,11 @@ private struct MathBlockView: View {
 
     @ViewBuilder
     private func rendered(image: NSImage, intrinsicSize: CGSize) -> some View {
-        let limit = maxContentWidth ?? intrinsicSize.width
+        // Match peer MarkdownSegment renderers: nil maxContentWidth means
+        // "no caller-specified limit", which collapses to the default chat
+        // bubble max. Treating nil as unlimited let long equations render
+        // at full intrinsic width in InlineFilePreviewView / SubagentDetailPanel.
+        let limit = maxContentWidth ?? VSpacing.chatBubbleMaxWidth
         let needsScroll = intrinsicSize.width > limit && intrinsicSize.width > 0
         let renderedWidth: CGFloat = needsScroll
             ? intrinsicSize.width
@@ -1021,6 +1025,8 @@ private struct MathBlockView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: intrinsicSize.width, height: intrinsicSize.height)
+                    .accessibilityLabel(latex)
+                    .accessibilityValue("math equation")
             }
             .frame(height: intrinsicSize.height)
         } else {
@@ -1029,6 +1035,8 @@ private struct MathBlockView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: renderedWidth, height: renderedHeight)
+                .accessibilityLabel(latex)
+                .accessibilityValue("math equation")
         }
     }
 


### PR DESCRIPTION
Addresses Codex P2 feedback on #26679:

**1. maxWidth contract divergence**
`MathBlockView` treated `maxContentWidth == nil` as "unlimited" (`intrinsicSize.width`), whereas peer `MarkdownSegment` renderers fall back to `VSpacing.chatBubbleMaxWidth`. In InlineFilePreviewView and SubagentDetailPanel (which intentionally pass nil), long equations rendered at full intrinsic width. Switch to `maxContentWidth ?? VSpacing.chatBubbleMaxWidth` to match peers.

**2. Accessibility regression**
Switching from plain text to `Image` silenced VoiceOver. Attach `.accessibilityLabel(latex)` and `.accessibilityValue("math equation")` to both the scrolling and non-scrolling math images so the LaTeX source is read aloud and the element is announced as an equation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
