### PR TITLE
fix(meet-join): widen MeetTtsBridgeLike to include onViseme/botBaseUrl/meetingId

### DIFF
--- a/skills/meet-join/daemon/session-manager.ts
+++ b/skills/meet-join/daemon/session-manager.ts
@@ -122,6 +122,7 @@ import {
   type MeetTtsBridgeDeps,
   MeetTtsCancelledError,
   type SpeakInput,
+  type VisemeListener,
 } from "./tts-bridge.js";
 import {
   startTtsLipsync,
@@ -457,14 +458,22 @@ export interface MeetStorageWriterLike {
 /**
  * Thin interface for the TTS-bridge surface the session manager uses. Lets
  * tests swap in a fake without spinning up ffmpeg or a real HTTP client.
+ *
+ * Includes the `onViseme` / `botBaseUrl` / `meetingId` surface consumed by
+ * {@link startTtsLipsync} so a Like-only fake passed via
+ * {@link MeetSessionManagerDeps.ttsBridgeFactory} remains compatible with
+ * the default lipsync factory without an unsafe cast.
  */
 export interface MeetTtsBridgeLike {
+  readonly meetingId: string;
+  readonly botBaseUrl: string;
   speak(
     input: SpeakInput,
   ): Promise<{ streamId: string; completion: Promise<void> }>;
   cancel(streamId: string): Promise<void>;
   cancelAll(): Promise<void>;
   activeStreamCount(): number;
+  onViseme(listener: VisemeListener): () => void;
 }
 
 /**
@@ -2241,17 +2250,15 @@ function defaultTtsBridgeFactory(
  * the session manager never observes a rejection from this path. Tests
  * can inject a fake via {@link MeetSessionManagerDeps.ttsLipsyncFactory}
  * to observe start/stop without touching the bridge's emit path or the
- * bot HTTP surface. The default cast is only safe because
- * {@link MeetTtsBridgeLike} is a strict subset of the {@link MeetTtsBridge}
- * shape {@link startTtsLipsync} reads — `onViseme`, `botBaseUrl`, and
- * `meetingId` are only accessed through the real bridge instance, not
- * through the narrow session-manager interface.
+ * bot HTTP surface. {@link MeetTtsBridgeLike} declares the `onViseme`,
+ * `botBaseUrl`, and `meetingId` surface {@link startTtsLipsync} reads, so
+ * a Like-only fake works without an unsafe cast.
  */
 function defaultTtsLipsyncFactory(
   args: MeetTtsLipsyncFactoryArgs,
 ): TtsLipsyncHandle {
   const lipsyncArgs: StartTtsLipsyncArgs = {
-    bridge: args.bridge as unknown as MeetTtsBridge,
+    bridge: args.bridge,
     botApiToken: args.botApiToken,
   };
   return startTtsLipsync(lipsyncArgs);

--- a/skills/meet-join/daemon/tts-lipsync.ts
+++ b/skills/meet-join/daemon/tts-lipsync.ts
@@ -24,7 +24,19 @@
 
 import { getLogger } from "../../../assistant/src/util/logger.js";
 
-import type { MeetTtsBridge, VisemeEvent } from "./tts-bridge.js";
+import type { VisemeEvent, VisemeListener } from "./tts-bridge.js";
+
+/**
+ * Minimal bridge surface the forwarder reads — matches the overlap between
+ * {@link MeetTtsBridge} and `MeetTtsBridgeLike` in session-manager.ts so
+ * the session manager's narrow fake (or the real bridge) can be passed in
+ * without casting.
+ */
+export interface TtsLipsyncBridge {
+  readonly meetingId: string;
+  readonly botBaseUrl: string;
+  onViseme(listener: VisemeListener): () => void;
+}
 
 const log = getLogger("meet-tts-lipsync");
 
@@ -43,7 +55,7 @@ export type LipsyncFetchFn = (
 
 export interface StartTtsLipsyncArgs {
   /** Bridge whose `onViseme` channel drives the forwarder. */
-  bridge: MeetTtsBridge;
+  bridge: TtsLipsyncBridge;
   /** Per-meeting bearer token — matches the token used for `/play_audio`. */
   botApiToken: string;
   /**


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #26684.

`defaultTtsLipsyncFactory` force-cast a `MeetTtsBridgeLike` to `MeetTtsBridge` and then called `bridge.onViseme` inside `startTtsLipsync`. Because `MeetTtsBridgeLike` didn't declare `onViseme`, `botBaseUrl`, or `meetingId`, a test (or any caller) that overrode only `ttsBridgeFactory` with a Like-only fake would crash inside the default lipsync factory.

Fix:
- Widen `MeetTtsBridgeLike` to declare the `onViseme` / `botBaseUrl` / `meetingId` surface that `startTtsLipsync` actually reads.
- Introduce a narrow `TtsLipsyncBridge` interface in `tts-lipsync.ts` and use it as `StartTtsLipsyncArgs.bridge`, so the session manager's Like type satisfies it structurally with no cast.
- Drop the `as unknown as MeetTtsBridge` cast in `defaultTtsLipsyncFactory`.

The real `MeetTtsBridge` still satisfies both shapes since it has `meetingId`/`botBaseUrl` as readonly public fields and `onViseme` as a public method.

## Test plan
- [x] `bun test skills/meet-join/daemon/__tests__/tts-lipsync.test.ts`
- [x] `bun test skills/meet-join/daemon/__tests__/session-manager.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
