### PR TITLE
fix(oauth): add retry with exponential backoff to token refresh

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4243,6 +4243,7 @@ paths:
                             - new
                             - seen
                             - acted_on
+                            - dismissed
                         expiresAt:
                           type: string
                         minTimeAway:
@@ -4265,6 +4266,13 @@ paths:
                               - label
                               - prompt
                             additionalProperties: false
+                        urgency:
+                          type: string
+                          enum:
+                            - low
+                            - medium
+                            - high
+                            - critical
                         author:
                           type: string
                           enum:
@@ -4365,6 +4373,7 @@ paths:
                       - new
                       - seen
                       - acted_on
+                      - dismissed
                   expiresAt:
                     type: string
                   minTimeAway:
@@ -4387,6 +4396,13 @@ paths:
                         - label
                         - prompt
                       additionalProperties: false
+                  urgency:
+                    type: string
+                    enum:
+                      - low
+                      - medium
+                      - high
+                      - critical
                   author:
                     type: string
                     enum:
@@ -4424,6 +4440,7 @@ paths:
                     - new
                     - seen
                     - acted_on
+                    - dismissed
               required:
                 - status
               additionalProperties: false

--- a/assistant/src/__tests__/oauth2-refresh-retry.test.ts
+++ b/assistant/src/__tests__/oauth2-refresh-retry.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+// Sequenceable fetch mock — each call pops the next response from the queue.
+let fetchResponses: Array<
+  | {
+      type: "response";
+      ok: boolean;
+      status: number;
+      body: Record<string, unknown>;
+    }
+  | { type: "error"; error: Error }
+> = [];
+let fetchCallCount = 0;
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  if (url.includes("token")) {
+    fetchCallCount++;
+    const next = fetchResponses.shift();
+    if (!next) {
+      return new Response(
+        JSON.stringify({
+          access_token: "ok",
+          refresh_token: "rt",
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    if (next.type === "error") throw next.error;
+    return new Response(JSON.stringify(next.body), {
+      status: next.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return originalFetch(input, _init);
+}) as unknown as typeof fetch;
+
+// Suppress real timers for speed — override setTimeout to fire immediately.
+const origSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = ((fn: (...args: unknown[]) => void) =>
+  origSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+
+import { refreshOAuth2Token } from "../security/oauth2.js";
+
+beforeEach(() => {
+  fetchResponses = [];
+  fetchCallCount = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("refreshOAuth2Token retry behavior", () => {
+  test("succeeds on first attempt with no retries", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: true,
+        status: 200,
+        body: { access_token: "at", refresh_token: "rt", expires_in: 3600 },
+      },
+    ];
+
+    const result = await refreshOAuth2Token(
+      "https://example.com/token",
+      "client-id",
+      "refresh-token",
+    );
+
+    expect(result.accessToken).toBe("at");
+    expect(fetchCallCount).toBe(1);
+  });
+
+  test("retries on network error and succeeds", async () => {
+    fetchResponses = [
+      { type: "error", error: new Error("ECONNREFUSED") },
+      {
+        type: "response",
+        ok: true,
+        status: 200,
+        body: { access_token: "at2", refresh_token: "rt", expires_in: 3600 },
+      },
+    ];
+
+    const result = await refreshOAuth2Token(
+      "https://example.com/token",
+      "client-id",
+      "refresh-token",
+    );
+
+    expect(result.accessToken).toBe("at2");
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("retries on 500 and succeeds", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: false,
+        status: 500,
+        body: { error: "server_error" },
+      },
+      {
+        type: "response",
+        ok: true,
+        status: 200,
+        body: { access_token: "at3", refresh_token: "rt", expires_in: 3600 },
+      },
+    ];
+
+    const result = await refreshOAuth2Token(
+      "https://example.com/token",
+      "client-id",
+      "refresh-token",
+    );
+
+    expect(result.accessToken).toBe("at3");
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("retries on 429 and succeeds", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: false,
+        status: 429,
+        body: { error: "rate_limited" },
+      },
+      {
+        type: "response",
+        ok: true,
+        status: 200,
+        body: { access_token: "at4", refresh_token: "rt", expires_in: 3600 },
+      },
+    ];
+
+    const result = await refreshOAuth2Token(
+      "https://example.com/token",
+      "client-id",
+      "refresh-token",
+    );
+
+    expect(result.accessToken).toBe("at4");
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("does NOT retry on 400 invalid_grant (credential error)", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: false,
+        status: 400,
+        body: { error: "invalid_grant" },
+      },
+    ];
+
+    await expect(
+      refreshOAuth2Token(
+        "https://example.com/token",
+        "client-id",
+        "refresh-token",
+      ),
+    ).rejects.toThrow("OAuth2 token refresh failed (HTTP 400: invalid_grant)");
+
+    expect(fetchCallCount).toBe(1);
+  });
+
+  test("does NOT retry on 401", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: false,
+        status: 401,
+        body: { error: "unauthorized" },
+      },
+    ];
+
+    await expect(
+      refreshOAuth2Token(
+        "https://example.com/token",
+        "client-id",
+        "refresh-token",
+      ),
+    ).rejects.toThrow("OAuth2 token refresh failed");
+
+    expect(fetchCallCount).toBe(1);
+  });
+
+  test("exhausts retries on persistent network errors", async () => {
+    fetchResponses = [
+      { type: "error", error: new Error("ECONNREFUSED") },
+      { type: "error", error: new Error("ETIMEDOUT") },
+      { type: "error", error: new Error("DNS_FAIL") },
+      { type: "error", error: new Error("ECONNRESET") },
+    ];
+
+    await expect(
+      refreshOAuth2Token(
+        "https://example.com/token",
+        "client-id",
+        "refresh-token",
+      ),
+    ).rejects.toThrow("ECONNRESET");
+
+    // 1 initial + 3 retries = 4 total attempts
+    expect(fetchCallCount).toBe(4);
+  });
+
+  test("exhausts retries on persistent 500s", async () => {
+    fetchResponses = [
+      {
+        type: "response",
+        ok: false,
+        status: 500,
+        body: { error: "server_error" },
+      },
+      {
+        type: "response",
+        ok: false,
+        status: 502,
+        body: { error: "bad_gateway" },
+      },
+      {
+        type: "response",
+        ok: false,
+        status: 503,
+        body: { error: "unavailable" },
+      },
+      {
+        type: "response",
+        ok: false,
+        status: 500,
+        body: { error: "server_error" },
+      },
+    ];
+
+    await expect(
+      refreshOAuth2Token(
+        "https://example.com/token",
+        "client-id",
+        "refresh-token",
+      ),
+    ).rejects.toThrow("OAuth2 token refresh failed");
+
+    expect(fetchCallCount).toBe(4);
+  });
+});

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -790,9 +790,22 @@ export async function startOAuth2Flow(
   );
 }
 
+// Retry constants for transient failures during token refresh.
+const REFRESH_MAX_RETRIES = 3;
+const REFRESH_INITIAL_DELAY_MS = 500;
+const REFRESH_MAX_DELAY_MS = 4_000;
+
+function isRetryableRefreshError(status: number): boolean {
+  return status >= 500 || status === 429;
+}
+
 /**
  * Refresh an OAuth2 access token using a refresh token.
  * Supports both PKCE (no secret) and client_secret flows.
+ *
+ * Retries up to {@link REFRESH_MAX_RETRIES} times on transient failures
+ * (network errors, 5xx, 429) with exponential backoff + jitter. Credential
+ * errors (400 invalid_grant/invalid_client, 401, 403) fail immediately.
  */
 export async function refreshOAuth2Token(
   tokenExchangeUrl: string,
@@ -830,45 +843,95 @@ export async function refreshOAuth2Token(
     }
   }
 
-  const resp = await fetch(tokenExchangeUrl, {
-    method: "POST",
-    headers,
-    body:
-      bodyFormat === "json" ? JSON.stringify(body) : new URLSearchParams(body),
-  });
+  const requestBody =
+    bodyFormat === "json" ? JSON.stringify(body) : new URLSearchParams(body);
 
-  if (!resp.ok) {
-    const rawBody = await resp.text().catch(() => "");
-    const safeDetail: Record<string, unknown> = {};
-    let errorCode = "";
-    try {
-      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
-      if (parsed.error) {
-        safeDetail.error = String(parsed.error);
-        errorCode = String(parsed.error);
-      }
-      if (parsed.error_description)
-        safeDetail.error_description = String(parsed.error_description);
-    } catch {
-      safeDetail.error = "[non-JSON response]";
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= REFRESH_MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const baseDelay = Math.min(
+        REFRESH_INITIAL_DELAY_MS * 2 ** (attempt - 1),
+        REFRESH_MAX_DELAY_MS,
+      );
+      const jitter = Math.random() * baseDelay * 0.5;
+      const delay = baseDelay + jitter;
+      log.info(
+        { attempt, delayMs: Math.round(delay) },
+        "Retrying OAuth2 token refresh after transient failure",
+      );
+      await new Promise((r) => setTimeout(r, delay));
     }
-    log.error(
-      { status: resp.status, ...safeDetail },
-      "OAuth2 token refresh failed",
-    );
-    const detail = errorCode
-      ? `HTTP ${resp.status}: ${errorCode}`
-      : `HTTP ${resp.status}`;
-    throw new Error(`OAuth2 token refresh failed (${detail})`);
+
+    let resp: Response;
+    try {
+      resp = await fetch(tokenExchangeUrl, {
+        method: "POST",
+        headers,
+        body: requestBody,
+      });
+    } catch (err) {
+      // Network error (DNS, connection refused, timeout)
+      lastError =
+        err instanceof Error ? err : new Error(`Network error: ${String(err)}`);
+      log.warn(
+        { err: lastError, attempt },
+        "OAuth2 token refresh network error",
+      );
+      continue;
+    }
+
+    if (!resp.ok) {
+      const rawBody = await resp.text().catch(() => "");
+      const safeDetail: Record<string, unknown> = {};
+      let errorCode = "";
+      try {
+        const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+        if (parsed.error) {
+          safeDetail.error = String(parsed.error);
+          errorCode = String(parsed.error);
+        }
+        if (parsed.error_description)
+          safeDetail.error_description = String(parsed.error_description);
+      } catch {
+        safeDetail.error = "[non-JSON response]";
+      }
+
+      const detail = errorCode
+        ? `HTTP ${resp.status}: ${errorCode}`
+        : `HTTP ${resp.status}`;
+
+      // Credential errors fail immediately — no retry will help.
+      if (!isRetryableRefreshError(resp.status)) {
+        log.error(
+          { status: resp.status, ...safeDetail },
+          "OAuth2 token refresh failed",
+        );
+        throw new Error(`OAuth2 token refresh failed (${detail})`);
+      }
+
+      lastError = new Error(`OAuth2 token refresh failed (${detail})`);
+      log.warn(
+        { status: resp.status, attempt, ...safeDetail },
+        "OAuth2 token refresh transient failure",
+      );
+      continue;
+    }
+
+    const data = (await resp.json()) as Record<string, unknown>;
+
+    return {
+      accessToken: data.access_token as string,
+      refreshToken: (data.refresh_token as string | undefined) ?? refreshToken,
+      expiresIn: data.expires_in as number | undefined,
+      scope: data.scope as string | undefined,
+      tokenType: data.token_type as string | undefined,
+    };
   }
 
-  const data = (await resp.json()) as Record<string, unknown>;
-
-  return {
-    accessToken: data.access_token as string,
-    refreshToken: (data.refresh_token as string | undefined) ?? refreshToken,
-    expiresIn: data.expires_in as number | undefined,
-    scope: data.scope as string | undefined,
-    tokenType: data.token_type as string | undefined,
-  };
+  log.error(
+    { attempts: REFRESH_MAX_RETRIES + 1 },
+    "OAuth2 token refresh failed after all retries",
+  );
+  throw lastError ?? new Error("OAuth2 token refresh failed after retries");
 }


### PR DESCRIPTION
## Summary
- `refreshOAuth2Token()` previously made a bare `fetch()` to the token endpoint with zero retries — a single DNS hiccup or network timeout would immediately throw and trip the circuit breaker, blocking all refresh attempts for 30s–10min
- Now retries up to 3 times on transient failures (network errors, 5xx, 429) with exponential backoff + jitter
- Credential errors (400 `invalid_grant`/`invalid_client`, 401, 403) still fail immediately since retrying won't help

Part of a series of 6 PRs to fix silent OAuth failure handling discovered during heartbeat investigation.

## Test plan
- [x] Existing `refreshOAuth2Token` tests pass (3/3)
- [x] New retry-specific tests cover: success on first attempt, retry on network error, retry on 500, retry on 429, no retry on credential errors (400/401), exhausted retries on persistent network/5xx errors (8/8)
- [ ] Manual: trigger transient network issue during token refresh, verify retries in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/26922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
