### PR TITLE
feat(stt-xai): wire xai batch provider into daemon adapter

### DIFF
--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -45,6 +45,19 @@ mock.module("../../providers/speech-to-text/google-gemini.js", () => ({
   },
 }));
 
+let mockXAITranscribeResult: { text: string } = { text: "" };
+let mockXAITranscribeError: Error | null = null;
+
+mock.module("../../providers/speech-to-text/xai.js", () => ({
+  XAIProvider: class MockXAIProvider {
+    constructor(_apiKey: string) {}
+    async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
+      if (mockXAITranscribeError) throw mockXAITranscribeError;
+      return mockXAITranscribeResult;
+    }
+  },
+}));
+
 // Dynamic import so mocks are active when the module loads.
 const { createDaemonBatchTranscriber, normalizeSttError } =
   await import("../daemon-batch-transcriber.js");
@@ -61,6 +74,8 @@ describe("createDaemonBatchTranscriber", () => {
     mockDeepgramTranscribeError = null;
     mockGeminiTranscribeResult = { text: "" };
     mockGeminiTranscribeError = null;
+    mockXAITranscribeResult = { text: "" };
+    mockXAITranscribeError = null;
   });
 
   // -------------------------------------------------------------------------
@@ -304,6 +319,67 @@ describe("createDaemonBatchTranscriber", () => {
   test("returns null for google-gemini when no API key is provided", () => {
     expect(createDaemonBatchTranscriber(null, "google-gemini")).toBeNull();
     expect(createDaemonBatchTranscriber(undefined, "google-gemini")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider identity — xAI
+  // -------------------------------------------------------------------------
+
+  test("reports providerId as xai when created with xai", () => {
+    const transcriber = createDaemonBatchTranscriber("xai-test-key", "xai");
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("xai");
+  });
+
+  test("reports boundaryId as daemon-batch for xai", () => {
+    const transcriber = createDaemonBatchTranscriber("xai-test-key", "xai");
+    expect(transcriber!.boundaryId).toBe("daemon-batch");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful transcription — xAI
+  // -------------------------------------------------------------------------
+
+  test("delegates transcription to the xAI provider", async () => {
+    mockXAITranscribeResult = { text: "Hello from xAI" };
+
+    const transcriber = createDaemonBatchTranscriber("xai-test-key", "xai");
+    const result = await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(result).toEqual({ text: "Hello from xAI" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation — xAI
+  // -------------------------------------------------------------------------
+
+  test("propagates xAI errors unchanged", async () => {
+    const original = new Error("xAI API error (401): Invalid credentials");
+    mockXAITranscribeError = original;
+
+    const transcriber = createDaemonBatchTranscriber("xai-test-key", "xai");
+
+    try {
+      await transcriber!.transcribe({
+        audio: Buffer.from("audio"),
+        mimeType: "audio/wav",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBe(original);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Null on missing key — xAI
+  // -------------------------------------------------------------------------
+
+  test("returns null for xai when no API key is provided", () => {
+    expect(createDaemonBatchTranscriber(null, "xai")).toBeNull();
+    expect(createDaemonBatchTranscriber(undefined, "xai")).toBeNull();
   });
 });
 

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -10,6 +10,7 @@
  * - OpenAI Whisper (`openai-whisper`)
  * - Deepgram (`deepgram`)
  * - Google Gemini (`google-gemini`)
+ * - xAI (`xai`)
  */
 
 import type {
@@ -121,6 +122,36 @@ class GoogleGeminiBatchTranscriber implements BatchTranscriber {
 }
 
 // ---------------------------------------------------------------------------
+// xAI adapter — implements BatchTranscriber on top of the xAI audio
+// transcription provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `XAIProvider` behind the `BatchTranscriber` contract.
+ *
+ * Same error-propagation semantics as WhisperBatchTranscriber: raw provider
+ * errors pass through unchanged.
+ */
+class XAIBatchTranscriber implements BatchTranscriber {
+  readonly providerId = "xai" as const;
+  readonly boundaryId = "daemon-batch" as const;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    request: SttTranscribeRequest,
+  ): Promise<SttTranscribeResult> {
+    const { XAIProvider } = await import("../providers/speech-to-text/xai.js");
+    const provider = new XAIProvider(this.apiKey);
+    return provider.transcribe(request.audio, request.mimeType, request.signal);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Error normalization
 // ---------------------------------------------------------------------------
 
@@ -186,7 +217,7 @@ export function createDaemonBatchTranscriber(
     case "google-gemini":
       return new GoogleGeminiBatchTranscriber(apiKey);
     case "xai":
-      return null;
+      return new XAIBatchTranscriber(apiKey);
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.


### PR DESCRIPTION
## Summary
- New `XAIBatchTranscriber` adapter class that lazy-imports `XAIProvider` from `../providers/speech-to-text/xai.js`
- Replace PR 1's stub `case "xai": return null;` with `case "xai": return new XAIBatchTranscriber(apiKey);`
- Test coverage for the new case (both apiKey and null-apiKey paths)

Part of plan: xai-stt-provider.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
