### PR TITLE
perf(slack-transcript): parse row content once; drop PR-number comments

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3694,13 +3694,13 @@ describe("assembleSlackChronologicalMessages", () => {
     }
   });
 
-  test("row content with interleaved text + tool_use preserves tool_use alongside tag line (PR 3)", () => {
-    // PR 3 preserves replayable content blocks (tool_use, tool_result,
-    // thinking, etc.) alongside the tag line. A row persisted with
-    // `[text, tool_use]` now renders as `[{type:text, tag-line}, {type:tool_use}]`.
+  test("row content with interleaved text + tool_use preserves tool_use alongside tag line", () => {
+    // Replayable content blocks (tool_use, tool_result, thinking, etc.) are
+    // preserved alongside the tag line. A row persisted with
+    // `[text, tool_use]` renders as `[{type:text, tag-line}, {type:tool_use}]`.
     //
     // The assistant tool_use is paired with a follow-up user tool_result so
-    // the PR 4 orphan-pair filter leaves both blocks intact.
+    // the orphan-pair filter leaves both blocks intact.
     const userMeta: SlackMessageMetadata = {
       source: "slack",
       channelId: DM_CHANNEL_ID,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1217,29 +1217,21 @@ export interface SlackTranscriptInputRow {
 }
 
 /**
- * Extract the user-facing plain text from a persisted message row's content
- * column. The persisted shape is a JSON-encoded `ContentBlock[]`; only `text`
- * blocks contribute to the rendered transcript line. Tool-use / tool-result /
- * thinking blocks are intentionally elided — they would clutter the
- * Slack-style transcript and the model can already recall them from the
+ * Extract the user-facing plain text from an already-parsed `ContentBlock[]`.
+ * Only `text` blocks contribute to the rendered transcript line. Tool-use /
+ * tool-result / thinking blocks are intentionally elided — they would clutter
+ * the Slack-style transcript and the model can already recall them from the
  * surrounding turn structure.
  *
- * Falls back to the raw column value when JSON parsing fails so legacy /
- * non-JSON-encoded rows still surface their text content.
+ * Rows with no text blocks (e.g. images, file uploads, pure tool turns) would
+ * otherwise render as an empty transcript line like `[14:25 @alice]: `;
+ * surface the attachment/tool context instead so the model can tell something
+ * was actually said on that turn.
  */
-function extractPlainText(rawContent: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawContent);
-  } catch {
-    return rawContent;
-  }
-  if (!Array.isArray(parsed)) {
-    return typeof parsed === "string" ? parsed : rawContent;
-  }
+function extractPlainTextFromBlocks(blocks: ContentBlock[]): string {
   const parts: string[] = [];
   const placeholderLabels: string[] = [];
-  for (const block of parsed as ContentBlock[]) {
+  for (const block of blocks) {
     if (!block || typeof block !== "object") continue;
     if (block.type === "text") {
       parts.push(block.text);
@@ -1253,10 +1245,6 @@ function extractPlainText(rawContent: string): string {
   if (parts.length > 0) {
     return parts.join("\n");
   }
-  // Rows with no text blocks (e.g. images, file uploads, pure tool turns)
-  // would otherwise render as an empty transcript line like
-  // `[14:25 @alice]: `. Surface the attachment/tool context instead so the
-  // model can tell something was actually said on that turn.
   return placeholderLabels.join(" ");
 }
 
@@ -1323,17 +1311,27 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
     senderLabel = slackMeta?.displayName ?? null;
   }
 
+  // Parse `row.content` once and derive both the structured `contentBlocks`
+  // view (for downstream tool-block preservation) and the flattened
+  // `plainText` view (used for tag-line rendering) from the same parsed
+  // result. Large Slack histories with many tool payloads would otherwise
+  // pay a double JSON-parse cost per row.
   let contentBlocks: ContentBlock[] = [];
+  let plainText: string;
   try {
     const parsed = JSON.parse(row.content);
     if (Array.isArray(parsed)) {
       contentBlocks = parsed as ContentBlock[];
+      plainText = extractPlainTextFromBlocks(contentBlocks);
+    } else if (typeof parsed === "string") {
+      plainText = parsed;
+    } else {
+      plainText = row.content;
     }
   } catch {
     // Plain string row (legacy) — no structured blocks to preserve.
+    plainText = row.content;
   }
-
-  const plainText = extractPlainText(row.content);
 
   // Attachment-only rows (images, files) carry no text block, so the
   // transcript renderer would normally emit them *without* a tag line —

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -841,20 +841,19 @@ describe("extractTagLineTexts", () => {
   });
 });
 
-// ── contentBlocks preservation (PR 3 behavioural change) ─────────────────────
+// ── contentBlocks preservation ───────────────────────────────────────────────
 
 describe("renderSlackTranscript — replayable content-block preservation", () => {
-  // PR 3 flips the behaviour established in PR 2: when `contentBlocks` is
-  // populated, the renderer preserves replayable Anthropic blocks
-  // (tool_use, tool_result, thinking, redacted_thinking, image, file)
-  // verbatim alongside the tag line. Non-replayable blocks (ui_surface,
-  // server_tool_use, web_search_tool_result, unknown types) are stripped.
-  // Legacy rows (no contentBlocks field) continue to render as a single
-  // text block.
+  // When `contentBlocks` is populated, the renderer preserves replayable
+  // Anthropic blocks (tool_use, tool_result, thinking, redacted_thinking,
+  // image, file) verbatim alongside the tag line. Non-replayable blocks
+  // (ui_surface, server_tool_use, web_search_tool_result, unknown types) are
+  // stripped. Legacy rows (no contentBlocks field) render as a single text
+  // block.
 
   test("[text, tool_use] assistant row preserves tool_use after tag line", () => {
     // Assistant tool_use is paired with a follow-up user tool_result so the
-    // PR 4 orphan filter leaves both blocks intact.
+    // orphan-pair filter leaves both blocks intact.
     const assistantRow: RenderableSlackMessage = {
       ...userMsg(TS_14_25, null, "looking it up", {
         role: "assistant",
@@ -882,7 +881,7 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
 
   test("[tool_result] user row emits only tool_result — no tag line", () => {
     // Pair the user tool_result with a preceding assistant tool_use so the
-    // PR 4 orphan filter leaves the row intact; the assertion still pins
+    // orphan-pair filter leaves the row intact; the assertion still pins
     // the shape of the user row specifically (no tag line, single block).
     const assistantRow: RenderableSlackMessage = {
       ...userMsg(TS_14_24, null, "", { role: "assistant" }),
@@ -1094,13 +1093,13 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
   });
 });
 
-// ── orphan tool_use / tool_result filter (PR 4) ──────────────────────────────
+// ── orphan tool_use / tool_result filter ─────────────────────────────────────
 
 describe("renderSlackTranscript — orphan tool_use / tool_result filter", () => {
-  // PR 4 adds a final safety pass that strips any tool_use without a
-  // matching tool_result (and vice versa) before returning. Messages that
-  // become empty after filtering are dropped entirely so the caller never
-  // sees `{role, content: []}`.
+  // A final safety pass strips any tool_use without a matching tool_result
+  // (and vice versa) before returning. Messages that become empty after
+  // filtering are dropped entirely so the caller never sees
+  // `{role, content: []}`.
 
   test("orphan tool_use is dropped; surrounding tag line survives", () => {
     // Assistant row has [text, tool_use] but no follower tool_result exists


### PR DESCRIPTION
## Summary

Follow-up to #26661.

- **Perf (Codex feedback):** \`rowToRenderable\` previously parsed \`row.content\` twice — once to populate \`contentBlocks\`, then again via \`extractPlainText\`. On Slack channels with long histories or large tool payloads, this doubled per-row JSON-parse cost on every transcript assembly. Now parses once and derives both the structured \`contentBlocks\` view and the flattened \`plainText\` via a shared \`extractPlainTextFromBlocks\` helper that takes the already-parsed array.
- **Comment hygiene (Devin feedback):** Removed \"PR 2\" / \"PR 3\" / \"PR 4\" narration from \`render-transcript.test.ts\` and \`conversation-runtime-assembly.test.ts\` per AGENTS.md — comments describe current state, not development history.

## Test plan

- [x] \`bun test src/__tests__/conversation-runtime-assembly.test.ts src/messaging/providers/slack/render-transcript.test.ts\` → 218 pass, 0 fail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
