### PR TITLE
fix(meet-bot): utterance-relative playback clock + dynamic avatar renderer resolve

### DIFF
--- a/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
+++ b/skills/meet-join/bot/__tests__/avatar-lipsync.test.ts
@@ -148,13 +148,11 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     // The full pipeline under test: viseme events stream in 100 ms
     // ahead of the corresponding audio, the bot queues PCM into the
     // audio-playback handle, and the handle's playback-timestamp
-    // stream drives the renderer's flush cadence. We inject a
-    // deterministic clock so the playback timestamps evolve in
-    // controlled increments instead of depending on real wall time.
-    let nowMs = 0;
-    const advance = (delta: number): void => {
-      nowMs += delta;
-    };
+    // stream drives the renderer's flush cadence. The playback clock
+    // is utterance-relative and seeded to 0 on `startAudioPlayback`,
+    // advancing by `byteCount / bytesPerMs` on every non-empty write —
+    // so deterministic PCM writes produce deterministic playback
+    // timestamps without any wall-clock dependence.
 
     const nativeMessaging = new FakeNativeMessaging();
     const renderer = await startRenderer(nativeMessaging);
@@ -162,7 +160,6 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     const shim = makePacatShim();
     const handle = startAudioPlayback({
       spawn: () => shim.proc,
-      now: () => nowMs,
     });
 
     // Wire the playback-timestamp stream into the renderer. This is
@@ -173,21 +170,21 @@ describe("TalkingHead renderer lip-sync alignment", () => {
       renderer.notifyPlaybackTimestamp(ts);
     });
 
-    // Capture every viseme the renderer forwards to the extension,
-    // tagged with the playback clock at forwarding time. A perfectly
-    // aligned pipeline emits each viseme at the moment audio for that
-    // viseme's timestamp actually plays out — NOT at the moment the
-    // viseme was pushed into the renderer.
-    const flushed: Array<{ phoneme: string; atMs: number }> = [];
+    // Capture every viseme the renderer forwards to the extension.
+    // A perfectly aligned pipeline emits each viseme at the moment
+    // audio for that viseme's utterance-relative timestamp actually
+    // plays out — NOT at the moment the viseme was pushed into the
+    // renderer.
+    const flushed: string[] = [];
     nativeMessaging.sendToExtension = (msg: BotAvatarMsg): void => {
       if (msg.type === "avatar.push_viseme") {
-        flushed.push({ phoneme: msg.phoneme, atMs: nowMs });
+        flushed.push(msg.phoneme);
       }
     };
 
     // Step 1: visemes arrive ahead of audio. The renderer MUST hold
     // them. Push three visemes with timestamps 100, 200, 300 (ms).
-    // They arrive at wall-clock time 0 — 100 ms before their
+    // They arrive before any PCM is written — 100 ms before their
     // declared audio timestamp, exactly the drift scenario from the
     // PR description.
     renderer.pushViseme({ phoneme: "ah", weight: 0.8, timestamp: 100 });
@@ -195,14 +192,14 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     renderer.pushViseme({ phoneme: "oh", weight: 0.4, timestamp: 300 });
 
     // None of the visemes should be forwarded yet — the audio-
-    // playback clock is still at time 0 and none of them has come
-    // due. This is the whole point of the buffering: the extension
-    // must not see the visemes ahead of the audio.
+    // playback clock is still at utterance-offset 0 and none of them
+    // has come due. This is the whole point of the buffering: the
+    // extension must not see the visemes ahead of the audio.
     expect(flushed).toEqual([]);
 
     // Step 2: audio starts flowing. Queue 100 ms worth of PCM. At
     // 48000 Hz mono s16le that's 9600 bytes (96 bytes/ms). Writing
-    // 9600 bytes with a now() of 0 advances the playback clock to
+    // 9600 bytes advances the utterance-relative playback clock to
     // 100 ms — the first viseme comes due.
     const BYTES_PER_MS = handle.bytesPerMs;
     const chunk100ms = new Uint8Array(100 * BYTES_PER_MS);
@@ -211,34 +208,22 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     // The "ah" viseme (timestamp 100) should now have been forwarded
     // because the playback clock advanced to exactly 100. The other
     // two remain buffered.
-    expect(flushed.map((f) => f.phoneme)).toEqual(["ah"]);
-    expect(flushed[0]!.atMs).toBe(0); // wall-clock at forwarding time
+    expect(flushed).toEqual(["ah"]);
 
-    // Step 3: simulate real time passing — 50 ms go by with no new
-    // audio. The audio buffer drains to real time but the playback
-    // clock does NOT advance (we don't emit playback timestamps in
-    // the drain direction — only on writes), so the second viseme
-    // stays buffered.
-    advance(50);
-    expect(flushed.map((f) => f.phoneme)).toEqual(["ah"]);
-
-    // Step 4: queue another 150 ms of audio. The `max(nowMs,
-    // effectivePlaybackMs)` rebase kicks in here because real time
-    // (50 ms) is past our previous estimate (100 ms)? No — 50 < 100,
-    // so the clock baselines off effectivePlaybackMs. New estimate:
+    // Step 3: queue another 150 ms of audio. The clock advances to
     // 100 + 150 = 250 ms. Viseme "ee" (t=200) comes due; "oh" (t=300)
     // stays.
     const chunk150ms = new Uint8Array(150 * BYTES_PER_MS);
     await handle.write(chunk150ms);
 
-    expect(flushed.map((f) => f.phoneme)).toEqual(["ah", "ee"]);
+    expect(flushed).toEqual(["ah", "ee"]);
 
-    // Step 5: queue the remaining 50 ms — clock reaches 300 ms, the
+    // Step 4: queue the remaining 50 ms — clock reaches 300 ms, the
     // last viseme drains.
     const chunk50ms = new Uint8Array(50 * BYTES_PER_MS);
     await handle.write(chunk50ms);
 
-    expect(flushed.map((f) => f.phoneme)).toEqual(["ah", "ee", "oh"]);
+    expect(flushed).toEqual(["ah", "ee", "oh"]);
 
     unsubscribe();
   });
@@ -249,13 +234,11 @@ describe("TalkingHead renderer lip-sync alignment", () => {
     // additionally delayed. Once a viseme's timestamp is already in
     // the past relative to the playback clock, the renderer must
     // release it as soon as pushViseme is called.
-    let nowMs = 0;
     const nativeMessaging = new FakeNativeMessaging();
     const renderer = await startRenderer(nativeMessaging);
     const shim = makePacatShim();
     const handle = startAudioPlayback({
       spawn: () => shim.proc,
-      now: () => nowMs,
     });
     const unsubscribe = handle.onPlaybackTimestamp((ts) => {
       renderer.notifyPlaybackTimestamp(ts);

--- a/skills/meet-join/bot/src/control/http-server.ts
+++ b/skills/meet-join/bot/src/control/http-server.ts
@@ -463,31 +463,22 @@ export function createHttpServer(
       // wiring is a no-op for them — this timing fix is inert for
       // hosted / GPU-sidecar backends whose audio-to-motion timing is
       // owned server-side.
-      const renderer = avatarRenderer;
-      let unsubscribePlaybackTimestamp: (() => void) | null = null;
-      if (
-        renderer !== null &&
-        renderer.capabilities.needsVisemes &&
-        typeof renderer.notifyPlaybackTimestamp === "function"
-      ) {
-        const notify = renderer.notifyPlaybackTimestamp.bind(renderer);
-        unsubscribePlaybackTimestamp = handle.onPlaybackTimestamp((ts) => {
-          // Guard against a mid-stream `/avatar/disable`: that handler
-          // sets `avatarRenderer = null` and calls `renderer.stop()`,
-          // but this closure still holds the renderer reference captured
-          // at stream start. Without the current-reference check, every
-          // playback-timestamp tick between disable-fire and stream-end
-          // would land on a stopped renderer. TalkingHead.js's stopped
-          // channel silently drops messages, but any renderer whose
-          // `notifyPlaybackTimestamp` treats post-stop notifications as
-          // an error would crash. The unsubscribe in `finally` only
-          // fires at stream end, so this guard is what severs the
-          // bridge immediately when disable lands.
-          if (avatarRenderer === renderer) {
-            notify(ts);
-          }
-        });
-      }
+      //
+      // The renderer is resolved DYNAMICALLY on every tick rather than
+      // snapshotted at stream start — otherwise a mid-stream
+      // `/avatar/disable` + `/avatar/enable` would leave every tick
+      // landing on the old (stopped) renderer while the freshly
+      // enabled one got nothing. Reading the closure variable on each
+      // tick also severs the bridge immediately when `/avatar/disable`
+      // nulls `avatarRenderer`, which is what the teardown regression
+      // test guards.
+      const unsubscribePlaybackTimestamp = handle.onPlaybackTimestamp((ts) => {
+        const current = avatarRenderer;
+        if (current === null) return;
+        if (!current.capabilities.needsVisemes) return;
+        if (typeof current.notifyPlaybackTimestamp !== "function") return;
+        current.notifyPlaybackTimestamp(ts);
+      });
 
       // Observability hook — invoked fire-and-forget so slow callbacks don't
       // stall the audio pipeline.
@@ -503,7 +494,7 @@ export function createHttpServer(
         } catch {
           // Best-effort; silence is cosmetic.
         }
-        unsubscribePlaybackTimestamp?.();
+        unsubscribePlaybackTimestamp();
         return c.json({ streamId, bytes: 0 }, 200);
       }
 
@@ -572,10 +563,9 @@ export function createHttpServer(
         } catch {
           // Best-effort.
         }
-        // Drop the playback→renderer bridge so a stale closure doesn't
-        // keep a reference to a renderer that might be torn down by a
-        // concurrent /avatar/disable.
-        unsubscribePlaybackTimestamp?.();
+        // Drop the playback→renderer bridge at stream end so the next
+        // stream subscribes fresh.
+        unsubscribePlaybackTimestamp();
       }
 
       if (writeError) {

--- a/skills/meet-join/bot/src/media/audio-playback.ts
+++ b/skills/meet-join/bot/src/media/audio-playback.ts
@@ -81,13 +81,6 @@ export interface StartAudioPlaybackOptions {
   rateHz?: number;
   channels?: number;
   spawn?: PacatSpawnFactory;
-  /**
-   * Override the wall-clock source for playback-timestamp estimation.
-   * Tests pass a deterministic clock so they can advance time in
-   * controlled increments without real delays. Production uses
-   * `performance.now()`.
-   */
-  now?: () => number;
 }
 
 /**
@@ -97,21 +90,18 @@ export interface StartAudioPlaybackOptions {
  * apply backpressure via a promise resolution). `flushSilence` pushes a
  * block of zeroes — typically 50ms at shutdown to avoid a popping sound.
  *
- * `onPlaybackTimestamp` exposes an estimate of the wall-clock time at
- * which the most recently written PCM byte will play out of the
- * `bot_out` sink. Consumers subscribe to this stream to align
- * audio-adjacent pipelines (e.g. the TalkingHead.js renderer aligning
- * viseme emission to audio) with the actual playback timeline rather
- * than with the time visemes are received from the daemon.
+ * `onPlaybackTimestamp` exposes an estimate of how many milliseconds
+ * into the current utterance the most recently queued PCM byte will
+ * play. The clock is **utterance-relative** — it starts at 0 on
+ * `startAudioPlayback` and advances by `byteCount / bytesPerMs` on
+ * every non-empty write, directly matching the coordinate system of
+ * `VisemeEvent.timestamp` (see `assistant/src/tts/types.ts`) so viseme-
+ * driven renderers can compare incoming timestamps against the stream
+ * without coordinate-system translation.
  *
- * The estimate is derived from
- *   `max(nowMs, lastEstimate) + byteCount / bytesPerMs`
- * so that sustained writes accumulate into the future (keeping track
- * of buffered audio) while a write after the buffer has drained snaps
- * back to real time. Because Chrome → PulseAudio → `bot_out` → WebRTC
- * resampler is all zero-copy for matching sample rates, the dominant
- * latency source is the ~10 ms pacat jitter buffer; the estimate is
- * therefore accurate to roughly ±30 ms.
+ * There is no real-wall-clock component — an utterance-relative clock
+ * stalls while no audio is being written, which is what downstream
+ * renderers want: if playback pauses, viseme emission pauses too.
  */
 export interface AudioPlaybackHandle {
   /** Whether this handle is still usable. Flips to `false` on stop. */
@@ -127,27 +117,18 @@ export interface AudioPlaybackHandle {
   /**
    * Subscribe to playback-timestamp updates. The callback fires after
    * every non-empty byte write (including silence flushes) with the
-   * wall-clock time at which the most recently written PCM byte is
-   * expected to play out of the sink. Returns an unsubscribe function;
-   * calling it more than once is a no-op.
+   * utterance-relative offset (ms since `startAudioPlayback`) at which
+   * the most recently written PCM byte will play out of the sink. This
+   * is the same coordinate system the daemon stamps on outbound
+   * `VisemeEvent.timestamp` values, so subscribers can compare the two
+   * directly. Returns an unsubscribe function; calling it more than
+   * once is a no-op.
    *
    * Timestamps are strictly monotonic: each emission advances the clock
-   * by at least `byteCount / bytesPerMs` past the previous emission, so
-   * subscribers can compare directly with `VisemeEvent.timestamp`
-   * values without worrying about equal-timestamp reordering.
+   * by exactly `byteCount / bytesPerMs` past the previous emission, so
+   * subscribers don't have to worry about equal-timestamp reordering.
    */
   onPlaybackTimestamp(cb: (ts: number) => void): () => void;
-}
-
-/**
- * Default monotonic clock — `performance.now()` gives millisecond-
- * resolution wall-clock time that tracks the same reference as the
- * `VisemeEvent.timestamp` field the daemon stamps on outbound viseme
- * events, so the alignment math works without coordinate-system
- * translation.
- */
-function defaultNow(): number {
-  return performance.now();
 }
 
 /** Default spawn factory — wraps `Bun.spawn` with the pacat flags. */
@@ -209,7 +190,6 @@ export function startAudioPlayback(
   const rateHz = opts.rateHz ?? DEFAULT_RATE_HZ;
   const channels = opts.channels ?? DEFAULT_CHANNELS;
   const spawn = opts.spawn ?? defaultSpawn;
-  const now = opts.now ?? defaultNow;
   const bytesPerMs = (rateHz * channels * DEFAULT_SAMPLE_BYTES) / 1000;
 
   const argv = buildPacatArgv(device, rateHz, channels);
@@ -232,17 +212,22 @@ export function startAudioPlayback(
 
   // --- playback-timestamp state ---------------------------------------
   //
-  // `effectivePlaybackMs` is the wall-clock time at which the most
-  // recently queued PCM byte is expected to play out. After every
-  // write we advance it by `byteCount / bytesPerMs` from either the
-  // current `effectivePlaybackMs` (buffer still has data) or from
-  // `now()` (buffer drained between writes) — whichever is later.
+  // `effectivePlaybackMs` is an UTTERANCE-RELATIVE offset (ms since
+  // this playback handle was started) at which the most recently queued
+  // PCM byte is expected to play out. It is seeded to 0 and advances by
+  // exactly `byteCount / bytesPerMs` on every non-empty write. This is
+  // the same coordinate system `VisemeEvent.timestamp` uses (see
+  // `assistant/src/tts/types.ts`), so viseme-driven renderers can
+  // compare the two values directly.
   //
-  // This matches the way the kernel's snd-aloop / PulseAudio scheduler
-  // model sink latency. Our error bound is dominated by pacat's
-  // internal jitter buffer (~10 ms) and the Pulse null-sink (~0 ms),
-  // so the estimate stays well under the 30 ms accuracy target.
-  let effectivePlaybackMs = now();
+  // There is deliberately no `performance.now()` / wall-clock input —
+  // mixing process-uptime-relative time into an utterance-relative
+  // clock would make every comparison against `VisemeEvent.timestamp`
+  // nonsensical (uptime dwarfs any plausible utterance offset). If
+  // playback pauses between writes the clock simply doesn't advance,
+  // which matches what downstream renderers want: no audio → no viseme
+  // emission.
+  let effectivePlaybackMs = 0;
   const timestampSubscribers: Array<(ts: number) => void> = [];
 
   const emitTimestamp = (): void => {
@@ -259,12 +244,7 @@ export function startAudioPlayback(
 
   const advanceAfterWrite = (byteCount: number): void => {
     if (byteCount <= 0) return;
-    const nowMs = now();
-    // If the buffer has fully drained since the last write (i.e. real
-    // time has moved past our previous estimate), rebase to now — the
-    // newly-written bytes play "now-ish", not at a stale pinned clock.
-    const baseline = Math.max(nowMs, effectivePlaybackMs);
-    effectivePlaybackMs = baseline + byteCount / bytesPerMs;
+    effectivePlaybackMs += byteCount / bytesPerMs;
     emitTimestamp();
   };
 


### PR DESCRIPTION
## Summary

PR #26671 introduced `onPlaybackTimestamp` buffering so TalkingHead.js visemes flush in lockstep with audio playback. But the handle seeded `effectivePlaybackMs = performance.now()` (process-uptime-relative, always a huge positive value) while `VisemeEvent.timestamp` is utterance-relative (0-based, see \`assistant/src/tts/types.ts\`). Every \`next.timestamp > currentPlaybackTimestamp\` comparison inside the renderer therefore became false and every viseme flushed immediately — the buffering was a no-op in production. Tests only passed because they injected \`now: () => 0\`.

**Fixes**

1. **Utterance-relative playback clock** (\`audio-playback.ts\`). \`effectivePlaybackMs\` is now seeded to 0 at \`startAudioPlayback\` and advances by exactly \`byteCount / bytesPerMs\` on each write. The \`performance.now()\` / \`max(now, effective)\` rebase is gone; the coordinate system now matches \`VisemeEvent.timestamp\` directly. The \`now\` option on \`StartAudioPlaybackOptions\` (dead code once the clock is pure-accumulation) is removed.
2. **Dynamic avatar renderer resolution** (\`http-server.ts\`, Codex P2). The \`/play_audio\` handler used to snapshot \`avatarRenderer\` once per stream. A mid-stream \`/avatar/disable\` + \`/avatar/enable\` cycle would leave every subsequent tick landing on the old (stopped) renderer while the freshly-enabled one got nothing. The callback now reads the current \`avatarRenderer\` closure variable on every tick.
3. **Docstring + test sweep.** The \`AudioPlaybackHandle\` / \`onPlaybackTimestamp\` docstrings and the \`avatar-lipsync\` tests that referenced the old wall-clock semantics are updated to describe the utterance-relative behavior.

## Test plan

- [x] \`bun test __tests__/audio-playback.test.ts __tests__/avatar-lipsync.test.ts __tests__/play-audio-teardown.test.ts\` — 16 pass
- [x] \`bun test __tests__/http-server.test.ts __tests__/talking-head-renderer.test.ts __tests__/voice-loopback.test.ts\` — 44 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
