### PR TITLE
Chrome Extension Environment Selector

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,7 @@ jobs:
         working-directory: clients/chrome-extension
         env:
           VERSION: ${{ needs.extract-version.outputs.version }}
+          VELLUM_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
         run: bash build.sh
 
       - name: Verify manifest version

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -66,6 +66,40 @@ For automated publishing, the `release.yml` GitHub Actions workflow builds, pack
 
 That's it. The extension auto-reconnects on browser restarts, network drops, and assistant restarts. Click **Pause** to intentionally stop the relay.
 
+## Environment Selector
+
+The popup's **Advanced** section includes an **Environment** dropdown that lets you switch between `local`, `dev`, `staging`, and `production` without rebuilding the extension. This controls which cloud API and web URLs are used for sign-in, pairing, and relay connections.
+
+### Precedence rules
+
+The effective environment is resolved in this order:
+
+| Priority | Source | Description |
+|---|---|---|
+| 1 (highest) | Popup override | Selected in the dropdown, persisted in `chrome.storage.local` |
+| 2 | Build-time default | Injected via `--define process.env.VELLUM_ENVIRONMENT=...` at bundle time |
+| 3 (fallback) | Hard-coded default | `dev` |
+
+### Expected defaults by context
+
+| Context | Build default | Notes |
+|---|---|---|
+| Local dev build (`bash build.sh`) | `dev` | No `--define` injection; falls back to `dev` |
+| `vel up` (local assistant) | `dev` build / `local` override | Build defaults to `dev`; use the popup dropdown to select `local` to target `localhost` endpoints |
+| Staging release artifact | `staging` | Set by `release.yml` via `--define` |
+| Production release artifact (CWS) | `production` | Set by `release.yml` via `--define` |
+
+### Behavior on change
+
+When you change the environment in the dropdown:
+
+1. The override is persisted immediately (survives popup close/reopen).
+2. The assistant catalog is refreshed (different environments may list different assistants).
+3. Local and cloud auth status panels are refreshed.
+4. If the extension is currently connected, it automatically disconnects and reconnects using the new environment's endpoints.
+
+To clear the override and revert to the build default, the dropdown simply selects the build-default value (no separate "reset" action needed since the worker treats selecting the same value as the build default equivalently).
+
 ## Debugging
 
 - **Service worker logs:** `chrome://extensions` > extension card > **Service worker** link

--- a/clients/chrome-extension/background/__tests__/extension-environment.test.ts
+++ b/clients/chrome-extension/background/__tests__/extension-environment.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the canonical extension environment contract.
+ *
+ * Covers:
+ *   - parseExtensionEnvironment: alias normalization, trimming, case-
+ *     insensitivity, and rejection of invalid values.
+ *   - resolveBuildDefaultEnvironment: fallback to 'dev' when the
+ *     bundler-defined env var is missing or invalid.
+ *   - cloudUrlsForEnvironment: full URL mapping table for every
+ *     supported environment.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+
+import {
+  parseExtensionEnvironment,
+  resolveBuildDefaultEnvironment,
+  cloudUrlsForEnvironment,
+  type ExtensionEnvironment,
+} from '../extension-environment.js';
+
+// ── parseExtensionEnvironment ───────────────────────────────────────
+
+describe('parseExtensionEnvironment', () => {
+  test('parses each canonical environment value', () => {
+    expect(parseExtensionEnvironment('local')).toBe('local');
+    expect(parseExtensionEnvironment('dev')).toBe('dev');
+    expect(parseExtensionEnvironment('staging')).toBe('staging');
+    expect(parseExtensionEnvironment('production')).toBe('production');
+  });
+
+  test('"prod" is an alias for "production"', () => {
+    expect(parseExtensionEnvironment('prod')).toBe('production');
+  });
+
+  test('is case-insensitive', () => {
+    expect(parseExtensionEnvironment('LOCAL')).toBe('local');
+    expect(parseExtensionEnvironment('Dev')).toBe('dev');
+    expect(parseExtensionEnvironment('STAGING')).toBe('staging');
+    expect(parseExtensionEnvironment('PRODUCTION')).toBe('production');
+    expect(parseExtensionEnvironment('Prod')).toBe('production');
+    expect(parseExtensionEnvironment('PROD')).toBe('production');
+  });
+
+  test('trims whitespace', () => {
+    expect(parseExtensionEnvironment('  dev  ')).toBe('dev');
+    expect(parseExtensionEnvironment('\tproduction\n')).toBe('production');
+    expect(parseExtensionEnvironment(' prod ')).toBe('production');
+  });
+
+  test('returns null for undefined', () => {
+    expect(parseExtensionEnvironment(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseExtensionEnvironment('')).toBeNull();
+  });
+
+  test('returns null for whitespace-only string', () => {
+    expect(parseExtensionEnvironment('   ')).toBeNull();
+    expect(parseExtensionEnvironment('\t')).toBeNull();
+  });
+
+  test('returns null for unrecognized values', () => {
+    expect(parseExtensionEnvironment('test')).toBeNull();
+    expect(parseExtensionEnvironment('unknown')).toBeNull();
+    expect(parseExtensionEnvironment('release')).toBeNull();
+    expect(parseExtensionEnvironment('development')).toBeNull();
+    expect(parseExtensionEnvironment('prod-us')).toBeNull();
+  });
+});
+
+// ── resolveBuildDefaultEnvironment ──────────────────────────────────
+
+describe('resolveBuildDefaultEnvironment', () => {
+  const savedEnv = process.env.VELLUM_ENVIRONMENT;
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = savedEnv;
+    }
+  });
+
+  test('returns the environment when VELLUM_ENVIRONMENT is a valid value', () => {
+    process.env.VELLUM_ENVIRONMENT = 'staging';
+    expect(resolveBuildDefaultEnvironment()).toBe('staging');
+  });
+
+  test('resolves "prod" alias via build env', () => {
+    process.env.VELLUM_ENVIRONMENT = 'prod';
+    expect(resolveBuildDefaultEnvironment()).toBe('production');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is unset', () => {
+    delete process.env.VELLUM_ENVIRONMENT;
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is empty', () => {
+    process.env.VELLUM_ENVIRONMENT = '';
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+
+  test('falls back to "dev" when VELLUM_ENVIRONMENT is invalid', () => {
+    process.env.VELLUM_ENVIRONMENT = 'bogus';
+    expect(resolveBuildDefaultEnvironment()).toBe('dev');
+  });
+});
+
+// ── cloudUrlsForEnvironment ─────────────────────────────────────────
+
+describe('cloudUrlsForEnvironment', () => {
+  const cases: Array<{
+    env: ExtensionEnvironment;
+    expectedApiBaseUrl: string;
+    expectedWebBaseUrl: string;
+  }> = [
+    {
+      env: 'production',
+      expectedApiBaseUrl: 'https://api.vellum.ai',
+      expectedWebBaseUrl: 'https://www.vellum.ai',
+    },
+    {
+      env: 'staging',
+      expectedApiBaseUrl: 'https://staging-api.vellum.ai',
+      expectedWebBaseUrl: 'https://staging-assistant.vellum.ai',
+    },
+    {
+      env: 'dev',
+      expectedApiBaseUrl: 'https://dev-api.vellum.ai',
+      expectedWebBaseUrl: 'https://dev-assistant.vellum.ai',
+    },
+    {
+      env: 'local',
+      expectedApiBaseUrl: 'http://localhost:8080',
+      expectedWebBaseUrl: 'http://localhost:3000',
+    },
+  ];
+
+  for (const { env, expectedApiBaseUrl, expectedWebBaseUrl } of cases) {
+    test(`${env}: apiBaseUrl is ${expectedApiBaseUrl}`, () => {
+      const urls = cloudUrlsForEnvironment(env);
+      expect(urls.apiBaseUrl).toBe(expectedApiBaseUrl);
+    });
+
+    test(`${env}: webBaseUrl is ${expectedWebBaseUrl}`, () => {
+      const urls = cloudUrlsForEnvironment(env);
+      expect(urls.webBaseUrl).toBe(expectedWebBaseUrl);
+    });
+  }
+
+  test('production parity: "prod" alias and "production" resolve to same URLs', () => {
+    const fromProd = cloudUrlsForEnvironment('production');
+    // Verify the canonical production values match what worker.ts currently uses
+    expect(fromProd.apiBaseUrl).toBe('https://api.vellum.ai');
+    expect(fromProd.webBaseUrl).toBe('https://www.vellum.ai');
+  });
+});

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -466,6 +466,46 @@ describe('bootstrapLocalToken', () => {
     expect(fakeStorage.data[localTokenStorageKey(ASSISTANT_A)]).toEqual(result);
   });
 
+  test('includes environment in the frame when provided', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'env-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-env',
+        });
+      });
+    };
+
+    await bootstrapLocalToken(ASSISTANT_A, { environment: 'dev' });
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'request_token', assistantId: ASSISTANT_A, environment: 'dev' },
+    ]);
+  });
+
+  test('omits environment from the frame when not provided', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'no-env-token',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-no-env',
+        });
+      });
+    };
+
+    await bootstrapLocalToken(ASSISTANT_A);
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'request_token', assistantId: ASSISTANT_A },
+    ]);
+  });
+
   test('ignores unknown frame types until a recognised frame arrives', async () => {
     const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
 

--- a/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-assistant-catalog.test.ts
@@ -235,6 +235,40 @@ describe('listAssistants', () => {
     expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'list_assistants' }]);
   });
 
+  test('includes environment in the frame when provided', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'assistants_response',
+          assistants: [],
+          activeAssistantId: null,
+          protocolVersion: 1,
+        });
+      });
+    };
+
+    await listAssistants({ environment: 'dev' });
+    expect(fakeRuntime.currentPort?.sent).toEqual([
+      { type: 'list_assistants', environment: 'dev' },
+    ]);
+  });
+
+  test('omits environment from the frame when not provided', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'assistants_response',
+          assistants: [],
+          activeAssistantId: null,
+          protocolVersion: 1,
+        });
+      });
+    };
+
+    await listAssistants();
+    expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'list_assistants' }]);
+  });
+
   test('returns empty catalog when native host reports no assistants', async () => {
     fakeRuntime.onConnect = (port) => {
       queueMicrotask(() => {

--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -30,6 +30,11 @@ import { type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';
 import { isCloudTokenStale, type StoredCloudToken } from '../cloud-auth.js';
 import type { StoredLocalToken } from '../self-hosted-auth.js';
+import {
+  type ExtensionEnvironment,
+  cloudUrlsForEnvironment,
+  resolveBuildDefaultEnvironment,
+} from '../extension-environment.js';
 
 // ── Types mirroring worker.ts internals ─────────────────────────────
 
@@ -73,16 +78,21 @@ interface PreflightDeps {
   refreshCloudToken: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
   getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
   getRelayPort: () => Promise<number>;
+  /** The effective environment used to resolve cloud URLs. Defaults to build default. */
+  effectiveEnvironment: ExtensionEnvironment;
 }
 
-const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
-const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 /**
  * Standalone preflight implementation that mirrors the worker's
  * `connectPreflight` function but accepts injectable deps so tests
  * can control the auth function outcomes without mocking globals.
+ *
+ * Cloud URLs are resolved from `deps.effectiveEnvironment` using the
+ * same `cloudUrlsForEnvironment` helper the worker uses, verifying
+ * that sign-in/refresh configs use the environment-resolved web URL
+ * and that the fallback gateway URL is derived from the environment.
  */
 async function connectPreflight(
   assistant: AssistantDescriptor | null,
@@ -122,13 +132,16 @@ async function connectPreflight(
       throw new MissingTokenError(missingTokenMessage(null));
     }
 
+    // Resolve cloud URLs from the effective environment — mirrors worker's getCloudUrls()
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment(deps.effectiveEnvironment);
+
     if (!options.interactive) {
       const refreshed = await deps.refreshCloudToken(assistantId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
-        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
       }
       // If the token is stale but still technically valid, fall back to
@@ -141,10 +154,10 @@ async function connectPreflight(
     }
 
     const stored = await deps.signInCloud(assistantId, {
-      webBaseUrl: CLOUD_WEB_BASE_URL,
+      webBaseUrl,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
-    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
     return { kind: 'cloud', baseUrl, token: stored.token };
   }
 
@@ -211,6 +224,8 @@ function makeDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
     refreshCloudToken: async () => null,
     getStoredCloudToken: async () => null,
     getRelayPort: async () => 7830,
+    // Default to the build-time default environment (typically 'dev' in tests)
+    effectiveEnvironment: resolveBuildDefaultEnvironment(),
     ...overrides,
   };
 }
@@ -582,9 +597,10 @@ describe('connectPreflight — edge cases', () => {
   });
 
   test('null assistant throws MissingTokenError for cloud profile', async () => {
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
     const mode: RelayMode = {
       kind: 'cloud',
-      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      baseUrl: apiBaseUrl,
       token: null,
     };
     const deps = makeDeps();
@@ -621,11 +637,12 @@ describe('connectPreflight — edge cases', () => {
     }
   });
 
-  test('cloud interactive falls back to default gateway for relay baseUrl when no runtimeUrl', async () => {
+  test('cloud interactive falls back to environment-resolved gateway for relay baseUrl when no runtimeUrl', async () => {
     const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
     const mode: RelayMode = {
       kind: 'cloud',
-      baseUrl: CLOUD_GATEWAY_BASE_URL,
+      baseUrl: apiBaseUrl,
       token: null,
     };
     const signedIn = makeStoredCloudToken({ token: 'fallback-jwt' });
@@ -641,7 +658,8 @@ describe('connectPreflight — edge cases', () => {
       deps,
     );
 
-    expect(result.baseUrl).toBe(CLOUD_GATEWAY_BASE_URL);
+    // The fallback baseUrl should match the environment-resolved API URL
+    expect(result.baseUrl).toBe(apiBaseUrl);
     expect(result.token).toBe('fallback-jwt');
   });
 });
@@ -920,5 +938,150 @@ describe('reconnect: silent recovery for self-hosted mode', () => {
       'Self-hosted relay token missing or expired. Pair the Vellum assistant again from the extension popup.';
     expect(abortError).toContain('Pair');
     expect(abortError).toContain('extension popup');
+  });
+});
+
+// ── Environment-resolved URL tests ──────────────────────────────────
+//
+// Verify that the preflight (and by extension the worker's cloud auth
+// paths) uses environment-resolved URLs rather than fixed production
+// constants. Each environment should yield different gateway/web URLs.
+
+describe('connectPreflight — environment-resolved cloud URLs', () => {
+  test('production environment uses production gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: prodApi } = cloudUrlsForEnvironment('production');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: prodApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'prod-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'production',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://api.vellum.ai');
+    expect(result.token).toBe('prod-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://www.vellum.ai');
+  });
+
+  test('staging environment uses staging gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: stagingApi } = cloudUrlsForEnvironment('staging');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: stagingApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'staging-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://staging-api.vellum.ai');
+    expect(result.token).toBe('staging-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('dev environment uses dev gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: devApi } = cloudUrlsForEnvironment('dev');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: devApi, token: null };
+    const refreshed = makeStoredCloudToken({ token: 'dev-refreshed-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'dev',
+      refreshCloudToken: async (_id, config) => {
+        capturedConfig = config;
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: false }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://dev-api.vellum.ai');
+    expect(result.token).toBe('dev-refreshed-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('https://dev-assistant.vellum.ai');
+  });
+
+  test('local environment uses localhost gateway and web URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: localApi } = cloudUrlsForEnvironment('local');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: localApi, token: null };
+    const signedIn = makeStoredCloudToken({ token: 'local-jwt' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'local',
+      signInCloud: async (_id, config) => {
+        capturedConfig = config;
+        return signedIn;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    expect(result.baseUrl).toBe('http://localhost:8080');
+    expect(result.token).toBe('local-jwt');
+    expect(capturedConfig!.webBaseUrl).toBe('http://localhost:3000');
+  });
+
+  test('non-interactive refresh also uses environment-resolved URLs', async () => {
+    const assistant = makeCloudAssistant({ runtimeUrl: '' });
+    const { apiBaseUrl: stagingApi } = cloudUrlsForEnvironment('staging');
+    const mode: RelayMode = { kind: 'cloud', baseUrl: stagingApi, token: null };
+    const refreshed = makeStoredCloudToken({ token: 'staging-refreshed' });
+    let capturedConfig: { webBaseUrl: string } | null = null;
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      refreshCloudToken: async (_id, config) => {
+        capturedConfig = config;
+        return refreshed;
+      },
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: false }, deps,
+    );
+
+    expect(result.baseUrl).toBe('https://staging-api.vellum.ai');
+    expect(capturedConfig!.webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('runtimeUrl takes precedence over environment-resolved gateway', async () => {
+    const assistant = makeCloudAssistant({
+      runtimeUrl: 'https://custom-runtime.example.com',
+    });
+    const mode: RelayMode = {
+      kind: 'cloud',
+      baseUrl: 'https://custom-runtime.example.com',
+      token: null,
+    };
+    const signedIn = makeStoredCloudToken({ token: 'custom-jwt' });
+    const deps = makeDeps({
+      effectiveEnvironment: 'staging',
+      signInCloud: async () => signedIn,
+    });
+
+    const result = await connectPreflight(
+      assistant, 'cloud-oauth', mode, { interactive: true }, deps,
+    );
+
+    // runtimeUrl should still take precedence over the environment gateway
+    expect(result.baseUrl).toBe('https://custom-runtime.example.com');
   });
 });

--- a/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-selected-assistant-connect.test.ts
@@ -32,6 +32,10 @@ import { describe, test, expect } from 'bun:test';
 
 import { resolveAuthProfile, type AssistantAuthProfile } from '../assistant-auth-profile.js';
 import type { AssistantDescriptor } from '../native-host-assistants.js';
+import {
+  cloudUrlsForEnvironment,
+  resolveBuildDefaultEnvironment,
+} from '../extension-environment.js';
 
 // ── Fixtures ────────────────────────────────────────────────────────
 
@@ -181,16 +185,20 @@ describe('relay mode derivation from assistant descriptor', () => {
     expect(assistant.runtimeUrl).toBe('https://custom-gateway.vellum.cloud');
   });
 
-  test('cloud-oauth assistant without runtimeUrl falls back to default gateway', () => {
+  test('cloud-oauth assistant without runtimeUrl falls back to environment-resolved gateway', () => {
     const assistant = makeCloudAssistant({ runtimeUrl: '' });
     const profile = resolveAuthProfile({
       cloud: assistant.cloud,
       runtimeUrl: assistant.runtimeUrl,
     });
     expect(profile).toBe('cloud-oauth');
-    // Empty runtimeUrl triggers the CLOUD_GATEWAY_BASE_URL fallback
-    // in buildRelayModeForAssistant.
+    // Empty runtimeUrl triggers the environment-resolved apiBaseUrl fallback
+    // in buildRelayModeForAssistant. The gateway URL depends on the effective
+    // environment (e.g. dev -> dev-api.vellum.ai, production -> api.vellum.ai).
     expect(assistant.runtimeUrl).toBe('');
+    const { apiBaseUrl } = cloudUrlsForEnvironment(resolveBuildDefaultEnvironment());
+    expect(typeof apiBaseUrl).toBe('string');
+    expect(apiBaseUrl.length).toBeGreaterThan(0);
   });
 });
 
@@ -249,5 +257,70 @@ describe('assistant switch behavior', () => {
       runtimeUrl: unsupported.runtimeUrl,
     });
     expect(profile).toBe('unsupported');
+  });
+});
+
+// ── Environment-resolved URL contract ────────────────────────────────
+//
+// The worker no longer uses hardcoded production constants for cloud auth
+// config. All cloud URL derivation flows through `cloudUrlsForEnvironment`
+// backed by the effective environment. These tests verify the contract
+// that sign-in/refresh configs use the correct URLs per environment.
+
+describe('environment-resolved cloud auth URLs', () => {
+  test('production environment resolves production cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('production');
+    expect(apiBaseUrl).toBe('https://api.vellum.ai');
+    expect(webBaseUrl).toBe('https://www.vellum.ai');
+  });
+
+  test('staging environment resolves staging cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('staging');
+    expect(apiBaseUrl).toBe('https://staging-api.vellum.ai');
+    expect(webBaseUrl).toBe('https://staging-assistant.vellum.ai');
+  });
+
+  test('dev environment resolves dev cloud URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('dev');
+    expect(apiBaseUrl).toBe('https://dev-api.vellum.ai');
+    expect(webBaseUrl).toBe('https://dev-assistant.vellum.ai');
+  });
+
+  test('local environment resolves localhost URLs', () => {
+    const { apiBaseUrl, webBaseUrl } = cloudUrlsForEnvironment('local');
+    expect(apiBaseUrl).toBe('http://localhost:8080');
+    expect(webBaseUrl).toBe('http://localhost:3000');
+  });
+
+  test('build default environment resolves to dev when VELLUM_ENVIRONMENT is unset', () => {
+    // In test environments (unbundled), process.env.VELLUM_ENVIRONMENT is
+    // typically unset, so resolveBuildDefaultEnvironment returns 'dev'.
+    const buildDefault = resolveBuildDefaultEnvironment();
+    expect(buildDefault).toBe('dev');
+  });
+
+  test('cloud auth sign-in config uses environment-resolved web URL (not hardcoded production)', () => {
+    // Simulates what the worker does: resolve webBaseUrl from the effective
+    // environment and pass it to signInCloud / refreshCloudToken configs.
+    const envs = ['local', 'dev', 'staging', 'production'] as const;
+    for (const env of envs) {
+      const { webBaseUrl } = cloudUrlsForEnvironment(env);
+      // The webBaseUrl should differ per environment — not always production
+      if (env !== 'production') {
+        expect(webBaseUrl).not.toBe('https://www.vellum.ai');
+      }
+    }
+  });
+
+  test('cloud relay fallback gateway uses environment-resolved API URL (not hardcoded production)', () => {
+    // Simulates what the worker does: when assistant has no runtimeUrl,
+    // the relay base URL falls back to apiBaseUrl from the effective env.
+    const envs = ['local', 'dev', 'staging', 'production'] as const;
+    for (const env of envs) {
+      const { apiBaseUrl } = cloudUrlsForEnvironment(env);
+      if (env !== 'production') {
+        expect(apiBaseUrl).not.toBe('https://api.vellum.ai');
+      }
+    }
   });
 });

--- a/clients/chrome-extension/background/extension-environment.ts
+++ b/clients/chrome-extension/background/extension-environment.ts
@@ -1,0 +1,136 @@
+/**
+ * Canonical environment contract for the Vellum Chrome extension.
+ *
+ * This module is the single source of truth for:
+ *   - the set of valid extension environments
+ *   - parsing / normalizing raw environment strings (including aliases)
+ *   - resolving the build-time default from `process.env.VELLUM_ENVIRONMENT`
+ *   - mapping each environment to its cloud API and web base URLs
+ *
+ * All other extension code that needs environment awareness should import
+ * from this module rather than hard-coding URLs or re-implementing parsing.
+ */
+
+// ── Environment type ────────────────────────────────────────────────
+
+/**
+ * The four deployment environments the extension can target.
+ *
+ * - `local`      — developer's machine (`vel up`), local gateway + relay
+ * - `dev`        — artifacts built from `main`, dev platform
+ * - `staging`    — QA against staging platform before production rollout
+ * - `production` — full production behavior
+ */
+export type ExtensionEnvironment = 'local' | 'dev' | 'staging' | 'production';
+
+const VALID_ENVIRONMENTS: ReadonlySet<string> = new Set<ExtensionEnvironment>([
+  'local',
+  'dev',
+  'staging',
+  'production',
+]);
+
+/** Aliases that map to a canonical {@link ExtensionEnvironment}. */
+const ENVIRONMENT_ALIASES: Readonly<Record<string, ExtensionEnvironment>> = {
+  prod: 'production',
+};
+
+// ── Parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw string into a validated {@link ExtensionEnvironment}.
+ *
+ * - Trims whitespace and lowercases before matching.
+ * - Accepts `"prod"` as an alias for `"production"`.
+ * - Returns `null` for `undefined`, empty, or unrecognized values.
+ */
+export function parseExtensionEnvironment(raw: string | undefined): ExtensionEnvironment | null {
+  if (raw === undefined) return null;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return null;
+
+  if (VALID_ENVIRONMENTS.has(normalized)) {
+    return normalized as ExtensionEnvironment;
+  }
+
+  const aliased = ENVIRONMENT_ALIASES[normalized];
+  if (aliased !== undefined) {
+    return aliased;
+  }
+
+  return null;
+}
+
+// ── Build-time default ──────────────────────────────────────────────
+
+/**
+ * Resolve the build-time default environment from the bundler-defined
+ * `process.env.VELLUM_ENVIRONMENT` constant.
+ *
+ * Falls back to `"dev"` when the variable is missing, empty, or set to
+ * an unrecognized value. This matches the convention that local extension
+ * builds (where the bundler does not inject a value) default to `dev`.
+ */
+export function resolveBuildDefaultEnvironment(): ExtensionEnvironment {
+  // `process.env.VELLUM_ENVIRONMENT` is replaced at bundle time by the
+  // build tool (e.g. `bun build --define`). At runtime in a bundled
+  // extension it becomes a string literal. In tests or unbundled
+  // contexts it may be the actual env var or undefined.
+  let raw: string | undefined;
+  try {
+    raw = process.env.VELLUM_ENVIRONMENT;
+  } catch {
+    // In some browser runtimes `process` is not defined at all.
+    raw = undefined;
+  }
+  // Intentional `dev` default: when the env var is absent it means we are in
+  // an unbundled local build where no `--define` injection has occurred. The
+  // release build pipeline (build.sh + release.yml) is responsible for setting
+  // `process.env.VELLUM_ENVIRONMENT` to `staging` or `production` at bundle
+  // time via `--define`. If that injection is ever accidentally omitted from a
+  // release build, it will surface as a clear "targeting dev" mismatch in
+  // pre-release smoke tests rather than silently hitting production.
+  return parseExtensionEnvironment(raw) ?? 'dev';
+}
+
+// ── Cloud URL mapping ───────────────────────────────────────────────
+
+export interface CloudUrls {
+  /** Gateway / API base URL (e.g. `https://api.vellum.ai`). */
+  apiBaseUrl: string;
+  /** Web app base URL for browser-facing pages (e.g. `https://www.vellum.ai`). */
+  webBaseUrl: string;
+}
+
+/**
+ * Return the cloud API and web base URLs for the given environment.
+ *
+ * Production uses the canonical Vellum production hosts. Non-production
+ * environments use environment-prefixed subdomains following the
+ * convention `<env>-api.vellum.ai` / `<env>-assistant.vellum.ai`, with
+ * `local` using `localhost` origins for both.
+ */
+export function cloudUrlsForEnvironment(env: ExtensionEnvironment): CloudUrls {
+  switch (env) {
+    case 'production':
+      return {
+        apiBaseUrl: 'https://api.vellum.ai',
+        webBaseUrl: 'https://www.vellum.ai',
+      };
+    case 'staging':
+      return {
+        apiBaseUrl: 'https://staging-api.vellum.ai',
+        webBaseUrl: 'https://staging-assistant.vellum.ai',
+      };
+    case 'dev':
+      return {
+        apiBaseUrl: 'https://dev-api.vellum.ai',
+        webBaseUrl: 'https://dev-assistant.vellum.ai',
+      };
+    case 'local':
+      return {
+        apiBaseUrl: 'http://localhost:8080',
+        webBaseUrl: 'http://localhost:3000',
+      };
+  }
+}

--- a/clients/chrome-extension/background/native-host-assistants.ts
+++ b/clients/chrome-extension/background/native-host-assistants.ts
@@ -57,6 +57,13 @@ export interface ListAssistantsOptions {
    * in the extension itself should rely on the default.
    */
   timeoutMs?: number;
+  /**
+   * Optional environment override. When provided, the native host uses
+   * this environment to resolve lockfile paths instead of the process-level
+   * `VELLUM_ENVIRONMENT`. This lets the extension switch environments
+   * (e.g. `dev`, `staging`, `production`) without restarting Chrome.
+   */
+  environment?: string;
 }
 
 /**
@@ -192,6 +199,10 @@ export async function listAssistants(
       finish(() => reject(new Error(message)));
     });
 
-    port.postMessage({ type: 'list_assistants' });
+    const listMessage: Record<string, unknown> = { type: 'list_assistants' };
+    if (options.environment) {
+      listMessage.environment = options.environment;
+    }
+    port.postMessage(listMessage);
   });
 }

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -104,6 +104,14 @@ export interface BootstrapLocalTokenOptions {
    * in the extension itself should rely on the default.
    */
   timeoutMs?: number;
+  /**
+   * Optional environment override. When provided, the native host uses
+   * this environment to resolve lockfile paths and daemon ports instead of
+   * the process-level `VELLUM_ENVIRONMENT`. This lets the extension switch
+   * environments (e.g. `dev`, `staging`, `production`) without restarting
+   * Chrome.
+   */
+  environment?: string;
 }
 
 /**
@@ -381,6 +389,9 @@ export async function bootstrapLocalToken(
     const pairMessage: Record<string, unknown> = { type: 'request_token' };
     if (assistantId) {
       pairMessage.assistantId = assistantId;
+    }
+    if (options.environment) {
+      pairMessage.environment = options.environment;
     }
     port.postMessage(pairMessage);
   });

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -50,6 +50,12 @@ import {
   decideCloudReconnectAction,
 } from './cloud-reconnect-decision.js';
 import {
+  type ExtensionEnvironment,
+  parseExtensionEnvironment,
+  resolveBuildDefaultEnvironment,
+  cloudUrlsForEnvironment,
+} from './extension-environment.js';
+import {
   listAssistants,
   type AssistantDescriptor,
   type AssistantCatalog,
@@ -85,12 +91,66 @@ import {
   type RelayReconnectDecision,
 } from './relay-connection.js';
 
-// Cloud OAuth defaults — kept here so the popup can stay a thin client and the
-// service worker is the single owner of the launchWebAuthFlow lifecycle. This
-// avoids the MV3 popup teardown race where closing the popup mid-auth kills
-// the awaited promise before the token is persisted.
-const CLOUD_GATEWAY_BASE_URL = 'https://api.vellum.ai';
-const CLOUD_WEB_BASE_URL = 'https://www.vellum.ai';
+// ── Environment resolution ──────────────────────────────────────────
+//
+// The effective environment drives all cloud auth URLs. Precedence:
+//   1. Popup override persisted in chrome.storage.local
+//   2. Build-time default injected via `--define` at bundle time
+//   3. Fallback to 'dev' (see resolveBuildDefaultEnvironment)
+//
+// The popup can read and write the override via `environment-get` and
+// `environment-set` worker messages without requiring an extension reload.
+
+const ENVIRONMENT_OVERRIDE_KEY = 'vellum.environmentOverride';
+
+/**
+ * Resolve the effective environment by checking for a popup-persisted
+ * override first, then falling back to the build-time default.
+ */
+async function getEffectiveEnvironment(): Promise<ExtensionEnvironment> {
+  const result = await chrome.storage.local.get(ENVIRONMENT_OVERRIDE_KEY);
+  const override = result[ENVIRONMENT_OVERRIDE_KEY];
+  if (typeof override === 'string') {
+    const parsed = parseExtensionEnvironment(override);
+    if (parsed) return parsed;
+  }
+  return resolveBuildDefaultEnvironment();
+}
+
+/**
+ * Read the raw override value from storage (null when unset).
+ */
+async function getOverrideEnvironment(): Promise<ExtensionEnvironment | null> {
+  const result = await chrome.storage.local.get(ENVIRONMENT_OVERRIDE_KEY);
+  const override = result[ENVIRONMENT_OVERRIDE_KEY];
+  if (typeof override === 'string') {
+    return parseExtensionEnvironment(override);
+  }
+  return null;
+}
+
+/**
+ * Persist an environment override. Pass `null` to clear.
+ */
+async function setOverrideEnvironment(env: ExtensionEnvironment | null): Promise<void> {
+  if (env === null) {
+    await chrome.storage.local.remove(ENVIRONMENT_OVERRIDE_KEY);
+  } else {
+    await chrome.storage.local.set({ [ENVIRONMENT_OVERRIDE_KEY]: env });
+  }
+}
+
+/**
+ * Resolve cloud URLs for the current effective environment.
+ * Replaces the old hardcoded CLOUD_GATEWAY_BASE_URL / CLOUD_WEB_BASE_URL
+ * constants — every call site now gets environment-appropriate URLs.
+ */
+async function getCloudUrls(): Promise<{ apiBaseUrl: string; webBaseUrl: string }> {
+  const env = await getEffectiveEnvironment();
+  return cloudUrlsForEnvironment(env);
+}
+
+// Cloud OAuth client ID — not environment-dependent.
 const CLOUD_OAUTH_CLIENT_ID = 'vellum-chrome-extension';
 
 const DEFAULT_RELAY_PORT = 7830;
@@ -588,9 +648,10 @@ async function buildRelayModeForAssistant(
     }
     const cloud = await getLegacyCloudToken();
     if (cloud) {
+      const { apiBaseUrl } = await getCloudUrls();
       return {
         kind: 'cloud',
-        baseUrl: CLOUD_GATEWAY_BASE_URL,
+        baseUrl: apiBaseUrl,
         token: cloud.token,
       };
     }
@@ -653,8 +714,9 @@ async function buildRelayModeForAssistant(
     const stored = await getStoredCloudToken(assistant.assistantId);
     // Use the assistant's runtime URL as the relay base when available.
     // This allows cloud-managed assistants to point to their specific
-    // gateway endpoint. Fall back to the default cloud gateway.
-    const baseUrl = assistant.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    // gateway endpoint. Fall back to the environment-resolved cloud gateway.
+    const { apiBaseUrl } = await getCloudUrls();
+    const baseUrl = assistant.runtimeUrl || apiBaseUrl;
     return {
       kind: 'cloud',
       baseUrl,
@@ -756,9 +818,10 @@ async function cloudReconnectHook(
   // token under the correct scoped key. When no assistant is selected
   // we can't scope the refresh, so we skip it — the user will be
   // prompted to sign in again (abort path on the next reconnect).
+  const { webBaseUrl } = await getCloudUrls();
   const refreshed = selectedId
     ? await refreshCloudToken(selectedId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       })
     : null;
@@ -1025,15 +1088,17 @@ async function connectPreflight(
       throw new MissingTokenError(missingTokenMessage(null));
     }
 
+    const { apiBaseUrl, webBaseUrl } = await getCloudUrls();
+
     if (!options.interactive) {
       // Non-interactive: attempt a silent refresh first.
       const refreshed = await refreshCloudToken(assistantId, {
-        webBaseUrl: CLOUD_WEB_BASE_URL,
+        webBaseUrl,
         runtimeBaseUrl: assistant?.runtimeUrl,
         clientId: CLOUD_OAUTH_CLIENT_ID,
       });
       if (refreshed) {
-        const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+        const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
         return { kind: 'cloud', baseUrl, token: refreshed.token };
       }
       // If the token is stale but still technically valid, fall back to
@@ -1047,11 +1112,11 @@ async function connectPreflight(
 
     // Interactive: launch the full OAuth sign-in flow.
     const stored = await signInCloud(assistantId, {
-      webBaseUrl: CLOUD_WEB_BASE_URL,
+      webBaseUrl,
       runtimeBaseUrl: assistant?.runtimeUrl,
       clientId: CLOUD_OAUTH_CLIENT_ID,
     });
-    const baseUrl = assistant?.runtimeUrl || CLOUD_GATEWAY_BASE_URL;
+    const baseUrl = assistant?.runtimeUrl || apiBaseUrl;
     return { kind: 'cloud', baseUrl, token: stored.token };
   }
 
@@ -1264,8 +1329,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         }
         const descriptor =
           assistants.find((assistant) => assistant.assistantId === resolvedId) ?? null;
+        const { webBaseUrl } = await getCloudUrls();
         const config: CloudAuthConfig = {
-          webBaseUrl: CLOUD_WEB_BASE_URL,
+          webBaseUrl,
           runtimeBaseUrl: descriptor?.runtimeUrl,
           clientId:
             typeof message.clientId === 'string' ? message.clientId : CLOUD_OAUTH_CLIENT_ID,
@@ -1407,6 +1473,90 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
           ok: true,
           selected: match,
           authProfile,
+        });
+      })
+      .catch((err) =>
+        sendResponseFn({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    return true; // async
+  }
+  if (message.type === 'environment-get') {
+    // Returns the effective environment and its components so the popup
+    // can display which environment is active and whether an override is
+    // in effect.
+    Promise.all([getEffectiveEnvironment(), getOverrideEnvironment()])
+      .then(([effectiveEnvironment, overrideEnvironment]) => {
+        sendResponseFn({
+          ok: true,
+          effectiveEnvironment,
+          overrideEnvironment,
+          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+        });
+      })
+      .catch((err) =>
+        sendResponseFn({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    return true; // async
+  }
+  if (message.type === 'environment-set') {
+    // Validates and persists an environment override. Pass
+    // `environment: null` to clear the override and revert to the
+    // build default.
+    //
+    // NOTE: This handler intentionally only persists the override — it
+    // does NOT disconnect or reconnect the active relay connection. The
+    // caller (popup) is responsible for orchestrating disconnect/reconnect
+    // after receiving the response if it wants the new environment to take
+    // effect immediately. `getCloudUrls()` is called fresh on each
+    // connect/reconnect cycle, so the persisted override is picked up
+    // automatically on the next connection without any additional plumbing.
+    const rawEnv = message.environment;
+    if (rawEnv === null || rawEnv === undefined) {
+      // Clear override
+      setOverrideEnvironment(null)
+        .then(async () => {
+          const effectiveEnvironment = await getEffectiveEnvironment();
+          sendResponseFn({
+            ok: true,
+            effectiveEnvironment,
+            overrideEnvironment: null,
+            buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+          });
+        })
+        .catch((err) =>
+          sendResponseFn({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      return true; // async
+    }
+    if (typeof rawEnv !== 'string') {
+      sendResponseFn({ ok: false, error: 'environment must be a string or null' });
+      return false;
+    }
+    const parsed = parseExtensionEnvironment(rawEnv);
+    if (!parsed) {
+      sendResponseFn({
+        ok: false,
+        error: `Invalid environment: "${rawEnv}". Must be one of: local, dev, staging, production`,
+      });
+      return false;
+    }
+    setOverrideEnvironment(parsed)
+      .then(async () => {
+        const effectiveEnvironment = await getEffectiveEnvironment();
+        sendResponseFn({
+          ok: true,
+          effectiveEnvironment,
+          overrideEnvironment: parsed,
+          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
         });
       })
       .catch((err) =>

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -38,7 +38,7 @@ import {
   refreshCloudToken,
   getStoredToken as getStoredCloudToken,
   getStoredTokenRaw as getStoredCloudTokenRaw,
-  clearStoredToken as clearCloudToken,
+
   validateCloudToken,
   isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
@@ -68,7 +68,7 @@ import {
 import {
   bootstrapLocalToken,
   getStoredLocalToken,
-  clearLocalToken,
+
   validateLocalToken,
   isLocalTokenStale,
   LEGACY_LOCAL_STORAGE_KEY,

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -38,6 +38,7 @@ import {
   refreshCloudToken,
   getStoredToken as getStoredCloudToken,
   getStoredTokenRaw as getStoredCloudTokenRaw,
+  clearStoredToken as clearCloudToken,
   validateCloudToken,
   isCloudTokenStale,
   CLOUD_AUTH_FAILURE_CLOSE_CODES,
@@ -67,6 +68,7 @@ import {
 import {
   bootstrapLocalToken,
   getStoredLocalToken,
+  clearLocalToken,
   validateLocalToken,
   isLocalTokenStale,
   LEGACY_LOCAL_STORAGE_KEY,
@@ -137,6 +139,24 @@ async function setOverrideEnvironment(env: ExtensionEnvironment | null): Promise
     await chrome.storage.local.remove(ENVIRONMENT_OVERRIDE_KEY);
   } else {
     await chrome.storage.local.set({ [ENVIRONMENT_OVERRIDE_KEY]: env });
+  }
+}
+
+/**
+ * Remove all stored auth tokens (cloud and local) for every assistant.
+ * Called when the effective environment changes so stale tokens minted
+ * against the previous environment are not reused on the next connect.
+ * Token storage keys use a well-known prefix (`vellum.cloudAuthToken` /
+ * `vellum.localCapabilityToken`) — we enumerate all storage keys and
+ * remove those matching either prefix.
+ */
+async function invalidateAuthTokens(): Promise<void> {
+  const all = await chrome.storage.local.get(null);
+  const keysToRemove = Object.keys(all).filter(
+    (k) => k.startsWith('vellum.cloudAuthToken') || k.startsWith('vellum.localCapabilityToken'),
+  );
+  if (keysToRemove.length > 0) {
+    await chrome.storage.local.remove(keysToRemove);
   }
 }
 
@@ -1515,32 +1535,39 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     // `environment: null` to clear the override and revert to the
     // build default.
     //
-    // NOTE: This handler intentionally only persists the override — it
-    // does NOT disconnect or reconnect the active relay connection. The
-    // caller (popup) is responsible for orchestrating disconnect/reconnect
-    // after receiving the response if it wants the new environment to take
-    // effect immediately. `getCloudUrls()` is called fresh on each
-    // connect/reconnect cycle, so the persisted override is picked up
-    // automatically on the next connection without any additional plumbing.
+    // NOTE: This handler only persists the override and invalidates
+    // stale auth tokens — it does NOT disconnect or reconnect the
+    // active relay connection. The caller (popup) is responsible for
+    // orchestrating disconnect/reconnect after receiving the response
+    // if it wants the new environment to take effect immediately.
+    // `getCloudUrls()` is called fresh on each connect/reconnect cycle,
+    // so the persisted override is picked up automatically on the next
+    // connection without any additional plumbing.
     const rawEnv = message.environment;
     if (rawEnv === null || rawEnv === undefined) {
       // Clear override
-      setOverrideEnvironment(null)
-        .then(async () => {
-          const effectiveEnvironment = await getEffectiveEnvironment();
-          sendResponseFn({
-            ok: true,
-            effectiveEnvironment,
-            overrideEnvironment: null,
-            buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
-          });
-        })
-        .catch((err) =>
-          sendResponseFn({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+      (async () => {
+        const previousEnv = await getEffectiveEnvironment();
+        await setOverrideEnvironment(null);
+        const effectiveEnvironment = await getEffectiveEnvironment();
+        // Invalidate cached auth tokens when the effective environment
+        // actually changes so stale credentials from the previous
+        // environment are not reused on the next connect cycle.
+        if (effectiveEnvironment !== previousEnv) {
+          await invalidateAuthTokens();
+        }
+        sendResponseFn({
+          ok: true,
+          effectiveEnvironment,
+          overrideEnvironment: null,
+          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+        });
+      })().catch((err) =>
+        sendResponseFn({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       return true; // async
     }
     if (typeof rawEnv !== 'string') {
@@ -1555,22 +1582,25 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
       });
       return false;
     }
-    setOverrideEnvironment(parsed)
-      .then(async () => {
-        const effectiveEnvironment = await getEffectiveEnvironment();
-        sendResponseFn({
-          ok: true,
-          effectiveEnvironment,
-          overrideEnvironment: parsed,
-          buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
-        });
-      })
-      .catch((err) =>
-        sendResponseFn({
-          ok: false,
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+    (async () => {
+      const previousEnv = await getEffectiveEnvironment();
+      await setOverrideEnvironment(parsed);
+      const effectiveEnvironment = await getEffectiveEnvironment();
+      if (effectiveEnvironment !== previousEnv) {
+        await invalidateAuthTokens();
+      }
+      sendResponseFn({
+        ok: true,
+        effectiveEnvironment,
+        overrideEnvironment: parsed,
+        buildDefaultEnvironment: resolveBuildDefaultEnvironment(),
+      });
+    })().catch((err) =>
+      sendResponseFn({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
     return true; // async
   }
 });

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -335,7 +335,8 @@ async function getAssistantCatalogAndSelection(): Promise<{
   selected: AssistantDescriptor | null;
   authProfile: AssistantAuthProfile | null;
 }> {
-  const catalog = await listAssistants();
+  const environment = await getEffectiveEnvironment();
+  const catalog = await listAssistants({ environment });
   const selected = await resolveSelectedAssistant(catalog);
   const authProfile = selected
     ? resolveAuthProfile({ cloud: selected.cloud, runtimeUrl: selected.runtimeUrl })
@@ -680,7 +681,8 @@ async function buildRelayModeForAssistant(
     // without a manual re-pair click in startup/reconnect flows.
     if (isLocalTokenStale(local)) {
       try {
-        local = await bootstrapLocalToken(assistant.assistantId);
+        const environment = await getEffectiveEnvironment();
+        local = await bootstrapLocalToken(assistant.assistantId, { environment });
       } catch (err) {
         // Non-recoverable native-host failures (missing host, forbidden
         // origin, pair endpoint failure) — leave the original `local`
@@ -937,7 +939,8 @@ function createRelayConnection(
       // silently refresh tokens without user interaction.
       if (isLocalTokenStale(local) && selectedId) {
         try {
-          local = await bootstrapLocalToken(selectedId);
+          const environment = await getEffectiveEnvironment();
+          local = await bootstrapLocalToken(selectedId, { environment });
         } catch (err) {
           // Leave original `local` value unchanged so a stale-but-not-expired
           // token can still be used on reconnect.
@@ -1073,7 +1076,8 @@ async function connectPreflight(
     }
     // Interactive: auto-bootstrap the local capability token.
     const assistantId = assistant?.assistantId ?? null;
-    const stored = await bootstrapLocalToken(assistantId);
+    const environment = await getEffectiveEnvironment();
+    const stored = await bootstrapLocalToken(assistantId, { environment });
     const port = stored.assistantPort ?? assistant?.daemonPort ?? (await getRelayPort());
     return {
       kind: 'self-hosted',
@@ -1359,7 +1363,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
       : loadSelectedAssistantId()
     )
       .then(async (resolvedId) => {
-        const stored = await bootstrapLocalToken(resolvedId);
+        const environment = await getEffectiveEnvironment();
+        const stored = await bootstrapLocalToken(resolvedId, { environment });
 
         // If the relay is intended to be connected, rotate the live socket
         // so the fresh paired token is applied immediately. Without this,
@@ -1413,7 +1418,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     // Fetch a fresh catalog so the selected ID is validated against the
     // current lockfile state — a stale ID from a previous session
     // should not be persisted.
-    listAssistants()
+    getEffectiveEnvironment()
+      .then((environment) => listAssistants({ environment }))
       .then(async (catalog) => {
         const match = catalog.assistants.find(
           (a) => a.assistantId === assistantId,

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -19,6 +19,11 @@ else
   EXT_VERSION=$(jq -r '.version' "$SCRIPT_DIR/manifest.json")
 fi
 
+# Resolve environment for bundle-time injection. The release workflow sets
+# VELLUM_ENVIRONMENT to 'staging' or 'production'; local dev builds
+# default to 'dev' when the variable is unset.
+VELLUM_ENV="${VELLUM_ENVIRONMENT:-dev}"
+
 # Chrome manifest requires 1-4 dot-separated integers. Strip any
 # prerelease suffix (e.g. "0.6.0-staging.3" -> "0.6.0") so staging
 # builds produce a valid extension zip.
@@ -40,12 +45,14 @@ mkdir -p "$DIST_DIR/icons"
 
 # Build service worker
 echo "Bundling service worker with bun build..."
+echo "  Environment: $VELLUM_ENV"
 bun build \
   "$SCRIPT_DIR/background/worker.ts" \
   --outdir "$DIST_DIR/background" \
   --target browser \
   --format esm \
-  --minify
+  --minify \
+  --define "process.env.VELLUM_ENVIRONMENT=\"$VELLUM_ENV\""
 
 # Build popup script
 echo "Bundling popup script with bun build..."
@@ -54,7 +61,8 @@ bun build \
   --outdir "$DIST_DIR/popup" \
   --target browser \
   --format esm \
-  --minify
+  --minify \
+  --define "process.env.VELLUM_ENVIRONMENT=\"$VELLUM_ENV\""
 
 # Copy static assets
 cp "$SCRIPT_DIR/manifest.json" "$DIST_DIR/manifest.json"

--- a/clients/chrome-extension/native-host/src/__tests__/index.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/index.test.ts
@@ -27,6 +27,7 @@
 
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -524,6 +525,106 @@ describe("native host — list_assistants response framing", () => {
     expect(frame.activeAssistantId).toBeNull();
     expect(frame.protocolVersion).toBe(1);
   });
+
+  test("list_assistants with environment override reads from the correct lockfile", async () => {
+    // Write a dev lockfile under an XDG-style path.
+    const devDir = join(lockfileDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-one",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: 7821 },
+          },
+        ],
+        activeAssistant: "dev-one",
+      }),
+    );
+
+    // Also write a production lockfile — the override should bypass it.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-one",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7840",
+            resources: { daemonPort: 7831 },
+          },
+        ],
+        activeAssistant: "prod-one",
+      }),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({
+        type: "list_assistants",
+        environment: "dev",
+      }),
+      timeoutMs: 2000,
+      env: {
+        XDG_CONFIG_HOME: lockfileDir,
+        // Clear VELLUM_LOCKFILE_DIR so XDG path is used for non-prod
+        VELLUM_LOCKFILE_DIR: undefined,
+      },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: Array<{ assistantId: string }>;
+      activeAssistantId: string | null;
+    };
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.assistants).toHaveLength(1);
+    expect(frame.assistants[0]!.assistantId).toBe("dev-one");
+    expect(frame.activeAssistantId).toBe("dev-one");
+  });
+
+  test("list_assistants with invalid environment override falls back to production", async () => {
+    // Write only a production lockfile.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-fallback",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+          },
+        ],
+      }),
+    );
+
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: pair!.port,
+      stdinBytes: encodeFrame({
+        type: "list_assistants",
+        environment: "foobar",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    const frame = result.frames[0] as {
+      type: string;
+      assistants: Array<{ assistantId: string }>;
+    };
+    expect(frame.type).toBe("assistants_response");
+    expect(frame.assistants).toHaveLength(1);
+    expect(frame.assistants[0]!.assistantId).toBe("prod-fallback");
+  });
 });
 
 describe("native host — assistant-scoped token request", () => {
@@ -720,6 +821,134 @@ describe("native host — assistant-scoped token request", () => {
     const frame = result.frames[0] as { type: string; token: string };
     expect(frame.type).toBe("token_response");
     expect(frame.token).toBe("tok-unknown-fallback");
+    expect(srvA.requests).toHaveLength(1);
+  });
+
+  test("request_token with environment override resolves port from the correct lockfile", async () => {
+    const srvA = pairA!;
+    const srvB = pairB!;
+    srvA.requests.length = 0;
+    srvB.requests.length = 0;
+
+    srvA.nextResponseBody = () => ({
+      token: "tok-prod",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-prod",
+    });
+    srvB.nextResponseBody = () => ({
+      token: "tok-dev",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-dev",
+    });
+
+    // Write a dev lockfile with assistant pointing to srvB.
+    const devDir = join(lockfileDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7831",
+            resources: { daemonPort: srvB.port },
+          },
+        ],
+      }),
+    );
+
+    // Write a prod lockfile with assistant pointing to srvA.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: srvA.port },
+          },
+        ],
+      }),
+    );
+
+    // Send a request_token with environment=dev and assistantId=dev-assistant.
+    // The helper should resolve the daemon port from the dev lockfile.
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "dev-assistant",
+        environment: "dev",
+      }),
+      timeoutMs: 2000,
+      env: {
+        XDG_CONFIG_HOME: lockfileDir,
+        VELLUM_LOCKFILE_DIR: undefined,
+      },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    expect(result.frames).toHaveLength(1);
+
+    const frame = result.frames[0] as {
+      type: string;
+      token: string;
+      assistantPort: number;
+    };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-dev");
+    expect(frame.assistantPort).toBe(srvB.port);
+
+    // srvB received the request (from the dev lockfile), not srvA.
+    expect(srvB.requests).toHaveLength(1);
+    expect(srvA.requests).toHaveLength(0);
+  });
+
+  test("request_token with 'prod' environment normalizes to 'production'", async () => {
+    const srvA = pairA!;
+    srvA.requests.length = 0;
+
+    srvA.nextResponseBody = () => ({
+      token: "tok-prod-short",
+      expiresAt: "2026-12-31T00:00:00Z",
+      guardianId: "g-prod-short",
+    });
+
+    // Write a production lockfile with an assistant pointing to srvA.
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "prod-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: srvA.port },
+          },
+        ],
+      }),
+    );
+
+    // Send environment="prod" — should be normalized to "production".
+    const result = await runHelper({
+      extensionOrigin: ALLOWED_ORIGIN,
+      assistantPort: srvA.port,
+      stdinBytes: encodeFrame({
+        type: "request_token",
+        assistantId: "prod-assistant",
+        environment: "prod",
+      }),
+      timeoutMs: 2000,
+      env: { VELLUM_LOCKFILE_DIR: lockfileDir },
+    });
+
+    expect(result.exitCode, `helper stderr: ${result.stderr}`).toBe(0);
+    const frame = result.frames[0] as { type: string; token: string };
+    expect(frame.type).toBe("token_response");
+    expect(frame.token).toBe("tok-prod-short");
     expect(srvA.requests).toHaveLength(1);
   });
 });

--- a/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
+++ b/clients/chrome-extension/native-host/src/__tests__/lockfile.test.ts
@@ -583,4 +583,139 @@ describe("lockfile — resolveDaemonPort", () => {
   test("returns undefined when lockfile is missing", () => {
     expect(resolveDaemonPort("anything")).toBeUndefined();
   });
+
+  test("uses environmentOverride to resolve the lockfile path", () => {
+    // Set process env to production (which reads .vellum.lock.json) but
+    // write the lockfile under the dev path. The override should win.
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    const devDir = join(tempDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-target",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7830",
+            resources: { daemonPort: 8888 },
+          },
+        ],
+      }),
+    );
+
+    // Without override, falls back to production path (no lockfile there)
+    expect(resolveDaemonPort("dev-target")).toBeUndefined();
+
+    // With override, reads from the dev lockfile
+    expect(resolveDaemonPort("dev-target", "dev")).toBe(8888);
+  });
+});
+
+describe("lockfile — environment override for readAssistantInventory", () => {
+  test("frame environment override takes precedence over process.env.VELLUM_ENVIRONMENT", () => {
+    // Set process env to production
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    // Write a prod lockfile with one assistant
+    const prodDir = tempDir;
+    process.env.VELLUM_LOCKFILE_DIR = prodDir;
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "prod-assistant",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+          resources: { daemonPort: 7821 },
+        },
+      ],
+    });
+
+    // Write a dev lockfile with a different assistant
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    const devDir = join(tempDir, "vellum-dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "lockfile.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "dev-assistant",
+            cloud: "local",
+            runtimeUrl: "http://localhost:7831",
+            resources: { daemonPort: 7822 },
+          },
+        ],
+      }),
+    );
+
+    // Without override, reads from production
+    process.env.VELLUM_LOCKFILE_DIR = prodDir;
+    const prodResult = readAssistantInventory();
+    expect(prodResult.assistants).toHaveLength(1);
+    expect(prodResult.assistants[0]!.assistantId).toBe("prod-assistant");
+
+    // With override "dev", reads from the dev lockfile
+    delete process.env.VELLUM_LOCKFILE_DIR;
+    const devResult = readAssistantInventory("dev");
+    expect(devResult.assistants).toHaveLength(1);
+    expect(devResult.assistants[0]!.assistantId).toBe("dev-assistant");
+  });
+
+  test("empty string override falls through to process.env.VELLUM_ENVIRONMENT", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    writeLockfile("lockfile.json", {
+      assistants: [
+        {
+          assistantId: "env-dev",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    // Empty string override should be treated as "no override"
+    const result = readAssistantInventory("");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("env-dev");
+  });
+
+  test("whitespace-only override falls through to process.env.VELLUM_ENVIRONMENT", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    writeLockfile("lockfile.json", {
+      assistants: [
+        {
+          assistantId: "env-dev",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    const result = readAssistantInventory("   ");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("env-dev");
+  });
+
+  test("invalid/unknown override falls back to production behavior", () => {
+    writeLockfile(".vellum.lock.json", {
+      assistants: [
+        {
+          assistantId: "prod-fallback",
+          cloud: "local",
+          runtimeUrl: "http://localhost:7830",
+        },
+      ],
+    });
+
+    // "foobar" is not a known environment, so falls back to production
+    const result = readAssistantInventory("foobar");
+    expect(result.assistants).toHaveLength(1);
+    expect(result.assistants[0]!.assistantId).toBe("prod-fallback");
+  });
 });

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -372,6 +372,27 @@ function fail(message: string, code = 1): never {
 }
 
 /**
+ * Normalize a frame-level environment override string.
+ *
+ * - Trims whitespace.
+ * - Normalizes the common `prod` shorthand to `production`.
+ * - Returns `undefined` for empty/whitespace-only strings so callers
+ *   can treat them as "no override".
+ *
+ * Invalid values (e.g. `foo`) are passed through rather than rejected
+ * here — the lockfile reader's `NON_PRODUCTION_ENVIRONMENTS` set
+ * handles the final gating and falls back to production for unknown
+ * values.
+ */
+export function normalizeFrameEnvironment(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed === "prod") return "production";
+  return trimmed;
+}
+
+/**
  * POST the extension origin to the assistant's pair endpoint and return the
  * issued capability token. Surfaces a uniform error message on failure so
  * the caller can wrap it in a native-messaging error frame.
@@ -385,6 +406,7 @@ async function requestToken(
   extensionOrigin: string,
   argv: readonly string[],
   assistantId?: string,
+  environmentOverride?: string,
 ): Promise<TokenResponse> {
   // When an assistantId is provided, attempt to resolve the daemon port
   // from the lockfile first. This lets the extension target a specific
@@ -394,7 +416,7 @@ async function requestToken(
   // for that assistant.
   let port: number;
   if (assistantId) {
-    const lockfilePort = resolveDaemonPort(assistantId);
+    const lockfilePort = resolveDaemonPort(assistantId, environmentOverride);
     if (lockfilePort !== undefined) {
       port = lockfilePort;
     } else {
@@ -523,8 +545,11 @@ async function main(): Promise<void> {
         if (frameType === "list_assistants") {
           // Return the assistant inventory from the lockfile. This is a
           // synchronous read — no network call needed.
+          const listEnv = normalizeFrameEnvironment(
+            (frame as { environment?: unknown }).environment,
+          );
           try {
-            const inventory = readAssistantInventory();
+            const inventory = readAssistantInventory(listEnv);
             await writeFrameAndExitAsync(
               {
                 type: "assistants_response",
@@ -546,10 +571,13 @@ async function main(): Promise<void> {
             typeof (frame as { assistantId?: unknown }).assistantId === "string"
               ? ((frame as { assistantId: string }).assistantId)
               : undefined;
+          const tokenEnv = normalizeFrameEnvironment(
+            (frame as { environment?: unknown }).environment,
+          );
 
           try {
             const { token, expiresAt, guardianId, assistantPort } =
-              await requestToken(extensionOrigin!, process.argv, assistantId);
+              await requestToken(extensionOrigin!, process.argv, assistantId, tokenEnv);
             await writeFrameAndExitAsync(
               {
                 type: "token_response",

--- a/clients/chrome-extension/native-host/src/index.ts
+++ b/clients/chrome-extension/native-host/src/index.ts
@@ -386,7 +386,7 @@ function fail(message: string, code = 1): never {
  */
 export function normalizeFrameEnvironment(raw: unknown): string | undefined {
   if (typeof raw !== "string") return undefined;
-  const trimmed = raw.trim();
+  const trimmed = raw.trim().toLowerCase();
   if (trimmed.length === 0) return undefined;
   if (trimmed === "prod") return "production";
   return trimmed;

--- a/clients/chrome-extension/native-host/src/lockfile.ts
+++ b/clients/chrome-extension/native-host/src/lockfile.ts
@@ -102,10 +102,15 @@ interface RawAssistantEntry {
  * Mirrors `getLockfilePaths()` in `cli/src/lib/environments/paths.ts`.
  * Unknown env names fall back to production silently — browser users
  * don't see warnings.
+ *
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT`. Invalid/unknown values fall back
+ *   to production behavior.
  */
-function getLockfileCandidates(): string[] {
+function getLockfileCandidates(environmentOverride?: string): string[] {
   const lockfileDirOverride = process.env.VELLUM_LOCKFILE_DIR?.trim();
-  const rawEnv = process.env.VELLUM_ENVIRONMENT?.trim() || "production";
+  const rawEnv = environmentOverride?.trim() || process.env.VELLUM_ENVIRONMENT?.trim() || "production";
   const isNonProd = NON_PRODUCTION_ENVIRONMENTS.has(rawEnv);
 
   if (!isNonProd) {
@@ -123,8 +128,8 @@ function getLockfileCandidates(): string[] {
  * Read and parse the lockfile from the first candidate path that exists
  * and contains valid JSON. Returns `null` if no valid lockfile is found.
  */
-function readRawLockfile(): RawLockfile | null {
-  for (const filePath of getLockfileCandidates()) {
+function readRawLockfile(environmentOverride?: string): RawLockfile | null {
+  for (const filePath of getLockfileCandidates(environmentOverride)) {
     try {
       const raw = readFileSync(filePath, "utf8");
       const parsed: unknown = JSON.parse(raw);
@@ -180,9 +185,13 @@ function extractDaemonPort(entry: RawAssistantEntry): number | undefined {
  * - Filtering entries that lack required fields
  * - Extracting `daemonPort` from `resources` when present
  * - Resolving which assistant is active
+ *
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT` for lockfile path resolution.
  */
-export function readAssistantInventory(): LockfileInventory {
-  const raw = readRawLockfile();
+export function readAssistantInventory(environmentOverride?: string): LockfileInventory {
+  const raw = readRawLockfile(environmentOverride);
   if (!raw) {
     return { assistants: [], activeAssistantId: null };
   }
@@ -211,9 +220,14 @@ export function readAssistantInventory(): LockfileInventory {
  *
  * This is a convenience wrapper used by the `request_token` handler when
  * an `assistantId` is provided in the request frame.
+ *
+ * @param assistantId - The assistant to look up.
+ * @param environmentOverride - Optional environment name from the
+ *   native-messaging frame. When provided, takes precedence over
+ *   `process.env.VELLUM_ENVIRONMENT` for lockfile path resolution.
  */
-export function resolveDaemonPort(assistantId: string): number | undefined {
-  const { assistants } = readAssistantInventory();
+export function resolveDaemonPort(assistantId: string, environmentOverride?: string): number | undefined {
+  const { assistants } = readAssistantInventory(environmentOverride);
   const match = assistants.find((a) => a.assistantId === assistantId);
   return match?.daemonPort;
 }

--- a/clients/chrome-extension/popup/popup-state.test.ts
+++ b/clients/chrome-extension/popup/popup-state.test.ts
@@ -27,6 +27,10 @@ import {
   deriveHealthStatusDisplay,
   shouldExpandTroubleshooting,
   hasTroubleshootingControls,
+  environmentLabel,
+  deriveEffectiveEnvironment,
+  deriveEnvironmentHint,
+  ENVIRONMENT_OPTIONS,
   type ConnectionPhase,
   type ConnectionHealthState,
   type ConnectionHealthDetail,
@@ -638,5 +642,122 @@ describe('integrated health-to-display scenarios', () => {
     expect(selectorDisplay.kind).toBe('visible');
     if (selectorDisplay.kind !== 'visible') throw new Error('unreachable');
     expect(selectorDisplay.options.length).toBe(2);
+  });
+});
+
+// ── environmentLabel ────────────────────────────────────────────────
+
+describe('environmentLabel', () => {
+  test('returns "Local" for local', () => {
+    expect(environmentLabel('local')).toBe('Local');
+  });
+
+  test('returns "Development" for dev', () => {
+    expect(environmentLabel('dev')).toBe('Development');
+  });
+
+  test('returns "Staging" for staging', () => {
+    expect(environmentLabel('staging')).toBe('Staging');
+  });
+
+  test('returns "Production" for production', () => {
+    expect(environmentLabel('production')).toBe('Production');
+  });
+
+  test('all environment options have labels', () => {
+    for (const env of ENVIRONMENT_OPTIONS) {
+      const label = environmentLabel(env);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── ENVIRONMENT_OPTIONS ─────────────────────────────────────────────
+
+describe('ENVIRONMENT_OPTIONS', () => {
+  test('contains exactly four environments', () => {
+    expect(ENVIRONMENT_OPTIONS.length).toBe(4);
+  });
+
+  test('includes local, dev, staging, production in order', () => {
+    expect(ENVIRONMENT_OPTIONS[0]).toBe('local');
+    expect(ENVIRONMENT_OPTIONS[1]).toBe('dev');
+    expect(ENVIRONMENT_OPTIONS[2]).toBe('staging');
+    expect(ENVIRONMENT_OPTIONS[3]).toBe('production');
+  });
+});
+
+// ── deriveEffectiveEnvironment ──────────────────────────────────────
+
+describe('deriveEffectiveEnvironment', () => {
+  test('returns override when present', () => {
+    expect(deriveEffectiveEnvironment('staging', 'dev')).toBe('staging');
+  });
+
+  test('returns build default when override is null', () => {
+    expect(deriveEffectiveEnvironment(null, 'staging')).toBe('staging');
+  });
+
+  test('returns build default when override is undefined', () => {
+    expect(deriveEffectiveEnvironment(undefined, 'production')).toBe('production');
+  });
+
+  test('falls back to dev when both override and build default are absent', () => {
+    expect(deriveEffectiveEnvironment(null, undefined)).toBe('dev');
+  });
+
+  test('falls back to dev when both are undefined', () => {
+    expect(deriveEffectiveEnvironment(undefined, undefined)).toBe('dev');
+  });
+
+  test('override takes precedence over build default', () => {
+    expect(deriveEffectiveEnvironment('local', 'production')).toBe('local');
+  });
+});
+
+// ── deriveEnvironmentHint ───────────────────────────────────────────
+
+describe('deriveEnvironmentHint', () => {
+  test('shows override message when override is active', () => {
+    const hint = deriveEnvironmentHint('staging', 'dev');
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('Development');
+  });
+
+  test('shows override with production default label', () => {
+    const hint = deriveEnvironmentHint('local', 'production');
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('Production');
+  });
+
+  test('shows build default message when no override', () => {
+    const hint = deriveEnvironmentHint(null, 'staging');
+    expect(hint).toBe('Using build default');
+  });
+
+  test('shows build default message when override is undefined', () => {
+    const hint = deriveEnvironmentHint(undefined, 'dev');
+    expect(hint).toBe('Using build default');
+  });
+
+  test('shows generic default when both are absent', () => {
+    const hint = deriveEnvironmentHint(null, undefined);
+    expect(hint).toBe('Using default');
+  });
+
+  test('shows generic default when both are undefined', () => {
+    const hint = deriveEnvironmentHint(undefined, undefined);
+    expect(hint).toBe('Using default');
+  });
+
+  test('override hint includes build default label in parentheses', () => {
+    const hint = deriveEnvironmentHint('production', 'dev');
+    expect(hint).toContain('(Development)');
+  });
+
+  test('override hint with no build default uses dev as fallback label', () => {
+    const hint = deriveEnvironmentHint('staging', undefined);
+    expect(hint).toContain('Overriding');
+    expect(hint).toContain('dev');
   });
 });

--- a/clients/chrome-extension/popup/popup-state.ts
+++ b/clients/chrome-extension/popup/popup-state.ts
@@ -21,6 +21,7 @@
 
 import type { AssistantDescriptor } from '../background/native-host-assistants.js';
 import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+import type { ExtensionEnvironment } from '../background/extension-environment.js';
 
 // ── Health state types (mirrored from worker.ts) ───────────────────
 
@@ -402,4 +403,97 @@ export function hasTroubleshootingControls(
   authProfile: AssistantAuthProfile | null,
 ): boolean {
   return authProfile === 'local-pair' || authProfile === 'cloud-oauth';
+}
+
+// ── Environment display helpers ─────────────────────────────────────
+//
+// These functions derive user-facing labels and display state for the
+// environment selector dropdown in the popup's Advanced section.
+
+/**
+ * Response shape from the worker's `environment-get` and
+ * `environment-set` messages.
+ */
+export interface EnvironmentStateResponse {
+  ok: boolean;
+  effectiveEnvironment?: ExtensionEnvironment;
+  overrideEnvironment?: ExtensionEnvironment | null;
+  buildDefaultEnvironment?: ExtensionEnvironment;
+  error?: string;
+}
+
+/**
+ * The set of environments available in the dropdown.
+ */
+export const ENVIRONMENT_OPTIONS: readonly ExtensionEnvironment[] = [
+  'local',
+  'dev',
+  'staging',
+  'production',
+] as const;
+
+/**
+ * Map an environment value to a user-friendly display label.
+ *
+ * | Value        | Label       |
+ * |--------------|-------------|
+ * | local        | Local       |
+ * | dev          | Development |
+ * | staging      | Staging     |
+ * | production   | Production  |
+ */
+export function environmentLabel(env: ExtensionEnvironment): string {
+  switch (env) {
+    case 'local':
+      return 'Local';
+    case 'dev':
+      return 'Development';
+    case 'staging':
+      return 'Staging';
+    case 'production':
+      return 'Production';
+  }
+}
+
+/**
+ * Derive the effective environment to display, applying the precedence
+ * rules:
+ *   1. overrideEnvironment (popup-persisted selection)
+ *   2. buildDefaultEnvironment (compile-time define)
+ *   3. fallback to 'dev'
+ *
+ * This mirrors the worker's resolution logic but operates on the
+ * pre-resolved response fields for display purposes.
+ */
+export function deriveEffectiveEnvironment(
+  overrideEnvironment: ExtensionEnvironment | null | undefined,
+  buildDefaultEnvironment: ExtensionEnvironment | undefined,
+): ExtensionEnvironment {
+  if (overrideEnvironment) return overrideEnvironment;
+  if (buildDefaultEnvironment) return buildDefaultEnvironment;
+  return 'dev';
+}
+
+/**
+ * Derive a brief hint string explaining the current environment
+ * selection source.
+ *
+ * - When an override is active: "Overriding build default (<default>)"
+ * - When using build default: "Using build default"
+ * - When no info available: "Using default"
+ */
+export function deriveEnvironmentHint(
+  overrideEnvironment: ExtensionEnvironment | null | undefined,
+  buildDefaultEnvironment: ExtensionEnvironment | undefined,
+): string {
+  if (overrideEnvironment) {
+    const defaultLabel = buildDefaultEnvironment
+      ? environmentLabel(buildDefaultEnvironment)
+      : 'dev';
+    return `Overriding build default (${defaultLabel})`;
+  }
+  if (buildDefaultEnvironment) {
+    return 'Using build default';
+  }
+  return 'Using default';
 }

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -601,6 +601,17 @@
 
     <div id="troubleshoot-body" hidden>
       <div class="advanced-setting">
+        <label for="environment-select">Environment</label>
+        <select id="environment-select">
+          <option value="local">Local</option>
+          <option value="dev">Development</option>
+          <option value="staging">Staging</option>
+          <option value="production">Production</option>
+        </select>
+        <p class="hint" id="environment-hint">Overrides the build default for this extension profile.</p>
+      </div>
+
+      <div class="advanced-setting">
         <label for="port-input">Connection port</label>
         <input
           type="text"

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -43,12 +43,14 @@ import {
   healthToPhase,
   shouldExpandTroubleshooting,
   hasTroubleshootingControls,
+  deriveEnvironmentHint,
   type ConnectionHealthState,
   type ConnectionHealthDetail,
   type ConnectionPhase,
   type GetStatusResponse,
   type AssistantsGetResponse,
   type AssistantSelectResponse,
+  type EnvironmentStateResponse,
 } from './popup-state.js';
 
 const DEFAULT_RELAY_PORT = 7830;
@@ -94,6 +96,13 @@ const assistantSelect = document.getElementById(
   'assistant-select',
 ) as HTMLSelectElement;
 
+const environmentSelect = document.getElementById(
+  'environment-select',
+) as HTMLSelectElement;
+const environmentHint = document.getElementById(
+  'environment-hint',
+) as HTMLParagraphElement;
+
 // ── Current assistant state ─────────────────────────────────────────
 //
 // Tracks the currently selected assistant and its auth profile so
@@ -109,6 +118,13 @@ let currentAuthProfile: AssistantAuthProfile | null = null;
 
 let currentHealthState: ConnectionHealthState = 'paused';
 let currentDebugDetails: string | null = null;
+
+// ── Current environment state ───────────────────────────────────────
+//
+// Tracks the build-default environment so the change handler can
+// detect when the user re-selects the default and clear the override.
+
+let currentBuildDefaultEnvironment: string | undefined;
 
 // ── Connection phase management ─────────────────────────────────────
 
@@ -772,3 +788,102 @@ btnCloudSignIn.addEventListener('click', async () => {
 });
 
 refreshCloudStatus();
+
+// ── Environment selector ────────────────────────────────────────────
+//
+// The environment dropdown allows developers to override the build-time
+// default environment for the current extension profile. This changes
+// which cloud API and web URLs are used for sign-in, pairing, and relay.
+//
+// On popup open we load the effective environment from the worker via
+// `environment-get` and render the selected value. On change we persist
+// the override via `environment-set`, refresh the assistant catalog and
+// auth status, and force a disconnect/reconnect if currently connected.
+
+/**
+ * Load environment state from the worker and render the selector.
+ */
+function loadEnvironmentState(): void {
+  chrome.runtime.sendMessage({ type: 'environment-get' }, (response: EnvironmentStateResponse) => {
+    if (chrome.runtime.lastError || !response?.ok) return;
+
+    currentBuildDefaultEnvironment = response.buildDefaultEnvironment;
+
+    const effective = response.effectiveEnvironment ?? 'dev';
+    environmentSelect.value = effective;
+    environmentHint.textContent = deriveEnvironmentHint(
+      response.overrideEnvironment,
+      response.buildDefaultEnvironment,
+    );
+  });
+}
+
+// Load on popup open.
+loadEnvironmentState();
+
+/**
+ * Handle environment dropdown changes.
+ *
+ * Orchestration after environment-set:
+ *   1. Refresh assistant catalog (endpoints may have changed).
+ *   2. Refresh local/cloud auth status panels.
+ *   3. If currently connected, disconnect and reconnect so the new
+ *      environment-sensitive endpoints take effect immediately.
+ */
+environmentSelect.addEventListener('change', async () => {
+  const newEnv = environmentSelect.value;
+  errorText.style.display = 'none';
+  hideDebugDetails();
+
+  // When the user selects the build-default environment, clear the
+  // override so future bundle updates can change the default without
+  // the user staying pinned to a stale value.
+  const isDefault = currentBuildDefaultEnvironment != null && newEnv === currentBuildDefaultEnvironment;
+  const overrideValue = isDefault ? null : newEnv;
+
+  // Persist the environment override via the worker.
+  const response = await new Promise<EnvironmentStateResponse>((resolve) => {
+    chrome.runtime.sendMessage(
+      { type: 'environment-set', environment: overrideValue },
+      (r: EnvironmentStateResponse) => {
+        if (chrome.runtime.lastError) {
+          resolve({ ok: false, error: chrome.runtime.lastError.message ?? 'Unknown error' });
+          return;
+        }
+        resolve(r ?? { ok: false, error: 'No response from service worker' });
+      },
+    );
+  });
+
+  if (!response.ok) {
+    showError(response.error ?? 'Failed to set environment');
+    return;
+  }
+
+  // Update the hint to reflect the new state.
+  environmentHint.textContent = deriveEnvironmentHint(
+    response.overrideEnvironment,
+    response.buildDefaultEnvironment,
+  );
+
+  // Refresh the assistant catalog — environment change may affect
+  // which assistants are available and their auth endpoints.
+  loadAssistantCatalog();
+
+  // Refresh auth status panels.
+  void refreshLocalStatus();
+  void refreshCloudStatus();
+
+  // If currently connected, force disconnect then reconnect so the new
+  // environment-sensitive endpoints take effect immediately. The worker's
+  // `environment-set` handler does NOT auto-reconnect — the popup
+  // orchestrates this explicitly.
+  if (currentHealthState === 'connected' || currentHealthState === 'connecting' || currentHealthState === 'reconnecting') {
+    // Disconnect first.
+    await new Promise<void>((resolve) => {
+      chrome.runtime.sendMessage({ type: 'pause' }, () => resolve());
+    });
+    // Reconnect with the new environment.
+    await requestConnect();
+  }
+});

--- a/clients/chrome-extension/types/chrome-globals.d.ts
+++ b/clients/chrome-extension/types/chrome-globals.d.ts
@@ -303,3 +303,16 @@ interface ChromeGlobal {
 }
 
 declare const chrome: ChromeGlobal;
+
+/**
+ * Minimal ambient declaration for `process.env` so bundler-injected
+ * constants like `process.env.VELLUM_ENVIRONMENT` can be referenced
+ * without pulling in the full `@types/node` package.
+ *
+ * At bundle time `bun build --define` replaces these references with
+ * string literals. In test contexts (bun:test) the real Node/Bun
+ * `process` global satisfies this shape.
+ */
+declare const process: {
+  env: Record<string, string | undefined>;
+};


### PR DESCRIPTION
## Summary
Add an explicit environment control to the Chrome extension popup Advanced section so developers can switch between `local`, `dev`, `staging`, and `production` without rebuilding. Environment selection drives cloud auth URLs, native-host lockfile resolution, and runtime pairing/sign-in calls.

## Self-review result
GAPS FOUND — 2 gaps fixed across 2 fix PRs (Round 1), PASS on re-review (Round 2)

## PRs merged into feature branch
- #26765: chrome-extension: add canonical environment model and URL mapping
- #26766: chrome-extension: add native-host frame environment override support
- #26769: chrome-extension: resolve effective environment in worker and build defaults
- #26782: chrome-extension: add Advanced environment selector and reconnect flow

### Fix PRs
- #26823: fix: add toLowerCase to native-host normalizeFrameEnvironment
- #26827: fix: thread effective environment to native-host calls

Part of plan: chrome-extension-env-selector.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
