### PR TITLE
fix(slack-dm-backfill): early-return scan and dedupe concurrent cold backfills

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -305,6 +305,47 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(backfillDmMock).toHaveBeenCalledTimes(0);
   });
 
+  test("concurrent cold DMs share a single backfill (no double-write)", async () => {
+    // Two near-simultaneous DMs into the same cold conversation must not
+    // each trigger their own backfill — the in-flight lock dedupes them so
+    // Slack history is fetched once and rows are written once.
+    let resolveBackfill: ((messages: Message[]) => void) | null = null;
+    backfillDmMock.mockImplementation(
+      () =>
+        new Promise<Message[]>((resolve) => {
+          resolveBackfill = resolve;
+        }),
+    );
+
+    const first = handleChannelInbound(
+      buildDmRequest("first concurrent DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+    const second = handleChannelInbound(
+      buildDmRequest("second concurrent DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    // Wait for both handlers to register their await on the in-flight
+    // promise before resolving the underlying backfill fetch.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolveBackfill).not.toBeNull();
+    resolveBackfill!([
+      makeBackfilledMessage({ id: "1700000000.000001", text: "older A" }),
+      makeBackfilledMessage({ id: "1700000000.000002", text: "older B" }),
+    ]);
+
+    await Promise.all([first, second]);
+
+    expect(backfillDmMock).toHaveBeenCalledTimes(1);
+    const rows = readPersistedSlackRows();
+    expect(rows.length).toBe(2);
+    const texts = rows.map((r) => r.content).sort();
+    expect(texts).toEqual(["older A", "older B"]);
+  });
+
   test("backfill skips channelTs values already stored", async () => {
     // First DM: backfill returns three rows.
     backfillDmMock.mockImplementation(async () => [

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1243,6 +1243,10 @@ function countSlackMetaMessages(conversationId: string): number {
     if (typeof raw !== "string") continue;
     if (readSlackMetadata(raw)) {
       count++;
+      // Early-return: callers only need to know if the count meets the
+      // warm threshold. Avoids parsing every row on warm conversations
+      // that would otherwise full-scan on each Slack DM.
+      if (count >= SLACK_DM_BACKFILL_WARM_THRESHOLD) return count;
     }
   }
   return count;
@@ -1311,6 +1315,17 @@ async function persistBackfilledSlackMessage(params: {
 }
 
 /**
+ * In-memory map of in-flight DM cold-start backfills keyed by conversationId.
+ * Concurrent inbound DMs to the same cold conversation share a single
+ * backfill promise instead of each issuing their own Slack history fetch and
+ * write — without this, two near-simultaneous DMs would both observe a cold
+ * count, both fetch the same history window, and both insert duplicate rows
+ * (channelTs lives inside a JSON metadata blob, so the DB has no uniqueness
+ * constraint to fall back on).
+ */
+const _dmBackfillInFlight = new Map<string, Promise<void>>();
+
+/**
  * One-shot DM cold-start backfill. When a Slack DM lands in a conversation
  * with fewer than `SLACK_DM_BACKFILL_WARM_THRESHOLD` stored Slack-tagged
  * messages, fetch a window of recent history via `backfillDm` and persist
@@ -1322,6 +1337,22 @@ async function persistBackfilledSlackMessage(params: {
  * proceeds with only the new message.
  */
 async function tryBackfillSlackDmIfCold(params: {
+  conversationId: string;
+  channelId: string;
+}): Promise<void> {
+  const existing = _dmBackfillInFlight.get(params.conversationId);
+  if (existing) {
+    await existing;
+    return;
+  }
+  const promise = runBackfillSlackDmIfCold(params).finally(() => {
+    _dmBackfillInFlight.delete(params.conversationId);
+  });
+  _dmBackfillInFlight.set(params.conversationId, promise);
+  await promise;
+}
+
+async function runBackfillSlackDmIfCold(params: {
   conversationId: string;
   channelId: string;
 }): Promise<void> {


### PR DESCRIPTION
## Summary

Addresses two issues Devin flagged on #26626:

- **Full-scan perf:** `countSlackMetaMessages` was reading every message in a conversation and JSON-parsing each metadata blob on every inbound Slack DM. Now early-returns once the warm threshold is met, so warm conversations stop scanning after the first 3 slack-tagged rows.
- **Concurrent cold double-backfill:** Two simultaneous DMs into the same cold conversation could both observe `count < 3`, both call `backfillDm`, and both insert the same rows (channelTs lives in JSON metadata so the DB has no uniqueness constraint). Added an in-memory in-flight map keyed by `conversationId` so concurrent callers share a single backfill promise.

The third Devin item (JSDoc "this PR" / "follow-up PR" wording) was already addressed in #26828.

## Test plan

- [x] `bun test src/__tests__/dm-backfill.test.ts` — all 6 tests pass, including a new `concurrent cold DMs share a single backfill (no double-write)` case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
