### PR TITLE
refactor: remove Connection Port UI from popup

### DIFF
--- a/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
+++ b/clients/chrome-extension/background/__tests__/worker-connect-preflight.test.ts
@@ -66,6 +66,8 @@ function missingTokenMessage(profile: AssistantAuthProfile | null): string {
   return 'Select an assistant before connecting';
 }
 
+const DEFAULT_RELAY_PORT = 7830;
+
 // ── Controllable fakes ──────────────────────────────────────────────
 
 /**
@@ -77,7 +79,6 @@ interface PreflightDeps {
   signInCloud: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken>;
   refreshCloudToken: (assistantId: string, config: { webBaseUrl: string; clientId: string }) => Promise<StoredCloudToken | null>;
   getStoredCloudToken: (assistantId: string) => Promise<StoredCloudToken | null>;
-  getRelayPort: () => Promise<number>;
   /** The effective environment used to resolve cloud URLs. Defaults to build default. */
   effectiveEnvironment: ExtensionEnvironment;
 }
@@ -118,7 +119,7 @@ async function connectPreflight(
     }
     const assistantId = assistant?.assistantId ?? null;
     const stored = await deps.bootstrapLocalToken(assistantId);
-    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await deps.getRelayPort());
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? DEFAULT_RELAY_PORT;
     return {
       kind: 'self-hosted',
       baseUrl: `http://127.0.0.1:${port}`,
@@ -223,7 +224,6 @@ function makeDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
     },
     refreshCloudToken: async () => null,
     getStoredCloudToken: async () => null,
-    getRelayPort: async () => 7830,
     // Default to the build-time default environment (typically 'dev' in tests)
     effectiveEnvironment: resolveBuildDefaultEnvironment(),
     ...overrides,

--- a/clients/chrome-extension/background/relay-connection.ts
+++ b/clients/chrome-extension/background/relay-connection.ts
@@ -737,7 +737,7 @@ export async function postHostBrowserResult(
 
   // self-hosted: POST to the local daemon. The base URL is whatever
   // `buildRelayModeConfig` resolved at connect time (usually
-  // `http://127.0.0.1:<relayPort>`).
+  // `http://127.0.0.1:<port>`).
   const headers: Record<string, string> = { 'content-type': 'application/json' };
   if (mode.token) headers.authorization = `Bearer ${mode.token}`;
   const url = `${mode.baseUrl.replace(/\/$/, '')}/v1/host-browser-result`;

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -38,9 +38,9 @@ export interface StoredLocalToken {
   /**
    * Assistant runtime HTTP port echoed by the native messaging helper.
    * When present the chrome extension uses this as the base URL for the
-   * self-hosted relay WebSocket instead of the hard-coded
-   * `DEFAULT_RELAY_PORT`. Optional for forward/back-compat with older
-   * native helpers that predate PR 3 of the browser-remediation plan.
+   * self-hosted relay WebSocket instead of the default port (7830).
+   * Optional for forward/back-compat with older native helpers that
+   * predate PR 3 of the browser-remediation plan.
    */
   assistantPort?: number;
   /**

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -3,7 +3,7 @@
  *
  * Connects to either
  *   - the local assistant's browser-relay endpoint
- *     (`ws://127.0.0.1:<relayPort>/v1/browser-relay`), or
+ *     (`ws://127.0.0.1:<port>/v1/browser-relay`), or
  *   - the cloud gateway's browser-relay endpoint
  *     (`wss://<cloud-gateway>/v1/browser-relay`)
  *
@@ -534,7 +534,7 @@ async function dispatchHostBrowserResult(
     ? await getStoredLocalToken(selectedId)
     : await getLegacyLocalToken();
   if (local) {
-    const fallbackPort = local.assistantPort ?? (await getRelayPort());
+    const fallbackPort = local.assistantPort ?? DEFAULT_RELAY_PORT;
     const fallbackMode: RelayMode = {
       kind: 'self-hosted',
       baseUrl: `http://127.0.0.1:${fallbackPort}`,
@@ -587,17 +587,6 @@ const hostBrowserDispatcher: HostBrowserDispatcher = createHostBrowserDispatcher
 });
 
 // ── Storage helpers ─────────────────────────────────────────────────
-
-async function getRelayPort(): Promise<number> {
-  const result = await chrome.storage.local.get('relayPort');
-  const stored = result.relayPort;
-  if (typeof stored === 'number' && stored > 0 && stored <= 65535) return stored;
-  if (typeof stored === 'string') {
-    const parsed = parseInt(stored, 10);
-    if (!isNaN(parsed) && parsed > 0 && parsed <= 65535) return parsed;
-  }
-  return DEFAULT_RELAY_PORT;
-}
 
 /**
  * Read a cloud auth token from the legacy unscoped storage key
@@ -660,7 +649,7 @@ async function buildRelayModeForAssistant(
     // first (matches the pre-PR4 default of `self-hosted`).
     const local = await getLegacyLocalToken();
     if (local) {
-      const port = local.assistantPort ?? (await getRelayPort());
+      const port = local.assistantPort ?? DEFAULT_RELAY_PORT;
       return {
         kind: 'self-hosted',
         baseUrl: `http://127.0.0.1:${port}`,
@@ -678,7 +667,7 @@ async function buildRelayModeForAssistant(
     }
     // No token at all — return a token-less self-hosted mode so the
     // caller can surface a missing-token error.
-    const port = await getRelayPort();
+    const port = DEFAULT_RELAY_PORT;
     return {
       kind: 'self-hosted',
       baseUrl: `http://127.0.0.1:${port}`,
@@ -716,7 +705,7 @@ async function buildRelayModeForAssistant(
     }
 
     if (local) {
-      const port = local.assistantPort ?? assistant.daemonPort ?? (await getRelayPort());
+      const port = local.assistantPort ?? assistant.daemonPort ?? DEFAULT_RELAY_PORT;
       return {
         kind: 'self-hosted',
         baseUrl: `http://127.0.0.1:${port}`,
@@ -724,7 +713,7 @@ async function buildRelayModeForAssistant(
       };
     }
     // No local token yet — return token-less mode for the error path.
-    const port = assistant.daemonPort ?? (await getRelayPort());
+    const port = assistant.daemonPort ?? DEFAULT_RELAY_PORT;
     return {
       kind: 'self-hosted',
       baseUrl: `http://127.0.0.1:${port}`,
@@ -751,7 +740,7 @@ async function buildRelayModeForAssistant(
   // actionable error.
   return {
     kind: 'self-hosted',
-    baseUrl: `http://127.0.0.1:${await getRelayPort()}`,
+    baseUrl: `http://127.0.0.1:${DEFAULT_RELAY_PORT}`,
     token: null,
   };
 }
@@ -1098,7 +1087,7 @@ async function connectPreflight(
     const assistantId = assistant?.assistantId ?? null;
     const environment = await getEffectiveEnvironment();
     const stored = await bootstrapLocalToken(assistantId, { environment });
-    const port = stored.assistantPort ?? assistant?.daemonPort ?? (await getRelayPort());
+    const port = stored.assistantPort ?? assistant?.daemonPort ?? DEFAULT_RELAY_PORT;
     return {
       kind: 'self-hosted',
       baseUrl: `http://127.0.0.1:${port}`,

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -611,18 +611,6 @@
         <p class="hint" id="environment-hint">Overrides the build default for this extension profile.</p>
       </div>
 
-      <div class="advanced-setting">
-        <label for="port-input">Connection port</label>
-        <input
-          type="text"
-          id="port-input"
-          placeholder="7830"
-          autocomplete="off"
-          spellcheck="false"
-        />
-        <p class="hint">Only change this if support asks you to.</p>
-      </div>
-
       <p class="local-status" id="local-status" style="display:none">Not paired</p>
       <button id="btn-pair-local" type="button" style="display:none">Re-pair with local assistant</button>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -53,11 +53,8 @@ import {
   type EnvironmentStateResponse,
 } from './popup-state.js';
 
-const DEFAULT_RELAY_PORT = 7830;
-
 // ── DOM references ──────────────────────────────────────────────────
 
-const portInput = document.getElementById('port-input') as HTMLInputElement;
 const connectionToggle = document.getElementById('connection-toggle') as HTMLInputElement;
 const connectionToggleHint = document.getElementById(
   'connection-toggle-hint',
@@ -203,8 +200,6 @@ function applyHealthState(
   statusBadge.textContent = badge.text;
   statusBadge.className = `status-badge ${badge.className}`;
 
-  portInput.disabled = phase === 'connecting' || phase === 'reconnecting';
-
   setSetupMessage(phase);
 
   if (health === 'connected') {
@@ -231,7 +226,6 @@ function setPhase(phase: ConnectionPhase): void {
     statusText.textContent = 'Desktop app required';
     statusBadge.textContent = 'Needs app';
     statusBadge.className = 'status-badge disconnected';
-    portInput.disabled = false;
     setSetupMessage('no-native-host');
     updateTroubleshootSection('error');
     return;
@@ -493,13 +487,6 @@ assistantSelect.addEventListener('change', () => {
   );
 });
 
-// Load saved relay port on open.
-chrome.storage.local.get(['relayPort']).then((result) => {
-  if (result.relayPort !== undefined) {
-    portInput.value = String(result.relayPort);
-  }
-});
-
 // Query current health state from service worker.
 chrome.runtime.sendMessage({ type: 'get_status' }, (response: GetStatusResponse) => {
   if (chrome.runtime.lastError) return;
@@ -513,15 +500,6 @@ chrome.runtime.sendMessage({ type: 'get_status' }, (response: GetStatusResponse)
   }
 });
 
-function getPort(): number {
-  const portStr = portInput.value.trim();
-  if (portStr) {
-    const portNum = parseInt(portStr, 10);
-    if (!isNaN(portNum) && portNum > 0 && portNum <= 65535) return portNum;
-  }
-  return DEFAULT_RELAY_PORT;
-}
-
 // ── Connection toggle ────────────────────────────────────────────────
 //
 // No local precheck -- the worker handles auth bootstrap (pairing/sign-in)
@@ -529,23 +507,9 @@ function getPort(): number {
 // even when not previously paired or signed in.
 
 async function requestConnect(): Promise<void> {
-  const port = getPort();
-
   errorText.style.display = 'none';
   hideDebugDetails();
   setPhase('connecting');
-
-  try {
-    if (portInput.value.trim()) {
-      await chrome.storage.local.set({ relayPort: port });
-    } else {
-      await chrome.storage.local.remove('relayPort');
-    }
-  } catch (err) {
-    showError(err instanceof Error ? err.message : String(err));
-    applyHealthState('error');
-    return;
-  }
 
   await new Promise<void>((resolve) => {
     chrome.runtime.sendMessage({ type: 'connect' }, (response: { ok: boolean; error?: string; debugDetails?: string }) => {


### PR DESCRIPTION
## Summary
- Remove the Connection Port input from the popup Advanced section (HTML + TS)
- Remove `getRelayPort()` function and `relayPort` storage key usage from worker.ts
- Replace all call sites with the hardcoded `DEFAULT_RELAY_PORT` constant (7830), which was already the effective default
- Update test file to remove `getRelayPort` from mock deps interface

## Original prompt
lets remove it entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
