### PR TITLE
feat(macos/voice): add TTS Test button to settings card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TTSTestPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TTSTestPlayer.swift
@@ -1,0 +1,75 @@
+import AVFoundation
+import Foundation
+import VellumAssistantShared
+
+/// One-shot TTS playback for the Voice Settings "Test" button.
+///
+/// Calls the existing generic TTS synthesis endpoint with the saved
+/// configuration and plays the returned audio through the default output
+/// device.
+@MainActor
+@Observable
+final class TTSTestPlayer: NSObject, AVAudioPlayerDelegate {
+    var isLoading: Bool = false
+    var isPlaying: Bool = false
+    var error: String? = nil
+
+    @ObservationIgnored private var audioPlayer: AVAudioPlayer?
+    @ObservationIgnored private let ttsClient: any TTSClientProtocol
+
+    init(ttsClient: any TTSClientProtocol = TTSClient()) {
+        self.ttsClient = ttsClient
+        super.init()
+    }
+
+    func playTest(text: String) async {
+        // Stop any prior playback so rapid Test taps don't overlap.
+        stop()
+        isLoading = true
+        error = nil
+
+        let result = await ttsClient.synthesizeText(text, context: nil, conversationId: nil)
+
+        switch result {
+        case .success(let data):
+            do {
+                let player = try AVAudioPlayer(data: data)
+                player.delegate = self
+                audioPlayer = player
+                player.play()
+                isPlaying = true
+            } catch {
+                self.error = "Failed to play audio"
+            }
+
+        case .featureDisabled:
+            error = "Text-to-speech is not enabled"
+
+        case .notConfigured:
+            error = "Text-to-speech is not configured"
+
+        case .notFound:
+            error = "TTS endpoint not found"
+
+        case .error(_, let message):
+            error = message
+        }
+
+        isLoading = false
+    }
+
+    func stop() {
+        audioPlayer?.stop()
+        audioPlayer = nil
+        isPlaying = false
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            isPlaying = false
+            audioPlayer = nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -28,6 +28,8 @@ struct VoiceSettingsView: View {
     @State private var ttsSaving: Bool = false
     /// Error message from key save.
     @State private var ttsSaveError: String? = nil
+    /// One-shot player for the TTS test button.
+    @State private var testPlayer = TTSTestPlayer()
 
     @State private var isRecordingCustomKey: Bool = false
     @State private var recordingMonitors: [Any] = []
@@ -393,6 +395,28 @@ struct VoiceSettingsView: View {
         ttsProviderHasKey && SettingsStore.ttsKeyIsExclusive(for: draftTTSProvider)
     }
 
+    /// Phrase synthesized when the Test button is tapped. Uses the active
+    /// assistant's lockfile name so the user hears their assistant's name
+    /// spoken in the configured voice.
+    private var ttsTestPhrase: String {
+        let name = LockfileAssistant.loadActiveAssistantId() ?? "your assistant"
+        return "Hey! It's \(name). How does this sound?"
+    }
+
+    /// Test button is enabled only when there are no unsaved changes AND a
+    /// key is stored for the active provider AND playback isn't already in
+    /// flight. Forcing Save before Test means we always exercise the same
+    /// configured TTS path used by the rest of the app — no override state.
+    private var ttsTestEnabled: Bool {
+        !ttsHasChanges && ttsProviderHasKey && !testPlayer.isLoading
+    }
+
+    private var ttsTestDisabledHint: String? {
+        if ttsHasChanges { return "Save your changes before testing" }
+        if !ttsProviderHasKey { return "Save an API key before testing" }
+        return nil
+    }
+
     private var ttsProviderCard: some View {
         SettingsCard(title: "Text-to-Speech", subtitle: "Choose a TTS provider for voice conversations and read-aloud. The selected provider is used globally across all speech features.") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -427,20 +451,36 @@ struct VoiceSettingsView: View {
                 // Credentials guide — contextual help for obtaining an API key
                 ttsCredentialsGuideView
 
-                // Save + Reset actions — reset is gated by ttsResetAllowed
-                // to prevent destructive actions on shared-key providers.
-                ServiceCardActions(
-                    hasChanges: ttsHasChanges,
-                    isSaving: ttsSaving,
-                    onSave: { saveTTS() },
-                    savingLabel: "Saving...",
-                    onReset: {
-                        store.clearTTSKey(ttsProviderId: draftTTSProvider)
-                        ttsProviderHasKey = false
-                        ttsApiKeyText = ""
-                    },
-                    showReset: ttsResetAllowed
-                )
+                // Test + Save + Reset actions. Test is gated by
+                // `ttsTestEnabled` so it always runs against the saved
+                // configuration — no separate test path on the backend.
+                HStack(spacing: VSpacing.sm) {
+                    VButton(
+                        label: testPlayer.isLoading ? "Testing\u{2026}" : "Test",
+                        style: .outlined,
+                        isDisabled: !ttsTestEnabled
+                    ) {
+                        Task { await testPlayer.playTest(text: ttsTestPhrase) }
+                    }
+                    .help(ttsTestDisabledHint ?? "")
+
+                    ServiceCardActions(
+                        hasChanges: ttsHasChanges,
+                        isSaving: ttsSaving,
+                        onSave: { saveTTS() },
+                        savingLabel: "Saving...",
+                        onReset: {
+                            store.clearTTSKey(ttsProviderId: draftTTSProvider)
+                            ttsProviderHasKey = false
+                            ttsApiKeyText = ""
+                        },
+                        showReset: ttsResetAllowed
+                    )
+                }
+
+                if let testError = testPlayer.error {
+                    VInlineMessage(testError, tone: .error)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add a Test button to the Voice → Text-to-Speech settings card that synthesizes `Hey! It's <assistant name>. How does this sound?` and plays it back, so users can verify their TTS configuration without waiting for a real conversation.
- Reuses the existing `POST /v1/tts/synthesize` endpoint and the saved provider config — no new backend route, no override mechanism, no provider refactor.
- Disabled while the form has unsaved changes or no API key is stored for the active provider; tooltip prompts the user to Save first.

## Original prompt
implement the single PR from .private/plans/tts-test-button.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
