### PR TITLE
feat(stt-xai): register xai in daemon and client stt catalogs

### DIFF
--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -219,6 +219,23 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       },
     },
   ],
+  [
+    "xai",
+    {
+      id: "xai",
+      credentialProvider: "xai",
+      supportedBoundaries: new Set<SttBoundaryId>([
+        "daemon-batch",
+        "daemon-streaming",
+      ]),
+      telephonyMode: "batch-only",
+      conversationStreamingMode: "realtime-ws",
+      supportsDiarization: true,
+      telephonyRouting: {
+        strategyKind: "media-stream-custom",
+      },
+    },
+  ],
 ]);
 
 // ---------------------------------------------------------------------------

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -213,6 +213,20 @@ private let fallbackRegistry = STTProviderRegistry(
                 linkLabel: "Open OpenAI Platform"
             )
         ),
+        STTProviderCatalogEntry(
+            id: "xai",
+            displayName: "xAI",
+            subtitle: "Real-time speech-to-text powered by xAI. Requires an xAI API key.",
+            setupMode: .apiKey,
+            setupHint: "Enter your xAI API key to enable xAI transcription.",
+            apiKeyProviderName: "xai",
+            conversationStreamingMode: .realtimeWs,
+            credentialsGuide: STTCredentialsGuide(
+                description: "Sign in to the xAI console, navigate to API Keys, and create a new key.",
+                url: "https://console.x.ai/",
+                linkLabel: "Open xAI Console"
+            )
+        ),
     ]
 )
 

--- a/meta/stt-provider-catalog.json
+++ b/meta/stt-provider-catalog.json
@@ -42,6 +42,20 @@
         "url": "https://platform.openai.com/api-keys",
         "linkLabel": "Open OpenAI Platform"
       }
+    },
+    {
+      "id": "xai",
+      "displayName": "xAI",
+      "subtitle": "Real-time speech-to-text powered by xAI. Requires an xAI API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your xAI API key to enable xAI transcription.",
+      "apiKeyProviderName": "xai",
+      "conversationStreamingMode": "realtime-ws",
+      "credentialsGuide": {
+        "description": "Sign in to the xAI console, navigate to API Keys, and create a new key.",
+        "url": "https://console.x.ai/",
+        "linkLabel": "Open xAI Console"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Daemon catalog: add `xai` entry with `credentialProvider: "xai"`, `telephonyMode: "batch-only"`, `conversationStreamingMode: "realtime-ws"`, `supportsDiarization: true`, `telephonyRouting: { strategyKind: "media-stream-custom" }`
- Client `meta/stt-provider-catalog.json`: append matching entry (`displayName: "xAI"`, `apiKeyProviderName: "xai"`, `conversationStreamingMode: "realtime-ws"`)
- Swift `STTProviderRegistry.swift` fallback registry: append matching struct literal

Part of plan: xai-stt-provider.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
