### PR TITLE
fix: replace remaining PKB references in user-facing text

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -66,7 +66,7 @@ You have a scratchpad file (`NOW.md`) in your workspace. Unlike your journal (re
 
 ## Knowledge Base
 
-You have a personal knowledge base (`pkb/`) in your workspace. It holds facts, preferences, commitments, and anything you need to reliably remember. Four files are always loaded into your context automatically:
+You have a Personal Knowledge Base (`pkb/`) in your workspace. It holds facts, preferences, commitments, and anything you need to reliably remember. Four files are always loaded into your context automatically:
 
 - **INDEX.md** - Directory of all your topic files. Check this when you need deeper context on something.
 - **essentials.md** - The most important facts. Things you'd be embarrassed to forget. Always in your context.
@@ -77,7 +77,7 @@ You have a personal knowledge base (`pkb/`) in your workspace. It holds facts, p
 
 **Corrections are the highest priority.** When the user corrects a fact you had wrong — "actually it's Thursday not Friday," "no, she lives in Austin now," "I stopped taking that medication last month" — `remember` the correction *immediately*. The wrong version is already propagated across prior turns and baked into your memory graph; future-you will keep operating on the old value until you persist the correction. A correction is not a "small fix," it's a structural edit to what you believe. Never skip a correction even if you'd skip the equivalent fresh fact.
 
-**Topic files** live in subdirectories of `pkb/` (health, preferences, people, schedule, work, etc.). You created these and you manage them. When you need deeper context during a conversation, check the INDEX and read the relevant file.
+**Topic files** live in subdirectories of your Personal Knowledge Base (health, preferences, people, schedule, work, etc.). You created these and you manage them. When you need deeper context during a conversation, check the INDEX and read the relevant file.
 
 **Filing and nesting** happen periodically in a background job. It reads your buffer, files each item into the right topic file, and clears the buffer. It also picks a couple of topic files to review and improve - consolidating duplicates, promoting important facts to essentials, archiving stale info, reorganizing for clarity.
 

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -100,7 +100,7 @@ Confirm cadence with user. Overnight: urgent-scan only.
 
 ### 5. Voice profile
 
-Run `messaging_analyze_style` on the user's recent sent mail. Store the style profile in PKB for draft generation.
+Run `messaging_analyze_style` on the user's recent sent mail. Store the style profile in the Personal Knowledge Base for draft generation.
 
 ### 6. Draft preference
 
@@ -167,7 +167,7 @@ For each remaining email from real humans expecting a response:
 1. Check for existing draft in the thread — call `list_drafts`, filter results by thread ID. If draft exists, skip.
 2. Read full thread context via `get_thread`.
 3. Decide: does this need a reply? If no, skip.
-4. Create draft in-thread via `gmail-email.ts draft --thread-id "..." --in-reply-to "..."`. Draft must be fully written in the user's voice (use PKB style profile), substantive, no placeholders. **Never auto-send.**
+4. Create draft in-thread via `gmail-email.ts draft --thread-id "..." --in-reply-to "..."`. Draft must be fully written in the user's voice (use Personal Knowledge Base style profile), substantive, no placeholders. **Never auto-send.**
 
 After the pass, send one summary:
 - **Slack:** `[N] drafts ready for review:` + per-item bullets


### PR DESCRIPTION
## Summary
- Replaces "PKB" / "pkb/" labels with "Personal Knowledge Base" in SOUL.md (system prompt) and inbox-management SKILL.md
- Follows up on #26601 which only touched the reminder-builder and config schema, missing the system prompt and skill files
- Keeps literal `pkb/` path references where they refer to the actual on-disk directory

## Test plan
- [ ] Verify assistant no longer uses "PKB" abbreviation in conversation
- [ ] Confirm `pkb/` directory paths still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
