### PR TITLE
fix(slack): handle web_search_tool_result in filterOrphanToolPairs

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -407,7 +407,8 @@ function filterOrphanToolPairs(messages: Message[]): Message[] {
   for (const msg of messages) {
     for (const b of msg.content) {
       if (b.type === "tool_use") produced.add(b.id);
-      else if (b.type === "tool_result") consumed.add(b.tool_use_id);
+      else if (b.type === "tool_result" || b.type === "web_search_tool_result")
+        consumed.add(b.tool_use_id);
     }
   }
   const out: Message[] = [];
@@ -415,7 +416,11 @@ function filterOrphanToolPairs(messages: Message[]): Message[] {
     const kept: ContentBlock[] = [];
     for (const b of msg.content) {
       if (b.type === "tool_use" && !consumed.has(b.id)) continue;
-      if (b.type === "tool_result" && !produced.has(b.tool_use_id)) continue;
+      if (
+        (b.type === "tool_result" || b.type === "web_search_tool_result") &&
+        !produced.has(b.tool_use_id)
+      )
+        continue;
       kept.push(b);
     }
     if (kept.length > 0) out.push({ role: msg.role, content: kept });


### PR DESCRIPTION
## Summary
- Add `|| b.type === "web_search_tool_result"` to both type checks in `filterOrphanToolPairs` so web search result blocks are correctly paired/pruned alongside regular tool results
- Fixes the `conversation-history-web-search.test.ts` structural guard that prevents web search results from being silently dropped

## Original prompt
help me fix this CI failure https://github.com/vellum-ai/vellum-assistant/actions/runs/24681965305/job/72181363405
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
