### PR TITLE
fix(avatar): graceful resvg-native fallback + pin darwin platform packages

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -11,6 +11,8 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@qdrant/js-client-rest": "1.17.0",
         "@resvg/resvg-js": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
         "@sentry/node": "10.43.0",
         "@vellumai/ces-contracts": "file:../packages/ces-contracts",
         "@vellumai/credential-storage": "file:../packages/credential-storage",

--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -27,6 +27,8 @@
   "ignoreDependencies": [
     "@vellumai/ces-contracts",
     "@vellumai/credential-storage",
-    "@vellumai/egress-proxy"
+    "@vellumai/egress-proxy",
+    "@resvg/resvg-js-darwin-arm64",
+    "@resvg/resvg-js-darwin-x64"
   ]
 }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4243,6 +4243,7 @@ paths:
                             - new
                             - seen
                             - acted_on
+                            - dismissed
                         expiresAt:
                           type: string
                         minTimeAway:
@@ -4265,6 +4266,13 @@ paths:
                               - label
                               - prompt
                             additionalProperties: false
+                        urgency:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                            - critical
                         author:
                           type: string
                           enum:
@@ -4365,6 +4373,7 @@ paths:
                       - new
                       - seen
                       - acted_on
+                      - dismissed
                   expiresAt:
                     type: string
                   minTimeAway:
@@ -4387,6 +4396,13 @@ paths:
                         - label
                         - prompt
                       additionalProperties: false
+                  urgency:
+                    type: string
+                    enum:
+                      - low
+                      - medium
+                      - high
+                      - critical
                   author:
                     type: string
                     enum:
@@ -4424,6 +4440,7 @@ paths:
                     - new
                     - seen
                     - acted_on
+                    - dismissed
               required:
                 - status
               additionalProperties: false

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -35,6 +35,8 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@qdrant/js-client-rest": "1.17.0",
     "@resvg/resvg-js": "2.6.2",
+    "@resvg/resvg-js-darwin-arm64": "2.6.2",
+    "@resvg/resvg-js-darwin-x64": "2.6.2",
     "@sentry/node": "10.43.0",
     "@vellumai/ces-contracts": "file:../packages/ces-contracts",
     "@vellumai/credential-storage": "file:../packages/credential-storage",

--- a/assistant/src/avatar/resvg-lazy.test.ts
+++ b/assistant/src/avatar/resvg-lazy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for resvg-lazy and the writeTraitsAndRenderAvatar fallback it feeds.
+ *
+ * Covers the graceful-degradation path when the native @resvg/resvg-js binding
+ * is missing (e.g. bun install skipped the platform-specific optional
+ * dependency). The lazy loader must warn once and report unavailability, and
+ * writeTraitsAndRenderAvatar must return `native_unavailable` so the HTTP
+ * layer can respond 503 instead of 500.
+ *
+ * Bun's `mock.module` evaluates factories eagerly on re-registration, which
+ * makes it awkward to flip a module between "throws" and "returns fake
+ * export" across tests in the same file. We instead install a single
+ * throwing mock at module scope for the require-path test, and use the
+ * `__setResvgCacheForTests` / `__resetResvgCacheForTests` hooks to drive the
+ * rest of the cases deterministically.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type LogCall = { bindings: unknown; msg: string };
+const warnCalls: LogCall[] = [];
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: (bindings: unknown, msg: string) => {
+      warnCalls.push({ bindings, msg });
+    },
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  }),
+}));
+
+mock.module("../util/platform.js", () => ({
+  AVATAR_IMAGE_FILENAME: "avatar-image.png",
+  getAvatarDir: () => "/tmp/vellum-test-avatar-never-written",
+}));
+
+// Install a throwing @resvg/resvg-js mock at module scope. Bun only calls
+// this factory the first time the module is required within the test worker;
+// later `require` calls return whatever was produced by that first call (or
+// throw, if the factory threw). That's exactly what we want for the
+// "require fails" test below.
+mock.module("@resvg/resvg-js", () => {
+  throw new Error("Cannot require module @resvg/resvg-js-darwin-x64");
+});
+
+describe("resvg-lazy — require failure path", () => {
+  beforeEach(async () => {
+    warnCalls.length = 0;
+    const { __resetResvgCacheForTests } = await import("./resvg-lazy.js");
+    __resetResvgCacheForTests();
+  });
+
+  test("real require failure triggers warn log with platform context", async () => {
+    const { isResvgAvailable } = await import("./resvg-lazy.js");
+
+    // Call twice — caching must prevent a duplicate warn.
+    expect(isResvgAvailable()).toBe(false);
+    expect(isResvgAvailable()).toBe(false);
+
+    expect(warnCalls.length).toBe(1);
+    const call = warnCalls[0]!;
+    const bindings = call.bindings as Record<string, unknown>;
+    expect(bindings.platform).toBe(process.platform);
+    expect(bindings.arch).toBe(process.arch);
+    expect(String(bindings.module)).toContain("@resvg/resvg-js-");
+    expect(bindings.err).toBeInstanceOf(Error);
+    expect(call.msg).toContain("@resvg/resvg-js");
+  });
+});
+
+describe("resvg-lazy — API shape when unavailable", () => {
+  beforeEach(async () => {
+    warnCalls.length = 0;
+    const { __setResvgCacheForTests } = await import("./resvg-lazy.js");
+    __setResvgCacheForTests({
+      available: false,
+      error: new Error("Cannot require module @resvg/resvg-js-darwin-x64"),
+    });
+  });
+
+  test("isResvgAvailable returns false", async () => {
+    const { isResvgAvailable } = await import("./resvg-lazy.js");
+    expect(isResvgAvailable()).toBe(false);
+  });
+
+  test("getResvg throws the underlying error", async () => {
+    const { getResvg } = await import("./resvg-lazy.js");
+    expect(() => getResvg()).toThrow(
+      /Cannot require module @resvg\/resvg-js-darwin-x64/,
+    );
+  });
+});
+
+describe("writeTraitsAndRenderAvatar — native module missing", () => {
+  beforeEach(async () => {
+    warnCalls.length = 0;
+    const { __setResvgCacheForTests } = await import("./resvg-lazy.js");
+    __setResvgCacheForTests({
+      available: false,
+      error: new Error("Cannot require module @resvg/resvg-js-darwin-x64"),
+    });
+  });
+
+  test("returns native_unavailable without attempting disk writes", async () => {
+    const { writeTraitsAndRenderAvatar } = await import("./traits-png-sync.js");
+
+    const result = writeTraitsAndRenderAvatar({
+      bodyShape: "blob",
+      eyeStyle: "curious",
+      color: "green",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return; // narrow for TypeScript
+    expect(result.reason).toBe("native_unavailable");
+    expect(result.message).toContain("@resvg/resvg-js");
+  });
+
+  test("returns invalid_traits (not native_unavailable) when traits are bad", async () => {
+    const { writeTraitsAndRenderAvatar } = await import("./traits-png-sync.js");
+
+    // Empty traits object fails the shape check before we ever consult resvg.
+    const result = writeTraitsAndRenderAvatar({
+      bodyShape: "",
+      eyeStyle: "",
+      color: "",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("invalid_traits");
+  });
+});

--- a/assistant/src/avatar/resvg-lazy.ts
+++ b/assistant/src/avatar/resvg-lazy.ts
@@ -1,21 +1,94 @@
 import type { Resvg as ResvgType } from "@resvg/resvg-js";
 
-let ResvgClass: typeof ResvgType | undefined;
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("resvg-lazy");
+
+type ResvgLoadResult =
+  | { available: true; Resvg: typeof ResvgType }
+  | { available: false; error: Error };
+
+let cached: ResvgLoadResult | undefined;
+
+function loadResvg(): ResvgLoadResult {
+  try {
+    // Inline require is necessary here: @resvg/resvg-js loads a platform-specific
+    // native .node addon at import time. A top-level import would crash the daemon
+    // on startup inside bun --compile binaries where native addons are unavailable.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("@resvg/resvg-js") as typeof import("@resvg/resvg-js");
+    return { available: true, Resvg: mod.Resvg };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    // Log once at warn level (not error) — the daemon should keep running and
+    // callers should fall back to a non-native path (ASCII only, or a 503 at
+    // the HTTP layer). Emitting at error level would page Sentry on every
+    // install that skipped the platform-specific optional dependency.
+    log.warn(
+      {
+        err: error,
+        platform: process.platform,
+        arch: process.arch,
+        module: `@resvg/resvg-js-${process.platform}-${process.arch}`,
+      },
+      "Failed to load @resvg/resvg-js native module — avatar PNG rendering will be unavailable. " +
+        "The platform-specific optional dependency is likely missing.",
+    );
+    return { available: false, error };
+  }
+}
+
+function getLoadResult(): ResvgLoadResult {
+  if (!cached) {
+    cached = loadResvg();
+  }
+  return cached;
+}
+
+/**
+ * Returns `true` if the native @resvg/resvg-js binding loaded successfully on
+ * first access. Callers should check this before calling `getResvg()` and fall
+ * back to a non-native path (e.g. ASCII-only rendering, or a 503 at the HTTP
+ * layer) when it is `false`.
+ *
+ * Loading is attempted lazily on first access and the result is cached, so
+ * calling this multiple times is cheap and does not re-emit warnings.
+ */
+export function isResvgAvailable(): boolean {
+  return getLoadResult().available;
+}
 
 /**
  * Returns the Resvg constructor, loading the native module on first call.
  * Defers the native-addon require so the daemon can start even when the
  * platform-specific binary is unavailable (e.g. inside a bun --compile
  * single-file executable).
+ *
+ * Throws if the native module could not be loaded. Callers that need to
+ * degrade gracefully should check `isResvgAvailable()` first.
  */
 export function getResvg(): typeof ResvgType {
-  if (!ResvgClass) {
-    // Inline require is necessary here: @resvg/resvg-js loads a platform-specific
-    // native .node addon at import time. A top-level import would crash the daemon
-    // on startup inside bun --compile binaries where native addons are unavailable.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require("@resvg/resvg-js") as typeof import("@resvg/resvg-js");
-    ResvgClass = mod.Resvg;
+  const result = getLoadResult();
+  if (!result.available) {
+    throw result.error;
   }
-  return ResvgClass;
+  return result.Resvg;
+}
+
+/**
+ * Test-only hook to reset the cached load result between test cases. Do not
+ * call from production code.
+ */
+export function __resetResvgCacheForTests(): void {
+  cached = undefined;
+}
+
+/**
+ * Test-only hook to force the cached load result to a specific state without
+ * exercising the real `require`. Useful for asserting the unavailable path
+ * without depending on Bun's module-mock behavior (which re-imports the real
+ * module after the factory throws once).
+ */
+export function __setResvgCacheForTests(result: ResvgLoadResult): void {
+  cached = result;
 }

--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -7,6 +7,7 @@ import { AVATAR_IMAGE_FILENAME, getAvatarDir } from "../util/platform.js";
 import { renderCharacterAscii } from "./ascii-renderer.js";
 import { getCharacterComponents } from "./character-components.js";
 import { renderCharacterPng } from "./png-renderer.js";
+import { isResvgAvailable } from "./resvg-lazy.js";
 
 const log = getLogger("traits-png-sync");
 
@@ -20,7 +21,7 @@ export type TraitsSyncResult =
   | { ok: true; asciiWritten: boolean }
   | {
       ok: false;
-      reason: "invalid_traits" | "render_error";
+      reason: "invalid_traits" | "render_error" | "native_unavailable";
       message: string;
     };
 
@@ -141,6 +142,25 @@ export function writeTraitsAndRenderAvatar(
       ok: false,
       reason: "invalid_traits",
       message: `Unknown color: "${traits.color}". Valid IDs: ${validColors.join(", ")}`,
+    };
+  }
+
+  // Short-circuit before touching disk when the native rasterizer is missing.
+  // Both PNG and ASCII rendering route through @resvg/resvg-js, so without it
+  // we cannot produce either artifact. Callers translate this into a 503 so
+  // the HTTP route returns an actionable status rather than a 500.
+  if (!isResvgAvailable()) {
+    log.warn(
+      { traits },
+      "Skipping avatar render — native @resvg/resvg-js binding is unavailable",
+    );
+    return {
+      ok: false,
+      reason: "native_unavailable",
+      message:
+        "Avatar PNG rendering is unavailable on this platform because the " +
+        "@resvg/resvg-js native binding failed to load. Reinstall dependencies " +
+        "to pull the platform-specific optional package.",
     };
   }
 

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -10,7 +10,7 @@ import { getAvatarImagePath } from "../../util/platform.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
-import { httpError } from "../http-errors.js";
+import { httpError, type HttpErrorCode } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("avatar-routes");
@@ -78,9 +78,25 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
         const result = writeTraitsAndRenderAvatar(body);
 
         if (!result.ok) {
-          const status = result.reason === "render_error" ? 500 : 400;
-          const code =
-            result.reason === "render_error" ? "INTERNAL_ERROR" : "BAD_REQUEST";
+          // Map each failure reason to an HTTP status that reflects its
+          // cause: invalid inputs → 400, missing native dependency → 503,
+          // everything else → 500.
+          let status: number;
+          let code: HttpErrorCode;
+          switch (result.reason) {
+            case "invalid_traits":
+              status = 400;
+              code = "BAD_REQUEST";
+              break;
+            case "native_unavailable":
+              status = 503;
+              code = "SERVICE_UNAVAILABLE";
+              break;
+            case "render_error":
+              status = 500;
+              code = "INTERNAL_ERROR";
+              break;
+          }
           return httpError(code, result.message, status);
         }
 


### PR DESCRIPTION
## Summary

- Harden `resvg-lazy.ts` so a failed `require("@resvg/resvg-js")` no longer throws from the daemon. Log a single structured warn (not error, so Sentry isn't paged) with platform/arch/module context and expose `isResvgAvailable()` so callers can check before asking for the constructor.
- `writeTraitsAndRenderAvatar()` now short-circuits with a new `native_unavailable` reason when the binding is missing, and `POST /v1/avatar/render-from-traits` maps that to 503 `SERVICE_UNAVAILABLE` instead of falling through to a generic 500. Input validation still returns 400 and unexpected render errors still return 500.
- Pin `@resvg/resvg-js-darwin-x64@2.6.2` and `@resvg/resvg-js-darwin-arm64@2.6.2` as direct `dependencies` in `assistant/package.json` (exact versions, repo convention) so bun install can't silently drop them from the darwin install set.

Closes JARVIS-474
Closes JARVIS-363
Closes JARVIS-364

## Test plan

- [x] `bun test src/avatar/resvg-lazy.test.ts` — 5 cases covering: real require-failure warn shape (exactly one log entry, includes platform/arch/module), `isResvgAvailable()` returns `false`, `getResvg()` rethrows, `writeTraitsAndRenderAvatar` returns `native_unavailable` without touching disk, and the pre-existing `invalid_traits` shape-check path remains intact.
- [x] `bunx tsc --noEmit` for assistant — no new errors (the zod/ces-contracts errors are pre-existing and unrelated).
- [x] `bun run lint` clean.
- [ ] Manual smoke on darwin-arm64 with both darwin subpackages present: avatar render returns 200 as before.
- [ ] Manual smoke with both darwin subpackages removed from `node_modules`: `/v1/avatar/render-from-traits` returns 503 (not 500) and the daemon log has one `resvg-lazy` warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
