### PR TITLE
test(guardian-approvals): track prompt ts in reaction tests

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -31,6 +31,10 @@ import {
 import * as approvalMessageComposer from "../runtime/approval-message-composer.js";
 import * as gatewayClient from "../runtime/gateway-client.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import {
+  _clearApprovalPromptTsTrackerForTesting,
+  trackApprovalPromptTs,
+} from "../runtime/routes/approval-prompt-ts-tracker.js";
 import { handleApprovalInterception } from "../runtime/routes/guardian-approval-interception.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 
@@ -60,6 +64,7 @@ function resetTables(): void {
     /* tables may not exist yet */
   }
   pendingInteractions.clear();
+  _clearApprovalPromptTsTrackerForTesting();
 }
 
 function createTestGuardianApproval(
@@ -227,6 +232,8 @@ describe("guardian grant minting on tool-approval decisions", () => {
       TOOL_NAME,
       TOOL_INPUT,
     );
+    const approvalMessageTs = "1700000000.000100";
+    trackApprovalPromptTs("slack", GUARDIAN_CHAT, approvalMessageTs);
 
     const result = await handleApprovalInterception({
       conversationId: "guardian-conv-1",
@@ -238,6 +245,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
       replyCallbackUrl: "https://gateway.test/deliver",
       trustCtx: makeTrustContext(),
       assistantId: ASSISTANT_ID,
+      approvalMessageTs,
     });
 
     expect(result.handled).toBe(true);

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -52,6 +52,10 @@ import {
 import { messages } from "../memory/schema/conversations.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import {
+  _clearApprovalPromptTsTrackerForTesting,
+  trackApprovalPromptTs,
+} from "../runtime/routes/approval-prompt-ts-tracker.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 import {
   isSlackReactionEvent,
@@ -461,6 +465,7 @@ describe("guardian approval-by-reaction integration via handleChannelInbound", (
     db.run("DELETE FROM contacts");
     db.run("DELETE FROM channel_guardian_approval_requests");
     pendingInteractions.clear();
+    _clearApprovalPromptTsTrackerForTesting();
     msgCounter = 0;
   });
 
@@ -486,6 +491,9 @@ describe("guardian approval-by-reaction integration via handleChannelInbound", (
     seedPendingGuardianApprovalForReaction(requestId, conversationId);
 
     const reactedTs = "1700000099.000001";
+    // Simulate the approval prompt having been delivered on this ts so the
+    // guardian reaction is scoped to a tracked prompt message.
+    trackApprovalPromptTs("slack", SLACK_CHANNEL_ID, reactedTs);
     const body = {
       sourceChannel: "slack",
       interface: "slack",


### PR DESCRIPTION
## Summary
- #26825 added an in-memory tracker requiring guardian reaction approvals to land on a ts previously registered as a delivered approval prompt. The \`guardian-grant-minting\` and \`reaction-persistence\` tests didn't update to match, so they were returning \`stale_ignored\` in CI.
- Each affected test now registers the simulated prompt ts via \`trackApprovalPromptTs\` before the reaction, passes the ts through as \`approvalMessageTs\` (or via \`sourceMetadata.messageId\` for the HTTP-level test), and clears the tracker in setup to prevent cross-test bleed.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24680624738/job/72176594135
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
