### PR TITLE
fix(meet-ext): split handle-send-chat out of content-script entrypoint

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the content-script `handleSendChat` handler.
+ * Unit tests for the `handleSendChat` runtime tool-path handler.
  *
  * `handleSendChat` is the path Meet takes when the daemon routes a
  * `meet_send_chat` tool invocation through the extension. We need to
@@ -9,12 +9,15 @@
  * from inside `runJoinFlow`. Without those emits, Meet's `isTrusted`
  * gate silently swallows every post-admission send.
  *
- * `content.ts` runs extension-scoped side effects at import time
- * (`console.log(location.href)` and `chrome.runtime.onMessage.addListener`),
- * so we install a fake `chrome` + JSDOM globals before the dynamic import
- * below. The test then drives the `__handleSendChat` export directly and
- * inspects the `chrome.runtime.sendMessage` call log for the expected
- * event sequence.
+ * The handler and queue live in `handle-send-chat.ts` — separate from
+ * `content.ts` so the content-script entrypoint stays side-effect-only
+ * (Chrome loads MV3 content scripts as classic scripts; a stray
+ * `export` at the top level of `content.js` makes the whole bundle
+ * fail to parse at load time). Tests install a fake `chrome` + JSDOM
+ * globals before the dynamic import below so `sendChat`'s bare
+ * `document` / `chrome.runtime` references resolve to the fixture, then
+ * drive the exported handler directly and inspect the
+ * `chrome.runtime.sendMessage` call log for the expected event sequence.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -155,15 +158,14 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
 
   beforeEach(async () => {
     harness = installHarness();
-    // Dynamic import so the content-script side effects (addListener,
-    // location.href console.log) execute against the installed harness
-    // instead of the bare Bun runtime.
-    const mod = (await import("../content.js")) as {
-      __handleSendChat: typeof handleSendChat;
-      __enqueueSendChat: typeof enqueueSendChat;
+    // Dynamic import so `sendChat`'s module-scoped references to DOM
+    // globals resolve against the installed harness on first evaluation.
+    const mod = (await import("../handle-send-chat.js")) as {
+      handleSendChat: typeof handleSendChat;
+      enqueueSendChat: typeof enqueueSendChat;
     };
-    handleSendChat = mod.__handleSendChat;
-    enqueueSendChat = mod.__enqueueSendChat;
+    handleSendChat = mod.handleSendChat;
+    enqueueSendChat = mod.enqueueSendChat;
   });
 
   afterEach(() => {

--- a/skills/meet-join/meet-controller-ext/src/content.ts
+++ b/skills/meet-join/meet-controller-ext/src/content.ts
@@ -24,18 +24,16 @@
  * in that case because the scrapers require an admitted meeting.
  */
 import type {
-  BotCameraDisableCommand,
-  BotCameraEnableCommand,
-  BotSendChatCommand,
   BotToExtensionMessage,
-  ExtensionCameraResultMessage,
-  ExtensionSendChatResultMessage,
   ExtensionToBotMessage,
 } from "../../contracts/native-messaging.js";
 import { BotToExtensionMessageSchema } from "../../contracts/native-messaging.js";
 
-import { disableCamera, enableCamera } from "./features/camera.js";
-import { type ChatReader, sendChat, startChatReader } from "./features/chat.js";
+import {
+  enqueueSendChat,
+  handleCameraToggle,
+} from "./handle-send-chat.js";
+import { type ChatReader, startChatReader } from "./features/chat.js";
 import { runJoinFlow } from "./features/join.js";
 import {
   startParticipantScraper,
@@ -193,37 +191,6 @@ function startMeetingSession(
  */
 let activeSession: MeetingSessionHandle | null = null;
 
-/**
- * Per-tab serialization chain for `send_chat` handling. `sendChat` mutates
- * a single shared textarea (`.value = text`) and then clicks the send
- * button, so overlapping requests would otherwise race on the composer.
- * Chaining onto this promise forces strict arrival-order processing while
- * leaving the `onMessage` listener synchronous (the listener returns
- * immediately; handling happens off-thread).
- */
-let sendChatQueue: Promise<void> = Promise.resolve();
-
-/**
- * Chain a `send_chat` invocation onto the per-tab queue so it runs
- * strictly after any prior in-flight `sendChat` call has completed.
- * Extracted from the inline listener wiring so tests can drive the queue
- * directly (Bun caches ESM modules across tests, so the listener's
- * `chrome.runtime.onMessage.addListener` registration happens once at
- * first-import time — not re-runnable against a fresh fake chrome on
- * each test).
- */
-function enqueueSendChat(cmd: BotSendChatCommand): Promise<void> {
-  sendChatQueue = sendChatQueue
-    .catch(() => {
-      // A prior `handleSendChat` rejection must not poison subsequent
-      // sends — the handler catches its own errors and reports them via
-      // `send_chat_result(ok=false)`, so any rejection here is a bug we
-      // still want to isolate from the next request.
-    })
-    .then(() => handleSendChat(cmd));
-  return sendChatQueue;
-}
-
 chrome.runtime.onMessage.addListener(
   (
     raw: unknown,
@@ -357,132 +324,3 @@ async function handleJoin(
   }
 }
 
-/**
- * Execute a {@link BotSendChatCommand} and emit a matching
- * {@link ExtensionSendChatResultMessage} back to the background. Errors
- * are caught and surfaced via `ok: false` so the bot can correlate the
- * failure with the originating request.
- *
- * Threads an `onEvent` sink + `window` reference through to
- * {@link sendChat} so the runtime `meet_send_chat` tool path emits
- * `trusted_type` (for the composer) and `trusted_click` (for the send
- * button) just like the consent-post path does inside `runJoinFlow`.
- * Without this, Meet's `isTrusted` gate silently swallows both the
- * synthetic composer input and the JS `.click()` on the send button —
- * every post-admission send would no-op on production Meet builds that
- * enforce the gate.
- */
-async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
-  const sendToBot = (event: ExtensionToBotMessage): void => {
-    try {
-      void chrome.runtime.sendMessage(event);
-    } catch (err) {
-      console.warn("[meet-ext] sendMessage failed:", err);
-    }
-  };
-
-  let reply: ExtensionSendChatResultMessage;
-  try {
-    await sendChat(cmd.text, {
-      onEvent: sendToBot,
-      // Pass the live `window` so `sendChat` can compute screen-space
-      // coordinates for the send button's `trusted_click`. Mirrors the
-      // fallback that `postConsentMessage` relies on in `features/join.ts`.
-      window: globalThis as unknown as {
-        screenX: number;
-        screenY: number;
-        outerHeight: number;
-        innerHeight: number;
-      },
-    });
-    reply = {
-      type: "send_chat_result",
-      requestId: cmd.requestId,
-      ok: true,
-    };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    reply = {
-      type: "send_chat_result",
-      requestId: cmd.requestId,
-      ok: false,
-      error: message,
-    };
-  }
-  try {
-    chrome.runtime.sendMessage(reply);
-  } catch (err) {
-    console.warn("[meet-ext] failed to send send_chat_result:", err);
-  }
-}
-
-/**
- * Execute a {@link BotCameraEnableCommand} / {@link BotCameraDisableCommand}
- * and emit a matching {@link ExtensionCameraResultMessage} back to the
- * background. Mirrors {@link handleSendChat}: forwards a trusted_click via
- * `onEvent` so the bot drives the click through xdotool (Meet's isTrusted
- * gate rejects synthetic clicks on bottom-toolbar controls in general, so
- * we assume the camera toggle is gated too and route through xdotool by
- * default). Errors are surfaced via `ok: false` with a descriptive reason.
- */
-async function handleCameraToggle(
-  cmd: BotCameraEnableCommand | BotCameraDisableCommand,
-): Promise<void> {
-  const sendToBot = (event: ExtensionToBotMessage): void => {
-    try {
-      void chrome.runtime.sendMessage(event);
-    } catch (err) {
-      console.warn("[meet-ext] sendMessage failed:", err);
-    }
-  };
-
-  let reply: ExtensionCameraResultMessage;
-  try {
-    const run = cmd.type === "camera.enable" ? enableCamera : disableCamera;
-    const result = await run({
-      onEvent: sendToBot,
-      // Pass the live `window` so the camera feature can compute screen-
-      // space coordinates for the toggle's `trusted_click`. Mirrors the
-      // fallback that `postConsentMessage` / `sendChat` rely on.
-      window: globalThis as unknown as {
-        screenX: number;
-        screenY: number;
-        outerHeight: number;
-        innerHeight: number;
-      },
-    });
-    reply = {
-      type: "camera_result",
-      requestId: cmd.requestId,
-      ok: true,
-      changed: result.changed,
-    };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    reply = {
-      type: "camera_result",
-      requestId: cmd.requestId,
-      ok: false,
-      error: message,
-    };
-  }
-  try {
-    chrome.runtime.sendMessage(reply);
-  } catch (err) {
-    console.warn("[meet-ext] failed to send camera_result:", err);
-  }
-}
-
-// Export the send-chat + camera-toggle handlers for unit testing. They are
-// wired into `chrome.runtime.onMessage` above when the script loads; the
-// tests import them directly to drive the tool paths end-to-end without
-// needing to fake the chrome.runtime.onMessage dispatcher. Not part of the
-// extension's public surface — the background SW never imports content.ts.
-export { handleSendChat as __handleSendChat };
-export { handleCameraToggle as __handleCameraToggle };
-// Exported so the per-tab serialization queue can be exercised directly
-// by tests. The `chrome.runtime.onMessage` listener is registered once at
-// module-load time (Bun's ESM cache prevents re-running module top level
-// across tests), so tests that want to assert ordering for overlapping
-// `send_chat` frames drive this helper instead of the raw listener.
-export { enqueueSendChat as __enqueueSendChat };

--- a/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/handle-send-chat.ts
@@ -1,0 +1,168 @@
+/**
+ * Runtime tool-path handlers for `send_chat` and `camera.*` commands.
+ *
+ * Split out from `content.ts` so the content-script entrypoint can stay
+ * side-effect-only with no top-level `export` tokens. Chrome loads
+ * `content_scripts` as classic scripts; any `export` in `content.js`
+ * makes the whole bundle fail to parse at load time, silently killing
+ * every Meet handler in production. Tests import the handlers from this
+ * module directly instead of the entrypoint.
+ */
+import type {
+  BotCameraDisableCommand,
+  BotCameraEnableCommand,
+  BotSendChatCommand,
+  ExtensionCameraResultMessage,
+  ExtensionSendChatResultMessage,
+  ExtensionToBotMessage,
+} from "../../contracts/native-messaging.js";
+
+import { disableCamera, enableCamera } from "./features/camera.js";
+import { sendChat } from "./features/chat.js";
+
+/**
+ * Execute a {@link BotSendChatCommand} and emit a matching
+ * {@link ExtensionSendChatResultMessage} back to the background. Errors
+ * are caught and surfaced via `ok: false` so the bot can correlate the
+ * failure with the originating request.
+ *
+ * Threads an `onEvent` sink + `window` reference through to
+ * {@link sendChat} so the runtime `meet_send_chat` tool path emits
+ * `trusted_type` (for the composer) and `trusted_click` (for the send
+ * button) just like the consent-post path does inside `runJoinFlow`.
+ * Without this, Meet's `isTrusted` gate silently swallows both the
+ * synthetic composer input and the JS `.click()` on the send button —
+ * every post-admission send would no-op on production Meet builds that
+ * enforce the gate.
+ */
+export async function handleSendChat(cmd: BotSendChatCommand): Promise<void> {
+  const sendToBot = (event: ExtensionToBotMessage): void => {
+    try {
+      void chrome.runtime.sendMessage(event);
+    } catch (err) {
+      console.warn("[meet-ext] sendMessage failed:", err);
+    }
+  };
+
+  let reply: ExtensionSendChatResultMessage;
+  try {
+    await sendChat(cmd.text, {
+      onEvent: sendToBot,
+      // Pass the live `window` so `sendChat` can compute screen-space
+      // coordinates for the send button's `trusted_click`. Mirrors the
+      // fallback that `postConsentMessage` relies on in `features/join.ts`.
+      window: globalThis as unknown as {
+        screenX: number;
+        screenY: number;
+        outerHeight: number;
+        innerHeight: number;
+      },
+    });
+    reply = {
+      type: "send_chat_result",
+      requestId: cmd.requestId,
+      ok: true,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    reply = {
+      type: "send_chat_result",
+      requestId: cmd.requestId,
+      ok: false,
+      error: message,
+    };
+  }
+  try {
+    chrome.runtime.sendMessage(reply);
+  } catch (err) {
+    console.warn("[meet-ext] failed to send send_chat_result:", err);
+  }
+}
+
+/**
+ * Execute a {@link BotCameraEnableCommand} / {@link BotCameraDisableCommand}
+ * and emit a matching {@link ExtensionCameraResultMessage} back to the
+ * background. Mirrors {@link handleSendChat}: forwards a trusted_click via
+ * `onEvent` so the bot drives the click through xdotool (Meet's isTrusted
+ * gate rejects synthetic clicks on bottom-toolbar controls in general, so
+ * we assume the camera toggle is gated too and route through xdotool by
+ * default). Errors are surfaced via `ok: false` with a descriptive reason.
+ */
+export async function handleCameraToggle(
+  cmd: BotCameraEnableCommand | BotCameraDisableCommand,
+): Promise<void> {
+  const sendToBot = (event: ExtensionToBotMessage): void => {
+    try {
+      void chrome.runtime.sendMessage(event);
+    } catch (err) {
+      console.warn("[meet-ext] sendMessage failed:", err);
+    }
+  };
+
+  let reply: ExtensionCameraResultMessage;
+  try {
+    const run = cmd.type === "camera.enable" ? enableCamera : disableCamera;
+    const result = await run({
+      onEvent: sendToBot,
+      // Pass the live `window` so the camera feature can compute screen-
+      // space coordinates for the toggle's `trusted_click`. Mirrors the
+      // fallback that `postConsentMessage` / `sendChat` rely on.
+      window: globalThis as unknown as {
+        screenX: number;
+        screenY: number;
+        outerHeight: number;
+        innerHeight: number;
+      },
+    });
+    reply = {
+      type: "camera_result",
+      requestId: cmd.requestId,
+      ok: true,
+      changed: result.changed,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    reply = {
+      type: "camera_result",
+      requestId: cmd.requestId,
+      ok: false,
+      error: message,
+    };
+  }
+  try {
+    chrome.runtime.sendMessage(reply);
+  } catch (err) {
+    console.warn("[meet-ext] failed to send camera_result:", err);
+  }
+}
+
+/**
+ * Per-tab serialization chain for `send_chat` handling. `sendChat` mutates
+ * a single shared textarea (`.value = text`) and then clicks the send
+ * button, so overlapping requests would otherwise race on the composer.
+ * Chaining onto this promise forces strict arrival-order processing while
+ * leaving the `onMessage` listener synchronous (the listener returns
+ * immediately; handling happens off-thread).
+ */
+let sendChatQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Chain a `send_chat` invocation onto the per-tab queue so it runs
+ * strictly after any prior in-flight `sendChat` call has completed.
+ * Extracted from the inline listener wiring so tests can drive the queue
+ * directly (Bun caches ESM modules across tests, so the listener's
+ * `chrome.runtime.onMessage.addListener` registration happens once at
+ * first-import time — not re-runnable against a fresh fake chrome on
+ * each test).
+ */
+export function enqueueSendChat(cmd: BotSendChatCommand): Promise<void> {
+  sendChatQueue = sendChatQueue
+    .catch(() => {
+      // A prior `handleSendChat` rejection must not poison subsequent
+      // sends — the handler catches its own errors and reports them via
+      // `send_chat_result(ok=false)`, so any rejection here is a bug we
+      // still want to isolate from the next request.
+    })
+    .then(() => handleSendChat(cmd));
+  return sendChatQueue;
+}


### PR DESCRIPTION
## Summary
- Move `handleSendChat`, `handleCameraToggle`, and the `enqueueSendChat` per-tab serialization queue into a new `skills/meet-join/meet-controller-ext/src/handle-send-chat.ts` module.
- `content.ts` imports them from the helper as a named-import side effect; all top-level `export` tokens (`__handleSendChat`, `__handleCameraToggle`, `__enqueueSendChat`) removed.
- Tests now dynamic-import `../handle-send-chat.js` and use the plain names.

## Why
Addresses Codex P1 on #26664: Chrome MV3 `content_scripts` are loaded as classic scripts, so any `export` token in the built `content.js` can make the entire bundle fail to parse at load time, silently dropping every Meet handler in production. The helper module keeps the test surface while `content.ts` stays side-effect-only.

Verified `dist/content.js` contains zero `export` tokens after `bun run build`, and the 4 existing `content-send-chat.test.ts` tests still pass.

## Test plan
- [x] `bun test skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts` — 4 pass
- [x] `bunx tsc --noEmit` inside `skills/meet-join/meet-controller-ext` — clean
- [x] `bun run build` produces `dist/content.js` with no top-level or embedded `export` tokens
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
