### PR TITLE
fix(meet-chat): skip synthetic setter when xdotool wired; scale type-wait to text length

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/chat.test.ts
@@ -447,9 +447,14 @@ describe("sendChat", () => {
     expect(sendButton).not.toBeNull();
 
     // Record the temporal order of:
-    //   1. the synthetic "input" event firing on the textarea (post `.value = text`)
-    //   2. each onEvent call (trusted_type or trusted_click for the send button)
-    //   3. the send-button click.
+    //   1. each onEvent call (trusted_type or trusted_click for the send button)
+    //   2. the send-button click.
+    //
+    // When `onEvent` is wired, `sendChat` deliberately does NOT dispatch
+    // the synthetic `input` event on the textarea — it relies on xdotool
+    // to land the keystrokes via trusted X-server events. The synthetic
+    // path is only taken as a fallback when no `onEvent` sink is
+    // provided (see the regression test below for that path).
     const timeline: Array<
       | { kind: "input"; value: string }
       | { kind: "event"; ev: ExtensionToBotMessage }
@@ -488,22 +493,17 @@ describe("sendChat", () => {
       expect(trustedType.text).toBe("hello");
     }
 
-    // Ordering: input event first (carries the native-setter value), then
-    // trusted_type, then any send-button trusted_click, then the JS click.
+    // With `onEvent` wired, no synthetic `input` event is dispatched —
+    // xdotool is the sole text-entry path. Ordering: trusted_type first,
+    // then any send-button trusted_click, then the JS click.
     const inputIdx = timeline.findIndex((e) => e.kind === "input");
     const trustedTypeIdx = timeline.findIndex(
       (e) => e.kind === "event" && e.ev.type === "trusted_type",
     );
     const sendClickIdx = timeline.findIndex((e) => e.kind === "send-click");
-    expect(inputIdx).toBeGreaterThanOrEqual(0);
-    expect(trustedTypeIdx).toBeGreaterThan(inputIdx);
+    expect(inputIdx).toBe(-1);
+    expect(trustedTypeIdx).toBeGreaterThanOrEqual(0);
     expect(sendClickIdx).toBeGreaterThan(trustedTypeIdx);
-
-    // The textarea should still carry the native-setter value at send time.
-    const sendEntry = timeline[sendClickIdx];
-    if (sendEntry && sendEntry.kind === "send-click") {
-      expect(sendEntry.inputValue).toBe("hello");
-    }
   });
 
   test("writes the textarea via the prototype value setter (React controlled-input bypass)", async () => {
@@ -677,9 +677,13 @@ describe("sendChat", () => {
     expect(trustedClicks[0]!.x).toBe(1330);
     expect(trustedClicks[0]!.y).toBe(820);
 
-    // Text populated + input event dispatched before the trusted_click emits.
-    expect(input.value).toBe("hello");
-    expect(inputEvents).toBeGreaterThanOrEqual(1);
+    // With `onEvent` wired, sendChat relies on xdotool for text entry and
+    // skips the synthetic `.value = text` + `input` event dispatch — the
+    // composer is populated by the bot's xdotool-driven keystrokes, not
+    // by the extension. So the textarea stays empty in-test, and no
+    // synthetic `input` event fires.
+    expect(input.value).toBe("");
+    expect(inputEvents).toBe(0);
 
     // JS click fallback still fires AFTER the trusted_click — the bot will
     // already have dispatched the real xdotool click by the time the JS
@@ -719,6 +723,8 @@ describe("postConsentMessage", () => {
 
     expect(installed!.panelToggleClicks()).toBe(1);
     expect(sendClicks).toBe(1);
+    // No `onEvent` wired → sendChat takes the synthetic-setter fallback,
+    // which still populates the composer in the jsdom harness.
     const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT);
     expect(input!.value).toBe("consent please");
   });

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-send-chat.test.ts
@@ -255,11 +255,13 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
     expect(trustedClickIdx).toBeGreaterThan(trustedTypeIdx);
     expect(resultIdx).toBeGreaterThan(trustedClickIdx);
 
-    // Composer value must also be populated via the native-setter path so
-    // the JS fallback still works for jsdom and any Meet build that does
-    // not enforce isTrusted on the composer.
+    // With `onEvent` wired (the handler always passes one), sendChat
+    // relies on xdotool to type the composer — the synthetic
+    // `.value = text` + `input` dispatch is skipped so that xdotool's
+    // appended keystrokes do not produce doubled text. In-test, where
+    // xdotool is stubbed out, the composer therefore remains empty.
     const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT)!;
-    expect(input.value).toBe("hello from runtime tool");
+    expect(input.value).toBe("");
   });
 
   test("still forwards send_chat_result(ok=false) when sendChat throws, without emitting trusted events", async () => {
@@ -332,39 +334,54 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
   });
 
   test("serializes overlapping send_chat commands so the wrong text is never posted", async () => {
-    // `sendChat` mutates a single shared textarea (`.value = text`) before
-    // clicking the send button, so two overlapping invocations would race
-    // on the composer: the second call's value-write lands before the
-    // first call's `.click()` fires, posting the wrong text while both
-    // requests still report ok=true. The fix chains `handleSendChat`
-    // invocations onto a per-tab Promise inside the `chrome.runtime
-    // .onMessage` listener, so the second call can't touch the DOM until
-    // the first has fully completed its send-button click.
+    // `sendChat` emits a `trusted_type` for the composer then waits
+    // (scaled to text length) before the send-button JS `.click()` +
+    // `trusted_click`, so two overlapping invocations would race on the
+    // shared Xvfb keyboard focus: the second call's trusted_type would
+    // interleave with the first call's keystrokes still in flight,
+    // producing a composer that contains "firstsecond" when the first
+    // send-click lands. The fix chains `handleSendChat` invocations onto
+    // a per-tab Promise inside the `chrome.runtime.onMessage` listener,
+    // so the second call can't emit its trusted_type until the first has
+    // fully completed its send-button click.
     //
     // This regression test drives two `send_chat` frames into the
     // exported `__enqueueSendChat` helper (the same entry point the
-    // listener uses) back-to-back and records the textarea value
-    // observed at each send-button click. With serialization, the clicks
-    // see "first" and "second" in order. Without it, both clicks see
-    // "second" because the second call's value-write clobbers the first
-    // before its click lands.
+    // listener uses) back-to-back and records the emitted-event stream
+    // so the ordering is visible. With serialization, the stream is
+    // [trusted_type("first"), trusted_click, js-click, trusted_type(
+    // "second"), trusted_click, js-click]. Without it, both
+    // trusted_types would fire before either click.
     const doc = harness!.dom.window.document;
-    const input = doc.querySelector<HTMLTextAreaElement>(chatSelectors.INPUT)!;
     const sendButton = doc.querySelector<HTMLButtonElement>(
       chatSelectors.SEND_BUTTON,
     )!;
 
-    const clickValues: string[] = [];
+    const timeline: string[] = [];
     sendButton.addEventListener("click", () => {
-      clickValues.push(input.value);
+      timeline.push("js-click");
     });
+
+    // Wrap sendMessage so emitted frames interleave with the js-click
+    // records above — must happen BEFORE enqueueing any handler call,
+    // since the first trusted_type emit fires synchronously on the
+    // handler's first turn.
+    const originalSendMessage = harness!.chrome.runtime.sendMessage;
+    harness!.chrome.runtime.sendMessage = (msg: unknown) => {
+      originalSendMessage.call(harness!.chrome.runtime, msg);
+      const m = msg as ExtensionToBotMessage;
+      if (m.type === "trusted_type") {
+        timeline.push(`trusted_type(${m.text})`);
+      } else if (m.type === "trusted_click") {
+        timeline.push("trusted_click");
+      }
+    };
 
     // Fire both frames synchronously into the queue, then wait for it to
     // drain. If the handler still `void`-launched each `handleSendChat`,
-    // both would run concurrently — the `setTimeout(250)` inside
-    // `sendChat` (onEvent-path delay before clicking send) would
-    // interleave the two calls and the second's value-write would
-    // clobber the first before click-1 fires.
+    // both would run concurrently — the length-scaled `setTimeout` inside
+    // `sendChat` (onEvent-path wait before clicking send) would
+    // interleave the two calls.
     const p1 = enqueueSendChat!({
       type: "send_chat",
       text: "first",
@@ -375,9 +392,18 @@ describe("handleSendChat (content-script meet_send_chat tool path)", () => {
       text: "second",
       requestId: "req-b",
     });
+
     await Promise.all([p1, p2]);
 
-    expect(clickValues).toEqual(["first", "second"]);
+    // Serialized ordering: every first-call event lands before any
+    // second-call event. In particular the first send-click fires before
+    // the second's trusted_type emits.
+    const firstTypeIdx = timeline.indexOf("trusted_type(first)");
+    const firstClickIdx = timeline.indexOf("js-click");
+    const secondTypeIdx = timeline.indexOf("trusted_type(second)");
+    expect(firstTypeIdx).toBeGreaterThanOrEqual(0);
+    expect(firstClickIdx).toBeGreaterThan(firstTypeIdx);
+    expect(secondTypeIdx).toBeGreaterThan(firstClickIdx);
 
     // Both results must still be emitted in order, each correlated with
     // the right requestId.

--- a/skills/meet-join/meet-controller-ext/src/features/chat.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/chat.ts
@@ -66,6 +66,22 @@ const ENSURE_PANEL_OPEN_TIMEOUT_MS = 2000;
  */
 export const MEET_CHAT_MAX_LENGTH = 2000;
 
+/**
+ * Per-character wait (ms) after emitting `trusted_type` so xdotool's
+ * X-server keystrokes finish landing in the composer before we dispatch
+ * the send-button click. Must match `xdotool --delay` (25ms/char) inside
+ * the bot — see `bot/src/browser/xdotool-type.ts`'s `DEFAULT_DELAY_MS`.
+ */
+const TRUSTED_TYPE_PER_CHAR_MS = 25;
+
+/**
+ * Fixed overhead added on top of the per-character scaling to cover
+ * xdotool startup + the native-messaging round-trip from extension →
+ * bot → X server. Sized from observed production latency (emit → first
+ * keystroke dispatched) plus a small safety margin.
+ */
+const TRUSTED_TYPE_OVERHEAD_MS = 250;
+
 /** Options passed to {@link startChatReader}. */
 export interface ChatReaderOptions {
   /** Meeting ID stamped on every emitted event. */
@@ -208,13 +224,20 @@ export function startChatReader(opts: ChatReaderOptions): ChatReader {
  * events (required by any Meet build that enforces `event.isTrusted` on
  * the corresponding controls):
  *
- * 1. After the native-setter `.value = text` + synthetic `input` event,
- *    the composer is focused and a `trusted_type` event is emitted so the
- *    bot can xdotool-type the text as real keystrokes. This is
- *    belt-and-suspenders: if Meet accepts the synthetic path, the
- *    xdotool-typed text lands in the same focused field and is harmless;
- *    if not, xdotool fills the gap. We wait ~250ms after emitting so the
- *    (async) keystrokes have time to land before clicking send.
+ * 1. The composer is focused and a `trusted_type` event is emitted so the
+ *    bot can xdotool-type the text as real keystrokes. We deliberately
+ *    skip the native-setter `.value = text` + synthetic `input` path when
+ *    `onEvent` is wired: xdotool types on top of whatever is already in
+ *    the composer, so populating it synthetically first would produce
+ *    doubled text ("hellohello"). The native-setter path is kept as a
+ *    fallback only for the `onEvent`-less case (jsdom tests and any Meet
+ *    build where synthetic input is accepted).
+ *
+ *    After emitting, we wait `text.length * TRUSTED_TYPE_PER_CHAR_MS +
+ *    TRUSTED_TYPE_OVERHEAD_MS` so the (async) xdotool keystrokes have
+ *    time to land before the send-button click is dispatched. A fixed
+ *    250ms window was too short for messages longer than ~10 characters
+ *    (xdotool's default per-keystroke delay is 25ms).
  *
  * 2. Before the send-button `.click()`, a `trusted_click` is emitted for
  *    the button's screen coordinates. This mirrors the panel-toggle fix
@@ -244,53 +267,74 @@ export async function sendChat(
     );
   }
 
-  // Meet's composer is a React-controlled textarea. React 16+ installs an
-  // instance-level property-descriptor interceptor (`inputValueTracking`)
-  // that hijacks `.value = ...`: when the synthetic `input` event fires,
-  // React compares the DOM value to its internal tracker and — because the
-  // interceptor updated the tracker in lockstep with the assignment —
-  // observes no change and skips the onChange dispatch. The result is a
-  // composer that visually shows the text but never commits to React state,
-  // so Send posts empty/stale content.
-  //
-  // The workaround is Playwright's `page.fill` trick: grab the native
-  // setter off `HTMLTextAreaElement.prototype` (which the React interceptor
-  // shadows at the instance level) and invoke it with `.call(input, text)`.
-  // That routes through the prototype setter without touching React's
-  // tracker, so the subsequent `input` event fires with a genuine value
-  // change and onChange runs normally. We still dispatch the synthetic
-  // `input` event ourselves — React relies on it as the trigger for
-  // onChange even after the value has been updated.
-  //
-  // If the native setter isn't resolvable for any reason (e.g. a jsdom
-  // build that doesn't expose the prototype descriptor), fall back to the
-  // direct `.value = ...` assignment. That path is adequate for the test
-  // harness and any pre-React-tracker Meet build.
-  const nativeSetter = Object.getOwnPropertyDescriptor(
-    HTMLTextAreaElement.prototype,
-    "value",
-  )?.set;
-  if (nativeSetter) {
-    nativeSetter.call(input, text);
-  } else {
-    input.value = text;
-  }
-  input.dispatchEvent(new Event("input", { bubbles: true }));
-
-  // If the caller wired up an `onEvent` sink, also drive the composer via
-  // xdotool-type. Focus the field first so xdotool's X-server keystrokes
-  // land on the right element, then emit the trusted_type event and give
-  // the bot a short window to type before we click send. No coord math
-  // here — the bot types into whatever is focused on the Xvfb display.
   if (opts?.onEvent) {
+    // When an `onEvent` sink is wired we drive the composer entirely via
+    // xdotool-type: focus the field first so the X-server keystrokes land
+    // on the right element, then emit `trusted_type` and wait for the
+    // bot's async typing to complete before we dispatch the send click.
+    //
+    // We deliberately do NOT take the synthetic-setter path below in this
+    // branch. xdotool appends to whatever is in the focused field, so if
+    // we pre-populated the composer with `.value = text` the xdotool-
+    // typed text would land on top and produce doubled output
+    // ("hellohello"). Relying solely on xdotool keeps the produced text
+    // correct on any Meet build that enforces `event.isTrusted` on the
+    // composer — which is the only reason we invoke xdotool in the first
+    // place.
+    //
+    // The wait scales with text length because xdotool's per-keystroke
+    // delay (25ms) dominates: a 100-char message takes ~2.5s of real-time
+    // typing. A fixed 250ms was too short for anything longer than ~10
+    // characters — the send button fired mid-type and posted a partial
+    // message.
     try {
       input.focus();
     } catch {
-      // Some jsdom / degraded DOM builds throw on .focus(); fall through
-      // and let the synthetic-setter path carry the composer.
+      // Some jsdom / degraded DOM builds throw on .focus(); the native-
+      // messaging emit below is still safe (the bot will type into
+      // whatever is focused on the Xvfb display) and the test harness
+      // does not require focus to succeed.
     }
     opts.onEvent({ type: "trusted_type", text });
-    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    const waitMs =
+      text.length * TRUSTED_TYPE_PER_CHAR_MS + TRUSTED_TYPE_OVERHEAD_MS;
+    await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+  } else {
+    // No `onEvent` sink — we can't drive xdotool, so fall back to the
+    // synthetic-setter path. Meet's composer is a React-controlled
+    // textarea. React 16+ installs an instance-level property-descriptor
+    // interceptor (`inputValueTracking`) that hijacks `.value = ...`:
+    // when the synthetic `input` event fires, React compares the DOM
+    // value to its internal tracker and — because the interceptor
+    // updated the tracker in lockstep with the assignment — observes no
+    // change and skips the onChange dispatch. The result is a composer
+    // that visually shows the text but never commits to React state, so
+    // Send posts empty/stale content.
+    //
+    // The workaround is Playwright's `page.fill` trick: grab the native
+    // setter off `HTMLTextAreaElement.prototype` (which the React
+    // interceptor shadows at the instance level) and invoke it with
+    // `.call(input, text)`. That routes through the prototype setter
+    // without touching React's tracker, so the subsequent `input` event
+    // fires with a genuine value change and onChange runs normally. We
+    // still dispatch the synthetic `input` event ourselves — React
+    // relies on it as the trigger for onChange even after the value has
+    // been updated.
+    //
+    // If the native setter isn't resolvable for any reason (e.g. a jsdom
+    // build that doesn't expose the prototype descriptor), fall back to
+    // the direct `.value = ...` assignment. That path is adequate for
+    // the test harness and any pre-React-tracker Meet build.
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (nativeSetter) {
+      nativeSetter.call(input, text);
+    } else {
+      input.value = text;
+    }
+    input.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
   const sendButton = document.querySelector<HTMLButtonElement>(


### PR DESCRIPTION
## Summary

Addresses review feedback on #26655.

1. **Doubled text (both reviewers):** The synthetic-setter path populated the textarea, then xdotool typed on top of the focused field → `hellohello`. Fixed by taking option (a): skip the synthetic setter when `onEvent` is wired and rely solely on xdotool. Keep the synthetic-setter path as the fallback only for the no-`onEvent` case (jsdom tests; pre-isTrusted builds).
2. **250ms wait too short (Devin):** xdotool's default `--delay` is 25ms/char, so 250ms only covered ~10 chars before the send click fired mid-type. Now scaled: `text.length * 25ms + 250ms overhead`.

## Test plan
- [x] `bun test meet-controller-ext/src/__tests__/chat.test.ts` passes (21 tests)
- [x] `bun test meet-controller-ext/src/__tests__/content-send-chat.test.ts` passes (4 tests)
- [x] `bun test bot/__tests__/main.test.ts` passes (36 tests)
- [x] `bunx tsc --noEmit` clean in `meet-controller-ext`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
