### PR TITLE
fix(teleport): bump export/import timeouts to 60 min for large bundles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -862,7 +862,7 @@ extension AssistantBackupsSection {
                 path: "migrations/import",
                 body: fileData,
                 contentType: "application/octet-stream",
-                timeout: 120
+                timeout: 3600
             )
 
             if response.isSuccess {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -543,7 +543,7 @@ struct AssistantBackupsSection: View {
         defer { isExporting = false }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 300)
+            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 3600)
 
             guard response.isSuccess else {
                 errorMessage = "Export failed (HTTP \(response.statusCode))"

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -285,7 +285,7 @@ struct AssistantTransferSection: View {
                     path: "migrations/import",
                     body: bundleData,
                     contentType: "application/octet-stream",
-                    timeout: 120
+                    timeout: 3600
                 )
             }
             guard importResponse.isSuccess else {
@@ -401,7 +401,7 @@ struct AssistantTransferSection: View {
             }
 
             let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
-            let timeout: TimeInterval = 600 // 10 minutes
+            let timeout: TimeInterval = 3600 // 60 minutes
             let start = Date()
 
             while Date().timeIntervalSince(start) < timeout {
@@ -432,7 +432,7 @@ struct AssistantTransferSection: View {
                     throw TransferError.importFailed(message: status.error ?? "Import job failed")
                 }
             }
-            throw TransferError.importFailed(message: "Import timed out after 10 minutes")
+            throw TransferError.importFailed(message: "Import timed out after 60 minutes")
         }
 
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -469,7 +469,7 @@ private enum TransferError: LocalizedError {
         case .exportFailed(let statusCode):
             return "Export failed (HTTP \(statusCode))"
         case .exportTimedOut:
-            return "Export timed out after 5 minutes"
+            return "Export timed out after 60 minutes"
         case .importFailed(let message):
             return "Import failed: \(message)"
         case .managedEntryNotFound:

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -330,7 +330,7 @@ struct AssistantTransferSection: View {
     private func exportAssistantBundle() async throws -> Data {
         let response = try await GatewayHTTPClient.post(
             path: "migrations/export",
-            timeout: 300
+            timeout: 3600
         )
         guard response.isSuccess else {
             throw TransferError.exportFailed(statusCode: response.statusCode)

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -205,10 +205,13 @@ struct AssistantTransferSection: View {
                 throw TransferError.exportFailed(statusCode: 0)
             }
 
-            // Step 2 — Poll for completion (up to 5 minutes)
+            // Step 2 — Poll for completion (up to 60 minutes, to match large-bundle timeout budget)
             currentStep = "Waiting for export..."
             var downloadUrl: String?
-            for _ in 0..<100 {
+            let pollInterval: UInt64 = 3_000_000_000 // 3 seconds
+            let exportPollTimeout: TimeInterval = 3600 // 60 minutes
+            let exportPollStart = Date()
+            while Date().timeIntervalSince(exportPollStart) < exportPollTimeout {
                 try Task.checkCancellation()
                 let (statusResult, statusResponse): (ExportStatusResponse?, _) = try await GatewayHTTPClient.get(
                     path: "migrations/export/\(jobId)/status"
@@ -226,7 +229,7 @@ struct AssistantTransferSection: View {
                 } else if statusResult.status == "failed" {
                     throw TransferError.importFailed(message: statusResult.error ?? "Export job failed")
                 } else if statusResult.status == "pending" || statusResult.status == "processing" {
-                    try await Task.sleep(nanoseconds: 3_000_000_000)
+                    try await Task.sleep(nanoseconds: pollInterval)
                 } else {
                     throw TransferError.exportFailed(statusCode: 0)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -482,7 +482,7 @@ struct TeleportSection: View {
                 path: "migrations/import",
                 body: bundleData,
                 contentType: "application/octet-stream",
-                timeout: 120
+                timeout: 3600
             )
         }
         guard importResponse.isSuccess else {
@@ -626,13 +626,13 @@ struct TeleportSection: View {
         if let onProgress {
             response = try await GatewayHTTPClient.post(
                 path: "migrations/export",
-                timeout: 300,
+                timeout: 3600,
                 onProgress: onProgress
             )
         } else {
             response = try await GatewayHTTPClient.post(
                 path: "migrations/export",
-                timeout: 300
+                timeout: 3600
             )
         }
         guard response.isSuccess else {
@@ -674,7 +674,7 @@ struct TeleportSection: View {
             }
 
             let pollInterval: UInt64 = 5_000_000_000 // 5 seconds
-            let timeout: TimeInterval = 600 // 10 minutes
+            let timeout: TimeInterval = 3600 // 60 minutes
             let start = Date()
 
             while Date().timeIntervalSince(start) < timeout {
@@ -705,7 +705,7 @@ struct TeleportSection: View {
                     throw TeleportError.importFailed(message: status.error ?? "Import job failed")
                 }
             }
-            throw TeleportError.importFailed(message: "Import timed out after 10 minutes")
+            throw TeleportError.importFailed(message: "Import timed out after 60 minutes")
         }
 
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -114,7 +114,7 @@ public enum PlatformMigrationClient {
         request.httpMethod = "PUT"
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         request.httpBody = bundleData
-        request.timeoutInterval = 600
+        request.timeoutInterval = 3600
 
         let (_, statusCode) = try await executeWithRetry(request: request, label: "signed-url-upload")
 
@@ -143,7 +143,7 @@ public enum PlatformMigrationClient {
         var request = URLRequest(url: uploadURL)
         request.httpMethod = "PUT"
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 600
+        request.timeoutInterval = 3600
 
         let delegate = UploadProgressDelegate(onProgress: onProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
@@ -194,7 +194,7 @@ public enum PlatformMigrationClient {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = 120
+        request.timeoutInterval = 3600
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(token, forHTTPHeaderField: "X-Session-Token")
         if let orgId {
@@ -266,7 +266,7 @@ public enum PlatformMigrationClient {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = 120
+        request.timeoutInterval = 3600
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         request.setValue(token, forHTTPHeaderField: "X-Session-Token")
         if let orgId {

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -14,8 +14,8 @@ import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("migration-proxy");
 
-/** Timeout for migration requests (5 minutes) — exports/imports can be large. */
-const MIGRATION_TIMEOUT_MS = 300_000;
+/** Timeout for migration requests (60 minutes) — exports/imports can be large (up to 8 GB bundles). */
+const MIGRATION_TIMEOUT_MS = 3_600_000;
 
 export function createMigrationExportProxyHandler(config: GatewayConfig) {
   return async function handleMigrationExport(req: Request): Promise<Response> {


### PR DESCRIPTION
## Summary

- Our bundle size limit is 8 GB. At typical home-fiber uplinks (10–25 Mbps), an 8 GB GCS upload alone can take 45 min to 1 h 45 m — the current 10 min upload cap means teleport fails for most users with large workspaces well before the actual upload completes. Similarly, the gateway migration proxy (5 min), docker import (2 min), and platform import triggers (2 min) all clip well below the realistic end-to-end duration of a large export/import.
- Bump every client-side and gateway-side timeout along the teleport export/import critical path to 60 min (3600 s / 3_600_000 ms): gateway migration proxy, macOS export (teleport/transfer/local-backup call sites), macOS docker import, GCS signed-URL upload (both variants), platform `importFromGcs` / `importInline` triggers, and the import-job poll ceiling (plus its user-facing "timed out after 10 minutes" message → "60 minutes").
- Scoped strictly to the teleport/migration path: no changes to `GatewayHTTPClient` defaults, URLSession config, daemon route handlers, or any unrelated HTTP client. Per-request timeouts that are not flow ceilings (retirement DELETE 30 s, guardian-init 15 s per attempt, import-status per-poll GET 30 s) are intentionally left alone. This is a stopgap — the real fix is resumable GCS uploads or idle-based timeouts, so large transfers are not gated on a single wall-clock number.

## Original prompt

bump all of these that will handle the export/import to 60 minutes for now. I want to make sure this is isolated to this flow however
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
