### PR TITLE
fix(home): preserve urgency in HomeFeedStore.replacingStatus()

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -247,6 +247,7 @@ public final class HomeFeedStore {
             expiresAt: item.expiresAt,
             minTimeAway: item.minTimeAway,
             actions: item.actions,
+            urgency: item.urgency,
             author: item.author,
             createdAt: item.createdAt
         )


### PR DESCRIPTION
## Summary
- `replacingStatus()` was rebuilding FeedItem without forwarding the new `urgency` field, silently dropping it to nil when status changed (e.g. markAllSeen, updateStatus)
- Adds `urgency: item.urgency` to the initializer call, matching the parameter order in FeedItem.init

## Test plan
- [ ] Verify feed items with urgency badges retain their urgency after status transitions (markAllSeen, updateStatus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
