### PR TITLE
test(credential-security): allowlist xai TTS provider as secure-keys importer

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -219,6 +219,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup
+      "tts/providers/xai-provider.ts", // xAI TTS API key lookup
       "meet/session-manager.ts", // Meet bot container provisioning (provider API key lookup for Deepgram/TTS)
       "credential-health/credential-health-service.ts", // credential health check reads access tokens for liveness pings
     ]);


### PR DESCRIPTION
## Summary
- Adds `tts/providers/xai-provider.ts` to the `ALLOWED_IMPORTERS` allowlist in `credential-security-invariants.test.ts`, matching the existing entries for ElevenLabs and Deepgram TTS providers.
- Unblocks main-branch CI, which has been red since the xAI TTS adapter landed in #26884.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24682907120/job/72184575516
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
