### PR TITLE
fix(chat): let pinned latest turn grow past viewport for tall responses

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -92,7 +92,11 @@ When `pinnedLatestTurnAnchorMessageId` is set, the newest turn is carved out int
 
 The section is flipped as a single unit (cancelling the outer ScrollView flip), so the visual order matches source order: anchor at the visual top, response below, the spacer fills the rest, sentinel at the bottom.
 
-The section's height is bound to the scroll viewport via SwiftUI's `containerRelativeFrame(.vertical, alignment: .top) { length, _ in length - VSpacing.md * 2 }` (subtracting the outer LazyVStack's vertical padding). Because `containerRelativeFrame` reads the nearest scroll container's visible height during layout, the section resizes in the **same** layout pass as composer-induced viewport changes. The remaining empty space is absorbed by the `Spacer`, eliminating the previous `LatestTurnSpacerCalculator` + `viewportHeight` `@State` pipeline (which lagged one frame and caused the anchor row to briefly clip on every Enter keystroke in the composer).
+The section's height is bound to the scroll viewport as a minimum — not a fixed size. A zero-width `Color.clear` probe in the section's `.background` uses `containerRelativeFrame(.vertical, alignment: .top) { length, _ in max(0, length - VSpacing.md * 2) }` to measure the scroll container's visible height, and `onGeometryChange` mirrors the result into a local `@State` that drives the VStack's `.frame(minHeight:, alignment: .top)`. The `max(0, …)` clamp keeps the probe non-negative during transient zero-height layout passes. This replaces the previous `LatestTurnSpacerCalculator` + `viewportHeight` `@State` pipeline (which lagged one frame and caused the anchor row to briefly clip on every Enter keystroke in the composer).
+
+### Tall-response behavior
+
+When the anchor row plus response cluster exceeds the viewport height, the VStack grows past its `minHeight` floor: the `Spacer` collapses to 0 and the LazyVStack sees the section's true (content-sized) height. This keeps the newest portion of a long assistant response scrollable. A fixed `containerRelativeFrame` on the VStack itself would cap the section at viewport height and make overflow content unreachable by scrolling, so the `minHeight` + probe approach is load-bearing, not an optimization — do not collapse it back to a single `containerRelativeFrame` modifier on the VStack.
 
 ---
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -459,6 +459,14 @@ private struct PinnedLatestTurnSection: View {
     let isUnanchoredThinking: Bool
     let thinkingLabel: String
 
+    // Minimum height equal to the scroll container's visible height
+    // (minus the outer LazyVStack's vertical padding). Sourced from a
+    // zero-size `containerRelativeFrame` probe in the `.background` so
+    // the section grows to fill the viewport when content is short but
+    // is still free to exceed it when an assistant response is longer
+    // than a viewport — preserving scrollability for tall answers.
+    @State private var viewportMinHeight: CGFloat = 0
+
     private var hasResponseContent: Bool {
         contentView.showsStandaloneLatestEdgeActivity
             || !contentView.state.orphanSubagents.isEmpty
@@ -470,13 +478,13 @@ private struct PinnedLatestTurnSection: View {
         // equals visual order: anchor at top, response below, spacer
         // fills remaining viewport, sentinel marks the latest edge.
         //
-        // The section's height is bound to the scroll viewport via
-        // `containerRelativeFrame` so it tracks the chat area's height in
-        // the SAME layout pass as composer-induced viewport changes. A
-        // previous `viewportHeight` @State + computed-spacer pattern lagged
-        // one frame behind the AppKit clip-view frame change and caused the
-        // anchor row's top to briefly clip on every Enter keystroke in the
-        // composer.
+        // `.frame(minHeight:)` (not a fixed `containerRelativeFrame` on
+        // the VStack) gives the section a viewport-sized floor while
+        // letting it grow when anchor + response exceeds the viewport.
+        // Without the floor, the `Spacer` below cannot keep the anchor
+        // pinned to the visual top while a short response is streaming.
+        // Without growth, a tall assistant response is capped at the
+        // viewport and the newest content becomes unreachable by scroll.
         VStack(alignment: .leading, spacing: 0) {
             contentView.transcriptRow(
                 row: anchorRow,
@@ -492,13 +500,30 @@ private struct PinnedLatestTurnSection: View {
 
             contentView.latestEdgeSentinel(isFlipped: false)
         }
-        .containerRelativeFrame(.vertical, alignment: .top) { length, _ in
-            // Subtract the outer LazyVStack's vertical padding (top + bottom
-            // of `MessageListContentView.body`) so the anchor row ends with
-            // the intentional VSpacing.md visual gap above it.
-            length - VSpacing.md * 2
-        }
+        .frame(minHeight: viewportMinHeight, alignment: .top)
+        .background(viewportMinHeightProbe)
         .flipped()
+    }
+
+    /// Zero-width `Color.clear` sized to the scroll container's visible
+    /// height via `containerRelativeFrame`. `onGeometryChange` mirrors the
+    /// resolved height into `@State` so the VStack's `minHeight` tracks
+    /// the viewport. `max(0, …)` keeps the closure non-negative for the
+    /// transient zero-height layout passes SwiftUI runs during setup and
+    /// window/split-view collapse — negative frame dimensions produce
+    /// layout warnings and unstable pinned-turn rendering.
+    private var viewportMinHeightProbe: some View {
+        Color.clear
+            .containerRelativeFrame(.vertical, alignment: .top) { length, _ in
+                max(0, length - VSpacing.md * 2)
+            }
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                if abs(viewportMinHeight - newHeight) > 0.5 {
+                    viewportMinHeight = newHeight
+                }
+            }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Addresses the two review threads on #26746 (already merged).

### Negative-height guard (Codex P2)

The `containerRelativeFrame` closure can be invoked with `length < VSpacing.md * 2` during transient zero-height layout passes or aggressive window/split-view collapse. SwiftUI treats negative frame dimensions as invalid. The closure now returns `max(0, length - VSpacing.md * 2)`, matching the prior `LatestTurnSpacerCalculator` guard.

### Tall-response clipping (Devin #1, weightier)

A fixed `containerRelativeFrame(.vertical)` on the VStack capped the pinned-turn section at viewport height. When an assistant response plus anchor exceeded that height, the VStack content overflowed a frame the parent `LazyVStack` thought was viewport-sized — the newest portion was unreachable by scroll.

Fix: measure the viewport via a hidden `Color.clear` probe in the section's `.background` that uses `containerRelativeFrame` + `onGeometryChange` to push the resolved height into a local `@State`. Apply that height as `.frame(minHeight:, alignment: .top)` on the content VStack. This gives the section:
- a viewport-sized floor — the `Spacer` keeps the anchor pinned to the visual top while a short response is streaming (the original PR's flicker fix);
- growth past the floor — when anchor + response exceeds the floor, the VStack expands to its content size, the `Spacer` collapses to 0, and the LazyVStack sees the true height, keeping the newest content scrollable.

### Documentation (Devin #2)

`clients/macos/SCROLL_STRATEGY.md` now describes the minHeight + probe pattern explicitly, including a "do not collapse back to a single containerRelativeFrame" note so future maintainers do not regress.

## Test plan

- [x] macOS app builds cleanly (verified locally).
- [ ] Short response: anchor user row stays pinned at the visual top while the assistant streams; Spacer fills the remaining viewport.
- [ ] Tall response: user can scroll through the entire response; newest content is reachable.
- [ ] Composer grow/shrink (Enter keystroke): anchor does not clip — original PR's flicker fix remains intact.
- [ ] Window resize / split-view collapse: no layout warnings.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
