### PR TITLE
refactor(gateway): use ruleScope() and remove scope from non-scoped trust rule handling

### DIFF
--- a/gateway/src/__tests__/trust-store.test.ts
+++ b/gateway/src/__tests__/trust-store.test.ts
@@ -13,10 +13,13 @@ import {
 import { join } from "node:path";
 import { describe, test, expect, beforeEach } from "bun:test";
 
+import { ruleScope } from "@vellumai/ces-contracts/trust-rules";
+
 import {
   loadRules,
   getAllRules,
   addRule,
+  updateRule,
   findMatchingRule,
   findHighestPriorityRule,
   clearRules,
@@ -246,6 +249,79 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect(rules[0].id).toBe("r7-good");
+  });
+
+  test("strips scope from non-scoped URL tool rules on load", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r-url-scope",
+          tool: "web_fetch",
+          pattern: "**",
+          scope: "/some/path",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    // Scope should have been stripped for non-scoped URL tool
+    expect("scope" in rules[0]).toBe(false);
+    // ruleScope() returns "everywhere" for non-scoped rules without scope
+    expect(ruleScope(rules[0])).toBe("everywhere");
+
+    // Verify file was re-saved with scope stripped
+    const saved = readTrustFile();
+    const savedRules = saved.rules as Array<Record<string, unknown>>;
+    expect("scope" in savedRules[0]).toBe(false);
+  });
+
+  test("strips scope from non-scoped managed skill rules on load", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r-skill-scope",
+          tool: "scaffold_managed_skill",
+          pattern: "**",
+          scope: "/some/path",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect("scope" in rules[0]).toBe(false);
+    expect(ruleScope(rules[0])).toBe("everywhere");
+  });
+
+  test("strips scope from non-scoped skill_load rules on load", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "r-skillload-scope",
+          tool: "skill_load",
+          pattern: "**",
+          scope: "/some/path",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect("scope" in rules[0]).toBe(false);
+    expect(ruleScope(rules[0])).toBe("everywhere");
   });
 
   test("does not re-save when no normalization is needed", () => {
@@ -572,6 +648,134 @@ describe("CRUD operations", () => {
 
     clearRules();
     expect(getAllRules()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ruleScope() integration
+// ---------------------------------------------------------------------------
+
+describe("ruleScope() integration", () => {
+  test("ruleScope returns 'everywhere' for non-scoped rules loaded from disk", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "rs-url",
+          tool: "web_fetch",
+          pattern: "**",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+        {
+          id: "rs-skill",
+          tool: "scaffold_managed_skill",
+          pattern: "**",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(2);
+    // Both non-scoped rules should have ruleScope() return "everywhere"
+    for (const rule of rules) {
+      expect(ruleScope(rule)).toBe("everywhere");
+    }
+  });
+
+  test("ruleScope returns explicit scope for scoped rules loaded from disk", () => {
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "rs-bash",
+          tool: "bash",
+          pattern: "**",
+          scope: "/home/user/project",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    const rules = loadRules();
+    expect(rules).toHaveLength(1);
+    expect(ruleScope(rules[0])).toBe("/home/user/project");
+  });
+
+  test("non-scoped rules match via ruleScope() even when loaded with scope on disk", () => {
+    // Write a web_fetch rule that has scope on disk (legacy data)
+    writeTrustFile({
+      version: 3,
+      rules: [
+        {
+          id: "rs-legacy-url",
+          tool: "web_fetch",
+          pattern: "**",
+          scope: "/specific/path",
+          decision: "allow",
+          priority: 100,
+          createdAt: 1000,
+        },
+      ],
+    });
+
+    loadRules();
+
+    // The rule should match everywhere because scope is stripped for URL tools
+    expect(
+      findMatchingRule("web_fetch", "https://example.com", "/any/path"),
+    ).toBeTruthy();
+    expect(
+      findMatchingRule("web_fetch", "https://example.com", "/other/path"),
+    ).toBeTruthy();
+  });
+
+  test("addRule omits scope for non-scoped tools", () => {
+    const rule = addRule(
+      "web_fetch",
+      "https://example.com/**",
+      "everywhere",
+      "allow",
+      80,
+    );
+    expect(rule.tool).toBe("web_fetch");
+    // Non-scoped rules should not carry scope
+    expect("scope" in rule).toBe(false);
+    expect(ruleScope(rule)).toBe("everywhere");
+  });
+
+  test("addRule preserves scope for scoped tools", () => {
+    const rule = addRule("bash", "echo **", "/home/user/project", "allow", 80);
+    expect(rule.tool).toBe("bash");
+    expect(rule.scope).toBe("/home/user/project");
+    expect(ruleScope(rule)).toBe("/home/user/project");
+  });
+
+  test("updateRule ignores scope updates for non-scoped tools", () => {
+    const rule = addRule(
+      "web_fetch",
+      "https://example.com/**",
+      "everywhere",
+      "allow",
+      80,
+    );
+    // Try to update scope on a non-scoped tool — should be ignored
+    const updated = updateRule(rule.id, { scope: "/some/dir" });
+    expect("scope" in updated).toBe(false);
+    expect(ruleScope(updated)).toBe("everywhere");
+  });
+
+  test("updateRule applies scope updates for scoped tools", () => {
+    const rule = addRule("bash", "echo **", "/home/user/project", "allow", 80);
+    const updated = updateRule(rule.id, { scope: "/home/user/other" });
+    expect(updated.scope).toBe("/home/user/other");
+    expect(ruleScope(updated)).toBe("/home/user/other");
   });
 });
 

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -11,6 +11,8 @@
  * URL-tool rule) are silently stripped before persistence.
  */
 
+import { SCOPED_TOOLS } from "@vellumai/ces-contracts/trust-rules";
+
 import { getLogger } from "../../logger.js";
 import {
   addRule,
@@ -23,6 +25,9 @@ import {
   acceptStarterBundle,
   type TrustDecision,
 } from "../../trust-store.js";
+
+/** Set for O(1) lookup when determining if a tool is scoped. */
+const SCOPED_TOOLS_SET: ReadonlySet<string> = new Set(SCOPED_TOOLS);
 
 const log = getLogger("trust-rules");
 
@@ -95,9 +100,18 @@ export function createTrustRulesAddHandler() {
         { status: 400 },
       );
     }
-    if (typeof scope !== "string" || !scope) {
+    // Scope is required for scoped tools; for non-scoped tools it defaults
+    // to "everywhere" (a no-op that parseTrustRule will strip).
+    const isScoped = SCOPED_TOOLS_SET.has(tool as string);
+    if (isScoped && (typeof scope !== "string" || !scope)) {
       return Response.json(
-        { error: '"scope" must be a non-empty string' },
+        { error: '"scope" must be a non-empty string for scoped tools' },
+        { status: 400 },
+      );
+    }
+    if (scope !== undefined && typeof scope !== "string") {
+      return Response.json(
+        { error: '"scope" must be a string when provided' },
         { status: 400 },
       );
     }
@@ -129,12 +143,16 @@ export function createTrustRulesAddHandler() {
       );
     }
 
+    // For non-scoped tools, pass "everywhere" as a no-op default — addRule
+    // will strip it via parseTrustRule for non-scoped tool families.
+    const effectiveScope = (scope as string) || "everywhere";
+
     try {
       // Canonicalization is handled inside trust-store addRule.
       const rule = addRule(
         tool as string,
         pattern as string,
-        scope as string,
+        effectiveScope,
         (decision as TrustDecision) ?? "allow",
         (priority as number) ?? 100,
         {
@@ -219,6 +237,8 @@ export function createTrustRulesUpdateHandler() {
     }
 
     try {
+      // For non-scoped tools, don't include scope in the update — updateRule
+      // will ignore it for non-scoped tool families anyway.
       const rule = updateRule(ruleId, {
         tool: tool as string | undefined,
         pattern: pattern as string | undefined,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2763,7 +2763,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Add a trust rule",
           description:
-            "Authenticated gateway endpoint that adds a new trust rule. Payloads are canonicalized through family-aware parsing before persistence: fields invalid for the tool's family (e.g. executionTarget on URL-tool rules) are silently stripped. Legacy request shapes are accepted without 4xx regressions.",
+            "Authenticated gateway endpoint that adds a new trust rule. Payloads are canonicalized through family-aware parsing before persistence: fields invalid for the tool's family (e.g. executionTarget on URL-tool rules, scope on non-scoped tools) are silently stripped. The `scope` field is required for scoped tools (bash, file_read, etc.) and optional for all others. Legacy request shapes are accepted without 4xx regressions.",
           operationId: "trustRulesPost",
           security: [{ BearerAuth: [] }],
           requestBody: {

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -535,7 +535,7 @@ export function acceptStarterBundle(): AcceptStarterBundleResult {
     } as TrustRule;
     // Only set scope on the pushed rule if the template has a defined scope.
     if (template.scope !== undefined) {
-      (newRule as Record<string, unknown>).scope = template.scope;
+      (newRule as unknown as Record<string, unknown>).scope = template.scope;
     }
     rules.push(newRule);
     added++;

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -27,6 +27,8 @@ import type {
 import {
   parseTrustFileData,
   parseTrustRule,
+  ruleScope,
+  SCOPED_TOOLS,
 } from "@vellumai/ces-contracts/trust-rules";
 
 import { getLogger } from "./logger.js";
@@ -35,6 +37,9 @@ import { getGatewaySecurityDir } from "./paths.js";
 export type { TrustDecision, TrustRule };
 
 const log = getLogger("trust-store");
+
+/** Set for O(1) lookup when determining if a tool is scoped. */
+const SCOPED_TOOLS_SET: ReadonlySet<string> = new Set(SCOPED_TOOLS);
 
 const TRUST_FILE_VERSION = 3;
 
@@ -354,11 +359,11 @@ export function addRule(
 
   // Canonicalize through the shared parser so fields invalid for the tool's
   // family are stripped before persistence, regardless of callsite.
-  const { rule: canonical } = parseTrustRule({
+  // Only include scope for scoped tools — non-scoped tools don't carry scope.
+  const rawRule: Record<string, unknown> = {
     id: uuid(),
     tool,
     pattern,
-    scope,
     decision,
     priority,
     createdAt: Date.now(),
@@ -368,7 +373,11 @@ export function addRule(
     ...(options?.executionTarget != null
       ? { executionTarget: options.executionTarget }
       : {}),
-  });
+  };
+  if (SCOPED_TOOLS_SET.has(tool)) {
+    rawRule.scope = scope;
+  }
+  const { rule: canonical } = parseTrustRule(rawRule);
   const rule = canonical;
   rules.push(rule);
   rules.sort(ruleOrder);
@@ -402,7 +411,11 @@ export function updateRule(
   const merged = { ...rules[index] };
   if (updates.tool != null) merged.tool = updates.tool;
   if (updates.pattern != null) merged.pattern = updates.pattern;
-  if (updates.scope != null) merged.scope = updates.scope;
+  // Only apply scope updates for scoped tools — non-scoped tools ignore scope.
+  const effectiveTool = updates.tool ?? merged.tool;
+  if (updates.scope != null && SCOPED_TOOLS_SET.has(effectiveTool)) {
+    merged.scope = updates.scope;
+  }
   if (updates.decision != null) merged.decision = updates.decision;
   if (updates.priority != null) merged.priority = updates.priority;
 
@@ -452,7 +465,7 @@ export function findMatchingRule(
     if (rule.tool !== tool) continue;
     const compiled = getCompiledPattern(rule.pattern);
     if (!compiled || !compiled.match(command)) continue;
-    if (!matchesScope(rule.scope, scope)) continue;
+    if (!matchesScope(ruleScope(rule), scope)) continue;
     return rule;
   }
   return null;
@@ -470,7 +483,7 @@ export function findHighestPriorityRule(
   const rules = getRules();
   for (const rule of rules) {
     if (rule.tool !== tool) continue;
-    if (!matchesScope(rule.scope, scope)) continue;
+    if (!matchesScope(ruleScope(rule), scope)) continue;
     const compiled = getCompiledPattern(rule.pattern);
     if (!compiled) continue;
     for (const command of commands) {
@@ -512,15 +525,19 @@ export function acceptStarterBundle(): AcceptStarterBundleResult {
 
   for (const template of getStarterBundleRules()) {
     if (existingIds.has(template.id)) continue;
-    rules.push({
+    const newRule: TrustRule = {
       id: template.id,
       tool: template.tool,
       pattern: template.pattern,
-      scope: template.scope,
       decision: template.decision,
       priority: template.priority,
       createdAt: Date.now(),
-    });
+    } as TrustRule;
+    // Only set scope on the pushed rule if the template has a defined scope.
+    if (template.scope !== undefined) {
+      (newRule as Record<string, unknown>).scope = template.scope;
+    }
+    rules.push(newRule);
     added++;
   }
 


### PR DESCRIPTION
## Summary
- Use ruleScope() from ces-contracts for scope matching in gateway trust-store
- Make scope optional in gateway HTTP API for non-scoped tools
- Update gateway tests for scope stripping behavior

Part of plan: rm-scope-non-scoped-rules.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
