### PR TITLE
fix(slack-render): remove unreachable server_tool_use filter branches

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -380,18 +380,21 @@ export function renderSlackTranscript(
 }
 
 /**
- * Final safety pass that drops unpaired tool-call blocks of either shape:
- * locally-executed (`tool_use` ↔ `tool_result`) and server-side web search
- * (`server_tool_use` ↔ `web_search_tool_result`).
+ * Final safety pass that drops unpaired `tool_use` ↔ `tool_result` blocks.
  *
- * Anthropic's API requires every producing block in an assistant turn to be
- * matched by its consuming block in the following user turn (and vice versa).
+ * Anthropic's API requires every `tool_use` in an assistant turn to be
+ * matched by a `tool_result` in the following user turn (and vice versa).
  * In normal operation `renderSlackTranscript` emits fully-paired turns
  * because the persisted transcript reflects completed tool exchanges, but
  * edge cases (mid-turn compaction, partial failures, a race between
  * producer persistence and consumer persistence) can leave an orphan in
  * the rendered output. Sending an orphan to the provider hard-fails the
  * entire request, so we defensively prune any unpaired block here.
+ *
+ * Server-side block types (`server_tool_use`, `web_search_tool_result`) are
+ * stripped earlier by `buildMessageContentBlocks` — they carry stale
+ * provider-specific `encrypted_content` and are never replayed — so they
+ * cannot reach this filter.
  *
  * A message that becomes empty after filtering (e.g. an assistant row that
  * carried only an orphaned `tool_use`) is dropped entirely rather than
@@ -403,32 +406,16 @@ function filterOrphanToolPairs(messages: Message[]): Message[] {
   const consumed = new Set<string>();
   for (const msg of messages) {
     for (const b of msg.content) {
-      if (b.type === "tool_use" || b.type === "server_tool_use") {
-        produced.add(b.id);
-      } else if (
-        b.type === "tool_result" ||
-        b.type === "web_search_tool_result"
-      ) {
-        consumed.add(b.tool_use_id);
-      }
+      if (b.type === "tool_use") produced.add(b.id);
+      else if (b.type === "tool_result") consumed.add(b.tool_use_id);
     }
   }
   const out: Message[] = [];
   for (const msg of messages) {
     const kept: ContentBlock[] = [];
     for (const b of msg.content) {
-      if (
-        (b.type === "tool_use" || b.type === "server_tool_use") &&
-        !consumed.has(b.id)
-      ) {
-        continue;
-      }
-      if (
-        (b.type === "tool_result" || b.type === "web_search_tool_result") &&
-        !produced.has(b.tool_use_id)
-      ) {
-        continue;
-      }
+      if (b.type === "tool_use" && !consumed.has(b.id)) continue;
+      if (b.type === "tool_result" && !produced.has(b.tool_use_id)) continue;
       kept.push(b);
     }
     if (kept.length > 0) out.push({ role: msg.role, content: kept });


### PR DESCRIPTION
## Summary

PR #26668 added `server_tool_use` / `web_search_tool_result` handling to `filterOrphanToolPairs`, but those branches are unreachable: `buildMessageContentBlocks` drops both block types before the filter runs (they are excluded from `REPLAYABLE_BLOCK_TYPES` because their `encrypted_content` goes stale and is rejected on re-send).

Revert the filter to its original `tool_use` ↔ `tool_result` shape and update the docstring to note that server-side block types are stripped upstream and cannot reach this pass.

Addresses Devin feedback on #26668.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing errors on main only)
- [x] `bun test src/messaging/providers/slack/render-transcript.test.ts` — 69/69 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
