### PR TITLE
refactor: remove allowHighRisk from trust rules, replace with runtime determination

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -764,14 +764,14 @@ Release-driven update notification system that dispatches a background conversat
 
 **Key source files:**
 
-| File                                   | Purpose                                                                                |
-| -------------------------------------- | -------------------------------------------------------------------------------------- |
-| `src/workspace/migrations/`            | Per-release migrations that append release notes to `UPDATES.md`                       |
-| `src/workspace/migrations/registry.ts` | Append-only `WORKSPACE_MIGRATIONS` registry                                            |
+| File                                   | Purpose                                                                                   |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `src/workspace/migrations/`            | Per-release migrations that append release notes to `UPDATES.md`                          |
+| `src/workspace/migrations/registry.ts` | Append-only `WORKSPACE_MIGRATIONS` registry                                               |
 | `src/prompts/update-bulletin-job.ts`   | `runUpdateBulletinJobIfNeeded()` — hash check, background dispatch, and checkpoint update |
-| `src/daemon/lifecycle.ts`              | Fire-and-forget dispatch of `runUpdateBulletinJobIfNeeded()` after DB init at startup  |
-| `src/config/schemas/updates.ts`        | `updates.enabled` config toggle (defaults to `true`; disables the background dispatch) |
-| `src/permissions/defaults.ts`          | Auto-allow rules for file_read/write/edit + bare-filename `rm UPDATES.md`              |
+| `src/daemon/lifecycle.ts`              | Fire-and-forget dispatch of `runUpdateBulletinJobIfNeeded()` after DB init at startup     |
+| `src/config/schemas/updates.ts`        | `updates.enabled` config toggle (defaults to `true`; disables the background dispatch)    |
+| `src/permissions/defaults.ts`          | Auto-allow rules for file_read/write/edit + bare-filename `rm UPDATES.md`                 |
 
 ---
 
@@ -1566,9 +1566,9 @@ graph TB
     FIND_RULE -->|"No match"| NO_MATCH{"Fallback logic"}
 
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
-    RISK_CHECK -->|"High"| HIGH_CHECK{"allowHighRisk<br/>on rule?"}
-    HIGH_CHECK -->|"true"| AUTO_ALLOW
-    HIGH_CHECK -->|"false / absent"| PROMPT_HIGH["decision: prompt<br/>High risk override"]
+    RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
+    HIGH_CHECK -->|"yes"| AUTO_ALLOW
+    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
@@ -1595,7 +1595,7 @@ The `permissions.mode` config option (`workspace` or `strict`) controls the defa
 | `browser_*` skill tools with system default rules  | Auto-allowed (priority 100 allow rules)       | Auto-allowed (priority 100 allow rules)       |
 | Skill-origin tools with no matching rule           | Prompted                                      | Prompted                                      |
 | Allow rules for non-high-risk tools                | Auto-allowed                                  | Auto-allowed                                  |
-| Allow rules with `allowHighRisk: true`             | Auto-allowed (even high risk)                 | Auto-allowed (even high risk)                 |
+| Allow rules + containerized bash (high risk)       | Auto-allowed (runtime check)                  | Auto-allowed (runtime check)                  |
 | Deny rules                                         | Blocked                                       | Blocked                                       |
 
 **Workspace mode** (default) auto-allows operations scoped to the workspace (file reads/writes/edits within the workspace directory, sandboxed bash) without prompting. Host operations, network requests, and operations outside the workspace still follow the normal approval flow. Explicit deny and ask rules override auto-allow.
@@ -1617,7 +1617,6 @@ Rules are stored in `~/.vellum/protected/trust.json` with version `3`. Each rule
 | `decision`        | `allow \| deny \| ask` | What to do when the rule matches                                         |
 | `priority`        | `number`               | Higher priority wins; deny wins ties at equal priority                   |
 | `executionTarget` | `string?`              | `sandbox` or `host` — restricts by execution context                     |
-| `allowHighRisk`   | `boolean?`             | When true, auto-allows even high-risk invocations                        |
 
 Missing optional fields act as wildcards. A rule with no `executionTarget` matches any target.
 
@@ -1711,7 +1710,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `always_allow_high_risk` (create allow rule with `allowHighRisk: true`), `deny` (one-time), or `always_deny` (create deny rule).
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
 
 ### Canonical Paths
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -20,9 +20,9 @@ graph TB
     FIND_RULE -->|"No match"| NO_MATCH{"Fallback logic"}
 
     RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
-    RISK_CHECK -->|"High"| HIGH_CHECK{"allowHighRisk<br/>on rule?"}
-    HIGH_CHECK -->|"true"| AUTO_ALLOW
-    HIGH_CHECK -->|"false / absent"| PROMPT_HIGH["decision: prompt<br/>High risk override"]
+    RISK_CHECK -->|"High"| HIGH_CHECK{"shouldAutoAllowHighRisk()<br/>(containerized bash?)"}
+    HIGH_CHECK -->|"yes"| AUTO_ALLOW
+    HIGH_CHECK -->|"no"| PROMPT_HIGH["decision: prompt<br/>High risk requires approval"]
 
     NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
     NO_MATCH -->|"strict mode"| PROMPT_STRICT["decision: prompt<br/>No implicit auto-allow"]
@@ -49,7 +49,7 @@ The `permissions.mode` config option (`workspace` or `strict`) controls the defa
 | `browser_*` skill tools with system default rules  | Auto-allowed (priority 100 allow rules)       | Auto-allowed (priority 100 allow rules)       |
 | Skill-origin tools with no matching rule           | Prompted                                      | Prompted                                      |
 | Allow rules for non-high-risk tools                | Auto-allowed                                  | Auto-allowed                                  |
-| Allow rules with `allowHighRisk: true`             | Auto-allowed (even high risk)                 | Auto-allowed (even high risk)                 |
+| Allow rules + containerized bash (high risk)       | Auto-allowed (runtime check)                  | Auto-allowed (runtime check)                  |
 | Deny rules                                         | Blocked                                       | Blocked                                       |
 
 **Workspace mode** (default) auto-allows operations scoped to the workspace (file reads/writes/edits within the workspace directory, sandboxed bash) without prompting. Host operations, network requests, and operations outside the workspace still follow the normal approval flow. Explicit deny and ask rules override auto-allow.
@@ -71,7 +71,6 @@ Rules are stored in `~/.vellum/protected/trust.json` with version `3`. Each rule
 | `decision`        | `allow \| deny \| ask` | What to do when the rule matches                                         |
 | `priority`        | `number`               | Higher priority wins; deny wins ties at equal priority                   |
 | `executionTarget` | `string?`              | `sandbox` or `host` — restricts by execution context                     |
-| `allowHighRisk`   | `boolean?`             | When true, auto-allows even high-risk invocations                        |
 
 Missing optional fields act as wildcards. A rule with no `executionTarget` matches any target.
 
@@ -165,7 +164,7 @@ When a permission prompt is sent to the client (via `confirmation_request` SSE e
 | `allowlistOptions` | Suggested patterns for "always allow" rules         |
 | `scopeOptions`     | Suggested scopes for rule persistence               |
 
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `always_allow_high_risk` (create allow rule with `allowHighRisk: true`), `deny` (one-time), or `always_deny` (create deny rule).
+The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). High-risk operations in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
 
 ### Canonical Paths
 
@@ -272,18 +271,18 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 
 ### Storage Layout
 
-| Component           | Location                                             | What it stores                                                                                                                                               |
-| ------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Component           | Location                                             | What it stores                                                                                                                                                   |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Secret values       | CES credential store or encrypted file store         | Encrypted credential values keyed as `credential/{service}/{field}`. Stored via CES RPC (primary), CES HTTP (containerized), or encrypted file store (fallback). |
-| Credential metadata | `~/.vellum/workspace/data/credentials/metadata.json` | Service, field, label, policy (allowedTools, allowedDomains), timestamps                                                                                     |
-| Config              | `~/.vellum/workspace/config.*`                       | `secretDetection` settings: enabled, action, entropyThreshold, allowOneTimeSend                                                                              |
+| Credential metadata | `~/.vellum/workspace/data/credentials/metadata.json` | Service, field, label, policy (allowedTools, allowedDomains), timestamps                                                                                         |
+| Config              | `~/.vellum/workspace/config.*`                       | `secretDetection` settings: enabled, action, entropyThreshold, allowOneTimeSend                                                                                  |
 
 ### Key Files
 
 | File                                                 | Role                                                                  |
 | ---------------------------------------------------- | --------------------------------------------------------------------- |
 | `assistant/src/tools/credentials/vault.ts`           | `credential_store` tool — store, list, delete, prompt actions         |
-| `assistant/src/security/secure-keys.ts`              | Async secure key CRUD via CES and encrypted file store               |
+| `assistant/src/security/secure-keys.ts`              | Async secure key CRUD via CES and encrypted file store                |
 | `assistant/src/tools/credentials/metadata-store.ts`  | JSON file metadata CRUD for credential records                        |
 | `assistant/src/tools/credentials/broker.ts`          | Brokered credential access with policy enforcement and transient send |
 | `assistant/src/tools/credentials/policy-validate.ts` | Policy input validation (allowedTools, allowedDomains)                |

--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -12,14 +12,14 @@ Because skills can introduce arbitrary tool behavior, they are subject to strict
 
 Skill-origin tools follow a stricter default permission policy than core tools:
 
-| Scenario                                              | Core tool behavior            | Skill tool behavior |
-| ----------------------------------------------------- | ----------------------------- | ------------------- |
-| Low risk, no matching rule                            | Auto-allowed (workspace mode) | **Prompted**        |
-| Medium risk, no matching rule                         | Prompted                      | Prompted            |
-| High risk, no matching rule                           | Prompted                      | Prompted            |
-| Allow rule matches, non-high risk                     | Auto-allowed                  | Auto-allowed        |
-| Allow rule matches, high risk, `allowHighRisk: true`  | Auto-allowed                  | Auto-allowed        |
-| Allow rule matches, high risk, `allowHighRisk` absent | Prompted                      | Prompted            |
+| Scenario                                          | Core tool behavior            | Skill tool behavior |
+| ------------------------------------------------- | ----------------------------- | ------------------- |
+| Low risk, no matching rule                        | Auto-allowed (workspace mode) | **Prompted**        |
+| Medium risk, no matching rule                     | Prompted                      | Prompted            |
+| High risk, no matching rule                       | Prompted                      | Prompted            |
+| Allow rule matches, non-high risk                 | Auto-allowed                  | Auto-allowed        |
+| Allow rule matches, high risk, containerized bash | Auto-allowed (runtime check)  | Auto-allowed        |
+| Allow rule matches, high risk, other              | Prompted                      | Prompted            |
 
 Even if a skill's `TOOLS.json` declares `"risk": "low"` for one of its tools, the permission checker will prompt the user unless an explicit trust rule in `~/.vellum/protected/trust.json` allows it. This prevents third-party skill tools from silently auto-executing.
 
@@ -73,7 +73,7 @@ Writing to skill source files is treated as a **high-risk** operation by the ris
 - **Workspace skills**: Project-local skill directories
 - **Extra skills**: Additional roots configured by the user
 
-When `file_write`, `file_edit`, `host_file_write`, or `host_file_edit` targets a path inside any of these directories, the risk level is escalated from its normal level (typically Medium) to **High**. High-risk operations always require user approval unless a matching trust rule with `allowHighRisk: true` exists.
+When `file_write`, `file_edit`, `host_file_write`, or `host_file_edit` targets a path inside any of these directories, the risk level is escalated from its normal level (typically Medium) to **High**. High-risk operations always require user approval (only containerized bash is auto-allowed at runtime for high-risk operations).
 
 This escalation prevents the agent from modifying skill code without explicit user consent. Since modifying a skill's source could grant the agent new capabilities or alter existing tool behavior, such mutations are treated as a privilege-escalation vector.
 
@@ -135,7 +135,7 @@ When you modify any file in a skill's directory, the version hash changes. If yo
 
 Writing to skill source paths is classified as high risk because it could alter the agent's capabilities. This is a deliberate security measure.
 
-**Fix**: If you trust the operation, approve it. To permanently allow it, select "Always allow" and choose the `allowHighRisk` option if offered.
+**Fix**: If you trust the operation, approve it. To permanently allow it, select "Always allow". Note that high-risk file operations will still prompt for each invocation since runtime auto-allow only applies to containerized bash.
 
 ### "Why is strict mode prompting for everything?"
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2088,7 +2088,7 @@ paths:
                   description: Pending interaction request ID
                 decision:
                   type: string
-                  description: "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny, always_allow_high_risk"
+                  description: "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny"
                 selectedPattern:
                   type: string
                   description: Allowlist pattern for persistent decisions
@@ -8496,9 +8496,6 @@ paths:
                 decision:
                   type: string
                   description: allow or deny
-                allowHighRisk:
-                  type: boolean
-                  description: Allow high-risk invocations
               required:
                 - requestId
                 - pattern
@@ -8568,9 +8565,6 @@ paths:
                 decision:
                   type: string
                   description: allow, deny, or ask
-                allowHighRisk:
-                  type: boolean
-                  description: Allow high-risk invocations
                 executionTarget:
                   type: string
                   description: Execution target

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -91,7 +91,7 @@ const addRuleCalls: Array<{
   scope: string;
   decision: string;
   priority?: number;
-  options?: { allowHighRisk?: boolean; executionTarget?: string };
+  options?: { executionTarget?: string };
 }> = [];
 mock.module("../permissions/trust-store.js", () => ({
   addRule: (
@@ -100,7 +100,7 @@ mock.module("../permissions/trust-store.js", () => ({
     scope: string,
     decision: string,
     priority?: number,
-    options?: { allowHighRisk?: boolean; executionTarget?: string },
+    options?: { executionTarget?: string },
   ) => {
     addRuleCalls.push({ tool, pattern, scope, decision, priority, options });
     return {
@@ -966,7 +966,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await stopServer();
     });
 
-    test("preserves allowHighRisk for scoped tool families (e.g. bash)", async () => {
+    test("trust rule creation works without allowHighRisk for scoped tool families", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
@@ -993,60 +993,12 @@ describe("standalone approval endpoints — HTTP layer", () => {
           pattern: "rm**",
           scope: "everywhere",
           decision: "allow",
-          allowHighRisk: true,
         }),
       });
 
       expect(res.status).toBe(200);
-      // Verify addRule was called with allowHighRisk preserved for the scoped tool
       expect(addRuleCalls).toHaveLength(1);
-      expect(addRuleCalls[0].options?.allowHighRisk).toBe(true);
-
-      await stopServer();
-    });
-
-    test("passes allowHighRisk through for URL tools (canonicalized in trust store)", async () => {
-      const session = makeIdleSession();
-      await startServer(() => session);
-
-      // web_fetch is a URL-family tool. The route forwards allowHighRisk and
-      // trust-store canonicalization decides final persisted shape.
-      pendingInteractions.register("req-url-hr", {
-        conversation: session,
-        conversationId: "conv-1",
-        kind: "confirmation",
-        confirmationDetails: {
-          toolName: "web_fetch",
-          input: { url: "https://example.com" },
-          riskLevel: "medium",
-          allowlistOptions: [
-            {
-              label: "Allow fetch",
-              description: "test",
-              pattern: "https://example.com/**",
-            },
-          ],
-          scopeOptions: [],
-        },
-      });
-
-      const res = await fetch(url("trust-rules"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
-        body: JSON.stringify({
-          requestId: "req-url-hr",
-          pattern: "https://example.com/**",
-          scope: "everywhere",
-          decision: "allow",
-          allowHighRisk: true,
-        }),
-      });
-
-      expect(res.status).toBe(200);
-      // Route layer passes raw options through to addRule; canonicalization
-      // happens in trust-store and the mock captures pre-canonicalization args.
-      expect(addRuleCalls).toHaveLength(1);
-      expect(addRuleCalls[0].options?.allowHighRisk).toBe(true);
+      expect(addRuleCalls[0].decision).toBe("allow");
 
       await stopServer();
     });

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1131,27 +1131,23 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    test("web_fetch allowHighRisk is preserved by canonicalization so private-network fetches can auto-allow", async () => {
-      // URL-family tools now preserve allowHighRisk through addRule's canonical
-      // parser, so high-risk private-network fetches can be explicitly
-      // auto-approved by user trust rules.
+    test("web_fetch private-network fetch with allow rule still prompts (high risk, non-bash tool)", async () => {
+      // allowHighRisk is no longer a persisted field — high-risk auto-allow
+      // is determined at runtime by shouldAutoAllowHighRisk(), which only
+      // covers containerized bash. Non-bash high-risk tools always prompt.
       addRule(
         "web_fetch",
         "web_fetch:http://localhost:3000/*",
         "/tmp",
         "allow",
         100,
-        { allowHighRisk: true },
       );
       const result = await check(
         "web_fetch",
         { url: "http://localhost:3000/health", allow_private_network: true },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
+      expect(result.decision).toBe("prompt");
     });
 
     test("web_fetch exact allowlist pattern matches query urls literally", async () => {
@@ -2223,11 +2219,11 @@ describe("Permission Checker", () => {
       );
       addRule("file_write", `file_write:${checkerTestDir}/skills/**`, "/tmp");
       const result = await check("file_write", { path: skillPath }, "/tmp");
-      // High risk requires explicit allowHighRisk — a plain allow rule is insufficient.
+      // High risk with allow rule prompts — shouldAutoAllowHighRisk() only covers containerized bash.
       expect(result.decision).toBe("prompt");
     });
 
-    test("file_write to skill directory is allowed with allowHighRisk: true rule", async () => {
+    test("file_write to skill directory with allow rule still prompts (high risk, non-bash tool)", async () => {
       ensureSkillsDir();
       const skillPath = join(
         checkerTestDir,
@@ -2241,11 +2237,10 @@ describe("Permission Checker", () => {
         "/tmp",
         "allow",
         2000,
-        { allowHighRisk: true },
       );
       const result = await check("file_write", { path: skillPath }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
+      // Non-bash high-risk tools always prompt regardless of allow rules.
+      expect(result.decision).toBe("prompt");
     });
 
     test("host_file_write to skill directory prompts (High risk overrides host ask rule)", async () => {
@@ -2438,12 +2433,10 @@ describe("Permission Checker", () => {
   // family-aware union type changes are wire-compatible with the platform.
 
   describe("family-aware rule shape regression", () => {
-    test("scoped tool (bash) preserves executionTarget and allowHighRisk through disk round-trip", () => {
+    test("scoped tool (bash) preserves executionTarget through disk round-trip (allowHighRisk stripped)", () => {
       const rule = addRule("bash", "kill *", "everywhere", "allow", 100, {
-        allowHighRisk: true,
         executionTarget: "/usr/local/bin/node",
       });
-      expect(rule.allowHighRisk).toBe(true);
       expect(rule.executionTarget).toBe("/usr/local/bin/node");
 
       // Force a disk round-trip by clearing the cache and re-reading
@@ -2455,23 +2448,17 @@ describe("Permission Checker", () => {
         { executionTarget: "/usr/local/bin/node" },
       );
       expect(reloaded).not.toBeNull();
-      // Scoped tools retain both fields after canonical normalization
-      expect(reloaded!.allowHighRisk).toBe(true);
       expect(reloaded!.executionTarget).toBe("/usr/local/bin/node");
     });
 
-    test("URL tool (web_fetch) preserves allowHighRisk after disk round-trip", () => {
-      // addRule canonicalizes rule shape but preserves allowHighRisk for URL
-      // tools for backward compatibility with persistent high-risk approvals.
-      const rule = addRule(
+    test("URL tool (web_fetch) round-trips without allowHighRisk", () => {
+      addRule(
         "web_fetch",
         "web_fetch:http://localhost:3000/*",
         "/tmp",
         "allow",
         100,
-        { allowHighRisk: true },
       );
-      expect(rule.allowHighRisk).toBe(true);
 
       // Force a disk round-trip.
       clearCache();
@@ -2481,19 +2468,11 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(reloaded).not.toBeNull();
-      expect(reloaded!.allowHighRisk).toBe(true);
+      expect(reloaded!.pattern).toBe("web_fetch:http://localhost:3000/*");
     });
 
-    test("generic tool (skill_test_tool) preserves optional fields through round-trip", () => {
-      const rule = addRule(
-        "skill_test_tool",
-        "skill_test_tool:*",
-        "/tmp",
-        "allow",
-        2000,
-        { allowHighRisk: true },
-      );
-      expect(rule.allowHighRisk).toBe(true);
+    test("generic tool (skill_test_tool) preserves executionTarget through round-trip", () => {
+      addRule("skill_test_tool", "skill_test_tool:*", "/tmp", "allow", 2000);
 
       clearCache();
       const reloaded = findHighestPriorityRule(
@@ -2502,8 +2481,7 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(reloaded).not.toBeNull();
-      // Generic tools preserve allowHighRisk for forward compatibility
-      expect(reloaded!.allowHighRisk).toBe(true);
+      expect(reloaded!.pattern).toBe("skill_test_tool:*");
     });
 
     test("rule without scope defaults to 'everywhere' after parsing", () => {
@@ -2658,31 +2636,11 @@ describe("Permission Checker", () => {
     });
   });
 
-  // ── persistent high-risk allow rules (PR 22) ──────────────────
+  // ── runtime high-risk auto-allow (replaces persistent allowHighRisk) ──
 
-  describe("persistent high-risk allow rules (PR 22)", () => {
-    test("high-risk tool with allowHighRisk: true allow rule returns allow", async () => {
-      addRule("bash", "kill *", "everywhere", "allow", 2000, {
-        allowHighRisk: true,
-      });
-      const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
-    });
-
-    test("high-risk tool with allow rule WITHOUT allowHighRisk still prompts", async () => {
+  describe("runtime high-risk auto-allow (shouldAutoAllowHighRisk)", () => {
+    test("high-risk bash with allow rule in non-containerized environment prompts", async () => {
       addRule("bash", "kill *", "everywhere", "allow", 2000);
-      const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
-      expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
-    });
-
-    test("high-risk tool with allowHighRisk: false still prompts", async () => {
-      addRule("bash", "kill *", "everywhere", "allow", 2000, {
-        allowHighRisk: false,
-      });
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("prompt");
       expect(result.reason).toContain("High risk");
@@ -2702,7 +2660,7 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    test("medium-risk tool with allow rule is NOT affected by allowHighRisk", async () => {
+    test("medium-risk tool with allow rule auto-allows normally", async () => {
       addRule("bash", "chmod *", "/tmp", "allow", 100);
       const result = await check(
         "bash",
@@ -2711,74 +2669,46 @@ describe("Permission Checker", () => {
       );
       expect(result.decision).toBe("allow");
       expect(result.reason).toContain("Matched trust rule");
-      // No mention of high-risk in the reason
-      expect(result.reason).not.toContain("high-risk");
     });
 
-    test("high-risk scaffold_managed_skill with allowHighRisk: true auto-allows", async () => {
-      // Managed-skill tools preserve allowHighRisk through addRule's canonical
-      // parser, allowing explicit high-risk auto-approval via trust rules.
+    test("high-risk scaffold_managed_skill with allow rule prompts (non-bash, no runtime auto-allow)", async () => {
       addRule(
         "scaffold_managed_skill",
         "scaffold_managed_skill:my-skill",
         "everywhere",
         "allow",
         2000,
-        { allowHighRisk: true },
       );
       const result = await check(
         "scaffold_managed_skill",
         { skill_id: "my-skill" },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
+      expect(result.decision).toBe("prompt");
     });
 
-    test("high-risk delete_managed_skill with allowHighRisk: true auto-allows", async () => {
-      // Managed-skill tools preserve allowHighRisk through addRule's canonical
-      // parser, allowing explicit high-risk auto-approval via trust rules.
+    test("high-risk delete_managed_skill with allow rule prompts (non-bash, no runtime auto-allow)", async () => {
       addRule(
         "delete_managed_skill",
         "delete_managed_skill:*",
         "everywhere",
         "allow",
         2000,
-        { allowHighRisk: true },
       );
       const result = await check(
         "delete_managed_skill",
         { skill_id: "any-skill" },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
+      expect(result.decision).toBe("prompt");
     });
 
-    test("deny rule still takes precedence over allowHighRisk allow rule", async () => {
-      addRule("bash", "kill *", "everywhere", "allow", 100, {
-        allowHighRisk: true,
-      });
+    test("deny rule still takes precedence over allow rule for high-risk", async () => {
+      addRule("bash", "kill *", "everywhere", "allow", 100);
       addRule("bash", "kill *", "everywhere", "deny", 200);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("deny");
       expect(result.reason).toContain("deny rule");
-    });
-
-    test("allowHighRisk persists through addRule", () => {
-      const rule = addRule("bash", "kill *", "everywhere", "allow", 100, {
-        allowHighRisk: true,
-      });
-      expect(rule.allowHighRisk).toBe(true);
-    });
-
-    test("addRule without allowHighRisk option does not set the field", () => {
-      const rule = addRule("bash", "git *", "/tmp");
-      expect(rule.allowHighRisk).toBeUndefined();
     });
   });
 
@@ -2796,19 +2726,7 @@ describe("Permission Checker", () => {
       expect(result.reason).toContain("Strict mode");
     });
 
-    test("strict mode: high-risk with allowHighRisk rule auto-allows", async () => {
-      testConfig.permissions.mode = "strict";
-      addRule("bash", "kill *", "everywhere", "allow", 2000, {
-        allowHighRisk: true,
-      });
-      const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
-    });
-
-    test("strict mode: high-risk with allow rule (no allowHighRisk) still prompts", async () => {
+    test("strict mode: high-risk bash with allow rule prompts in non-containerized env", async () => {
       testConfig.permissions.mode = "strict";
       addRule("bash", "kill *", "everywhere", "allow", 2000);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
@@ -2828,41 +2746,16 @@ describe("Permission Checker", () => {
       expect(result.reason).toContain("Matched trust rule");
     });
 
-    test("strict mode: deny rule overrides allowHighRisk rule even in strict mode", async () => {
+    test("strict mode: deny rule overrides allow rule for high-risk", async () => {
       testConfig.permissions.mode = "strict";
-      addRule("bash", "kill *", "everywhere", "allow", 100, {
-        allowHighRisk: true,
-      });
+      addRule("bash", "kill *", "everywhere", "allow", 100);
       addRule("bash", "kill *", "everywhere", "deny", 200);
       const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
       expect(result.decision).toBe("deny");
       expect(result.reason).toContain("deny rule");
     });
 
-    test("strict mode: scaffold_managed_skill with allowHighRisk auto-allows", async () => {
-      testConfig.permissions.mode = "strict";
-      // Managed-skill tools preserve allowHighRisk through addRule's canonical
-      // parser, so explicit high-risk rules can auto-allow even in strict mode.
-      addRule(
-        "scaffold_managed_skill",
-        "scaffold_managed_skill:my-skill",
-        "everywhere",
-        "allow",
-        2000,
-        { allowHighRisk: true },
-      );
-      const result = await check(
-        "scaffold_managed_skill",
-        { skill_id: "my-skill" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule).toBeDefined();
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
-    });
-
-    test("strict mode: scaffold_managed_skill without allowHighRisk still prompts", async () => {
+    test("strict mode: scaffold_managed_skill with allow rule still prompts (non-bash)", async () => {
       testConfig.permissions.mode = "strict";
       addRule(
         "scaffold_managed_skill",
@@ -2877,12 +2770,11 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
     });
   });
 
   // ── skill mutation approval regression tests (PR 30) ──────────
-  // Lock full behavior for skill-source edit/write prompts, allowHighRisk
+  // Lock full behavior for skill-source edit/write prompts, high-risk
   // persistence, and version mismatch rejection.
 
   describe("skill mutation approval regressions (PR 30)", () => {
@@ -2977,53 +2869,10 @@ describe("Permission Checker", () => {
       });
     });
 
-    // ── always_allow_high_risk: persisted allow auto-allows on repeat ──
+    // ── high-risk skill source writes: non-bash tools always prompt ──
 
-    describe("always_allow_high_risk: persisted rule auto-allows subsequent requests", () => {
-      test("file_write to skill source with allowHighRisk rule auto-allows", async () => {
-        ensureSkillsDir();
-        const skillPath = join(
-          checkerTestDir,
-          "skills",
-          "my-skill",
-          "executor.ts",
-        );
-        addRule(
-          "file_write",
-          `file_write:${checkerTestDir}/skills/**`,
-          "/tmp",
-          "allow",
-          2000,
-          { allowHighRisk: true },
-        );
-        const result = await check("file_write", { path: skillPath }, "/tmp");
-        expect(result.decision).toBe("allow");
-        expect(result.reason).toContain("high-risk trust rule");
-        expect(result.matchedRule!.allowHighRisk).toBe(true);
-      });
-
-      test("file_edit of skill source with allowHighRisk rule auto-allows", async () => {
-        ensureSkillsDir();
-        const skillPath = join(
-          checkerTestDir,
-          "skills",
-          "my-skill",
-          "SKILL.md",
-        );
-        addRule(
-          "file_edit",
-          `file_edit:${checkerTestDir}/skills/**`,
-          "/tmp",
-          "allow",
-          2000,
-          { allowHighRisk: true },
-        );
-        const result = await check("file_edit", { path: skillPath }, "/tmp");
-        expect(result.decision).toBe("allow");
-        expect(result.reason).toContain("high-risk trust rule");
-      });
-
-      test("file_write to skill source with allow rule (no allowHighRisk) still prompts", async () => {
+    describe("high-risk skill source writes always prompt (non-bash, no runtime auto-allow)", () => {
+      test("file_write to skill source with allow rule still prompts", async () => {
         ensureSkillsDir();
         const skillPath = join(
           checkerTestDir,
@@ -3040,32 +2889,28 @@ describe("Permission Checker", () => {
         );
         const result = await check("file_write", { path: skillPath }, "/tmp");
         expect(result.decision).toBe("prompt");
-        expect(result.reason).toContain("High risk");
       });
 
-      test("strict mode: file_write to skill source with allowHighRisk rule auto-allows", async () => {
-        testConfig.permissions.mode = "strict";
+      test("file_edit of skill source with allow rule still prompts", async () => {
         ensureSkillsDir();
         const skillPath = join(
           checkerTestDir,
           "skills",
           "my-skill",
-          "executor.ts",
+          "SKILL.md",
         );
         addRule(
-          "file_write",
-          `file_write:${checkerTestDir}/skills/**`,
+          "file_edit",
+          `file_edit:${checkerTestDir}/skills/**`,
           "/tmp",
           "allow",
           2000,
-          { allowHighRisk: true },
         );
-        const result = await check("file_write", { path: skillPath }, "/tmp");
-        expect(result.decision).toBe("allow");
-        expect(result.reason).toContain("high-risk trust rule");
+        const result = await check("file_edit", { path: skillPath }, "/tmp");
+        expect(result.decision).toBe("prompt");
       });
 
-      test("deny rule for skill source takes precedence over allowHighRisk rule", async () => {
+      test("deny rule for skill source takes precedence over allow rule", async () => {
         ensureSkillsDir();
         const skillPath = join(
           checkerTestDir,
@@ -3079,7 +2924,6 @@ describe("Permission Checker", () => {
           "/tmp",
           "allow",
           100,
-          { allowHighRisk: true },
         );
         addRule(
           "file_write",
@@ -3113,26 +2957,7 @@ describe("Permission Checker", () => {
       mkdirSync(wsSkillsDir, { recursive: true });
     }
 
-    test("user allowHighRisk rule at priority 100 overrides default ask for skill source writes", async () => {
-      ensureSkillsDir();
-      const skillPath = join(wsSkillsDir, "my-skill", "executor.ts");
-      addRule(
-        "file_write",
-        `file_write:${wsSkillsDir}/**`,
-        "everywhere",
-        "allow",
-        100,
-        { allowHighRisk: true },
-      );
-      const result = await check("file_write", { path: skillPath }, "/tmp");
-      // The user's allow rule (priority 100) must win over the default ask (priority 50),
-      // and allowHighRisk must auto-allow the High-risk skill mutation.
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("high-risk trust rule");
-      expect(result.matchedRule!.allowHighRisk).toBe(true);
-    });
-
-    test("user allow rule without allowHighRisk at priority 100 overrides default ask but high-risk still prompts", async () => {
+    test("user allow rule at priority 100 overrides default ask but high-risk non-bash still prompts", async () => {
       ensureSkillsDir();
       const skillPath = join(wsSkillsDir, "my-skill", "executor.ts");
       addRule(
@@ -3143,10 +2968,9 @@ describe("Permission Checker", () => {
         100,
       );
       const result = await check("file_write", { path: skillPath }, "/tmp");
-      // The user rule wins over default ask, but skill mutations are High risk,
-      // so the allow rule without allowHighRisk falls through to high-risk prompt.
+      // The user rule wins over default ask, but skill mutations are High risk
+      // and shouldAutoAllowHighRisk only covers containerized bash.
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
     });
 
     test("without user rule, default ask rule matches and prompts for skill source mutations", async () => {
@@ -3859,7 +3683,6 @@ describe("Permission Checker", () => {
       scope: string;
       decision: "allow" | "deny" | "ask";
       priority: number;
-      allowHighRisk?: boolean;
     }): Promise<void> {
       const trustPath = join(checkerTestDir, "protected", "trust.json");
       const {
@@ -4176,7 +3999,7 @@ describe("Permission Checker", () => {
         expect(result.reason).toContain("High risk");
       });
 
-      test("allowHighRisk: true rule can explicitly approve skill mutation", async () => {
+      test("allow rule for skill mutation prompts (high risk, non-bash tool)", async () => {
         ensureSkillsDir();
         const skillPath = join(
           checkerTestDir,
@@ -4190,11 +4013,9 @@ describe("Permission Checker", () => {
           "/tmp",
           "allow",
           2000,
-          { allowHighRisk: true },
         );
         const result = await check("file_write", { path: skillPath }, "/tmp");
-        expect(result.decision).toBe("allow");
-        expect(result.reason).toContain("high-risk trust rule");
+        expect(result.decision).toBe("prompt");
       });
     });
 
@@ -4242,18 +4063,15 @@ describe("Permission Checker", () => {
         expect(r2.decision).toBe("allow");
       });
 
-      test("high-risk allowHighRisk: true rule auto-allows dangerous commands", async () => {
-        addRule("bash", "sudo *", "everywhere", "allow", 2000, {
-          allowHighRisk: true,
-        });
+      test("high-risk bash with allow rule prompts in non-containerized environment", async () => {
+        addRule("bash", "sudo *", "everywhere", "allow", 2000);
         const result = await check(
           "bash",
           { command: "sudo rm -rf /" },
           "/tmp",
         );
-        expect(result.decision).toBe("allow");
-        expect(result.reason).toContain("high-risk trust rule");
-        expect(result.matchedRule!.allowHighRisk).toBe(true);
+        // Non-containerized bash: shouldAutoAllowHighRisk returns false
+        expect(result.decision).toBe("prompt");
       });
 
       test("broad skill_load wildcard rule allows all skill loads in strict mode", async () => {
@@ -4401,7 +4219,7 @@ describe("Permission Checker", () => {
         expect(bashRule).toBeDefined();
         expect(bashRule!.tool).toBe("bash");
         expect(bashRule!.pattern).toBe("**");
-        expect(bashRule!.allowHighRisk).toBe(true);
+        expect(bashRule!.decision).toBe("allow");
       } finally {
         if (orig === undefined) {
           delete process.env.IS_CONTAINERIZED;

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -83,7 +83,7 @@ describe("ephemeral-permissions", () => {
       expect(fileReadRule.createdAt).toBeGreaterThan(0);
 
       // Ephemeral task rules should not auto-allow high-risk tools
-      expect(fileReadRule.allowHighRisk).toBeUndefined();
+      // allowHighRisk is no longer a field on rules
 
       // Check other rules have correct tool names
       expect(rules[1].tool).toBe("bash");
@@ -276,7 +276,7 @@ describe("ephemeral-permissions", () => {
       expect(result.decision).toBe("allow");
     });
 
-    test("high-risk tool still prompts even with ephemeral allow rule (no allowHighRisk)", async () => {
+    test("high-risk tool still prompts even with ephemeral allow rule", async () => {
       const ephemeralRules: TrustRule[] = [
         {
           id: "ephemeral:run-1:bash",
@@ -286,7 +286,7 @@ describe("ephemeral-permissions", () => {
           decision: "allow",
           priority: 50,
           createdAt: Date.now(),
-          // Note: allowHighRisk is NOT set
+          // allowHighRisk is no longer a field
         },
       ];
 
@@ -357,7 +357,7 @@ describe("ephemeral-permissions", () => {
     test("ephemeral rule does not carry stray metadata fields for non-scoped tools", () => {
       // buildTaskRules generates canonical ephemeral rules.
       // For a tool like file_read (scoped family), the generated rule
-      // should have no executionTarget or allowHighRisk.
+      // should have no executionTarget.
       const rules = buildTaskRules("run-canon", ["file_read", "bash"], "/tmp");
 
       for (const rule of rules) {

--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -13,7 +13,6 @@ describe("isAllowDecision", () => {
     "allow_10m",
     "allow_conversation",
     "always_allow",
-    "always_allow_high_risk",
     "temporary_override",
   ];
 

--- a/assistant/src/__tests__/starter-bundle.test.ts
+++ b/assistant/src/__tests__/starter-bundle.test.ts
@@ -152,10 +152,9 @@ describe("Starter approval bundle", () => {
       expect(rule.scope).toBe("everywhere");
 
       // Starter rules are all allow decisions — they should not carry
-      // family-specific metadata signals (allowHighRisk, executionTarget).
+      // family-specific metadata signals (executionTarget).
       // These rules cover read-only/information-gathering tools that are
       // either generic or scoped family, but none require high-risk access.
-      expect(rule.allowHighRisk).toBeUndefined();
       expect(rule.executionTarget).toBeUndefined();
 
       // Base fields must be present

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -463,7 +463,7 @@ describe("ToolExecutor contextual rule creation", () => {
         scope: string,
         decision = "allow",
         priority = 100,
-        options?: { allowHighRisk?: boolean; executionTarget?: string },
+        options?: { executionTarget?: string },
       ) => {
         return {
           id: "spy-rule-id",
@@ -528,7 +528,7 @@ describe("ToolExecutor contextual rule creation", () => {
     expect(options.executionTarget).toBe("sandbox");
   });
 
-  test("always_allow_high_risk sets allowHighRisk and captures execution target", async () => {
+  test("always_allow captures execution target without allowHighRisk", async () => {
     checkResultOverride = { decision: "prompt", reason: "test prompt" };
     const spy = setupAddRuleSpy();
 
@@ -553,7 +553,7 @@ describe("ToolExecutor contextual rule creation", () => {
     };
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "risky_tool:*",
       "everywhere",
     );
@@ -569,7 +569,6 @@ describe("ToolExecutor contextual rule creation", () => {
     expect(scope).toBe("everywhere");
     expect(decision).toBe("allow");
     expect(options).toBeDefined();
-    expect(options.allowHighRisk).toBe(true);
     expect(options.executionTarget).toBe("host");
   });
 
@@ -663,13 +662,13 @@ describe("ToolExecutor contextual rule creation", () => {
     expect(scope).toBe("everywhere");
   });
 
-  test("always_allow_high_risk for core tool sets allowHighRisk without execution target", async () => {
+  test("always_allow for core tool creates rule without execution target", async () => {
     checkResultOverride = { decision: "prompt", reason: "test prompt" };
     const spy = setupAddRuleSpy();
     getToolOverride = undefined;
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "sudo *",
       "everywhere",
     );
@@ -684,7 +683,7 @@ describe("ToolExecutor contextual rule creation", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const [, , , , , options] = spy.mock.calls[0];
     expect(options).toBeDefined();
-    expect(options.allowHighRisk).toBe(true);
+    expect(options.executionTarget).toBeDefined();
     // No execution target for core tools
     expect(options.executionTarget).toBeUndefined();
   });
@@ -754,7 +753,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
         scope: string,
         decision = "allow",
         priority = 100,
-        options?: { allowHighRisk?: boolean; executionTarget?: string },
+        options?: { executionTarget?: string },
       ) => {
         return {
           id: "spy-rule-id",
@@ -771,7 +770,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     return addRuleSpy;
   }
 
-  test("always_allow_high_risk creates rule with allowHighRisk: true for high-risk skill tool", async () => {
+  test("always_allow creates rule with execution target for high-risk skill tool", async () => {
     checkResultOverride = {
       decision: "prompt",
       reason: "High risk: always requires approval",
@@ -799,7 +798,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     };
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "deploy_tool:*",
       "everywhere",
     );
@@ -818,12 +817,12 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     expect(pattern).toBe("deploy_tool:*");
     expect(scope).toBe("everywhere");
     expect(decision).toBe("allow");
-    // The key integration assertion: allowHighRisk + execution target together
-    expect(options.allowHighRisk).toBe(true);
+    // The key integration assertion: execution target is captured
+    expect(options.executionTarget).toBeDefined();
     expect(options.executionTarget).toBe("host");
   });
 
-  test("always_allow creates rule without allowHighRisk even for high-risk skill tool", async () => {
+  test("always_allow creates rule with execution target for skill tool", async () => {
     checkResultOverride = { decision: "prompt", reason: "test prompt" };
     const spy = setupAddRuleSpy();
 
@@ -847,9 +846,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
       };
     };
 
-    // User chooses always_allow (NOT always_allow_high_risk) — the rule
-    // should NOT have allowHighRisk set, meaning future high-risk checks
-    // will still prompt.
+    // User chooses always_allow — rule is created with execution target.
     const prompter = makePrompterWithDecision(
       "always_allow",
       "risky_op:*",
@@ -864,8 +861,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     expect(options).toBeDefined();
     // executionTarget should be present
     expect(options.executionTarget).toBe("sandbox");
-    // But allowHighRisk should NOT be set
-    expect(options.allowHighRisk).toBeUndefined();
+    // Rule should have execution target
+    // allowHighRisk is no longer persisted
   });
 
   test("executor forwards policyContext to check() for version-bound skill tool", async () => {
@@ -900,7 +897,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
 
   // ── Skill mutation approval regression tests (PR 30) ──────────
 
-  test("always_allow_high_risk for skill source write creates rule with allowHighRisk and execution target", async () => {
+  test("always_allow for skill source write creates rule with execution target", async () => {
     checkResultOverride = {
       decision: "prompt",
       reason: "High risk: always requires approval",
@@ -928,7 +925,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     };
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "file_write:*/skills/**",
       "everywhere",
     );
@@ -946,11 +943,11 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     expect(pattern).toBe("file_write:*/skills/**");
     expect(scope).toBe("everywhere");
     expect(decision).toBe("allow");
-    expect(options.allowHighRisk).toBe(true);
+    expect(options.executionTarget).toBeDefined();
     expect(options.executionTarget).toBe("sandbox");
   });
 
-  test("always_allow (not high risk) for skill source write creates rule WITHOUT allowHighRisk", async () => {
+  test("always_allow for skill source write creates rule with execution target (baseline)", async () => {
     checkResultOverride = {
       decision: "prompt",
       reason: "High risk: always requires approval",
@@ -977,7 +974,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
       };
     };
 
-    // User chooses always_allow instead of always_allow_high_risk
+    // User chooses always_allow
     const prompter = makePrompterWithDecision(
       "always_allow",
       "file_write:*/skills/**",
@@ -995,8 +992,8 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     const [, , , , , options] = spy.mock.calls[0];
     expect(options).toBeDefined();
     expect(options.executionTarget).toBe("sandbox");
-    // Without always_allow_high_risk, the allowHighRisk flag should NOT be set
-    expect(options.allowHighRisk).toBeUndefined();
+    // Execution target is captured from the tool context
+    // allowHighRisk is no longer persisted
   });
 
   test("skill version is captured in rule for future version-bound matching", async () => {
@@ -1027,7 +1024,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     };
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "file_edit:*/skills/**",
       "everywhere",
     );
@@ -1042,7 +1039,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const [tool, , , , , options] = spy.mock.calls[0];
     expect(tool).toBe("file_edit");
-    expect(options.allowHighRisk).toBe(true);
+    expect(options.executionTarget).toBeDefined();
     expect(options.executionTarget).toBe("sandbox");
   });
 
@@ -1080,7 +1077,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     });
   });
 
-  test("executor creates rule on always_allow_high_risk with full context", async () => {
+  test("executor creates rule on always_allow with full context", async () => {
     checkResultOverride = {
       decision: "prompt",
       reason: "High risk: always requires approval",
@@ -1108,7 +1105,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     };
 
     const prompter = makePrompterWithDecision(
-      "always_allow_high_risk",
+      "always_allow",
       "admin_action:*",
       "everywhere",
     );
@@ -1128,7 +1125,7 @@ describe("ToolExecutor strict mode + high-risk integration (PR 25)", () => {
     expect(pattern).toBe("admin_action:*");
     expect(scope).toBe("everywhere");
     expect(decision).toBe("allow");
-    expect(options.allowHighRisk).toBe(true);
+    expect(options.executionTarget).toBeDefined();
     expect(options.executionTarget).toBe("host");
   });
 });
@@ -1787,7 +1784,7 @@ describe("ToolExecutor persistentDecisionsAllowed contract", () => {
         scope: string,
         decision = "allow",
         priority = 100,
-        options?: { allowHighRisk?: boolean; executionTarget?: string },
+        options?: { executionTarget?: string },
       ) => {
         return {
           id: "spy-rule-id",
@@ -2127,7 +2124,7 @@ describe("ToolExecutor persistent-allow lifecycle", () => {
         scope: string,
         decision = "allow",
         priority = 100,
-        options?: { allowHighRisk?: boolean; executionTarget?: string },
+        options?: { executionTarget?: string },
       ) => {
         return {
           id: "spy-rule-id",

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -683,7 +683,6 @@ describe("ToolExecutor contextual rule creation", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const [, , , , , options] = spy.mock.calls[0];
     expect(options).toBeDefined();
-    expect(options.executionTarget).toBeDefined();
     // No execution target for core tools
     expect(options.executionTarget).toBeUndefined();
   });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -129,27 +129,11 @@ describe("Trust Store", () => {
       expect(userRules[2].priority).toBe(0);
     });
 
-    test("accepts allowHighRisk option and persists it", () => {
-      const rule = addRule("bash", "sudo *", "everywhere", "allow", 100, {
-        allowHighRisk: true,
-      });
-      expect(rule.allowHighRisk).toBe(true);
-      // Verify it persists to disk
-      clearCache();
-      const rules = getAllRules();
-      const found = rules.find((r) => r.id === rule.id);
-      expect(found).toBeDefined();
-      expect(found!.allowHighRisk).toBe(true);
-    });
-
-    test("addRule without allowHighRisk option does not set the field", () => {
-      const rule = addRule("bash", "git *", "/tmp");
-      expect(rule.allowHighRisk).toBeUndefined();
-      // Verify on disk
-      const raw = JSON.parse(readFileSync(trustPath, "utf-8"));
-      const diskRule = raw.rules.find((r: { id: string }) => r.id === rule.id);
-      expect(diskRule).toBeDefined();
-      expect(diskRule).not.toHaveProperty("allowHighRisk");
+    test("allowHighRisk option is stripped during normalization", () => {
+      // allowHighRisk is no longer persisted — the parser strips it.
+      const rule = addRule("bash", "sudo *", "everywhere", "allow", 100);
+      // Verify the field is not on the rule
+      expect((rule as Record<string, unknown>).allowHighRisk).toBeUndefined();
     });
 
     test("at same priority deny rules sort before allow rules", () => {
@@ -176,7 +160,7 @@ describe("Trust Store", () => {
       expect(found!.executionTarget).toBe("sandbox");
     });
 
-    test("accepts all contextual options together (target, allowHighRisk)", () => {
+    test("accepts executionTarget option (allowHighRisk no longer supported)", () => {
       const rule = addRule(
         "risky_tool",
         "risky_tool:*",
@@ -184,18 +168,16 @@ describe("Trust Store", () => {
         "allow",
         100,
         {
-          allowHighRisk: true,
           executionTarget: "host",
         },
       );
-      expect(rule.allowHighRisk).toBe(true);
       expect(rule.executionTarget).toBe("host");
 
-      // Verify on disk
+      // Verify on disk — allowHighRisk should not appear
       const raw = JSON.parse(readFileSync(trustPath, "utf-8"));
       const diskRule = raw.rules.find((r: { id: string }) => r.id === rule.id);
       expect(diskRule).toBeDefined();
-      expect(diskRule.allowHighRisk).toBe(true);
+      expect(diskRule).not.toHaveProperty("allowHighRisk");
       expect(diskRule.executionTarget).toBe("host");
     });
 
@@ -944,7 +926,7 @@ describe("Trust Store", () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:allow-bash-rm-bootstrap");
       expect(match!.decision).toBe("allow");
-      expect(match!.allowHighRisk).toBe(true);
+      expect(match!.decision).toBe("allow");
       // Outside workspace, the bootstrap rule doesn't match — without
       // IS_CONTAINERIZED there is no catch-all bash allow rule either.
       const other = findHighestPriorityRule(
@@ -965,7 +947,7 @@ describe("Trust Store", () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:allow-bash-rm-updates");
       expect(match!.decision).toBe("allow");
-      expect(match!.allowHighRisk).toBe(true);
+      expect(match!.decision).toBe("allow");
       // Outside workspace, should NOT match the updates rule — without
       // IS_CONTAINERIZED there is no catch-all bash allow rule either.
       const other = findHighestPriorityRule(
@@ -1218,11 +1200,10 @@ describe("Trust Store", () => {
   // ── trust rule schema v3 (PR 14) ──────────────────────────────
 
   describe("trust rule schema v3 (PR 14)", () => {
-    test("new rules can include v3 optional fields", () => {
+    test("new rules can include v3 optional fields (executionTarget)", () => {
       const rule = addRule("bash", "git *", "/tmp");
-      // Manually set v3 optional fields on the rule and persist
+      // Manually set v3 optional field on the rule and persist
       rule.executionTarget = "/usr/local/bin/node";
-      rule.allowHighRisk = true;
       // Re-persist the updated rules
       const rules = getAllRules().map((r) => (r.id === rule.id ? rule : r));
       // Write directly to verify round-trip
@@ -1233,7 +1214,6 @@ describe("Trust Store", () => {
       const found = reloaded.find((r) => r.id === rule.id);
       expect(found).toBeDefined();
       expect(found!.executionTarget).toBe("/usr/local/bin/node");
-      expect(found!.allowHighRisk).toBe(true);
     });
 
     test("trust file persists with version 3", () => {
@@ -1268,7 +1248,6 @@ describe("Trust Store", () => {
           priority: 100,
           createdAt: 7000,
           executionTarget: "/usr/bin/node",
-          allowHighRisk: false,
         },
         {
           id: "v3-without-options",
@@ -1288,7 +1267,6 @@ describe("Trust Store", () => {
       const withOptions = rules.find((r) => r.id === "v3-with-options");
       expect(withOptions).toBeDefined();
       expect(withOptions!.executionTarget).toBe("/usr/bin/node");
-      expect(withOptions!.allowHighRisk).toBe(false);
 
       // Rule without optional fields should remain without them
       const withoutOptions = rules.find((r) => r.id === "v3-without-options");
@@ -1775,7 +1753,7 @@ describe("canonical parser normalization-on-load", () => {
     expect(diskRule).not.toHaveProperty("executionTarget");
   });
 
-  test("URL rule with allowHighRisk is preserved on load", () => {
+  test("URL rule with allowHighRisk is stripped on load (normalized)", () => {
     mkdirSync(dirname(trustPath), { recursive: true });
     writeFileSync(
       trustPath,
@@ -1799,10 +1777,11 @@ describe("canonical parser normalization-on-load", () => {
     const rules = getAllRules();
     const found = rules.find((r) => r.id === "url-rule-with-ahr");
     expect(found).toBeDefined();
-    expect((found as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+    // allowHighRisk is stripped during normalization
+    expect((found as Record<string, unknown>).allowHighRisk).toBeUndefined();
   });
 
-  test("scoped rule preserves executionTarget and allowHighRisk on load", () => {
+  test("scoped rule preserves executionTarget but strips allowHighRisk on load", () => {
     mkdirSync(dirname(trustPath), { recursive: true });
     writeFileSync(
       trustPath,
@@ -1830,7 +1809,8 @@ describe("canonical parser normalization-on-load", () => {
     expect((found as { executionTarget?: string }).executionTarget).toBe(
       "/usr/local/bin/node",
     );
-    expect((found as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+    // allowHighRisk is stripped during normalization
+    expect((found as Record<string, unknown>).allowHighRisk).toBeUndefined();
   });
 
   test("normalization on v2 file triggers re-save as v3", () => {

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -412,12 +412,11 @@ function mapDecisionToOptionId(
     decision === "allow_10m" ||
     decision === "allow_conversation" ||
     decision === "always_allow" ||
-    decision === "always_allow_high_risk" ||
     decision === "temporary_override";
 
   if (isAllow) {
     // Prefer allow_always for persistent decisions, fallback to allow_once
-    if (decision === "always_allow" || decision === "always_allow_high_risk") {
+    if (decision === "always_allow") {
       const alwaysOpt = options.find((o) => o.kind === "allow_always");
       if (alwaysOpt) return alwaysOpt.optionId;
     }

--- a/assistant/src/cli/commands/trust.ts
+++ b/assistant/src/cli/commands/trust.ts
@@ -42,7 +42,7 @@ Displays a table of all trust rules with the following columns:
             non-global scopes, i.e. not "everywhere")
   Dcn       Decision: allow, deny, or ask
   Pri       Priority (higher values take precedence)
-  Flags     Metadata: H = allowHighRisk, T:<target> = executionTarget
+  Flags     Metadata: T:<target> = executionTarget
   Created   Date the rule was created (YYYY-MM-DD)
 
 IDs are shown truncated to 8 characters. Use the full ID or any unique
@@ -65,10 +65,8 @@ Examples:
       );
 
       // Only show the Flags column when at least one rule carries
-      // metadata signals (allowHighRisk or executionTarget).
-      const hasFlags = rules.some(
-        (r) => r.allowHighRisk != null || r.executionTarget != null,
-      );
+      // metadata signals (executionTarget).
+      const hasFlags = rules.some((r) => r.executionTarget != null);
 
       const idW = 8;
       const toolW = 12;
@@ -109,7 +107,6 @@ Examples:
 
         if (hasFlags) {
           const flags: string[] = [];
-          if (r.allowHighRisk === true) flags.push("H");
           if (r.executionTarget) flags.push(`T:${r.executionTarget}`);
           line += (flags.join(" ") || "").slice(0, flagsW - 2).padEnd(flagsW);
         }

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -87,7 +87,6 @@ function mapUserDecisionToCesDecision(
         userDecision: decision,
       };
     case "always_allow":
-    case "always_allow_high_risk":
       // Persistent grant — no expiry. CES stores it with expiresAt: null.
       return {
         grantDecision: "approved",

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -116,8 +116,7 @@ export async function approveHostAttachmentRead(
   );
 
   if (
-    (response.decision === "always_allow" ||
-      response.decision === "always_allow_high_risk") &&
+    response.decision === "always_allow" &&
     response.selectedPattern &&
     response.selectedScope
   ) {
@@ -127,9 +126,6 @@ export async function approveHostAttachmentRead(
       response.selectedScope,
       "allow",
       100,
-      response.decision === "always_allow_high_risk"
-        ? { allowHighRisk: true }
-        : undefined,
     );
   }
   if (

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -424,18 +424,15 @@ export function createProxyApprovalCallback(
 
     // Persist trust rule if the user chose "always allow" or "always deny"
     if (
-      (response.decision === "always_allow" ||
-        response.decision === "always_allow_high_risk") &&
+      response.decision === "always_allow" &&
       response.selectedPattern &&
       response.selectedScope
     ) {
-      const allowHighRisk = response.decision === "always_allow_high_risk";
       log.info(
         {
           toolName,
           pattern: response.selectedPattern,
           scope: response.selectedScope,
-          allowHighRisk,
         },
         "Persisting always-allow trust rule (proxy)",
       );
@@ -445,7 +442,6 @@ export function createProxyApprovalCallback(
         response.selectedScope,
         "allow",
         100,
-        allowHighRisk ? { allowHighRisk: true } : undefined,
       );
     }
     if (

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -977,7 +977,7 @@ export class Conversation {
    * confirmations in the same conversation that match the decision.
    *
    * - allow_10m / allow_conversation → approve ALL pending in conversation
-   * - always_allow / always_allow_high_risk → approve pattern-matching pending
+   * - always_allow → approve pattern-matching pending
    * - always_deny → deny pattern-matching pending
    * - allow / deny (one-time) → no cascading
    */
@@ -1071,14 +1071,9 @@ export class Conversation {
     }
 
     // Persistent allow: cascade if the pattern matches any allowlist candidate.
-    // "always_allow" must NOT cascade to high-risk pending confirmations —
-    // only "always_allow_high_risk" has consent for those.
-    if (
-      (decision === "always_allow" || decision === "always_allow_high_risk") &&
-      selectedPattern &&
-      details
-    ) {
-      if (decision === "always_allow" && details.riskLevel === "high") {
+    // "always_allow" must NOT cascade to high-risk pending confirmations.
+    if (decision === "always_allow" && selectedPattern && details) {
+      if (details.riskLevel === "high") {
         return null;
       }
       for (const option of details.allowlistOptions) {

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -33,7 +33,6 @@ export interface ConfirmationResponse {
     | "allow_10m"
     | "allow_conversation"
     | "always_allow"
-    | "always_allow_high_risk"
     | "deny"
     | "always_deny";
   selectedPattern?: string;

--- a/assistant/src/daemon/message-types/trust.ts
+++ b/assistant/src/daemon/message-types/trust.ts
@@ -8,8 +8,6 @@ export interface AddTrustRule {
   pattern: string;
   scope: string;
   decision: "allow" | "deny" | "ask";
-  /** When true, the rule also covers high-risk invocations. */
-  allowHighRisk?: boolean;
   /** Execution target override for this rule. */
   executionTarget?: "host" | "sandbox";
 }

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -22,7 +22,6 @@ export interface ToolDomainEvents {
       | "allow_10m"
       | "allow_conversation"
       | "always_allow"
-      | "always_allow_high_risk"
       | "deny"
       | "always_deny"
       | "temporary_override";

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -168,10 +168,7 @@ const LOW_RISK_PROGRAMS = new Set([
  * special handling here.
  */
 function shouldAutoAllowHighRisk(toolName: string): boolean {
-  if (
-    (toolName === "bash" || toolName === "host_bash") &&
-    getIsContainerized()
-  ) {
+  if (toolName === "bash" && getIsContainerized()) {
     return true;
   }
   return false;

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -155,6 +155,28 @@ const LOW_RISK_PROGRAMS = new Set([
   "df",
 ]);
 
+/**
+ * Determines at runtime whether a high-risk operation should be auto-allowed
+ * without requiring a persisted allowHighRisk flag. This replaces the
+ * stateful allowHighRisk field on trust rules with a context-aware check.
+ *
+ * Auto-allow cases:
+ * - Containerized bash: all commands are sandboxed, so high-risk is safe.
+ *
+ * Note: `rm BOOTSTRAP.md` and `rm UPDATES.md` are already classified as
+ * Medium risk (not High) by `isRmOfKnownSafeFile()`, so they don't need
+ * special handling here.
+ */
+function shouldAutoAllowHighRisk(toolName: string): boolean {
+  if (
+    (toolName === "bash" || toolName === "host_bash") &&
+    getIsContainerized()
+  ) {
+    return true;
+  }
+  return false;
+}
+
 // High-risk shell programs / patterns
 const HIGH_RISK_PROGRAMS = new Set([
   "sudo",
@@ -321,9 +343,8 @@ function firstPositionalArg(
 }
 
 // Bare filenames that `rm` is allowed to delete at Medium risk (instead of
-// High) so workspace-scoped allow rules can approve them without the
-// dangerous `allowHighRisk` flag. Only matches when the args contain no
-// flags and exactly one of these filenames.
+// High) so workspace-scoped allow rules can approve them without prompting.
+// Only matches when the args contain no flags and exactly one of these filenames.
 const RM_SAFE_BARE_FILES = new Set(["BOOTSTRAP.md", "UPDATES.md"]);
 
 function isRmOfKnownSafeFile(args: string[]): boolean {
@@ -1041,15 +1062,15 @@ export async function check(
         matchedRule,
       };
     }
-    // High risk with allow rule that explicitly permits high-risk → auto-allow
-    if (matchedRule.allowHighRisk === true) {
+    // High risk with allow rule — check runtime context for auto-allow
+    if (shouldAutoAllowHighRisk(toolName)) {
       return {
         decision: "allow",
-        reason: `Matched high-risk trust rule: ${matchedRule.pattern}`,
+        reason: `Matched trust rule in auto-allow-high-risk context: ${matchedRule.pattern}`,
         matchedRule,
       };
     }
-    // High risk with allow rule (without allowHighRisk) → fall through to prompt
+    // High risk with allow rule (no runtime auto-allow) → fall through to prompt
   }
 
   // No matching rule (or High risk with allow rule) → risk-based fallback

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,13 +1,7 @@
 import { join } from "node:path";
 
-import type {
-  ScopedTrustRule,
-  TrustRuleBase,
-} from "@vellumai/ces-contracts";
-import {
-  MANAGED_SKILL_TOOLS,
-  SKILL_LOAD_TOOL,
-} from "@vellumai/ces-contracts";
+import type { ScopedTrustRule, TrustRuleBase } from "@vellumai/ces-contracts";
+import { MANAGED_SKILL_TOOLS, SKILL_LOAD_TOOL } from "@vellumai/ces-contracts";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
@@ -18,15 +12,12 @@ import { getWorkspaceDir } from "../util/platform.js";
 /**
  * A default rule template is structurally identical to TrustRuleBase
  * minus `createdAt` (set at backfill time) and `userModifiedAt` (set
- * when users explicitly override defaults), plus the optional
- * `allowHighRisk` field that some tool families support.
+ * when users explicitly override defaults).
  */
 export type DefaultRuleTemplate = Omit<
   TrustRuleBase,
   "createdAt" | "userModifiedAt"
-> & {
-  allowHighRisk?: boolean;
-};
+>;
 
 /**
  * Escape minimatch metacharacters so a literal path is matched literally when
@@ -91,8 +82,9 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   };
 
   // When running inside a container (IS_CONTAINERIZED=true), bash commands
-  // execute in an isolated environment — auto-allow all of them (including
-  // high-risk) so the user is never prompted.  Outside a container, bash
+  // execute in an isolated environment — auto-allow all of them so the user
+  // is never prompted. High-risk operations are handled by
+  // shouldAutoAllowHighRisk() in checker.ts. Outside a container, bash
   // commands run on the host and go through normal permission checks.
   const bashShellRule: DefaultRuleTemplate | null = getIsContainerized()
     ? {
@@ -102,7 +94,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
         scope: "everywhere",
         decision: "allow",
         priority: 50,
-        allowHighRisk: true,
       }
     : null;
 
@@ -198,7 +189,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: "allow",
     priority: 100,
-    allowHighRisk: true,
   };
 
   const updatesDeleteRule: DefaultRuleTemplate = {
@@ -208,7 +198,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: "allow",
     priority: 100,
-    allowHighRisk: true,
   };
 
   // Skill source directories — writing or editing skill source files should

--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -211,7 +211,6 @@ export async function addRule(params: {
   scope: string;
   decision?: TrustRule["decision"];
   priority?: number;
-  allowHighRisk?: boolean;
   executionTarget?: string;
 }): Promise<TrustRule> {
   const data = await request<{ rule: unknown }>(
@@ -231,7 +230,6 @@ export async function updateRule(
     scope?: string;
     decision?: TrustRule["decision"];
     priority?: number;
-    allowHighRisk?: boolean;
     executionTarget?: string;
   },
 ): Promise<TrustRule> {
@@ -306,7 +304,6 @@ export function addRuleSync(params: {
   scope: string;
   decision?: TrustRule["decision"];
   priority?: number;
-  allowHighRisk?: boolean;
   executionTarget?: string;
 }): TrustRule {
   const data = requestSync<{ rule: unknown }>(
@@ -326,7 +323,6 @@ export function updateRuleSync(
     scope?: string;
     decision?: TrustRule["decision"];
     priority?: number;
-    allowHighRisk?: boolean;
     executionTarget?: string;
   },
 ): TrustRule {

--- a/assistant/src/permissions/trust-store-interface.ts
+++ b/assistant/src/permissions/trust-store-interface.ts
@@ -45,11 +45,7 @@ export interface TrustStoreBackend {
   ): TrustRule | null;
 
   /** Find the first matching deny rule for a tool/command/scope. */
-  findDenyRule(
-    tool: string,
-    command: string,
-    scope: string,
-  ): TrustRule | null;
+  findDenyRule(tool: string, command: string, scope: string): TrustRule | null;
 
   /** Add a new trust rule and persist it. */
   addRule(
@@ -59,7 +55,6 @@ export interface TrustStoreBackend {
     decision?: "allow" | "deny" | "ask",
     priority?: number,
     options?: {
-      allowHighRisk?: boolean;
       executionTarget?: string;
     },
   ): TrustRule;

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -315,8 +315,7 @@ function loadFromDisk(): TrustRule[] {
 
         // Apply canonical parser for family-aware normalization.
         // The parser strips fields that are invalid for a rule's tool family
-        // (e.g. executionTarget on URL rules), preserves compatible optional
-        // fields (e.g. executionTarget on URL rules), and coerces malformed values.
+        // (e.g. executionTarget on URL rules) and coerces malformed values.
         const { data: parsedData, normalized } = parseTrustFileData({
           ...data,
           rules: sanitizedRules,

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -198,23 +198,31 @@ function backfillDefaults(rules: TrustRule[]): boolean {
     }
   }
 
-  // Migrate existing default rules whose priority, pattern, scope, decision,
-  // or allowHighRisk has changed in the template (e.g. host_bash pattern
-  // changed from '*' to '**', host tool priorities changed from 1000 to 50,
-  // workspace scope changed from getRootDir()+workspace to getWorkspaceDir()).
+  // Migrate existing default rules whose priority, pattern, scope, or decision
+  // has changed in the template (e.g. host_bash pattern changed from '*' to
+  // '**', host tool priorities changed from 1000 to 50, workspace scope
+  // changed from getRootDir()+workspace to getWorkspaceDir()).
+  //
+  // Also strip any leftover allowHighRisk fields from persisted default rules
+  // since the field has been replaced by runtime determination.
   //
   // Rules with `userModifiedAt` set are skipped — the user explicitly
   // customized them and their override should be preserved across upgrades.
   for (const template of getDefaultRuleTemplates()) {
     if (existingIds.has(template.id)) {
       const rule = rules.find((r) => r.id === template.id);
+      if (!rule) continue;
+      // Strip legacy allowHighRisk from persisted default rules.
+      const ruleRecord = rule as unknown as Record<string, unknown>;
+      if ("allowHighRisk" in ruleRecord) {
+        delete ruleRecord.allowHighRisk;
+        changed = true;
+      }
       if (
-        rule &&
-        (rule.priority !== template.priority ||
-          rule.pattern !== template.pattern ||
-          rule.scope !== template.scope ||
-          rule.decision !== template.decision ||
-          rule.allowHighRisk !== template.allowHighRisk)
+        rule.priority !== template.priority ||
+        rule.pattern !== template.pattern ||
+        rule.scope !== template.scope ||
+        rule.decision !== template.decision
       ) {
         if (rule.userModifiedAt != null) {
           log.info(
@@ -239,11 +247,6 @@ function backfillDefaults(rules: TrustRule[]): boolean {
         rule.pattern = template.pattern;
         rule.scope = template.scope;
         rule.decision = template.decision;
-        if (template.allowHighRisk != null) {
-          rule.allowHighRisk = template.allowHighRisk;
-        } else {
-          delete rule.allowHighRisk;
-        }
         changed = true;
       }
     }
@@ -313,7 +316,7 @@ function loadFromDisk(): TrustRule[] {
         // Apply canonical parser for family-aware normalization.
         // The parser strips fields that are invalid for a rule's tool family
         // (e.g. executionTarget on URL rules), preserves compatible optional
-        // fields like allowHighRisk, and coerces malformed values.
+        // fields (e.g. executionTarget on URL rules), and coerces malformed values.
         const { data: parsedData, normalized } = parseTrustFileData({
           ...data,
           rules: sanitizedRules,
@@ -420,7 +423,6 @@ function fileAddRule(
   decision: "allow" | "deny" | "ask" = "allow",
   priority: number = 100,
   options?: {
-    allowHighRisk?: boolean;
     executionTarget?: string;
   },
 ): TrustRule {
@@ -438,9 +440,6 @@ function fileAddRule(
     decision,
     priority,
     createdAt: Date.now(),
-    ...(options?.allowHighRisk != null
-      ? { allowHighRisk: options.allowHighRisk }
-      : {}),
     ...(options?.executionTarget != null
       ? { executionTarget: options.executionTarget }
       : {}),
@@ -501,8 +500,7 @@ function fileUpdateRule(
       merged.pattern !== template.pattern ||
       merged.scope !== template.scope ||
       merged.decision !== template.decision ||
-      merged.priority !== template.priority ||
-      merged.allowHighRisk !== template.allowHighRisk;
+      merged.priority !== template.priority;
     if (diverges) {
       merged.userModifiedAt = Date.now();
     } else {
@@ -1033,7 +1031,6 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
     decision: "allow" | "deny" | "ask" = "allow",
     priority: number = 100,
     options?: {
-      allowHighRisk?: boolean;
       executionTarget?: string;
     },
   ): TrustRule {
@@ -1052,20 +1049,11 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       decision,
       priority,
       createdAt: 0,
-      ...(options?.allowHighRisk != null
-        ? { allowHighRisk: options.allowHighRisk }
-        : {}),
       ...(options?.executionTarget != null
         ? { executionTarget: options.executionTarget }
         : {}),
     });
-    const canonicalOpts: { allowHighRisk?: boolean; executionTarget?: string } =
-      {};
-    if ("allowHighRisk" in canonical) {
-      canonicalOpts.allowHighRisk = (
-        canonical as { allowHighRisk?: boolean }
-      ).allowHighRisk;
-    }
+    const canonicalOpts: { executionTarget?: string } = {};
     if ("executionTarget" in canonical) {
       canonicalOpts.executionTarget = (
         canonical as { executionTarget?: string }
@@ -1079,7 +1067,6 @@ class GatewayTrustStoreAdapter implements TrustStoreBackend {
       scope: canonical.scope,
       decision: canonical.decision,
       priority: canonical.priority,
-      allowHighRisk: canonicalOpts.allowHighRisk,
       executionTarget: canonicalOpts.executionTarget,
     });
     // Update local cache
@@ -1244,7 +1231,6 @@ export function addRule(
   decision: "allow" | "deny" | "ask" = "allow",
   priority: number = 100,
   options?: {
-    allowHighRisk?: boolean;
     executionTarget?: string;
   },
 ): TrustRule {

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -11,7 +11,6 @@ import type { TrustRuleBase } from "@vellumai/ces-contracts";
  */
 export type TrustRule = TrustRuleBase & {
   executionTarget?: string;
-  allowHighRisk?: boolean;
 };
 
 export enum RiskLevel {
@@ -25,7 +24,6 @@ export type UserDecision =
   | "allow_10m"
   | "allow_conversation"
   | "always_allow"
-  | "always_allow_high_risk"
   | "deny"
   | "always_deny"
   | "temporary_override";
@@ -37,7 +35,6 @@ export function isAllowDecision(decision: UserDecision): boolean {
     decision === "allow_10m" ||
     decision === "allow_conversation" ||
     decision === "always_allow" ||
-    decision === "always_allow_high_risk" ||
     decision === "temporary_override"
   );
 }

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -18,9 +18,9 @@ Approvals are **orthogonal to message sending**. The assistant asks for approval
 
 - **Discovery**: Clients discover pending approvals via SSE events (`confirmation_request`, `secret_request`) which include a `requestId`.
 - **Resolution**: Clients respond via standalone endpoints keyed by `requestId`:
-  - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_conversation"`, `"deny"`, `"always_allow"`, `"always_deny"`, `"always_allow_high_risk"`. For persistent decisions (`always_allow`, `always_deny`, `always_allow_high_risk`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
+  - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_conversation"`, `"deny"`, `"always_allow"`, `"always_deny"`. For persistent decisions (`always_allow`, `always_deny`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
   - `POST /v1/secret` — `{ requestId, value, delivery }`
-  - `POST /v1/trust-rules` — `{ requestId, pattern, scope, decision, allowHighRisk? }`. Validates pattern/scope against server-provided options. Does not resolve the confirmation itself.
+  - `POST /v1/trust-rules` — `{ requestId, pattern, scope, decision }`. Validates pattern/scope against server-provided options. Does not resolve the confirmation itself.
 - **Tracking**: The `pending-interactions` tracker (`assistant/src/runtime/pending-interactions.ts`) maps `requestId → conversation`. Use `register()` to track, `resolve()` to consume, `getByConversation()` to query.
 
 Do NOT couple approval handling to message sending. Do NOT add run/status tracking to the send path.

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -77,7 +77,11 @@ export async function handleConfirm(
     selectedScope?: string;
   };
 
-  const { requestId, decision, selectedPattern, selectedScope } = body;
+  const { requestId, selectedPattern, selectedScope } = body;
+  // Normalize legacy decision: older clients may still send
+  // "always_allow_high_risk" for high-risk prompts.
+  const decision =
+    body.decision === "always_allow_high_risk" ? "always_allow" : body.decision;
 
   if (!requestId || typeof requestId !== "string") {
     return httpError("BAD_REQUEST", "requestId is required", 400);

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -50,9 +50,7 @@ function canonicalizeV2ConfirmDecision(params: {
   }
 
   if (
-    (decision === "always_allow" ||
-      decision === "always_allow_high_risk" ||
-      decision === "always_deny") &&
+    (decision === "always_allow" || decision === "always_deny") &&
     details.persistentDecisionsAllowed
   ) {
     return decision === "always_deny" ? "deny" : "allow";
@@ -111,7 +109,6 @@ export async function handleConfirm(
     "deny",
     "always_allow",
     "always_deny",
-    "always_allow_high_risk",
   ];
   if (
     (v2Enabled && effectiveDecision == null) ||
@@ -152,9 +149,7 @@ export async function handleConfirm(
   // and selectedScope are among the options the server actually offered.
   // This prevents a crafted request from injecting overly-broad rules.
   const persistsRule =
-    decision === "always_allow" ||
-    decision === "always_deny" ||
-    decision === "always_allow_high_risk";
+    decision === "always_allow" || decision === "always_deny";
   if (persistsRule && (selectedPattern || selectedScope)) {
     const confirmation = peeked.confirmationDetails;
     if (!confirmation) {
@@ -312,10 +307,9 @@ export async function handleTrustRule(
     pattern?: string;
     scope?: string;
     decision?: string;
-    allowHighRisk?: boolean;
   };
 
-  const { requestId, pattern, scope, decision, allowHighRisk } = body;
+  const { requestId, pattern, scope, decision } = body;
 
   if (!requestId || typeof requestId !== "string") {
     return httpError("BAD_REQUEST", "requestId is required", 400);
@@ -399,7 +393,6 @@ export async function handleTrustRule(
 
     // Canonicalization is handled inside addRule — no need to pre-parse here.
     addRule(confirmation.toolName, pattern, scope, decision, undefined, {
-      ...(allowHighRisk ? { allowHighRisk: true } : {}),
       ...(executionTarget != null ? { executionTarget } : {}),
     });
     log.info(
@@ -506,7 +499,7 @@ export function approvalRouteDefinitions(): RouteDefinition[] {
         decision: z
           .string()
           .describe(
-            "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny, always_allow_high_risk",
+            "One of: allow, allow_10m, allow_conversation, deny, always_allow, always_deny",
           ),
         selectedPattern: z
           .string()
@@ -553,10 +546,6 @@ export function approvalRouteDefinitions(): RouteDefinition[] {
         pattern: z.string().describe("Allowlist pattern"),
         scope: z.string().describe("Scope for the rule"),
         decision: z.string().describe("allow or deny"),
-        allowHighRisk: z
-          .boolean()
-          .describe("Allow high-risk invocations")
-          .optional(),
       }),
       responseBody: z.object({
         accepted: z.boolean(),

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -35,7 +35,7 @@ function handleListTrustRules(): Response {
 /**
  * POST /v1/trust-rules/manage — add a trust rule (standalone, not approval-flow).
  *
- * Body: { toolName, pattern, scope, decision, allowHighRisk?, executionTarget? }
+ * Body: { toolName, pattern, scope, decision, executionTarget? }
  *
  * Legacy payloads that include fields invalid for the tool's family (e.g.
  * `executionTarget` on a `web_fetch` rule) are accepted but canonicalized:
@@ -49,12 +49,10 @@ export async function handleAddTrustRuleManage(
     pattern?: string;
     scope?: string;
     decision?: string;
-    allowHighRisk?: boolean;
     executionTarget?: string;
   };
 
-  const { toolName, pattern, scope, decision, allowHighRisk, executionTarget } =
-    body;
+  const { toolName, pattern, scope, decision, executionTarget } = body;
 
   if (!toolName || typeof toolName !== "string") {
     return httpError("BAD_REQUEST", "toolName is required", 400);
@@ -95,7 +93,6 @@ export async function handleAddTrustRuleManage(
       decision as "allow" | "deny" | "ask",
       undefined,
       {
-        ...(allowHighRisk != null ? { allowHighRisk } : {}),
         ...(executionTarget != null ? { executionTarget } : {}),
       },
     );
@@ -213,10 +210,6 @@ export function trustRulesRouteDefinitions(): RouteDefinition[] {
         pattern: z.string().describe("Allowlist pattern"),
         scope: z.string().describe("Scope"),
         decision: z.string().describe("allow, deny, or ask"),
-        allowHighRisk: z
-          .boolean()
-          .describe("Allow high-risk invocations")
-          .optional(),
         executionTarget: z.string().describe("Execution target").optional(),
       }),
       responseBody: z.object({

--- a/assistant/src/tasks/ephemeral-permissions.ts
+++ b/assistant/src/tasks/ephemeral-permissions.ts
@@ -29,9 +29,8 @@ export function clearTaskRunRules(taskRunId: string): void {
  * default rules (50) so pre-approved tools aren't shadowed by default
  * `ask` rules (which would trigger prompting and auto-deny in
  * non-interactive task runs), but below user rules (100) so user deny
- * rules still take precedence. `allowHighRisk` is intentionally omitted:
- * high-risk tool invocations still flow through the normal risk-classification
- * path rather than being blanket-approved.
+ * rules still take precedence. High-risk tool invocations still flow through
+ * the normal risk-classification path rather than being blanket-approved.
  */
 export function buildTaskRules(
   taskRunId: string,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -453,18 +453,12 @@ export class PermissionChecker {
 
         if (
           promptOptions.persistentDecisionsAllowed &&
-          (decision === "always_allow" ||
-            decision === "always_allow_high_risk") &&
+          decision === "always_allow" &&
           response.selectedPattern
         ) {
           const ruleOptions: {
-            allowHighRisk?: boolean;
             executionTarget?: string;
           } = {};
-
-          if (decision === "always_allow_high_risk") {
-            ruleOptions.allowHighRisk = true;
-          }
 
           if (policyContext?.executionTarget != null) {
             ruleOptions.executionTarget = policyContext.executionTarget;

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -382,13 +382,13 @@ final class ChatViewModelIOSTests: XCTestCase {
             requestId: "req-1",
             selectedPattern: "rm -rf *",
             selectedScope: "project",
-            decision: "always_allow_high_risk"
+            decision: "always_allow"
         )
 
         await waitForMockCalls(mockInteraction, count: 1)
 
         XCTAssertEqual(mockInteraction.calls.count, 1)
-        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow_high_risk")
+        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow")
         XCTAssertEqual(mockInteraction.calls[0].selectedPattern, "rm -rf *")
         XCTAssertEqual(mockInteraction.calls[0].selectedScope, "project")
     }
@@ -414,7 +414,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
     func testRespondToAlwaysAllowFallsBackWhenSendFails() async {
         let mockInteraction = MockInteractionClient()
-        // First call (always_allow_high_risk) fails, fallback (allow) also fails
+        // First call (always_allow) fails, fallback (allow) also fails
         mockInteraction.results = [.failed, .failed]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
@@ -439,21 +439,21 @@ final class ChatViewModelIOSTests: XCTestCase {
             requestId: "req-3",
             selectedPattern: "npm install",
             selectedScope: "project",
-            decision: "always_allow_high_risk"
+            decision: "always_allow"
         )
 
         await waitForMockCalls(mockInteraction, count: 2)
 
         // Both attempts failed — confirmation should be reverted to pending
         XCTAssertEqual(mockInteraction.calls.count, 2)
-        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow_high_risk")
+        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow")
         XCTAssertEqual(mockInteraction.calls[1].decision, "allow")
         XCTAssertEqual(vm.messages[0].confirmation?.state, .pending)
     }
 
     func testRespondToAlwaysAllowConnectedSendFailureFallsBackToAllow() async {
         let mockInteraction = MockInteractionClient()
-        // First call (always_allow_high_risk) fails, fallback (allow) succeeds
+        // First call (always_allow) fails, fallback (allow) succeeds
         mockInteraction.results = [.failed, .success]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
@@ -478,14 +478,14 @@ final class ChatViewModelIOSTests: XCTestCase {
             requestId: "req-fail",
             selectedPattern: "rm -rf *",
             selectedScope: "project",
-            decision: "always_allow_high_risk"
+            decision: "always_allow"
         )
 
         await waitForMockCalls(mockInteraction, count: 2)
 
-        // First attempted decision should be always_allow_high_risk (the one that failed)
+        // First attempted decision should be always_allow (the one that failed)
         XCTAssertEqual(mockInteraction.calls.count, 2)
-        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow_high_risk")
+        XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow")
 
         // Fallback should be a one-time "allow"
         XCTAssertEqual(mockInteraction.calls[1].decision, "allow")

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -386,7 +386,6 @@ final class ToolPermissionTesterModel: ObservableObject {
                     pattern: pattern,
                     scope: scope,
                     decision: "allow",
-                    allowHighRisk: isHighRisk ? true : nil,
                     executionTarget: snapshot.snapshotExecutionTarget
                 )
                 // Re-simulate to show the updated outcome with the new rule in effect.

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -295,7 +295,6 @@ private struct TrustRuleFormView: View {
                     pattern: trimmedPattern,
                     scope: resolvedScope,
                     decision: decision,
-                    allowHighRisk: nil,
                     executionTarget: nil
                 )
             }

--- a/clients/macos/vellum-assistantTests/MockTrustRuleClient.swift
+++ b/clients/macos/vellum-assistantTests/MockTrustRuleClient.swift
@@ -6,7 +6,7 @@ import Foundation
 final class MockTrustRuleClient: TrustRuleClientProtocol {
     // MARK: - Spy State
 
-    var addTrustRuleCalls: [(toolName: String, pattern: String, scope: String, decision: String, allowHighRisk: Bool?, executionTarget: String?)] = []
+    var addTrustRuleCalls: [(toolName: String, pattern: String, scope: String, decision: String, executionTarget: String?)] = []
     var removeTrustRuleCalls: [String] = []
     var updateTrustRuleCalls: [(id: String, tool: String?, pattern: String?, scope: String?, decision: String?, priority: Int?)] = []
     var fetchTrustRulesCallCount = 0
@@ -32,10 +32,9 @@ final class MockTrustRuleClient: TrustRuleClientProtocol {
         pattern: String,
         scope: String,
         decision: String,
-        allowHighRisk: Bool?,
         executionTarget: String?
     ) async throws {
-        addTrustRuleCalls.append((toolName, pattern, scope, decision, allowHighRisk, executionTarget))
+        addTrustRuleCalls.append((toolName, pattern, scope, decision, executionTarget))
         if let error = addTrustRuleError { throw error }
     }
 

--- a/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolPermissionTesterModelTests.swift
@@ -294,32 +294,6 @@ final class ToolPermissionTesterModelTests: XCTestCase {
 
         let trustCall = mockTrustRuleClient.addTrustRuleCalls[0]
         XCTAssertEqual(trustCall.decision, "allow")
-        XCTAssertEqual(trustCall.allowHighRisk, true)
-    }
-
-    func testAlwaysAllow_mediumRisk_doesNotSetAllowHighRisk() {
-        mockToolClient.simulateResponse = ToolPermissionSimulateResponseMessage(
-            type: "tool_permission_simulate_response",
-            success: true, decision: "allow", riskLevel: "low", reason: "ok",
-            promptPayload: nil, executionTarget: nil, matchedRuleId: nil, error: nil
-        )
-
-        model.toolName = "host_bash"
-        model.lastResult = SimulationResult(
-            decision: "prompt", riskLevel: "medium", reason: "test",
-            matchedRuleId: nil, promptPayload: nil,
-            snapshotToolName: "", snapshotInputJSON: "{}", snapshotExecutionTarget: nil
-        )
-
-        model.alwaysAllow(pattern: "echo *", scope: "project")
-
-        let predicate = NSPredicate { _, _ in self.mockTrustRuleClient.addTrustRuleCalls.count >= 1 }
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
-        wait(for: [expectation], timeout: 2.0)
-
-        let trustCall = mockTrustRuleClient.addTrustRuleCalls[0]
-        XCTAssertEqual(trustCall.decision, "allow")
-        XCTAssertNil(trustCall.allowHighRisk)
     }
 
     func testAlwaysAllow_emptyMetadata_doesNotPassNilFields() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1959,7 +1959,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     private func markConfirmationInFlight(requestId: String, decision: String) {
         guard let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) else { return }
         let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_conversation"
-            || decision == "always_allow" || decision == "always_allow_high_risk"
+            || decision == "always_allow"
         messages[index].confirmation?.state = isApproval ? .approved : .denied
         if isApproval {
             messages[index].confirmation?.approvedDecision = decision
@@ -2050,7 +2050,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     pattern: pattern,
                     scope: scope,
                     decision: decision,
-                    allowHighRisk: nil,
                     executionTarget: nil
                 )
             } catch {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -55,10 +55,8 @@ public struct ToolConfirmationBubble: View {
     }
 
     /// The decision value to send when "Always Allow" is clicked.
-    /// High-risk prompts use `always_allow_high_risk` so the daemon persists
-    /// a rule with `allowHighRisk: true`.
     private var alwaysAllowDecision: String {
-        confirmation.riskLevel.lowercased() == "high" ? "always_allow_high_risk" : "always_allow"
+        "always_allow"
     }
 
     /// The full input preview for the inline display (all key-value pairs).

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -37,18 +37,15 @@ public struct AddTrustRule: Codable, Sendable {
     public let pattern: String
     public let scope: String
     public let decision: String
-    /// When true, the rule also covers high-risk invocations.
-    public let allowHighRisk: Bool?
     /// Execution target override for this rule.
     public let executionTarget: String?
 
-    public init(type: String, toolName: String, pattern: String, scope: String, decision: String, allowHighRisk: Bool? = nil, executionTarget: String? = nil) {
+    public init(type: String, toolName: String, pattern: String, scope: String, decision: String, executionTarget: String? = nil) {
         self.type = type
         self.toolName = toolName
         self.pattern = pattern
         self.scope = scope
         self.decision = decision
-        self.allowHighRisk = allowHighRisk
         self.executionTarget = executionTarget
     }
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1986,7 +1986,6 @@ extension AddTrustRule {
         pattern: String,
         scope: String,
         decision: String,
-        allowHighRisk: Bool? = nil,
         executionTarget: String? = nil
     ) {
         self.init(
@@ -1995,7 +1994,6 @@ extension AddTrustRule {
             pattern: pattern,
             scope: scope,
             decision: decision,
-            allowHighRisk: allowHighRisk,
             executionTarget: executionTarget
         )
     }

--- a/clients/shared/Network/TrustRuleClient.swift
+++ b/clients/shared/Network/TrustRuleClient.swift
@@ -11,7 +11,6 @@ public protocol TrustRuleClientProtocol {
         pattern: String,
         scope: String,
         decision: String,
-        allowHighRisk: Bool?,
         executionTarget: String?
     ) async throws
     func removeTrustRule(id: String) async throws
@@ -60,7 +59,6 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         pattern: String,
         scope: String,
         decision: String,
-        allowHighRisk: Bool? = nil,
         executionTarget: String? = nil
     ) async throws {
         var body: [String: Any] = [
@@ -69,7 +67,6 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
             "scope": scope,
             "decision": decision,
         ]
-        if let allowHighRisk { body["allowHighRisk"] = allowHighRisk }
         if let executionTarget { body["executionTarget"] = executionTarget }
 
         let response = try await GatewayHTTPClient.post(

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -187,7 +187,7 @@ User approval decisions are persisted as trust rules in `~/.vellum/protected/tru
 
 - **Pattern matching**: Minimatch glob patterns for tool commands and file paths.
 - **Execution target binding**: Rules can be scoped to `sandbox` or `host` execution contexts.
-- **High-risk override**: Rules with `allowHighRisk: true` auto-allow even high-risk tool invocations.
+- **Runtime high-risk auto-allow**: High-risk bash commands in containerized environments are auto-allowed at runtime by `shouldAutoAllowHighRisk()` without requiring persisted state.
 
 #### Shell command allowlist options
 

--- a/gateway/src/__tests__/trust-rules-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-routes.test.ts
@@ -48,7 +48,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("POST /v1/trust-rules — canonicalization", () => {
-  test("strips executionTarget from URL-family tool rules", async () => {
+  test("strips executionTarget and allowHighRisk from URL-family tool rules", async () => {
     const handler = createTrustRulesAddHandler();
     const req = new Request("http://localhost/v1/trust-rules", {
       method: "POST",
@@ -69,12 +69,12 @@ describe("POST /v1/trust-rules — canonicalization", () => {
     const body = (await res.json()) as { rule: Record<string, unknown> };
     expect(body.rule.tool).toBe("web_fetch");
     // URL rules should NOT have executionTarget after canonicalization.
-    // allowHighRisk is preserved for backward compatibility.
+    // allowHighRisk is stripped (replaced by runtime determination).
     expect("executionTarget" in body.rule).toBe(false);
-    expect(body.rule.allowHighRisk).toBe(true);
+    expect("allowHighRisk" in body.rule).toBe(false);
   });
 
-  test("preserves executionTarget and allowHighRisk for scoped tool rules", async () => {
+  test("preserves executionTarget but strips allowHighRisk for scoped tool rules", async () => {
     const handler = createTrustRulesAddHandler();
     const req = new Request("http://localhost/v1/trust-rules", {
       method: "POST",
@@ -95,7 +95,8 @@ describe("POST /v1/trust-rules — canonicalization", () => {
     const body = (await res.json()) as { rule: Record<string, unknown> };
     expect(body.rule.tool).toBe("bash");
     expect(body.rule.executionTarget).toBe("host");
-    expect(body.rule.allowHighRisk).toBe(true);
+    // allowHighRisk is stripped during normalization
+    expect("allowHighRisk" in body.rule).toBe(false);
   });
 
   test("strips executionTarget from managed-skill tool rules", async () => {
@@ -142,7 +143,7 @@ describe("POST /v1/trust-rules — canonicalization", () => {
     expect("executionTarget" in body.rule).toBe(false);
   });
 
-  test("preserves executionTarget and allowHighRisk for generic (unknown) tool rules", async () => {
+  test("preserves executionTarget but strips allowHighRisk for generic (unknown) tool rules", async () => {
     const handler = createTrustRulesAddHandler();
     const req = new Request("http://localhost/v1/trust-rules", {
       method: "POST",
@@ -163,12 +164,13 @@ describe("POST /v1/trust-rules — canonicalization", () => {
     const body = (await res.json()) as { rule: Record<string, unknown> };
     expect(body.rule.tool).toBe("some_future_tool");
     expect(body.rule.executionTarget).toBe("container");
-    expect(body.rule.allowHighRisk).toBe(false);
+    // allowHighRisk is stripped during normalization
+    expect("allowHighRisk" in body.rule).toBe(false);
   });
 
-  test("accepts legacy payloads with invalid-for-family fields without 4xx", async () => {
+  test("accepts legacy payloads with allowHighRisk without 4xx (silently ignored)", async () => {
     const handler = createTrustRulesAddHandler();
-    // Send a legacy payload with executionTarget on a URL tool — should succeed
+    // Send a legacy payload with allowHighRisk — should succeed without error
     const req = new Request("http://localhost/v1/trust-rules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -188,10 +190,10 @@ describe("POST /v1/trust-rules — canonicalization", () => {
     expect(res.status).toBe(201);
 
     const body = (await res.json()) as { rule: Record<string, unknown> };
-    // The persisted rule should strip invalid executionTarget but keep
-    // allowHighRisk for compatibility with existing high-risk trust rules.
+    // The persisted rule should strip both executionTarget (invalid for URL tool)
+    // and allowHighRisk (no longer supported).
     expect("executionTarget" in body.rule).toBe(false);
-    expect(body.rule.allowHighRisk).toBe(true);
+    expect("allowHighRisk" in body.rule).toBe(false);
   });
 });
 
@@ -200,8 +202,8 @@ describe("POST /v1/trust-rules — canonicalization", () => {
 // ---------------------------------------------------------------------------
 
 describe("GET /v1/trust-rules — list", () => {
-  test("returns canonicalized rules", async () => {
-    // Write a rule with fields that should be stripped on load
+  test("returns canonicalized rules (allowHighRisk stripped)", async () => {
+    // Write rules with allowHighRisk fields that should be stripped on load
     writeTrustFile({
       version: 3,
       rules: [
@@ -242,15 +244,15 @@ describe("GET /v1/trust-rules — list", () => {
     };
     expect(body.rules).toHaveLength(2);
 
-    // URL rule should have been normalized: executionTarget stripped.
+    // URL rule should have been normalized: executionTarget and allowHighRisk stripped.
     const urlRule = body.rules.find((r) => r.id === "r-url")!;
     expect("executionTarget" in urlRule).toBe(false);
-    expect(urlRule.allowHighRisk).toBe(true);
+    expect("allowHighRisk" in urlRule).toBe(false);
 
-    // Scoped rule should preserve fields
+    // Scoped rule should preserve executionTarget but strip allowHighRisk
     const bashRule = body.rules.find((r) => r.id === "r-bash")!;
     expect(bashRule.executionTarget).toBe("host");
-    expect(bashRule.allowHighRisk).toBe(true);
+    expect("allowHighRisk" in bashRule).toBe(false);
   });
 });
 

--- a/gateway/src/__tests__/trust-store.test.ts
+++ b/gateway/src/__tests__/trust-store.test.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("normalization on load", () => {
-  test("strips executionTarget but preserves allowHighRisk on URL tool rules", () => {
+  test("strips executionTarget and allowHighRisk on URL tool rules", () => {
     writeTrustFile({
       version: 3,
       rules: [
@@ -82,9 +82,9 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect(rules[0].id).toBe("r1");
-    // URL rules should not have executionTarget.
+    // URL rules should not have executionTarget or allowHighRisk.
     expect("executionTarget" in rules[0]).toBe(false);
-    expect((rules[0] as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rules[0]).toBe(false);
 
     // Verify file was re-saved with normalized rules
     const saved = readTrustFile();
@@ -92,10 +92,10 @@ describe("normalization on load", () => {
     const savedRules = saved.rules as Array<Record<string, unknown>>;
     expect(savedRules).toHaveLength(1);
     expect("executionTarget" in savedRules[0]).toBe(false);
-    expect(savedRules[0].allowHighRisk).toBe(true);
+    expect("allowHighRisk" in savedRules[0]).toBe(false);
   });
 
-  test("strips executionTarget but preserves allowHighRisk on managed skill rules", () => {
+  test("strips executionTarget and allowHighRisk on managed skill rules", () => {
     writeTrustFile({
       version: 3,
       rules: [
@@ -116,10 +116,10 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect("executionTarget" in rules[0]).toBe(false);
-    expect((rules[0] as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rules[0]).toBe(false);
   });
 
-  test("strips executionTarget but preserves allowHighRisk on skill_load rules", () => {
+  test("strips executionTarget and allowHighRisk on skill_load rules", () => {
     writeTrustFile({
       version: 3,
       rules: [
@@ -140,10 +140,10 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect("executionTarget" in rules[0]).toBe(false);
-    expect((rules[0] as { allowHighRisk?: boolean }).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rules[0]).toBe(false);
   });
 
-  test("preserves executionTarget and allowHighRisk on scoped tool rules", () => {
+  test("preserves executionTarget but strips allowHighRisk on scoped tool rules", () => {
     writeTrustFile({
       version: 3,
       rules: [
@@ -164,10 +164,10 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect((rules[0] as any).executionTarget).toBe("host");
-    expect((rules[0] as any).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rules[0]).toBe(false);
   });
 
-  test("preserves executionTarget and allowHighRisk on generic (unknown) tool rules", () => {
+  test("preserves executionTarget but strips allowHighRisk on generic (unknown) tool rules", () => {
     writeTrustFile({
       version: 3,
       rules: [
@@ -188,7 +188,7 @@ describe("normalization on load", () => {
     const rules = loadRules();
     expect(rules).toHaveLength(1);
     expect((rules[0] as any).executionTarget).toBe("container");
-    expect((rules[0] as any).allowHighRisk).toBe(false);
+    expect("allowHighRisk" in rules[0]).toBe(false);
   });
 
   test("strips legacy principal-scoped fields and re-saves", () => {

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -73,15 +73,8 @@ export function createTrustRulesAddHandler() {
       );
     }
 
-    const {
-      tool,
-      pattern,
-      scope,
-      decision,
-      priority,
-      allowHighRisk,
-      executionTarget,
-    } = body as Record<string, unknown>;
+    const { tool, pattern, scope, decision, priority, executionTarget } =
+      body as Record<string, unknown>;
 
     if (typeof tool !== "string" || !tool) {
       return Response.json(
@@ -116,12 +109,6 @@ export function createTrustRulesAddHandler() {
         { status: 400 },
       );
     }
-    if (allowHighRisk !== undefined && typeof allowHighRisk !== "boolean") {
-      return Response.json(
-        { error: '"allowHighRisk" must be a boolean' },
-        { status: 400 },
-      );
-    }
     if (executionTarget !== undefined && typeof executionTarget !== "string") {
       return Response.json(
         { error: '"executionTarget" must be a string' },
@@ -138,7 +125,6 @@ export function createTrustRulesAddHandler() {
         (decision as TrustDecision) ?? "allow",
         (priority as number) ?? 100,
         {
-          ...(allowHighRisk != null ? { allowHighRisk } : {}),
           ...(executionTarget != null ? { executionTarget } : {}),
         },
       );

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -341,7 +341,6 @@ export function addRule(
   decision: TrustDecision = "allow",
   priority: number = 100,
   options?: {
-    allowHighRisk?: boolean;
     executionTarget?: string;
   },
 ): TrustRule {
@@ -362,9 +361,6 @@ export function addRule(
     decision,
     priority,
     createdAt: Date.now(),
-    ...(options?.allowHighRisk != null
-      ? { allowHighRisk: options.allowHighRisk }
-      : {}),
     ...(options?.executionTarget != null
       ? { executionTarget: options.executionTarget }
       : {}),

--- a/packages/ces-contracts/src/__tests__/trust-rules.test.ts
+++ b/packages/ces-contracts/src/__tests__/trust-rules.test.ts
@@ -2,10 +2,9 @@
  * Tests for trust-rule family types and canonical parsing/normalization.
  *
  * Verifies:
- * 1. Scoped-rule parsing preserves executionTarget and allowHighRisk.
- * 2. Non-scoped known-tool rules strip executionTarget but preserve boolean
- *    allowHighRisk for backward compatibility.
- * 3. Unknown-tool rules preserve all fields for forward compatibility.
+ * 1. Scoped-rule parsing preserves executionTarget, strips allowHighRisk.
+ * 2. Non-scoped known-tool rules strip executionTarget and allowHighRisk.
+ * 3. Unknown-tool rules preserve executionTarget, strip allowHighRisk.
  * 4. Normalization flag behavior signals when a re-save is warranted.
  * 5. parseTrustFileData handles full trust file objects.
  */
@@ -54,17 +53,19 @@ function makeRaw(overrides: Record<string, unknown> = {}): Record<string, unknow
 // ---------------------------------------------------------------------------
 
 describe("parseTrustRule — scoped tools", () => {
-  test.each([...SCOPED_TOOLS])("preserves executionTarget and allowHighRisk for %s", (tool) => {
+  test.each([...SCOPED_TOOLS])("preserves executionTarget and strips allowHighRisk for %s", (tool) => {
     const raw = makeRaw({
       tool,
       executionTarget: "container-a",
       allowHighRisk: true,
     });
     const { rule, normalized } = parseTrustRule(raw);
-    expect(normalized).toBe(false);
+    // allowHighRisk triggers normalization
+    expect(normalized).toBe(true);
     expect(rule.tool).toBe(tool);
     expect((rule as ScopedTrustRule).executionTarget).toBe("container-a");
-    expect((rule as ScopedTrustRule).allowHighRisk).toBe(true);
+    // allowHighRisk is stripped
+    expect("allowHighRisk" in rule).toBe(false);
   });
 
   test("scoped rule without optional fields is not normalized", () => {
@@ -91,7 +92,7 @@ describe("parseTrustRule — scoped tools", () => {
 
 describe("parseTrustRule — URL tools strip invalid fields", () => {
   test.each([...URL_TOOLS])(
-    "strips executionTarget but preserves allowHighRisk on %s",
+    "strips executionTarget and allowHighRisk on %s",
     (tool) => {
       const raw = makeRaw({
         tool,
@@ -102,7 +103,7 @@ describe("parseTrustRule — URL tools strip invalid fields", () => {
       expect(normalized).toBe(true);
       expect(rule.tool).toBe(tool);
       expect("executionTarget" in rule).toBe(false);
-      expect((rule as UrlTrustRule).allowHighRisk).toBe(true);
+      expect("allowHighRisk" in rule).toBe(false);
     },
   );
 
@@ -122,7 +123,7 @@ describe("parseTrustRule — URL tools strip invalid fields", () => {
 
 describe("parseTrustRule — managed skill tools strip invalid fields", () => {
   test.each([...MANAGED_SKILL_TOOLS])(
-    "strips executionTarget but preserves allowHighRisk on %s",
+    "strips executionTarget and allowHighRisk on %s",
     (tool) => {
       const raw = makeRaw({
         tool,
@@ -132,7 +133,7 @@ describe("parseTrustRule — managed skill tools strip invalid fields", () => {
       const { rule, normalized } = parseTrustRule(raw);
       expect(normalized).toBe(true);
       expect("executionTarget" in rule).toBe(false);
-      expect((rule as ManagedSkillTrustRule).allowHighRisk).toBe(false);
+      expect("allowHighRisk" in rule).toBe(false);
     },
   );
 
@@ -144,7 +145,7 @@ describe("parseTrustRule — managed skill tools strip invalid fields", () => {
 });
 
 describe("parseTrustRule — skill_load strips invalid fields", () => {
-  test("strips executionTarget but preserves allowHighRisk on skill_load", () => {
+  test("strips executionTarget and allowHighRisk on skill_load", () => {
     const raw = makeRaw({
       tool: SKILL_LOAD_TOOL,
       executionTarget: "container-b",
@@ -154,7 +155,7 @@ describe("parseTrustRule — skill_load strips invalid fields", () => {
     expect(normalized).toBe(true);
     expect(rule.tool).toBe(SKILL_LOAD_TOOL);
     expect("executionTarget" in rule).toBe(false);
-    expect((rule as SkillLoadTrustRule).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rule).toBe(false);
   });
 
   test("skill_load without invalid fields is not normalized", () => {
@@ -176,17 +177,18 @@ describe("parseTrustRule — skill_load strips invalid fields", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseTrustRule — unknown tools", () => {
-  test("preserves executionTarget and allowHighRisk for unknown tools", () => {
+  test("preserves executionTarget but strips allowHighRisk for unknown tools", () => {
     const raw = makeRaw({
       tool: "future_tool_v99",
       executionTarget: "edge-worker",
       allowHighRisk: true,
     });
     const { rule, normalized } = parseTrustRule(raw);
-    expect(normalized).toBe(false);
+    // allowHighRisk triggers normalization
+    expect(normalized).toBe(true);
     expect(rule.tool).toBe("future_tool_v99");
     expect((rule as GenericTrustRule).executionTarget).toBe("edge-worker");
-    expect((rule as GenericTrustRule).allowHighRisk).toBe(true);
+    expect("allowHighRisk" in rule).toBe(false);
   });
 
   test("unknown tool without optional fields is not normalized", () => {
@@ -212,16 +214,22 @@ describe("parseTrustRule — unknown tools", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseTrustRule — normalization flag", () => {
-  test("normalized is false when no changes needed", () => {
-    const raw = makeRaw({ tool: "host_bash", allowHighRisk: true });
+  test("normalized is false when no changes needed (no allowHighRisk)", () => {
+    const raw = makeRaw({ tool: "host_bash" });
     const { normalized } = parseTrustRule(raw);
     expect(normalized).toBe(false);
   });
 
-  test("normalized is false when URL tool has only valid fields (allowHighRisk preserved)", () => {
+  test("normalized is true when allowHighRisk is present (stripped)", () => {
+    const raw = makeRaw({ tool: "host_bash", allowHighRisk: true });
+    const { normalized } = parseTrustRule(raw);
+    expect(normalized).toBe(true);
+  });
+
+  test("normalized is true when URL tool has allowHighRisk (stripped)", () => {
     const raw = makeRaw({ tool: "web_fetch", allowHighRisk: true });
     const { normalized } = parseTrustRule(raw);
-    expect(normalized).toBe(false);
+    expect(normalized).toBe(true);
   });
 
   test("normalized is true when decision is coerced", () => {
@@ -279,6 +287,19 @@ describe("parseTrustFileData", () => {
     expect("executionTarget" in data.rules[1]).toBe(false);
   });
 
+  test("reports normalized when allowHighRisk is present (stripped)", () => {
+    const raw = {
+      version: 3,
+      rules: [
+        makeRaw({ id: "r1", tool: "bash", allowHighRisk: true }),
+      ],
+    };
+    const { data, normalized } = parseTrustFileData(raw);
+    expect(normalized).toBe(true);
+    expect(data.rules).toHaveLength(1);
+    expect("allowHighRisk" in data.rules[0]).toBe(false);
+  });
+
   test("skips null/non-object entries and flags as normalized", () => {
     const raw = {
       version: 3,
@@ -327,7 +348,6 @@ describe("type-level compatibility", () => {
       priority: 50,
       createdAt: 0,
       executionTarget: "host",
-      allowHighRisk: true,
     };
     const url: UrlTrustRule = {
       id: "u1",

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -100,24 +100,20 @@ export interface TrustRuleBase {
  * A trust rule for a scoped tool (filesystem-path-based candidates).
  *
  * Scoped rules may carry `executionTarget` to constrain matching to a
- * specific execution environment and `allowHighRisk` to permit high-risk
- * operations under the rule's allow decision.
+ * specific execution environment.
  */
 export interface ScopedTrustRule extends TrustRuleBase {
   tool: (typeof SCOPED_TOOLS)[number];
   executionTarget?: string;
-  allowHighRisk?: boolean;
 }
 
 /**
  * A trust rule for a URL-based tool.
  *
- * URL rules do not use `executionTarget`, but they may carry `allowHighRisk`
- * for backward compatibility with persistent high-risk allow rules.
+ * URL rules do not use `executionTarget`.
  */
 export interface UrlTrustRule extends TrustRuleBase {
   tool: (typeof URL_TOOLS)[number];
-  allowHighRisk?: boolean;
 }
 
 /**
@@ -125,7 +121,6 @@ export interface UrlTrustRule extends TrustRuleBase {
  */
 export interface ManagedSkillTrustRule extends TrustRuleBase {
   tool: (typeof MANAGED_SKILL_TOOLS)[number];
-  allowHighRisk?: boolean;
 }
 
 /**
@@ -133,19 +128,17 @@ export interface ManagedSkillTrustRule extends TrustRuleBase {
  */
 export interface SkillLoadTrustRule extends TrustRuleBase {
   tool: typeof SKILL_LOAD_TOOL;
-  allowHighRisk?: boolean;
 }
 
 /**
  * A trust rule for any tool that doesn't belong to a known family.
  *
- * Generic rules preserve `executionTarget` and `allowHighRisk` for backward
- * compatibility — existing rules for unknown/new tools may carry these fields.
+ * Generic rules preserve `executionTarget` for backward compatibility —
+ * existing rules for unknown/new tools may carry this field.
  */
 export interface GenericTrustRule extends TrustRuleBase {
   tool: string;
   executionTarget?: string;
-  allowHighRisk?: boolean;
 }
 
 /**
@@ -214,11 +207,12 @@ export interface ParsedTrustRule {
  * - URL rules: `executionTarget` is stripped (URL tools don't support it).
  * - Managed skill rules: `executionTarget` is stripped.
  * - Skill load rules: `executionTarget` is stripped.
- * - Scoped rules, generic rules, and all families with `allowHighRisk`: the
- *   field is preserved when it is a boolean.
+ * - All families: `allowHighRisk` is stripped (replaced by runtime
+ *   determination in checker.ts). Old trust.json files with `allowHighRisk`
+ *   are normalized on load.
  *
- * Unknown tools (generic family) preserve all fields for forward compatibility
- * — we don't know what semantics future tools may require.
+ * Unknown tools (generic family) preserve `executionTarget` for forward
+ * compatibility — we don't know what semantics future tools may require.
  */
 export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   let normalized = false;
@@ -260,55 +254,49 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
 
   // Determine the family and strip invalid fields
   if (URL_TOOLS_SET.has(tool)) {
-    // URL rules must not carry executionTarget, but allowHighRisk is preserved
-    // for backward compatibility with persistent high-risk allow rules.
+    // URL rules must not carry executionTarget.
     if (raw.executionTarget !== undefined) {
       normalized = true;
     }
-    const rule: UrlTrustRule = { ...base, tool: tool as UrlTrustRule["tool"] };
-    if (typeof raw.allowHighRisk === "boolean") {
-      rule.allowHighRisk = raw.allowHighRisk;
-    } else if (raw.allowHighRisk !== undefined) {
+    // allowHighRisk is stripped (replaced by runtime determination).
+    if (raw.allowHighRisk !== undefined) {
       normalized = true;
     }
+    const rule: UrlTrustRule = { ...base, tool: tool as UrlTrustRule["tool"] };
     return { rule, normalized };
   }
 
   if (MANAGED_SKILL_TOOLS_SET.has(tool)) {
-    // Managed skill rules must not carry executionTarget, but allowHighRisk is
-    // preserved for backward compatibility.
+    // Managed skill rules must not carry executionTarget.
     if (raw.executionTarget !== undefined) {
+      normalized = true;
+    }
+    // allowHighRisk is stripped (replaced by runtime determination).
+    if (raw.allowHighRisk !== undefined) {
       normalized = true;
     }
     const rule: ManagedSkillTrustRule = {
       ...base,
       tool: tool as ManagedSkillTrustRule["tool"],
     };
-    if (typeof raw.allowHighRisk === "boolean") {
-      rule.allowHighRisk = raw.allowHighRisk;
-    } else if (raw.allowHighRisk !== undefined) {
-      normalized = true;
-    }
     return { rule, normalized };
   }
 
   if (tool === SKILL_LOAD_TOOL) {
-    // Skill-load rules must not carry executionTarget, but allowHighRisk is
-    // preserved for backward compatibility.
+    // Skill-load rules must not carry executionTarget.
     if (raw.executionTarget !== undefined) {
       normalized = true;
     }
-    const rule: SkillLoadTrustRule = { ...base, tool: SKILL_LOAD_TOOL };
-    if (typeof raw.allowHighRisk === "boolean") {
-      rule.allowHighRisk = raw.allowHighRisk;
-    } else if (raw.allowHighRisk !== undefined) {
+    // allowHighRisk is stripped (replaced by runtime determination).
+    if (raw.allowHighRisk !== undefined) {
       normalized = true;
     }
+    const rule: SkillLoadTrustRule = { ...base, tool: SKILL_LOAD_TOOL };
     return { rule, normalized };
   }
 
   if (SCOPED_TOOLS_SET.has(tool)) {
-    // Scoped rules preserve executionTarget and allowHighRisk
+    // Scoped rules preserve executionTarget.
     const rule: ScopedTrustRule = {
       ...base,
       tool: tool as ScopedTrustRule["tool"],
@@ -321,15 +309,14 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
     } else if (raw.executionTarget !== undefined && raw.executionTarget !== "") {
       normalized = true;
     }
-    if (typeof raw.allowHighRisk === "boolean") {
-      rule.allowHighRisk = raw.allowHighRisk;
-    } else if (raw.allowHighRisk !== undefined) {
+    // allowHighRisk is stripped (replaced by runtime determination).
+    if (raw.allowHighRisk !== undefined) {
       normalized = true;
     }
     return { rule, normalized };
   }
 
-  // Generic (unknown) tool — preserve all optional fields for forward compat
+  // Generic (unknown) tool — preserve executionTarget for forward compat.
   const rule: GenericTrustRule = { ...base };
   if (
     typeof raw.executionTarget === "string" &&
@@ -339,9 +326,8 @@ export function parseTrustRule(raw: Record<string, unknown>): ParsedTrustRule {
   } else if (raw.executionTarget !== undefined && raw.executionTarget !== "") {
     normalized = true;
   }
-  if (typeof raw.allowHighRisk === "boolean") {
-    rule.allowHighRisk = raw.allowHighRisk;
-  } else if (raw.allowHighRisk !== undefined) {
+  // allowHighRisk is stripped (replaced by runtime determination).
+  if (raw.allowHighRisk !== undefined) {
     normalized = true;
   }
   return { rule, normalized };


### PR DESCRIPTION
## Summary
- Remove the persisted `allowHighRisk` field from all trust rule types and the `always_allow_high_risk` user decision
- Replace with a runtime `shouldAutoAllowHighRisk()` function that checks containerized environment context
- Strip `allowHighRisk` from old trust.json files during normalization for backward compatibility

Part of plan: remove-allow-high-risk.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
