### PR TITLE
test(avatar-teardown): replace sleep with deterministic spawn signal

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-teardown.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-teardown.test.ts
@@ -471,6 +471,14 @@ describe("TalkingHeadRenderer stop() kills in-flight ffmpeg transcodes", () => {
     const nativeMessaging = new FakeNativeMessaging();
     const spawned: TrackedTranscode[] = [];
 
+    // Resolved the first time the spawn factory is invoked, so the test
+    // can deterministically wait for the renderer's `handleFrame` to
+    // reach the spawn call instead of racing a fixed-duration sleep.
+    let signalFirstSpawn!: () => void;
+    const firstSpawn = new Promise<void>((resolve) => {
+      signalFirstSpawn = resolve;
+    });
+
     // Spawn factory whose readY4m hangs until the child is killed —
     // mimicking an ffmpeg invocation that stalls on its input pipe. The
     // readY4m promise rejects when kill() is called so the renderer's
@@ -489,6 +497,7 @@ describe("TalkingHeadRenderer stop() kills in-flight ffmpeg transcodes", () => {
         },
       };
       spawned.push(tracked);
+      signalFirstSpawn();
       return {
         readY4m: () => blocking,
         exited: Promise.resolve(0),
@@ -521,8 +530,9 @@ describe("TalkingHeadRenderer stop() kills in-flight ffmpeg transcodes", () => {
       ts: 1,
     });
 
-    // Give the async handler path a turn to reach the `readY4m()` await.
-    await new Promise((r) => setTimeout(r, 5));
+    // Wait deterministically for the renderer's `handleFrame` to reach
+    // the spawn call — `firstSpawn` resolves inside the factory itself.
+    await firstSpawn;
     expect(spawned).toHaveLength(1);
     expect(spawned[0]!.killed).toBe(false);
 


### PR DESCRIPTION
Addresses Codex P2 feedback on #26673.

The `TalkingHeadRenderer stop() kills in-flight ffmpeg transcodes`
test used `await new Promise((r) => setTimeout(r, 5))` as a
spin-wait before asserting a spawned transcode child. That relies on
`handleFrame`'s async body reaching the spawn call within 5ms,
which is not guaranteed on a slow/loaded CI runner.

Replaced the sleep with a deterministic signal: the spawn factory
resolves a promise the first time it is invoked, and the test awaits
that promise instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
