### PR TITLE
fix(meet-join): align audio-ingest test with xai-inclusive error message

### DIFF
--- a/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
+++ b/skills/meet-join/daemon/__tests__/audio-ingest.test.ts
@@ -329,7 +329,7 @@ describe("MeetAudioIngest.start", () => {
       createTranscriber: async () => {
         throw new MeetAudioIngestError(
           "No streaming-capable STT provider is configured. " +
-            "Set services.stt.provider to deepgram, google-gemini, or openai-whisper " +
+            "Set services.stt.provider to deepgram, google-gemini, openai-whisper, or xai " +
             "and ensure credentials are present.",
         );
       },


### PR DESCRIPTION
## Summary
PR #26899 updated `audio-ingest.ts` to include xai in the unsupported-streaming-provider error message but the matching test assertion was missed. Update the assertion so the test passes.

Part of plan: xai-stt-provider.md (self-review fix, round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
