### PR TITLE
fix(slack-render): preserve rows when all blocks are non-replayable

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -1053,6 +1053,40 @@ describe("renderSlackTranscript — replayable content-block preservation", () =
     ]);
   });
 
+  test("row with only non-replayable blocks emits fallback tag line annotated with what was stripped", () => {
+    // Regression: previously `buildMessageContentBlocks` returned an empty
+    // array when every block was filtered out (e.g. a row whose only
+    // blocks are `server_tool_use` and `ui_surface`), causing the caller
+    // to drop the turn entirely — silently altering chronology and
+    // potentially orphaning adjacent tool_result context. The renderer
+    // now preserves the turn by emitting a single fallback text block
+    // annotated with the stripped block types/names.
+    const base: RenderableSlackMessage = {
+      ...userMsg(TS_14_25, null, "ran a web search", { role: "assistant" }),
+      contentBlocks: [
+        {
+          type: "server_tool_use",
+          id: "st_1",
+          name: "web_search",
+          input: { q: "x" },
+        },
+        { type: "ui_surface", foo: "bar" } as unknown as never,
+      ] as never,
+    };
+    const out = renderSlackTranscript([base]);
+    expect(out).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "[11/14/23 14:25]: ran a web search [stripped non-replayable: server_tool_use(web_search), ui_surface]",
+          },
+        ],
+      },
+    ]);
+  });
+
   test("legacy row (contentBlocks undefined) renders as single tag line — unchanged", () => {
     const base = userMsg(TS_14_25, "@alice", "legacy plain");
     // No `contentBlocks` field assigned — emulates a row whose JSON content

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -37,10 +37,14 @@ export interface RenderableSlackMessage {
   /**
    * Full structured content blocks parsed from the persisted row, when
    * available. Optional so existing fixtures and callers that only need the
-   * flattened `content` string continue to compile. The current
-   * `renderSlackTranscript` implementation ignores this field — it exists so
-   * downstream consumers (tool-block preservation) can access the original
-   * `tool_use` / `tool_result` blocks without re-parsing the row.
+   * flattened `content` string continue to compile. `renderSlackTranscript`
+   * consumes this field to preserve replayable Anthropic blocks
+   * (`tool_use`, `tool_result`, `thinking`, `redacted_thinking`, `image`,
+   * `file`) in their original order, emitting the tag line inline at the
+   * position of the first `text` block. Non-replayable blocks
+   * (`ui_surface`, `server_tool_use`, `web_search_tool_result`, unknown
+   * types) are stripped; when stripping empties the row entirely, a
+   * fallback tag-line text block is emitted so chronology is preserved.
    */
   readonly contentBlocks?: readonly ContentBlock[];
 }
@@ -200,6 +204,12 @@ function renderReaction(msg: RenderableSlackMessage): string | null {
  * - **Pure tool-only rows** (`contentBlocks` present but no `text` block):
  *   emit only the replayable blocks — no tag line. Anthropic accepts role-
  *   correct messages with only tool blocks.
+ * - **All-non-replayable rows** (`contentBlocks` present but every block is
+ *   filtered out — e.g. a row whose only blocks are `server_tool_use` or
+ *   `ui_surface`): emit a single fallback tag-line text block annotated
+ *   with the stripped block types/names. Dropping the row entirely would
+ *   silently alter chronology and can orphan adjacent tool_result context
+ *   in later repair/conversion steps.
  */
 function buildMessageContentBlocks(
   msg: RenderableSlackMessage,
@@ -220,6 +230,7 @@ function buildMessageContentBlocks(
 
   const out: ContentBlock[] = [];
   let tagEmitted = false;
+  const strippedLabels: string[] = [];
   for (const block of blocks) {
     if (block.type === "text") {
       if (!tagEmitted) {
@@ -234,7 +245,23 @@ function buildMessageContentBlocks(
       continue;
     }
     // Non-replayable (ui_surface, server_tool_use, web_search_tool_result,
-    // unknown) — drop silently.
+    // unknown) — drop, but remember what we saw in case we need a fallback.
+    if (block.type === "server_tool_use") {
+      strippedLabels.push(`server_tool_use(${block.name})`);
+    } else {
+      strippedLabels.push(block.type);
+    }
+  }
+
+  // Non-empty source fully filtered to nothing: emit a fallback tag line so
+  // the turn still appears in chronology. Annotate with the stripped block
+  // types/names so the model has a hint about what was there.
+  if (out.length === 0) {
+    const suffix =
+      strippedLabels.length > 0
+        ? ` [stripped non-replayable: ${strippedLabels.join(", ")}]`
+        : "";
+    return [{ type: "text", text: `${tagLine}${suffix}` }];
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Addresses review feedback on #26665.

- **Codex P2 — empty-blocks row drop.** When `buildMessageContentBlocks` filtered every block as non-replayable (e.g. a row whose only blocks are `server_tool_use` / `ui_surface`), the caller's `if (blocks.length === 0) continue` silently dropped the row, altering chronology and potentially orphaning adjacent tool_result context. The helper now emits a single fallback text block containing the tag line plus an annotation of the stripped block types/names, so the turn persists in history.
- **Devin — stale docstring.** The `RenderableSlackMessage.contentBlocks` docstring still claimed `renderSlackTranscript` ignored the field. Rewrote it to describe current behaviour (consumes the field for structured passthrough, with the fallback behaviour documented).
- Added a regression test covering the all-non-replayable case.

## Test plan
- [x] `bun test src/messaging/providers/slack/render-transcript.test.ts` — 69 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
