### PR TITLE
test(stt-xai): add xai to iOS expected credential mapping

### DIFF
--- a/clients/ios/Tests/STTProviderRegistryIOSTests.swift
+++ b/clients/ios/Tests/STTProviderRegistryIOSTests.swift
@@ -96,6 +96,7 @@ final class STTProviderRegistryIOSTests: XCTestCase {
             "openai-whisper": "openai",
             "deepgram": "deepgram",
             "google-gemini": "gemini",
+            "xai": "xai",
         ]
         for provider in registry.providers {
             guard let expected = expectedMappings[provider.id] else {


### PR DESCRIPTION
## Summary
- Adds `xai` → `xai` to the `expectedMappings` dictionary in `STTProviderRegistryIOSTests.testAllProvidersHaveExpectedCredentialMapping` so the iOS test suite passes now that xAI is registered in the STT provider catalog.
- Fixes the iOS Build & test failure from run [24683976593](https://github.com/vellum-ai/vellum-assistant/actions/runs/24683976593/job/72188347593): `Provider 'xai' has no expected mapping — add it to expectedMappings`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24683976593/job/72188347593
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
