### PR TITLE
feat(cli): accept positional args, stdin, and `--output` for `tts synthesize`

### DIFF
--- a/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
@@ -26,8 +26,13 @@ let mockSynthesisResult: MockSynthesisResult = {
   contentType: "audio/mpeg",
 };
 let mockSynthesizeThrow: Error | null = null;
+let mockSynthesizeTextArg: string | undefined;
 let logErrorMessages: string[] = [];
 let writeFileCalls: Array<{ path: string; buffer: Buffer }> = [];
+let mkdirCalls: Array<{ path: string; options: unknown }> = [];
+let readFileSyncImpl: (path: string, encoding: string) => string = () => {
+  throw new Error("stdin unavailable");
+};
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before module-under-test import
@@ -52,7 +57,8 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../../../tts/synthesize-text.js", () => ({
-  synthesizeText: async () => {
+  synthesizeText: async (args: { text: string }) => {
+    mockSynthesizeTextArg = args.text;
     if (mockSynthesizeThrow) throw mockSynthesizeThrow;
     return mockSynthesisResult;
   },
@@ -72,7 +78,11 @@ mock.module("../../../tts/providers/register-builtins.js", () => ({
 
 mock.module("node:fs", () => ({
   existsSync: () => true,
-  mkdirSync: () => {},
+  mkdirSync: (path: string, options: unknown) => {
+    mkdirCalls.push({ path, options });
+  },
+  readFileSync: (path: string, encoding: string) =>
+    readFileSyncImpl(path, encoding),
   writeFileSync: (path: string, buffer: Buffer) => {
     writeFileCalls.push({ path, buffer });
   },
@@ -152,8 +162,13 @@ beforeEach(() => {
     contentType: "audio/mpeg",
   };
   mockSynthesizeThrow = null;
+  mockSynthesizeTextArg = undefined;
   logErrorMessages = [];
   writeFileCalls = [];
+  mkdirCalls = [];
+  readFileSyncImpl = () => {
+    throw new Error("stdin unavailable");
+  };
   process.exitCode = 0;
 });
 
@@ -242,5 +257,68 @@ describe("success cases", () => {
     expect(call.buffer.equals(Buffer.from("fake-audio"))).toBe(true);
 
     expect(stdout).toContain(call.path);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flexible input
+// ---------------------------------------------------------------------------
+
+describe("flexible input", () => {
+  test("positional args are joined with spaces and passed as text", async () => {
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "hello",
+      "world",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(mockSynthesizeTextArg).toBe("hello world");
+    expect(writeFileCalls.length).toBe(1);
+  });
+
+  test("stdin fallback is used when no --text or positional arg is given", async () => {
+    readFileSyncImpl = (path: string) => {
+      if (path === "/dev/stdin") return "piped text\n";
+      throw new Error("unexpected readFileSync call");
+    };
+
+    const { exitCode } = await runCommand(["tts", "synthesize"]);
+
+    expect(exitCode).toBe(0);
+    expect(mockSynthesizeTextArg).toBe("piped text");
+  });
+
+  test("empty input from every channel exits 1 with actionable error", async () => {
+    readFileSyncImpl = () => {
+      throw new Error("stdin unavailable");
+    };
+
+    const { exitCode, stderr } = await runCommand(["tts", "synthesize"]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No text provided");
+    expect(mockSynthesizeTextArg).toBeUndefined();
+    expect(writeFileCalls.length).toBe(0);
+  });
+
+  test("--output override writes to the given path and creates parent dir", async () => {
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--output",
+      "/custom/path/out.mp3",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(writeFileCalls.length).toBe(1);
+    expect(writeFileCalls[0].path).toBe("/custom/path/out.mp3");
+
+    const mkdirForParent = mkdirCalls.find((c) => c.path === "/custom/path");
+    expect(mkdirForParent).toBeDefined();
+    expect(mkdirForParent?.options).toEqual({ recursive: true });
   });
 });

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -62,7 +62,8 @@ Built-in providers: elevenlabs, fish-audio, deepgram.
 
 Examples:
   $ assistant tts synthesize --text "hello world"
-  $ assistant tts synthesize --text "announcement"`,
+  $ assistant tts synthesize "spoken sentence"
+  $ echo "piped input" | assistant tts synthesize`,
   );
 
   // ── synthesize ──────────────────────────────────────────────────────
@@ -70,59 +71,105 @@ Examples:
   ttsCmd
     .command("synthesize")
     .description("Synthesize text to audio using the configured TTS provider")
-    .requiredOption("--text <text>", "Text to synthesize to audio")
+    .option(
+      "--text <text>",
+      "Text to synthesize to audio (alternative: pass as positional arg or pipe via stdin)",
+    )
+    .option(
+      "--output <path>",
+      "Path to write the audio file (defaults to system temp dir with auto-generated name)",
+    )
+    .argument(
+      "[text...]",
+      "Text to synthesize (joined with spaces; alternative to --text or stdin)",
+    )
     .addHelpText(
       "after",
       `
-Arguments:
-  --text <text>   Text to synthesize to audio (required).
+Input modes (pick one):
+  --text <text>         Text to synthesize to audio.
+  [text...]             Positional argument(s) joined with spaces.
+  stdin                 Piped input when neither --text nor a positional is given.
 
-Writes the audio file to the system temp directory with a random name.
-The file extension is derived from the provider's returned MIME type
-(mp3 for ElevenLabs, wav for Deepgram/Fish Audio in WAV mode).
+Options:
+  --output <path>       Path to write the audio file. When omitted, a file is
+                        written to the system temp directory with a random
+                        name and the extension derived from the provider's
+                        returned MIME type (mp3 for ElevenLabs, wav for
+                        Deepgram/Fish Audio in WAV mode). Parent directories
+                        are created as needed.
 
 Examples:
   $ assistant tts synthesize --text "hello world"
-  $ assistant tts synthesize --text "announcement"`,
+  $ assistant tts synthesize "spoken sentence" --output /tmp/out.mp3
+  $ echo "hello" | assistant tts synthesize`,
     )
-    .action(async (opts: { text: string }) => {
-      // Providers must be registered in the CLI process since the daemon is
-      // a separate process and each process has its own registry.
-      registerBuiltinTtsProviders();
-
-      try {
-        const result = await synthesizeText({
-          text: opts.text,
-          useCase: "message-playback",
-        });
-
-        const filePath = join(
-          tmpdir(),
-          `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
-        );
-
-        const dir = dirname(filePath);
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
+    .action(
+      async (
+        positionalParts: string[],
+        opts: { text?: string; output?: string },
+      ) => {
+        // Resolve effective text from --text, positional args, or stdin.
+        let messageText =
+          opts.text ??
+          (positionalParts.length > 0 ? positionalParts.join(" ") : "");
+        if (!messageText) {
+          try {
+            messageText = readFileSync("/dev/stdin", "utf-8").trim();
+          } catch {
+            /* stdin unavailable */
+          }
         }
-
-        writeFileSync(filePath, result.audio);
-        process.stdout.write(filePath + "\n");
-      } catch (err) {
-        if (
-          err instanceof TtsSynthesisError &&
-          err.code === "TTS_PROVIDER_NOT_CONFIGURED"
-        ) {
+        if (!messageText) {
           log.error(
-            "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+            "No text provided. Pass --text, a positional argument, or pipe via stdin.",
           );
           process.exitCode = 1;
           return;
         }
 
-        const msg = err instanceof Error ? err.message : String(err);
-        log.error(`TTS synthesis failed: ${msg}`);
-        process.exitCode = 1;
-      }
-    });
+        // Providers must be registered in the CLI process since the daemon is
+        // a separate process and each process has its own registry.
+        registerBuiltinTtsProviders();
+
+        try {
+          const result = await synthesizeText({
+            text: messageText,
+            useCase: "message-playback",
+          });
+
+          const filePath =
+            opts.output ??
+            join(
+              tmpdir(),
+              `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
+            );
+
+          const dir = dirname(filePath);
+          if (opts.output) {
+            mkdirSync(dir, { recursive: true });
+          } else if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+          }
+
+          writeFileSync(filePath, result.audio);
+          process.stdout.write(filePath + "\n");
+        } catch (err) {
+          if (
+            err instanceof TtsSynthesisError &&
+            err.code === "TTS_PROVIDER_NOT_CONFIGURED"
+          ) {
+            log.error(
+              "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          const msg = err instanceof Error ? err.message : String(err);
+          log.error(`TTS synthesis failed: ${msg}`);
+          process.exitCode = 1;
+        }
+      },
+    );
 }


### PR DESCRIPTION
## Summary
- Relaxes `--text` from required to optional; the command now accepts text from positional args (`assistant tts synthesize 'hello'`), stdin (`echo 'hello' | assistant tts synthesize`), or the `--text` flag.
- Adds `--output <path>` to override the auto-generated tmpdir destination; parent directory is created recursively if missing.
- Empty-input paths exit with an actionable error naming all three input modes.

Part of plan: cli-tts-commands.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
