### PR TITLE
fix(home): use contentBackground for HomeLinkFileRow icon circle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeLinkFileRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/RecapCards/HomeLinkFileRow.swift
@@ -33,11 +33,14 @@ struct HomeLinkFileRow: View {
 
     // MARK: - Icon circle
 
-    /// 26pt circular container with active surface background.
+    /// 26pt circular container with the `contentBackground` token as its
+    /// fill so the circle reads as a distinct beige chip against the
+    /// lighter `surfaceOverlay` outer pill (matches Figma node
+    /// `3496:72525` — `bg-[#f2f0ee]`).
     private var iconCircle: some View {
         ZStack {
             Circle()
-                .fill(VColor.surfaceLift)
+                .fill(VColor.contentBackground)
                 .frame(width: 26, height: 26)
 
             VIconView(icon, size: 12)


### PR DESCRIPTION
## Summary
The `HomeLinkFileRow` icon circle was filled with `VColor.surfaceLift` (`#FFFFFF`), which made it blend into the `VColor.surfaceOverlay` (`#FDFDFC`) pill behind it — the circle looked like it wasn't rendered. Swap the fill to `VColor.contentBackground` (`#F2F0EE`) so it reads as a distinct beige chip, matching Figma node `3496:72525` (`bg-[#f2f0ee] rounded-[100px]`).

## Test plan
- [x] `swift build` green
- [ ] Open the gallery → `HomeEmailEditor`: the attachment chip's icon now sits in a visible beige circle inside the pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
