### PR TITLE
fix(daemon): drop duplicate slackChronologicalMessages keys causing TS1117

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1088,7 +1088,6 @@ export async function runAgentLoopImpl(
         // loop would never converge.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          slackChronologicalMessages: null,
           ...(step.compactionResult?.compacted && {
             pkbContext: currentPkbContent,
           }),
@@ -1324,7 +1323,6 @@ export async function runAgentLoopImpl(
       // reducer loop above for the rationale.
       runMessages = await applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
-        slackChronologicalMessages: null,
         pkbContext: currentPkbContent,
         nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
@@ -1560,7 +1558,6 @@ export async function runAgentLoopImpl(
         // override — the reducer has already shaped ctx.messages.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          slackChronologicalMessages: null,
           pkbContext: currentPkbContent,
           nowScratchpad: convergenceStripped ? currentNowContent : null,
           workspaceTopLevelContext: shouldInjectWorkspace
@@ -1703,7 +1700,6 @@ export async function runAgentLoopImpl(
             // shaped ctx.messages.
             runMessages = await applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
-              slackChronologicalMessages: null,
               pkbContext: currentPkbContent,
               nowScratchpad: convergenceStripped ? currentNowContent : null,
               workspaceTopLevelContext: shouldInjectWorkspace
@@ -1842,7 +1838,6 @@ export async function runAgentLoopImpl(
           // ctx.messages.
           runMessages = await applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
-            slackChronologicalMessages: null,
             pkbContext: currentPkbContent,
             nowScratchpad: convergenceStripped ? currentNowContent : null,
             workspaceTopLevelContext: shouldInjectWorkspace


### PR DESCRIPTION
## Summary
- PR #26847 added a conditional `slackChronologicalMessages: reducerCompacted ? null : injectionOpts.slackChronologicalMessages` at each of 5 `applyRuntimeInjections` re-injection sites without removing the pre-existing `slackChronologicalMessages: null,` line above it, causing TS1117 duplicate-property errors and a failing Type Check CI job.
- Removed the 5 dead `slackChronologicalMessages: null,` lines. The later conditional entry was the one taking effect at runtime (last key wins), so behavior is unchanged.
- Verified the only remaining `slackChronologicalMessages` references in each object literal are the conditional entries.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24681170827/job/72178518848
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
