### PR TITLE
fix(stt-xai): clean up xai-realtime lifecycle edge cases

### DIFF
--- a/assistant/src/providers/speech-to-text/xai-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/xai-realtime.test.ts
@@ -390,4 +390,126 @@ describe("XAIRealtimeTranscriber", () => {
     expect(transcriber.providerId).toBe("xai");
     expect(transcriber.boundaryId).toBe("daemon-streaming");
   });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Lifecycle: stop() cancels inactivity timer so the CLOSE_GRACE
+  // window can't emit a spurious timeout error.
+  // ─────────────────────────────────────────────────────────────────
+
+  test("stop() cancels inactivity timer so the close-grace window can't emit a timeout error", async () => {
+    const { transcriber, events } = await startSession({
+      // Short inactivity timeout — would fire within the CLOSE_GRACE
+      // window if stop() failed to cancel it.
+      inactivityTimeoutMs: 30,
+    });
+
+    transcriber.stop();
+
+    // Wait longer than the inactivity window but less than CLOSE_GRACE
+    // (5s) to confirm the timer doesn't fire during the grace period.
+    await new Promise((r) => setTimeout(r, 80));
+
+    // No timeout-category error must have been emitted — stop() is
+    // an intentional teardown.
+    const timeoutErrors = events.filter(
+      (e) => e.type === "error" && e.category === "timeout",
+    );
+    expect(timeoutErrors).toHaveLength(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Lifecycle: connect-phase listeners are removed after the Promise
+  // settles — they must not fire alongside session-lifetime handlers.
+  // ─────────────────────────────────────────────────────────────────
+
+  test("connect-phase listeners are detached after start() resolves", async () => {
+    const { events } = await startSession();
+
+    // After the connect Promise resolves, only the session handlers
+    // (attachSessionHandlers) should be attached. A stray connect-phase
+    // `onClose` listener would also fire on simulateClose and could
+    // reject a (dead) Promise or run stale cleanup code.
+    //
+    // We can't introspect the mock's listener map via the public API,
+    // but we can verify the session-level handler is the only one that
+    // reacts: simulating close under `stopping=true` and code=1000 must
+    // produce exactly one closed event, and simulating a transcript
+    // frame before that must behave normally.
+    mockWs.simulateMessage(partialFrame("ok", { is_final: true }));
+    expect(events.filter((e) => e.type === "final")).toHaveLength(1);
+
+    // Drive a direct inspection: the MockWebSocket exposes a private
+    // listeners map; asserting size === 1 for each type after start()
+    // confirms connect-phase listeners were removed.
+    const listenersByType = (
+      mockWs as unknown as { listeners: Map<string, unknown[]> }
+    ).listeners;
+    expect(listenersByType.get("open")?.length ?? 0).toBe(0);
+    expect(listenersByType.get("error")?.length ?? 0).toBe(1);
+    expect(listenersByType.get("close")?.length ?? 0).toBe(1);
+    expect(listenersByType.get("message")?.length ?? 0).toBe(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Lifecycle: connect-phase error/close paths null out this.ws so
+  // a retry can reuse the same transcriber instance.
+  // ─────────────────────────────────────────────────────────────────
+
+  test("start() allows retry after connect-phase close rejects", async () => {
+    const transcriber = new XAIRealtimeTranscriber(TEST_API_KEY, {
+      connectTimeoutMs: 1_000,
+    });
+    const { onEvent } = createEventCollector();
+
+    // First attempt: socket closes before opening.
+    const firstAttempt = transcriber.start(onEvent);
+    mockWs.simulateClose(4001, "unauthorized");
+    await expect(firstAttempt).rejects.toThrow(
+      /xAI WebSocket closed before open/,
+    );
+
+    // Second attempt with a fresh mock — must not throw
+    // "start() called twice" because the first attempt null'd out
+    // this.ws.
+    mockWs = new MockWebSocket();
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(
+        _url: string,
+        _options?: { headers?: Record<string, string> },
+      ) {
+        return mockWs;
+      }
+    };
+
+    const secondAttempt = transcriber.start(onEvent);
+    mockWs.simulateOpen();
+    await expect(secondAttempt).resolves.toBeUndefined();
+  });
+
+  test("start() allows retry after connect-phase error rejects", async () => {
+    const transcriber = new XAIRealtimeTranscriber(TEST_API_KEY, {
+      connectTimeoutMs: 1_000,
+    });
+    const { onEvent } = createEventCollector();
+
+    // First attempt: transport-level error before open.
+    const firstAttempt = transcriber.start(onEvent);
+    mockWs.simulateError(new Error("ECONNREFUSED"));
+    await expect(firstAttempt).rejects.toThrow(/xAI realtime connect error/);
+
+    // Second attempt — instance must be reusable.
+    mockWs = new MockWebSocket();
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(
+        _url: string,
+        _options?: { headers?: Record<string, string> },
+      ) {
+        return mockWs;
+      }
+    };
+
+    const secondAttempt = transcriber.start(onEvent);
+    mockWs.simulateOpen();
+    await expect(secondAttempt).resolves.toBeUndefined();
+  });
 });

--- a/assistant/src/providers/speech-to-text/xai-realtime.ts
+++ b/assistant/src/providers/speech-to-text/xai-realtime.ts
@@ -237,12 +237,26 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
     this.ws = ws;
 
     // Wait for the WebSocket to open or fail.
+    //
+    // The connect-phase listeners below are removed in every settle path
+    // (resolve, reject, timeout) so they can't fire alongside the
+    // session-lifetime handlers attached after this Promise resolves.
+    // Leaving them attached would leak stale closures for the life of
+    // the session — they'd be no-ops (short-circuited by `settled`),
+    // but would still run on every message/error/close dispatch.
     await new Promise<void>((resolve, reject) => {
       let settled = false;
+
+      const cleanup = () => {
+        ws.removeEventListener("open", onOpen);
+        ws.removeEventListener("error", onError);
+        ws.removeEventListener("close", onClose);
+      };
 
       const connectTimer = setTimeout(() => {
         if (settled) return;
         settled = true;
+        cleanup();
         this.forceClose();
         reject(new Error("xAI realtime connect timeout"));
       }, this.connectTimeoutMs);
@@ -251,6 +265,7 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
         if (settled) return;
         settled = true;
         clearTimeout(connectTimer);
+        cleanup();
         resolve();
       };
 
@@ -258,12 +273,19 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
         if (settled) return;
         settled = true;
         clearTimeout(connectTimer);
+        cleanup();
         const msg =
           ev instanceof Error
             ? ev.message
             : typeof ev === "object" && ev !== null && "message" in ev
               ? String((ev as { message: unknown }).message)
               : "WebSocket error during connect";
+        // Match the connect-timeout path — null out this.ws (via
+        // forceClose) so the instance can be reused for a retry.
+        // Without this, a subsequent start() call would throw
+        // "start() called twice" even though no session was ever
+        // established.
+        this.forceClose();
         reject(new Error(`xAI realtime connect error: ${msg}`));
       };
 
@@ -271,10 +293,15 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
         if (settled) return;
         settled = true;
         clearTimeout(connectTimer);
+        cleanup();
         // 401 / 403 on connect arrive as WebSocket close codes 4001 /
         // 4003 in most runtimes (or 1008 policy-violation in others).
         // We surface the underlying code in the message — callers that
         // need granular auth handling can branch on the rejection text.
+        //
+        // Null out this.ws so the instance can be reused for a retry
+        // (see onError above for the same rationale).
+        this.forceClose();
         reject(
           new Error(
             `xAI WebSocket closed before open (code=${ev.code}, reason=${ev.reason})`,
@@ -319,6 +346,18 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
   stop(): void {
     if (this.closed || this.stopping) return;
     this.stopping = true;
+
+    // Cancel the inactivity timer immediately. If it were left running,
+    // it could fire inside the CLOSE_GRACE window (waiting on xAI to
+    // flush finals after `audio.done`) and spuriously emit a
+    // `{type:"error", category:"timeout"}` event on an intentional stop.
+    // The inactivity callback also double-checks `this.stopping` as a
+    // safety net against any future code path that re-arms the timer
+    // after stop() runs.
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
 
     log.info("Stopping xAI realtime session");
 
@@ -643,7 +682,11 @@ export class XAIRealtimeTranscriber implements StreamingTranscriber {
     }
 
     this.inactivityTimer = setTimeout(() => {
-      if (this.closed) return;
+      // Belt-and-suspenders guard. stop() clears this timer before the
+      // CLOSE_GRACE window starts, but a future refactor that re-arms
+      // or forgets to clear it must not resurrect the spurious-timeout
+      // bug where an intentional stop emits a timeout error event.
+      if (this.closed || this.stopping) return;
 
       log.warn("xAI realtime inactivity timeout");
       this.emitEvent({


### PR DESCRIPTION
## Summary
Fixes three lifecycle issues in `XAIRealtimeTranscriber` surfaced during self-review of the xai-stt-provider plan:
- Clear the inactivity timer on `stop()` so the close-grace window cannot emit a bogus timeout error.
- Remove connect-phase `open`/`error`/`close` listeners once the Promise settles so session handlers don't run alongside stale closures.
- Call `forceClose()` on connect-phase `error`/`close` rejection so `this.ws` isn't left dangling and the instance remains reusable.

Part of plan: xai-stt-provider.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
