### PR TITLE
test(web-search-guard): allowlist slack render-transcript filterOrphanToolPairs

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -795,6 +795,12 @@ describe("web_search_tool_result structural guard", () => {
     // image/file blocks. web_search_tool_result has opaque content with no
     // contentBlocks property, so it cannot contain nested media.
     "daemon/context-overflow-reducer.ts",
+
+    // Final orphan-pair safety pass in the Slack transcript renderer.
+    // Server-side block types (`server_tool_use`, `web_search_tool_result`)
+    // are stripped earlier by `buildMessageContentBlocks` and cannot reach
+    // this filter, so only `tool_use` ↔ `tool_result` pairing is relevant.
+    "messaging/providers/slack/render-transcript.ts",
   ]);
 
   /**


### PR DESCRIPTION
## Summary
- Adds `messaging/providers/slack/render-transcript.ts` to the `ALLOWLISTED_FILES` set in `conversation-history-web-search.test.ts` so the `web_search_tool_result structural guard` no longer flags `filterOrphanToolPairs`.
- `filterOrphanToolPairs` only needs `tool_use` ↔ `tool_result` pairing; server-side block types (`server_tool_use`, `web_search_tool_result`) are stripped earlier by `buildMessageContentBlocks` and cannot reach this filter.
- Fixes the CI failure surfaced by PR #26853, which removed the unreachable `server_tool_use`/`web_search_tool_result` branches from the filter and inadvertently tripped the guard test.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24682040054/job/72181554216
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
