### PR TITLE
fix(tts-xai): update stale provider enumerations outside the catalog

### DIFF
--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 
 import { Command } from "commander";
 
+import { listCatalogProviderIds } from "../../tts/provider-catalog.js";
 import { registerBuiltinTtsProviders } from "../../tts/providers/register-builtins.js";
 import {
   synthesizeText,
@@ -69,6 +70,8 @@ export function registerTtsCommand(program: Command): void {
     .command("tts")
     .description("Text-to-speech operations");
 
+  const builtinProviders = listCatalogProviderIds().join(", ");
+
   ttsCmd.addHelpText(
     "after",
     `
@@ -77,7 +80,7 @@ The provider is set via:
 
   $ assistant config set services.tts.provider <provider>
 
-Built-in providers: elevenlabs, fish-audio, deepgram.
+Built-in providers: ${builtinProviders}.
 
 Examples:
   $ assistant tts synthesize --text "hello world"
@@ -214,7 +217,7 @@ Examples:
             err.code === "TTS_PROVIDER_NOT_CONFIGURED"
           ) {
             emitError(
-              "No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. elevenlabs, fish-audio, deepgram), then 'assistant keys set <provider>' to add the API key.",
+              `No TTS provider configured or registered. Run 'assistant config set services.tts.provider <provider>' to select one (e.g. ${listCatalogProviderIds().join(", ")}), then 'assistant keys set <provider>' to add the API key.`,
             );
             process.exitCode = 1;
             return;

--- a/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md
@@ -15,18 +15,19 @@ All call-related settings can be managed via `assistant config`:
 | `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                                                                                                                                                   | _(empty)_                                                                                                |
 | `calls.voice.language`                      | Language code for TTS and transcription                                                                                                                                                                                                   | `en-US`                                                                                                  |
 | `services.stt.provider`                     | STT provider for transcription and telephony. Determines the Twilio integration path at call setup time (Deepgram/Google use native ConversationRelay; OpenAI Whisper uses media-stream).                                                 | `deepgram`                                                                                               |
-| `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (`elevenlabs`, `fish-audio`, `deepgram`). New providers can be added via the catalog without code changes to call routing.                               | `elevenlabs`                                                                                             |
+| `services.tts.provider`                     | Active TTS provider for speech synthesis. Must be a provider ID from the catalog (`elevenlabs`, `fish-audio`, `deepgram`, `xai`). New providers can be added via the catalog without code changes to call routing.                        | `elevenlabs`                                                                                             |
 | `services.tts.providers.<id>.*`             | Provider-specific settings block. Each catalog provider has its own settings namespace under `services.tts.providers.<id>`. See voice settings in the desktop/iOS app or run `assistant config list` for available settings per provider. | _(per-provider defaults)_                                                                                |
 
 ## TTS provider call-path behavior
 
 Each TTS provider uses one of two call-path modes during phone calls:
 
-| Provider     | Call mode          | Description                                                                                                                                                           |
-| ------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `elevenlabs` | `native-twilio`    | Text tokens are forwarded to Twilio's ConversationRelay, which synthesizes audio via its built-in ElevenLabs integration.                                             |
-| `fish-audio` | `synthesized-play` | The assistant synthesizes audio server-side via Fish Audio's HTTP API and streams chunks to Twilio via play messages.                                                 |
-| `deepgram`   | `synthesized-play` | The assistant synthesizes audio server-side via Deepgram's HTTP API and streams chunks to Twilio via play messages. Uses the same API key as Deepgram speech-to-text. |
+| Provider     | Call mode          | Description                                                                                                                                                              |
+| ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `elevenlabs` | `native-twilio`    | Text tokens are forwarded to Twilio's ConversationRelay, which synthesizes audio via its built-in ElevenLabs integration.                                                |
+| `fish-audio` | `synthesized-play` | The assistant synthesizes audio server-side via Fish Audio's HTTP API and streams chunks to Twilio via play messages.                                                    |
+| `deepgram`   | `synthesized-play` | The assistant synthesizes audio server-side via Deepgram's HTTP API and streams chunks to Twilio via play messages. Uses the same API key as Deepgram speech-to-text.    |
+| `xai`        | `synthesized-play` | The assistant synthesizes audio server-side via xAI's HTTP API and streams chunks to Twilio via play messages. No native Twilio fallback (`allowNativeFallback: false`). |
 
 Providers using `synthesized-play` add a small amount of latency compared to `native-twilio` because audio must be synthesized server-side before playback. The assistant handles chunk buffering and streaming automatically.
 

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers: elevenlabs, fish-audio, deepgram — defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Changes persist to services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (any provider ID listed by the TTS provider catalog under services.tts.providers). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Changes persist to services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -18,10 +18,10 @@
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (elevenlabs, fish-audio, deepgram). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key."
+            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (any provider ID configured under services.tts.providers). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: a valid provider ID from the provider catalog (elevenlabs, fish-audio, deepgram). For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
+            "description": "The new value for the setting. For tts_provider: a valid provider ID from the provider catalog (any provider ID configured under services.tts.providers). For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -995,27 +995,23 @@ describe("xAI TTS provider adapter", () => {
 // ===========================================================================
 
 describe("registerBuiltinTtsProviders", () => {
-  test("registers elevenlabs, fish-audio, and deepgram providers", () => {
+  test("registers every catalog provider ID", () => {
     registerBuiltinTtsProviders();
 
     const providers = listTtsProviders();
     const ids = providers.map((p) => p.id);
-    expect(ids).toContain("elevenlabs");
-    expect(ids).toContain("fish-audio");
-    expect(ids).toContain("deepgram");
+    for (const id of listCatalogProviderIds()) {
+      expect(ids).toContain(id);
+    }
   });
 
   test("providers are discoverable via getTtsProvider after registration", () => {
     registerBuiltinTtsProviders();
 
-    const el = getTtsProvider("elevenlabs");
-    expect(el.id).toBe("elevenlabs");
-
-    const fa = getTtsProvider("fish-audio");
-    expect(fa.id).toBe("fish-audio");
-
-    const dg = getTtsProvider("deepgram");
-    expect(dg.id).toBe("deepgram");
+    for (const id of listCatalogProviderIds()) {
+      const provider = getTtsProvider(id);
+      expect(provider.id).toBe(id);
+    }
   });
 
   test("idempotent — calling twice does not throw", () => {


### PR DESCRIPTION
## Summary
Post-merge integration review flagged four places enumerating TTS providers by name that weren't updated when xAI was added:
- `assistant/src/config/bundled-skills/settings/TOOLS.json` — LLM-facing tool descriptions
- `assistant/src/cli/commands/tts.ts` — help text + TTS_PROVIDER_NOT_CONFIGURED error guidance
- `assistant/src/config/bundled-skills/phone-calls/references/CONFIG.md` — provider list + call-mode table
- `assistant/src/tts/__tests__/provider-adapters.test.ts` — built-in registration test

Preferred pattern where feasible: derive the list from `listCatalogProviderIds()` so future catalog additions don't require text edits.

Follow-up to plan: xai-tts-provider.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
