### PR TITLE
fix(context): include retained thread refs in summary prompt

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -9,6 +9,7 @@ import {
   getSummaryFromContextMessage,
 } from "../context/window-manager.js";
 import type {
+  ContentBlock,
   Message,
   Provider,
   ProviderResponse,
@@ -1225,6 +1226,95 @@ describe("ContextWindowManager", () => {
     expect(seenPrompt).toBeDefined();
     expect(seenPrompt).toContain("Thread anchors");
     expect(seenPrompt).toContain("verbatim");
+  });
+
+  test("summary prompt lists retained-tail thread-reply references", async () => {
+    const capturedMessages: Message[][] = [];
+    const provider: Provider = {
+      name: "mock",
+      async sendMessage(messages: Message[]): Promise<ProviderResponse> {
+        capturedMessages.push(messages);
+        return {
+          content: [{ type: "text", text: "## Goals\n- ok" }],
+          model: "mock-model",
+          usage: { inputTokens: 60, outputTokens: 12 },
+          stopReason: "end_turn",
+        };
+      },
+    };
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ maxInputTokens: 600 }),
+    });
+    const long = "x".repeat(240);
+    // Compactable region ends before the retained tail, which contains a
+    // Slack-style reply line that cites its parent via `→ M1a2b3c`. The
+    // summary prompt must surface that reference so the Thread-anchors
+    // instruction has something to act on.
+    const history: Message[] = [
+      message("user", `[11/14/23 14:25 @alice]: parent kickoff ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `[11/14/23 14:28 @bob → M1a2b3c]: reply ${long}`),
+      message("assistant", `a3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    expect(capturedMessages.length).toBeGreaterThan(0);
+    const userPromptText = capturedMessages[0]
+      .flatMap((m) => m.content)
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n");
+    expect(userPromptText).toContain("### Retained Thread References");
+    expect(userPromptText).toContain("→ M1a2b3c");
+  });
+
+  test("summary prompt omits retained references when retained tail has no thread markers", async () => {
+    const capturedMessages: Message[][] = [];
+    const provider: Provider = {
+      name: "mock",
+      async sendMessage(messages: Message[]): Promise<ProviderResponse> {
+        capturedMessages.push(messages);
+        return {
+          content: [{ type: "text", text: "## Goals\n- ok" }],
+          model: "mock-model",
+          usage: { inputTokens: 60, outputTokens: 12 },
+          stopReason: "end_turn",
+        };
+      },
+    };
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ maxInputTokens: 600 }),
+    });
+    const long = "x".repeat(240);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+      message("assistant", `a3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    const userPromptText = capturedMessages[0]
+      .flatMap((m) => m.content)
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n");
+    expect(userPromptText).not.toContain("### Retained Thread References");
+    expect(userPromptText).not.toMatch(/→ M[0-9a-f]{6}]/);
   });
 
   test("does not subtract summaryOffset when summary at index 0 is child-owned from prior compaction", async () => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -31,7 +31,7 @@ const SUMMARY_SYSTEM_PROMPT = [
   "Focus on actionable state, not prose.",
   "Preserve concrete facts: goals, constraints, decisions, pending questions, file paths, commands, errors, and TODOs.",
   "Remove repetition and stale details that were superseded.",
-  'Thread anchors: when a compacted message is the parent of a thread whose replies survive in the retained context, preserve the parent\'s text verbatim — do not summarize or paraphrase it. Reactions on such anchors may be aggregated (e.g., "three users reacted").',
+  'Thread anchors: when a "Retained Thread References" section is present, each listed reply cites its parent via `→ Mxxxxxx`. If that parent appears in the Transcript, preserve its text verbatim (reactions may be aggregated as "N users reacted"). Omit when the section is absent.',
   "Return concise markdown using these section headers exactly:",
   "## Goals",
   "## Constraints",
@@ -40,6 +40,17 @@ const SUMMARY_SYSTEM_PROMPT = [
   "## Key Artifacts",
   "## Recent Progress",
 ].join("\n");
+
+/**
+ * Pattern matching a Slack-style reply tag-line's parent-alias reference.
+ * The chronological renderer emits reply lines as
+ * `[MM/DD/YY HH:MM @sender → Mxxxxxx]: body`, where `Mxxxxxx` is the first 6
+ * hex chars of sha256(threadTs). A retained-tail text block that contains
+ * this pattern is carrying a live reference to a parent that may still live
+ * in the compactable region — the summarizer needs to know about it to act
+ * on the Thread-anchors clause of SUMMARY_SYSTEM_PROMPT.
+ */
+const THREAD_REPLY_REFERENCE_PATTERN = /→ M[0-9a-f]{6}]/;
 
 export interface ContextWindowResult {
   messages: Message[];
@@ -457,13 +468,18 @@ export class ContextWindowManager {
       };
     }
 
+    const retainedThreadRefs = collectRetainedThreadReferences(
+      messages.slice(keepPlan.keepFromIndex),
+    );
     const transcriptBlocks = this.capTranscriptBlocksToTokenBudget(
       serializeMessagesToContentBlocks(compactableMessages),
       existingSummary ?? "No previous summary.",
+      retainedThreadRefs,
     );
     const summaryUpdate = await this.updateSummary(
       existingSummary ?? "No previous summary.",
       transcriptBlocks,
+      retainedThreadRefs,
       signal,
     );
     const summary = summaryUpdate.summary;
@@ -674,10 +690,13 @@ export class ContextWindowManager {
   private capTranscriptBlocksToTokenBudget(
     blocks: ContentBlock[],
     currentSummary: string,
+    retainedThreadRefs: string[],
   ): ContentBlock[] {
+    const retainedRefsText = retainedThreadRefs.join("\n");
     const overheadTokens =
       estimateTextTokens(SUMMARY_SYSTEM_PROMPT) +
       estimateTextTokens(currentSummary) +
+      estimateTextTokens(retainedRefsText) +
       // Scaffolding text in buildSummaryContentBlocks ("Update the summary...",
       // section headers, etc.) — generous fixed estimate.
       200 +
@@ -778,6 +797,7 @@ export class ContextWindowManager {
   private async updateSummary(
     currentSummary: string,
     transcriptBlocks: ContentBlock[],
+    retainedThreadRefs: string[],
     signal?: AbortSignal,
   ): Promise<{
     summary: string;
@@ -791,6 +811,7 @@ export class ContextWindowManager {
     const contentBlocks = buildSummaryContentBlocks(
       currentSummary,
       transcriptBlocks,
+      retainedThreadRefs,
     );
     const summaryMessage: Message = { role: "user", content: contentBlocks };
     try {
@@ -992,24 +1013,66 @@ export function createContextSummaryMessage(summary: string): Message {
 function buildSummaryContentBlocks(
   currentSummary: string,
   transcriptBlocks: ContentBlock[],
+  retainedThreadRefs: string[],
 ): ContentBlock[] {
+  const lines = [
+    "Update the summary with new transcript data.",
+    "If new information conflicts with older notes, keep the most recent and explicit detail.",
+    "Keep all unresolved asks and next steps.",
+    "For any images included below, describe their visual content in the summary so the information is preserved after compaction.",
+    "",
+    "### Existing Summary",
+    currentSummary.trim().length > 0 ? currentSummary.trim() : "None.",
+    "",
+  ];
+  if (retainedThreadRefs.length > 0) {
+    lines.push(
+      "### Retained Thread References",
+      "These reply tag lines remain in the live context after compaction. Each `→ Mxxxxxx` cites a parent message by alias; if that parent appears in the Transcript below, preserve its text verbatim.",
+      ...retainedThreadRefs.map((ref) => `- ${ref}`),
+      "",
+    );
+  }
+  lines.push("### Transcript");
   return [
     {
       type: "text",
-      text: [
-        "Update the summary with new transcript data.",
-        "If new information conflicts with older notes, keep the most recent and explicit detail.",
-        "Keep all unresolved asks and next steps.",
-        "For any images included below, describe their visual content in the summary so the information is preserved after compaction.",
-        "",
-        "### Existing Summary",
-        currentSummary.trim().length > 0 ? currentSummary.trim() : "None.",
-        "",
-        "### Transcript",
-      ].join("\n"),
+      text: lines.join("\n"),
     } as ContentBlock,
     ...transcriptBlocks,
   ];
+}
+
+/**
+ * Scan retained-tail messages for Slack-style reply tag lines that cite a
+ * thread parent via the `→ Mxxxxxx` alias convention. Returns the full tag
+ * line for each match (de-duplicated, order-preserved) so the summarizer
+ * has a concrete list of parents whose text must be preserved verbatim.
+ *
+ * Non-slack conversations and retained tails without any reply markers
+ * produce an empty list — in that case the summarizer is told explicitly
+ * that no verbatim preservation is required.
+ */
+function collectRetainedThreadReferences(
+  retainedMessages: Message[],
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const msg of retainedMessages) {
+    for (const block of msg.content) {
+      if (block.type !== "text") continue;
+      const text = (block as { text: string }).text;
+      for (const line of text.split("\n")) {
+        if (!THREAD_REPLY_REFERENCE_PATTERN.test(line)) continue;
+        const trimmed = line.trim();
+        if (trimmed.length === 0) continue;
+        if (seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        out.push(trimmed);
+      }
+    }
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a `### Retained Thread References` section to the summary prompt, populated by scanning the retained tail for Slack-style reply tag lines (`→ Mxxxxxx`)
- Tightens the `Thread anchors` clause in `SUMMARY_SYSTEM_PROMPT` to reference the new section
- Addresses Codex feedback on #26610: the previous Thread-anchors clause had no way to identify which parents had surviving replies, so it could silently no-op

## Why
The summary prompt's transcript covers only `compactableMessages` — the retained tail is excluded. Without the retained-tail reply references, the summarizer has no way to correlate thread anchors with surviving replies. The new section gives it a concrete list of reply tag lines so the verbatim-preservation instruction is actionable.

## Test plan
- [x] `bun test src/__tests__/context-window-manager.test.ts` (33 pass)
- [x] `bunx tsc --noEmit`
- [x] New test: section is emitted with `→ Mxxxxxx` lines when retained tail has reply markers
- [x] New test: section is omitted entirely when retained tail has no markers (zero overhead for non-Slack)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
