### PR TITLE
feat(stt-xai): add xai provider id and stub switch cases

### DIFF
--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -381,6 +381,8 @@ async function createStreamingTranscriber(
         pcmSampleRate: options.sampleRate,
       });
     }
+    case "xai":
+      return null;
     default: {
       const _exhaustive: never = providerId;
       return null;

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -185,6 +185,8 @@ export function createDaemonBatchTranscriber(
       return new DeepgramBatchTranscriber(apiKey);
     case "google-gemini":
       return new GoogleGeminiBatchTranscriber(apiKey);
+    case "xai":
+      return null;
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -20,7 +20,11 @@
  * Canonical provider identifiers for daemon-hosted STT backends.
  * Extend this union as new providers are integrated.
  */
-export type SttProviderId = "openai-whisper" | "deepgram" | "google-gemini";
+export type SttProviderId =
+  | "openai-whisper"
+  | "deepgram"
+  | "google-gemini"
+  | "xai";
 
 /**
  * Telephony-specific STT capability class.


### PR DESCRIPTION
## Summary
- Append `"xai"` to the `SttProviderId` union
- Add stub `case "xai": return null;` to `createDaemonBatchTranscriber()` and `createStreamingTranscriber()` so tsc's exhaustive-never guards pass
- Scaffolding only — real xai batch/streaming adapters land in PR 5 / PR 7

Part of plan: xai-stt-provider.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
