### PR TITLE
fix(memory): gate capability fallback on distinct IDs

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -52,6 +52,13 @@ import { isCapabilityNode } from "./types.js";
 
 const log = getLogger("graph-retriever");
 
+function extractCapabilityId(node: MemoryNode): string | null {
+  const match = node.content.match(
+    /^skill:(\S+)\n|^cli:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)|^\s*The "assistant (\S+)" CLI command/,
+  );
+  return match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4] ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // LLM re-ranking + deduplication
 // ---------------------------------------------------------------------------
@@ -642,13 +649,8 @@ export async function loadContextMemory(
 
   // 5b. Reserve slots for skill/CLI capabilities.
   //
-  // Source candidates primarily from the semantic-search candidate set
-  // (the same strategy `retrieveForTurn` uses). A prior approach pulled
-  // top-N procedural rows ordered by significance, but organic procedural
-  // memories share `type = 'procedural'` with capability nodes and
-  // dominate the significance ordering on mature assistants, starving
-  // the capability slots entirely.
-  //
+  // Source candidates from the hydrated semantic-search set (the same
+  // strategy `retrieveForTurn` uses) so ranking reflects query relevance.
   // For cold-start cases (capability nodes exist in SQLite but their
   // embeddings haven't landed in Qdrant yet), fall back to a narrow
   // SQL pull that matches only capability-shaped content so organic
@@ -656,6 +658,8 @@ export async function loadContextMemory(
   const capabilityReserve = ctxLoadCfg.capabilityReserve;
   const capabilityEntries: { node: MemoryNode; sim: number }[] = [];
   if (capabilityReserve > 0) {
+    const uniqueCapabilityIds = new Set<string>();
+    let untaggedCount = 0;
     for (const [nodeId, node] of nodeMap) {
       if (node.fidelity === "gone") continue;
       if (!isCapabilityNode(node)) continue;
@@ -664,9 +668,18 @@ export async function loadContextMemory(
         semanticCandidateIds.get(nodeId) ??
         0;
       capabilityEntries.push({ node, sim });
+      const capId = extractCapabilityId(node);
+      if (capId) uniqueCapabilityIds.add(capId);
+      else untaggedCount++;
     }
 
-    if (capabilityEntries.length < capabilityReserve) {
+    // Gate the fallback on distinct capability IDs (plus any entries
+    // whose content didn't match a known ID pattern), not raw entry
+    // count — duplicate capability-ID seeding formats can otherwise push
+    // `capabilityEntries.length` past the threshold and then collapse
+    // below it during the dedup pass below.
+    const distinctCount = uniqueCapabilityIds.size + untaggedCount;
+    if (distinctCount < capabilityReserve) {
       const alreadySeen = new Set(capabilityEntries.map((e) => e.node.id));
       const fallback = queryCapabilityNodes(
         opts.scopeId,
@@ -691,10 +704,7 @@ export async function loadContextMemory(
   const selectedCapabilities: MemoryNode[] = [];
   for (const { node } of capabilityEntries) {
     if (selectedCapabilities.length >= capabilityReserve) break;
-    const match = node.content.match(
-      /^skill:(\S+)\n|^cli:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)|^\s*The "assistant (\S+)" CLI command/,
-    );
-    const capId = match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4];
+    const capId = extractCapabilityId(node);
     if (capId) {
       if (seenCapabilityIds.has(capId)) continue;
       seenCapabilityIds.add(capId);


### PR DESCRIPTION
Addresses review feedback on #26739.

## Summary
- **Codex P2**: the capability fallback trigger used `capabilityEntries.length` before dedup, so duplicate capability-ID seeding formats could push the count past `capabilityReserve`, skip the fallback, then collapse to fewer slots in the dedup pass. Now counts distinct capability IDs (plus entries whose content didn't match a known ID pattern) before deciding whether to fall back.
- **Devin**: rewrote the 5b comment to describe current behavior instead of narrating the removed prior approach, per `assistant/AGENTS.md` comment rules.

Extracted `extractCapabilityId` so the fallback trigger and the dedup pass share a single regex.

## Test plan
- [x] `bun test src/memory/graph/retriever.test.ts` — 10 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
