### PR TITLE
test(meet): fix meetingId mismatch in consent-monitor live harness

### DIFF
--- a/skills/meet-join/daemon/__tests__/consent-monitor-live.test.ts
+++ b/skills/meet-join/daemon/__tests__/consent-monitor-live.test.ts
@@ -237,8 +237,9 @@ maybeDescribe("consent-monitor live LLM judgement", () => {
         const session = makeFakeSessionManager();
         const timer = makeTimerControl();
 
+        const meetingId = fixture.events[0]!.meetingId;
         const monitor = new MeetConsentMonitor({
-          meetingId: `live-${fixture.name}`,
+          meetingId,
           assistantId: "self",
           sessionManager: session,
           config: {
@@ -257,7 +258,6 @@ maybeDescribe("consent-monitor live LLM judgement", () => {
         });
         monitor.start();
 
-        const meetingId = fixture.events[0]!.meetingId;
         for (const event of fixture.events) {
           dispatcher.dispatch(meetingId, event);
         }


### PR DESCRIPTION
## Summary
Follow-up to #26640. The live smoke harness constructed the monitor with a synthetic `live-${fixture.name}` meetingId while dispatching events keyed on each fixture's own meetingId (`live-1`, `live-2`, …). The fake dispatcher's Map lookup never matched, so the monitor buffer stayed empty and the LLM was never invoked — objection cases failed and non-objection cases passed vacuously.

Use `fixture.events[0]!.meetingId` for monitor construction so subscribe and dispatch agree.

## Test plan
- [ ] `MEET_CONSENT_MONITOR_LIVE=1 bun test skills/meet-join/daemon/__tests__/consent-monitor-live.test.ts` (manual, maintainer-run)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
