### PR TITLE
fix(slack): trust-filter transcript, fix DM chatType check, and skip chronological override post-compaction

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -30,6 +30,7 @@ import {
   injectNowScratchpad,
   injectSubagentStatus,
   isGroupChatType,
+  isSlackChannelConversation,
   loadSlackActiveThreadFocusBlock,
   loadSlackChronologicalMessages,
   resolveChannelCapabilities,
@@ -366,6 +367,56 @@ describe("isGroupChatType", () => {
   test("returns false for undefined/empty", () => {
     expect(isGroupChatType(undefined)).toBe(false);
     expect(isGroupChatType("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSlackChannelConversation
+// ---------------------------------------------------------------------------
+
+describe("isSlackChannelConversation", () => {
+  const base = {
+    dashboardCapable: false,
+    supportsDynamicUi: false,
+    supportsVoiceInput: false,
+  } as const;
+
+  test("returns true for Slack channels (chatType === channel)", () => {
+    expect(
+      isSlackChannelConversation({
+        channel: "slack",
+        chatType: "channel",
+        ...base,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for Slack DMs regardless of chatType shape", () => {
+    // Gateway omits chatType entirely for DM message events — the prior
+    // `chatType !== "im"` check misclassified these (undefined !== "im")
+    // as channels and leaked thread-only behaviour into DMs.
+    expect(isSlackChannelConversation({ channel: "slack", ...base })).toBe(
+      false,
+    );
+    expect(
+      isSlackChannelConversation({
+        channel: "slack",
+        chatType: "im",
+        ...base,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for non-Slack channels", () => {
+    expect(
+      isSlackChannelConversation({
+        channel: "telegram",
+        chatType: "channel",
+        ...base,
+      }),
+    ).toBe(false);
+    expect(isSlackChannelConversation(null)).toBe(false);
+    expect(isSlackChannelConversation()).toBe(false);
   });
 });
 
@@ -2171,7 +2222,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const slackChronologicalMessages = loadSlackChronologicalMessages(
       "conv-1",
       slackChannelCaps,
-      () => rows,
+      { loader: () => rows, trustClass: "guardian" },
     );
     const lastUserMessage: Message = {
       role: "user",
@@ -2661,7 +2712,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const slackChronologicalMessages = loadSlackChronologicalMessages(
       "conv-1",
       slackChannelCaps,
-      () => rows,
+      { loader: () => rows, trustClass: "guardian" },
     );
 
     const result = await applyRuntimeInjections(
@@ -2735,6 +2786,52 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).toContain("please answer concisely");
   });
 
+  // ── trust-filter regression for loadSlackChronologicalMessages ───────
+  // PR 26628 originally bypassed the trust filter by calling `getMessages`
+  // directly. For untrusted actors, guardian-scoped rows must be excluded
+  // from the chronological transcript the same way `loadFromDb` filters
+  // them out of the default history.
+  test("loadSlackChronologicalMessages filters guardian-scoped rows for untrusted actors", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    // Row 1 has no provenance → guardian-scoped (filtered out).
+    // Row 2 has provenance.trustClass === "trusted_contact" (kept).
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m1",
+        createdAt: 1700000000_000,
+        text: "guardian-only context",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+      userRow({
+        id: "m2",
+        createdAt: 1700000010_000,
+        text: "from untrusted actor",
+        slackMeta: buildSlackMeta({ channelTs: T1, displayName: "bob" }),
+        extraOuterMetadata: {
+          provenanceTrustClass: "trusted_contact",
+        },
+      }),
+    ];
+    const result = loadSlackChronologicalMessages("conv-1", caps, {
+      loader: () => rows,
+      trustClass: "trusted_contact",
+    });
+    expect(result).not.toBeNull();
+    const allText = result!
+      .flatMap((m) => m.content)
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).not.toContain("guardian-only context");
+    expect(allText).toContain("from untrusted actor");
+  });
+
   // ── loadSlackChronologicalMessages returns null for non-slack channels ─
   test("loadSlackChronologicalMessages returns null for non-slack channels", () => {
     const result = loadSlackChronologicalMessages(
@@ -2746,7 +2843,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         supportsVoiceInput: false,
         chatType: "private",
       },
-      () => [],
+      { loader: () => [] },
     );
     expect(result).toBeNull();
   });
@@ -2779,12 +2876,12 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const slackChronologicalMessages = loadSlackChronologicalMessages(
       "conv-1",
       slackChannelCaps,
-      () => rows,
+      { loader: () => rows, trustClass: "guardian" },
     );
     const focusBlock = loadSlackActiveThreadFocusBlock(
       "conv-1",
       slackChannelCaps,
-      () => rows,
+      { loader: () => rows, trustClass: "guardian" },
     );
     const lastUserMessage: Message = {
       role: "user",
@@ -3139,7 +3236,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         supportsVoiceInput: false,
         chatType: "private",
       },
-      () => [],
+      { loader: () => [] },
     );
     expect(result).toBeNull();
   });
@@ -3147,23 +3244,39 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   test("loadSlackActiveThreadFocusBlock returns null for Slack DMs (no threads)", () => {
     // DMs do not have threads, so the focus block is always a no-op.
     // The loader short-circuits before invoking the row loader so the
-    // DB read is skipped entirely.
+    // DB read is skipped entirely. Covers both the gateway-omitted
+    // `chatType === undefined` case and the explicit `chatType === "im"`
+    // shape some fixtures still emit.
     let loaderCalls = 0;
-    const result = loadSlackActiveThreadFocusBlock(
-      "conv-1",
-      {
-        channel: "slack",
-        dashboardCapable: false,
-        supportsDynamicUi: false,
-        supportsVoiceInput: false,
-        chatType: "im",
-      },
-      () => {
-        loaderCalls += 1;
-        return [];
-      },
-    );
-    expect(result).toBeNull();
+    const dmCapsWithImType: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "im",
+    };
+    expect(
+      loadSlackActiveThreadFocusBlock("conv-1", dmCapsWithImType, {
+        loader: () => {
+          loaderCalls += 1;
+          return [];
+        },
+      }),
+    ).toBeNull();
+    const dmCapsNoChatType: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+    expect(
+      loadSlackActiveThreadFocusBlock("conv-1", dmCapsNoChatType, {
+        loader: () => {
+          loaderCalls += 1;
+          return [];
+        },
+      }),
+    ).toBeNull();
     expect(loaderCalls).toBe(0);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -904,6 +904,7 @@ export async function runAgentLoopImpl(
       ? loadSlackChronologicalMessages(
           ctx.conversationId,
           ctx.channelCapabilities!,
+          { trustClass: ctx.trustContext?.trustClass },
         )
       : null;
 
@@ -918,8 +919,17 @@ export async function runAgentLoopImpl(
       ? loadSlackActiveThreadFocusBlock(
           ctx.conversationId,
           ctx.channelCapabilities!,
+          { trustClass: ctx.trustContext?.trustClass },
         )
       : null;
+
+    // Guards the chronological-transcript override on re-injection after
+    // the reducer compacts `ctx.messages`. The captured transcript is the
+    // full persisted history; blindly replaying it on every re-inject would
+    // overwrite the reducer's compacted messages and undo compaction. Flip
+    // to `true` after any compaction so subsequent re-injections fall back
+    // to the reduced `ctx.messages`.
+    let reducerCompacted = compactedThisTurn;
 
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
@@ -1064,6 +1074,7 @@ export async function runAgentLoopImpl(
             step.compactionResult.compactedPersistedMessages,
           );
           shouldInjectWorkspace = true;
+          reducerCompacted = true;
         }
 
         // Re-inject with potentially downgraded injection mode.
@@ -1081,6 +1092,13 @@ export async function runAgentLoopImpl(
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
+          // Once the reducer has compacted `ctx.messages`, the captured
+          // `slackChronologicalMessages` snapshot (built from the full
+          // persisted transcript) would overwrite the compacted history
+          // and undo compaction. Suppress the override from here on.
+          slackChronologicalMessages: reducerCompacted
+            ? null
+            : injectionOpts.slackChronologicalMessages,
           mode: currentInjectionMode,
         });
         if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -1249,6 +1267,7 @@ export async function runAgentLoopImpl(
       );
       if (midLoopCompact.compacted) {
         ctx.messages = midLoopCompact.messages;
+        reducerCompacted = true;
         ctx.contextCompactedMessageCount +=
           midLoopCompact.compactedPersistedMessages;
         ctx.contextCompactedAt = Date.now();
@@ -1302,6 +1321,12 @@ export async function runAgentLoopImpl(
         workspaceTopLevelContext: shouldInjectWorkspace
           ? ctx.workspaceTopLevelContext
           : null,
+        // Suppress the chronological-transcript snapshot once the reducer
+        // has collapsed `ctx.messages`; the captured snapshot reflects the
+        // full persisted transcript and would overwrite compaction.
+        slackChronologicalMessages: reducerCompacted
+          ? null
+          : injectionOpts.slackChronologicalMessages,
         mode: currentInjectionMode,
       });
       if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -1517,6 +1542,7 @@ export async function runAgentLoopImpl(
             step.compactionResult.compactedPersistedMessages,
           );
           shouldInjectWorkspace = true;
+          reducerCompacted = true;
         }
 
         // Only re-inject NOW.md when ctx.messages was actually stripped;
@@ -1529,6 +1555,9 @@ export async function runAgentLoopImpl(
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
+          slackChronologicalMessages: reducerCompacted
+            ? null
+            : injectionOpts.slackChronologicalMessages,
           mode: currentInjectionMode,
         });
         if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -1612,6 +1641,7 @@ export async function runAgentLoopImpl(
               );
             if (emergencyCompact.compacted) {
               ctx.messages = emergencyCompact.messages;
+              reducerCompacted = true;
               ctx.contextCompactedMessageCount +=
                 emergencyCompact.compactedPersistedMessages;
               ctx.contextCompactedAt = Date.now();
@@ -1665,6 +1695,9 @@ export async function runAgentLoopImpl(
               workspaceTopLevelContext: shouldInjectWorkspace
                 ? ctx.workspaceTopLevelContext
                 : null,
+              slackChronologicalMessages: reducerCompacted
+                ? null
+                : injectionOpts.slackChronologicalMessages,
               mode: currentInjectionMode,
             });
             if (isTrustedActor && currentInjectionMode !== "minimal") {
@@ -1744,6 +1777,7 @@ export async function runAgentLoopImpl(
           );
           if (emergencyCompact.compacted) {
             ctx.messages = emergencyCompact.messages;
+            reducerCompacted = true;
             ctx.contextCompactedMessageCount +=
               emergencyCompact.compactedPersistedMessages;
             ctx.contextCompactedAt = Date.now();
@@ -1797,6 +1831,9 @@ export async function runAgentLoopImpl(
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext
               : null,
+            slackChronologicalMessages: reducerCompacted
+              ? null
+              : injectionOpts.slackChronologicalMessages,
             mode: currentInjectionMode,
           });
           if (isTrustedActor && currentInjectionMode !== "minimal") {

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -25,10 +25,7 @@ import {
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
 import { unregisterConversationSender } from "../tools/browser/browser-screencast.js";
-import {
-  type AbortReason,
-  createAbortReason,
-} from "../util/abort-reasons.js";
+import { type AbortReason, createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import {
   unregisterCallNotifiers,
@@ -65,7 +62,9 @@ function parseProvenanceTrustClass(
   return undefined;
 }
 
-function filterMessagesForUntrustedActor(messages: MessageRow[]): MessageRow[] {
+export function filterMessagesForUntrustedActor(
+  messages: MessageRow[],
+): MessageRow[] {
   return messages.filter((m) => {
     const provenanceTrustClass = parseProvenanceTrustClass(m.metadata);
     return (

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -25,13 +25,18 @@ import {
 } from "../messaging/providers/slack/render-transcript.js";
 import { isPermissionControlsV2Enabled } from "../permissions/v2-consent-policy.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+import {
+  type ActorTrustContext,
+  isUntrustedTrustClass,
+  type TrustClass,
+} from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import { filterMessagesForUntrustedActor } from "./conversation-lifecycle.js";
 import {
   getInContextPkbPaths,
   type PkbContextConversation,
@@ -1185,8 +1190,15 @@ export function stripTransportHints(messages: Message[]): Message[] {
 /**
  * True when the channel capabilities describe a Slack non-DM conversation
  * (group/channel/mpim). Used to gate thread-only behavior such as the
- * `<active_thread>` focus block. DMs (`chatType === "im"`) are excluded
- * because they have no threads.
+ * `<active_thread>` focus block. DMs are excluded because they have no
+ * threads.
+ *
+ * The gateway normalizer sets `chatType: "channel"` for every non-DM Slack
+ * conversation (public, private, and mpim alike — see
+ * `gateway/src/slack/normalize.ts`) and omits the field entirely for DMs.
+ * We therefore accept on `chatType === "channel"` rather than negating
+ * against `"im"` — the prior `!== "im"` check incorrectly classified DMs
+ * (where the gateway-omitted field is `undefined`) as channels.
  *
  * The chronological-transcript override applies to ALL Slack
  * conversations (channels and DMs) — gate that on
@@ -1197,7 +1209,7 @@ export function isSlackChannelConversation(
 ): boolean {
   return (
     channelCapabilities?.channel === "slack" &&
-    channelCapabilities.chatType !== "im"
+    channelCapabilities.chatType === "channel"
   );
 }
 
@@ -1343,19 +1355,33 @@ export function assembleSlackChronologicalMessages(
  * The loader is exposed as a parameter so tests can substitute a stub. In
  * production it defaults to `getMessages` from `conversation-crud.ts`.
  *
+ * When `trustClass` identifies an untrusted actor (guardian-scoped rows
+ * must not leak into the model context), rows are passed through
+ * `filterMessagesForUntrustedActor` before assembly — mirroring the
+ * filtering applied in `loadFromDb` so the chronological transcript
+ * respects the same per-actor scoping as the default history path.
+ *
  * Returns `null` when the channel is not Slack — callers should fall
  * through to the default in-memory message history.
  */
 export function loadSlackChronologicalMessages(
   conversationId: string,
   capabilities: ChannelCapabilities,
-  loader: (id: string) => MessageRow[] = defaultGetMessages,
+  options: {
+    loader?: (id: string) => MessageRow[];
+    trustClass?: TrustClass;
+  } = {},
 ): Message[] | null {
   if (capabilities.channel !== "slack") {
     return null;
   }
+  const loader = options.loader ?? defaultGetMessages;
+  const allRows = loader(conversationId);
+  const scopedRows = isUntrustedTrustClass(options.trustClass)
+    ? filterMessagesForUntrustedActor(allRows)
+    : allRows;
   // Coerce MessageRow.role (string) to the structural row's stricter union.
-  const rows: SlackTranscriptInputRow[] = loader(conversationId).map((row) => ({
+  const rows: SlackTranscriptInputRow[] = scopedRows.map((row) => ({
     role: row.role === "assistant" ? "assistant" : "user",
     content: row.content,
     createdAt: row.createdAt,
@@ -1494,8 +1520,11 @@ export function assembleSlackActiveThreadFocusBlock(
 ): string | null {
   if (capabilities.channel !== "slack") return null;
   // DMs do not have threads, so the focus block is always a no-op.
-  // Short-circuit explicitly to avoid scanning rows on every turn.
-  if (capabilities.chatType === "im") return null;
+  // The gateway sets `chatType: "channel"` for every non-DM Slack
+  // conversation and omits the field for DMs, so gate the focus block
+  // on the positive match rather than negating against `"im"` (which
+  // leaks through when `chatType` is `undefined`).
+  if (capabilities.chatType !== "channel") return null;
   const renderable = rows.map(rowToRenderable);
   const activeThreadTs = detectActiveThreadTs(renderable);
   if (!activeThreadTs) return null;
@@ -1511,11 +1540,19 @@ export function assembleSlackActiveThreadFocusBlock(
 export function loadSlackActiveThreadFocusBlock(
   conversationId: string,
   capabilities: ChannelCapabilities,
-  loader: (id: string) => MessageRow[] = defaultGetMessages,
+  options: {
+    loader?: (id: string) => MessageRow[];
+    trustClass?: TrustClass;
+  } = {},
 ): string | null {
   if (capabilities.channel !== "slack") return null;
-  if (capabilities.chatType === "im") return null;
-  const rows: SlackTranscriptInputRow[] = loader(conversationId).map((row) => ({
+  if (capabilities.chatType !== "channel") return null;
+  const loader = options.loader ?? defaultGetMessages;
+  const allRows = loader(conversationId);
+  const scopedRows = isUntrustedTrustClass(options.trustClass)
+    ? filterMessagesForUntrustedActor(allRows)
+    : allRows;
+  const rows: SlackTranscriptInputRow[] = scopedRows.map((row) => ({
     role: row.role === "assistant" ? "assistant" : "user",
     content: row.content,
     createdAt: row.createdAt,


### PR DESCRIPTION
Addresses four reviewer-flagged issues on #26628:

1. **Trust-filter bypass** — `loadSlackChronologicalMessages` and `loadSlackActiveThreadFocusBlock` used `getMessages` directly, bypassing the `filterMessagesForUntrustedActor` pass that `loadFromDb` applies. Guardian-scoped rows could leak into the context of an untrusted Slack actor. Both loaders now accept an optional `trustClass` and filter rows with the same predicate as the default-history path.

2. **DM misclassification** — `isSlackChannelConversation` and `assembleSlackActiveThreadFocusBlock` used `chatType !== 'im'`. The gateway sets `chatType: 'channel'` for non-DM Slack and **omits** the field for DMs (`undefined`, not `'im'`), so DMs were being treated as channels. Gated on `chatType === 'channel'` instead.

3. **Non-text blocks preserved** — the review concern about image/file/tool_result blocks being stripped was already addressed by #26661 (which plumbs `contentBlocks` through `rowToRenderable`). No additional change here.

4. **Stale-snapshot vs. compaction** — `injectionOpts.slackChronologicalMessages` is captured once per turn and re-used across preflight / mid-loop / convergence / emergency re-inject sites. After the reducer compacts, that captured snapshot would overwrite `ctx.messages` on the next re-inject and undo the compaction. Added a `reducerCompacted` flag that flips on any successful compact result and is consulted at each re-inject site to skip the override.

## Test plan

- [x] `bun test src/__tests__/conversation-runtime-assembly.test.ts` — all 153 tests pass including new regression coverage for `isSlackChannelConversation` (channel → true, DM with `'im'` or undefined → false), expanded DM focus-block test across both chatType shapes, and a new trust-filter regression test.
- [x] `bunx tsc --noEmit` clean for touched files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
