### PR TITLE
fix(macos-client): cancel pending avatar retry tasks on disconnect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -241,29 +241,35 @@ final class AvatarAppearanceManager {
     }
 
     /// Guards against stacking overlapping retries when repeated transient
-    /// failures arrive before the first retry has completed.
+    /// failures arrive before the first retry has completed. Tracked as Task
+    /// handles so `resetForDisconnect()` can cancel a pending retry before it
+    /// writes into the next assistant's state.
     @ObservationIgnored private var avatarRetryInFlight = false
     @ObservationIgnored private var traitsRetryInFlight = false
+    @ObservationIgnored private var avatarRetryTask: Task<Void, Never>?
+    @ObservationIgnored private var traitsRetryTask: Task<Void, Never>?
 
     private func scheduleAvatarRetry() {
         guard !avatarRetryInFlight else { return }
         avatarRetryInFlight = true
-        Task { [weak self] in
+        avatarRetryTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
-            guard let self else { return }
+            guard !Task.isCancelled, let self else { return }
             await self.fetchAvatarViaHTTP()
             self.avatarRetryInFlight = false
+            self.avatarRetryTask = nil
         }
     }
 
     private func scheduleTraitsRetry() {
         guard !traitsRetryInFlight else { return }
         traitsRetryInFlight = true
-        Task { [weak self] in
+        traitsRetryTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: Self.transientRetryDelayNs)
-            guard let self else { return }
+            guard !Task.isCancelled, let self else { return }
             await self.fetchTraitsViaHTTP()
             self.traitsRetryInFlight = false
+            self.traitsRetryTask = nil
         }
     }
 
@@ -388,6 +394,16 @@ final class AvatarAppearanceManager {
     func resetForDisconnect() {
         identityLoadTask?.cancel()
         identityLoadTask = nil
+        // Cancel any pending retry Tasks and clear in-flight flags so a retry
+        // spawned against the previous assistant cannot fire after state has
+        // been cleared, and so the next connection's legitimate retries are
+        // not silently no-oped by a stale in-flight flag.
+        avatarRetryTask?.cancel()
+        avatarRetryTask = nil
+        avatarRetryInFlight = false
+        traitsRetryTask?.cancel()
+        traitsRetryTask = nil
+        traitsRetryInFlight = false
         customAvatarImage = nil
         characterBodyShape = nil
         characterEyeStyle = nil


### PR DESCRIPTION
## Summary

Addresses review feedback on #26659 — both reviewers flagged the same lifecycle gap.

`resetForDisconnect()` cleared all cached avatar state but did not cancel the delayed retry `Task`s added in #26659 or reset the `avatarRetryInFlight` / `traitsRetryInFlight` flags. This created two problems on logout/account switch:

1. A retry `Task` spawned before disconnect would fire ~2s later and mutate avatar state for the *next* assistant context.
2. With the in-flight flag stuck at `true`, the new connection's legitimate `scheduleAvatarRetry()` / `scheduleTraitsRetry()` calls were silently no-oped.

Fix: store each retry as a tracked `Task<Void, Never>?` handle, and in `resetForDisconnect()` cancel both pending tasks and reset both in-flight flags. Retry closures also check `Task.isCancelled` after the sleep to avoid doing work post-cancellation.

## Test plan

- [x] Manual review of `resetForDisconnect()` lifecycle
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
