### PR TITLE
fix(slack): short-circuit guardian reactions before conversational engine

### DIFF
--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -396,12 +396,12 @@ describe("Slack delete propagation", () => {
 
   test("delete from non-member actor is rejected by ACL and does not apply", async () => {
     // Use a channel where NO active member is seeded so the actor cannot
-    // resolve via the channel's externalChatId either. This is the
-    // regression check for the gap where the delete short-circuit ran
-    // before ingress ACL — under the fix the ACL must reject the delete
-    // so no row is mutated. Also clear the C0123CHANNEL seed for the
-    // alt channel below since beforeEach wires the seed on C0123CHANNEL
-    // only.
+    // resolve via the channel's externalChatId either. Verifies that ACL
+    // enforcement rejects delete events from non-members before the delete
+    // handler processes them — the delete must not apply and no row should
+    // be mutated when the actor is not an active member of the target
+    // channel. Also clear the C0123CHANNEL seed for the alt channel below
+    // since beforeEach wires the seed on C0123CHANNEL only.
     const altChannel = "C0_NON_MEMBER_CHAN";
     const seeded = seedSlackMessage({
       externalChatId: altChannel,

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -391,11 +391,9 @@ describe("Slack reaction event persistence", () => {
 // Guardian approval-by-reaction integration test
 // ---------------------------------------------------------------------------
 //
-// Verifies that a guardian's `reaction:` event on a pending approval prompt
-// applies the decision via `handleApprovalInterception` and short-circuits
-// the reaction-persistence path so no transcript-line row is written. This
-// is the regression check for the gap where the reaction short-circuit ran
-// before approval interception, silently breaking guardian approval-by-reaction.
+// Verifies that approval interception runs before reaction persistence so a
+// guardian's `reaction:` event on a pending approval prompt applies the
+// decision and no transcript-line row is written for the reaction itself.
 
 const GUARDIAN_USER_ID = "U_GUARDIAN_REACT";
 const GUARDIAN_DISPLAY_NAME = "Guardian Reactor";
@@ -510,18 +508,34 @@ describe("guardian approval-by-reaction integration via handleChannelInbound", (
       body: JSON.stringify(body),
     });
 
-    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    // Wire a non-undefined `approvalConversationGenerator` to mirror the
+    // production configuration. The deterministic reaction handler must
+    // short-circuit before the generator is consulted — if it runs, it
+    // returns `keep_pending` so the assertions below would fail loudly.
+    const approvalConversationGenerator = mock(async () => ({
+      disposition: "keep_pending" as const,
+      replyText: "mock conversational turn should not be invoked for reactions",
+    }));
+
+    const resp = await handleChannelInbound(
+      req,
+      undefined,
+      TEST_BEARER_TOKEN,
+      undefined,
+      approvalConversationGenerator,
+    );
     const json = (await resp.json()) as Record<string, unknown>;
 
     expect(resp.status).toBe(200);
     expect(json.accepted).toBe(true);
     expect(json.approval).toBe("guardian_decision_applied");
+    expect(approvalConversationGenerator).not.toHaveBeenCalled();
 
     // The pending approval row is resolved (no longer pending).
     expect(getPendingApprovalForRequest(requestId)).toBeNull();
 
-    // No transcript row was written for the reaction itself — pre-upgrade
-    // semantics carried no transcript trace for resolved approvals.
+    // No transcript row was written for the reaction itself — resolved
+    // guardian approval reactions have no transcript representation.
     const reactionRows = readPersistedMessages().filter((row) => {
       if (!row.metadata) return false;
       try {

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -102,6 +102,15 @@ export async function handleGuardianCallbackDecision(
     approvalMessageTs,
   } = params;
 
+  // Reactions have their own deterministic emoji-to-action mapping in
+  // `handleApprovalInterception`. Return null immediately so reaction
+  // callbackData never enters the conversational engine below, which would
+  // misclassify `reaction:white_check_mark` etc. as plain text and only
+  // ever produce `approve_once`/`reject`.
+  if (callbackData?.startsWith("reaction:")) {
+    return null;
+  }
+
   // Callback/button path: deterministic and takes priority.
   let callbackDecision: ApprovalDecisionResult | null = null;
   if (callbackData) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -562,8 +562,8 @@ export async function handleChannelInbound(
   //   1. Guardian approval-by-reaction. A `reaction:` (added) event from
   //      the guardian on an active approval prompt is consumed by
   //      `handleApprovalInterception` to apply the decision. In that case
-  //      we do NOT persist the reaction as a transcript line — pre-upgrade
-  //      semantics carried no transcript trace for resolved reactions.
+  //      we do NOT persist the reaction as a transcript line — resolved
+  //      guardian approval reactions have no transcript representation.
   //   2. All other reactions (non-guardian, no pending approval, stale,
   //      and any `reaction_removed:` event regardless of actor) fall
   //      through to `persistSlackReactionAsMessage` so the chronological


### PR DESCRIPTION
## Summary
Follow-up to #26635. Reactions (`reaction:white_check_mark`, etc.) still fell through the LLM conversational engine in production because `handleApprovalInterception` calls `handleGuardianCallbackDecision` first, and that function routed reaction callbackData to the conversational engine when `approvalConversationGenerator` was wired.

- `handleGuardianCallbackDecision` now early-returns `null` when `callbackData` starts with `reaction:`, so the deterministic emoji-to-action mapping in `handleApprovalInterception` runs.
- `reaction-persistence.test.ts` now passes a non-undefined mock `approvalConversationGenerator` and asserts it is never invoked — closes the test-coverage gap that let the original bug ship.
- Three comments rewritten per AGENTS.md "do not narrate history" rule.

## Test plan
- [x] `bun test src/__tests__/reaction-persistence.test.ts`
- [x] `bun test src/__tests__/delete-propagation.test.ts`
- [x] `bun test src/__tests__/approval-conversation-turn.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
