### PR TITLE
fix(meet-bot): avatar backpressure + renderer cleanup on start() throw

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-device-writer.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-device-writer.test.ts
@@ -198,6 +198,38 @@ describe("attachDeviceWriter", () => {
     expect(renderer.subscriberCount()).toBe(0);
   });
 
+  test("sink.write returning false (backpressure) counts as a drop", () => {
+    // Node writable streams signal backpressure by returning `false`
+    // without throwing. The writer must account for that or diagnostic
+    // counters will mis-report overload as success.
+    const renderer = new FakeAvatarRenderer();
+    const backpressuredSink = {
+      writes: [] as Uint8Array[],
+      write(chunk: Uint8Array): boolean {
+        this.writes.push(chunk);
+        return false;
+      },
+    };
+    let now = 0;
+    const handle = attachDeviceWriter({
+      renderer,
+      sink: backpressuredSink,
+      maxFps: 30,
+      now: () => now,
+    });
+
+    renderer.emitFrame(makeFrame({ timestamp: 1 }));
+    now = 50;
+    renderer.emitFrame(makeFrame({ timestamp: 2 }));
+
+    // Both writes were attempted but neither was accepted cleanly.
+    expect(backpressuredSink.writes).toHaveLength(2);
+    expect(handle.dispatchedCount()).toBe(0);
+    expect(handle.droppedCount()).toBe(2);
+
+    handle.stop();
+  });
+
   test("sink.write throwing counts as a drop (no crash)", () => {
     const renderer = new FakeAvatarRenderer();
     const angrySink = {

--- a/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-http-server.test.ts
@@ -336,6 +336,37 @@ describe("avatar HTTP routes", () => {
       expect(openCalls).toBe(1);
     });
 
+    test("when renderer.start() throws a non-Unavailable error, renderer.stop() runs before rethrow", async () => {
+      // Renderer partially initializes (GPU session, WebRTC tab) then
+      // crashes. The handler must call stop() so those resources don't
+      // linger — avatarRenderer is still null so no /avatar/disable
+      // retry could clean them up.
+      class ExplodingStartRenderer extends FakeAvatarRenderer {
+        override async start(): Promise<void> {
+          this.startCount += 1;
+          throw new TypeError("gpu context lost mid-init");
+        }
+      }
+      const fake = new ExplodingStartRenderer({ id: "fake" });
+      const { server: s } = makeServer({
+        config: { enabled: true, renderer: "fake" },
+        resolveRenderer: () => fake,
+      });
+      server = s;
+      const base = await startOnRandomPort(server);
+
+      const res = await fetch(`${base}/avatar/enable`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${API_TOKEN}` },
+      });
+      // Non-Unavailable error bubbles as a 500 from hono's default
+      // error boundary. The assertion that matters here is the cleanup
+      // below.
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect(fake.startCount).toBe(1);
+      expect(fake.stopCount).toBe(1);
+    });
+
     test("when the renderer starts but the device open fails, returns 503 and tears the renderer down", async () => {
       const fake = new FakeAvatarRenderer({ id: "fake" });
       const { server: s } = makeServer({

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -753,6 +753,12 @@ export function createHttpServer(
       try {
         await renderer.start();
       } catch (err) {
+        // `start()` may have partially initialized resources (GPU
+        // session, WebRTC connection, spawned tab) before throwing.
+        // Best-effort teardown so an unexpected error doesn't leak
+        // them — `avatarRenderer` is still null, so no later
+        // `/avatar/disable` call would clean up.
+        await renderer.stop().catch(() => {});
         if (err instanceof AvatarRendererUnavailableError) {
           return c.json(
             {

--- a/skills/meet-join/bot/src/media/avatar/device-writer.ts
+++ b/skills/meet-join/bot/src/media/avatar/device-writer.ts
@@ -28,7 +28,12 @@ export const DEFAULT_MAX_FPS = 30;
 
 /** Minimal slice of {@link VideoDeviceHandle} the writer actually consumes. */
 export interface DeviceWriterSink {
-  /** Write a chunk of frame bytes. */
+  /**
+   * Write a chunk of frame bytes. Returns `true` when the chunk was
+   * accepted cleanly, `false` to signal backpressure — matching the
+   * Node `stream.Writable.write()` contract (see
+   * https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback).
+   */
   write(chunk: Uint8Array): boolean;
 }
 
@@ -121,14 +126,23 @@ export function attachDeviceWriter(
 
     lastDispatchedAt = ts;
     try {
-      sink.write(frame.bytes);
-      dispatched += 1;
-      onFrameProcessed?.(frame, true);
+      // Node writable streams (and our v4l2 sink) return `false` from
+      // `write()` to signal backpressure — the chunk was buffered but
+      // the consumer can't keep up. Treat that as a drop: incrementing
+      // `dispatched` would hide the overload in diagnostics and
+      // continued writes would balloon the internal buffer.
+      const accepted = sink.write(frame.bytes);
+      if (accepted) {
+        dispatched += 1;
+        onFrameProcessed?.(frame, true);
+      } else {
+        dropped += 1;
+        onFrameProcessed?.(frame, false);
+      }
     } catch {
-      // Sink errors are best-effort — a failed write usually means the
-      // kernel buffer hit back-pressure or the device handle was torn
-      // down out from under us. Count it as a drop so the diagnostic
-      // counters stay consistent.
+      // Sink errors are best-effort — a thrown write usually means the
+      // device handle was torn down out from under us. Count it as a
+      // drop so the diagnostic counters stay consistent.
       dropped += 1;
       onFrameProcessed?.(frame, false);
     }


### PR DESCRIPTION
## Summary

Addresses review feedback on #26666.

- **Backpressure (Codex P2)**: `attachDeviceWriter` was counting every non-throwing `sink.write()` as a successful dispatch, but Node writable streams signal backpressure by returning \`false\` without throwing. Under sustained overload (large Y4M frames + slow v4l2 consumer), this masked the overload in diagnostics and let the internal buffer grow. Now a \`false\` return increments \`droppedCount\` and fires \`onFrameProcessed(frame, false)\`.
- **Renderer leak on non-Unavailable start() throw (Devin P0)**: In \`/avatar/enable\`, when \`renderer.start()\` throws an error that isn't \`AvatarRendererUnavailableError\` (e.g. TypeError, network error), the handler re-threw without calling \`renderer.stop()\`. Since \`avatarRenderer\` is still null at that point, no subsequent \`/avatar/disable\` could clean up — leaking GPU sessions / WebRTC tabs. Now wraps the catch with \`await renderer.stop().catch(() => {})\` before rethrow, matching the device-open failure branch two blocks below.

The third Codex finding (avatar device path not threaded into \`runBot\`'s Chrome launch) was already addressed by #26682, which wired \`avatarDevicePath\` through to the launcher.

## Test plan
- [x] New regression test for backpressure: \`sink.write\` returning \`false\` counts as a drop.
- [x] New regression test for start() throw cleanup: ExplodingStartRenderer asserts \`startCount=1\` + \`stopCount=1\`.
- [x] \`bun test avatar-device-writer.test.ts avatar-http-server.test.ts\` — 40 pass, 0 fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
