### PR TITLE
fix(cli-tts): cover audio/pcm and audio/basic MIME types; distinguish write failures from synthesis failures

### DIFF
--- a/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts-synthesize.test.ts
@@ -41,6 +41,8 @@ let mkdirCalls: Array<{ path: string; options: unknown }> = [];
 let readFileSyncImpl: (path: string, encoding: string) => string = () => {
   throw new Error("stdin unavailable");
 };
+let writeFileSyncImpl: ((path: string, buffer: Buffer) => void) | null = null;
+let mkdirSyncImpl: ((path: string, options: unknown) => void) | null = null;
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before module-under-test import
@@ -97,10 +99,12 @@ mock.module("node:fs", () => ({
   existsSync: () => true,
   mkdirSync: (path: string, options: unknown) => {
     mkdirCalls.push({ path, options });
+    if (mkdirSyncImpl) mkdirSyncImpl(path, options);
   },
   readFileSync: (path: string, encoding: string) =>
     readFileSyncImpl(path, encoding),
   writeFileSync: (path: string, buffer: Buffer) => {
+    if (writeFileSyncImpl) writeFileSyncImpl(path, buffer);
     writeFileCalls.push({ path, buffer });
   },
 }));
@@ -187,6 +191,8 @@ beforeEach(() => {
   readFileSyncImpl = () => {
     throw new Error("stdin unavailable");
   };
+  writeFileSyncImpl = null;
+  mkdirSyncImpl = null;
   process.exitCode = 0;
 });
 
@@ -457,5 +463,132 @@ describe("--json output", () => {
     expect(parsed.error).toContain(
       "assistant config set services.tts.provider",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MIME → extension coverage
+// ---------------------------------------------------------------------------
+
+describe("MIME → extension coverage", () => {
+  test("audio/pcm (ElevenLabs pcm_*, Deepgram linear16, xAI pcm) produces .pcm", async () => {
+    mockSynthesisResult = {
+      audio: Buffer.from("fake-pcm"),
+      contentType: "audio/pcm",
+    };
+
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(writeFileCalls.length).toBe(1);
+    expect(writeFileCalls[0].path.endsWith(".pcm")).toBe(true);
+  });
+
+  test("audio/basic (ElevenLabs ulaw_8000) produces .ulaw", async () => {
+    mockSynthesisResult = {
+      audio: Buffer.from("fake-ulaw"),
+      contentType: "audio/basic",
+    };
+
+    const { exitCode } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(writeFileCalls.length).toBe(1);
+    expect(writeFileCalls[0].path.endsWith(".ulaw")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write-path failure distinction
+// ---------------------------------------------------------------------------
+
+describe("write-path failures", () => {
+  test("writeFileSync EISDIR surfaces as 'Failed to write audio', not synthesis failure", async () => {
+    writeFileSyncImpl = () => {
+      const err = new Error(
+        "EISDIR: illegal operation on a directory, open '/tmp'",
+      ) as NodeJS.ErrnoException;
+      err.code = "EISDIR";
+      throw err;
+    };
+
+    const { exitCode, stderr } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--output",
+      "/tmp",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Failed to write audio");
+    expect(stderr).toContain("/tmp");
+    expect(stderr).not.toContain("TTS synthesis failed");
+    // synthesizeText was called — synthesis succeeded before the write threw.
+    expect(synthesizeCalls.length).toBe(1);
+  });
+
+  test("mkdirSync EACCES surfaces as 'Failed to write audio', not synthesis failure", async () => {
+    mkdirSyncImpl = () => {
+      const err = new Error(
+        "EACCES: permission denied, mkdir '/readonly/dir'",
+      ) as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    };
+
+    const { exitCode, stderr } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--output",
+      "/readonly/dir/out.mp3",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Failed to write audio");
+    expect(stderr).toContain("/readonly/dir/out.mp3");
+    expect(stderr).not.toContain("TTS synthesis failed");
+    expect(synthesizeCalls.length).toBe(1);
+    // writeFileSync never reached because mkdir threw first.
+    expect(writeFileCalls.length).toBe(0);
+  });
+
+  test("write-path failure in --json mode emits distinct error", async () => {
+    writeFileSyncImpl = () => {
+      const err = new Error(
+        "EISDIR: illegal operation on a directory",
+      ) as NodeJS.ErrnoException;
+      err.code = "EISDIR";
+      throw err;
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "tts",
+      "synthesize",
+      "--text",
+      "hello",
+      "--output",
+      "/tmp",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Failed to write audio");
+    expect(parsed.error).not.toContain("TTS synthesis failed");
   });
 });

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -46,6 +46,15 @@ function extensionForMime(mimeType: string): string {
       return "webm";
     case "audio/opus":
       return "opus";
+    // Raw PCM — ElevenLabs `pcm_{16000,22050,24000,44100}`, Deepgram
+    // `linear16`, xAI `pcm`. No universal container format; `.pcm` is the
+    // conventional extension for headerless linear-PCM samples.
+    case "audio/pcm":
+      return "pcm";
+    // µ-law telephony audio — ElevenLabs `ulaw_8000`. `.ulaw` is the
+    // conventional extension for raw 8 kHz µ-law samples.
+    case "audio/basic":
+      return "ulaw";
     default:
       return "bin";
   }
@@ -190,41 +199,15 @@ Examples:
         // a separate process and each process has its own registry.
         registerBuiltinTtsProviders();
 
+        // Synthesis step — any error here is a provider/synthesis failure.
+        // Billing has NOT yet occurred for the post-synthesis write path.
+        let result: Awaited<ReturnType<typeof synthesizeText>>;
         try {
-          const result = await synthesizeText({
+          result = await synthesizeText({
             text: messageText,
             useCase,
             voiceId: opts.voice,
           });
-
-          const filePath =
-            opts.output ??
-            join(
-              tmpdir(),
-              `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
-            );
-
-          const dir = dirname(filePath);
-          if (opts.output) {
-            mkdirSync(dir, { recursive: true });
-          } else if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
-          }
-
-          writeFileSync(filePath, result.audio);
-
-          if (jsonOutput) {
-            process.stdout.write(
-              JSON.stringify({
-                ok: true,
-                path: filePath,
-                contentType: result.contentType,
-                sizeBytes: result.audio.length,
-              }) + "\n",
-            );
-          } else {
-            process.stdout.write(filePath + "\n");
-          }
         } catch (err) {
           if (
             err instanceof TtsSynthesisError &&
@@ -240,6 +223,47 @@ Examples:
           const msg = err instanceof Error ? err.message : String(err);
           emitError(`TTS synthesis failed: ${msg}`);
           process.exitCode = 1;
+          return;
+        }
+
+        // Write step — synthesis has already succeeded (and been billed) by
+        // this point. Errors from mkdir/writeFile are filesystem failures,
+        // NOT synthesis failures, and must be reported as such so the user
+        // understands their audio was generated but could not be persisted.
+        const filePath =
+          opts.output ??
+          join(
+            tmpdir(),
+            `vellum-tts-${randomUUID()}.${extensionForMime(result.contentType)}`,
+          );
+
+        try {
+          const dir = dirname(filePath);
+          if (opts.output) {
+            mkdirSync(dir, { recursive: true });
+          } else if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+          }
+
+          writeFileSync(filePath, result.audio);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          emitError(`Failed to write audio to ${filePath}: ${msg}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              path: filePath,
+              contentType: result.contentType,
+              sizeBytes: result.audio.length,
+            }) + "\n",
+          );
+        } else {
+          process.stdout.write(filePath + "\n");
         }
       },
     );


### PR DESCRIPTION
## Summary
Fixes two gaps caught during self-review of the cli-tts-commands plan.

**Gap 1:** `extensionForMime` in `assistant tts synthesize` defaulted to `.bin` for `audio/pcm` (ElevenLabs PCM formats, Deepgram `linear16`) and `audio/basic` (ElevenLabs `ulaw_8000`). Added mappings so real provider responses always get a meaningful file extension.

**Gap 2:** Errors from `mkdirSync`/`writeFileSync` were caught by the same handler that wraps `synthesizeText()`, producing `TTS synthesis failed: EISDIR...` when `--output` pointed at a directory. Synthesis had already succeeded (and been billed), so the message mislabeled the failure. Split the try/catch so write errors surface as `Failed to write audio to <path>: ...`.

Part of plan: cli-tts-commands.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
