### PR TITLE
fix(home): use .dismissed status in HomeFeedStore.dismiss()

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -151,10 +151,10 @@ public final class HomeFeedStore {
         }
     }
 
-    /// Wrapper around `updateStatus(..., .actedOn)`. Used by the feed
+    /// Wrapper around `updateStatus(..., .dismissed)`. Used by the feed
     /// card's explicit dismiss affordance.
     public func dismiss(itemId: String) async {
-        await updateStatus(itemId: itemId, status: .actedOn)
+        await updateStatus(itemId: itemId, status: .dismissed)
     }
 
     /// Batches status updates to `.seen` for every item still in the


### PR DESCRIPTION
## Summary
- HomeFeedStore.dismiss() was still sending `.actedOn` instead of the newly added `.dismissed` status
- Updates the method and its doc comment to use `.dismissed`, which is the whole reason the status was added (JARVIS-564)

## Test plan
- [x] Verify dismiss() calls updateStatus with `.dismissed`
- [x] Doc comment matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
