### PR TITLE
fix: address self-review gaps from allowHighRisk removal

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2646,6 +2646,25 @@ describe("Permission Checker", () => {
       expect(result.reason).toContain("High risk");
     });
 
+    test("high-risk bash with allow rule in containerized environment auto-allows", async () => {
+      const orig = process.env.IS_CONTAINERIZED;
+      process.env.IS_CONTAINERIZED = "true";
+      try {
+        // Re-seed trust store so the containerized default bash allow rule is present.
+        clearCache();
+        addRule("bash", "**", "everywhere", "allow", 2000);
+        const result = await check("bash", { command: "kill -9 1234" }, "/tmp");
+        expect(result.decision).toBe("allow");
+        expect(result.reason).toContain("auto-allow-high-risk context");
+      } finally {
+        if (orig === undefined) {
+          delete process.env.IS_CONTAINERIZED;
+        } else {
+          process.env.IS_CONTAINERIZED = orig;
+        }
+      }
+    });
+
     test("high-risk host_bash with no matching user rule returns prompt", async () => {
       const result = await check(
         "host_bash",

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -926,7 +926,6 @@ describe("Trust Store", () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:allow-bash-rm-bootstrap");
       expect(match!.decision).toBe("allow");
-      expect(match!.decision).toBe("allow");
       // Outside workspace, the bootstrap rule doesn't match — without
       // IS_CONTAINERIZED there is no catch-all bash allow rule either.
       const other = findHighestPriorityRule(
@@ -946,7 +945,6 @@ describe("Trust Store", () => {
       );
       expect(match).not.toBeNull();
       expect(match!.id).toBe("default:allow-bash-rm-updates");
-      expect(match!.decision).toBe("allow");
       expect(match!.decision).toBe("allow");
       // Outside workspace, should NOT match the updates rule — without
       // IS_CONTAINERIZED there is no catch-all bash allow rule either.

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -377,8 +377,6 @@ final class ToolPermissionTesterModel: ObservableObject {
             return
         }
 
-        let isHighRisk = snapshot.riskLevel.lowercased() == "high"
-
         Task {
             do {
                 try await trustRuleClient.addTrustRule(


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during self-review of the allowHighRisk removal plan:
- Remove dead `isHighRisk` variable in ToolPermissionTesterModel.swift
- Remove duplicate assertions in trust-store.test.ts
- Add positive integration test for containerized bash auto-allow path

Part of plan: remove-allow-high-risk.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
