### PR TITLE
docs(graph-retriever): drop historical PR references in dual-query embed comments

### DIFF
--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -164,7 +164,6 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
     expect(result.queryVector).toBeUndefined();
     expect(result.sparseVector).toBeUndefined();
   });
-
 });
 
 describe("retrieveForTurn — query/sparse vector surfacing", () => {
@@ -244,8 +243,7 @@ describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
   // Build a config where capabilityReserve=1 so the ranking code actually
   // prunes (it only prunes when capabilityNodes.length > capabilityReserve).
   const DUAL_QUERY_CONFIG: AssistantConfig = structuredClone(DEFAULT_CONFIG);
-  DUAL_QUERY_CONFIG.memory.retrieval.injection.contextLoad.capabilityReserve =
-    1;
+  DUAL_QUERY_CONFIG.memory.retrieval.injection.contextLoad.capabilityReserve = 1;
 
   // Keyword-routed embed: any text that contains a topic keyword returns a
   // one-hot vector identifying that topic. Anything else falls back to a
@@ -372,11 +370,9 @@ describe("loadContextMemory — dual-query capability ranking (PR 3)", () => {
     embedRouter = keywordEmbedRouter;
     searchRouter = vectorSearchRouter;
 
-    // Summary is short and the user query is much longer — in the pre-PR-6
-    // world the length-ratio guard would have skipped the dedicated embed
-    // here. After PR 6 removed the firstUserText unshift, summaries and the
-    // user query are disjoint signals, so we always pay for both embeds
-    // when a userQuery is present.
+    // Summary is short and the user query is much longer. Summaries and
+    // the user query are disjoint signals, so we always pay for both
+    // embeds when a userQuery is present.
     const result = await loadContextMemory({
       scopeId: "default",
       recentSummaries: ["hi"],

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -435,14 +435,11 @@ export async function loadContextMemory(
     }
   }
 
-  // 1b. (PR 3) Dedicated user-query embedding. Always run the dedicated
-  //     user-query embed when a user query is present. Summaries and the
-  //     user query are now disjoint signals (the unshift was removed in
-  //     PR 6), so there is no redundancy between the two vectors — the
-  //     length-ratio short-circuit that previously lived here was written
-  //     against pre-PR-6 semantics and would drop the embed precisely in
-  //     the workloads that benefit most (short summaries + substantive
-  //     user question).
+  // 1b. Dedicated user-query embedding. Always embed the user query
+  //     independently when present. Summaries and the user query are
+  //     disjoint signals, so both vectors carry unique retrieval value —
+  //     especially in workloads with short summaries and a substantive
+  //     user question.
   let userQueryVector: number[] | null = null;
   const userQueryCandidateIds = new Map<string, number>(); // nodeId → score
   const trimmedUserQuery = opts.userQuery?.trim() ?? "";


### PR DESCRIPTION
Addresses Devin + Codex feedback on #26576: comments in `retriever.ts` and `retriever.test.ts` narrated removed code and past PRs, violating the AGENTS.md code-comment rule.

Rewrote the 1b. embedding comment and the corresponding test comment to describe the current invariant only — summaries and `userQuery` are disjoint signals, so we always embed both when `userQuery` is non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
