### PR TITLE
fix(stt-xai): update stale provider enumerations outside the catalog

### DIFF
--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -12,6 +12,7 @@ import { extname, join } from "node:path";
 
 import type { Command } from "commander";
 
+import { listProviderIds } from "../../providers/speech-to-text/provider-catalog.js";
 import { resolveBatchTranscriber } from "../../providers/speech-to-text/resolve.js";
 import type { BatchTranscriber } from "../../stt/types.js";
 import {
@@ -183,6 +184,8 @@ export function registerSttCommand(program: Command): void {
     .command("stt")
     .description("Speech-to-text operations");
 
+  const supportedProviders = listProviderIds().join(", ");
+
   sttCmd.addHelpText(
     "after",
     `
@@ -191,7 +194,7 @@ audio and video files. The provider is set via:
 
   $ assistant config set services.stt.provider <provider>
 
-Supported providers include openai-whisper, deepgram, and google-gemini.
+Supported providers: ${supportedProviders}.
 
 Examples:
   $ assistant stt transcribe --file /path/to/meeting.wav

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -30,6 +30,10 @@
  *   configurable window.
  */
 
+import {
+  listProviderIds,
+  supportsBoundary,
+} from "../providers/speech-to-text/provider-catalog.js";
 import { getLogger } from "../util/logger.js";
 import type { StreamingTranscriber, SttStreamServerEvent } from "./types.js";
 
@@ -172,10 +176,13 @@ export class SttStreamSession {
           { provider: this.provider },
           "Streaming transcriber unavailable for provider",
         );
+        const streamingProviders = listProviderIds()
+          .filter((id) => supportsBoundary(id, "daemon-streaming"))
+          .join(", ");
         this.sendEvent({
           type: "error",
           category: "provider-error",
-          message: `Streaming transcription is not supported for provider "${this.provider}". Supported providers: deepgram, google-gemini, openai-whisper.`,
+          message: `Streaming transcription is not supported for provider "${this.provider}". Supported providers: ${streamingProviders}.`,
         });
         this.sendEvent({ type: "closed" });
         this.state = "closed";

--- a/skills/meet-join/daemon/audio-ingest.ts
+++ b/skills/meet-join/daemon/audio-ingest.ts
@@ -576,7 +576,7 @@ async function defaultCreateTranscriber(): Promise<StreamingTranscriber> {
   if (!transcriber) {
     throw new MeetAudioIngestError(
       "The configured STT provider is unusable for Meet transcription. " +
-        "Set services.stt.provider to deepgram, google-gemini, or openai-whisper " +
+        "Set services.stt.provider to deepgram, google-gemini, openai-whisper, or xai " +
         "and ensure credentials are present.",
     );
   }


### PR DESCRIPTION
## Summary
Three user-facing strings that enumerate STT providers still listed only deepgram / google-gemini / openai-whisper, omitting xAI:
- Meet-join audio-ingest error when streaming is unsupported
- STT stream-session error sent to WebSocket clients for unsupported providers
- `assistant stt --help` description text

Update each to include xai, preferring catalog-derived dynamic enumeration where straightforward.

Part of plan: xai-stt-provider.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
