### PR TITLE
fix(macos): ignore replayed meet.joined for already-joined meeting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Meet/MeetStatusPanel.swift
@@ -80,14 +80,21 @@ public final class MeetStatusViewModel {
             state = .joining(meetingId: m.meetingId, url: m.url)
 
         case .meetJoined(let m):
+            // If we're already `.joined` for this meeting, ignore the replay.
+            // The daemon republishes `meet.joined` (but not `meet.joining`) on
+            // SSE reconnect mid-meeting; rebuilding state here would clobber
+            // the URL-based title with the meetingId fallback and reset
+            // `joinedAt`, restarting the elapsed counter from 00:00.
+            if case let .joined(existingId, _, _) = state, existingId == m.meetingId {
+                return
+            }
             // Carry the joining URL forward as the title when we saw a
             // matching `meet.joining` for this meeting. Otherwise this is
-            // either a reconnect (the SSE stream dropped and resubscribed
-            // mid-meeting, so the daemon has already published `meet.joining`
-            // and will not republish it) or an event we observed before the
-            // view model was constructed. In both cases the bot is live, so
-            // we must transition into `.joined` anyway — using the meetingId
-            // as a title fallback until a later event populates real data.
+            // either a reconnect that happened before we ever saw `.joining`,
+            // or an event we observed before the view model was constructed.
+            // In both cases the bot is live, so we must transition into
+            // `.joined` anyway — using the meetingId as a title fallback until
+            // a later event populates real data.
             let title: String
             if case let .joining(existingId, url) = state, existingId == m.meetingId {
                 title = url

--- a/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/MeetStatusPanelTests.swift
@@ -205,6 +205,50 @@ final class MeetStatusPanelTests: XCTestCase {
         XCTAssertEqual(joinedAt, fixedNow)
     }
 
+    /// SSE reconnect mid-meeting when the panel is already `.joined` — the
+    /// daemon replays `meet.joined` (but not `meet.joining`). The replay must
+    /// be a no-op: the URL-based title and original `joinedAt` must survive
+    /// so the elapsed counter doesn't reset to 00:00.
+    func testReplayedJoinedForSameMeetingPreservesTitleAndJoinedAt() async throws {
+        let initialNow = Date(timeIntervalSince1970: 1_700_800_000)
+        var clockValue = initialNow
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let vm = MeetStatusViewModel(
+            messageStream: stream,
+            clock: { clockValue }
+        )
+
+        continuation.yield(.meetJoining(
+            MeetJoiningMessage(
+                type: "meet.joining",
+                meetingId: "replay-meeting",
+                url: "https://meet.google.com/replay"
+            )
+        ))
+        continuation.yield(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "replay-meeting")
+        ))
+        try await waitUntil(timeout: 2.0) {
+            if case .joined = vm.state { return true }
+            return false
+        }
+
+        // Advance the clock, then replay meet.joined (no meet.joining) as
+        // would happen on an SSE reconnect.
+        clockValue = initialNow.addingTimeInterval(120)
+        continuation.yield(.meetJoined(
+            MeetJoinedMessage(type: "meet.joined", meetingId: "replay-meeting")
+        ))
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        guard case let .joined(meetingId, title, joinedAt) = vm.state else {
+            return XCTFail("expected .joined state after replay")
+        }
+        XCTAssertEqual(meetingId, "replay-meeting")
+        XCTAssertEqual(title, "https://meet.google.com/replay")
+        XCTAssertEqual(joinedAt, initialNow)
+    }
+
     // MARK: - meetingId scoping
 
     /// With multiple simultaneous meetings, a stale `meet.left` for meeting A


### PR DESCRIPTION
## Summary
Addresses Devin feedback on #26662. On SSE reconnect mid-meeting the daemon replays `meet.joined` without a preceding `meet.joining`. The relaxed handler from #26662 rebuilt `.joined` state unconditionally — clobbering the URL-based title with the meetingId fallback and resetting `joinedAt`, which restarted the elapsed counter at 00:00.

Fix: early-return when state is already `.joined` for the same `meetingId`, so the replay is idempotent and the live title + elapsed clock survive.

Added a regression test that replays `meet.joined` after advancing the clock and asserts title and `joinedAt` are preserved.

## Test plan
- [x] `MeetStatusPanelTests` covers the replay path
- [x] Swift build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
