### PR TITLE
refactor(trust-rules): remove scope from TrustRuleBase — now only on ScopedTrustRule and GenericTrustRule

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8564,7 +8564,7 @@ paths:
                   description: Allowlist pattern
                 scope:
                   type: string
-                  description: Scope
+                  description: Scope (required for scoped tools, ignored for others)
                 decision:
                   type: string
                   description: allow, deny, or ask
@@ -8577,7 +8577,6 @@ paths:
               required:
                 - toolName
                 - pattern
-                - scope
                 - decision
               additionalProperties: false
   /v1/trust-rules/manage/{id}:

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -13,12 +13,13 @@ import { getWorkspaceDir } from "../util/platform.js";
  * A default rule template is structurally identical to TrustRuleBase
  * minus `createdAt` (set at backfill time) and `userModifiedAt` (set
  * when users explicitly override defaults), plus the optional
- * `allowHighRisk` field that some tool families support.
+ * `scope` and `allowHighRisk` fields that some tool families support.
  */
 export type DefaultRuleTemplate = Omit<
   TrustRuleBase,
   "createdAt" | "userModifiedAt"
 > & {
+  scope?: string;
   allowHighRisk?: boolean;
 };
 

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -1084,7 +1084,7 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       pattern: canonical.pattern,
       // Only send scope for scoped tools — non-scoped tools omit it.
       ...(SCOPED_TOOLS_SET.has(canonical.tool)
-        ? { scope: canonical.scope || "everywhere" }
+        ? { scope: ruleScope(canonical) }
         : {}),
       decision: canonical.decision,
       priority: canonical.priority,

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -10,6 +10,7 @@ import type { TrustRuleBase } from "@vellumai/ces-contracts";
  * we flatten the union here by intersecting the base with the optional fields.
  */
 export type TrustRule = TrustRuleBase & {
+  scope?: string;
   executionTarget?: string;
   allowHighRisk?: boolean;
 };

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -83,7 +83,6 @@ export interface TrustRuleBase {
   id: string;
   tool: string;
   pattern: string;
-  scope?: string;
   decision: TrustDecision;
   priority: number;
   createdAt: number;
@@ -140,11 +139,13 @@ export interface SkillLoadTrustRule extends TrustRuleBase {
 /**
  * A trust rule for any tool that doesn't belong to a known family.
  *
- * Generic rules preserve `executionTarget` and `allowHighRisk` for backward
- * compatibility — existing rules for unknown/new tools may carry these fields.
+ * Generic rules preserve `scope`, `executionTarget`, and `allowHighRisk` for
+ * forward compatibility — existing rules for unknown/new tools may carry these
+ * fields.
  */
 export interface GenericTrustRule extends TrustRuleBase {
   tool: string;
+  scope?: string;
   executionTarget?: string;
   allowHighRisk?: boolean;
 }


### PR DESCRIPTION
## Summary
- Remove scope from TrustRuleBase entirely
- scope: string only exists on ScopedTrustRule (required)
- scope?: string only exists on GenericTrustRule (forward compat)
- UrlTrustRule, ManagedSkillTrustRule, SkillLoadTrustRule have no scope field
- Add scope?: string to flattened TrustRule in assistant types.ts
- Add scope?: string to DefaultRuleTemplate (since it derives from TrustRuleBase)
- Use ruleScope() helper in trust-store.ts instead of direct canonical.scope access

Part of plan: rm-scope-non-scoped-rules.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
