### PR TITLE
feat(cli): add `--voice`, `--use-case`, `--json` flags to `tts synthesize`

### DIFF
--- a/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
@@ -28,6 +28,11 @@ let mockSynthesisResult: MockSynthesisResult = {
 let mockSynthesizeThrow: Error | null = null;
 let logErrorMessages: string[] = [];
 let writeFileCalls: Array<{ path: string; buffer: Buffer }> = [];
+let synthesizeCalls: Array<{
+  text: string;
+  useCase: string;
+  voiceId?: string;
+}> = [];
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before module-under-test import
@@ -52,7 +57,16 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../../../tts/synthesize-text.js", () => ({
-  synthesizeText: async () => {
+  synthesizeText: async (opts: {
+    text: string;
+    useCase: string;
+    voiceId?: string;
+  }) => {
+    synthesizeCalls.push({
+      text: opts.text,
+      useCase: opts.useCase,
+      voiceId: opts.voiceId,
+    });
     if (mockSynthesizeThrow) throw mockSynthesizeThrow;
     return mockSynthesisResult;
   },
@@ -154,6 +168,7 @@ beforeEach(() => {
   mockSynthesizeThrow = null;
   logErrorMessages = [];
   writeFileCalls = [];
+  synthesizeCalls = [];
   process.exitCode = 0;
 });
 
@@ -242,5 +257,124 @@ describe("success cases", () => {
     expect(call.buffer.equals(Buffer.from("fake-audio"))).toBe(true);
 
     expect(stdout).toContain(call.path);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option pass-through
+// ---------------------------------------------------------------------------
+
+describe("option pass-through", () => {
+  test("--voice is forwarded to synthesizeText as voiceId", async () => {
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--voice",
+      "voice-123",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(synthesizeCalls.length).toBe(1);
+    expect(synthesizeCalls[0].voiceId).toBe("voice-123");
+  });
+
+  test("--use-case phone-call is forwarded to synthesizeText", async () => {
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--use-case",
+      "phone-call",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(synthesizeCalls.length).toBe(1);
+    expect(synthesizeCalls[0].useCase).toBe("phone-call");
+  });
+
+  test("default --use-case is 'message-playback'", async () => {
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(synthesizeCalls.length).toBe(1);
+    expect(synthesizeCalls[0].useCase).toBe("message-playback");
+  });
+
+  test("invalid --use-case exits 1 with message naming the valid values", async () => {
+    const { exitCode, stderr } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--use-case",
+      "invalid",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("message-playback");
+    expect(stderr).toContain("phone-call");
+    // synthesizeText should not have been called
+    expect(synthesizeCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+describe("--json output", () => {
+  test("success emits single-line JSON with ok, path, contentType, sizeBytes", async () => {
+    const audio = Buffer.from("fake-audio-bytes");
+    mockSynthesisResult = {
+      audio,
+      contentType: "audio/mpeg",
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(writeFileCalls.length).toBe(1);
+
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe(writeFileCalls[0].path);
+    expect(parsed.contentType).toBe("audio/mpeg");
+    expect(parsed.sizeBytes).toBe(audio.length);
+  });
+
+  test("provider-not-configured error emits JSON with ok: false and actionable error", async () => {
+    mockSynthesizeThrow = new TtsSynthesisError(
+      "TTS_PROVIDER_NOT_CONFIGURED",
+      "not registered",
+    );
+
+    const { exitCode, stdout } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      "assistant config set services.tts.provider",
+    );
   });
 });

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -17,7 +17,17 @@ import {
   synthesizeText,
   TtsSynthesisError,
 } from "../../tts/synthesize-text.js";
+import type { TtsUseCase } from "../../tts/types.js";
 import { log } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALID_USE_CASES: readonly TtsUseCase[] = [
+  "message-playback",
+  "phone-call",
+];
 
 // ---------------------------------------------------------------------------
 // MIME type → file extension mapping
@@ -71,11 +81,28 @@ Examples:
     .command("synthesize")
     .description("Synthesize text to audio using the configured TTS provider")
     .requiredOption("--text <text>", "Text to synthesize to audio")
+    .option(
+      "--voice <id>",
+      "Provider-specific voice identifier (ElevenLabs voiceId, Fish Audio referenceId, etc.) — overrides configured default",
+    )
+    .option(
+      "--use-case <case>",
+      "Synthesis use case: 'message-playback' (default, higher quality) or 'phone-call' (lower latency)",
+      "message-playback",
+    )
+    .option("--json", "Output structured JSON instead of plain file path")
     .addHelpText(
       "after",
       `
 Arguments:
-  --text <text>   Text to synthesize to audio (required).
+  --text <text>       Text to synthesize to audio (required).
+  --voice <id>        Provider-specific voice identifier that overrides the
+                      configured default. Format depends on the provider
+                      (e.g. an ElevenLabs voiceId or a Fish Audio referenceId).
+  --use-case <case>   Synthesis use case — 'message-playback' (default,
+                      higher quality) or 'phone-call' (lower latency).
+  --json              Output a single-line JSON object on stdout instead of
+                      the plain file path. Errors are also emitted as JSON.
 
 Writes the audio file to the system temp directory with a random name.
 The file extension is derived from the provider's returned MIME type
@@ -83,46 +110,90 @@ The file extension is derived from the provider's returned MIME type
 
 Examples:
   $ assistant tts synthesize --text "hello world"
-  $ assistant tts synthesize --text "announcement"`,
+  $ assistant tts synthesize --text "hi" --voice <voice-id>
+  $ assistant tts synthesize --text "hi" --use-case phone-call
+  $ assistant tts synthesize --text "hi" --json`,
     )
-    .action(async (opts: { text: string }) => {
-      // Providers must be registered in the CLI process since the daemon is
-      // a separate process and each process has its own registry.
-      registerBuiltinTtsProviders();
+    .action(
+      async (opts: {
+        text: string;
+        voice?: string;
+        useCase: string;
+        json?: boolean;
+      }) => {
+        const jsonOutput = opts.json ?? false;
 
-      try {
-        const result = await synthesizeText({
-          text: opts.text,
-          useCase: "message-playback",
-        });
+        const emitError = (msg: string): void => {
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: msg }) + "\n",
+            );
+          } else {
+            log.error(msg);
+          }
+        };
 
-        const filePath = join(
-          tmpdir(),
-          `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
-        );
-
-        const dir = dirname(filePath);
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
-        }
-
-        writeFileSync(filePath, result.audio);
-        process.stdout.write(filePath + "\n");
-      } catch (err) {
-        if (
-          err instanceof TtsSynthesisError &&
-          err.code === "TTS_PROVIDER_NOT_CONFIGURED"
-        ) {
-          log.error(
-            "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+        // Validate --use-case
+        if (!VALID_USE_CASES.includes(opts.useCase as TtsUseCase)) {
+          emitError(
+            `Invalid --use-case: '${opts.useCase}'. Must be one of: ${VALID_USE_CASES.join(", ")}.`,
           );
           process.exitCode = 1;
           return;
         }
+        const useCase = opts.useCase as TtsUseCase;
 
-        const msg = err instanceof Error ? err.message : String(err);
-        log.error(`TTS synthesis failed: ${msg}`);
-        process.exitCode = 1;
-      }
-    });
+        // Providers must be registered in the CLI process since the daemon is
+        // a separate process and each process has its own registry.
+        registerBuiltinTtsProviders();
+
+        try {
+          const result = await synthesizeText({
+            text: opts.text,
+            useCase,
+            voiceId: opts.voice,
+          });
+
+          const filePath = join(
+            tmpdir(),
+            `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
+          );
+
+          const dir = dirname(filePath);
+          if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+          }
+
+          writeFileSync(filePath, result.audio);
+
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                ok: true,
+                path: filePath,
+                contentType: result.contentType,
+                sizeBytes: result.audio.length,
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write(filePath + "\n");
+          }
+        } catch (err) {
+          if (
+            err instanceof TtsSynthesisError &&
+            err.code === "TTS_PROVIDER_NOT_CONFIGURED"
+          ) {
+            emitError(
+              "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          const msg = err instanceof Error ? err.message : String(err);
+          emitError(`TTS synthesis failed: ${msg}`);
+          process.exitCode = 1;
+        }
+      },
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `--voice <id>` to override the configured default voice (provider-specific identifier), and `--use-case <case>` to pick between `message-playback` (default) and `phone-call`.
- Adds `--json` for structured `{ ok, path, contentType, sizeBytes }` success output and `{ ok: false, error }` on failure; matches the pattern used by `assistant stt transcribe --json`.
- Validates `--use-case` against the canonical enum and rejects invalid values with an actionable message.

Part of plan: cli-tts-commands.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
