### PR TITLE
fix(providers/anthropic): stop paging on billing/auth + format "(undefined)" gracefully

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4243,6 +4243,7 @@ paths:
                             - new
                             - seen
                             - acted_on
+                            - dismissed
                         expiresAt:
                           type: string
                         minTimeAway:
@@ -4265,6 +4266,13 @@ paths:
                               - label
                               - prompt
                             additionalProperties: false
+                        urgency:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                            - critical
                         author:
                           type: string
                           enum:
@@ -4365,6 +4373,7 @@ paths:
                       - new
                       - seen
                       - acted_on
+                      - dismissed
                   expiresAt:
                     type: string
                   minTimeAway:
@@ -4387,6 +4396,13 @@ paths:
                         - label
                         - prompt
                       additionalProperties: false
+                  urgency:
+                    type: string
+                    enum:
+                      - low
+                      - medium
+                      - high
+                      - critical
                   author:
                     type: string
                     enum:
@@ -4424,6 +4440,7 @@ paths:
                     - new
                     - seen
                     - acted_on
+                    - dismissed
               required:
                 - status
               additionalProperties: false

--- a/assistant/src/__tests__/agent-loop-sentry-hygiene.test.ts
+++ b/assistant/src/__tests__/agent-loop-sentry-hygiene.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldCaptureAgentLoopError } from "../agent/loop.js";
+import { ProviderError } from "../util/errors.js";
+
+/**
+ * Regression coverage for JARVIS-446 and JARVIS-513.
+ *
+ * The agent loop reports uncaught turn-processing errors to Sentry, but two
+ * categories of errors are user-environment noise and should not page:
+ *
+ *  - JARVIS-446: billing/auth/forbidden from the provider (402/401/403). The
+ *    user-facing error path already surfaces a credits-exhausted message; a
+ *    Sentry issue adds no engineering signal.
+ *  - JARVIS-513: retry-exhausted transient network errors (ECONNRESET, Bun's
+ *    "socket closed unexpectedly", etc.). The retry loop already did its job.
+ *
+ * `shouldCaptureAgentLoopError` gates the `Sentry.captureException` call.
+ */
+describe("shouldCaptureAgentLoopError", () => {
+  describe("JARVIS-446 — billing/auth/forbidden ProviderError", () => {
+    test("skips capture for 402 (billing exhausted)", () => {
+      const err = new ProviderError(
+        "Anthropic API error (402): credit balance too low",
+        "anthropic",
+        402,
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("skips capture for 401 (bad API key)", () => {
+      const err = new ProviderError(
+        "Anthropic API error (401): invalid x-api-key",
+        "anthropic",
+        401,
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("skips capture for 403 (forbidden / plan-gated)", () => {
+      const err = new ProviderError(
+        "Anthropic API error (403): permission denied",
+        "anthropic",
+        403,
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("still captures 500 (real server error)", () => {
+      const err = new ProviderError(
+        "Anthropic API error (500): internal server error",
+        "anthropic",
+        500,
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(true);
+    });
+
+    test("still captures 400 (bad request — engineering bug)", () => {
+      const err = new ProviderError(
+        "Anthropic API error (400): invalid tool definition",
+        "anthropic",
+        400,
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(true);
+    });
+
+    test("still captures ProviderError with no status (surprise error)", () => {
+      const err = new ProviderError(
+        "Anthropic API error: unexpected internal state",
+        "anthropic",
+      );
+      expect(shouldCaptureAgentLoopError(err)).toBe(true);
+    });
+  });
+
+  describe("JARVIS-513 — retry-exhausted transient network errors", () => {
+    test("skips capture when retriesExhausted is set on an ECONNRESET", () => {
+      const err = Object.assign(new Error("connection reset"), {
+        code: "ECONNRESET",
+        retriesExhausted: true,
+      });
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("skips capture for Bun 'socket closed unexpectedly' with retriesExhausted", () => {
+      const err = new Error("The socket connection was closed unexpectedly");
+      (err as Error & { retriesExhausted?: boolean }).retriesExhausted = true;
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("skips capture for wrapped ProviderError whose cause is a transient socket error", () => {
+      const cause = new Error("The socket connection was closed unexpectedly");
+      const err = new ProviderError(
+        "Anthropic request failed: The socket connection was closed unexpectedly",
+        "anthropic",
+        undefined,
+        { cause },
+      );
+      (err as Error & { retriesExhausted?: boolean }).retriesExhausted = true;
+      expect(shouldCaptureAgentLoopError(err)).toBe(false);
+    });
+
+    test("still captures ECONNRESET when retries were NOT exhausted", () => {
+      // If the first attempt threw with ECONNRESET and the retry loop somehow
+      // didn't run (e.g. a caller bypassed RetryProvider), we still want
+      // visibility — `retriesExhausted` wasn't set.
+      const err = Object.assign(new Error("connection reset"), {
+        code: "ECONNRESET",
+      });
+      expect(shouldCaptureAgentLoopError(err)).toBe(true);
+    });
+
+    test("still captures retriesExhausted marker on a non-network error", () => {
+      // The suppression is narrow: only retryable-network errors with the
+      // marker. A 500 with retriesExhausted still merits Sentry attention.
+      const err = new ProviderError(
+        "Anthropic API error (500): internal server error",
+        "anthropic",
+        500,
+      );
+      (err as Error & { retriesExhausted?: boolean }).retriesExhausted = true;
+      expect(shouldCaptureAgentLoopError(err)).toBe(true);
+    });
+  });
+
+  describe("default behavior — everything else still pages", () => {
+    test("captures a plain surprise Error", () => {
+      expect(shouldCaptureAgentLoopError(new Error("boom"))).toBe(true);
+    });
+
+    test("captures a TypeError", () => {
+      expect(shouldCaptureAgentLoopError(new TypeError("x is not a fn"))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/assistant/src/__tests__/anthropic-error-formatting.test.ts
+++ b/assistant/src/__tests__/anthropic-error-formatting.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Message } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock Anthropic SDK — inject a throwing stream so we can assert on the
+// message format produced by the client's error-mapping path (JARVIS-390).
+// ---------------------------------------------------------------------------
+
+class FakeAPIError extends Error {
+  status: number | undefined;
+  headers: Map<string, string> = new Map();
+  constructor(status: number | undefined, message: string) {
+    super(message);
+    this.status = status;
+    this.name = "APIError";
+  }
+}
+
+let nextThrown: FakeAPIError | null = null;
+
+mock.module("@anthropic-ai/sdk", () => ({
+  default: class MockAnthropic {
+    static APIError = FakeAPIError;
+    constructor(_args: Record<string, unknown>) {}
+    #streamImpl = () => ({
+      on() {
+        return this;
+      },
+      async finalMessage() {
+        if (nextThrown) throw nextThrown;
+        return {
+          content: [],
+          model: "claude-sonnet-4-6",
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          stop_reason: "end_turn",
+        };
+      },
+    });
+    messages = { stream: () => this.#streamImpl() };
+    beta = { messages: { stream: () => this.#streamImpl() } };
+  },
+}));
+
+import { AnthropicProvider } from "../providers/anthropic/client.js";
+import { ProviderError } from "../util/errors.js";
+
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+describe("AnthropicProvider — error message formatting (JARVIS-390)", () => {
+  beforeEach(() => {
+    nextThrown = null;
+  });
+
+  test("omits the `(status)` parenthetical when the SDK reports no HTTP status", async () => {
+    // Reproduces the abort/mid-stream path where `error.status` is undefined.
+    nextThrown = new FakeAPIError(undefined, "Request was aborted.");
+
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+
+    try {
+      await provider.sendMessage([userMsg("hi")]);
+      throw new Error("expected sendMessage to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      const message = (err as Error).message;
+      expect(message).toBe("Anthropic API error: Request was aborted.");
+      // Belt-and-suspenders: the literal "(undefined)" must never appear.
+      expect(message).not.toContain("(undefined)");
+    }
+  });
+
+  test("includes the `(status)` parenthetical when the SDK reports an HTTP status", async () => {
+    nextThrown = new FakeAPIError(
+      402,
+      "Billing issue: your credit balance is too low.",
+    );
+
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+
+    try {
+      await provider.sendMessage([userMsg("hi")]);
+      throw new Error("expected sendMessage to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      const message = (err as Error).message;
+      expect(message).toContain("Anthropic API error (402):");
+      expect((err as ProviderError).statusCode).toBe(402);
+    }
+  });
+});

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -121,7 +121,7 @@ describe("classifyConversationError", () => {
 
     it("classifies Anthropic overloaded_error (no statusCode) as PROVIDER_OVERLOADED", () => {
       const err = new ProviderError(
-        'Anthropic API error (undefined): {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+        'Anthropic API error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
         "anthropic",
       );
       const result = classifyConversationError(err, baseCtx);
@@ -614,7 +614,7 @@ describe("classifyConversationError", () => {
     for (const kind of taggedKinds) {
       it(`treats ProviderError with abortReason kind="${kind}" as user cancellation`, () => {
         const wrapped = new ProviderError(
-          "Anthropic API error (undefined): Request was aborted.",
+          "Anthropic API error: Request was aborted.",
           "anthropic",
           undefined,
           { abortReason: createAbortReason(kind, `test:${kind}`) },
@@ -625,7 +625,7 @@ describe("classifyConversationError", () => {
 
     it("does NOT treat tagged ProviderError as cancellation when ctx.aborted is false", () => {
       const wrapped = new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
+        "Anthropic API error: Request was aborted.",
         "anthropic",
         undefined,
         { abortReason: createAbortReason("user_cancel", "test") },
@@ -636,7 +636,7 @@ describe("classifyConversationError", () => {
 
     it("does NOT treat ProviderError without abortReason as cancellation", () => {
       const wrapped = new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
+        "Anthropic API error: Request was aborted.",
         "anthropic",
         undefined,
       );
@@ -645,7 +645,7 @@ describe("classifyConversationError", () => {
 
     it("does NOT treat ProviderError with foreign reason as cancellation", () => {
       const wrapped = new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
+        "Anthropic API error: Request was aborted.",
         "anthropic",
         undefined,
         { abortReason: { kind: "user_cancel", source: "spoofed" } },
@@ -655,7 +655,7 @@ describe("classifyConversationError", () => {
 
     it("falls through to CONVERSATION_ABORTED when wrapped ProviderError has no tagged reason", () => {
       const wrapped = new ProviderError(
-        "Anthropic API error (undefined): Request was aborted.",
+        "Anthropic API error: Request was aborted.",
         "anthropic",
         undefined,
       );

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -217,6 +217,47 @@ describe("RetryProvider — rate limit backoff", () => {
     }
   });
 
+  test("tags final error with retriesExhausted=true after retry loop gives up (JARVIS-513)", async () => {
+    // Transient socket flap from Bun's native fetch: wrapped in a
+    // ProviderError but still network-retryable via message pattern match.
+    const inner = makeFailing(
+      new ProviderError(
+        "Anthropic request failed: The socket connection was closed unexpectedly",
+        "anthropic",
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    try {
+      await provider.sendMessage(MESSAGES);
+      expect(true).toBe(false);
+    } catch (err) {
+      const flag = (err as Error & { retriesExhausted?: boolean })
+        .retriesExhausted;
+      expect(flag).toBe(true);
+      // Retry loop should have used all attempts before surrendering.
+      expect(inner.calls).toBe(DEFAULT_MAX_RETRIES + 1);
+    }
+  });
+
+  test("does NOT tag retriesExhausted on non-retryable errors (no retry was attempted)", async () => {
+    // ProviderError without statusCode and without a retryable pattern: the
+    // retry loop short-circuits on the first attempt. No "exhaustion"
+    // occurred, so the marker must stay unset.
+    const inner = makeFailing(new ProviderError("model not found", "test"));
+    const provider = new RetryProvider(inner);
+
+    try {
+      await provider.sendMessage(MESSAGES);
+      expect(true).toBe(false);
+    } catch (err) {
+      const flag = (err as Error & { retriesExhausted?: boolean })
+        .retriesExhausted;
+      expect(flag).toBeUndefined();
+      expect(inner.calls).toBe(1);
+    }
+  });
+
   test("uses retryAfterMs from ProviderError when present", async () => {
     const error = new ProviderError("rate limited", "anthropic", 429, {
       retryAfterMs: 30_000,
@@ -471,7 +512,7 @@ describe("RetryProvider — network error retries", () => {
   test("does NOT retry 'Anthropic stream timed out' (inner streamTimeoutMs fired)", async () => {
     const inner = makeFailing(
       new ProviderError(
-        "Anthropic API error (undefined): Anthropic stream timed out after 1800s (inner streamTimeoutMs)",
+        "Anthropic API error: Anthropic stream timed out after 1800s (inner streamTimeoutMs)",
         "anthropic",
       ),
     );
@@ -646,7 +687,7 @@ describe("RetryProvider — streaming response handling", () => {
         callCount++;
         if (callCount <= 1) {
           throw new ProviderError(
-            'Anthropic API error (undefined): {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+            'Anthropic API error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
             "anthropic",
             undefined,
           );

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -16,7 +16,9 @@ import {
   applyStreamingSubstitution,
   applySubstitutions,
 } from "../tools/sensitive-output-placeholders.js";
+import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { isRetryableNetworkError } from "../util/retry.js";
 
 const log = getLogger("agent-loop");
 
@@ -111,6 +113,42 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
 const MAX_EMPTY_RESPONSE_RETRIES = 1;
+
+/**
+ * User-config HTTP status codes that should never page the on-call: billing
+ * exhaustion (402), invalid credentials (401), and forbidden/plan-gated (403).
+ * The user-facing error path already surfaces an actionable message (e.g.
+ * credits_exhausted); a Sentry issue adds noise without engineering signal.
+ */
+const USER_CONFIG_STATUS_CODES = new Set([401, 402, 403]);
+
+/**
+ * Whether an agent-loop error should be reported to Sentry. Suppresses:
+ *
+ *  - `ProviderError` carrying a user-config status code (401/402/403) — these
+ *    are bad API keys, exhausted billing, or plan gates, not engineering bugs.
+ *  - Retry-exhausted transient network errors (`retriesExhausted === true` +
+ *    still categorized as retryable network) — the retry loop already tried
+ *    its best; the user's network was flaky, not our code.
+ *
+ * Everything else (5xx with no retry-exhaustion tag, surprise errors, tool
+ * failures, etc.) still pages.
+ */
+export function shouldCaptureAgentLoopError(err: Error): boolean {
+  if (
+    err instanceof ProviderError &&
+    err.statusCode !== undefined &&
+    USER_CONFIG_STATUS_CODES.has(err.statusCode)
+  ) {
+    return false;
+  }
+  const exhausted = (err as Error & { retriesExhausted?: boolean })
+    .retriesExhausted;
+  if (exhausted === true && isRetryableNetworkError(err)) {
+    return false;
+  }
+  return true;
+}
 
 export interface ResolvedSystemPrompt {
   systemPrompt: string;
@@ -767,7 +805,9 @@ export class AgentLoop {
           { err, turn: toolUseTurns, messageCount: history.length },
           "Agent loop error during turn processing",
         );
-        Sentry.captureException(err);
+        if (shouldCaptureAgentLoopError(err)) {
+          Sentry.captureException(err);
+        }
         onEvent({ type: "error", error: err });
         break;
       }

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -121,7 +121,7 @@ export interface ErrorContext {
  * instead of `conversation_error`.
  *
  * Provider SDKs wrap the underlying AbortError in their own error class
- * (e.g. `ProviderError("Anthropic API error (undefined): Request was aborted.")`),
+ * (e.g. `ProviderError("Anthropic API error: Request was aborted.")`),
  * which erases the `AbortError` name. To compensate, the daemon tags every
  * `controller.abort(reason)` call with an `AbortReason` object — when the
  * wrapped `ProviderError` carries that tagged reason, we treat it as a user

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1282,7 +1282,8 @@ export class AnthropicProvider implements Provider {
           abortReason?: unknown;
           cause?: unknown;
         } = {};
-        if (retryAfterMs !== undefined) errorOptions.retryAfterMs = retryAfterMs;
+        if (retryAfterMs !== undefined)
+          errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
         // Only preserve the original error as `cause` for transport aborts
         // without a daemon-tagged reason — it's the diagnostic signal the
@@ -1295,8 +1296,14 @@ export class AnthropicProvider implements Provider {
           isAbortMessage && innerTimeoutFired
             ? `Anthropic stream timed out after ${Math.round(elapsedMs / 1000)}s (inner streamTimeoutMs)`
             : error.message;
+        // Only include the `(status)` parenthetical when the SDK surfaced a
+        // real HTTP status. Abort paths and mid-stream protocol errors have
+        // `error.status === undefined`, and string-interpolating that produces
+        // a confusing "Anthropic API error (undefined): …" message.
+        const statusPart =
+          error.status !== undefined ? ` (${error.status})` : "";
         throw new ProviderError(
-          `Anthropic API error (${error.status}): ${rewrittenMessage}`,
+          `Anthropic API error${statusPart}: ${rewrittenMessage}`,
           "anthropic",
           error.status,
           Object.keys(errorOptions).length > 0 ? errorOptions : undefined,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -212,6 +212,14 @@ function normalizeSendMessageOptions(
   };
 }
 
+/**
+ * `RetryProvider` sets `retriesExhausted = true` on the final thrown error
+ * when the retry loop burned through all attempts against a retryable error
+ * (transient network, 5xx, provider-overloaded, mid-stream corruption).
+ * Consumers can read it via `(err as { retriesExhausted?: boolean })` to
+ * suppress Sentry captures for user-network-flap noise — the retry loop
+ * already did its job, and no engineering action would change the outcome.
+ */
 export class RetryProvider implements Provider {
   public readonly name: string;
 
@@ -230,6 +238,7 @@ export class RetryProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     let lastError: unknown;
+    let didRetry = false;
 
     const normalizedOptions = normalizeSendMessageOptions(this.name, options);
 
@@ -277,14 +286,32 @@ export class RetryProvider implements Provider {
             },
             "Retrying after transient error",
           );
+          didRetry = true;
           await sleep(delay);
           continue;
+        }
+
+        // If we exhausted retries on a retryable error, tag the error so
+        // downstream consumers (Sentry capture, etc.) can recognize that the
+        // retry loop already tried its best. The catch-site logic above only
+        // stops retrying when either (a) retries are exhausted, or (b) the
+        // error isn't retryable — so we check the retryable predicate here to
+        // distinguish the two cases.
+        if (didRetry && isRetryableError(error) && error instanceof Error) {
+          (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
+            true;
         }
 
         throw error;
       }
     }
 
+    // Unreachable in practice — the loop body always either returns or throws —
+    // but mark the last error in case execution somehow falls through.
+    if (lastError instanceof Error && isRetryableError(lastError)) {
+      (lastError as Error & { retriesExhausted?: boolean }).retriesExhausted =
+        true;
+    }
     throw lastError;
   }
 }


### PR DESCRIPTION
## Summary

Three related fixes in the Anthropic client + agent error path, bundled because they all touch the same error-handling seam:

- **JARVIS-390** — The Anthropic client string-interpolated `error.status` into the error message unconditionally. For abort paths and mid-stream protocol errors the SDK reports `error.status === undefined`, producing the confusing message `Anthropic API error (undefined): Request was aborted.`. Now the `(status)` parenthetical is only added when the SDK actually surfaced a status.
- **JARVIS-446** — The agent loop's error catch called `Sentry.captureException` unconditionally. For `ProviderError` with `statusCode ∈ {401, 402, 403}` this is user-config noise (bad API key, exhausted billing, plan gate), not an engineering bug. Those three status codes now skip the capture. The user-facing error path already surfaces an actionable message.
- **JARVIS-513** — Same catch site paged on retry-exhausted transient network errors (e.g. Bun's `"socket closed unexpectedly"` flap, `ECONNRESET`). `RetryProvider` now stamps `(err as any).retriesExhausted = true` on the final thrown error when it burned all attempts against a retryable error, and the agent loop skips Sentry for retryable-network errors carrying that marker. Scope is tight — only retryable-network errors are suppressed; 5xx, stream corruption, and provider-overloaded still page.

## Test plan

- [x] `bunx tsc --noEmit` clean for `assistant/` (cross-package zod errors from `skills/meet-join/` and `packages/ces-contracts/` exist on `main` and are unrelated)
- [x] `bun test src/__tests__/conversation-error.test.ts` — 107 pass (fixture updated to drop `(undefined)`)
- [x] `bun test src/__tests__/provider-error-scenarios.test.ts` — 41 pass including two new cases for the `retriesExhausted` marker
- [x] `bun test src/__tests__/anthropic-error-formatting.test.ts` — new unit test, 2 pass: `(undefined)` suppression and status-included-when-defined
- [x] `bun test src/__tests__/agent-loop-sentry-hygiene.test.ts` — new unit test, 13 pass covering 401/402/403 skip, 500/400 still captured, retry-exhausted network skip, non-network retriesExhausted still captured
- [x] `bun test src/__tests__/anthropic-provider.test.ts` — existing test suite still green (65 pass)
- [x] `bun test src/__tests__/agent-loop.test.ts` — existing test suite still green (46 pass)
- [x] `bun run lint` clean for all changed files

## Notes for review

- The Sentry suppression is deliberately narrow. A 402 still shows the user a friendly error, and we still log at `error` level so the raw detail is in logs if needed; we just don't page on-call.
- `RetryProvider` only tags `retriesExhausted` when retries actually ran — if an error was non-retryable (no network code, not 5xx, no overloaded/stream pattern) and short-circuited on attempt 0, the marker stays unset so the error still routes through Sentry.
- `shouldCaptureAgentLoopError` is exported for test visibility.

Closes JARVIS-390
Closes JARVIS-446
Closes JARVIS-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
