### PR TITLE
fix(tts-xai): add xai to Swift fallbackRegistry to match bundled catalog

### DIFF
--- a/clients/shared/Utilities/TTSProviderRegistry.swift
+++ b/clients/shared/Utilities/TTSProviderRegistry.swift
@@ -203,6 +203,22 @@ private let fallbackRegistry = TTSProviderRegistry(
                 linkLabel: "Open Deepgram Console"
             )
         ),
+        TTSProviderCatalogEntry(
+            id: "xai",
+            displayName: "xAI",
+            subtitle: "Text-to-speech from xAI with expressive voices (eve, ara, rex, sal, leo). Requires an xAI API key.",
+            setupMode: .cli,
+            setupHint: "Run the setup commands in your terminal to configure xAI credentials.",
+            credentialMode: .credential,
+            credentialNamespace: "xai",
+            apiKeyProviderName: nil,
+            supportsVoiceSelection: true,
+            credentialsGuide: TTSCredentialsGuide(
+                description: "Sign in to the xAI console, navigate to API Keys, and create a new key.",
+                url: "https://console.x.ai/",
+                linkLabel: "Open xAI Console"
+            )
+        ),
     ]
 )
 


### PR DESCRIPTION
## Summary
Post-merge review found that `clients/shared/Utilities/TTSProviderRegistry.swift` has a hardcoded `fallbackRegistry` used when the bundled `tts-provider-catalog.json` is missing or corrupt. That fallback still listed only the pre-xai providers, so a corrupt bundle would silently drop xAI from the macOS/iOS settings UI.

This fix mirrors the bundled JSON's xai entry into the fallback. In practice the fallback path is unreachable under normal builds (the JSON is baked in), but keeping the fallback in sync prevents silent drift.

Follow-up to plan: xai-tts-provider.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
