### PR TITLE
feat(stt-xai): allow xai as services.stt.provider value

### DIFF
--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -8,6 +8,7 @@ export const VALID_STT_PROVIDERS = [
   "deepgram",
   "google-gemini",
   "openai-whisper",
+  "xai",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Append `"xai"` to `VALID_STT_PROVIDERS` so `services.stt.provider: "xai"` passes Zod validation
- No runtime behavior yet — real adapters land in PR 5 / PR 7

Part of plan: xai-stt-provider.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
