### PR TITLE
fix(meet-join): avatar frame dedupe + targetFps + TalkingHead container

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/avatar-feature.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/avatar-feature.test.ts
@@ -154,6 +154,16 @@ describe("startAvatarFeature", () => {
     );
   });
 
+  test("avatar.start forwards targetFps as a query string", async () => {
+    await feature.handleBotCommand({
+      type: "avatar.start",
+      targetFps: 30,
+    });
+    expect(tabs.createCalls).toHaveLength(1);
+    const url = new URL(tabs.createCalls[0]!.url);
+    expect(url.searchParams.get("fps")).toBe("30");
+  });
+
   test("avatar.push_viseme is forwarded to the avatar tab", async () => {
     await feature.handleBotCommand({ type: "avatar.start" });
     await feature.handleBotCommand({

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-bridge.test.ts
@@ -10,20 +10,26 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import type { BotToExtensionMessage } from "../../../contracts/native-messaging.js";
+import type {
+  BotToExtensionMessage,
+  ExtensionToBotMessage,
+} from "../../../contracts/native-messaging.js";
 
 import { startContentBridge } from "../messaging/content-bridge.js";
 import type { NativePort } from "../messaging/native-port.js";
 
 interface FakePort extends NativePort {
   emitFromBot(msg: BotToExtensionMessage): void;
+  posted: ExtensionToBotMessage[];
 }
 
 function makeFakePort(): FakePort {
   const messageCallbacks: Array<(msg: BotToExtensionMessage) => void> = [];
+  const posted: ExtensionToBotMessage[] = [];
   return {
-    post() {
-      /* no-op: these tests only exercise bot→extension fan-out */
+    posted,
+    post(msg: ExtensionToBotMessage) {
+      posted.push(msg);
     },
     onMessage(cb) {
       messageCallbacks.push(cb);
@@ -43,12 +49,20 @@ function makeFakePort(): FakePort {
   };
 }
 
+type RuntimeOnMessageListener = (
+  raw: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean;
+
 interface FakeChrome {
   sendMessageCalls: Array<{ tabId: number; msg: unknown }>;
   queryCalls: Array<chrome.tabs.QueryInfo>;
+  runtimeListeners: RuntimeOnMessageListener[];
+  emitFromContent(msg: unknown): void;
   runtime: {
     onMessage: {
-      addListener: (cb: (...args: unknown[]) => boolean) => void;
+      addListener: (cb: RuntimeOnMessageListener) => void;
     };
   };
   tabs: {
@@ -60,13 +74,19 @@ interface FakeChrome {
 function installFakeChrome(): FakeChrome {
   const sendMessageCalls: FakeChrome["sendMessageCalls"] = [];
   const queryCalls: FakeChrome["queryCalls"] = [];
+  const runtimeListeners: RuntimeOnMessageListener[] = [];
   const fake: FakeChrome = {
     sendMessageCalls,
     queryCalls,
+    runtimeListeners,
+    emitFromContent(msg) {
+      for (const cb of runtimeListeners.slice())
+        cb(msg, undefined, () => {});
+    },
     runtime: {
       onMessage: {
-        addListener() {
-          /* content→bot direction is not exercised here */
+        addListener(cb) {
+          runtimeListeners.push(cb);
         },
       },
     },
@@ -138,5 +158,52 @@ describe("startContentBridge bot→content fan-out", () => {
       tabId: 1,
       msg: leave,
     });
+  });
+});
+
+describe("startContentBridge content→bot forwarding", () => {
+  let fake: FakeChrome;
+  let port: FakePort;
+
+  beforeEach(() => {
+    fake = installFakeChrome();
+    port = makeFakePort();
+    startContentBridge(port);
+  });
+
+  afterEach(() => {
+    uninstallFakeChrome();
+  });
+
+  test("avatar.frame from runtime is NOT relayed to the native port", () => {
+    // The avatar feature owns this forwarding path; relaying here would
+    // double every frame.
+    fake.emitFromContent({
+      type: "avatar.frame",
+      bytes: "AA==",
+      width: 320,
+      height: 240,
+      format: "jpeg",
+      ts: 0,
+    });
+    expect(port.posted).toHaveLength(0);
+  });
+
+  test("avatar.started from runtime is NOT relayed to the native port", () => {
+    fake.emitFromContent({ type: "avatar.started" });
+    expect(port.posted).toHaveLength(0);
+  });
+
+  test("non-avatar content→bot messages still forward to the native port", () => {
+    const msg: ExtensionToBotMessage = {
+      type: "chat.inbound",
+      meetingId: "abc",
+      timestamp: "2026-04-15T00:00:00Z",
+      fromId: "p-1",
+      fromName: "Alice",
+      text: "hey",
+    };
+    fake.emitFromContent(msg);
+    expect(port.posted).toContainEqual(msg);
   });
 });

--- a/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
+++ b/skills/meet-join/meet-controller-ext/src/avatar/avatar.ts
@@ -139,6 +139,20 @@ function resolveModelUrl(): string {
 }
 
 /**
+ * Resolve the target capture cadence. `?fps=<n>` in the page URL wins
+ * when present and parses as a finite positive integer; otherwise we
+ * fall back to {@link DEFAULT_TARGET_FPS}.
+ */
+function resolveTargetFps(): number {
+  const params = new URLSearchParams(location.search);
+  const raw = params.get("fps");
+  if (!raw) return DEFAULT_TARGET_FPS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TARGET_FPS;
+  return parsed;
+}
+
+/**
  * Render-loop context. Keeps the active canvas and the TalkingHead.js
  * instance so the viseme handler and capture loop share state.
  *
@@ -149,6 +163,18 @@ function resolveModelUrl(): string {
  * `avatar/README.md` for the operator replacement procedure.
  */
 interface AvatarContext {
+  /**
+   * Container element handed to TalkingHead.js. TalkingHead.js mounts
+   * its own three.js renderer canvas as a child; the capture loop
+   * composites that child canvas into {@link canvas} each tick.
+   */
+  container: HTMLDivElement;
+  /**
+   * The canvas we read out via `toBlob` for the JPEG frame stream.
+   * When TalkingHead.js is live we paint its internal canvas into
+   * this one each frame; otherwise it shows the neutral background
+   * filled at boot.
+   */
   canvas: HTMLCanvasElement;
   head: TalkingHeadInstance | null;
   targetFps: number;
@@ -212,17 +238,33 @@ async function bootAvatar(): Promise<AvatarContext> {
   const statusEl = document.getElementById("avatar-status");
   if (statusEl) statusEl.remove();
 
-  const canvas = document.createElement("canvas");
-  canvas.width = CANVAS_WIDTH;
-  canvas.height = CANVAS_HEIGHT;
-  canvas.style.width = "100%";
-  canvas.style.height = "100%";
-  root.appendChild(canvas);
+  // TalkingHead.js expects a container element and creates its own
+  // three.js-backed canvas inside it. Handing it a raw <canvas>
+  // would cause it either to reject the element or to mount a child
+  // canvas that `captureCanvas.toBlob` can't see. Give it a sized
+  // <div> and keep a separate `captureCanvas` we paint into for the
+  // placeholder background and capture loop; when TalkingHead.js is
+  // live we draw its internal canvas into `captureCanvas` each tick.
+  const container = document.createElement("div");
+  container.style.position = "relative";
+  container.style.width = `${CANVAS_WIDTH}px`;
+  container.style.height = `${CANVAS_HEIGHT}px`;
+  root.appendChild(container);
 
-  // Fill the canvas with a neutral background up-front so early
-  // frames (before TalkingHead.js finishes loading) don't stream a
-  // transparent/black frame that Chrome's camera encoder may drop.
-  const ctx = canvas.getContext("2d");
+  const captureCanvas = document.createElement("canvas");
+  captureCanvas.width = CANVAS_WIDTH;
+  captureCanvas.height = CANVAS_HEIGHT;
+  captureCanvas.style.position = "absolute";
+  captureCanvas.style.inset = "0";
+  captureCanvas.style.width = "100%";
+  captureCanvas.style.height = "100%";
+  container.appendChild(captureCanvas);
+
+  // Fill the capture canvas with a neutral background up-front so
+  // early frames (before TalkingHead.js finishes loading) don't
+  // stream a transparent/black frame that Chrome's camera encoder
+  // may drop.
+  const ctx = captureCanvas.getContext("2d");
   if (ctx) {
     ctx.fillStyle = "#1a1a2e";
     ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
@@ -243,7 +285,7 @@ async function bootAvatar(): Promise<AvatarContext> {
   let head: TalkingHeadInstance | null = null;
   if (TalkingHeadCtor) {
     try {
-      head = new TalkingHeadCtor(canvas, {
+      head = new TalkingHeadCtor(container, {
         modelRoot: modelUrl.replace(/\/[^/]+$/, "/"),
         cameraView: "upper",
       });
@@ -260,9 +302,10 @@ async function bootAvatar(): Promise<AvatarContext> {
   }
 
   return {
-    canvas,
+    container,
+    canvas: captureCanvas,
     head,
-    targetFps: DEFAULT_TARGET_FPS,
+    targetFps: resolveTargetFps(),
     glbProbe,
   };
 }
@@ -301,12 +344,33 @@ function startCaptureLoop(ctx: AvatarContext): () => void {
   let lastEmitTs = 0;
 
   const minInterval = Math.floor(1000 / ctx.targetFps);
+  const captureCtx = ctx.canvas.getContext("2d");
 
   const emitFrame = async (): Promise<void> => {
     if (!running) return;
     const now = performance.now();
     if (now - lastEmitTs < minInterval) return;
     lastEmitTs = now;
+
+    // TalkingHead.js renders into its own child <canvas> inside the
+    // container. Composite that canvas into our capture surface so
+    // toBlob reflects the live avatar rather than the static fill.
+    if (captureCtx && ctx.head) {
+      const live = ctx.container.querySelector("canvas");
+      if (live && live !== ctx.canvas) {
+        try {
+          captureCtx.drawImage(
+            live,
+            0,
+            0,
+            ctx.canvas.width,
+            ctx.canvas.height,
+          );
+        } catch (err) {
+          console.warn("[avatar-tab] drawImage from talkinghead failed:", err);
+        }
+      }
+    }
 
     const blob: Blob | null = await new Promise((resolve) =>
       ctx.canvas.toBlob(resolve, "image/jpeg", JPEG_QUALITY),

--- a/skills/meet-join/meet-controller-ext/src/features/avatar.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/avatar.ts
@@ -68,6 +68,12 @@ export const AVATAR_PAGE_PATH = "avatar/avatar.html";
 export const AVATAR_MODEL_QUERY_PARAM = "model";
 
 /**
+ * Query-string key the avatar page reads at load time to determine the
+ * capture cadence. When absent, the page uses its default target fps.
+ */
+export const AVATAR_FPS_QUERY_PARAM = "fps";
+
+/**
  * Minimal slice of the Chrome tabs API the feature actually uses.
  * Exposed as a type so unit tests can inject a fake without needing
  * `@types/chrome` at the test-site.
@@ -190,11 +196,18 @@ export function startAvatarFeature(
     return false;
   });
 
-  async function openAvatarTab(modelUrl: string | undefined): Promise<void> {
+  async function openAvatarTab(
+    modelUrl: string | undefined,
+    targetFps: number | undefined,
+  ): Promise<void> {
     const base = runtime.getURL(AVATAR_PAGE_PATH);
-    const url = modelUrl
-      ? `${base}?${AVATAR_MODEL_QUERY_PARAM}=${encodeURIComponent(modelUrl)}`
-      : base;
+    const params = new URLSearchParams();
+    if (modelUrl) params.set(AVATAR_MODEL_QUERY_PARAM, modelUrl);
+    if (typeof targetFps === "number") {
+      params.set(AVATAR_FPS_QUERY_PARAM, String(targetFps));
+    }
+    const query = params.toString();
+    const url = query ? `${base}?${query}` : base;
     try {
       const tab = await tabs.create({ url, active: false, pinned: true });
       if (typeof tab.id !== "number") {
@@ -251,7 +264,7 @@ export function startAvatarFeature(
       if (avatarTabId !== null) {
         await closeAvatarTab();
       }
-      await openAvatarTab(msg.modelUrl);
+      await openAvatarTab(msg.modelUrl, msg.targetFps);
       return;
     }
     if (msg.type === "avatar.stop") {

--- a/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
+++ b/skills/meet-join/meet-controller-ext/src/messaging/content-bridge.ts
@@ -30,6 +30,12 @@ export const MEET_TAB_URL_PATTERN = "https://meet.google.com/*";
 export function startContentBridge(port: NativePort): void {
   // Content scripts post messages up to the service worker via
   // chrome.runtime.sendMessage; we validate and forward to the native host.
+  //
+  // `avatar.started` / `avatar.frame` originate in the separate avatar
+  // tab (see `features/avatar.ts`) and are forwarded to the native port
+  // by the avatar feature's own listener. Relaying them here would
+  // double-post every frame — doubling base64 decode, JPEG→Y4M ffmpeg
+  // spawns, and device-writer load on the bot side.
   chrome.runtime.onMessage.addListener(
     (
       raw: unknown,
@@ -42,6 +48,12 @@ export function startContentBridge(port: NativePort): void {
           "[meet-ext] dropped invalid content->bot message:",
           result.error.message,
         );
+        return false;
+      }
+      if (
+        result.data.type === "avatar.started" ||
+        result.data.type === "avatar.frame"
+      ) {
         return false;
       }
       try {


### PR DESCRIPTION
## Summary
Addresses review feedback on #26670:

- **Duplicate avatar frame relay (P1, both reviewers):** The content-bridge runtime→bot listener and the avatar feature's own listener both forwarded every \`avatar.started\` / \`avatar.frame\` to the native port, doubling base64 decode + JPEG→Y4M ffmpeg spawns + device-writer load on the bot. The content bridge now skips those two message types; the avatar feature remains the single forwarder.
- **targetFps dropped (Devin):** \`avatar.start\` accepts an optional \`targetFps\` from the bot but it was silently discarded. \`openAvatarTab\` now threads it through as a \`?fps=<n>\` query param, and the avatar page resolves it in \`bootAvatar\` with the existing \`DEFAULT_TARGET_FPS\` fallback.
- **Canvas vs div for TalkingHead.js (Devin):** TalkingHead.js expects a container element and manages its own Three.js-backed canvas internally. We now hand it a \`<div>\` and keep a sibling \`captureCanvas\` that the capture loop composites the live TalkingHead.js child canvas into before \`toBlob\` — so JPEG frames reflect the actual avatar render, not a detached canvas.

## Test plan
- [x] \`bunx tsc --noEmit\` clean in \`meet-controller-ext\`
- [x] Updated \`content-bridge.test.ts\` with content→bot listener coverage: \`avatar.frame\` and \`avatar.started\` are NOT relayed to the native port; non-avatar (\`chat.inbound\`) still is
- [x] New \`avatar-feature.test.ts\` case: \`avatar.start\` with \`targetFps: 30\` forwards \`?fps=30\` on the tab URL
- [x] 23 tests pass across both affected files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
