### PR TITLE
feat(home): add optional urgency field to FeedItem (JARVIS-565)

### DIFF
--- a/assistant/src/home/assistant-feed-authoring.ts
+++ b/assistant/src/home/assistant-feed-authoring.ts
@@ -41,6 +41,7 @@ import {
   feedItemSchema,
   type FeedItemSource,
   type FeedItemType,
+  type FeedItemUrgency,
 } from "./feed-types.js";
 import { appendFeedItem } from "./feed-writer.js";
 
@@ -80,6 +81,8 @@ export interface WriteAssistantFeedItemParams {
   minTimeAway?: number;
   /** Absolute ISO-8601 expiry timestamp. */
   expiresAt?: string;
+  /** Visual urgency treatment — controls badge color independently of sort priority. */
+  urgency?: FeedItemUrgency;
 }
 
 /**
@@ -110,6 +113,7 @@ export async function writeAssistantFeedItem(
     timestamp: now,
     createdAt: now,
     actions: params.actions,
+    urgency: params.urgency,
     minTimeAway: params.minTimeAway,
     expiresAt: params.expiresAt,
   };

--- a/assistant/src/home/emit-feed-event.ts
+++ b/assistant/src/home/emit-feed-event.ts
@@ -43,6 +43,7 @@ import {
   type FeedItem,
   feedItemSchema,
   type FeedItemSource,
+  type FeedItemUrgency,
 } from "./feed-types.js";
 import { appendFeedItem } from "./feed-writer.js";
 
@@ -93,6 +94,8 @@ export interface EmitFeedEventParams {
    * until the user dismisses it (default for activity-log actions).
    */
   expiresAt?: string;
+  /** Visual urgency treatment — controls badge color independently of sort priority. */
+  urgency?: FeedItemUrgency;
 }
 
 /**
@@ -144,6 +147,7 @@ export async function emitFeedEvent(
     timestamp: now,
     createdAt: now,
     actions: params.actions,
+    urgency: params.urgency,
     minTimeAway: params.minTimeAway,
     expiresAt: params.expiresAt,
   };

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -46,6 +46,9 @@ export type FeedItemSource = "gmail" | "slack" | "calendar" | "assistant";
  */
 export type FeedItemAuthor = "assistant" | "platform";
 
+/** Visual urgency treatment — controls badge color independently of sort priority. */
+export type FeedItemUrgency = "low" | "medium" | "high" | "critical";
+
 /**
  * A single action button attached to a feed item.
  *
@@ -89,6 +92,8 @@ export interface FeedItem {
   /** Minimum seconds the user must be away before the item is shown. */
   minTimeAway?: number;
   actions?: FeedAction[];
+  /** Visual urgency treatment — controls badge color independently of sort priority. */
+  urgency?: FeedItemUrgency;
   /** Internal: who authored this item. */
   author: FeedItemAuthor;
   /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
@@ -125,6 +130,8 @@ const feedItemSourceSchema = z.enum([
 
 const feedItemAuthorSchema = z.enum(["assistant", "platform"]);
 
+const feedItemUrgencySchema = z.enum(["low", "medium", "high", "critical"]);
+
 const feedActionSchema = z.object({
   id: z.string(),
   label: z.string(),
@@ -157,6 +164,7 @@ export const feedItemSchema = z.object({
   expiresAt: z.string().optional(),
   minTimeAway: z.number().int().min(0).optional(),
   actions: z.array(feedActionSchema).optional(),
+  urgency: feedItemUrgencySchema.optional(),
   author: feedItemAuthorSchema,
   createdAt: z.string(),
 });

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -44,6 +44,14 @@ public enum FeedItemSource: String, Codable, Sendable, Hashable {
     case assistant
 }
 
+/// Visual urgency treatment — controls badge color independently of sort priority.
+public enum FeedItemUrgency: String, Codable, Sendable, Hashable {
+    case low
+    case medium
+    case high
+    case critical
+}
+
 /// Internal field used by the hybrid authoring resolver.
 ///
 /// Distinguishes items the assistant produced on its own from items
@@ -99,6 +107,8 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
     /// Minimum seconds the user must be away before the item is shown.
     public let minTimeAway: TimeInterval?
     public let actions: [FeedAction]?
+    /// Visual urgency treatment — controls badge color independently of sort priority.
+    public let urgency: FeedItemUrgency?
     /// Internal: who authored this item.
     public let author: FeedItemAuthor
     /// Internal: writer-record time, used for ordering + TTL.
@@ -116,6 +126,7 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
         expiresAt: Date? = nil,
         minTimeAway: TimeInterval? = nil,
         actions: [FeedAction]? = nil,
+        urgency: FeedItemUrgency? = nil,
         author: FeedItemAuthor,
         createdAt: Date
     ) {
@@ -130,6 +141,7 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
         self.expiresAt = expiresAt
         self.minTimeAway = minTimeAway
         self.actions = actions
+        self.urgency = urgency
         self.author = author
         self.createdAt = createdAt
     }


### PR DESCRIPTION
## Summary
- Add `FeedItemUrgency` type (`low | medium | high | critical`) to control visual badge color independently of the sort-order `priority` field
- Thread the optional `urgency` field through `FeedItem` interface, zod schema, `emitFeedEvent`, `writeAssistantFeedItem`, and the Swift mirror
- No changes needed in `feed-writer.ts` since it operates on `FeedItem` generically

## Test plan
- [ ] Existing feed-writer, feed-types, assistant-feed-authoring, and emit-feed-event tests continue to pass (field is optional)
- [ ] Swift builds successfully with the new `FeedItemUrgency` enum and optional field on `FeedItem`
- [ ] Verify a feed item with `urgency: "critical"` round-trips through write/read/decode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
