### PR TITLE
fix(meet-ext): avoid double-toggle on camera by skipping JS click when trusted_click fires

### DIFF
--- a/skills/meet-join/meet-controller-ext/src/__tests__/camera-feature.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/camera-feature.test.ts
@@ -167,7 +167,7 @@ describe("enableCamera", () => {
     expect(isCameraOn()).toBe(true);
   });
 
-  test("emits a trusted_click with computed screen coords before clicking", async () => {
+  test("emits a trusted_click with computed screen coords and skips the JS click fallback when onEvent is wired", async () => {
     installed!.setCameraState(false);
 
     // Stub the toggle's getBoundingClientRect so the coordinate math is
@@ -193,15 +193,17 @@ describe("enableCamera", () => {
       }) as DOMRect;
 
     const events: ExtensionToBotMessage[] = [];
-    // Record the trusted_click emit against the JS click fallback so the
-    // ordering assertion has something to compare.
-    const callOrder: string[] = [];
-    toggle.addEventListener("click", () => callOrder.push("js-click"));
+    // Because the camera toggle inverts state on every accepted click, the
+    // production path fires trusted_click ONLY (no JS `.click()` fallback).
+    // Simulate xdotool landing the X-server click by flipping aria-label
+    // from the onEvent sink — same state transition Meet would publish on a
+    // real trusted click.
+    const clicksBeforeEmit = installed!.clicks();
 
     const result = await enableCamera({
       onEvent: (ev) => {
         events.push(ev);
-        if (ev.type === "trusted_click") callOrder.push("trusted-click");
+        if (ev.type === "trusted_click") installed!.setCameraState(true);
       },
       // chrome = outerHeight - innerHeight = 100; screen origin = (0, 0).
       // Expected: x = 800 + 30 = 830, y = 100 + 680 + 20 = 800.
@@ -223,10 +225,9 @@ describe("enableCamera", () => {
     expect(trustedClicks[0]!.x).toBe(830);
     expect(trustedClicks[0]!.y).toBe(800);
 
-    // trusted_click emits BEFORE the JS click fallback — so the bot will
-    // have dispatched the real xdotool click by the time the fallback
-    // runs, mirroring `features/chat.ts`.
-    expect(callOrder).toEqual(["trusted-click", "js-click"]);
+    // No JS `.click()` was dispatched — trusted_click is the only path in
+    // production, and a second click would invert the toggle back off.
+    expect(installed!.clicks()).toBe(clicksBeforeEmit);
   });
 
   test("throws a descriptive error when the toggle is missing", async () => {

--- a/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
+++ b/skills/meet-join/meet-controller-ext/src/__tests__/content-camera.test.ts
@@ -89,6 +89,24 @@ function installHarness(): InstalledHarness {
     runtime: {
       sendMessage: (msg) => {
         sent.push(msg);
+        // Simulate xdotool landing a real click when the extension emits a
+        // `trusted_click`: camera.ts emits trusted_click and NO LONGER calls
+        // `toggle.click()` itself (that would invert the toggle twice if the
+        // isTrusted gate is ever relaxed). Flip the aria-label here so the
+        // poll in `enableCamera`/`disableCamera` observes the transition.
+        if (
+          flipOnClick &&
+          typeof msg === "object" &&
+          msg !== null &&
+          (msg as { type?: unknown }).type === "trusted_click"
+        ) {
+          const label = camera.getAttribute("aria-label");
+          if (label === "Turn off camera") {
+            camera.setAttribute("aria-label", "Turn on camera");
+          } else if (label === "Turn on camera") {
+            camera.setAttribute("aria-label", "Turn off camera");
+          }
+        }
       },
       onMessage: {
         addListener: () => {},
@@ -146,10 +164,10 @@ describe("handleCameraToggle", () => {
 
   beforeEach(async () => {
     harness = installHarness();
-    const mod = (await import("../content.js")) as {
-      __handleCameraToggle: typeof handleCameraToggle;
+    const mod = (await import("../handle-send-chat.js")) as {
+      handleCameraToggle: typeof handleCameraToggle;
     };
-    handleCameraToggle = mod.__handleCameraToggle;
+    handleCameraToggle = mod.handleCameraToggle;
   });
 
   afterEach(() => {

--- a/skills/meet-join/meet-controller-ext/src/features/camera.ts
+++ b/skills/meet-join/meet-controller-ext/src/features/camera.ts
@@ -33,9 +33,13 @@
  *      keeps the feature modules symmetric.
  *
  * We therefore emit a `trusted_click` over native messaging with the
- * button's computed screen coordinates, then also call the JS `.click()`
- * fallback so the jsdom test harness exercises a real click path and any
- * Meet build that ever relaxes the `isTrusted` gate continues to work.
+ * button's computed screen coordinates when an `onEvent` sink is wired,
+ * and fall back to a JS `.click()` ONLY when `onEvent` is absent (jsdom
+ * unit tests that don't stand up the native-messaging bridge). We cannot
+ * do both per attempt because the camera toggle is a stateful flip —
+ * unlike chat-send or panel-open, each accepted click inverts the state,
+ * so if Meet ever relaxes the `isTrusted` gate and both clicks land the
+ * toggle inverts twice per attempt and settles in the wrong state.
  *
  * ## Polling confirmation
  *
@@ -191,6 +195,7 @@ async function toggleCameraTo(
   // the assumptions about screenX/Y, chrome offsets, and DPI. Production
   // Xvfb pins the window to (0,0) with no bottom chrome, so the
   // `outerHeight - innerHeight` delta is the top chrome offset.
+  let trustedClickEmitted = false;
   if (opts.onEvent) {
     try {
       const rect = toggle.getBoundingClientRect();
@@ -210,18 +215,27 @@ async function toggleCameraTo(
           rect.height / 2,
       );
       opts.onEvent({ type: "trusted_click", x: screenX, y: screenY });
+      trustedClickEmitted = true;
     } catch {
-      // If the rect or window shape is bogus, fall through to the JS click
-      // fallback rather than swallowing the whole toggle attempt.
+      // If the rect or window shape is bogus, or the sink throws, fall
+      // through to the JS click fallback rather than swallowing the whole
+      // toggle attempt.
     }
   }
 
-  try {
-    toggle.click();
-  } catch {
-    // `.click()` can fail if the button is detached mid-flight; fall
-    // through to the poll — if the trusted_click also failed to produce a
-    // state transition, we'll time out below with a descriptive error.
+  // Only click as a fallback when trusted_click did not fire. The camera
+  // toggle inverts state on every accepted click, so firing both paths
+  // would flip twice if Meet's isTrusted gate is ever relaxed. If the
+  // trusted_click is dropped (e.g. xdotool crashes mid-emit), we'll time
+  // out below with a descriptive error rather than second-guessing the
+  // bridge here.
+  if (!trustedClickEmitted) {
+    try {
+      toggle.click();
+    } catch {
+      // `.click()` can fail if the button is detached mid-flight; fall
+      // through to the poll — we'll time out below with a descriptive error.
+    }
   }
 
   // Poll the aria-state for the post-click transition. Shared between


### PR DESCRIPTION
## Summary
- Codex P2 on #26669: camera toggle inverts state per click, so firing both `trusted_click` + unconditional `toggle.click()` would invert twice if Meet's `isTrusted` gate ever relaxes. Skip the JS `.click()` fallback when `trusted_click` emits successfully.
- Fallback still runs when `onEvent` is absent (jsdom tests without the native-messaging bridge) or the emit throws.
- Fix stale import in `content-camera.test.ts` — `handleCameraToggle` moved to `handle-send-chat.ts` in #26843; the test was still dynamic-importing the removed `__handleCameraToggle` export from `content.ts`.

## Notes
- Codex P1 (wire `avatar.camera` into `buildAvatarHttpOptions`) was already addressed in a subsequent plan PR — verified `main.ts:1238-1256` creates the camera channel and threads `enableCamera`/`disableCamera` into the http-server options. No production call-site change needed here.

## Test plan
- [x] `bun test src/__tests__/camera-feature.test.ts src/__tests__/content-camera.test.ts` (15/15 pass)
- [x] `bunx tsc --noEmit` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
