### PR TITLE
feat(cli): add `assistant tts synthesize` command

### DIFF
--- a/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for the `assistant tts synthesize` CLI command.
+ *
+ * Validates:
+ *   - Help text renders correctly for `tts` and `tts synthesize`
+ *   - Error when the provider is not configured (TTS_PROVIDER_NOT_CONFIGURED)
+ *   - Generic synthesis failure (TTS_SYNTHESIS_FAILED)
+ *   - Success case: writes audio to a temp file and prints its path
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+interface MockSynthesisResult {
+  audio: Buffer;
+  contentType: string;
+}
+
+let mockSynthesisResult: MockSynthesisResult = {
+  audio: Buffer.from("fake-audio"),
+  contentType: "audio/mpeg",
+};
+let mockSynthesizeThrow: Error | null = null;
+let logErrorMessages: string[] = [];
+let writeFileCalls: Array<{ path: string; buffer: Buffer }> = [];
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before module-under-test import
+// ---------------------------------------------------------------------------
+
+mock.module("../../logger.js", () => ({
+  log: {
+    error: (msg: string) => {
+      logErrorMessages.push(msg);
+      process.stderr.write(msg + "\n");
+    },
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+  },
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  initFeatureFlagOverrides: async () => {},
+  _setOverridesForTesting: () => {},
+  isFeatureEnabled: () => true,
+}));
+
+mock.module("../../../tts/synthesize-text.js", () => ({
+  synthesizeText: async () => {
+    if (mockSynthesizeThrow) throw mockSynthesizeThrow;
+    return mockSynthesisResult;
+  },
+  TtsSynthesisError: class TtsSynthesisError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "TtsSynthesisError";
+      this.code = code;
+    }
+  },
+}));
+
+mock.module("../../../tts/providers/register-builtins.js", () => ({
+  registerBuiltinTtsProviders: () => {},
+}));
+
+mock.module("node:fs", () => ({
+  existsSync: () => true,
+  mkdirSync: () => {},
+  writeFileSync: (path: string, buffer: Buffer) => {
+    writeFileCalls.push({ path, buffer });
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerTtsCommand } = await import("../tts.js");
+const { TtsSynthesisError } = await import("../../../tts/synthesize-text.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  const originalExit = process.exit;
+  process.exit = ((code?: number) => {
+    process.exitCode = code ?? 0;
+    throw new Error(`__EXIT_${code ?? 0}__`);
+  }) as typeof process.exit;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (str: string) => stderrChunks.push(str),
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerTtsCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    /* commander exit override or process.exit mock throws */
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockSynthesisResult = {
+    audio: Buffer.from("fake-audio"),
+    contentType: "audio/mpeg",
+  };
+  mockSynthesizeThrow = null;
+  logErrorMessages = [];
+  writeFileCalls = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+describe("help text", () => {
+  test("tts --help renders command group with examples", async () => {
+    const { stdout } = await runCommand(["tts", "--help"]);
+    expect(stdout).toContain("Text-to-speech");
+    expect(stdout).toContain("assistant tts synthesize");
+  });
+
+  test("tts synthesize --help renders argument docs and examples", async () => {
+    const { stdout } = await runCommand(["tts", "synthesize", "--help"]);
+    expect(stdout).toContain("--text");
+    expect(stdout).toContain("assistant tts synthesize --text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe("error cases", () => {
+  test("provider not configured exits with code 1 and actionable error", async () => {
+    mockSynthesizeThrow = new TtsSynthesisError(
+      "TTS_PROVIDER_NOT_CONFIGURED",
+      "not registered",
+    );
+
+    const { exitCode, stderr } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("assistant config set services.tts.provider");
+  });
+
+  test("generic synthesis failure exits with code 1 and includes error message", async () => {
+    mockSynthesizeThrow = new TtsSynthesisError(
+      "TTS_SYNTHESIS_FAILED",
+      "upstream 500",
+    );
+
+    const { exitCode, stderr } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("upstream 500");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success case
+// ---------------------------------------------------------------------------
+
+describe("success cases", () => {
+  test("synthesizes text, writes audio to temp dir, prints file path", async () => {
+    mockSynthesisResult = {
+      audio: Buffer.from("fake-audio"),
+      contentType: "audio/mpeg",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(writeFileCalls.length).toBe(1);
+
+    const call = writeFileCalls[0];
+    expect(call.path).toContain("vellum-tts-");
+    expect(call.path.endsWith(".mp3")).toBe(true);
+    expect(call.buffer.equals(Buffer.from("fake-audio"))).toBe(true);
+
+    expect(stdout).toContain(call.path);
+  });
+});

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -1,0 +1,128 @@
+/**
+ * CLI command group: `assistant tts`
+ *
+ * Text-to-speech operations using the configured TTS provider.
+ * Stateless, request-response commands — no daemon dependency.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { Command } from "commander";
+
+import { registerBuiltinTtsProviders } from "../../tts/providers/register-builtins.js";
+import {
+  synthesizeText,
+  TtsSynthesisError,
+} from "../../tts/synthesize-text.js";
+import { log } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// MIME type → file extension mapping
+// ---------------------------------------------------------------------------
+
+function extensionForMime(mimeType: string): string {
+  switch (mimeType) {
+    case "audio/mpeg":
+      return "mp3";
+    case "audio/wav":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/ogg":
+      return "ogg";
+    case "audio/webm":
+      return "webm";
+    case "audio/opus":
+      return "opus";
+    default:
+      return "bin";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerTtsCommand(program: Command): void {
+  const ttsCmd = program
+    .command("tts")
+    .description("Text-to-speech operations");
+
+  ttsCmd.addHelpText(
+    "after",
+    `
+TTS commands use your configured TTS provider to synthesize text to audio.
+The provider is set via:
+
+  $ assistant config set services.tts.provider <provider>
+
+Built-in providers: elevenlabs, fish-audio, deepgram.
+
+Examples:
+  $ assistant tts synthesize --text "hello world"
+  $ assistant tts synthesize --text "announcement"`,
+  );
+
+  // ── synthesize ──────────────────────────────────────────────────────
+
+  ttsCmd
+    .command("synthesize")
+    .description("Synthesize text to audio using the configured TTS provider")
+    .requiredOption("--text <text>", "Text to synthesize to audio")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  --text <text>   Text to synthesize to audio (required).
+
+Writes the audio file to the system temp directory with a random name.
+The file extension is derived from the provider's returned MIME type
+(mp3 for ElevenLabs, wav for Deepgram/Fish Audio in WAV mode).
+
+Examples:
+  $ assistant tts synthesize --text "hello world"
+  $ assistant tts synthesize --text "announcement"`,
+    )
+    .action(async (opts: { text: string }) => {
+      // Providers must be registered in the CLI process since the daemon is
+      // a separate process and each process has its own registry.
+      registerBuiltinTtsProviders();
+
+      try {
+        const result = await synthesizeText({
+          text: opts.text,
+          useCase: "message-playback",
+        });
+
+        const filePath = join(
+          tmpdir(),
+          `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
+        );
+
+        const dir = dirname(filePath);
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
+
+        writeFileSync(filePath, result.audio);
+        process.stdout.write(filePath + "\n");
+      } catch (err) {
+        if (
+          err instanceof TtsSynthesisError &&
+          err.code === "TTS_PROVIDER_NOT_CONFIGURED"
+        ) {
+          log.error(
+            "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`TTS synthesis failed: ${msg}`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -42,6 +42,7 @@ import { registerSkillsCommand } from "./commands/skills.js";
 import { registerSttCommand } from "./commands/stt.js";
 import { registerTaskCommand } from "./commands/task.js";
 import { registerTrustCommand } from "./commands/trust.js";
+import { registerTtsCommand } from "./commands/tts.js";
 import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { registerWatchersCommand } from "./commands/watchers.js";
@@ -111,6 +112,7 @@ Examples:
   registerShotgunCommand(program);
   registerSequenceCommand(program);
   registerSttCommand(program);
+  registerTtsCommand(program);
 
   registerInferenceCommand(program);
 


### PR DESCRIPTION
## Summary
- Adds `assistant tts synthesize --text <text>` CLI command that synthesizes text to audio using the configured TTS provider via `synthesizeText()`.
- Writes the audio file to the system temp directory and prints its path; exits with actionable errors when the provider is not configured or synthesis fails.
- Registers built-in TTS providers inside the CLI process (providers self-register at daemon startup; the CLI runs in a separate process).

Part of plan: cli-tts-commands.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
