### PR TITLE
feat(tts-xai): register xAI provider in catalog and client artifact

### DIFF
--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -158,6 +158,24 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
       },
     ],
   },
+  {
+    id: "xai",
+    displayName: "xAI",
+    callMode: "synthesized-play",
+    allowNativeFallback: false,
+    capabilities: {
+      supportsStreaming: false,
+      supportedFormats: ["mp3", "wav"],
+    },
+    secretRequirements: [
+      {
+        credentialStoreKey: "credential/xai/api_key",
+        displayName: "xAI API Key",
+        setCommand:
+          "assistant credentials set --service xai --field api_key <key>",
+      },
+    ],
+  },
 ] as const;
 
 /** Index for O(1) lookup by provider ID. */

--- a/assistant/src/tts/providers/index.ts
+++ b/assistant/src/tts/providers/index.ts
@@ -13,6 +13,7 @@ import type { TtsProvider, TtsProviderId } from "../types.js";
 import { createDeepgramProvider } from "./deepgram-provider.js";
 import { createElevenLabsProvider } from "./elevenlabs-provider.js";
 import { createFishAudioProvider } from "./fish-audio-provider.js";
+import { createXaiProvider } from "./xai-provider.js";
 
 // ---------------------------------------------------------------------------
 // Factory type
@@ -39,4 +40,5 @@ export const providerFactories: ReadonlyMap<TtsProviderId, TtsProviderFactory> =
     ["elevenlabs", createElevenLabsProvider],
     ["fish-audio", createFishAudioProvider],
     ["deepgram", createDeepgramProvider],
+    ["xai", createXaiProvider],
   ]);

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -20,6 +20,7 @@ export type TtsProviderId =
   | "elevenlabs"
   | "fish-audio"
   | "deepgram"
+  | "xai"
   | (string & {});
 
 // ---------------------------------------------------------------------------

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "providers": [
     {
       "id": "elevenlabs",
@@ -44,6 +44,21 @@
         "description": "Sign in to Deepgram, navigate to your API Keys page, and create or copy an existing key. This is the same key used for speech-to-text.",
         "url": "https://console.deepgram.com/",
         "linkLabel": "Open Deepgram Console"
+      }
+    },
+    {
+      "id": "xai",
+      "displayName": "xAI",
+      "subtitle": "Text-to-speech from xAI with expressive voices (eve, ara, rex, sal, leo). Requires an xAI API key.",
+      "setupMode": "cli",
+      "setupHint": "Run the setup commands in your terminal to configure xAI credentials.",
+      "credentialMode": "credential",
+      "credentialNamespace": "xai",
+      "supportsVoiceSelection": true,
+      "credentialsGuide": {
+        "description": "Sign in to the xAI console, navigate to API Keys, and create a new key.",
+        "url": "https://console.x.ai/",
+        "linkLabel": "Open xAI Console"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `xai` to `TtsProviderId`, the assistant provider catalog, the factory map, and the client-side `meta/tts-provider-catalog.json` (bumped to version 4).
- `callMode: synthesized-play`, `allowNativeFallback: false`, supports mp3/wav.
- Credential key `credential/xai/api_key`; client `credentialMode: credential`, `credentialNamespace: xai`.
- Users can now select xAI via `services.tts.provider: xai` in `assistant-config.yml`.

Completes plan: xai-tts-provider.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
