### PR TITLE
fix(daemon): remove duplicate slackChronologicalMessages keys

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1081,14 +1081,8 @@ export async function runAgentLoopImpl(
         // When compaction ran it strips existing NOW.md / PKB blocks, so we
         // must re-inject the current content. Otherwise rely on the deduplicated
         // value from injectionOpts to avoid duplicate injection.
-        // Drop the Slack chronological override: the reducer has already
-        // shaped ctx.messages, and the transcript is rebuilt from ALL
-        // persisted rows (compaction doesn't delete rows), so re-applying
-        // it here would overwrite the reducer's output and the overflow
-        // loop would never converge.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          slackChronologicalMessages: null,
           ...(step.compactionResult?.compacted && {
             pkbContext: currentPkbContent,
           }),
@@ -1320,11 +1314,8 @@ export async function runAgentLoopImpl(
       // stripInjectionsForCompaction() unconditionally removed the existing
       // NOW.md block from ctx.messages above, so we must always re-inject
       // the current content regardless of whether compaction actually ran.
-      // Drop the Slack chronological override here too — see the preflight
-      // reducer loop above for the rationale.
       runMessages = await applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
-        slackChronologicalMessages: null,
         pkbContext: currentPkbContent,
         nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
@@ -1556,11 +1547,9 @@ export async function runAgentLoopImpl(
 
         // Only re-inject NOW.md when ctx.messages was actually stripped;
         // otherwise the existing NOW.md block is still present and
-        // re-injecting would duplicate it. Drop the Slack chronological
-        // override — the reducer has already shaped ctx.messages.
+        // re-injecting would duplicate it.
         runMessages = await applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          slackChronologicalMessages: null,
           pkbContext: currentPkbContent,
           nowScratchpad: convergenceStripped ? currentNowContent : null,
           workspaceTopLevelContext: shouldInjectWorkspace
@@ -1698,12 +1687,9 @@ export async function runAgentLoopImpl(
             }
 
             // Only re-inject NOW.md when ctx.messages was actually stripped;
-            // otherwise the existing block is still present. Drop the Slack
-            // chronological override — emergency compaction has already
-            // shaped ctx.messages.
+            // otherwise the existing block is still present.
             runMessages = await applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
-              slackChronologicalMessages: null,
               pkbContext: currentPkbContent,
               nowScratchpad: convergenceStripped ? currentNowContent : null,
               workspaceTopLevelContext: shouldInjectWorkspace
@@ -1837,12 +1823,9 @@ export async function runAgentLoopImpl(
           }
 
           // Only re-inject NOW.md when ctx.messages was actually stripped;
-          // otherwise the existing block is still present. Drop the Slack
-          // chronological override — auto-compress has already shaped
-          // ctx.messages.
+          // otherwise the existing block is still present.
           runMessages = await applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
-            slackChronologicalMessages: null,
             pkbContext: currentPkbContent,
             nowScratchpad: convergenceStripped ? currentNowContent : null,
             workspaceTopLevelContext: shouldInjectWorkspace


### PR DESCRIPTION
## Summary
- Fix TS1117 failures on `main` (run 24681555761, commit c939517) by removing five duplicate `slackChronologicalMessages: null` keys in `conversation-agent-loop.ts`.
- The duplicates came from PR #26847 adding the conditional `slackChronologicalMessages: reducerCompacted ? null : injectionOpts.slackChronologicalMessages` at the five re-injection sites (preflight, mid-loop, convergence, emergency, auto-compress fallback) without removing the earlier unconditional `null` from #26831.
- Keeps the newer conditional assignment (drop the override only when the reducer actually compacted) and cleans up the now-stale explanatory comments.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24681555761/job/72179866469
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
