### PR TITLE
feat(home): add dismissed status to FeedItemStatus

### DIFF
--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -25,7 +25,7 @@ import { z } from "zod";
 export type FeedItemType = "nudge" | "digest" | "action" | "thread";
 
 /** User-facing lifecycle of a feed item. */
-export type FeedItemStatus = "new" | "seen" | "acted_on";
+export type FeedItemStatus = "new" | "seen" | "acted_on" | "dismissed";
 
 /**
  * Origin of the underlying event.
@@ -114,7 +114,7 @@ export interface HomeFeedFile {
 
 const feedItemTypeSchema = z.enum(["nudge", "digest", "action", "thread"]);
 
-const feedItemStatusSchema = z.enum(["new", "seen", "acted_on"]);
+const feedItemStatusSchema = z.enum(["new", "seen", "acted_on", "dismissed"]);
 
 const feedItemSourceSchema = z.enum([
   "gmail",

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -76,7 +76,7 @@ const getHomeFeedResponseSchema = z.object({
 });
 
 const patchFeedItemRequestSchema = z.object({
-  status: z.enum(["new", "seen", "acted_on"]),
+  status: z.enum(["new", "seen", "acted_on", "dismissed"]),
 });
 
 // ---------------------------------------------------------------------------
@@ -269,7 +269,7 @@ function maybeTriggerOnVisitRollupRefresh(now: Date): void {
 /**
  * `PATCH /v1/home/feed/:id`.
  *
- * Body: `{ status: "new" | "seen" | "acted_on" }`. Returns the updated
+ * Body: `{ status: "new" | "seen" | "acted_on" | "dismissed" }`. Returns the updated
  * `FeedItem` on success.
  *
  * Disambiguates the writer's `null` return by looking up the item via

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -30,6 +30,7 @@ public enum FeedItemStatus: String, Codable, Sendable, Hashable {
     case new
     case seen
     case actedOn = "acted_on"
+    case dismissed
 }
 
 /// Origin of the underlying event.


### PR DESCRIPTION
## Summary
- Add `"dismissed"` to `FeedItemStatus` TypeScript type and Zod schema in `feed-types.ts`
- Add `"dismissed"` to the PATCH request schema in `home-feed-routes.ts`
- Add `case dismissed` to the Swift `FeedItemStatus` enum in `FeedItem.swift`

Closes JARVIS-564

## Test plan
- [ ] Verify the daemon accepts `PATCH /v1/home/feed/:id` with `{ "status": "dismissed" }` and persists it
- [ ] Verify the Swift client decodes `"dismissed"` status from the feed response without error
- [ ] Verify existing statuses (`new`, `seen`, `acted_on`) continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
