### PR TITLE
fix(cli): distinguish unreachable gateway from missing API key in credential read

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -200,17 +200,18 @@ export async function login(): Promise<void> {
         // 1. Use fresh key from registration (first-time only)
         // 2. Use existing key from the daemon's credential store
         // 3. Reprovision (rotate) as a last resort — this revokes the
-        //    old key server-side, so we avoid it when possible.
+        //    old key server-side, so we only do it when the gateway
+        //    confirms no key exists (not when it's merely unreachable).
         let assistantApiKey = registration.assistant_api_key;
         if (!assistantApiKey) {
-          const existingKey = await readGatewayCredential(
+          const cached = await readGatewayCredential(
             entry.runtimeUrl,
             "vellum:assistant_api_key",
             entry.bearerToken,
           );
-          if (existingKey) {
-            assistantApiKey = existingKey;
-          } else {
+          if (cached.value) {
+            assistantApiKey = cached.value;
+          } else if (!cached.unreachable) {
             console.log("No API key available locally — reprovisioning...");
             const reprovision = await reprovisionAssistantApiKey(
               token,

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1139,16 +1139,18 @@ async function tryInjectPlatformCredentials(
 
     // Resolve the API key: 1) fresh from registration, 2) existing from
     // daemon credential store, 3) reprovision as last resort (revokes old key).
+    // Only reprovision when the gateway confirms no key exists — not when
+    // the gateway is merely unreachable (would revoke without injecting).
     let assistantApiKey = registration.assistant_api_key;
     if (!assistantApiKey) {
-      const existingKey = await readGatewayCredential(
+      const cached = await readGatewayCredential(
         entry.runtimeUrl,
         "vellum:assistant_api_key",
         entry.bearerToken,
       );
-      if (existingKey) {
-        assistantApiKey = existingKey;
-      } else {
+      if (cached.value) {
+        assistantApiKey = cached.value;
+      } else if (!cached.unreachable) {
         const reprovision = await reprovisionAssistantApiKey(
           token,
           orgId,

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -331,10 +331,21 @@ export async function readGatewayCredential(
     });
 
     if (!response.ok) {
-      return { value: null, unreachable: false };
+      // 5xx means the gateway/daemon backend is down — treat as unreachable
+      // so callers don't revoke a potentially valid key.
+      return { value: null, unreachable: response.status >= 500 };
     }
 
-    const json = (await response.json()) as { found: boolean; value?: string };
+    const json = (await response.json()) as {
+      found: boolean;
+      value?: string;
+      unreachable?: boolean;
+    };
+    // The daemon's /v1/secrets/read returns `unreachable: true` when the
+    // credential backend (CES) can't be reached. Respect that signal.
+    if (json.unreachable) {
+      return { value: null, unreachable: true };
+    }
     return {
       value: json.found && json.value ? json.value : null,
       unreachable: false,

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -289,19 +289,31 @@ export async function reprovisionAssistantApiKey(
 // Credential reading from running assistant via gateway
 // ---------------------------------------------------------------------------
 
+export interface GatewayCredentialResult {
+  /** The credential value, if found. */
+  value: string | null;
+  /** True when the gateway/daemon was unreachable (network error, timeout, etc.). */
+  unreachable: boolean;
+}
+
 /**
  * Read an existing credential from the assistant's secret store via the
  * gateway-proxied `POST /v1/secrets/read` endpoint (with `reveal: true`).
  *
- * Returns the credential value if found, or `null` if the credential is
- * missing or the assistant is unreachable. Never throws — failures are
- * treated as "not found" so the caller can fall through to reprovisioning.
+ * Returns a result distinguishing "key not found" (`value: null,
+ * unreachable: false`) from "gateway unreachable" (`value: null,
+ * unreachable: true`). Callers should only reprovision when the gateway
+ * is reachable but the key is genuinely missing — reprovisioning while
+ * the gateway is down would revoke the old key server-side without being
+ * able to inject the replacement.
+ *
+ * Never throws.
  */
 export async function readGatewayCredential(
   gatewayUrl: string,
   name: string,
   bearerToken?: string,
-): Promise<string | null> {
+): Promise<GatewayCredentialResult> {
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -318,12 +330,18 @@ export async function readGatewayCredential(
       signal: AbortSignal.timeout(10_000),
     });
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+      return { value: null, unreachable: false };
+    }
 
     const json = (await response.json()) as { found: boolean; value?: string };
-    return json.found && json.value ? json.value : null;
+    return {
+      value: json.found && json.value ? json.value : null,
+      unreachable: false,
+    };
   } catch {
-    return null;
+    // Network error, timeout, or gateway down
+    return { value: null, unreachable: true };
   }
 }
 


### PR DESCRIPTION
## Summary
- Changed `readGatewayCredential()` to return `{ value, unreachable }` instead of `string | null`, distinguishing "key not found" from "gateway down"
- Updated `login.ts` and `teleport.ts` to only call `reprovisionAssistantApiKey` when the gateway is reachable but the key is genuinely missing — avoids revoking a valid key when the assistant is simply stopped

## Original prompt
the follow up — address PR #26820 review feedback: `readGatewayCredential` collapsing all failures into null causes unnecessary key revocation when the gateway is unreachable
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
