### PR TITLE
fix(macos-menu): update authFailed status line to reflect disabled behavior

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
@@ -18,7 +18,7 @@ enum AssistantStatus {
         case .thinking: return "\(name) is thinking..."
         case .error: return "\(name) encountered an error"
         case .disconnected: return "Disconnected from \(name)"
-        case .authFailed: return "Authentication failed — click to re-pair \(name)"
+        case .authFailed: return "Authentication failed — use Re-pair \(name) below"
         }
     }
 


### PR DESCRIPTION
## Summary

The menu status line for `.authFailed` still read `"Authentication failed — click to re-pair"` even though the status line itself is disabled (not clickable). Re-pairing is handled by the dedicated **Re-pair Assistant** menu item added in #26492, so point users there instead.

Addresses the remaining unresolved feedback on #26492 (the other items were handled in follow-ups #26494 and #26521).

## Test plan

- [ ] Force an auth failure and confirm the menu now reads `"Authentication failed — use Re-pair <Name> below"`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
